### PR TITLE
Remove deprecated TextCompletionBackend call from Getting Started workbook

### DIFF
--- a/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
+++ b/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
@@ -118,6 +118,7 @@
    "source": [
     "// Setup SemanticFunctions and the Kernel\n",
     "using Microsoft.SemanticKernel;\n",
+    "using Microsoft.SemanticKernel.Configuration;\n",
     "using Microsoft.SemanticKernel.SemanticFunctions;\n",
     "using Microsoft.SemanticKernel.KernelExtensions;\n",
     "using System.IO;\n",
@@ -145,9 +146,9 @@
     "// Configure AI backend used by the kernel\n",
     "var (useAzureOpenAI,model, azureEndpoint, apiKey, orgId) = Settings.LoadFromFile();\n",
     "if (useAzureOpenAI)\n",
-    "    kernel.Config.AddAzureOpenAICompletionBackend(\"davinci\", model, azureEndpoint, apiKey);\n",
+    "    kernel.Config.AddAzureOpenAITextCompletion(\"davinci\", model, azureEndpoint, apiKey);\n",
     "else\n",
-    "    kernel.Config.AddOpenAICompletionBackend(\"davinci\", model, apiKey, orgId);"
+    "    kernel.Config.AddOpenAITextCompletion(\"davinci\", model, apiKey, orgId);"
    ]
   },
   {

--- a/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
+++ b/samples/notebooks/dotnet/Getting-Started-Notebook.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "// Import Semantic Kernel\n",
-    "#r \"nuget: Microsoft.SemanticKernel, *-*\""
+    "#r \"nuget: Microsoft.SemanticKernel, 0.9.61.1-preview\""
    ]
   },
   {


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?

- The following PR missed the getting started workbook https://github.com/microsoft/semantic-kernel/pull/206

2. What problem does it solve?

- The getting started workbook does not run successfully due to use of a deprecated method

3. What scenario does it contribute to?

- Unsure. 

4. If it fixes an open issue, please link to the issue here.

- No current issue that I saw. I just opened the PR instead of raising the issue.

-->


### Description
Pinned the version of the workbook, included the kernel configuration namespace, updated to the appropriate method calls.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ x] The code builds clean without any errors or warnings
- [ x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ n/a ] All unit tests pass, and I have added new tests where possible
- [ x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
