### PR TITLE
python: Porting TimeSkill

### DIFF
--- a/python/semantic_kernel/core_skills/__init__.py
+++ b/python/semantic_kernel/core_skills/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from semantic_kernel.core_skills.text_memory_skill import TextMemorySkill
+from semantic_kernel.core_skills.file_io_skill import FileIOSkill
+from semantic_kernel.core_skills.time_skill import TimeSkill
 
-__all__ = ["TextMemorySkill"]
+__all__ = ["TextMemorySkill","FileIOSkill","TimeSkill"]

--- a/python/semantic_kernel/core_skills/__init__.py
+++ b/python/semantic_kernel/core_skills/__init__.py
@@ -4,4 +4,4 @@ from semantic_kernel.core_skills.text_memory_skill import TextMemorySkill
 from semantic_kernel.core_skills.file_io_skill import FileIOSkill
 from semantic_kernel.core_skills.time_skill import TimeSkill
 
-__all__ = ["TextMemorySkill","FileIOSkill","TimeSkill"]
+__all__ = ["TextMemorySkill", "FileIOSkill", "TimeSkill"]

--- a/python/semantic_kernel/core_skills/__init__.py
+++ b/python/semantic_kernel/core_skills/__init__.py
@@ -3,5 +3,6 @@
 from semantic_kernel.core_skills.text_memory_skill import TextMemorySkill
 from semantic_kernel.core_skills.file_io_skill import FileIOSkill
 from semantic_kernel.core_skills.time_skill import TimeSkill
+from semantic_kernel.core_skills.text_skill import TextSkill
 
-__all__ = ["TextMemorySkill", "FileIOSkill", "TimeSkill"]
+__all__ = ["TextMemorySkill", "TextSkill", "FileIOSkill", "TimeSkill"]

--- a/python/semantic_kernel/core_skills/time_skill.py
+++ b/python/semantic_kernel/core_skills/time_skill.py
@@ -53,7 +53,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%A, %B %d, %Y %I:%M %p")
-    
+
     @sk_function(description="Get the current date and time in UTC", name="utcNow")
     def utc_now(self) -> str:
         """
@@ -97,7 +97,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%B")
-    
+
     @sk_function(description="Get the current month number")
     def month_number(self) -> str:
         """
@@ -108,7 +108,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%m")
-    
+
     @sk_function(description="Get the current day")
     def day(self) -> str:
         """
@@ -120,7 +120,7 @@ class TimeSkill:
         now = datetime.datetime.now()
         return now.strftime("%d")
 
-    @sk_function(description="Get the current day of the week",name="dayOfWeek")
+    @sk_function(description="Get the current day of the week", name="dayOfWeek")
     def day_of_week(self) -> str:
         """
         Get the current day of the week
@@ -130,7 +130,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%A")
-    
+
     @sk_function(description="Get the current hour")
     def hour(self) -> str:
         """
@@ -143,7 +143,7 @@ class TimeSkill:
         return now.strftime("%I %p")
 
     @sk_function(description="Get the current hour number", name="hourNumber")
-    def hour_number(self) -> str:   
+    def hour_number(self) -> str:
         """
         Get the current hour number
 
@@ -152,7 +152,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%H")
-    
+
     @sk_function(description="Get the current minute")
     def minute(self) -> str:
         """
@@ -163,7 +163,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%M")
-    
+
     @sk_function(description="Get the seconds on the current minute")
     def second(self) -> str:
         """
@@ -174,7 +174,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%S")
-    
+
     @sk_function(description="Get the current time zone offset", name="timeZoneOffset")
     def time_zone_offset(self) -> str:
         """
@@ -185,7 +185,7 @@ class TimeSkill:
         """
         now = datetime.datetime.now()
         return now.strftime("%z")
