### PR TITLE
Correct namespaces in KernelHttpServer, Fixed code style warnings

### DIFF
--- a/dotnet/src/IntegrationTest/AI/OpenAIEmbeddingTests.cs
+++ b/dotnet/src/IntegrationTest/AI/OpenAIEmbeddingTests.cs
@@ -15,7 +15,7 @@ namespace IntegrationTests.AI;
 public sealed class OpenAIEmbeddingTests : IDisposable
 {
     private readonly IConfigurationRoot _configuration;
-    private const int ADA_VECTOR_LENGTH = 1536;
+    private const int AdaVectorLength = 1536;
 
     public OpenAIEmbeddingTests(ITestOutputHelper output)
     {
@@ -46,7 +46,7 @@ public sealed class OpenAIEmbeddingTests : IDisposable
         var batchResult = await embeddingGenerator.GenerateEmbeddingsAsync(new List<string> { testInputString, testInputString, testInputString });
 
         // Assert
-        Assert.Equal(ADA_VECTOR_LENGTH, singleResult.Count);
+        Assert.Equal(AdaVectorLength, singleResult.Count);
         Assert.Equal(3, batchResult.Count);
 
         embeddingGenerator.Dispose();
@@ -70,7 +70,7 @@ public sealed class OpenAIEmbeddingTests : IDisposable
         var batchResult = await embeddingGenerator.GenerateEmbeddingsAsync(new List<string> { testInputString, testInputString, testInputString });
 
         // Assert
-        Assert.Equal(ADA_VECTOR_LENGTH, singleResult.Count);
+        Assert.Equal(AdaVectorLength, singleResult.Count);
         Assert.Equal(3, batchResult.Count);
 
         embeddingGenerator.Dispose();

--- a/dotnet/src/SemanticKernel.Skills/Skills.Web/WebFileDownloadSkill.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Web/WebFileDownloadSkill.cs
@@ -56,11 +56,11 @@ public class WebFileDownloadSkill : IDisposable
     [SKFunctionContextParameter(Name = Parameters.FilePath, Description = "Path where to save file locally")]
     public async Task DownloadToFileAsync(string source, SKContext context)
     {
-        this._logger.LogDebug($"{nameof(DownloadToFileAsync)} got called");
+        this._logger.LogDebug($"{nameof(this.DownloadToFileAsync)} got called");
 
         if (!context.Variables.Get(Parameters.FilePath, out string filePath))
         {
-            this._logger.LogError($"Missing context variable in {nameof(DownloadToFileAsync)}");
+            this._logger.LogError($"Missing context variable in {nameof(this.DownloadToFileAsync)}");
             string errorMessage = $"Missing variable {Parameters.FilePath}";
             context.Fail(errorMessage);
 

--- a/dotnet/src/SemanticKernel.Test/AI/OpenAI/Services/BackendConfigTests.cs
+++ b/dotnet/src/SemanticKernel.Test/AI/OpenAI/Services/BackendConfigTests.cs
@@ -5,6 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 using Xunit;
 
 namespace SemanticKernelTests.AI.OpenAI.Services;
+
 public class BackendConfigTests
 {
     [Fact]

--- a/dotnet/src/SemanticKernel/AI/OpenAI/Services/AzureTextEmbeddings.cs
+++ b/dotnet/src/SemanticKernel/AI/OpenAI/Services/AzureTextEmbeddings.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.Embeddings;

--- a/dotnet/src/SemanticKernel/AI/OpenAI/Services/BackendConfig.cs
+++ b/dotnet/src/SemanticKernel/AI/OpenAI/Services/BackendConfig.cs
@@ -4,6 +4,7 @@ using Microsoft.SemanticKernel.Configuration;
 using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.AI.OpenAI.Services;
+
 public abstract class BackendConfig : IBackendConfig
 {
     /// <summary>

--- a/samples/dotnet/KernelHttpServer/Config/ApiKeyConfig.cs
+++ b/samples/dotnet/KernelHttpServer/Config/ApiKeyConfig.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace SemanticKernelFunction.Config;
+namespace KernelHttpServer.Config;
 
 public class ApiKeyConfig
 {

--- a/samples/dotnet/KernelHttpServer/Config/CompletionService.cs
+++ b/samples/dotnet/KernelHttpServer/Config/CompletionService.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace SemanticKernelFunction.Config;
+namespace KernelHttpServer.Config;
 
 public enum CompletionService
 {

--- a/samples/dotnet/KernelHttpServer/Extensions.cs
+++ b/samples/dotnet/KernelHttpServer/Extensions.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using KernelHttpServer.Config;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -22,10 +23,9 @@ using Microsoft.SemanticKernel.Skills.Document.OpenXml;
 using Microsoft.SemanticKernel.Skills.MsGraph;
 using Microsoft.SemanticKernel.Skills.MsGraph.Connectors;
 using Microsoft.SemanticKernel.TemplateEngine;
-using SemanticKernelFunction.Config;
 using Directory = System.IO.Directory;
 
-namespace SemanticKernelFunction;
+namespace KernelHttpServer;
 
 internal static class Extensions
 {

--- a/samples/dotnet/KernelHttpServer/Model/Ask.cs
+++ b/samples/dotnet/KernelHttpServer/Model/Ask.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SemanticKernelFunction.Model;
+namespace KernelHttpServer.Model;
 
 public class Ask
 {

--- a/samples/dotnet/KernelHttpServer/Model/AskResult.cs
+++ b/samples/dotnet/KernelHttpServer/Model/AskResult.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SemanticKernelFunction.Model;
+namespace KernelHttpServer.Model;
 
 public class AskResult
 {

--- a/samples/dotnet/KernelHttpServer/Model/Skill.cs
+++ b/samples/dotnet/KernelHttpServer/Model/Skill.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SemanticKernelFunction.Model;
+namespace KernelHttpServer.Model;
 
 public class Skill
 {

--- a/samples/dotnet/KernelHttpServer/PingEndpoint.cs
+++ b/samples/dotnet/KernelHttpServer/PingEndpoint.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 
 // This endpoint exists as a convenience for the UI to check if the function it is dependent
 // on is running. You won't need this endpoint in a typical app.
-namespace SemanticKernelFunction;
+namespace KernelHttpServer;
 
 public class PingEndpoint
 {

--- a/samples/dotnet/KernelHttpServer/Program.cs
+++ b/samples/dotnet/KernelHttpServer/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace SemanticKernelFunction;
+namespace KernelHttpServer;
 
 public static class Program
 {

--- a/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
 
 using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
+using KernelHttpServer.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Orchestration.Extensions;
-using SemanticKernelFunction.Model;
 
-namespace SemanticKernelFunction;
+namespace KernelHttpServer;
 
 public class SemanticKernelEndpoint
 {

--- a/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
@@ -3,13 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using KernelHttpServer.Config;
+using KernelHttpServer.Utils;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
-using SemanticKernelFunction.Config;
-using SemanticKernelFunction.Utils;
 
-namespace SemanticKernelFunction;
+namespace KernelHttpServer;
 
 internal static class SemanticKernelFactory
 {

--- a/samples/dotnet/KernelHttpServer/TokenAuthenticationProvider.cs
+++ b/samples/dotnet/KernelHttpServer/TokenAuthenticationProvider.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Graph;
 
-namespace SemanticKernelFunction;
+namespace KernelHttpServer;
 
 internal sealed class TokenAuthenticationProvider : IAuthenticationProvider
 {

--- a/samples/dotnet/KernelHttpServer/Utils/RepoFiles.cs
+++ b/samples/dotnet/KernelHttpServer/Utils/RepoFiles.cs
@@ -3,7 +3,7 @@
 using System.IO;
 using System.Reflection;
 
-namespace SemanticKernelFunction.Utils;
+namespace KernelHttpServer.Utils;
 
 internal static class RepoFiles
 {

--- a/samples/dotnet/KernelHttpServer/Utils/YourAppException.cs
+++ b/samples/dotnet/KernelHttpServer/Utils/YourAppException.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace SemanticKernelFunction.Utils;
+namespace KernelHttpServer.Utils;
 
 public class YourAppException : Exception
 {


### PR DESCRIPTION
### Motivation and Context

The Semantic Kernel naming convention of Skills and Functions can cause confusion with the naming of the Azure Function sample project.

### Description
1. Updated sample `KernelHttpServer` project namespaces to match the project name. 
1. Small adjustments to code style warnings (naming, unused namespaces, spacing).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
