### PR TITLE
Fix a few minor issues in the graph-api-skills readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,7 @@ global.json
 **/bin/
 **/obj/
 _site
+
+# Yarn
+.yarn
+.yarnrc.yml

--- a/samples/apps/auth-api-webapp-react/README.md
+++ b/samples/apps/auth-api-webapp-react/README.md
@@ -18,7 +18,7 @@
    [register your application](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app)
    in the Azure Portal. Follow the steps to register your app
    [here](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app).
-    - Select **`single-page application (SPA)`** as platform type, and the Redirect URI will be **`http://localhost:3000`**
+    - Select **`Single-page application (SPA)`** as platform type, and the Redirect URI will be **`http://localhost:3000`**
     - It is recommended you use the **`Personal Microsoft accounts`** account type for this sample.
 4. Once registered, copy the **Application (client) ID** from the Azure Portal and paste
    the GUID into the **[.env](.env)** file next to `REACT_APP_GRAPH_CLIENT_ID=` (first line of the .env file).

--- a/samples/dotnet/graph-api-skills/README.md
+++ b/samples/dotnet/graph-api-skills/README.md
@@ -10,16 +10,18 @@ This example program demonstrates how to use the Microsoft Graph API skills with
    - This example can use either Azure OpenAI or OpenAI models for summarization.
    - In your `appsettings.Development.json` fill out the `OpenAI` and/or `AzureOpenAI` sections with an appropriate label and API key.
 3. If you have not already, [register an application with the Microsoft identity platform](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app).
-   - Make sure the API permissions include the scopes outines in your `appsettings` (e.g. Mail.Read).
-4. Update the `MsGraph` sections in your `appsettings` with your application registrations IDs and parameters.
-5. Update the `OneDrivePathToFile` to point to a text file that exists in your OneDrive. 
+   - Select **`Mobile and desktop applications`** as platform type, and the Redirect URI will be **`http://localhost`**
+   - It is recommended you use the **`Personal Microsoft accounts`** account type for this sample.
+   - Make sure the API permissions include the scopes outines in your `appsettings.json` (e.g. Mail.Send, ...).
+4. Update the `MsGraph` sections in your `appsettings.json` with your application registrations IDs and parameters.
+5. Update the `OneDrivePathToFile` to point to a text file that exists in your OneDrive.
    - This file will be used as content to summarize in the example.
 
 Example `appsettings.Development.json`:
 
 ```json
 {
-  "GraphApi": {
+  "MsGraph": {
     "ClientId": "YOUR_APPLICATION_CLIENTID",
     "RedirectUri": "http://localhost"
   },
@@ -30,6 +32,7 @@ Example `appsettings.Development.json`:
   },
   "AzureOpenAI": {
     "Label": "azure-text-davinci-003",
+    "DeploymentName": "azure-text-davinci-003",
     "Endpoint": "YOUR_AZURE_OPENAI_ENDPOINT (e.g. https://contoso.openai.azure.com/",
     "ApiKey": "YOUR_AZURE_OPENAPI_KEY"
   }

--- a/samples/dotnet/graph-api-skills/appsettings.json
+++ b/samples/dotnet/graph-api-skills/appsettings.json
@@ -22,14 +22,14 @@
   "OneDrivePathToFile": "<path to a text file in your OneDrive>", // e.g. "Documents/MyFile.txt"
   "DefaultCompletionBackendLabel": "text-davinci-003",
   "OpenAI": {
-    "Label": "text-davinci-003",
-    "ModelId": "text-davinci-003",
-    "ApiKey": ""
+  //  "Label": "text-davinci-003",
+  //  "ModelId": "text-davinci-003",
+  //  "ApiKey": ""
   }
-  //"AzureOpenAI": {
+  "AzureOpenAI": {
   //  "Label": "",
   //  "DeploymentName": "",
   //  "Endpoint": "",
   //  "ApiKey": ""
-  //}
+  }
 }


### PR DESCRIPTION
### Motivation and Context
Fixed a few issues in the graph-api-skils readme 

1. Why is this change required? Will help developers running the sample to avoid some pitfalls
3. What problem does it solve? Running the sample with just Azure Open API results in an error
4. What scenario does it contribute to? Developer onboarding
5. If it fixes an open issue, please link to the issue here.


### Description
1. Ignore `.yarn` folder and `.yarnrc.yml` files
2. Change graph-api-skils readme to fix some errors, add more detail on the app registration and fix the sample json
3. Comment out the OpenAI config in appsettings.json so that the sample won't always try to use it


### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