-    
+
     @sk_function(description="Get the current time zone name", name="timeZoneName")
     def time_zone_name(self) -> str:
         """

--- a/python/semantic_kernel/core_skills/time_skill.py
+++ b/python/semantic_kernel/core_skills/time_skill.py
@@ -1,0 +1,198 @@
+import datetime
+
+from semantic_kernel.skill_definition import sk_function
+
+
+class TimeSkill:
+    """
+    Description: TimeSkill provides a set of functions
+                 to get the current time and date.
+
+    Usage:
+        kernel.import_skill("time", TimeSkill())
+
+    Examples:
+        {{time.date}}            => Sunday, 12 January, 2031
+        {{time.today}}           => Sunday, 12 January, 2031
+        {{time.now}}             => Sunday, January 12, 2031 9:15 PM
+        {{time.utcNow}}          => Sunday, January 13, 2031 5:15 AM
+        {{time.time}}            => 09:15:07 PM
+        {{time.year}}            => 2031
+        {{time.month}}           => January
+        {{time.monthNumber}}     => 01
+        {{time.day}}             => 12
+        {{time.dayOfWeek}}       => Sunday
+        {{time.hour}}            => 9 PM
+        {{time.hourNumber}}      => 21
+        {{time.minute}}          => 15
+        {{time.minutes}}         => 15
+        {{time.second}}          => 7
+        {{time.seconds}}         => 7
+        {{time.timeZoneOffset}}  => -0800
+        {{time.timeZoneName}}    => PST
+    """
+
+    @sk_function(description="Get the current time.")
+    def date(self) -> str:
+        """
+        Get the current date
+
+        Example:
+            {{time.date}} => Sunday, 12 January, 2031
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%A, %d %B, %Y")
+
+    @sk_function(description="Get the current date and time in the local time zone")
+    def now(self) -> str:
+        """
+        Get the current date and time in the local time zone"
+
+        Example:
+            {{time.now}} => Sunday, January 12, 2031 9:15 PM
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%A, %B %d, %Y %I:%M %p")
+    
+    @sk_function(description="Get the current date and time in UTC", name="utcNow")
+    def utc_now(self) -> str:
+        """
+        Get the current date and time in UTC
+
+        Example:
+            {{time.utcNow}} => Sunday, January 13, 2031 5:15 AM
+        """
+        now = datetime.datetime.utcnow()
+        return now.strftime("%A, %B %d, %Y %I:%M %p")
+
+    @sk_function(description="Get the current time in the local time zone")
+    def time(self) -> str:
+        """
+        Get the current time in the local time zone
+
+        Example:
+            {{time.time}} => 09:15:07 PM
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%I:%M:%S %p")
+
+    @sk_function(description="Get the current year")
+    def year(self) -> str:
+        """
+        Get the current year
+
+        Example:
+            {{time.year}} => 2031
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%Y")
+
+    @sk_function(description="Get the current month")
+    def month(self) -> str:
+        """
+        Get the current month
+
+        Example:
+            {{time.month}} => January
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%B")
+    
+    @sk_function(description="Get the current month number")
+    def month_number(self) -> str:
+        """
+        Get the current month number
+
+        Example:
+            {{time.monthNumber}} => 01
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%m")
+    
+    @sk_function(description="Get the current day")
+    def day(self) -> str:
+        """
+        Get the current day of the month
+
+        Example:
+            {{time.day}} => 12
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%d")
+
+    @sk_function(description="Get the current day of the week",name="dayOfWeek")
+    def day_of_week(self) -> str:
+        """
+        Get the current day of the week
+
+        Example:
+            {{time.dayOfWeek}} => Sunday
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%A")
+    
+    @sk_function(description="Get the current hour")
+    def hour(self) -> str:
+        """
+        Get the current hour
+
+        Example:
+            {{time.hour}} => 9 PM
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%I %p")
+
+    @sk_function(description="Get the current hour number", name="hourNumber")
+    def hour_number(self) -> str:   
+        """
+        Get the current hour number
+
+        Example:
+            {{time.hourNumber}} => 21
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%H")
+    
+    @sk_function(description="Get the current minute")
+    def minute(self) -> str:
+        """
+        Get the current minute
+
+        Example:
+            {{time.minute}} => 15
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%M")
+    
+    @sk_function(description="Get the seconds on the current minute")
+    def second(self) -> str:
+        """
+        Get the seconds on the current minute
+
+        Example:
+            {{time.second}} => 7
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%S")
+    
+    @sk_function(description="Get the current time zone offset", name="timeZoneOffset")
+    def time_zone_offset(self) -> str:
+        """
+        Get the current time zone offset
+
+        Example:
+            {{time.timeZoneOffset}} => -08:00
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%z")
+    
+    @sk_function(description="Get the current time zone name", name="timeZoneName")
+    def time_zone_name(self) -> str:
+        """
+        Get the current time zone name
+
+        Example:
+            {{time.timeZoneName}} => PST
+        """
+        now = datetime.datetime.now()
+        return now.strftime("%Z")

