### PR TITLE
add nuget sources troubleshooting

### DIFF
--- a/samples/notebooks/dotnet/README.md
+++ b/samples/notebooks/dotnet/README.md
@@ -95,6 +95,7 @@ If you see `No sources found.`, add the NuGet official package source:
 ```sh
 dotnet nuget add source "https://api.nuget.org/v3/index.json" --name "nuget.org"
 ```
+Run `dotnet nuget list source` again to verify the source was added.
 
 ## Polyglot Notebooks
 

--- a/samples/notebooks/dotnet/README.md
+++ b/samples/notebooks/dotnet/README.md
@@ -87,7 +87,7 @@ Enter the notebooks folder, and run this to launch the browser interface:
 
 ## Nuget
 
-If you are unable to get the Nuget package, first list your nuget sources:
+If you are unable to get the Nuget package, first list your Nuget sources:
 ```sh
 dotnet nuget list source
 ```

--- a/samples/notebooks/dotnet/README.md
+++ b/samples/notebooks/dotnet/README.md
@@ -85,7 +85,18 @@ Enter the notebooks folder, and run this to launch the browser interface:
 
 # Troubleshooting
 
-If you are unable to get the Nuget package, run one of the `force-nuget-download` scripts for your machine.
+## Nuget
+
+If you are unable to get the Nuget package, first list your nuget sources:
+```sh
+dotnet nuget list source
+```
+If you see `No sources found.`, add the NuGet official package source:
+```sh
+dotnet nuget add source "https://api.nuget.org/v3/index.json" --name "nuget.org"
+```
+
+## Polyglot Notebooks
 
 If somehow the notebooks don't work, run these commands:
 


### PR DESCRIPTION
I was trying to run the Getting Started Notebook from step 3 on the [Setting up Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/get-started) documentation page. 

In the first cell, I got a nuget error:
`error NU1101: Unable to find package ...`

Incorporated a fix from https://stackoverflow.com/a/73961223/620501 into the troubleshooting section of the readme.

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
