### PR TITLE
Fixed Intermittent UnitTest error

### DIFF
--- a/dotnet/src/SemanticKernel.Test/TemplateEngine/PromptTemplateEngineTests.cs
+++ b/dotnet/src/SemanticKernel.Test/TemplateEngine/PromptTemplateEngineTests.cs
@@ -25,11 +25,11 @@ public sealed class TemplateEngineTests : IDisposable
     public TemplateEngineTests(ITestOutputHelper testOutputHelper)
     {
         this._testOutputHelper = new RedirectOutput(testOutputHelper);
-        Console.SetOut(this._testOutputHelper);
-
         this._target = new PromptTemplateEngine(ConsoleLogger.Log);
         this._variables = new ContextVariables(Guid.NewGuid().ToString("X"));
         this._skills = new Mock<IReadOnlySkillCollection>();
+
+        Console.SetOut(this._testOutputHelper);
     }
 
     [Fact]
@@ -237,13 +237,13 @@ public sealed class TemplateEngineTests : IDisposable
         // Arrange
         [SKFunction("test")]
         [SKFunctionName("test")]
-        static string MyFunctionAsync(SKContext cx)
+        string MyFunctionAsync(SKContext cx)
         {
-            Console.WriteLine($"MyFunction call received, input: {cx.Variables.Input}");
+            this._testOutputHelper.WriteLine($"MyFunction call received, input: {cx.Variables.Input}");
             return $"F({cx.Variables.Input})";
         }
 
-        var func = SKFunction.FromNativeMethod(Method(MyFunctionAsync));
+        var func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);
         Assert.NotNull(func);
 
         this._variables.Update("INPUT-BAR");
@@ -265,13 +265,13 @@ public sealed class TemplateEngineTests : IDisposable
         // Arrange
         [SKFunction("test")]
         [SKFunctionName("test")]
-        static string MyFunctionAsync(SKContext cx)
+        string MyFunctionAsync(SKContext cx)
         {
-            Console.WriteLine($"MyFunction call received, input: {cx.Variables.Input}");
+            this._testOutputHelper.WriteLine($"MyFunction call received, input: {cx.Variables.Input}");
             return $"F({cx.Variables.Input})";
         }
 
-        var func = SKFunction.FromNativeMethod(Method(MyFunctionAsync));
+        var func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);
         Assert.NotNull(func);
 
         this._variables.Set("myVar", "BAR");
@@ -293,14 +293,14 @@ public sealed class TemplateEngineTests : IDisposable
         // Arrange
         [SKFunction("test")]
         [SKFunctionName("test")]
-        static Task<string> MyFunctionAsync(SKContext cx)
+        Task<string> MyFunctionAsync(SKContext cx)
         {
             // Input value should be "BAR" because the variable $myVar is passed in
-            Console.WriteLine($"MyFunction call received, input: {cx.Variables.Input}");
+            this._testOutputHelper.WriteLine($"MyFunction call received, input: {cx.Variables.Input}");
             return Task.FromResult(cx.Variables.Input);
         }
 
-        var func = SKFunction.FromNativeMethod(Method(MyFunctionAsync));
+        var func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);
         Assert.NotNull(func);
 
         this._variables.Set("myVar", "BAR");

--- a/dotnet/src/SemanticKernel/CoreSkills/PlannerSkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/PlannerSkill.cs
@@ -153,6 +153,7 @@ public class PlannerSkill
                 NotSupportedException or
                 ArgumentNullException)
         {
+            context.Log.LogWarning("Error parsing bucket outputs: {0}", e.Message);
             return context.Fail($"Error parsing bucket outputs: {e.Message}");
         }
     }

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -183,14 +183,12 @@ public sealed class Kernel : IKernel, IDisposable
                     return context;
                 }
             }
-#pragma warning disable CA1031 // We need to catch all exceptions to handle the execution state
             catch (Exception e) when (!e.IsCriticalException())
             {
                 this._log.LogError(e, "Something went wrong in pipeline step {0}: {1}.{2}. Error: {3}", pipelineStepCount, f.SkillName, f.Name, e.Message);
                 context.Fail(e.Message, e);
                 return context;
             }
-#pragma warning restore CA1031
         }
 
         return context;

--- a/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
@@ -113,9 +113,10 @@ public sealed class SKFunction : ISKFunction, IDisposable
                 context.Variables.Update(completion);
             }
 #pragma warning disable CA1031 // We need to catch all exceptions to handle the execution state
-            catch (Exception e) when (!e.IsCriticalException())
+            catch (Exception ex) when (!ex.IsCriticalException())
             {
-                context.Fail(e.Message, e);
+                log?.LogError(ex, "Something went wrong loading semantic function from config: {0}.{1}. Error: {2}", skillName, functionName, ex.Message);
+                context.Fail(ex.Message, ex);
             }
 #pragma warning restore CA1031
 

--- a/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
@@ -112,13 +112,11 @@ public sealed class SKFunction : ISKFunction, IDisposable
                 string completion = await client.CompleteAsync(prompt, requestSettings);
                 context.Variables.Update(completion);
             }
-#pragma warning disable CA1031 // We need to catch all exceptions to handle the execution state
             catch (Exception ex) when (!ex.IsCriticalException())
             {
                 log?.LogError(ex, "Something went wrong loading semantic function from config: {0}.{1}. Error: {2}", skillName, functionName, ex.Message);
                 context.Fail(ex.Message, ex);
             }
-#pragma warning restore CA1031
 
             return context;
         }

--- a/dotnet/src/SemanticKernel/Orchestration/SKFunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/SKFunctionExtensions.cs
@@ -112,6 +112,8 @@ public static class SKFunctionExtensions
         }
         catch (Exception ex) when (!ex.IsCriticalException())
         {
+            log.LogError(ex, "Something went wrong when invoking function with custom input: {0}.{1}. Error: {2}", function.SkillName,
+                function.Name, ex.Message);
             tmpContext.Fail(ex.Message, ex);
         }
 


### PR DESCRIPTION
### Motivation and Context

Bugfix to an intermittent error happening in the Unit Tests.
Added missing error handling logging

### Description

As part of the investigation I found that there was no logging happening when an exception was happening in the function invocation, added as part of this bugfix, this helped to identify the real error below.

It ended up being caused by the usage of Console.Writeline within the embedded methods that had no more reference in the context of the method execution.

Reordered the Console.SetOut in the contructor to properly output test logging using the command:

`dotnet test --logger "console;verbosity=detailed"`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: