### PR TITLE
Fix bug in SKFunction: remove duplicate RequestSettings objects

### DIFF
--- a/dotnet/src/SemanticKernel.Test/Orchestration/SKFunctionTests1.cs
+++ b/dotnet/src/SemanticKernel.Test/Orchestration/SKFunctionTests1.cs
@@ -2,261 +2,84 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
-using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
+using Moq;
 using SemanticKernelTests.XunitHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SemanticKernelTests.Orchestration;
 
-[SuppressMessage("", "CA1812:internal class apparently never instantiated", Justification = "Classes required by tests")]
 public sealed class SKFunctionTests1 : IDisposable
 {
     private readonly RedirectOutput _testOutputHelper;
+    private readonly Mock<IPromptTemplate> _promptTemplate;
 
     public SKFunctionTests1(ITestOutputHelper testOutputHelper)
     {
         this._testOutputHelper = new RedirectOutput(testOutputHelper);
         Console.SetOut(this._testOutputHelper);
+
+        this._promptTemplate = new Mock<IPromptTemplate>();
+        this._promptTemplate.Setup(x => x.RenderAsync(It.IsAny<SKContext>())).ReturnsAsync("foo");
+        this._promptTemplate.Setup(x => x.GetParameters()).Returns(new List<ParameterView>());
     }
 
     [Fact]
-    public void ItDoesntThrowForValidFunctions()
+    public void ItHasDefaultRequestSettings()
     {
         // Arrange
-        var skillInstance = new LocalExampleSkill();
-        MethodInfo[] methods = skillInstance.GetType()
-            .GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod)
-            .Where(m => m.Name != "GetType" && m.Name != "Equals" && m.Name != "GetHashCode" && m.Name != "ToString")
-            .ToArray();
+        var templateConfig = new PromptTemplateConfig();
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
 
-        IEnumerable<ISKFunction> functions = from method in methods select SKFunction.FromNativeMethod(method, skillInstance, "skill");
-        List<ISKFunction> result = (from function in functions where function != null select function).ToList();
-
-        // Act - Assert that no exception occurs and functions are not null
-        Assert.Equal(26, methods.Length);
-        Assert.Equal(26, result.Count);
-        foreach (var method in methods)
-        {
-            ISKFunction? func = SKFunction.FromNativeMethod(method, skillInstance, "skill");
-            Assert.NotNull(func);
-        }
-    }
-
-    [Fact]
-    public void ItThrowsForInvalidFunctions()
-    {
-        // Arrange
-        var instance = new InvalidSkill();
-        MethodInfo[] methods = instance.GetType()
-            .GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod)
-            .Where(m => m.Name != "GetType" && m.Name != "Equals" && m.Name != "GetHashCode")
-            .ToArray();
-
-        // Act - Assert that no exception occurs
-        var count = 0;
-        foreach (var method in methods)
-        {
-            try
-            {
-                SKFunction.FromNativeMethod(method, instance, "skill");
-            }
-            catch (KernelException e) when (e.ErrorCode == KernelException.ErrorCodes.FunctionTypeNotSupported)
-            {
-                count++;
-            }
-        }
+        // Act
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig);
 
         // Assert
