### PR TITLE
Adding conditional capability to Planning

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Planning/ConditionalFlowHelperTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/ConditionalFlowHelperTests.cs
@@ -1,0 +1,349 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.Configuration;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Planning;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.UnitTests.Planning;
+
+public class ConditionalFlowHelperTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public ConditionalFlowHelperTests(ITestOutputHelper testOutputHelper)
+    {
+        this._testOutputHelper = testOutputHelper;
+        this._testOutputHelper.WriteLine("Tests initialized");
+    }
+
+    [Fact]
+    public void ItCanBeInstantiated()
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var completionBackendMock = new Mock<ITextCompletion>();
+
+        // Act - Assert no exception occurs
+        _ = new ConditionalFlowHelper(kernel);
+        _ = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+    }
+
+    [Fact]
+    public async Task ItCanRunIfAsync()
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], "{\"valid\": true}" },
+            { ConditionalFlowHelper.EvaluateConditionPrompt[..30], "TRUE" },
+            { ConditionalFlowHelper.ExtractThenOrElseFromIfPrompt[..30], "Something" },
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        // Act
+        var context = await target.IfAsync("<if><conditiongroup/></if>", this.CreateSKContext(kernel));
+
+        // Assert
+        Assert.NotNull(context);
+        Assert.Equal("Something", context.ToString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Unexpected Result")]
+    public async Task InvalidJsonIfStatementCheckResponseShouldFailContextAsync(string llmResult)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], llmResult }
+        });
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ConditionException>(async () =>
+        {
+            await target.IfAsync("Any", this.CreateSKContext(kernel));
+        });
+
+        // Assert
+        Assert.Equal(ConditionException.ErrorCodes.JsonResponseNotFound, exception.ErrorCode);
+    }
+
+    [Fact]
+    public async Task InvalidIfStatementWithoutConditionShouldFailAsync()
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+
+        // To be able to check the condition need ensure success in the if statement check first
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], "{\"valid\": true}" },
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ConditionException>(async () =>
+        {
+            await target.IfAsync("Any", this.CreateSKContext(kernel));
+        });
+
+        // Assert
+        Assert.Equal(ConditionException.ErrorCodes.InvalidConditionFormat, exception.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("{\"valid\": false, \"reason\": null}", ConditionalFlowHelper.NoReasonMessage)]
+    [InlineData("{\"valid\": false, \"reason\": \"Something1 Error\"}", "Something1 Error")]
+    [InlineData("{\"valid\": false, \n\"reason\": \"Something2 Error\"}", "Something2 Error")]
+    [InlineData("{\"valid\": false, \n\n\"reason\": \"Something3 Error\"}", "Something3 Error")]
+    public async Task InvalidIfStatementCheckResponseShouldFailContextWithReasonMessageAsync(string llmResult, string expectedReason)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], llmResult },
+        });
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ConditionException>(async () =>
+        {
+            await target.IfAsync("Any", this.CreateSKContext(kernel));
+        });
+
+        // Assert
+        Assert.Equal(ConditionException.ErrorCodes.InvalidStatementStructure, exception.ErrorCode);
+        Assert.Equal($"{nameof(ConditionException.ErrorCodes.InvalidStatementStructure)}: {expectedReason}", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("", ConditionalFlowHelper.NoReasonMessage)]
+    [InlineData("Unexpected Result", ConditionalFlowHelper.NoReasonMessage)]
+    [InlineData("ERROR", ConditionalFlowHelper.NoReasonMessage)]
+    [InlineData("ERROR reason: Something1 Error", "Something1 Error")]
+    [InlineData("ERROR\nREASON:Something2 Error", "Something2 Error")]
+    [InlineData("ERROR\n\n ReAson:\nSomething3 Error", "Something3 Error")]
+    public async Task InvalidEvaluateConditionResponseShouldFailContextWithReasonMessageAsync(string llmResult, string expectedReason)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var ifContent = "<if><conditiongroup/></if>";
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], "{\"valid\": true}" },
+            { ConditionalFlowHelper.EvaluateConditionPrompt[..30], llmResult },
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ConditionException>(async () =>
+        {
+            await target.IfAsync(ifContent, this.CreateSKContext(kernel));
+        });
+
+        // Assert
+        Assert.Equal(ConditionException.ErrorCodes.InvalidConditionFormat, exception.ErrorCode);
+        Assert.Equal($"{nameof(ConditionException.ErrorCodes.InvalidConditionFormat)}: {expectedReason}", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("TRUE", "Then")]
+    [InlineData("True", "Then")]
+    [InlineData("true", "Then")]
+    [InlineData("FALSE", "Else")]
+    [InlineData("False", "Else")]
+    [InlineData("false", "Else")]
+    public async Task ValidEvaluateConditionResponseShouldReturnAsync(string llmResult, string expectedBranchTag)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var ifContent = "<if><conditiongroup></conditiongroup><then></then></if>";
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], "{\"valid\": true}" },
+            { ConditionalFlowHelper.EvaluateConditionPrompt[..30], llmResult },
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        // Act
+        var context = await target.IfAsync(ifContent, this.CreateSKContext(kernel));
+
+        // Assert
+        Assert.NotNull(context);
+        Assert.True(context.Variables.ContainsKey("EvaluateIfBranchTag"));
+        Assert.Equal(expectedBranchTag, context["EvaluateIfBranchTag"]);
+    }
+
+    [Theory]
+    [InlineData("Variable1,Variable2", "Variable1")]
+    [InlineData("Variable1,Variable2", "")]
+    [InlineData("Variable1,Variable2,Variable3", "Variable2")]
+    public async Task EvaluateShouldUseExistingConditionVariablesOnlyAsync(string existingVariables, string conditionVariables)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var ifContent = "<if><conditiongroup></conditiongroup><then></then></if>";
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            {
+                ConditionalFlowHelper.IfStructureCheckPrompt[..30],
+                $"{{\"valid\": true, \"variables\": [\"{string.Join("\",\"", conditionVariables.Split(','))}\"]}}"
+            },
+            { ConditionalFlowHelper.EvaluateConditionPrompt[..30], "TRUE" },
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        var contextVariables = new ContextVariables(ifContent);
+        if (!string.IsNullOrEmpty(existingVariables))
+        {
+            foreach (var variableName in existingVariables.Split(','))
+            {
+                contextVariables.Set(variableName, "x");
+            }
+        }
+
+        IEnumerable<string> notExpectedVariablesInPrompt = existingVariables.Split(',');
+        if (!string.IsNullOrEmpty(conditionVariables))
+        {
+            notExpectedVariablesInPrompt = notExpectedVariablesInPrompt.Except(conditionVariables.Split(','));
+        }
+
+        // Act
+        var context = await target.IfAsync(ifContent, this.CreateSKContext(kernel, contextVariables));
+
+        // Assert
+        Assert.NotNull(context);
+        Assert.True(context.Variables.ContainsKey("ConditionalVariables"));
+        if (!string.IsNullOrEmpty(conditionVariables))
+        {
+            foreach (var variableName in conditionVariables.Split(','))
+            {
+                Assert.Contains(variableName, context.Variables["ConditionalVariables"], StringComparison.InvariantCulture);
+            }
+        }
+
+        foreach (var variableName in notExpectedVariablesInPrompt)
+        {
+            Assert.DoesNotContain(variableName, context.Variables["ConditionalVariables"], StringComparison.InvariantCulture);
+        }
+    }
+
+    [Theory]
+    [InlineData("Variable1,Variable2", "Variable4")]
+    [InlineData("Variable1,Variable2,Variable3", "Variable5,Variable2")]
+    public async Task InvalidEvaluateWhenConditionVariablesDontExistsAsync(string existingVariables, string conditionVariables)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var ifContent = "<if><conditiongroup></conditiongroup><then></then></if>";
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], $"{{\"valid\": true, \"variables\": [\"{string.Join("\",\"", conditionVariables.Split(','))}\"]}}" },
+            { ConditionalFlowHelper.EvaluateConditionPrompt[..30], "TRUE" },
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+
+        var contextVariables = new ContextVariables(ifContent);
+        if (!string.IsNullOrEmpty(existingVariables))
+        {
+            foreach (var variableName in existingVariables.Split(','))
+            {
+                contextVariables.Set(variableName, "x");
+            }
+        }
+
+        IEnumerable<string> expectedNotFound = Enumerable.Empty<string>();
+        if (!string.IsNullOrEmpty(conditionVariables))
+        {
+            expectedNotFound = conditionVariables.Split(',').Except(existingVariables?.Split(",") ?? Array.Empty<string>());
+        }
+
+        // Act
+        var exception = await Assert.ThrowsAsync<ConditionException>(async () =>
+        {
+            await target.IfAsync("<if><conditiongroup/></if>", this.CreateSKContext(kernel, contextVariables));
+        });
+
+        // Assert
+        Assert.Equal(ConditionException.ErrorCodes.ContextVariablesNotFound, exception.ErrorCode);
+        Assert.Equal($"{nameof(ConditionException.ErrorCodes.ContextVariablesNotFound)}: {string.Join(", ", expectedNotFound)}", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Result1")]
+    public async Task ValidIfShouldReturnGetThenOrElseBranchResponseAsync(string thenOrElseLlmResult)
+    {
+        // Arrange
+        var kernel = KernelBuilder.Create();
+        _ = kernel.Config.AddOpenAITextCompletion("test", "test", "test");
+        var ifContent = "<if><conditiongroup></conditiongroup><then></then></if>";
+        var completionBackendMock = SetupCompletionBackendMock(new Dictionary<string, string>
+        {
+            { ConditionalFlowHelper.IfStructureCheckPrompt[..30], "{ \"valid\": true }" },
+            { ConditionalFlowHelper.EvaluateConditionPrompt[..30], "TRUE" },
+            { ConditionalFlowHelper.ExtractThenOrElseFromIfPrompt[..30], thenOrElseLlmResult }
+        });
+
+        var target = new ConditionalFlowHelper(kernel, completionBackendMock.Object);
+        // Act
+        var context = await target.IfAsync(ifContent, this.CreateSKContext(kernel));
+
+        // Assert
+        Assert.NotNull(context);
+        Assert.False(context.ErrorOccurred);
+        Assert.Equal(thenOrElseLlmResult, context.ToString());
+    }
+
+    private SKContext CreateSKContext(IKernel kernel, ContextVariables? variables = null, CancellationToken cancellationToken = default)
+    {
+        return new SKContext(variables ?? new ContextVariables(), kernel.Memory, kernel.Skills, kernel.Log, cancellationToken);
+    }
+
+    private static Mock<ITextCompletion> SetupCompletionBackendMock(Dictionary<string, string> promptsAndResponses)
+    {
+        var completionBackendMock = new Mock<ITextCompletion>();
+
+        // For each prompt and response pair, setup the mock to return the response when the prompt is passed as an argument
+        foreach (var pair in promptsAndResponses)
+        {
+            completionBackendMock.Setup(a => a.CompleteAsync(
+                It.Is<string>(prompt => prompt.Contains(pair.Key)), // Match the prompt by checking if it contains the expected substring
+                It.IsAny<CompleteRequestSettings>(), // Ignore the settings parameter
+                It.IsAny<CancellationToken>() // Ignore the cancellation token parameter
+            )).ReturnsAsync(pair.Value); // Return the expected response
+        }
+
+        return completionBackendMock;
+    }
+}

