### PR TITLE
Fix Integration test OpenAIEmbeddingTests

### DIFF
--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -39,11 +39,11 @@ jobs:
         AzureOpenAI__Label: azure-text-davinci-003
         AzureOpenAIEmbedding__Label: azure-text-embedding-ada-002
         AzureOpenAI__DeploymentName: ${{ vars.AZUREOPENAI__DEPLOYMENTNAME }}
-        AzureOpenAIEmbedding__DeploymentName: ${{ vars.AZUREOPENAIEMBEDDING__DEPLOYMENTNAME }}
+        AzureOpenAIEmbeddings__DeploymentName: ${{ vars.AZUREOPENAIEMBEDDING__DEPLOYMENTNAME }}
         AzureOpenAI__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
-        AzureOpenAIEmbedding__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
+        AzureOpenAIEmbeddings__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
         AzureOpenAI__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
-        AzureOpenAIEmbedding__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
+        AzureOpenAIEmbeddings__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
         Bing__ApiKey: ${{ secrets.BING__APIKEY }}
         OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
       run: |

--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -41,7 +41,9 @@ jobs:
         AzureOpenAI__DeploymentName: ${{ vars.AZUREOPENAI__DEPLOYMENTNAME }}
         AzureOpenAIEmbedding__DeploymentName: ${{ vars.AZUREOPENAIEMBEDDING__DEPLOYMENTNAME }}
         AzureOpenAI__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
+        AzureOpenAIEmbedding__Endpoint: ${{ secrets.AZUREOPENAI__ENDPOINT }}
         AzureOpenAI__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
+        AzureOpenAIEmbedding__ApiKey: ${{ secrets.AZUREOPENAI__APIKEY }}
         Bing__ApiKey: ${{ secrets.BING__APIKEY }}
         OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
       run: |


### PR DESCRIPTION
### Motivation and Context
OpenAIEmbeddingTests were failing because the GitHub workflow could not find an endpoint or API key

### Description
Modified github workflows yaml to map the configuration names to the correct secrets.

Verified via GitHub actions against this branch. 
