### PR TITLE
Fix setting plan arguments twice in UpdateWithPlanEntry

### DIFF
--- a/dotnet/src/SemanticKernel/Orchestration/Extensions/ContextVariablesExtensions.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/Extensions/ContextVariablesExtensions.cs
@@ -37,7 +37,6 @@ public static class ContextVariablesExtensions
         vars.Set(Plan.IsCompleteKey, plan.IsComplete.ToString());
         vars.Set(Plan.IsSuccessfulKey, plan.IsSuccessful.ToString());
         vars.Set(Plan.ResultKey, plan.Result);
-        vars.Set(Plan.ArgumentsKey, plan.Arguments);
 
         return vars;
     }


### PR DESCRIPTION
### Motivation and Context

Please help reviewers and future users, providing the following information:

1. Why is this change required? 
The plan arguments are already being set a few lines above this
2. What problem does it solve? 
Removes a duplicate and unnecessary line
3. What scenario does it contribute to?
Planner
4. If it fixes an open issue, please link to the issue here. 
Didn't make an issue


### Description

Remove a duplicate line in setting plan arguments in the UpdateWithPlanEntry().
The plan arguments are already set a few lines above this


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
