### PR TITLE
Small fix to TimeSkill minutes and seconds

### DIFF
--- a/dotnet/src/SemanticKernel/CoreSkills/TimeSkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/TimeSkill.cs
@@ -203,7 +203,7 @@ public class TimeSkill
     public string Minute()
     {
         // Example: 15
-        return DateTimeOffset.Now.ToString("m", CultureInfo.CurrentCulture);
+        return DateTimeOffset.Now.ToString("mm", CultureInfo.CurrentCulture);
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ public class TimeSkill
     public string Second()
     {
         // Example: 7
-        return DateTimeOffset.Now.ToString("s", CultureInfo.CurrentCulture);
+        return DateTimeOffset.Now.ToString("ss", CultureInfo.CurrentCulture);
     }
 
     /// <summary>


### PR DESCRIPTION
### Bugfix

Minutes and Seconds returning wrong information

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
