### PR TITLE
Fixing testsettings for integration tests

### DIFF
--- a/dotnet/src/IntegrationTest/testsettings.json
+++ b/dotnet/src/IntegrationTest/testsettings.json
@@ -6,7 +6,7 @@
   },
   "AzureOpenAI": {
     "Label": "azure-text-davinci-002",
-    "DeploymentName": "",
+    "DeploymentName": "text-davinci-002",
     "Endpoint": "",
     "ApiKey": ""
   },
@@ -17,7 +17,7 @@
   },
   "AzureOpenAIEmbeddings": {
     "Label": "azure-text-embedding-ada-002",
-    "DeploymentName": "",
+    "DeploymentName": "text-embedding-ada-002",
     "Endpoint": "",
     "ApiKey": ""
   },


### PR DESCRIPTION
### Motivation and Context
Integration tests are failing due to missing deployment name for AzureOpenAI.

### Description
Populating the DeploymentName field in the `AzureOpenAI` and `AzureOpenAIEmbeddings` test configurations.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