-        Assert.Equal(3, count);
+        Assert.Equal(0, skFunction.RequestSettings.Temperature);
+        Assert.Equal(100, skFunction.RequestSettings.MaxTokens);
+    }
+
+    [Fact]
+    public void ItAllowsToUpdateRequestSettings()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig();
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig);
+        var settings = new CompleteRequestSettings
+        {
+            Temperature = 0.9,
+            MaxTokens = 2001,
+        };
+
+        // Act
+        skFunction.RequestSettings.Temperature = 1.3;
+        skFunction.RequestSettings.MaxTokens = 130;
+
+        // Assert
+        Assert.Equal(1.3, skFunction.RequestSettings.Temperature);
+        Assert.Equal(130, skFunction.RequestSettings.MaxTokens);
+
+        // Act
+        skFunction.RequestSettings.Temperature = 0.7;
+
+        // Assert
+        Assert.Equal(0.7, skFunction.RequestSettings.Temperature);
+
+        // Act
+        skFunction.SetAIConfiguration(settings);
+
+        // Assert
+        Assert.Equal(settings.Temperature, skFunction.RequestSettings.Temperature);
+        Assert.Equal(settings.MaxTokens, skFunction.RequestSettings.MaxTokens);
     }
 
     public void Dispose()
     {
         this._testOutputHelper.Dispose();
-    }
-
-    public class InvalidSkill
-    {
-        [SKFunction("one")]
-        public void Invalid1(string x, string y)
-        {
-        }
-
-        [SKFunction("two")]
-        public void Invalid2(SKContext cx, string y)
-        {
-        }
-
-        [SKFunction("three")]
-        public void Invalid3(string y, int n)
-        {
-        }
-    }
-
-    public class LocalExampleSkill
-    {
-        [SKFunction("one")]
-        public void Type01()
-        {
-        }
-
-        [SKFunction("two")]
-        public string Type02()
-        {
-            return "";
-        }
-
-        [SKFunction("two2")]
-        public string? Type02Nullable()
-        {
-            return null;
-        }
-
-        [SKFunction("three")]
-        public async Task<string> Type03Async()
-        {
-            await Task.Delay(0);
-            return "";
-        }
-
-        [SKFunction("three2")]
-        public async Task<string?> Type03NullableAsync()
-        {
-            await Task.Delay(0);
-            return null;
-        }
-
-        [SKFunction("four")]
-        public void Type04(SKContext context)
-        {
-        }
-
-        [SKFunction("four2")]
-        public void Type04Nullable(SKContext? context)
-        {
-        }
-
-        [SKFunction("five")]
-        public string Type05(SKContext context)
-        {
-            return "";
-        }
-
-        [SKFunction("five2")]
-        public string? Type05Nullable(SKContext? context)
-        {
-            return null;
-        }
-
-        [SKFunction("six")]
-        public async Task<string> Type06Async(SKContext context)
-        {
-            await Task.Delay(0);
-            return "";
-        }
-
-        [SKFunction("seven")]
-        public async Task<SKContext> Type07Async(SKContext context)
-        {
-            await Task.Delay(0);
-            return context;
-        }
-
-        [SKFunction("eight")]
-        public void Type08(string x)
-        {
-        }
-
-        [SKFunction("eight2")]
-        public void Type08Nullable(string? x)
-        {
-        }
-
-        [SKFunction("nine")]
-        public string Type09(string x)
-        {
-            return "";
-        }
-
-        [SKFunction("nine2")]
-        public string? Type09Nullable(string? x = null)
-        {
-            return "";
-        }
-
-        [SKFunction("ten")]
-        public async Task<string> Type10Async(string x)
-        {
-            await Task.Delay(0);
-            return "";
-        }
-
-        [SKFunction("ten2")]
-        public async Task<string?> Type10NullableAsync(string? x)
-        {
-            await Task.Delay(0);
-            return "";
-        }
-
-        [SKFunction("eleven")]
-        public void Type11(string x, SKContext context)
-        {
-        }
-
-        [SKFunction("eleven2")]
-        public void Type11Nullable(string? x = null, SKContext? context = null)
-        {
-        }
-
-        [SKFunction("twelve")]
-        public string Type12(string x, SKContext context)
-        {
-            return "";
-        }
-
-        [SKFunction("thirteen")]
-        public async Task<string> Type13Async(string x, SKContext context)
-        {
-            await Task.Delay(0);
-            return "";
-        }
-
-        [SKFunction("fourteen")]
-        public async Task<SKContext> Type14Async(string x, SKContext context)
-        {
-            await Task.Delay(0);
-            return context;
-        }
-
-        [SKFunction("fifteen")]
-        public async Task Type15Async(string x)
-        {
-            await Task.Delay(0);
-        }
-
-        [SKFunction("sixteen")]
-        public async Task Type16Async(SKContext context)
-        {
-            await Task.Delay(0);
-        }
-
-        [SKFunction("seventeen")]
-        public async Task Type17Async(string x, SKContext context)
-        {
-            await Task.Delay(0);
-        }
-
-        [SKFunction("eighteen")]
-        public async Task Type18Async()
-        {
-            await Task.Delay(0);
-        }
     }
 }

