### PR TITLE
Enable using Fiddler and similar tools in development scenarios

### DIFF
--- a/dotnet/src/SemanticKernel/AI/OpenAI/Clients/OpenAIClientAbstract.cs
+++ b/dotnet/src/SemanticKernel/AI/OpenAI/Clients/OpenAIClientAbstract.cs
@@ -39,7 +39,15 @@ public abstract class OpenAIClientAbstract : IDisposable
         if (log != null) { this.Log = log; }
 
         // TODO: allow injection of retry logic, e.g. Polly
-        this._httpClientHandler = new() { CheckCertificateRevocationList = true };
+        this._httpClientHandler = new()
+        {
+#if DEBUG
+            // This enables using Fiddler and similar tools in development scenarios
+            CheckCertificateRevocationList = false
+#else
+            CheckCertificateRevocationList = true
+#endif
+        };
         this.HTTPClient = new HttpClient(this._httpClientHandler);
         this.HTTPClient.DefaultRequestHeaders.Add("User-Agent", HTTPUseragent);
     }


### PR DESCRIPTION
# Motivation and Context

Many developers use Fiddler or related tools to inspect traffic being sent over the wire. Fiddler does this by acting as a proxy, but the current `CheckCertificateRevocationList = true` breaks this. Not checking for certificate revocation in DEBUG builds will enable this again