--- a/python/tests/test_time_skill.py
+++ b/python/tests/test_time_skill.py
@@ -7,6 +7,7 @@ from semantic_kernel.core_skills.time_skill import TimeSkill
 
 test_mock_now = datetime.datetime(2031, 1, 12, 12, 24, 56, tzinfo=datetime.timezone.utc)
 
+
 def test_can_be_instantiated():
     assert TimeSkill()
 
@@ -15,6 +16,7 @@ def test_can_be_imported():
     kernel = sk.create_kernel()
     assert kernel.import_skill(TimeSkill(), "time")
     assert kernel.skills.has_native_function("time", "now")
+
 
 def test_date():
     skill = TimeSkill()

--- a/python/tests/test_time_skill.py
+++ b/python/tests/test_time_skill.py
@@ -1,0 +1,119 @@
+import datetime
+
+from unittest import mock
+
+from semantic_kernel.core_skills.time_skill import TimeSkill
+
+test_mock_now = datetime.datetime(2031, 1, 12, 12, 24, 56, tzinfo=datetime.timezone.utc)
+
+
+def test_date():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.date() == "Sunday, 12 January, 2031"
+
+
+def test_now():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.now() == "Sunday, January 12, 2031 12:24 PM"
+
+
+def test_utc_now():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.utcnow.return_value = test_mock_now
+        assert skill.utc_now() == "Sunday, January 12, 2031 12:24 PM"
+
+
+def test_time():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.time() == "12:24:56 PM"
+
+
+def test_year():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.year() == "2031"
+
+
+def test_month():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.month() == "January"
+
+
+def test_month_number():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.month_number() == "01"
+
+
+def test_day():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.day() == "12"
+
+
+def test_day_of_week():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.day_of_week() == "Sunday"
+
+
+def test_hour():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.hour() == "12 PM"
+
+
+def test_minute():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.minute() == "24"
+
+
+def test_second():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.second() == "56"
+
+
+def test_time_zone_offset():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.time_zone_offset() == "+0000"
+
+
+def test_time_zone_name():
+    skill = TimeSkill()
+
+    with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt:
+        dt.now.return_value = test_mock_now
+        assert skill.time_zone_name() == "UTC"

--- a/python/tests/test_time_skill.py
+++ b/python/tests/test_time_skill.py
@@ -1,4 +1,5 @@
 import datetime
+import semantic_kernel as sk
 
 from unittest import mock
 
@@ -6,6 +7,14 @@ from semantic_kernel.core_skills.time_skill import TimeSkill
 
 test_mock_now = datetime.datetime(2031, 1, 12, 12, 24, 56, tzinfo=datetime.timezone.utc)
 
+def test_can_be_instantiated():
+    assert TimeSkill()
+
+
+def test_can_be_imported():
+    kernel = sk.create_kernel()
+    assert kernel.import_skill(TimeSkill(), "time")
+    assert kernel.skills.has_native_function("time", "now")
 
 def test_date():
     skill = TimeSkill()


### PR DESCRIPTION
### Motivation and Context
Port of the core TimeSkill

### Description
This PR adds the core TimeSkill with unit tests.

```
kernel = sk.create_kernel()
kernel.import_skill(TimeSkill(), "time")
```

```
sk_prompt = """
{{time.now}}
"""
```



### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