--- a/dotnet/src/SemanticKernel.Test/Orchestration/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.Test/Orchestration/SKFunctionTests2.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -16,7 +15,6 @@ using Xunit.Abstractions;
 
 namespace SemanticKernelTests.Orchestration;
 
-[SuppressMessage("", "CA1812:internal class apparently never instantiated", Justification = "Classes required by tests")]
 public sealed class SKFunctionTests2 : IDisposable
 {
     private readonly RedirectOutput _testOutputHelper;

--- a/dotnet/src/SemanticKernel.Test/Orchestration/SKFunctionTests3.cs
+++ b/dotnet/src/SemanticKernel.Test/Orchestration/SKFunctionTests3.cs
@@ -1,0 +1,262 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SkillDefinition;
+using SemanticKernelTests.XunitHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernelTests.Orchestration;
+
+[SuppressMessage("", "CA1812:internal class apparently never instantiated", Justification = "Classes required by tests")]
+public sealed class SKFunctionTests3 : IDisposable
+{
+    private readonly RedirectOutput _testOutputHelper;
+
+    public SKFunctionTests3(ITestOutputHelper testOutputHelper)
+    {
+        this._testOutputHelper = new RedirectOutput(testOutputHelper);
+        Console.SetOut(this._testOutputHelper);
+    }
+
+    [Fact]
+    public void ItDoesntThrowForValidFunctions()
+    {
+        // Arrange
+        var skillInstance = new LocalExampleSkill();
+        MethodInfo[] methods = skillInstance.GetType()
+            .GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod)
+            .Where(m => m.Name != "GetType" && m.Name != "Equals" && m.Name != "GetHashCode" && m.Name != "ToString")
+            .ToArray();
+
+        IEnumerable<ISKFunction> functions = from method in methods select SKFunction.FromNativeMethod(method, skillInstance, "skill");
+        List<ISKFunction> result = (from function in functions where function != null select function).ToList();
+
+        // Act - Assert that no exception occurs and functions are not null
+        Assert.Equal(26, methods.Length);
+        Assert.Equal(26, result.Count);
+        foreach (var method in methods)
+        {
+            ISKFunction? func = SKFunction.FromNativeMethod(method, skillInstance, "skill");
+            Assert.NotNull(func);
+        }
+    }
+
+    [Fact]
+    public void ItThrowsForInvalidFunctions()
+    {
+        // Arrange
+        var instance = new InvalidSkill();
+        MethodInfo[] methods = instance.GetType()
+            .GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod)
+            .Where(m => m.Name != "GetType" && m.Name != "Equals" && m.Name != "GetHashCode")
+            .ToArray();
+
+        // Act - Assert that no exception occurs
+        var count = 0;
+        foreach (var method in methods)
+        {
+            try
+            {
+                SKFunction.FromNativeMethod(method, instance, "skill");
+            }
+            catch (KernelException e) when (e.ErrorCode == KernelException.ErrorCodes.FunctionTypeNotSupported)
+            {
+                count++;
+            }
+        }
+
+        // Assert
+        Assert.Equal(3, count);
+    }
+
+    public void Dispose()
+    {
+        this._testOutputHelper.Dispose();
+    }
+
+    private class InvalidSkill
+    {
+        [SKFunction("one")]
+        public void Invalid1(string x, string y)
+        {
+        }
+
+        [SKFunction("two")]
+        public void Invalid2(SKContext cx, string y)
+        {
+        }
+
+        [SKFunction("three")]
+        public void Invalid3(string y, int n)
+        {
+        }
+    }
+
+    private class LocalExampleSkill
+    {
+        [SKFunction("one")]
+        public void Type01()
+        {
+        }
+
+        [SKFunction("two")]
+        public string Type02()
+        {
+            return "";
+        }
+
+        [SKFunction("two2")]
+        public string? Type02Nullable()
+        {
+            return null;
+        }
+
+        [SKFunction("three")]
+        public async Task<string> Type03Async()
+        {
+            await Task.Delay(0);
+            return "";
+        }
+
+        [SKFunction("three2")]
+        public async Task<string?> Type03NullableAsync()
+        {
+            await Task.Delay(0);
+            return null;
+        }
+
+        [SKFunction("four")]
+        public void Type04(SKContext context)
+        {
+        }
+
+        [SKFunction("four2")]
+        public void Type04Nullable(SKContext? context)
+        {
+        }
+
+        [SKFunction("five")]
+        public string Type05(SKContext context)
+        {
+            return "";
+        }
+
+        [SKFunction("five2")]
+        public string? Type05Nullable(SKContext? context)
+        {
+            return null;
+        }
+
+        [SKFunction("six")]
+        public async Task<string> Type06Async(SKContext context)
+        {
+            await Task.Delay(0);
+            return "";
+        }
+
+        [SKFunction("seven")]
+        public async Task<SKContext> Type07Async(SKContext context)
+        {
+            await Task.Delay(0);
+            return context;
+        }
+
+        [SKFunction("eight")]
+        public void Type08(string x)
+        {
+        }
+
+        [SKFunction("eight2")]
+        public void Type08Nullable(string? x)
+        {
+        }
+
+        [SKFunction("nine")]
+        public string Type09(string x)
+        {
+            return "";
+        }
+
+        [SKFunction("nine2")]
+        public string? Type09Nullable(string? x = null)
+        {
+            return "";
+        }
+
+        [SKFunction("ten")]
+        public async Task<string> Type10Async(string x)
+        {
+            await Task.Delay(0);
+            return "";
+        }
+
+        [SKFunction("ten2")]
+        public async Task<string?> Type10NullableAsync(string? x)
+        {
+            await Task.Delay(0);
+            return "";
+        }
+
+        [SKFunction("eleven")]
+        public void Type11(string x, SKContext context)
+        {
+        }
+
+        [SKFunction("eleven2")]
+        public void Type11Nullable(string? x = null, SKContext? context = null)
+        {
+        }
+
+        [SKFunction("twelve")]
+        public string Type12(string x, SKContext context)
+        {
+            return "";
+        }
+
+        [SKFunction("thirteen")]
+        public async Task<string> Type13Async(string x, SKContext context)
+        {
+            await Task.Delay(0);
+            return "";
+        }
+
+        [SKFunction("fourteen")]
+        public async Task<SKContext> Type14Async(string x, SKContext context)
+        {
+            await Task.Delay(0);
+            return context;
+        }
+
+        [SKFunction("fifteen")]
+        public async Task Type15Async(string x)
+        {
+            await Task.Delay(0);
+        }
+
+        [SKFunction("sixteen")]
+        public async Task Type16Async(SKContext context)
+        {
+            await Task.Delay(0);
+        }
+
+        [SKFunction("seventeen")]
+        public async Task Type17Async(string x, SKContext context)
+        {
+            await Task.Delay(0);
+        }
+
+        [SKFunction("eighteen")]
+        public async Task Type18Async()
+        {
+            await Task.Delay(0);
+        }
+    }
+}

