### PR TITLE
Update GitHub Actions, PR, NuGet version process

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
@@ -48,17 +47,14 @@ jobs:
         allProjectFiles=$(find ./dotnet -type f -name "*.csproj" | tr '\n' ' ');
         if [ $? -ne 0 ]; then exit 1; fi
         echo "$allProjectFiles"
-        branchName="${{ github.ref }}"
+
+        propsFile="./dotnet/nuget/nuget-package.props"
         
         buildAndRevisionNumber="${{ github.run_number }}.${{ github.run_attempt }}"
-        if [ $branchName != "refs/heads/main" ]; then
-          buildAndRevisionNumber="$buildAndRevisionNumber-dev"
-        fi
-        
         echo "buildAndRevisionNumber: $buildAndRevisionNumber"
 
         for file in $allProjectFiles; do
-            ./.github/workflows/update-version.sh --file $file --buildAndRevisionNumber $buildAndRevisionNumber
+          ./.github/workflows/update-version.sh --file $file --propsFile $propsFile --buildAndRevisionNumber $buildAndRevisionNumber
         done
 
     - name: Find solutions
@@ -108,36 +104,3 @@ jobs:
         name: drop-${{ matrix.os }}-${{ matrix.configuration }}
         path: ./out
       if: ${{ github.event_name == 'push' }}
-  
-  publish-nuget:
-    runs-on: ubuntu-latest
-    needs: build
-    continue-on-error: true
-    if: ${{ github.event_name == 'push' }}
-    steps:
-      # Pull all nuget packages (*.nupkg) and the accompanying symbols packages (*.snupkg)
-      - uses: actions/download-artifact@v3
-        with:
-          name: drop-ubuntu-latest-Release
-          path: ./out/dotnet/**/*nupkg
-          
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.0.x
-
-      - name: Find nupkg files
-        shell: bash
-        run: echo "nuget_packages=$(find ./out/dotnet -type f -name "*nupkg" | tr '\n' ' ')" >> $GITHUB_ENV
-
-      # Publish NuGet to GitHub Package Repository
-      # This will publish both the nuget package (*.nupkg) and the accompanying symbols (*.snupkg).
-      - name: Publish to GitHub package repository
-        shell: bash
-        run: |
-          for nupkg in ${{ env.nuget_packages }}; do
-            dotnet nuget push $nupkg \
-              --api-key ${{ secrets.GITHUB_TOKEN }} \
-              --source https://nuget.pkg.github.com/${{ github.repository_owner }} \
-              --skip-duplicate
-          done

--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -8,8 +8,6 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -41,25 +41,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget
 
-    - name: Update project versions
-      shell: bash
-      run: |
-        allProjectFiles=$(find ./dotnet -type f -name "*.csproj" | tr '\n' ' ');
-        if [ $? -ne 0 ]; then exit 1; fi
-        echo "$allProjectFiles"
-        branchName="${{ github.ref }}"
-        
-        buildAndRevisionNumber="${{ github.run_number }}.${{ github.run_attempt }}"
-        if [ $branchName != "refs/heads/main" ]; then
-          buildAndRevisionNumber="$buildAndRevisionNumber-dev"
-        fi
-        
-        echo "buildAndRevisionNumber: $buildAndRevisionNumber"
-
-        for file in $allProjectFiles; do
-            ./.github/workflows/update-version.sh --file $file --buildAndRevisionNumber $buildAndRevisionNumber
-        done
-
     - name: Find solutions
       shell: bash
       run: echo "solutions=$(find ./ -type f -name "*.sln" | tr '\n' ' ')" >> $GITHUB_ENV
@@ -88,10 +69,3 @@ jobs:
         for project in ${{ env.projects }}; do
             dotnet test $project --no-build --verbosity normal --logger trx --results-directory ./TestResults --configuration ${{ matrix.configuration }}
         done
-
-    - name: Upload dotnet test results
-      uses: actions/upload-artifact@v3
-      with:
-        name: dotnet-testresults-${{ matrix.configuration }}
-        path: ./TestResults
-      if: ${{ always() }}    

--- a/.github/workflows/update-version.sh
+++ b/.github/workflows/update-version.sh
@@ -11,6 +11,11 @@ while [[ $# -gt 0 ]]; do
             shift # past argument
             shift # past value
         ;;
+        -p|--propsFile)
+            propsFile="$2"
+            shift # past argument
+            shift # past value
+        ;;
         -b|--buildAndRevisionNumber)
             buildAndRevisionNumber="$2"
             shift # past argument

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -2,6 +2,8 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
+    <!-- Central version prefix - applies to all nuget packages -->
+    <Version>0.8</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.Document/Skills.Document.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Document/Skills.Document.csproj
@@ -15,7 +15,6 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.Document</PackageId>
     <Title>Semantic Kernel - OpenXml Connector</Title>
-    <Version>0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.Memory.Sqlite/Skills.Memory.Sqlite.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Memory.Sqlite/Skills.Memory.Sqlite.csproj
@@ -15,7 +15,6 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.Memory.Sqlite</PackageId>
     <Title>Semantic Kernel - SQLite Connector</Title>
-    <Version>0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.MsGraph/Skills.MsGraph.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.MsGraph/Skills.MsGraph.csproj
@@ -15,7 +15,6 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.MsGraph</PackageId>
     <Title>Semantic Kernel - Microsoft Graph Connector</Title>
-    <Version>0.8</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.Web/Skills.Web.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Web/Skills.Web.csproj
@@ -15,7 +15,6 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.Web</PackageId>
     <Title>Semantic Kernel - Microsoft Bing Connector</Title>
-    <Version>0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -16,7 +16,6 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel</PackageId>
     <Title>Semantic Kernel</Title>
-    <Version>0.8</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
### Description
 - **PR Action**
   - removing nuget version update and artifacts upload from the PR actions definition -- neither of these are used.
 - **CI Action** 
   - updating with versioning parameters, to load version from a central props file
   - removing GitHub feed (NuGet) publishing, since NuGet packs are now available on NuGet.org feed
   - NuGet packs from specific builds are still available in each CI build's artifacts
 - **Integration Tests**
   - running only on CI (not on PR) as PR tests do not work for repo non-owners
 - **Update Version script**
   - reading version from a central props file (specified in args from Actions)
   - script no longer assumes default version of 1.0 if not found -- exits with failure code instead
 - **.csproj files**
   - removing build version specified in each file (they'll load from central nuget props instead)

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
