### PR TITLE
Fix method name in Getting-Started-Notebook

### DIFF
--- a/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
+++ b/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
@@ -145,9 +145,9 @@
     "// Configure AI backend used by the kernel\n",
     "var (useAzureOpenAI,model, azureEndpoint, apiKey, orgId) = Settings.LoadFromFile();\n",
     "if (useAzureOpenAI)\n",
-    "    kernel.Config.AddAzureOpenAICompletionBackend(\"davinci\", model, azureEndpoint, apiKey);\n",
+    "    kernel.Config.AddAzureOpenAITextCompletion(\"davinci\", model, azureEndpoint, apiKey);\n",
     "else\n",
-    "    kernel.Config.AddOpenAICompletionBackend(\"davinci\", model, apiKey, orgId);"
+    "    kernel.Config.AddOpenAITextCompletion(\"davinci\", model, apiKey, orgId);"
    ]
   },
   {

--- a/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
+++ b/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
@@ -118,6 +118,7 @@
    "source": [
     "// Setup SemanticFunctions and the Kernel\n",
     "using Microsoft.SemanticKernel;\n",
+    "using Microsoft.SemanticKernel.Configuration;\n",
     "using Microsoft.SemanticKernel.SemanticFunctions;\n",
     "using Microsoft.SemanticKernel.KernelExtensions;\n",
     "using System.IO;\n",


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->

I found some errors. Please check below.

![image](https://user-images.githubusercontent.com/2929102/228728583-ae3c8950-d41b-4e46-8c52-386065bfe640.png)


### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->

The Getting-Started-Notebook was not updated in "Update README and lock notebooks to 0.9 #206 "

I fix the method name.

![image](https://user-images.githubusercontent.com/2929102/228728846-8029c267-e1bf-4e2e-bfdf-fde744b70c40.png)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