--- a/dotnet/src/SemanticKernel/AI/CompleteRequestSettings.cs
+++ b/dotnet/src/SemanticKernel/AI/CompleteRequestSettings.cs
@@ -42,22 +42,6 @@ public class CompleteRequestSettings
     public IList<string> StopSequences { get; set; } = Array.Empty<string>();
 
     /// <summary>
-    /// Update this settings object with the values from another settings object.
-    /// </summary>
-    /// <param name="config">The config whose values to use</param>
-    /// <returns>Returns this CompleteRequestSettings object</returns>
-    public CompleteRequestSettings UpdateFromCompletionConfig(PromptTemplateConfig.CompletionConfig config)
-    {
-        this.Temperature = config.Temperature;
-        this.TopP = config.TopP;
-        this.PresencePenalty = config.PresencePenalty;
-        this.FrequencyPenalty = config.FrequencyPenalty;
-        this.MaxTokens = config.MaxTokens;
-        this.StopSequences = config.StopSequences;
-        return this;
-    }
-
-    /// <summary>
     /// Create a new settings object with the values from another settings object.
     /// </summary>
     /// <param name="config"></param>

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -250,16 +250,15 @@ public sealed class Kernel : IKernel, IDisposable
         }
 
         ISKFunction func = SKFunction.FromSemanticConfig(skillName, functionName, functionConfig);
