### PR TITLE
Inheriting IDisposable by IKernel

### DIFF
--- a/dotnet/src/SemanticKernel.IntegrationTests/AI/OpenAICompletionTests.cs
+++ b/dotnet/src/SemanticKernel.IntegrationTests/AI/OpenAICompletionTests.cs
@@ -37,7 +37,7 @@ public sealed class OpenAICompletionTests : IDisposable
     public async Task OpenAITestAsync(string prompt, string expectedAnswerContains)
     {
         // Arrange
-        IKernel target = Kernel.Builder.WithLogger(this._logger).Build();
+        using IKernel target = Kernel.Builder.WithLogger(this._logger).Build();
 
         OpenAIConfiguration? openAIConfiguration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
         Assert.NotNull(openAIConfiguration);
@@ -63,7 +63,7 @@ public sealed class OpenAICompletionTests : IDisposable
     public async Task AzureOpenAITestAsync(string prompt, string expectedAnswerContains)
     {
         // Arrange
-        IKernel target = Kernel.Builder.WithLogger(this._logger).Build();
+        using IKernel target = Kernel.Builder.WithLogger(this._logger).Build();
 
         // OpenAIConfiguration? openAIConfiguration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
         // Assert.NotNull(openAIConfiguration);
@@ -97,7 +97,7 @@ public sealed class OpenAICompletionTests : IDisposable
         // Arrange
         var retryConfig = new HttpRetryConfig();
         retryConfig.RetryableStatusCodes.Add(System.Net.HttpStatusCode.Unauthorized);
-        IKernel target = Kernel.Builder.WithLogger(this._testOutputHelper).Configure(c => c.SetDefaultHttpRetryConfig(retryConfig)).Build();
+        using IKernel target = Kernel.Builder.WithLogger(this._testOutputHelper).Configure(c => c.SetDefaultHttpRetryConfig(retryConfig)).Build();
 
         OpenAIConfiguration? openAIConfiguration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
         Assert.NotNull(openAIConfiguration);

--- a/dotnet/src/SemanticKernel.IntegrationTests/CoreSkills/PlannerSkillTests.cs
+++ b/dotnet/src/SemanticKernel.IntegrationTests/CoreSkills/PlannerSkillTests.cs
@@ -43,7 +43,7 @@ public sealed class PlannerSkillTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        IKernel target = Kernel.Builder
+        using IKernel target = Kernel.Builder
             .WithLogger(this._logger)
             .Configure(config =>
             {

--- a/dotnet/src/SemanticKernel.IntegrationTests/WebSkill/WebSkillTests.cs
+++ b/dotnet/src/SemanticKernel.IntegrationTests/WebSkill/WebSkillTests.cs
@@ -43,7 +43,7 @@ public sealed class WebSkillTests : IDisposable
     public async Task BingSkillTestAsync(string prompt, string expectedAnswerContains)
     {
         // Arrange
-        IKernel kernel = Kernel.Builder.WithLogger(this._logger).Build();
+        using IKernel kernel = Kernel.Builder.WithLogger(this._logger).Build();
 
         using XunitLogger<BingConnector> connectorLogger = new(this._output);
         using BingConnector connector = new(this._bingApiKey, connectorLogger);
@@ -65,7 +65,7 @@ public sealed class WebSkillTests : IDisposable
     public async Task WebFileDownloadSkillFileTestAsync()
     {
         // Arrange
-        IKernel kernel = Kernel.Builder.WithLogger(this._logger).Build();
+        using IKernel kernel = Kernel.Builder.WithLogger(this._logger).Build();
         using XunitLogger<WebFileDownloadSkill> skillLogger = new(this._output);
         using var skill = new WebFileDownloadSkill(skillLogger);
         var download = kernel.ImportSkill(skill, "WebFileDownload");

--- a/dotnet/src/SemanticKernel/IKernel.cs
+++ b/dotnet/src/SemanticKernel/IKernel.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Interface for the semantic kernel.
 /// </summary>
-public interface IKernel
+public interface IKernel : IDisposable
 {
     /// <summary>
     /// Settings required to execute functions, including details about AI dependencies, e.g. endpoints and API keys.

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -32,7 +32,7 @@ namespace Microsoft.SemanticKernel;
 /// * RPC functions and secure environments, e.g. sandboxing and credentials management
 /// * auto-generate pipelines given a higher level goal
 /// </summary>
-public sealed class Kernel : IKernel, IDisposable
+public sealed class Kernel : IKernel
 {
     /// <inheritdoc/>
     public KernelConfig Config => this._config;

--- a/samples/dotnet/KernelBuilder/Program.cs
+++ b/samples/dotnet/KernelBuilder/Program.cs
@@ -122,6 +122,10 @@ var kernel9 = Kernel.Builder
 
 var kernel10 = Kernel.Builder.WithRetryHandlerFactory(new RetryThreeTimesFactory()).Build();
 
+// ==========================================================================================================
+// Kernel instances should be Disposed when they are not required anymore to free OS resources they might hold.
+new List<IKernel>(new[] { kernel1, kernel2, kernel3, kernel4, kernel5, kernel6, kernel7, kernel8, kernel9, kernel10 }).ForEach(k => k.Dispose());
+
 // Example of a basic custom retry handler
 public class RetryThreeTimesFactory : IDelegatingHandlerFactory
 {

--- a/samples/dotnet/KernelBuilder/Program.cs
+++ b/samples/dotnet/KernelBuilder/Program.cs
@@ -123,7 +123,7 @@ var kernel9 = Kernel.Builder
 var kernel10 = Kernel.Builder.WithRetryHandlerFactory(new RetryThreeTimesFactory()).Build();
 
 // ==========================================================================================================
-// Kernel instances should be Disposed when they are not required anymore to free OS resources they might hold.
+// Kernel instance should be disposed to release OS resources it may hold, when it's not required anymore.
 new List<IKernel>(new[] { kernel1, kernel2, kernel3, kernel4, kernel5, kernel6, kernel7, kernel8, kernel9, kernel10 }).ForEach(k => k.Dispose());
 
 // Example of a basic custom retry handler

--- a/samples/dotnet/graph-api-skills/Program.cs
+++ b/samples/dotnet/graph-api-skills/Program.cs
@@ -186,6 +186,9 @@ public sealed class Program
         await sk.RunAsync(followUpTaskMemory, todo["AddTaskAsync"]);
 
         logger.LogInformation("Done!");
+
+        //Dispose Kernel instance
+        sk.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

The change is required to make it clear to the SK SDK clients/users that an instance of Kernel (regardless whether it's declared as a variable of IKernel or Kernel type) class is disposable so that clients know about it and dispose it.

### Description

The IKernel interface inherited IDisposable one.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
