### PR TITLE
Rename DownloadToFileAsync to DownloadToFile in WebSkillTests

### DIFF
--- a/dotnet/src/SemanticKernel.IntegrationTests/WebSkill/WebSkillTests.cs
+++ b/dotnet/src/SemanticKernel.IntegrationTests/WebSkill/WebSkillTests.cs
@@ -74,7 +74,7 @@ public sealed class WebSkillTests : IDisposable
         contextVariables.Set(WebFileDownloadSkill.Parameters.FilePath, fileWhereToSaveWebPage);
 
         // Act
-        await kernel.RunAsync(contextVariables, download["DownloadToFileAsync"]);
+        await kernel.RunAsync(contextVariables, download["DownloadToFile"]);
 
         // Assert
         var fileInfo = new FileInfo(fileWhereToSaveWebPage);


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
Integration Tests have started to fail regularly.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
This commit renames the method DownloadToFileAsync to DownloadToFile in the WebSkillTests class, to match the name of the method in the WebFileDownloadSkill class. This change fixes the `WebFileDownloadSkillFileTestAsync` integration test. No functional changes are made to the method or the test.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
