### PR TITLE
Bug fix: surface exceptions thrown by native functions

### DIFF
--- a/dotnet/src/SemanticKernel.Test/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.Test/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.AI;
+using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.TemplateEngine;
+using Microsoft.SemanticKernel.TemplateEngine.Blocks;
+using Moq;
+using Xunit;
+
+namespace SemanticKernelTests.TemplateEngine.Blocks;
+
+public class CodeBlockTests
+{
+    private readonly Mock<IReadOnlySkillCollection> _skills;
+    private readonly Mock<ILogger> _log;
+
+    public CodeBlockTests()
+    {
+        this._skills = new Mock<IReadOnlySkillCollection>();
+        this._log = new Mock<ILogger>();
+    }
+
+    [Fact]
+    public async Task ItThrowsIfAFunctionDoesntExistAsync()
+    {
+        // Arrange
+        var context = new SKContext(new ContextVariables(), NullMemory.Instance, this._skills.Object, this._log.Object);
+        this._skills.Setup(x => x.HasNativeFunction("functionName")).Returns(false);
+        var target = new CodeBlock("functionName", this._log.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<TemplateException>(async () => await target.RenderCodeAsync(context));
+
+        // Assert
+        Assert.Equal(TemplateException.ErrorCodes.FunctionNotFound, exception.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ItThrowsIfAFunctionCallThrowsAsync()
+    {
+        // Arrange
+        var context = new SKContext(new ContextVariables(), NullMemory.Instance, this._skills.Object, this._log.Object);
+        var function = new Mock<ISKFunction>();
+        function
+            .Setup(x => x.InvokeAsync(It.IsAny<SKContext?>(), It.IsAny<CompleteRequestSettings?>(), It.IsAny<ILogger?>(), It.IsAny<CancellationToken?>()))
+            .Throws(new RuntimeWrappedException("error"));
+        this._skills.Setup(x => x.HasNativeFunction("functionName")).Returns(true);
+        this._skills.Setup(x => x.GetNativeFunction("functionName")).Returns(function.Object);
+        var target = new CodeBlock("functionName", this._log.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<TemplateException>(async () => await target.RenderCodeAsync(context));
+
+        // Assert
+        Assert.Equal(TemplateException.ErrorCodes.RuntimeError, exception.ErrorCode);
+    }
+}

--- a/dotnet/src/SemanticKernel/AI/AIException.cs
+++ b/dotnet/src/SemanticKernel/AI/AIException.cs
@@ -92,7 +92,7 @@ public class AIException : Exception<AIException.ErrorCodes>
     /// <param name="errCode">Error code of the exception.</param>
     /// <param name="message">Message of the exception.</param>
     /// <param name="e">An exception that was thrown.</param>
-    public AIException(ErrorCodes errCode, string message, Exception e) : base(errCode, message, e)
+    public AIException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
     {
         this.ErrorCode = errCode;
     }

--- a/dotnet/src/SemanticKernel/Diagnostics/ValidationException.cs
+++ b/dotnet/src/SemanticKernel/Diagnostics/ValidationException.cs
@@ -66,7 +66,7 @@ public class ValidationException : Exception<ValidationException.ErrorCodes>
     /// <param name="errCode">The error code.</param>
     /// <param name="message">The message.</param>
     /// <param name="e">The inner exception.</param>
-    public ValidationException(ErrorCodes errCode, string message, Exception e) : base(errCode, message, e)
+    public ValidationException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
     {
         this.ErrorCode = errCode;
     }

--- a/dotnet/src/SemanticKernel/KernelException.cs
+++ b/dotnet/src/SemanticKernel/KernelException.cs
@@ -82,7 +82,7 @@ public class KernelException : Exception<KernelException.ErrorCodes>
     /// <param name="errCode">Error code to put in KernelException.</param>
     /// <param name="message">Message to put in KernelException.</param>
     /// <param name="e">Exception to embed in KernelException.</param>
-    public KernelException(ErrorCodes errCode, string message, Exception e) : base(errCode, message, e)
+    public KernelException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
     {
         this.ErrorCode = errCode;
     }

--- a/dotnet/src/SemanticKernel/Planning/PlanningException.cs
+++ b/dotnet/src/SemanticKernel/Planning/PlanningException.cs
@@ -52,7 +52,7 @@ public class PlanningException : Exception<PlanningException.ErrorCodes>
     /// <param name="errCode">The error code.</param>
     /// <param name="message">The message.</param>
     /// <param name="e">The inner exception.</param>
-    public PlanningException(ErrorCodes errCode, string message, Exception e) : base(errCode, message, e)
+    public PlanningException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
     {
         this.ErrorCode = errCode;
     }

--- a/dotnet/src/SemanticKernel/TemplateEngine/TemplateException.cs
+++ b/dotnet/src/SemanticKernel/TemplateEngine/TemplateException.cs
@@ -16,14 +16,24 @@ public class TemplateException : Exception<TemplateException.ErrorCodes>
     public enum ErrorCodes
     {
         /// <summary>
-        /// Unknown.
+        /// Unknown/undefined error type. Don't use this value.
         /// </summary>
         Unknown = -1,
 
         /// <summary>
-        /// Syntax error.
+        /// Syntax error, the template syntax used is not valid.
         /// </summary>
         SyntaxError = 0,
+
+        /// <summary>
+        /// The template requires an unknown function.
+        /// </summary>
+        FunctionNotFound = 1,
+
+        /// <summary>
+        /// The template execution failed, e.g. a function call threw an exception.
+        /// </summary>
+        RuntimeError = 2,
     }
 
     /// <summary>
@@ -48,7 +58,7 @@ public class TemplateException : Exception<TemplateException.ErrorCodes>
     /// <param name="errCode">Error code of the exception.</param>
     /// <param name="message">Message of the exception.</param>
     /// <param name="e">An exception that was thrown.</param>
-    public TemplateException(ErrorCodes errCode, string message, Exception e) : base(errCode, message, e)
+    public TemplateException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
     {
         this.ErrorCode = errCode;
     }


### PR DESCRIPTION
### Motivation and Context

When a semantic function invokes a native function:
* if the native function fails, the failure should surface through the result (bug fix)
* if the native function doesn't exist, it should fail (change of behavior for better dev experience)

Bug report: https://github.com/microsoft/semantic-kernel/issues/47

### Description

* Fix `CodeBlock` to capture and manage errors correctly and provide a better dev experience.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