-        func.RequestSettings.UpdateFromCompletionConfig(functionConfig.PromptTemplateConfig.Completion);
 
         // Connect the function to the current kernel skill collection, in case the function
         // is invoked manually without a context and without a way to find other functions.
         func.SetDefaultSkillCollection(this.Skills);
 
+        func.SetAIConfiguration(CompleteRequestSettings.FromCompletionConfig(functionConfig.PromptTemplateConfig.Completion));
+
         // TODO: allow to postpone this (e.g. use lazy init), allow to create semantic functions without a default backend
         var backend = this._config.GetCompletionBackend(functionConfig.PromptTemplateConfig.DefaultBackends.FirstOrDefault());
-
-        func.SetAIConfiguration(CompleteRequestSettings.FromCompletionConfig(functionConfig.PromptTemplateConfig.Completion));
 
         switch (backend.BackendType)
         {

--- a/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
@@ -37,7 +37,10 @@ public sealed class SKFunction : ISKFunction, IDisposable
     public bool IsSemantic { get; }
 
     /// <inheritdoc/>
-    public CompleteRequestSettings RequestSettings { get; } = new();
+    public CompleteRequestSettings RequestSettings
+    {
+        get { return this._aiRequestSettings; }
+    }
 
     /// <summary>
     /// List of function parameters
@@ -98,25 +101,25 @@ public sealed class SKFunction : ISKFunction, IDisposable
         async Task<SKContext> LocalFunc(
             ITextCompletionClient client,
             CompleteRequestSettings requestSettings,
-            SKContext executionContext)
+            SKContext context)
         {
             Verify.NotNull(client, "AI LLM backed is empty");
 
             try
             {
-                string prompt = await functionConfig.PromptTemplate.RenderAsync(executionContext);
+                string prompt = await functionConfig.PromptTemplate.RenderAsync(context);
 
                 string completion = await client.CompleteAsync(prompt, requestSettings);
-                executionContext.Variables.Update(completion);
+                context.Variables.Update(completion);
             }
 #pragma warning disable CA1031 // We need to catch all exceptions to handle the execution state
             catch (Exception e) when (!e.IsCriticalException())
             {
-                executionContext.Fail(e.Message, e);
+                context.Fail(e.Message, e);
             }
 #pragma warning restore CA1031
 
-            return executionContext;
+            return context;
         }
 
         return new SKFunction(


### PR DESCRIPTION
### Motivation and Context

SKFunction offers 2 ways to update semantic functions' request settings. The 2 APIs use different instances of `CompleteRequestSettings` instead of one, leading to situations where the settings are out of sync or settings requested by the user are ignored.

### Description

Remove the duplicate object and point the 2 APIs to the same settings instance.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