--- a/dotnet/src/SemanticKernel/CoreSkills/PlannerSkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/PlannerSkill.cs
@@ -276,10 +276,10 @@ public class PlannerSkill
             _ = executeResultContext.Variables.Get(Plan.PlanKey, out var planProgress);
             _ = executeResultContext.Variables.Get(Plan.ResultKey, out var results);
 
-            var isComplete = planProgress.Contains($"<{FunctionFlowRunner.SolutionTag}>", StringComparison.InvariantCultureIgnoreCase) &&
+            var isComplete = planProgress.Contains($"<{FunctionFlowRunner.PlanTag}>", StringComparison.InvariantCultureIgnoreCase) &&
                              !planProgress.Contains($"<{FunctionFlowRunner.FunctionTag}", StringComparison.InvariantCultureIgnoreCase);
             var isSuccessful = !executeResultContext.ErrorOccurred &&
-                               planProgress.Contains($"<{FunctionFlowRunner.SolutionTag}>", StringComparison.InvariantCultureIgnoreCase);
+                               planProgress.Contains($"<{FunctionFlowRunner.PlanTag}>", StringComparison.InvariantCultureIgnoreCase);
 
             if (string.IsNullOrEmpty(results) && isComplete && isSuccessful)
             {

--- a/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/SKFunction.cs
@@ -484,7 +484,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     private void EnsureContextHasSkills(SKContext context)
     {
         // If the function is invoked manually, the user might have left out the skill collection
-        if (context.Skills == null) { context.Skills = this._skillCollection; }
+        context.Skills ??= this._skillCollection;
     }
 
     private static MethodDetails GetMethodDetails(MethodInfo methodSignature, object? methodContainerInstance, ILogger? log = null)

--- a/dotnet/src/SemanticKernel/Planning/ConditionException.cs
+++ b/dotnet/src/SemanticKernel/Planning/ConditionException.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Diagnostics;
+
+namespace Microsoft.SemanticKernel.Planning;
+
+public class ConditionException : Exception<ConditionException.ErrorCodes>
+{
+    /// <summary>
+    /// Error codes for <see cref="ConditionException"/>.
+    /// </summary>
+    public enum ErrorCodes
+    {
+        /// <summary>
+        /// Unknown error.
+        /// </summary>
+        UnknownError = -1,
+
+        /// <summary>
+        /// Invalid condition structure.
+        /// </summary>
+        InvalidConditionFormat = 0,
+
+        /// <summary>
+        /// Invalid statement structure.
+        /// </summary>
+        InvalidStatementStructure = 1,
+
+        /// <summary>
+        /// Json Response was not present in the output
+        /// </summary>
+        JsonResponseNotFound = 2,
+
+        /// <summary>
+        /// Required context variables are not present in the context
+        /// </summary>
+        ContextVariablesNotFound = 3,
+    }
+
+    /// <summary>
+    /// Gets the error code of the exception.
+    /// </summary>
+    public ErrorCodes ErrorCode { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionException"/> class.
+    /// </summary>
+    /// <param name="errCode">The error code.</param>
+    /// <param name="message">The message.</param>
+    public ConditionException(ErrorCodes errCode, string? message = null) : base(errCode, message)
+    {
+        this.ErrorCode = errCode;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionException"/> class.
+    /// </summary>
+    /// <param name="errCode">The error code.</param>
+    /// <param name="message">The message.</param>
+    /// <param name="e">The inner exception.</param>
+    public ConditionException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
+    {
+        this.ErrorCode = errCode;
+    }
+
+    #region private ================================================================================
+
+    private ConditionException()
+    {
+        // Not allowed, error code is required
+    }
+
+    private ConditionException(string message) : base(message)
+    {
+        // Not allowed, error code is required
+    }
+
+    private ConditionException(string message, Exception innerException) : base(message, innerException)
+    {
+        // Not allowed, error code is required
+    }
+
+    #endregion
+}

--- a/dotnet/src/SemanticKernel/Planning/ConditionalFlowHelper.cs
+++ b/dotnet/src/SemanticKernel/Planning/ConditionalFlowHelper.cs
@@ -1,0 +1,378 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.KernelExtensions;
+using Microsoft.SemanticKernel.Orchestration;
+
+namespace Microsoft.SemanticKernel.Planning;
+
+/// <summary>
+/// <para>Semantic skill that evaluates conditional structures</para>
+/// <para>
+/// Usage:
+/// var kernel = SemanticKernel.Build(ConsoleLogger.Log);
+/// kernel.ImportSkill("conditional", new ConditionalSkill(kernel));
+/// </para>
+/// </summary>
+public class ConditionalFlowHelper
+{
+    #region Prompts
+
+    internal const string IfStructureCheckPrompt =
+        @"Structure:
+<if>
+	<conditiongroup/>
+	<then/>
+	<else/>
+</if>
+
+Rules:
+. A ""Condition Group"" must exists and have at least one ""Condition"" or ""Condition Group"" child
+. Check recursively if any existing the children ""Condition Group"" follow the Rule 1
+. ""Then"" must exists and have at least one child node
+. ""Else"" is optional
+. If ""Else"" is provided must have one or more children nodes
+. Return true if Test Structure is valid
+. Return false if Test Structure is not valid with a reason
+. Give a json list of variables used inside all the ""Condition Group""s
+. All the return should be in Json format.
+. Response Json Structure:
+{
+  ""valid"": bool,
+  ""reason"": string,
+  ""variables"": [string] (only the variables within ""Condition Group"")
+}
+
+Test Structure:
+{{$IfStatementContent}}";
+
+    internal const string EvaluateConditionPrompt =
+        @"Rules
+1 ""and"" and ""or"" should be self closing tags
+2 Expect should be TRUE, FALSE OR ERROR
+
+Given Example:
+<conditiongroup>
+    <condition variable=""$x"" exact=""1"" />
+    <and/>
+    <condition variable=""$y"" contains=""asd"" />
+    <or/>
+    <not>
+        <condition variable=""$z"" greaterthan=""10"" />
+    </not>
+</conditiongroup>
+
+Expect Example: TRUE
+
+Evaluate Example:
+(x == ""1"" ^ y.Contains(""asd"") ∨ ¬(z > 10))
+(TRUE ^ TRUE ∨ ¬ (FALSE))
+(TRUE ^ TRUE ∨ TRUE) = TRUE
+
+Variables Example:
+x = ""2""
+y = ""adfsdasfgsasdddsf""
+z = ""100""
+w = ""sdf""
+
+Given Example:
+<if>
+     <conditiongroup>
+          <condition variable=""$24hour"" exact=""1"" />
+          <and/>
+          <condition variable=""$24hour"" greaterthan=""10"" />
+     </conditiongroup>
+     <then><if>Good Morning</if></then>
+     <else><else>Good afternoon</else></else>
+</if>
+
+Variables Example:
+24hour = 11
+
+Expect Example: FALSE
+
+Evaluate Example:
+(24hour == 1 ^ 24hour > 10)
+(FALSE ^ TRUE) = FALSE
+
+
+Given Example:
+Invalid XML
+
+Variables Example:
+24hour = 11
+
+Expect Example: ERROR
+Reason Example: 
+
+Given Example:
+<conditiongroup>
+<condition variable=""$23hour"" exact=""10""/>
+</conditiongroup>
+
+Variables Example:
+24hour = 11
+
+Expect Example: ERROR
+Reason Example: 23hour is not a valid variable. 
+
+Given:
+{{$IfCondition}}
+
+Variables:
+{{$ConditionalVariables}}
+
+Expect: ";
+
+    internal const string ExtractThenOrElseFromIfPrompt =
+        @"Consider the below structure, ignore any format error:
+
+{{$IfStatementContent}}
+
+Rules:
+Don't ignore non xml 
+Invalid XML is part of the content
+
+Now, write the exact content inside the first child ""{{$EvaluateIfBranchTag}}"" from the root If element
+
+The exact content inside the first child ""{{$EvaluateIfBranchTag}}"" element from the root If element is:
+
+";
+
+    #endregion
+
+    internal const string ReasonIdentifier = "Reason:";
+    internal const string NoReasonMessage = "No reason was provided";
+
+    private readonly ISKFunction _ifStructureCheckFunction;
+    private readonly ISKFunction _evaluateConditionFunction;
+    private readonly ISKFunction _evaluateIfBranchFunction;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalFlowHelper"/> class.
+    /// </summary>
+    /// <param name="kernel"> The kernel to use </param>
+    /// <param name="completionBackend"> A optional completion backend to run the internal semantic functions </param>
+    internal ConditionalFlowHelper(IKernel kernel, ITextCompletion? completionBackend = null)
+    {
+        this._ifStructureCheckFunction = kernel.CreateSemanticFunction(
+            IfStructureCheckPrompt,
+            skillName: nameof(ConditionalFlowHelper),
+            description: "Evaluate if an If structure is valid and returns TRUE or FALSE",
+            maxTokens: 100,
+            temperature: 0,
+            topP: 0.5);
+
+        this._evaluateConditionFunction = kernel.CreateSemanticFunction(
+            EvaluateConditionPrompt,
+            skillName: nameof(ConditionalFlowHelper),
+            description: "Evaluate a condition group and returns TRUE or FALSE",
+            maxTokens: 100,
+            temperature: 0,
+            topP: 0.5);
+
+        this._evaluateIfBranchFunction = kernel.CreateSemanticFunction(
+            ExtractThenOrElseFromIfPrompt,
+            skillName: nameof(ConditionalFlowHelper),
+            description: "Extract the content of the first child tag from the root If element",
+            maxTokens: 1000,
+            temperature: 0,
+            topP: 0.5);
+
+        if (completionBackend is not null)
+        {
+            this._ifStructureCheckFunction.SetAIBackend(() => completionBackend);
+            this._evaluateIfBranchFunction.SetAIBackend(() => completionBackend);
+            this._evaluateConditionFunction.SetAIBackend(() => completionBackend);
+        }
+    }
+
+    /// <summary>
+    /// Get a planner if statement content and output then or else contents depending on the conditional evaluation.
+    /// </summary>
+    /// <param name="ifContent">If statement content.</param>
+    /// <param name="context"> The context to use </param>
+    /// <returns>Then or Else contents depending on the conditional evaluation</returns>
+    /// <remarks>
+    /// This skill is initially intended to be used only by the Plan Runner.
+    /// </remarks>
+    public async Task<SKContext> IfAsync(string ifContent, SKContext context)
+    {
+        var usedVariables = await this.GetVariablesAndEnsureIfStructureIsValidAsync(ifContent, context).ConfigureAwait(false);
+
+        bool conditionEvaluation = await this.EvaluateConditionAsync(ifContent, usedVariables, context).ConfigureAwait(false);
+
+        return await this.GetThenOrElseBranchAsync(ifContent, conditionEvaluation, context).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the content from the Then or the Else branch based in the condition provided
+    /// </summary>
+    /// <param name="ifContent">If Structure content</param>
+    /// <param name="trueCondition">Condition used to decide on Then or Else returning data</param>
+    /// <param name="context">Current context</param>
+    /// <returns>SKContext with the input as the Then or the Else branches data</returns>
+    private async Task<SKContext> GetThenOrElseBranchAsync(string ifContent, bool trueCondition, SKContext context)
+    {
+        var branchVariables = new ContextVariables(ifContent);
+        context.Variables.Set("EvaluateIfBranchTag", trueCondition ? "Then" : "Else");
+        context.Variables.Set("IfStatementContent", ifContent);
+
+        return (await this._evaluateIfBranchFunction.InvokeAsync(context).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Get the variables used in the If statement and ensure the structure is valid
+    /// </summary>
+    /// <param name="ifContent">If structure content</param>
+    /// <param name="context">Current context</param>
+    /// <returns>List of used variables in the if condition</returns>
+    /// <exception cref="ConditionException">InvalidStatementStructure</exception>
+    /// <exception cref="ConditionException">JsonResponseNotFound</exception>
+    private async Task<IEnumerable<string>> GetVariablesAndEnsureIfStructureIsValidAsync(string ifContent, SKContext context)
+    {
+        context.Variables.Set("IfStatementContent", ifContent);
+        var llmCheckFunctionResponse = (await this._ifStructureCheckFunction.InvokeAsync(ifContent, context).ConfigureAwait(false)).ToString();
+
+        JsonNode llmResponse = this.IfCheckResponseAsJson(llmCheckFunctionResponse);
+        var valid = llmResponse["valid"]!.GetValue<bool>();
+
+        if (!valid)
+        {
+            throw new ConditionException(ConditionException.ErrorCodes.InvalidStatementStructure, llmResponse?["reason"]?.GetValue<string>() ?? NoReasonMessage);
+        }
+
+        // Get all variables from the json array and remove the $ prefix, return empty list if no variables are found
+        var usedVariables = llmResponse["variables"]?.Deserialize<string[]>()?
+                                .Where(v => !string.IsNullOrWhiteSpace(v))
+                                .Select(v => v.TrimStart('$'))
+                            ?? Enumerable.Empty<string>();
+
+        return usedVariables;
+    }
+
+    /// <summary>
+    /// Evaluates a condition group and returns TRUE or FALSE
+    /// </summary>
+    /// <param name="ifContent">If structure content</param>
+    /// <param name="usedVariables">Used variables to send for evaluation</param>
+    /// <param name="context">Current context</param>
+    /// <returns>Condition result</returns>
+    /// <exception cref="ConditionException">InvalidConditionFormat</exception>
+    /// <exception cref="ConditionException">ContextVariablesNotFound</exception>
+    private async Task<bool> EvaluateConditionAsync(string ifContent, IEnumerable<string> usedVariables, SKContext context)
+    {
+        var conditionContent = this.ExtractConditionalContent(ifContent);
+
+        context.Variables.Set("IfCondition", conditionContent);
+        context.Variables.Set("ConditionalVariables", this.GetConditionalVariablesFromContext(usedVariables, context.Variables));
+
+        var llmConditionResponse = (await this._evaluateConditionFunction.InvokeAsync(conditionContent, context).ConfigureAwait(false))
+            .ToString()
+            .Trim();
+
+        var reason = this.GetReason(llmConditionResponse);
+        var error = !Regex.Match(llmConditionResponse.Trim(), @"^(true|false)", RegexOptions.IgnoreCase).Success;
+        if (error)
+        {
+            throw new ConditionException(ConditionException.ErrorCodes.InvalidConditionFormat, reason);
+        }
+
+        return llmConditionResponse.StartsWith("TRUE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Extracts the condition root group content closest the If structure
+    /// </summary>
+    /// <param name="ifContent">If structure content to extract from</param>
+    /// <returns>Conditiongroup contents</returns>
+    private string ExtractConditionalContent(string ifContent)
+    {
+        XmlDocument xmlDoc = new();
+        xmlDoc.LoadXml("<xml>" + ifContent + "</xml>");
+
+        XmlNode parentConditionGroupNode =
+            xmlDoc.SelectSingleNode("//if/conditiongroup")
+            ?? throw new ConditionException(ConditionException.ErrorCodes.InvalidConditionFormat, "Conditiongroup definition is not present");
+
+        return parentConditionGroupNode.OuterXml;
+    }
+
+    /// <summary>
+    /// Gets all the variables used in the condition and their values from the context
+    /// </summary>
+    /// <param name="usedVariables">Variables used in the condition</param>
+    /// <param name="variables">Context variables</param>
+    /// <returns>List of variables and its values for prompting</returns>
+    /// <exception cref="ConditionException">ContextVariablesNotFound</exception>
+    private string GetConditionalVariablesFromContext(IEnumerable<string> usedVariables, ContextVariables variables)
+    {
+        var checkNotFoundVariables = usedVariables.Where(u => !variables.ContainsKey(u)).ToArray();
+        if (checkNotFoundVariables.Any())
+        {
+            throw new ConditionException(ConditionException.ErrorCodes.ContextVariablesNotFound, string.Join(", ", checkNotFoundVariables));
+        }
+
+        var existingVariables = variables.Where(v => usedVariables.Contains(v.Key));
+
+        var conditionalVariables = new StringBuilder();
+        foreach (var v in existingVariables)
+        {
+            // Numeric don't add quotes
+            var value = Regex.IsMatch(v.Value, "^[0-9.,]+$") ? v.Value : JsonSerializer.Serialize(v.Value);
+            conditionalVariables.AppendLine($"{v.Key} = {value}");
+        }
+
+        return conditionalVariables.ToString();
+    }
+
+    /// <summary>
+    /// Gets the reason from the LLM response
+    /// </summary>
+    /// <param name="llmResponse">Raw LLM response</param>
+    /// <returns>Reason details</returns>
+    private string? GetReason(string llmResponse)
+    {
+        var hasReasonIndex = llmResponse.IndexOf(ReasonIdentifier, StringComparison.OrdinalIgnoreCase);
+        if (hasReasonIndex > -1)
+        {
+            return llmResponse[(hasReasonIndex + ReasonIdentifier.Length)..].Trim();
+        }
+
+        return NoReasonMessage;
+    }
+
+    /// <summary>
+    /// Gets a JsonNode traversable structure from the LLM text response
+    /// </summary>
+    /// <param name="llmResponse"></param>
+    /// <returns></returns>
+    /// <exception cref="ConditionException"></exception>
+    private JsonNode IfCheckResponseAsJson(string llmResponse)
+    {
+        var startIndex = llmResponse?.IndexOf('{', StringComparison.InvariantCultureIgnoreCase) ?? -1;
+        JsonNode? response = null;
+
+        if (startIndex > -1)
+        {
+            var jsonResponse = llmResponse![startIndex..];
+            response = JsonSerializer.Deserialize<JsonNode>(jsonResponse);
+        }
+
+        if (response is null)
+        {
+            throw new ConditionException(ConditionException.ErrorCodes.JsonResponseNotFound);
+        }
+
+        return response;
+    }
+}

--- a/dotnet/src/SemanticKernel/Planning/FunctionFlowRunner.cs
+++ b/dotnet/src/SemanticKernel/Planning/FunctionFlowRunner.cs
@@ -7,6 +7,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.AI;
+using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Orchestration.Extensions;
@@ -26,12 +28,17 @@ internal class FunctionFlowRunner
     /// <summary>
     /// The tag name used in the plan xml for the solution.
     /// </summary>
-    internal const string SolutionTag = "plan";
+    internal const string PlanTag = "plan";
 
     /// <summary>
     /// The tag name used in the plan xml for a step that calls a skill function.
     /// </summary>
     internal const string FunctionTag = "function.";
+
+    /// <summary>
+    /// The tag name used in the plan xml for a conditional check
+    /// </summary>
+    internal const string ConditionIfTag = "if";
 
     /// <summary>
     /// The attribute tag used in the plan xml for setting the context variable name to set the output of a function to.
@@ -45,9 +52,12 @@ internal class FunctionFlowRunner
 
     private readonly IKernel _kernel;
 
-    public FunctionFlowRunner(IKernel kernel)
+    private readonly ConditionalFlowHelper _conditionalFlowHelper;
+
+    public FunctionFlowRunner(IKernel kernel, ITextCompletion? completionBackend = null)
     {
         this._kernel = kernel;
+        this._conditionalFlowHelper = new ConditionalFlowHelper(kernel, completionBackend);
     }
 
     /// <summary>
@@ -58,10 +68,10 @@ internal class FunctionFlowRunner
     /// <returns>The resulting plan xml after executing a step in the plan.</returns>
     /// <context>
     /// Brief overview of how it works:
-    /// 1. The plan xml is parsed into an XmlDocument.
+    /// 1. The Solution xml is parsed into an XmlDocument.
     /// 2. The Goal node is extracted from the plan xml.
-    /// 3. The Solution node is extracted from the plan xml.
-    /// 4. The first function node in the Solution node is processed.
+    /// 3. The Plan node is extracted from the plan xml.
+    /// 4. The first function node in the plan node is processed.
     /// 5. The resulting plan xml is returned.
     /// </context>
     /// <exception cref="PlanningException">Thrown when the plan xml is invalid.</exception>
@@ -69,10 +79,10 @@ internal class FunctionFlowRunner
     {
         try
         {
-            XmlDocument xmlDoc = new();
+            XmlDocument solutionXml = new();
             try
             {
-                xmlDoc.LoadXml("<xml>" + planPayload + "</xml>");
+                solutionXml.LoadXml("<xml>" + planPayload + "</xml>");
             }
             catch (XmlException e)
             {
@@ -80,14 +90,14 @@ internal class FunctionFlowRunner
             }
 
             // Get the Goal
-            var (goalTxt, goalXmlString) = GatherGoal(xmlDoc);
+            var (goalTxt, goalXmlString) = GatherGoal(solutionXml);
 
             // Get the Solution
-            XmlNodeList solution = xmlDoc.GetElementsByTagName(SolutionTag);
+            XmlNodeList planNodes = solutionXml.GetElementsByTagName(PlanTag);
 
             // Prepare content for the new plan xml
-            var solutionContent = new StringBuilder();
-            _ = solutionContent.AppendLine($"<{SolutionTag}>");
+            var planContent = new StringBuilder();
+            _ = planContent.AppendLine($"<{PlanTag}>");
 
             // Use goal as default function {{INPUT}} -- check and see if it's a plan in Input, if so, use goalTxt, otherwise, use the input.
             if (!context.Variables.Get("PLAN__INPUT", out var planInput))
@@ -112,12 +122,12 @@ internal class FunctionFlowRunner
             context.Log.LogDebug("Processing solution");
 
             // Process the solution nodes
-            string stepResults = await this.ProcessNodeListAsync(solution, functionInput, context);
+            string stepResults = await this.ProcessNodeListAsync(planNodes, functionInput, context);
             // Add the solution and variable updates to the new plan xml
-            _ = solutionContent.Append(stepResults)
-                .AppendLine($"</{SolutionTag}>");
+            _ = planContent.Append(stepResults)
+                .AppendLine($"</{PlanTag}>");
             // Update the plan xml
-            var updatedPlan = goalXmlString + solutionContent.Replace("\r\n", "\n");
+            var updatedPlan = goalXmlString + planContent.Replace("\r\n", "\n");
             updatedPlan = updatedPlan.Trim();
 
             context.Variables.Set(Plan.PlanKey, updatedPlan);
@@ -155,12 +165,37 @@ internal class FunctionFlowRunner
                     continue;
                 }
 
+                if (processFunctions && o2.Name.StartsWith(ConditionIfTag, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var ifContent = o2.OuterXml;
+                    var functionVariables = new ContextVariables();
+                    functionVariables.Update(context.Variables);
+                    functionVariables.Set("INPUT", o2.OuterXml);
+
+                    var result = await this._conditionalFlowHelper.IfAsync(ifContent,
+                        new SKContext(functionVariables, this._kernel.Memory, this._kernel.Skills, this._kernel.Log, context.CancellationToken));
+
+                    if (result.ErrorOccurred)
+                    {
+                        throw new PlanningException(PlanningException.ErrorCodes.InvalidPlan, result.LastErrorDescription, result.LastException);
+                    }
+
+                    _ = stepAndTextResults.Append(INDENT).AppendLine(result.Variables.Input);
+                    processFunctions = false;
+                    continue;
+                }
+
                 if (o2.Name.StartsWith(FunctionTag, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var skillFunctionName = o2.Name.Split(FunctionTag)?[1] ?? string.Empty;
                     context.Log.LogTrace("{0}: found skill node {1}", parentNodeName, skillFunctionName);
                     GetSkillFunctionNames(skillFunctionName, out var skillName, out var functionName);
-                    if (processFunctions && !string.IsNullOrEmpty(functionName) && context.IsFunctionRegistered(skillName, functionName, out var skillFunction))
+                    if (!context.IsFunctionRegistered(skillName, functionName, out var skillFunction))
+                    {
+                        throw new PlanningException(PlanningException.ErrorCodes.InvalidPlan, $"Plan is using an unavailable skill: {skillName}.{functionName}");
+                    }
+
+                    if (processFunctions && !string.IsNullOrEmpty(functionName))
                     {
                         Verify.NotNull(functionName, nameof(functionName));
                         Verify.NotNull(skillFunction, nameof(skillFunction));

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Threading.Tasks;
 
-#pragma warning disable CS1591
 public static class Program
 {
     // ReSharper disable once InconsistentNaming
@@ -64,4 +63,3 @@ public static class Program
         Console.WriteLine("== DONE ==");
     }
 }
-#pragma warning restore CS1591


### PR DESCRIPTION
### Motivation and Context

Currently, the core planner doesn’t support conditional behavior. 
This design offers an initial “If” statement capability skill that allows planner control flow execution conditioned to check for equals/contains/greaterthan against context variables.

This change will allow Plan to run correctly for prompts like: `Summarize an outline about AI, if the summarization contains any reference to "AGI" then Generate a summary outline for AGI.
After that generate a list of synopsis for a novel using the resulting summarization.`

### Description

This change adds a conditional structure to the plan as a way to be able to use a standard conditional structure for branching that can be recursive as follows.

```
<plan>
  ... plan steps
  <if>
     <conditiongroup>
         <condition variable="variable1" equals|contains|greaterthan="value" />
     </conditiongroup>
     <then>
         ... plan steps
     </then>
     <else> (Optional)
        ... plan steps
        <if /> (nested ifs)
     </else>
  </if>
  ... plan steps
</plan>
```
When resolving the conditional group this skill returns the content in Then or Else branches including potential nested ifs. 

This structure was build in a way that it can allow future nested complex conditions and checks like:  
```
<conditiongroup>
  <condition variable="…" pattern|email|numeric|custom="…" />
  <and|or|xor|not …/>
  <conditiongroup> 
      (recursive and nested conditions...)
  </conditiongroup>
</conditiongroup>
```
The nested scenarios above were not yet fully tested and are not officially supported by this PR. 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: