### PR TITLE
Enpoint and ApiKey Required for Embedding Integration Tests

### DIFF
--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -39,11 +39,11 @@ jobs:
         AzureOpenAI__Label: azure-text-davinci-003
         AzureOpenAIEmbedding__Label: azure-text-embedding-ada-002
         AzureOpenAI__DeploymentName: ${{ vars.AZUREOPENAI__DEPLOYMENTNAME }}
-        AzureOpenAIEmbedding__DeploymentName: ${{ vars.AZUREOPENAIEMBEDDING__DEPLOYMENTNAME }}
+        AzureOpenAIEmbeddings__DeploymentName: ${{ vars.AZUREOPENAIEMBEDDING__DEPLOYMENTNAME }}
         AzureOpenAI__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
-        AzureOpenAIEmbedding__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
+        AzureOpenAIEmbeddings__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
         AzureOpenAI__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
-        AzureOpenAIEmbedding__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
+        AzureOpenAIEmbeddings__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
         Bing__ApiKey: ${{ secrets.BING__APIKEY }}
         OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
       run: |

--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -41,7 +41,9 @@ jobs:
         AzureOpenAI__DeploymentName: ${{ vars.AZUREOPENAI__DEPLOYMENTNAME }}
         AzureOpenAIEmbedding__DeploymentName: ${{ vars.AZUREOPENAIEMBEDDING__DEPLOYMENTNAME }}
         AzureOpenAI__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
+        AzureOpenAIEmbedding__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
         AzureOpenAI__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
+        AzureOpenAIEmbedding__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
         Bing__ApiKey: ${{ secrets.BING__APIKEY }}
         OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
       run: |


### PR DESCRIPTION
### Motivation and Context
OpenAIEmbeddingTests are failing because:

_Microsoft.SemanticKernel.Diagnostics.ValidationException : EmptyValue: The Azure endpoint cannot be empty_

### Description
Updated intergration tests yaml ENV variables to provide endpoint and key for embeddings tests. The endpoint and key are the same as the completion tests, but this change leaves the flexibility to use a different endpoint in the future. 

