### PR TITLE
[Docs] Sample 5: move the text about the planner just after the planner output

### DIFF
--- a/samples/notebooks/dotnet/5-using-the-planner.ipynb
+++ b/samples/notebooks/dotnet/5-using-the-planner.ipynb
@@ -188,6 +188,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "dotnet_interactive": {
@@ -198,7 +199,11 @@
     }
    },
    "source": [
-    "As you can see in the above plan, the Planner has taken my ask and converted it into an XML-based plan detailing how the AI would go about solving this task, making use of the skills that the Kernel has available to it, determining which functions to call in order to fulfill the user asks. The output of each step of the plan gets set as `setContextVariable` which makes it available as `input` to the next skill. "
+    "As you can see in the above plan, the Planner has taken the user's ask and converted it into an XML-based plan detailing how the AI would go about solving this task.\n",
+    "\n",
+    "It makes use of the skills that the Kernel has available to it and determines which functions to call in order to fullfill the user's ask.\n",
+    "\n",
+    "The output of each step of the plan gets set as `setContextVariable` which makes it available as `input` to the next skill."
    ]
   },
   {

--- a/samples/notebooks/dotnet/5-using-the-planner.ipynb
+++ b/samples/notebooks/dotnet/5-using-the-planner.ipynb
@@ -108,22 +108,6 @@
     }
    },
    "source": [
-    "You can see that the Planner took my ask and converted it into an XML-based plan detailing\n",
-    "how the AI would go about solving this task, making use of the skills that the Kernel has available to it."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    },
-    "polyglot_notebook": {
-     "kernelName": "csharp"
-    }
-   },
-   "source": [
     "### Providing skills to the planner\n",
     "The planner needs to know what skills are available to it. Here we'll give it access to the `SummarizeSkill` and `WriterSkill` we have defined on disk."
    ]
@@ -214,8 +198,7 @@
     }
    },
    "source": [
-    "As you can see in the above plan, the AI has determined which functions to call \n",
-    "in order to fulfill the user ask. The output of each step of the plan gets set as `setContextVariable` which makes it available as `input` to the next skill. "
+    "As you can see in the above plan, the Planner has taken my question and converted it into an XML-based plan detailing how the AI would go about solving this task, making use of the skills that the Kernel has available to it, determining which functions to call in order to fulfill the user asks. The output of each step of the plan gets set as `setContextVariable` which makes it available as `input` to the next skill. "
    ]
   },
   {

--- a/samples/notebooks/dotnet/5-using-the-planner.ipynb
+++ b/samples/notebooks/dotnet/5-using-the-planner.ipynb
@@ -198,7 +198,7 @@
     }
    },
    "source": [
-    "As you can see in the above plan, the Planner has taken my question and converted it into an XML-based plan detailing how the AI would go about solving this task, making use of the skills that the Kernel has available to it, determining which functions to call in order to fulfill the user asks. The output of each step of the plan gets set as `setContextVariable` which makes it available as `input` to the next skill. "
+    "As you can see in the above plan, the Planner has taken my ask and converted it into an XML-based plan detailing how the AI would go about solving this task, making use of the skills that the Kernel has available to it, determining which functions to call in order to fulfill the user asks. The output of each step of the plan gets set as `setContextVariable` which makes it available as `input` to the next skill. "
    ]
   },
   {


### PR DESCRIPTION
In Sample 5, I moved the text about the planner just after the planner output, as it feels like a better fit.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] I didn't break anyone :smile: