### PR TITLE
fix: delegate compatibility issue for python 3.9

### DIFF
--- a/python/semantic_kernel/orchestration/delegate_handlers.py
+++ b/python/semantic_kernel/orchestration/delegate_handlers.py
@@ -141,10 +141,9 @@ class DelegateHandlers:
     @staticmethod
     def get_handler(delegate_type):
         for name, value in DelegateHandlers.__dict__.items():
-            if name.startswith("handle_") and hasattr(
-                value.__wrapped__, "_delegate_type"
-            ):
-                if value.__wrapped__._delegate_type == delegate_type:
+            wrapped = getattr(value, "__wrapped__", getattr(value, "__func__", None))
+            if name.startswith("handle_") and hasattr(wrapped, "_delegate_type"):
+                if wrapped._delegate_type == delegate_type:
                     return value
 
         return DelegateHandlers.handle_unknown

--- a/python/semantic_kernel/orchestration/sk_function.py
+++ b/python/semantic_kernel/orchestration/sk_function.py
@@ -256,6 +256,9 @@ class SKFunction(SKFunctionBase):
         self._ensure_context_has_skills(context)
 
         delegate = DelegateHandlers.get_handler(self._delegate_type)
+        # for python3.9 compatibility (staticmethod is not callable)
+        if not hasattr(delegate, "__call__"):
+            delegate = delegate.__func__
         new_context = await delegate(self._function, context)
 
         return new_context


### PR DESCRIPTION
### Motivation and Context
1. Why is this change required? compatibility for python 3.9
2. What problem does it solve? if user use PromptTemplateEngine with skills inside, it does not work.
3. What scenario does it contribute to? PromptTemplateEngine will work
4. If it fixes an open issue, please link to the issue here.
#182 



### Description
detailed in #182 
similar concept with #169 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
