### PR TITLE
Add Roslyn and VS Threading analyzers

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -37,9 +37,15 @@
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.26.0" />
 
     <!-- Analyzers -->
-    <!-- <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22"> -->
-    <!--   <PrivateAssets>all</PrivateAssets> -->
-    <!--   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets> -->
-    <!-- </PackageReference> -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/dotnet/src/SemanticKernel.Test/CoreSkills/PlannerSkillTests.cs
+++ b/dotnet/src/SemanticKernel.Test/CoreSkills/PlannerSkillTests.cs
@@ -473,8 +473,9 @@ This is some text
         }
 
         [SKFunction("Split the input into two parts")]
+        [SKFunctionName("SplitInput")]
         [SKFunctionInput(Description = "The input text to split")]
-        public Task<SKContext> SplitInput(string input, SKContext context)
+        public Task<SKContext> SplitInputAsync(string input, SKContext context)
         {
             var parts = input.Split(':');
             context.Variables.Set("First", parts[0]);
@@ -483,7 +484,8 @@ This is some text
         }
 
         [SKFunction("Echo the input text")]
-        public Task<SKContext> Echo(string text, SKContext context)
+        [SKFunctionName("Echo")]
+        public Task<SKContext> EchoAsync(string text, SKContext context)
         {
             this._testOutputHelper.WriteLine(text);
             _ = context.Variables.Update("Echo Result: " + text);


### PR DESCRIPTION
### Motivation and Context

Roslyn and VS Threading analyzers provide automated and free recommendations about about C# best practices. The PR includes one of many easy misses during PR reviews, that the VS analyzer detected.

### Description

* Add [Roslyn analyzers](https://github.com/dotnet/roslyn-analyzers) to the build process
* Add [VS threading analyzers](https://github.com/Microsoft/vs-threading)