### PR TITLE
Bring embeddings and memory to KernelHttpServer

### DIFF
--- a/dotnet/src/IntegrationTest/AI/OpenAIEmbeddingTests.cs
+++ b/dotnet/src/IntegrationTest/AI/OpenAIEmbeddingTests.cs
@@ -14,8 +14,8 @@ namespace IntegrationTests.AI;
 
 public sealed class OpenAIEmbeddingTests : IDisposable
 {
-    private readonly IConfigurationRoot _configuration;
     private const int AdaVectorLength = 1536;
+    private readonly IConfigurationRoot _configuration;
 
     public OpenAIEmbeddingTests(ITestOutputHelper output)
     {

--- a/samples/apps/auth-api-webapp-react/src/components/ServiceConfig.tsx
+++ b/samples/apps/auth-api-webapp-react/src/components/ServiceConfig.tsx
@@ -44,13 +44,15 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
     };
 
     useEffect(() => {
-        setKeyConfig((keyConfig) => ({
-            ...keyConfig,
+        keyConfig.completionConfig = {
             key: isOpenAI ? openAiKey : azureOpenAiKey,
             deploymentOrModelId: isOpenAI ? openAiModel : azureOpenAiDeployment,
+            label: isOpenAI ? openAiModel : azureOpenAiDeployment,
             endpoint: isOpenAI ? '' : azureOpenAiEndpoint,
-            completionBackend: isOpenAI ? 1 : 0,
-        }));
+            backend: isOpenAI ? 1 : 0
+        }
+
+        setKeyConfig((keyConfig) => ({ ...keyConfig }));
     }, [isOpenAI, openAiKey, openAiModel, azureOpenAiKey, azureOpenAiDeployment, azureOpenAiEndpoint]);
 
     return (
@@ -81,7 +83,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={openAiKey}
                         onChange={(e, d) => {
                             setOpenAiKey(d.value);
-                            setKeyConfig({ ...keyConfig, key: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, key: d.value } });
                         }}
                         placeholder="Enter your OpenAI key here"
                     />
@@ -91,7 +93,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={openAiModel}
                         onChange={(e, d) => {
                             setOpenAiModel(d.value);
-                            setKeyConfig({ ...keyConfig, deploymentOrModelId: d.value, label: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, deploymentOrModelId: d.value, label: d.value } });
                         }}
                         placeholder="Enter the model id here, ie: text-davinci-003"
                     />
@@ -105,7 +107,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiKey}
                         onChange={(e, d) => {
                             setAzureOpenAiKey(d.value);
-                            setKeyConfig({ ...keyConfig, key: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, key: d.value } });
                         }}
                         placeholder="Enter your Azure OpenAI key here"
                     />
@@ -115,7 +117,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiDeployment}
                         onChange={(e, d) => {
                             setAzureOpenAiDeployment(d.value);
-                            setKeyConfig({ ...keyConfig, deploymentOrModelId: d.value, label: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, deploymentOrModelId: d.value, label: d.value } });
                         }}
                         placeholder="Enter your deployment id here, ie: my-deployment"
                     />
@@ -125,7 +127,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiEndpoint}
                         onChange={(e, d) => {
                             setAzureOpenAiEndpoint(d.value);
-                            setKeyConfig({ ...keyConfig, endpoint: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, endpoint: d.value } });
                         }}
                         placeholder="Enter the endpoint here, ie: https://my-resource.openai.azure.com"
                     />

--- a/samples/apps/auth-api-webapp-react/src/hooks/SemanticKernel.ts
+++ b/samples/apps/auth-api-webapp-react/src/hooks/SemanticKernel.ts
@@ -3,12 +3,7 @@
 import { IAsk } from '../model/Ask';
 import { IAskResult } from '../model/AskResult';
 import {
-    IKeyConfig,
-    SK_HTTP_HEADER_API_KEY,
-    SK_HTTP_HEADER_COMPLETION,
-    SK_HTTP_HEADER_ENDPOINT,
-    SK_HTTP_HEADER_MODEL,
-    SK_HTTP_HEADER_MSGRAPH
+    IKeyConfig, SK_HTTP_HEADER_COMPLETION_BACKEND, SK_HTTP_HEADER_COMPLETION_ENDPOINT, SK_HTTP_HEADER_COMPLETION_KEY, SK_HTTP_HEADER_COMPLETION_MODEL, SK_HTTP_HEADER_EMBEDDING_BACKEND, SK_HTTP_HEADER_EMBEDDING_ENDPOINT, SK_HTTP_HEADER_EMBEDDING_KEY, SK_HTTP_HEADER_EMBEDDING_MODEL, SK_HTTP_HEADER_MSGRAPH
 } from '../model/KeyConfig';
 
 interface ServiceRequest {
@@ -41,10 +36,20 @@ export class SemanticKernel {
         const { commandPath, method, body, keyConfig } = request;
 
         const headers = new Headers();
-        headers.append(SK_HTTP_HEADER_MODEL, keyConfig.deploymentOrModelId);
-        headers.append(SK_HTTP_HEADER_ENDPOINT, keyConfig.endpoint);
-        headers.append(SK_HTTP_HEADER_API_KEY, keyConfig.key);
-        headers.append(SK_HTTP_HEADER_COMPLETION, keyConfig.completionBackend.toString());
+
+        if (keyConfig.completionConfig !== undefined) {
+            headers.append(SK_HTTP_HEADER_COMPLETION_KEY, keyConfig.completionConfig.key);
+            headers.append(SK_HTTP_HEADER_COMPLETION_MODEL, keyConfig.completionConfig.deploymentOrModelId);
+            headers.append(SK_HTTP_HEADER_COMPLETION_ENDPOINT, keyConfig.completionConfig.endpoint);
+            headers.append(SK_HTTP_HEADER_COMPLETION_BACKEND, keyConfig.completionConfig.backend.toString());
+        }
+
+        if (keyConfig.embeddingConfig !== undefined) {
+            headers.append(SK_HTTP_HEADER_EMBEDDING_KEY, keyConfig.embeddingConfig.key);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_MODEL, keyConfig.embeddingConfig.deploymentOrModelId);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_ENDPOINT, keyConfig.embeddingConfig.endpoint);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_BACKEND, keyConfig.embeddingConfig.backend.toString());
+        }
 
         if (keyConfig.graphToken !== undefined) {
             headers.append(SK_HTTP_HEADER_MSGRAPH, keyConfig.graphToken);

--- a/samples/apps/auth-api-webapp-react/src/hooks/SemanticKernel.ts
+++ b/samples/apps/auth-api-webapp-react/src/hooks/SemanticKernel.ts
@@ -15,7 +15,7 @@ interface ServiceRequest {
 
 export class SemanticKernel {
     // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-    constructor(private readonly serviceUrl: string) {}
+    constructor(private readonly serviceUrl: string) { }
 
     public invokeAsync = async (
         keyConfig: IKeyConfig,
@@ -25,6 +25,16 @@ export class SemanticKernel {
     ): Promise<IAskResult> => {
         const result = await this.getResponseAsync<IAskResult>({
             commandPath: `/api/skills/${skillName}/invoke/${functionName}`,
+            method: 'POST',
+            body: ask,
+            keyConfig: keyConfig,
+        });
+        return result;
+    };
+
+    public executePlanAsync = async (keyConfig: IKeyConfig, ask: IAsk, maxSteps: number = 10): Promise<IAskResult> => {
+        const result = await this.getResponseAsync<IAskResult>({
+            commandPath: `/api/planner/execute/${maxSteps}`,
             method: 'POST',
             body: ask,
             keyConfig: keyConfig,

--- a/samples/apps/auth-api-webapp-react/src/model/KeyConfig.ts
+++ b/samples/apps/auth-api-webapp-react/src/model/KeyConfig.ts
@@ -1,14 +1,28 @@
-export const SK_HTTP_HEADER_MODEL: string = 'x-ms-sk-model';
-export const SK_HTTP_HEADER_ENDPOINT: string = 'x-ms-sk-endpoint';
-export const SK_HTTP_HEADER_API_KEY: string = 'x-ms-sk-apikey';
-export const SK_HTTP_HEADER_COMPLETION: string = 'x-ms-sk-completion-backend';
+// Copyright (c) Microsoft. All rights reserved.
+
+export const SK_HTTP_HEADER_COMPLETION_MODEL: string = 'x-ms-sk-completion-model';
+export const SK_HTTP_HEADER_COMPLETION_ENDPOINT: string = 'x-ms-sk-completion-endpoint';
+export const SK_HTTP_HEADER_COMPLETION_BACKEND: string = 'x-ms-sk-completion-backend';
+export const SK_HTTP_HEADER_COMPLETION_KEY: string = 'x-ms-sk-completion-key';
+        
+export const SK_HTTP_HEADER_EMBEDDING_MODEL: string = 'x-ms-sk-embedding-model';
+export const SK_HTTP_HEADER_EMBEDDING_ENDPOINT: string = 'x-ms-sk-embedding-endpoint';
+export const SK_HTTP_HEADER_EMBEDDING_BACKEND: string = 'x-ms-sk-embedding-backend';
+export const SK_HTTP_HEADER_EMBEDDING_KEY: string = 'x-ms-sk-embedding-key';
+
 export const SK_HTTP_HEADER_MSGRAPH: string = 'x-ms-sk-msgraph';
 
-export interface IKeyConfig {
-    completionBackend: number; //OpenAI = 0, Azure OpenAI = 1
-    deploymentOrModelId: string;
+export interface IBackendConfig {
+    backend: number; //OpenAI = 0, Azure OpenAI = 1
     label: string;
+    deploymentOrModelId: string;
     endpoint: string;
     key: string;
+}
+
+export interface IKeyConfig {
     graphToken?: string;
+
+    embeddingConfig: IBackendConfig;
+    completionConfig: IBackendConfig;
 }

--- a/samples/apps/book-creator-webapp-react/src/components/ServiceConfig.tsx
+++ b/samples/apps/book-creator-webapp-react/src/components/ServiceConfig.tsx
@@ -44,13 +44,15 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
     };
 
     useEffect(() => {
-        setKeyConfig((keyConfig) => ({
-            ...keyConfig,
+        keyConfig.completionConfig = {
             key: isOpenAI ? openAiKey : azureOpenAiKey,
             deploymentOrModelId: isOpenAI ? openAiModel : azureOpenAiDeployment,
+            label: isOpenAI ? openAiModel : azureOpenAiDeployment,
             endpoint: isOpenAI ? '' : azureOpenAiEndpoint,
-            completionBackend: isOpenAI ? 1 : 0,
-        }));
+            backend: isOpenAI ? 1 : 0
+        }
+
+        setKeyConfig((keyConfig) => ({ ...keyConfig }));
     }, [isOpenAI, openAiKey, openAiModel, azureOpenAiKey, azureOpenAiDeployment, azureOpenAiEndpoint]);
 
     return (
@@ -81,7 +83,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={openAiKey}
                         onChange={(e, d) => {
                             setOpenAiKey(d.value);
-                            setKeyConfig({ ...keyConfig, key: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, key: d.value } });
                         }}
                         placeholder="Enter your OpenAI key here"
                     />
@@ -91,7 +93,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={openAiModel}
                         onChange={(e, d) => {
                             setOpenAiModel(d.value);
-                            setKeyConfig({ ...keyConfig, deploymentOrModelId: d.value, label: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, deploymentOrModelId: d.value, label: d.value } });
                         }}
                         placeholder="Enter the model id here, ie: text-davinci-003"
                     />
@@ -105,7 +107,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiKey}
                         onChange={(e, d) => {
                             setAzureOpenAiKey(d.value);
-                            setKeyConfig({ ...keyConfig, key: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, key: d.value } });
                         }}
                         placeholder="Enter your Azure OpenAI key here"
                     />
@@ -115,7 +117,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiDeployment}
                         onChange={(e, d) => {
                             setAzureOpenAiDeployment(d.value);
-                            setKeyConfig({ ...keyConfig, deploymentOrModelId: d.value, label: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, deploymentOrModelId: d.value, label: d.value } });
                         }}
                         placeholder="Enter your deployment id here, ie: my-deployment"
                     />
@@ -125,7 +127,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiEndpoint}
                         onChange={(e, d) => {
                             setAzureOpenAiEndpoint(d.value);
-                            setKeyConfig({ ...keyConfig, endpoint: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, endpoint: d.value } });
                         }}
                         placeholder="Enter the endpoint here, ie: https://my-resource.openai.azure.com"
                     />

--- a/samples/apps/book-creator-webapp-react/src/components/TaskButton.tsx
+++ b/samples/apps/book-creator-webapp-react/src/components/TaskButton.tsx
@@ -45,8 +45,8 @@ const TaskButton: FC<IData> = ({
 
         try {
             await taskRunner.runTask(taskDescription, taskResponseFormat, skills, onPlanCreated, onTaskCompleted);
-        } catch {
-            alert('Unable to complete task, please check the azure function is online');
+        } catch (e) {
+            alert('Something went wrong.\n\nDetails:\n' + e);
         }
 
         setIsBusy(false);

--- a/samples/apps/book-creator-webapp-react/src/hooks/SemanticKernel.ts
+++ b/samples/apps/book-creator-webapp-react/src/hooks/SemanticKernel.ts
@@ -15,7 +15,7 @@ interface ServiceRequest {
 
 export class SemanticKernel {
     // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-    constructor(private readonly serviceUrl: string) {}
+    constructor(private readonly serviceUrl: string) { }
 
     public invokeAsync = async (
         keyConfig: IKeyConfig,
@@ -25,6 +25,16 @@ export class SemanticKernel {
     ): Promise<IAskResult> => {
         const result = await this.getResponseAsync<IAskResult>({
             commandPath: `/api/skills/${skillName}/invoke/${functionName}`,
+            method: 'POST',
+            body: ask,
+            keyConfig: keyConfig,
+        });
+        return result;
+    };
+
+    public executePlanAsync = async (keyConfig: IKeyConfig, ask: IAsk, maxSteps: number = 10): Promise<IAskResult> => {
+        const result = await this.getResponseAsync<IAskResult>({
+            commandPath: `/api/planner/execute/${maxSteps}`,
             method: 'POST',
             body: ask,
             keyConfig: keyConfig,

--- a/samples/apps/book-creator-webapp-react/src/hooks/SemanticKernel.ts
+++ b/samples/apps/book-creator-webapp-react/src/hooks/SemanticKernel.ts
@@ -3,12 +3,7 @@
 import { IAsk } from '../model/Ask';
 import { IAskResult } from '../model/AskResult';
 import {
-    IKeyConfig,
-    SK_HTTP_HEADER_API_KEY,
-    SK_HTTP_HEADER_COMPLETION,
-    SK_HTTP_HEADER_ENDPOINT,
-    SK_HTTP_HEADER_MODEL,
-    SK_HTTP_HEADER_MSGRAPH
+    IKeyConfig, SK_HTTP_HEADER_COMPLETION_BACKEND, SK_HTTP_HEADER_COMPLETION_ENDPOINT, SK_HTTP_HEADER_COMPLETION_KEY, SK_HTTP_HEADER_COMPLETION_MODEL, SK_HTTP_HEADER_EMBEDDING_BACKEND, SK_HTTP_HEADER_EMBEDDING_ENDPOINT, SK_HTTP_HEADER_EMBEDDING_KEY, SK_HTTP_HEADER_EMBEDDING_MODEL, SK_HTTP_HEADER_MSGRAPH
 } from '../model/KeyConfig';
 
 interface ServiceRequest {
@@ -37,24 +32,24 @@ export class SemanticKernel {
         return result;
     };
 
-    public executePlanAsync = async (keyConfig: IKeyConfig, ask: IAsk, maxSteps: number = 10): Promise<IAskResult> => {
-        const result = await this.getResponseAsync<IAskResult>({
-            commandPath: `/api/planner/execute/${maxSteps}`,
-            method: 'POST',
-            body: ask,
-            keyConfig: keyConfig,
-        });
-        return result;
-    };
-
     private readonly getResponseAsync = async <T>(request: ServiceRequest): Promise<T> => {
         const { commandPath, method, body, keyConfig } = request;
 
         const headers = new Headers();
-        headers.append(SK_HTTP_HEADER_MODEL, keyConfig.deploymentOrModelId);
-        headers.append(SK_HTTP_HEADER_ENDPOINT, keyConfig.endpoint);
-        headers.append(SK_HTTP_HEADER_API_KEY, keyConfig.key);
-        headers.append(SK_HTTP_HEADER_COMPLETION, keyConfig.completionBackend.toString());
+
+        if (keyConfig.completionConfig !== undefined) {
+            headers.append(SK_HTTP_HEADER_COMPLETION_KEY, keyConfig.completionConfig.key);
+            headers.append(SK_HTTP_HEADER_COMPLETION_MODEL, keyConfig.completionConfig.deploymentOrModelId);
+            headers.append(SK_HTTP_HEADER_COMPLETION_ENDPOINT, keyConfig.completionConfig.endpoint);
+            headers.append(SK_HTTP_HEADER_COMPLETION_BACKEND, keyConfig.completionConfig.backend.toString());
+        }
+
+        if (keyConfig.embeddingConfig !== undefined) {
+            headers.append(SK_HTTP_HEADER_EMBEDDING_KEY, keyConfig.embeddingConfig.key);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_MODEL, keyConfig.embeddingConfig.deploymentOrModelId);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_ENDPOINT, keyConfig.embeddingConfig.endpoint);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_BACKEND, keyConfig.embeddingConfig.backend.toString());
+        }
 
         if (keyConfig.graphToken !== undefined) {
             headers.append(SK_HTTP_HEADER_MSGRAPH, keyConfig.graphToken);

--- a/samples/apps/book-creator-webapp-react/src/model/KeyConfig.ts
+++ b/samples/apps/book-creator-webapp-react/src/model/KeyConfig.ts
@@ -1,16 +1,28 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-export const SK_HTTP_HEADER_MODEL: string = 'x-ms-sk-model';
-export const SK_HTTP_HEADER_ENDPOINT: string = 'x-ms-sk-endpoint';
-export const SK_HTTP_HEADER_API_KEY: string = 'x-ms-sk-apikey';
-export const SK_HTTP_HEADER_COMPLETION: string = 'x-ms-sk-completion-backend';
+export const SK_HTTP_HEADER_COMPLETION_MODEL: string = 'x-ms-sk-completion-model';
+export const SK_HTTP_HEADER_COMPLETION_ENDPOINT: string = 'x-ms-sk-completion-endpoint';
+export const SK_HTTP_HEADER_COMPLETION_BACKEND: string = 'x-ms-sk-completion-backend';
+export const SK_HTTP_HEADER_COMPLETION_KEY: string = 'x-ms-sk-completion-key';
+        
+export const SK_HTTP_HEADER_EMBEDDING_MODEL: string = 'x-ms-sk-embedding-model';
+export const SK_HTTP_HEADER_EMBEDDING_ENDPOINT: string = 'x-ms-sk-embedding-endpoint';
+export const SK_HTTP_HEADER_EMBEDDING_BACKEND: string = 'x-ms-sk-embedding-backend';
+export const SK_HTTP_HEADER_EMBEDDING_KEY: string = 'x-ms-sk-embedding-key';
+
 export const SK_HTTP_HEADER_MSGRAPH: string = 'x-ms-sk-msgraph';
 
-export interface IKeyConfig {
-    completionBackend: number; //OpenAI = 0, Azure OpenAI = 1
-    deploymentOrModelId: string;
+export interface IBackendConfig {
+    backend: number; //OpenAI = 0, Azure OpenAI = 1
     label: string;
+    deploymentOrModelId: string;
     endpoint: string;
     key: string;
+}
+
+export interface IKeyConfig {
     graphToken?: string;
+
+    embeddingConfig: IBackendConfig;
+    completionConfig: IBackendConfig;
 }

--- a/samples/apps/chat-summary-webapp-react/src/components/ServiceConfig.tsx
+++ b/samples/apps/chat-summary-webapp-react/src/components/ServiceConfig.tsx
@@ -44,14 +44,16 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
     };
 
     useEffect(() => {
-        setKeyConfig((keyConfig) => ({
-            ...keyConfig,
+        keyConfig.completionConfig = {
             key: isOpenAI ? openAiKey : azureOpenAiKey,
             deploymentOrModelId: isOpenAI ? openAiModel : azureOpenAiDeployment,
+            label: isOpenAI ? openAiModel : azureOpenAiDeployment,
             endpoint: isOpenAI ? '' : azureOpenAiEndpoint,
-            completionBackend: isOpenAI ? 1 : 0,
-        }));
-    }, [isOpenAI, azureOpenAiDeployment, azureOpenAiEndpoint, azureOpenAiKey, openAiKey, openAiModel]);
+            backend: isOpenAI ? 1 : 0
+        }
+
+        setKeyConfig((keyConfig) => ({ ...keyConfig }));
+    }, [isOpenAI, openAiKey, openAiModel, azureOpenAiKey, azureOpenAiDeployment, azureOpenAiEndpoint]);
 
     return (
         <>
@@ -81,7 +83,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={openAiKey}
                         onChange={(e, d) => {
                             setOpenAiKey(d.value);
-                            setKeyConfig({ ...keyConfig, key: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, key: d.value } });
                         }}
                         placeholder="Enter your OpenAI key here"
                     />
@@ -91,7 +93,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={openAiModel}
                         onChange={(e, d) => {
                             setOpenAiModel(d.value);
-                            setKeyConfig({ ...keyConfig, deploymentOrModelId: d.value, label: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, deploymentOrModelId: d.value, label: d.value } });
                         }}
                         placeholder="Enter the model id here, ie: text-davinci-003"
                     />
@@ -105,7 +107,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiKey}
                         onChange={(e, d) => {
                             setAzureOpenAiKey(d.value);
-                            setKeyConfig({ ...keyConfig, key: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, key: d.value } });
                         }}
                         placeholder="Enter your Azure OpenAI key here"
                     />
@@ -115,7 +117,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiDeployment}
                         onChange={(e, d) => {
                             setAzureOpenAiDeployment(d.value);
-                            setKeyConfig({ ...keyConfig, deploymentOrModelId: d.value, label: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, deploymentOrModelId: d.value, label: d.value } });
                         }}
                         placeholder="Enter your deployment id here, ie: my-deployment"
                     />
@@ -125,7 +127,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                         value={azureOpenAiEndpoint}
                         onChange={(e, d) => {
                             setAzureOpenAiEndpoint(d.value);
-                            setKeyConfig({ ...keyConfig, endpoint: d.value });
+                            setKeyConfig({ ...keyConfig, completionConfig: { ...keyConfig.completionConfig, endpoint: d.value } });
                         }}
                         placeholder="Enter the endpoint here, ie: https://my-resource.openai.azure.com"
                     />

--- a/samples/apps/chat-summary-webapp-react/src/hooks/SemanticKernel.ts
+++ b/samples/apps/chat-summary-webapp-react/src/hooks/SemanticKernel.ts
@@ -3,12 +3,7 @@
 import { IAsk } from '../model/Ask';
 import { IAskResult } from '../model/AskResult';
 import {
-    IKeyConfig,
-    SK_HTTP_HEADER_API_KEY,
-    SK_HTTP_HEADER_COMPLETION,
-    SK_HTTP_HEADER_ENDPOINT,
-    SK_HTTP_HEADER_MODEL,
-    SK_HTTP_HEADER_MSGRAPH
+    IKeyConfig, SK_HTTP_HEADER_COMPLETION_BACKEND, SK_HTTP_HEADER_COMPLETION_ENDPOINT, SK_HTTP_HEADER_COMPLETION_KEY, SK_HTTP_HEADER_COMPLETION_MODEL, SK_HTTP_HEADER_EMBEDDING_BACKEND, SK_HTTP_HEADER_EMBEDDING_ENDPOINT, SK_HTTP_HEADER_EMBEDDING_KEY, SK_HTTP_HEADER_EMBEDDING_MODEL, SK_HTTP_HEADER_MSGRAPH
 } from '../model/KeyConfig';
 
 interface ServiceRequest {
@@ -41,10 +36,20 @@ export class SemanticKernel {
         const { commandPath, method, body, keyConfig } = request;
 
         const headers = new Headers();
-        headers.append(SK_HTTP_HEADER_MODEL, keyConfig.deploymentOrModelId);
-        headers.append(SK_HTTP_HEADER_ENDPOINT, keyConfig.endpoint);
-        headers.append(SK_HTTP_HEADER_API_KEY, keyConfig.key);
-        headers.append(SK_HTTP_HEADER_COMPLETION, keyConfig.completionBackend.toString());
+
+        if (keyConfig.completionConfig !== undefined) {
+            headers.append(SK_HTTP_HEADER_COMPLETION_KEY, keyConfig.completionConfig.key);
+            headers.append(SK_HTTP_HEADER_COMPLETION_MODEL, keyConfig.completionConfig.deploymentOrModelId);
+            headers.append(SK_HTTP_HEADER_COMPLETION_ENDPOINT, keyConfig.completionConfig.endpoint);
+            headers.append(SK_HTTP_HEADER_COMPLETION_BACKEND, keyConfig.completionConfig.backend.toString());
+        }
+
+        if (keyConfig.embeddingConfig !== undefined) {
+            headers.append(SK_HTTP_HEADER_EMBEDDING_KEY, keyConfig.embeddingConfig.key);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_MODEL, keyConfig.embeddingConfig.deploymentOrModelId);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_ENDPOINT, keyConfig.embeddingConfig.endpoint);
+            headers.append(SK_HTTP_HEADER_EMBEDDING_BACKEND, keyConfig.embeddingConfig.backend.toString());
+        }
 
         if (keyConfig.graphToken !== undefined) {
             headers.append(SK_HTTP_HEADER_MSGRAPH, keyConfig.graphToken);

--- a/samples/apps/chat-summary-webapp-react/src/hooks/SemanticKernel.ts
+++ b/samples/apps/chat-summary-webapp-react/src/hooks/SemanticKernel.ts
@@ -15,7 +15,7 @@ interface ServiceRequest {
 
 export class SemanticKernel {
     // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-    constructor(private readonly serviceUrl: string) {}
+    constructor(private readonly serviceUrl: string) { }
 
     public invokeAsync = async (
         keyConfig: IKeyConfig,
@@ -25,6 +25,16 @@ export class SemanticKernel {
     ): Promise<IAskResult> => {
         const result = await this.getResponseAsync<IAskResult>({
             commandPath: `/api/skills/${skillName}/invoke/${functionName}`,
+            method: 'POST',
+            body: ask,
+            keyConfig: keyConfig,
+        });
+        return result;
+    };
+
+    public executePlanAsync = async (keyConfig: IKeyConfig, ask: IAsk, maxSteps: number = 10): Promise<IAskResult> => {
+        const result = await this.getResponseAsync<IAskResult>({
+            commandPath: `/api/planner/execute/${maxSteps}`,
             method: 'POST',
             body: ask,
             keyConfig: keyConfig,

--- a/samples/apps/chat-summary-webapp-react/src/model/KeyConfig.ts
+++ b/samples/apps/chat-summary-webapp-react/src/model/KeyConfig.ts
@@ -1,16 +1,28 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-export const SK_HTTP_HEADER_MODEL: string = 'x-ms-sk-model';
-export const SK_HTTP_HEADER_ENDPOINT: string = 'x-ms-sk-endpoint';
-export const SK_HTTP_HEADER_API_KEY: string = 'x-ms-sk-apikey';
-export const SK_HTTP_HEADER_COMPLETION: string = 'x-ms-sk-completion-backend';
+export const SK_HTTP_HEADER_COMPLETION_MODEL: string = 'x-ms-sk-completion-model';
+export const SK_HTTP_HEADER_COMPLETION_ENDPOINT: string = 'x-ms-sk-completion-endpoint';
+export const SK_HTTP_HEADER_COMPLETION_BACKEND: string = 'x-ms-sk-completion-backend';
+export const SK_HTTP_HEADER_COMPLETION_KEY: string = 'x-ms-sk-completion-key';
+        
+export const SK_HTTP_HEADER_EMBEDDING_MODEL: string = 'x-ms-sk-embedding-model';
+export const SK_HTTP_HEADER_EMBEDDING_ENDPOINT: string = 'x-ms-sk-embedding-endpoint';
+export const SK_HTTP_HEADER_EMBEDDING_BACKEND: string = 'x-ms-sk-embedding-backend';
+export const SK_HTTP_HEADER_EMBEDDING_KEY: string = 'x-ms-sk-embedding-key';
+
 export const SK_HTTP_HEADER_MSGRAPH: string = 'x-ms-sk-msgraph';
 
-export interface IKeyConfig {
-    completionBackend: number; //OpenAI = 0, Azure OpenAI = 1
-    deploymentOrModelId: string;
+export interface IBackendConfig {
+    backend: number; //OpenAI = 0, Azure OpenAI = 1
     label: string;
+    deploymentOrModelId: string;
     endpoint: string;
     key: string;
+}
+
+export interface IKeyConfig {
     graphToken?: string;
+
+    embeddingConfig: IBackendConfig;
+    completionConfig: IBackendConfig;
 }

--- a/samples/dotnet/KernelHttpServer/Config/AIService.cs
+++ b/samples/dotnet/KernelHttpServer/Config/AIService.cs
@@ -2,7 +2,7 @@
 
 namespace KernelHttpServer.Config;
 
-public enum CompletionService
+public enum AIService
 {
     AzureOpenAI = 0,
 

--- a/samples/dotnet/KernelHttpServer/Config/ApiKeyConfig.cs
+++ b/samples/dotnet/KernelHttpServer/Config/ApiKeyConfig.cs
@@ -1,36 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 namespace KernelHttpServer.Config;
-
 public class ApiKeyConfig
 {
-    public CompletionService CompletionBackend { get; set; }
+    public BackendConfig CompletionConfig { get; set; } = new();
 
-    public string DeploymentOrModelId { get; set; } = string.Empty;
-
-    public string Endpoint { get; set; } = string.Empty;
-
-    public string Key { get; set; } = string.Empty;
-
-    public string Label { get; set; } = string.Empty;
-
-    public bool IsValid()
-    {
-        switch (this.CompletionBackend)
-        {
-            case CompletionService.OpenAI:
-                return
-                    !string.IsNullOrEmpty(this.Label) &&
-                    !string.IsNullOrEmpty(this.DeploymentOrModelId) &&
-                    !string.IsNullOrEmpty(this.Key);
-            case CompletionService.AzureOpenAI:
-                return
-                    !string.IsNullOrEmpty(this.Endpoint) &&
-                    !string.IsNullOrEmpty(this.Label) &&
-                    !string.IsNullOrEmpty(this.DeploymentOrModelId) &&
-                    !string.IsNullOrEmpty(this.Key);
-        }
-
-        return false;
-    }
+    public BackendConfig EmbeddingConfig { get; set; } = new();
 }

--- a/samples/dotnet/KernelHttpServer/Config/BackendConfig.cs
+++ b/samples/dotnet/KernelHttpServer/Config/BackendConfig.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KernelHttpServer.Config;
+public class BackendConfig
+{
+    public AIService AIService { get; set; }
+
+    public string DeploymentOrModelId { get; set; } = string.Empty;
+
+    public string Endpoint { get; set; } = string.Empty;
+
+    public string Key { get; set; } = string.Empty;
+
+    public string Label { get; set; } = string.Empty;
+
+    public bool IsValid()
+    {
+        switch (this.AIService)
+        {
+            case AIService.OpenAI:
+                return
+                    !string.IsNullOrEmpty(this.Label) &&
+                    !string.IsNullOrEmpty(this.DeploymentOrModelId) &&
+                    !string.IsNullOrEmpty(this.Key);
+            case AIService.AzureOpenAI:
+                return
+                    !string.IsNullOrEmpty(this.Endpoint) &&
+                    !string.IsNullOrEmpty(this.Label) &&
+                    !string.IsNullOrEmpty(this.DeploymentOrModelId) &&
+                    !string.IsNullOrEmpty(this.Key);
+        }
+
+        return false;
+    }
+}

--- a/samples/dotnet/KernelHttpServer/Config/Constants.cs
+++ b/samples/dotnet/KernelHttpServer/Config/Constants.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KernelHttpServer.Config;
+internal class Constants
+{
+    public class SKHttpHeaders
+    {
+        public const string CompletionModel = "x-ms-sk-completion-model";
+        public const string CompletionEndpoint = "x-ms-sk-completion-endpoint";
+        public const string CompletionBackend = "x-ms-sk-completion-backend";
+        public const string CompletionKey = "x-ms-sk-completion-key";
+
+        public const string EmbeddingModel = "x-ms-sk-embedding-model";
+        public const string EmbeddingEndpoint = "x-ms-sk-embedding-endpoint";
+        public const string EmbeddingBackend = "x-ms-sk-embedding-backend";
+        public const string EmbeddingKey = "x-ms-sk-embedding-key";
+
+        public const string MSGraph = "x-ms-sk-msgraph";
+    }
+}

--- a/samples/dotnet/KernelHttpServer/Extensions.cs
+++ b/samples/dotnet/KernelHttpServer/Extensions.cs
@@ -23,12 +23,64 @@ using Microsoft.SemanticKernel.Skills.Document.OpenXml;
 using Microsoft.SemanticKernel.Skills.MsGraph;
 using Microsoft.SemanticKernel.Skills.MsGraph.Connectors;
 using Microsoft.SemanticKernel.TemplateEngine;
+using static KernelHttpServer.Config.Constants;
 using Directory = System.IO.Directory;
 
 namespace KernelHttpServer;
 
 internal static class Extensions
 {
+    internal static ApiKeyConfig ToApiKeyConfig(this HttpRequestData req)
+    {
+        var apiConfig = new ApiKeyConfig();
+
+        // completion values
+        if (req.Headers.TryGetValues(SKHttpHeaders.CompletionBackend, out var completionAIService))
+        {
+            apiConfig.CompletionConfig.AIService = Enum.Parse<AIService>(completionAIService.First());
+        }
+
+        if (req.Headers.TryGetValues(SKHttpHeaders.CompletionModel, out var completionModelValue))
+        {
+            apiConfig.CompletionConfig.DeploymentOrModelId = completionModelValue.First();
+            apiConfig.CompletionConfig.Label = apiConfig.CompletionConfig.DeploymentOrModelId;
+        }
+
+        if (req.Headers.TryGetValues(SKHttpHeaders.CompletionEndpoint, out var completionEndpoint))
+        {
+            apiConfig.CompletionConfig.Endpoint = completionEndpoint.First();
+        }
+
+        if (req.Headers.TryGetValues(SKHttpHeaders.CompletionKey, out var completionKey))
+        {
+            apiConfig.EmbeddingConfig.Key = completionKey.First();
+        }
+
+        // embedding values
+        if (req.Headers.TryGetValues(SKHttpHeaders.EmbeddingBackend, out var embeddingAIService))
+        {
+            apiConfig.EmbeddingConfig.AIService = Enum.Parse<AIService>(embeddingAIService.First());
+        }
+
+        if (req.Headers.TryGetValues(SKHttpHeaders.EmbeddingModel, out var embeddingModelValue))
+        {
+            apiConfig.EmbeddingConfig.DeploymentOrModelId = embeddingModelValue.First();
+            apiConfig.EmbeddingConfig.Label = apiConfig.EmbeddingConfig.DeploymentOrModelId;
+        }
+
+        if (req.Headers.TryGetValues(SKHttpHeaders.EmbeddingEndpoint, out var embeddingEndpoint))
+        {
+            apiConfig.EmbeddingConfig.Endpoint = embeddingEndpoint.First();
+        }
+
+        if (req.Headers.TryGetValues(SKHttpHeaders.EmbeddingKey, out var embeddingKey))
+        {
+            apiConfig.EmbeddingConfig.Key = embeddingKey.First();
+        }
+
+        return apiConfig;
+    }
+
     internal static async Task<HttpResponseData> CreateResponseWithMessageAsync(this HttpRequestData req, HttpStatusCode statusCode, string message)
     {
         HttpResponseData response = req.CreateResponse(statusCode);
@@ -91,6 +143,11 @@ internal static class Extensions
         _ = kernel.ImportSkill(planner, nameof(PlannerSkill));
     }
 
+    internal static void RegisterTextMemory(this IKernel kernel)
+    {
+        _ = kernel.ImportSkill(new TextMemorySkill(), nameof(TextMemorySkill));
+    }
+
     internal static void RegisterNativeSkills(this IKernel kernel, IEnumerable<string>? skillsToLoad = null)
     {
         if (_ShouldLoad(nameof(DocumentSkill), skillsToLoad))
@@ -133,33 +190,6 @@ internal static class Extensions
                     logger.LogWarning("Could not load skill from {0} with error: {1}", currentFolder.Name, e.Message);
                 }
             }
-        }
-    }
-
-    internal static void ConfigureCompletionBackend(this IKernel kernel, ApiKeyConfig apiConfig)
-    {
-        // The Semantic Kernel supports both Azure OpenAI and OpenAI completion backends (and both can exist concurrently)
-        // Each Skill can determine which model it needs which via internal orchestration, the kernel will delegate to the appropriate backend
-
-        switch (apiConfig.CompletionBackend)
-        {
-            case CompletionService.AzureOpenAI:
-                _ = kernel.Config.AddAzureOpenAICompletionBackend(
-                    apiConfig.Label,
-                    apiConfig.DeploymentOrModelId,
-                    apiConfig.Endpoint,
-                    apiConfig.Key);
-
-                break;
-            case CompletionService.OpenAI:
-                _ = kernel.Config.AddOpenAICompletionBackend(
-                    apiConfig.Label,
-                    apiConfig.DeploymentOrModelId,
-                    apiConfig.Key);
-
-                break;
-            default:
-                break;
         }
     }
 }

--- a/samples/dotnet/KernelHttpServer/Extensions.cs
+++ b/samples/dotnet/KernelHttpServer/Extensions.cs
@@ -53,7 +53,7 @@ internal static class Extensions
 
         if (req.Headers.TryGetValues(SKHttpHeaders.CompletionKey, out var completionKey))
         {
-            apiConfig.EmbeddingConfig.Key = completionKey.First();
+            apiConfig.CompletionConfig.Key = completionKey.First();
         }
 
         // embedding values

--- a/samples/dotnet/KernelHttpServer/Program.cs
+++ b/samples/dotnet/KernelHttpServer/Program.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.SemanticKernel.Memory;
 
 namespace KernelHttpServer;
 
@@ -23,6 +24,8 @@ public static class Program
             })
             .ConfigureServices(services =>
             {
+                services.AddSingleton<IMemoryStore<float>>(new VolatileMemoryStore());
+
                 // return JSON with expected lowercase naming
                 services.Configure<JsonSerializerOptions>(options =>
                 {

--- a/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using KernelHttpServer.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Orchestration.Extensions;
 
@@ -15,6 +16,14 @@ namespace KernelHttpServer;
 
 public class SemanticKernelEndpoint
 {
+    private readonly IMemoryStore<float> _memoryStore;
+
+    public SemanticKernelEndpoint(IMemoryStore<float> memoryStore)
+    {
+        this._memoryStore = memoryStore;
+    }
+
+
     [Function("InvokeFunction")]
     public async Task<HttpResponseData> InvokeFunctionAsync(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "skills/{skillName}/invoke/{functionName}")]
@@ -35,7 +44,8 @@ public class SemanticKernelEndpoint
         var kernel = SemanticKernelFactory.CreateForRequest(
             req,
             executionContext.GetLogger<SemanticKernelEndpoint>(),
-            ask.Skills);
+            ask.Skills,
+            this._memoryStore);
 
         if (kernel == null)
         {

--- a/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using KernelHttpServer.Config;
@@ -8,57 +7,90 @@ using KernelHttpServer.Utils;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Memory;
+using static KernelHttpServer.Config.Constants;
 
 namespace KernelHttpServer;
 
 internal static class SemanticKernelFactory
 {
-    private const string SKHTTPHeaderModel = "x-ms-sk-model";
-    private const string SKHTTPHeaderEndpoint = "x-ms-sk-endpoint";
-    private const string SKHTTPHeaderAPIKey = "x-ms-sk-apikey";
-    private const string SKHTTPHeaderCompletion = "x-ms-sk-completion-backend";
-    private const string SKHTTPHeaderMSGraph = "x-ms-sk-msgraph";
-
-    internal static IKernel? CreateForRequest(HttpRequestData req, ILogger logger, IEnumerable<string>? skillsToLoad = null)
+    internal static IKernel? CreateForRequest(
+        HttpRequestData req,
+        ILogger logger,
+        IEnumerable<string>? skillsToLoad = null,
+        VolatileMemoryStore? memoryStore = null)
     {
-        var apiConfig = new ApiKeyConfig();
+        var apiConfig = req.ToApiKeyConfig();
 
-        if (req.Headers.TryGetValues(SKHTTPHeaderCompletion, out var service))
+        //must have a completion backend (embedding is optional)
+        if (!apiConfig.CompletionConfig.IsValid())
         {
-            apiConfig.CompletionBackend = Enum.Parse<CompletionService>(service.First());
-        }
-
-        if (req.Headers.TryGetValues(SKHTTPHeaderModel, out var modelValues))
-        {
-            apiConfig.DeploymentOrModelId = modelValues.First();
-            apiConfig.Label = apiConfig.DeploymentOrModelId;
-        }
-
-        if (req.Headers.TryGetValues(SKHTTPHeaderEndpoint, out var endpointValues))
-        {
-            apiConfig.Endpoint = endpointValues.First();
-        }
-
-        if (req.Headers.TryGetValues(SKHTTPHeaderAPIKey, out var apikeyValues))
-        {
-            apiConfig.Key = apikeyValues.First();
-        }
-
-        if (!apiConfig.IsValid())
-        {
+            logger.LogWarning("Completion backend has not been supplied.");
             return null;
         }
 
-        var kernel = KernelBuilder.Create();
-        kernel.ConfigureCompletionBackend(apiConfig);
+        if (memoryStore != null &&
+            !apiConfig.EmbeddingConfig.IsValid())
+        {
+            logger.LogWarning("Embedding backend has not been supplied.");
+            return null;
+        }
+
+        KernelBuilder builder = Kernel.Builder;
+        builder = _ConfigureKernelBuilder(apiConfig, builder, memoryStore);
+        return _CompleteKernelSetup(req, builder, logger, skillsToLoad);
+    }
+
+    private static KernelBuilder _ConfigureKernelBuilder(ApiKeyConfig config, KernelBuilder builder, VolatileMemoryStore? memoryStore)
+    {
+        builder = builder
+            .Configure(c =>
+            {
+                switch (config.CompletionConfig.AIService)
+                {
+                    case AIService.AzureOpenAI:
+                        c.AddOpenAICompletionBackend(config.CompletionConfig.Label, config.CompletionConfig.DeploymentOrModelId, config.CompletionConfig.Key);
+                        break;
+                    case AIService.OpenAI:
+                        c.AddAzureOpenAICompletionBackend(config.CompletionConfig.Label, config.CompletionConfig.DeploymentOrModelId, config.CompletionConfig.Endpoint, config.CompletionConfig.Key);
+                        break;
+                }
+
+                if (memoryStore != null)
+                {
+                    switch (config.EmbeddingConfig.AIService)
+                    {
+                        case AIService.AzureOpenAI:
+                            c.AddOpenAICompletionBackend(config.EmbeddingConfig.Label, config.EmbeddingConfig.DeploymentOrModelId, config.EmbeddingConfig.Key);
+                            break;
+                        case AIService.OpenAI:
+                            c.AddAzureOpenAICompletionBackend(config.EmbeddingConfig.Label, config.EmbeddingConfig.DeploymentOrModelId, config.EmbeddingConfig.Endpoint, config.EmbeddingConfig.Key);
+                            break;
+                    }
+
+                    builder.WithMemoryStorage(memoryStore);
+                }
+            });
+
+        return builder;
+    }
+
+    private static IKernel _CompleteKernelSetup(HttpRequestData req, KernelBuilder builder, ILogger logger, IEnumerable<string>? skillsToLoad = null)
+    {
+        IKernel kernel = builder.Build();
 
         kernel.RegisterSemanticSkills(RepoFiles.SampleSkillsPath(), logger, skillsToLoad);
         kernel.RegisterNativeSkills(skillsToLoad);
         kernel.RegisterPlanner();
 
-        if (req.Headers.TryGetValues(SKHTTPHeaderMSGraph, out var graphToken))
+        if (req.Headers.TryGetValues(SKHttpHeaders.MSGraph, out var graphToken))
         {
             kernel.RegisterNativeGraphSkills(graphToken.First());
+        }
+
+        if (kernel.Config.DefaultEmbeddingsBackend != null)
+        {
+            kernel.RegisterTextMemory();
         }
 
         return kernel;

--- a/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
@@ -48,10 +48,10 @@ internal static class SemanticKernelFactory
             {
                 switch (config.CompletionConfig.AIService)
                 {
-                    case AIService.AzureOpenAI:
+                    case AIService.OpenAI:
                         c.AddOpenAICompletionBackend(config.CompletionConfig.Label, config.CompletionConfig.DeploymentOrModelId, config.CompletionConfig.Key);
                         break;
-                    case AIService.OpenAI:
+                    case AIService.AzureOpenAI:
                         c.AddAzureOpenAICompletionBackend(config.CompletionConfig.Label, config.CompletionConfig.DeploymentOrModelId, config.CompletionConfig.Endpoint, config.CompletionConfig.Key);
                         break;
                 }
@@ -60,10 +60,10 @@ internal static class SemanticKernelFactory
                 {
                     switch (config.EmbeddingConfig.AIService)
                     {
-                        case AIService.AzureOpenAI:
+                        case AIService.OpenAI:
                             c.AddOpenAICompletionBackend(config.EmbeddingConfig.Label, config.EmbeddingConfig.DeploymentOrModelId, config.EmbeddingConfig.Key);
                             break;
-                        case AIService.OpenAI:
+                        case AIService.AzureOpenAI:
                             c.AddAzureOpenAICompletionBackend(config.EmbeddingConfig.Label, config.EmbeddingConfig.DeploymentOrModelId, config.EmbeddingConfig.Endpoint, config.EmbeddingConfig.Key);
                             break;
                     }


### PR DESCRIPTION
### Motivation and Context
This change modifies the expected headers at the KernelHttpServer and allows future samples to leverage memory/embedding capabilities via the KernelHttpServer.

### Description
* Introduces distinct headers for completion and embedding 
  * Allows one to have completion endpoint on Azure OpenAI and embedding endpoint on OpenAI, for example
* Updates dependent app samples to use the new header convention 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
