### PR TITLE
fix: static functions has no attr __wrapped__

### DIFF
--- a/python/semantic_kernel/orchestration/delegate_inference.py
+++ b/python/semantic_kernel/orchestration/delegate_inference.py
@@ -236,11 +236,11 @@ class DelegateInference:
         awaitable = iscoroutinefunction(function)
 
         for name, value in DelegateInference.__dict__.items():
-            if name.startswith("infer_") and hasattr(
-                value.__wrapped__, "_delegate_type"
-            ):
+            wrapped = getattr(value, "__wrapped__", getattr(value, "__func__", None))
+
+            if name.startswith("infer_") and hasattr(wrapped, "_delegate_type"):
                 # Get the delegate type
-                if value.__wrapped__(function_signature, awaitable):
-                    return value.__wrapped__._delegate_type
+                if wrapped(function_signature, awaitable):
+                    return wrapped._delegate_type
 
         return DelegateTypes.Unknown


### PR DESCRIPTION
### Motivation and Context
1. Why is this change required? `pytest .` raises error
2. What problem does it solve? pass all test
3. What scenario does it contribute to? `infer_delegate_type` will not raise error
4. If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/semantic-kernel/issues/168

### Description
static function has no attribute __wrapped__ and this raises error.
use __func__ for this.
I think `wrapped = getattr(value, "__wrapped__", getattr(value, "__func__", None))` is reasonable for this issue.

```@staticmethod
def infer_delegate_type(function) -> DelegateTypes:
    # Get the function signature
    function_signature = signature(function)
    awaitable = iscoroutinefunction(function)

    for name, value in DelegateInference.__dict__.items():
        if name.startswith("infer_") and hasattr(
>               value.__wrapped__, "_delegate_type"
        ):
E           AttributeError: 'staticmethod' object has no attribute '__wrapped__'

../semantic_kernel/orchestration/delegate_inference.py:240: AttributeError
======================================================================================= short test summary info =======================================================================================
FAILED test_text_skill.py::test_can_be_imported - AttributeError: 'staticmethod' object has no attribute '__wrapped__'
FAILED test_text_skill.py::test_can_be_imported_with_name - AttributeError: 'staticmethod' object has no attribute '__wrapped__'
===================================================================================== 2 failed, 9 passed in 0.23s =====================================================================================
```



### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
