### PR TITLE
Add python-preview link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ To learn more and get started:
 - Read the [documentation](https://aka.ms/sk/learn)
 - Learn how to [contribute](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) to the project
 - Join the [Discord community](https://aka.ms/SKDiscord)
-- Hear from the team on our [blog](https://aka.ms/sk/blog)
+- Follow the team on our [blog](https://aka.ms/sk/blog)
+
+<img src="https://user-images.githubusercontent.com/36091529/225807182-22ad65e9-82c6-4727-bb77-d1c256736045.png" align="left" width="40px"/>
+<b>Python developers:</b> Semantic Kernel is coming to Python soon! Check out the work-in-progress and contribute in the <a href="https://github.com/microsoft/semantic-kernel/tree/python-preview"><b>python-preview</b></a> branch.
+<br clear="left"/>
 
 ## Code of Conduct
 


### PR DESCRIPTION
### Description
Adding notice to Python developers and link to python-preview branch:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/36091529/225811015-06a072ac-120d-4cdc-9a7d-e374d235dfd5.png">

### Contribution Checklist
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile: