### PR TITLE
Update README and lock notebooks to 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,14 @@ Here is a quick example of how to use Semantic Kernel from a C# console app.
 
 ```csharp
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Configuration;
 using Microsoft.SemanticKernel.KernelExtensions;
 
 var kernel = Kernel.Builder.Build();
 
 // For Azure Open AI service endpoint and keys please see
 // https://learn.microsoft.com/azure/cognitive-services/openai/quickstart?pivots=rest-api
-kernel.Config.AddAzureOpenAICompletionBackend(
+kernel.Config.AddAzureOpenAITextCompletion(
     "davinci-backend",                   // Alias used by the kernel
     "text-davinci-003",                  // Azure OpenAI *Deployment ID*
     "https://contoso.openai.azure.com/", // Azure OpenAI *Endpoint*

--- a/samples/notebooks/dotnet/1-basic-loading-the-kernel.ipynb
+++ b/samples/notebooks/dotnet/1-basic-loading-the-kernel.ipynb
@@ -32,7 +32,7 @@
    },
    "outputs": [],
    "source": [
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\""
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\""
    ]
   },
   {

--- a/samples/notebooks/dotnet/2-running-prompts-from-file.ipynb
+++ b/samples/notebooks/dotnet/2-running-prompts-from-file.ipynb
@@ -100,7 +100,7 @@
     }
    ],
    "source": [
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\"\n",
     "#!import config/Settings.cs\n",
     "\n",
     "using Microsoft.SemanticKernel;\n",

--- a/samples/notebooks/dotnet/3-semantic-function-inline.ipynb
+++ b/samples/notebooks/dotnet/3-semantic-function-inline.ipynb
@@ -58,7 +58,7 @@
     }
    ],
    "source": [
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\"\n",
     "#!import config/Settings.cs\n",
     "\n",
     "\n",

--- a/samples/notebooks/dotnet/4-context-variables-chat.ipynb
+++ b/samples/notebooks/dotnet/4-context-variables-chat.ipynb
@@ -44,7 +44,7 @@
     }
    ],
    "source": [
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\"\n",
     "#!import config/Settings.cs\n",
     "\n",
     "\n",

--- a/samples/notebooks/dotnet/5-using-the-planner.ipynb
+++ b/samples/notebooks/dotnet/5-using-the-planner.ipynb
@@ -25,7 +25,7 @@
    },
    "outputs": [],
    "source": [
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\"\n",
     "#!import config/Settings.cs\n",
     "\n",
     "using Microsoft.Extensions;\n",

--- a/samples/notebooks/dotnet/6-memory-and-embeddings.ipynb
+++ b/samples/notebooks/dotnet/6-memory-and-embeddings.ipynb
@@ -43,7 +43,7 @@
     }
    ],
    "source": [
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\"\n",
     "#!import config/Settings.cs\n",
     "\n",
     "\n",


### PR DESCRIPTION
### Motivation and Context

Update README with new API.
Lock notebooks to 0.9 so we can release new APIs breaking notebooks.