### PR TITLE
Resource releasing improvements

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SkillCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SkillCollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -30,7 +31,8 @@ public class SkillCollectionTests
     {
         //Arrange
         var semanticFunction = SKFunction.FromSemanticConfig("sk", "name", this._semanticFunctionConfig);
-        var nativeFunction = SKFunction.FromNativeMethod(typeof(SkillCollectionTests).GetMethod(nameof(TestNativeFunction), BindingFlags.Static | BindingFlags.NonPublic));
+        var nativeFunction = SKFunction.FromNativeMethod(Method(TestNativeFunctionAsync));
+        Assert.NotNull(nativeFunction);
 
         var sut = new SkillCollection();
         sut.AddSemanticFunction(semanticFunction);
@@ -45,8 +47,13 @@ public class SkillCollectionTests
         Assert.Contains(allFunctions, f => f.IsSemantic == false);
     }
 
+    private static MethodInfo Method(Delegate method)
+    {
+        return method.Method;
+    }
+
     [SKFunction("TestNativeFunction")]
-    private static Task TestNativeFunction(SKContext context)
+    private static Task TestNativeFunctionAsync(SKContext context)
     {
         return Task.FromResult(0);
     }

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SkillCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SkillCollectionTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SemanticFunctions;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.SkillDefinition;
+public class SkillCollectionTests
+{
+    private readonly Mock<IPromptTemplate> _promptTemplate;
+    private readonly SemanticFunctionConfig _semanticFunctionConfig;
+
+    public SkillCollectionTests()
+    {
+        this._promptTemplate = new Mock<IPromptTemplate>();
+        this._promptTemplate.Setup(x => x.RenderAsync(It.IsAny<SKContext>())).ReturnsAsync("foo");
+        this._promptTemplate.Setup(x => x.GetParameters()).Returns(new List<ParameterView>());
+
+        var templateConfig = new PromptTemplateConfig();
+        this._semanticFunctionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+    }
+
+    [Fact]
+    public void ItReturnsAllRegisteredFunctions()
+    {
+        //Arrange
+        var semanticFunction = SKFunction.FromSemanticConfig("sk", "name", this._semanticFunctionConfig);
+        var nativeFunction = SKFunction.FromNativeMethod(typeof(SkillCollectionTests).GetMethod(nameof(TestNativeFunction), BindingFlags.Static | BindingFlags.NonPublic));
+
+        var sut = new SkillCollection();
+        sut.AddSemanticFunction(semanticFunction);
+        sut.AddNativeFunction(nativeFunction);
+
+        // Act
+        var allFunctions = sut.GetAllFunctions();
+
+        //Assert
+        Assert.Equal(2, allFunctions.Count);
+        Assert.Contains(allFunctions, f => f.IsSemantic == true);
+        Assert.Contains(allFunctions, f => f.IsSemantic == false);
+    }
+
+    [SKFunction("TestNativeFunction")]
+    private static Task TestNativeFunction(SKContext context)
+    {
+        return Task.FromResult(0);
+    }
+}

--- a/dotnet/src/SemanticKernel/AI/OpenAI/Clients/OpenAIClientAbstract.cs
+++ b/dotnet/src/SemanticKernel/AI/OpenAI/Clients/OpenAIClientAbstract.cs
@@ -247,13 +247,5 @@ public abstract class OpenAIClientAbstract : IDisposable
         }
     }
 
-    /// <summary>
-    /// C# finalizer
-    /// </summary>
-    ~OpenAIClientAbstract()
-    {
-        this.Dispose(false);
-    }
-
     #endregion
 }

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -220,8 +220,14 @@ public sealed class Kernel : IKernel, IDisposable
         // ReSharper disable once SuspiciousTypeConversion.Global
         if (this._memory is IDisposable mem) { mem.Dispose(); }
 
-        // ReSharper disable once SuspiciousTypeConversion.Global
-        if (this._skillCollection is IDisposable reg) { reg.Dispose(); }
+        //Dispose all registered functions
+        foreach (var function in this._skillCollection.GetAllFunctions())
+        {
+            if (function is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
     }
 
     #region private ================================================================================

--- a/dotnet/src/SemanticKernel/SkillDefinition/IReadOnlySkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/IReadOnlySkillCollection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using Microsoft.SemanticKernel.Orchestration;
 
 namespace Microsoft.SemanticKernel.SkillDefinition;
@@ -93,6 +94,12 @@ public interface IReadOnlySkillCollection
     /// <param name="functionName">Function name</param>
     /// <returns>Native function delegate</returns>
     ISKFunction GetNativeFunction(string functionName);
+
+    /// <summary>
+    /// Return all functions in the collection.
+    /// </summary>
+    /// <returns>List of functions(wrapped function delegates)</returns>
+    IReadOnlyList<ISKFunction> GetAllFunctions();
 
     /// <summary>
     /// Get all registered functions details, minus the delegates

--- a/dotnet/src/SemanticKernel/SkillDefinition/ReadOnlySkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/ReadOnlySkillCollection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using Microsoft.SemanticKernel.Orchestration;
 
 namespace Microsoft.SemanticKernel.SkillDefinition;
@@ -86,5 +87,11 @@ internal class ReadOnlySkillCollection : IReadOnlySkillCollection
     public FunctionsView GetFunctionsView(bool includeSemantic = true, bool includeNative = true)
     {
         return this._skillCollection.GetFunctionsView(includeSemantic, includeNative);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ISKFunction> GetAllFunctions()
+    {
+        return this._skillCollection.GetAllFunctions();
     }
 }

--- a/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -183,6 +184,12 @@ public class SkillCollection : ISkillCollection
         }
 
         return result;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ISKFunction> GetAllFunctions()
+    {
+        return this._skillCollection.SelectMany(s => s.Value.Select(f => f.Value)).ToList();
     }
 
     #region private ================================================================================


### PR DESCRIPTION
### Motivation and Context

These changes are required to:
- fix potential memory leaks related to not disposed managed and unmanaged resources used by Skills.
- improve GC performance by removing unnecessary finalizer.

The first issue may manifest itself when Kernel having Skills that use managed/unmanaged resources is Disposed 

The issue may manifest itself any time skills that work with managed and unmanaged resources like files, network, etc... are registered in Kernel and the Kernel is disposed but the Skills aren't.

### Description

This PR adds functionality that disposes all Skills registered in Kernel when Kernel.Dispose method is called and removes unnecessary (*OpenAI backends don't hold unmanaged resources directly through OS handles) class destructor/finalizer.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
