### PR TITLE
Added lost unit tests after refactoring

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Memory/Collections/MinHeapTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/Collections/MinHeapTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Memory.Collections;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Memory.Collections;
+
+/// <summary>
+/// Contains tests for the <see cref="MinHeap{T}"/> class.
+/// </summary>
+public class MinHeapTests
+{
+    private const int MinValue = 1;
+
+    [Fact]
+    public void ItThrowsExceptionWhenCapacityIsInvalid()
+    {
+        // Arrange
+        const int invalidCapacity = -1;
+
+        var action = () => { var minHeap = new MinHeap<int>(MinValue, invalidCapacity); };
+
+        // Act
+        var exception = Assert.Throws<ValidationException>(() => action());
+
+        // Assert
+        Assert.Equal(ValidationException.ErrorCodes.OutOfRange, exception.ErrorCode);
+        Assert.Equal("OutOfRange: MinHeap capacity must be greater than 0.", exception.Message);
+    }
+
+    [Fact]
+    public void ItAddsItemsInCorrectOrder()
+    {
+        // Arrange
+        const int expectedTopItem = 1;
+        const int expectedCount = 3;
+
+        // Act
+        var minHeap = new MinHeap<int>(MinValue) { 3, 1, 2 };
+
+        // Assert
+        Assert.Equal(expectedTopItem, minHeap.Top);
+        Assert.Equal(expectedCount, minHeap.Count);
+    }
+
+    [Fact]
+    public void ItErasesItemsCorrectly()
+    {
+        // Arrange
+        const int expectedCount = 0;
+        var minHeap = new MinHeap<int>(MinValue) { 3, 1, 2 };
+
+        // Act
+        minHeap.Erase();
+
+        // Assert
+        Assert.Equal(expectedCount, minHeap.Count);
+    }
+
+    [Fact]
+    public void ItReturnsItemsOnBufferDetaching()
+    {
+        // Arrange
+        const int expectedHeapCount = 0;
+
+        var minHeap = new MinHeap<int>(MinValue) { 3, 1, 2 };
+
+        // Act
+        var items = minHeap.DetachBuffer();
+
+        // Assert
+        Assert.True(items.Length > 0);
+        Assert.Equal(expectedHeapCount, minHeap.Count);
+    }
+
+    [Fact]
+    public void ItThrowsExceptionOnAddingItemsAtInvalidIndex()
+    {
+        // Arrange
+        const int startIndex = 4;
+
+        var items = new List<int> { 3, 1, 2 };
+        var minHeap = new MinHeap<int>(MinValue);
+
+        var action = () => { minHeap.Add(items, startIndex); };
+
+        // Act
+        var exception = Assert.Throws<ValidationException>(() => action());
+
+        // Assert
+        Assert.Equal(ValidationException.ErrorCodes.OutOfRange, exception.ErrorCode);
+        Assert.Equal("OutOfRange: startAt value must be less than items count.", exception.Message);
+    }
+
+    [Fact]
+    public void ItRemovesTopItemCorrectly()
+    {
+        // Arrange
+        const int expectedTopItem = 2;
+        const int expectedHeapCount = 2;
+
+        var minHeap = new MinHeap<int>(MinValue) { 3, 1, 2 };
+
+        // Act
+        minHeap.RemoveTop();
+
+        // Assert
+        Assert.Equal(expectedTopItem, minHeap.Top);
+        Assert.Equal(expectedHeapCount, minHeap.Count);
+    }
+
+    [Fact]
+    public void ItRemovesAllItemsCorrectly()
+    {
+        // Arrange
+        const int expectedHeapCount = 0;
+
+        var minHeap = new MinHeap<int>(MinValue) { 3, 1, 2 };
+
+        // Act
+        var items = minHeap.RemoveAll().ToList();
+
+        // Assert
+        Assert.Equal(1, items[0]);
+        Assert.Equal(2, items[1]);
+        Assert.Equal(3, items[2]);
+
+        Assert.Equal(expectedHeapCount, minHeap.Count);
+    }
+
+    [Fact]
+    public void ItEnsuresCapacityToExpectedValue()
+    {
+        // Arrange
+        const int expectedCapacity = 16;
+
+        var minHeap = new MinHeap<int>(MinValue);
+
+        // Act
+        minHeap.EnsureCapacity(expectedCapacity);
+
+        // Assert
+        Assert.Equal(expectedCapacity, minHeap.Capacity);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Memory/Collections/TopNCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/Collections/TopNCollectionTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Memory.Collections;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Memory.Collections;
+
+/// <summary>
+/// Contains tests for the <see cref="TopNCollection{T}"/> class.
+/// </summary>
+public class TopNCollectionTests
+{
+    private const int MaxItemsCount = 5;
+
+    [Fact]
+    public void ItResetsCollectionCorrectly()
+    {
+        // Arrange
+        const int expectedItemsCount = 0;
+
+        var topNCollection = this.GetTestCollection(MaxItemsCount);
+
+        // Act
+        topNCollection.Reset();
+
+        // Assert
+        Assert.Equal(expectedItemsCount, topNCollection.Count);
+    }
+
+    [Fact]
+    public void ItKeepsMaxItemsCountWhenMoreItemsWereAdded()
+    {
+        // Arrange
+        const int expectedCollectionCount = 5;
+
+        // Act
+        var topNCollection = this.GetTestCollection(expectedCollectionCount);
+
+        // Assert
+        Assert.Equal(expectedCollectionCount, topNCollection.Count);
+    }
+
+    [Fact]
+    public void ItSortsCollectionByScoreInDescendingOrder()
+    {
+        // Arrange
+        var topNCollection = this.GetTestCollection(MaxItemsCount);
+
+        // Act
+        topNCollection.SortByScore();
+
+        // Assert
+        for (var i = 0; i < topNCollection.Count - 1; i++)
+        {
+            Assert.True(topNCollection[i].Score > topNCollection[i + 1].Score);
+        }
+    }
+
+    private TopNCollection<int> GetTestCollection(int maxItemsCount)
+    {
+        return new TopNCollection<int>(maxItemsCount)
+        {
+            new ScoredValue<int>(1, 0.5),
+            new ScoredValue<int>(2, 0.6),
+            new ScoredValue<int>(3, 0.4),
+            new ScoredValue<int>(4, 0.2),
+            new ScoredValue<int>(5, 0.9),
+            new ScoredValue<int>(6, 0.1),
+        };
+    }
+}


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
After test project refactoring some tests got lost due to change of project name. This PR adds them back to increase code coverage.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
Added two missed unit-tests from this commit: https://github.com/microsoft/semantic-kernel/commit/d76de654f2533c16c1c32b31aa15c0bdbfba0c4f.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
