### PR TITLE
Dynamic payload for OpenAPI skills CRU requests

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Resources;
-using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -21,7 +20,7 @@ using RestSkills.Authentication;
 namespace Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 
 /// <summary>
-/// Class for extensions methods for IKernel interface.
+/// Class for extensions methods for <see cref="IKernel"/> interface.
 /// </summary>
 public static class KernelOpenApiExtensions
 {
@@ -102,7 +101,8 @@ public static class KernelOpenApiExtensions
             try
             {
                 kernel.Log.LogTrace("Registering Rest function {0}.{1}.", skillName, operation.Id);
-                skill[skillName] = kernel.RegisterRestFunction(skillName, operation);
+                var function = kernel.RegisterRestApiFunction(skillName, operation);
+                skill[function.Name] = function;
             }
             catch (Exception ex) when (!ex.IsCriticalException())
             {
@@ -115,7 +115,15 @@ public static class KernelOpenApiExtensions
     }
 
     #region private
-    private static ISKFunction RegisterRestFunction(this IKernel kernel, string skillName, RestApiOperation operation)
+
+    /// <summary>
+    /// Registers SKFunction for a REST API operation.
+    /// </summary>
+    /// <param name="kernel">Semantic Kernel instance.</param>
+    /// <param name="skillName">Skill name.</param>
+    /// <param name="operation">The REST API operation.</param>
+    /// <returns>An instance of <see cref="SKFunction"/> class.</returns>
+    private static ISKFunction RegisterRestApiFunction(this IKernel kernel, string skillName, RestApiOperation operation)
     {
         var restOperationParameters = operation.GetParameters();
 
@@ -141,14 +149,7 @@ public static class KernelOpenApiExtensions
                     }
                 }
 
-                //Create payload. It's a workaround that should be removed when payload is automatically created by RestOperation class
-                var payload = default(JsonNode);
-                if (context.Variables.Get("body", out var body))
-                {
-                    payload = JsonValue.Parse(body);
-                }
-
-                var result = await runner.RunAsync(operation, arguments, payload, context.CancellationToken);
+                var result = await runner.RunAsync(operation, arguments, context.CancellationToken);
                 if (result != null)
                 {
                     context.Variables.Update(result.ToString());
@@ -163,15 +164,12 @@ public static class KernelOpenApiExtensions
             return context;
         }
 
-        //Temporary workaround to advertize the 'value' parameter
-        //restOperation.Parameters.Add(new RestParameter() { Location = RestParameterLocation.Body, IsRequired = true, Name = "value" });
-
         //TODO: to be fixed later
 #pragma warning disable CA2000 // Dispose objects before losing scope.
         var function = new SKFunction(
             delegateType: SKFunction.DelegateTypes.ContextSwitchInSKContextOutTaskSKContext,
             delegateFunction: ExecuteAsync,
-            parameters: restOperationParameters.Select(p => new ParameterView() { Name = p.Name, Description = p.Name, DefaultValue = p.DefaultValue }).ToList(), //functionConfig.PromptTemplate.GetParameters(),
+            parameters: restOperationParameters.Select(p => new ParameterView() { Name = p.Name, Description = p.Name, DefaultValue = p.DefaultValue ?? string.Empty }).ToList(), //functionConfig.PromptTemplate.GetParameters(),
             description: operation.Description,
             skillName: skillName,
             functionName: operation.Id,

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/RestApiOperationExtensions.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
+
+namespace Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
+
+/// <summary>
+/// Class for extensions methods for the <see cref="RestApiOperation"/> class.
+/// </summary>
+internal static class RestApiOperationExtensions
+{
+    /// <summary>
+    /// Returns list of REST API operation parameters.
+    /// </summary>
+    /// <returns>The list of parameters.</returns>
+    public static IReadOnlyList<RestApiOperationParameter> GetParameters(this RestApiOperation operation)
+    {
+        var parameters = new List<RestApiOperationParameter>(operation.Parameters);
+
+        //Register "server-url" as a parameter so that it's possible to override it if needed.
+        parameters.Add(new RestApiOperationParameter(RestApiOperation.ServerUrlArgumentName, false, RestApiOperationParameterType.Path, operation.ServerUrl));
+
+        //Add Payload properties.
+        parameters.AddRange(CreateParametersFromPayloadProperties(operation.Payload));
+
+        return parameters;
+    }
+
+    /// <summary>
+    /// Creates parameters from REST API operation payload properties.
+    /// </summary>
+    /// <param name="payload">REST API operation payload.</param>
+    /// <returns>The list of parameters.</returns>
+    private static IEnumerable<RestApiOperationParameter> CreateParametersFromPayloadProperties(RestApiOperationPayload? payload)
+    {
+        if (payload == null)
+        {
+            return Enumerable.Empty<RestApiOperationParameter>();
+        }
+
+        IList<RestApiOperationParameter> ConverLeafProperties(RestApiOperationPayloadProperty property)
+        {
+            var parameters = new List<RestApiOperationParameter>();
+
+            if (!property.Properties.Any()) //It's a leaf property
+            {
+                parameters.Add(new RestApiOperationParameter(property.Name, property.IsRequired, RestApiOperationParameterType.Body, null, property.Description));
+            }
+
+            foreach (var childProperty in property.Properties)
+            {
+                parameters.AddRange(ConverLeafProperties(childProperty));
+            }
+
+            return parameters;
+        }
+
+        var result = new List<RestApiOperationParameter>();
+
+        foreach (var property in payload.Properties)
+        {
+            result.AddRange(ConverLeafProperties(property));
+        }
+
+        return result;
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameter.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 namespace Microsoft.SemanticKernel.Skills.OpenAPI.Model;
+
 /// <summary>
 /// The REST API operation parameter.
 /// </summary>
@@ -10,6 +11,11 @@ internal class RestApiOperationParameter
     /// The parameter name.
     /// </summary>
     public string Name { get; }
+
+    /// <summary>
+    /// The parameter description.
+    /// </summary>
+    public string? Description { get; }
 
     /// <summary>
     /// Flag specifying if the parameter is required or not.
@@ -24,7 +30,7 @@ internal class RestApiOperationParameter
     /// <summary>
     /// The default value.
     /// </summary>
-    public string DefaultValue { get; }
+    public string? DefaultValue { get; }
 
     /// <summary>
     /// Creates an instance of a <see cref="RestApiOperationParameter"/> class.
@@ -33,11 +39,13 @@ internal class RestApiOperationParameter
     /// <param name="isRequired">Flag specifying if the parameter is required or not.</param>
     /// <param name="type">The parameter type.</param>
     /// <param name="defaultValue">The parameter default value.</param>
-    public RestApiOperationParameter(string name, bool isRequired, RestApiOperationParameterType type, string defaultValue)
+    /// <param name="description">The parameter description.</param>
+    public RestApiOperationParameter(string name, bool isRequired, RestApiOperationParameterType type, string? defaultValue, string? description = null)
     {
         this.Name = name;
         this.IsRequired = isRequired;
         this.Type = type;
         this.DefaultValue = defaultValue;
+        this.Description = description;
     }
 }

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameterType.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameterType.cs
@@ -31,9 +31,4 @@ internal enum RestApiOperationParameterType
     /// Body parameter.
     /// </summary>
     Body,
-
-    /// <summary>
-    /// Override parameter.
-    /// </summary>
-    Override,
 }

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationPayload.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationPayload.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Skills.OpenAPI.Model;
+
+/// <summary>
+/// The REST API operation payload.
+/// </summary>
+internal record RestApiOperationPayload
+{
+    /// <summary>
+    /// The payload MediaType.
+    /// </summary>
+    public string MediaType { get; }
+
+    /// <summary>
+    /// The payload properties. 
+    /// </summary>
+    public IList<RestApiOperationPayloadProperty> Properties { get; }
+
+    /// <summary>
+    /// Creates an instance of a <see cref="RestApiOperationPayload"/> class.
+    /// </summary>
+    /// <param name="mediaType">The media type.</param>
+    /// <param name="properties">The properties.</param>
+    public RestApiOperationPayload(string mediaType, IList<RestApiOperationPayloadProperty> properties)
+    {
+        this.MediaType = mediaType;
+        this.Properties = properties;
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationPayloadProperty.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationPayloadProperty.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Skills.OpenAPI.Model;
+
+/// <summary>
+/// The REST API operation payload property.
+/// </summary>
+internal class RestApiOperationPayloadProperty
+{
+    /// <summary>
+    /// The property name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The property type.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>
+    /// The property description.
+    /// </summary>
+    public string? Description { get; }
+
+    /// <summary>
+    /// Flag specifying if the property is required or not.
+    /// </summary>
+    public bool IsRequired { get; }
+
+    /// <summary>
+    /// The properties.
+    /// </summary>
+    public IList<RestApiOperationPayloadProperty> Properties { get; }
+
+    /// <summary>
+    /// Creates an instance of a <see cref="RestApiOperationPayloadProperty"/> class.
+    /// </summary>
+    /// <param name="name">Property name.</param>
+    /// <param name="type">Property type.</param>
+    /// <param name="isRequired">Flag specifying if the property is required or not.</param>
+    /// <param name="description">Property description.</param>
+    /// <param name="properties">Properties.</param>
+    public RestApiOperationPayloadProperty(string name, string type, bool isRequired, IList<RestApiOperationPayloadProperty> properties, string? description = null)
+    {
+        this.Name = name;
+        this.Type = type;
+        this.IsRequired = isRequired;
+        this.Description = description;
+        this.Properties = properties;
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Rest/IRestApiOperationRunner.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Rest/IRestApiOperationRunner.cs
@@ -17,9 +17,8 @@ internal interface IRestApiOperationRunner
     /// Runs a REST API operation.
     /// </summary>
     /// <param name="operation">The operation to run.</param>
-    /// <param name="arguments">The arguments.</param>
-    /// <param name="payload">The payload</param>
+    /// <param name="arguments">The operation arguments.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The result of the operation run.</returns>
-    Task<JsonNode?> RunAsync(RestApiOperation operation, IDictionary<string, string> arguments, JsonNode? payload = null, CancellationToken cancellationToken = default);
+    Task<JsonNode?> RunAsync(RestApiOperation operation, IDictionary<string, string> arguments, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Skills.OpenAPI.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Skills.OpenAPI.csproj
@@ -25,6 +25,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>KernelSyntaxExamples</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>SemanticKernel.Skills.UnitTests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserTests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserTests.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Net.Http;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
+using Microsoft.SemanticKernel.Skills.OpenAPI.OpenApi;
+using SemanticKernel.Skills.UnitTests.OpenAPI.TestSkills;
+using Xunit;
+
+namespace SemanticKernel.Skills.UnitTests.OpenAPI;
+
+public class OpenApiDocumentParserTests
+{
+    [Fact]
+    public void ItCanParsePutOperationBodyOfV20SpecSuccessfully()
+    {
+        //Arrange
+        using var stream = ResourceSkillsProvider.LoadFromResource("v2_0.operation.json");
+
+        var sut = new OpenApiDocumentParser();
+
+        //Act
+        var operations = sut.Parse(stream);
+
+        //Assert
+        Assert.NotNull(operations);
+        Assert.True(operations.Any());
+
+        var putOperation = operations.Single(o => o.Id == "SetSecret");
+        Assert.NotNull(putOperation);
+
+        var payload = putOperation.Payload;
+        Assert.NotNull(payload);
+        Assert.Equal("application/json", payload.MediaType);
+
+        var properties = payload.Properties;
+        Assert.NotNull(properties);
+        Assert.Equal(2, properties.Count);
+
+        var valueProperty = properties.FirstOrDefault(p => p.Name == "value");
+        Assert.NotNull(valueProperty);
+        Assert.True(valueProperty.IsRequired);
+        Assert.Equal("The value of the secret.", valueProperty.Description);
+        Assert.NotNull(valueProperty.Properties);
+        Assert.False(valueProperty.Properties.Any());
+
+        var attributesProperty = properties.FirstOrDefault(p => p.Name == "attributes");
+        Assert.NotNull(attributesProperty);
+        Assert.False(attributesProperty.IsRequired);
+        Assert.Equal("attributes", attributesProperty.Description);
+        Assert.NotNull(attributesProperty.Properties);
+        Assert.True(attributesProperty.Properties.Any());
+
+        var enabledProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "enabled");
+        Assert.NotNull(enabledProperty);
+        Assert.False(enabledProperty.IsRequired);
+        Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
+        Assert.NotNull(enabledProperty.Properties);
+        Assert.False(enabledProperty.Properties.Any());
+    }
+
+    [Fact]
+    public void ItCanParsePutOperationMetadataOfV20SpecSuccessfully()
+    {
+        //Arrange
+        using var stream = ResourceSkillsProvider.LoadFromResource("v2_0.operation.json");
+
+        var sut = new OpenApiDocumentParser();
+
+        //Act
+        var operations = sut.Parse(stream);
+
+        //Assert
+        Assert.NotNull(operations);
+        Assert.True(operations.Any());
+
+        var putOperation = operations.Single(o => o.Id == "SetSecret");
+        Assert.NotNull(putOperation);
+        Assert.Equal("Sets a secret in a specified key vault.", putOperation.Description);
+        Assert.Equal("https://my-key-vault.vault.azure.net", putOperation.ServerUrl);
+        Assert.Equal(HttpMethod.Put, putOperation.Method);
+        Assert.Equal("/secrets/{secret-name}", putOperation.Path);
+
+        var parameters = putOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(5, parameters.Count);
+
+        var pathParameter = parameters.Single(p => p.Name == "secret-name"); //'secret-name' path parameter.
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiOperationParameterType.Path, pathParameter.Type);
+        Assert.Null(pathParameter.DefaultValue);
+
+        var apiVersionParameter = parameters.Single(p => p.Name == "api-version"); //'api-version' query string parameter.
+        Assert.True(apiVersionParameter.IsRequired);
+        Assert.Equal(RestApiOperationParameterType.Query, apiVersionParameter.Type);
+        Assert.Equal("7.0", apiVersionParameter.DefaultValue);
+
+        var serverUrlParameter = parameters.Single(p => p.Name == "server-url"); //'server-url' artificial parameter.
+        Assert.False(serverUrlParameter.IsRequired);
+        Assert.Equal(RestApiOperationParameterType.Path, serverUrlParameter.Type);
+        Assert.Equal("https://my-key-vault.vault.azure.net", serverUrlParameter.DefaultValue);
+
+        var valueParameter = parameters.Single(p => p.Name == "value"); //'value' body parameter.
+        Assert.True(valueParameter.IsRequired);
+        Assert.Equal(RestApiOperationParameterType.Body, valueParameter.Type);
+        Assert.Null(valueParameter.DefaultValue);
+        Assert.Equal("The value of the secret.", valueParameter.Description);
+
+        var enabledParameter = parameters.Single(p => p.Name == "enabled"); //'attributes.enabled' body parameter.
+        Assert.False(enabledParameter.IsRequired);
+        Assert.Equal(RestApiOperationParameterType.Body, enabledParameter.Type);
+        Assert.Null(enabledParameter.DefaultValue);
+        Assert.Equal("Determines whether the object is enabled.", enabledParameter.Description);
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/TestSkills/ResourceSkillsProvider.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/TestSkills/ResourceSkillsProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.IO;
+using System.Resources;
+
+namespace SemanticKernel.Skills.UnitTests.OpenAPI.TestSkills;
+internal class ResourceSkillsProvider
+{
+    /// <summary>
+    /// Loads OpenApi document from assembly resource.
+    /// </summary>
+    /// <param name="resourceName">The resource name.</param>
+    /// <returns>The OpenApi document resource stream.</returns>
+    public static Stream LoadFromResource(string resourceName)
+    {
+        var type = typeof(ResourceSkillsProvider);
+
+        var stream = type.Assembly.GetManifestResourceStream(type, resourceName);
+        if (stream == null)
+        {
+            throw new MissingManifestResourceException($"Unable to load OpenApi skill from assembly resource '{resourceName}'.");
+        }
+
+        return stream;
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/TestSkills/v2_0/operation.json
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/TestSkills/v2_0/operation.json
@@ -1,0 +1,127 @@
+{
+  "basePath": "/",
+  "consumes": [],
+  "definitions": {},
+  "host": "my-key-vault.vault.azure.net",
+  "info": {
+    "description": "A sample connector for the Azure Key Vault service.  This connector is built for the Azure Key Vault REST API.  You can see the details of the API here: https://docs.microsoft.com/rest/api/keyvault/.",
+    "title": "Azure Key Vault [Sample]",
+    "version": "1.0"
+  },
+  "parameters": {},
+  "paths": {
+    "/secrets/{secret-name}": {
+      "put": {
+        "description": "Sets a secret in a specified key vault.",
+        "operationId": "SetSecret",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "secret-name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "7.0",
+            "in": "query",
+            "name": "api-version",
+            "required": true,
+            "type": "string",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "properties": {
+                "attributes": {
+                  "description": "attributes",
+                  "properties": {
+                    "enabled": {
+                      "description": "Determines whether the object is enabled.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "value": {
+                  "description": "The value of the secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "properties": {
+                "attributes": {
+                  "description": "attributes",
+                  "properties": {
+                    "created": {
+                      "description": "created",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "enabled": {
+                      "description": "enabled",
+                      "type": "boolean"
+                    },
+                    "recoverylevel": {
+                      "description": "recoverylevel",
+                      "type": "string"
+                    },
+                    "updated": {
+                      "description": "updated",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "id": {
+                  "description": "id",
+                  "type": "string"
+                },
+                "value": {
+                  "description": "value",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Create or update secret value"
+      }
+    }
+  },
+  "produces": [],
+  "responses": {},
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "oauth2_auth": []
+    }
+  ],
+  "securityDefinitions": {
+    "oauth2_auth": {
+      "authorizationUrl": "https://login.windows.net/common/oauth2/authorize",
+      "flow": "accessCode",
+      "scopes": {},
+      "tokenUrl": "https://login.windows.net/common/oauth2/authorize",
+      "type": "oauth2"
+    }
+  },
+  "swagger": "2.0",
+  "tags": []
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Rest/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Rest/RestApiOperationRunnerTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
+using RestSkills;
+using RestSkills.Authentication;
+using Xunit;
+
+namespace SemanticKernel.Skills.UnitTests.OpenAPI;
+
+public class RestApiOperationRunnerTests
+{
+    [Fact]
+    public async Task ItCanRunCrudOperationWithJsonPayloadSuccessfullyAsync()
+    {
+        //Arrange
+        using var httpMessageHandlerStub = new HttpMessageHandlerStub();
+        using var httpClient = new HttpClient(httpMessageHandlerStub);
+        var authHandler = new BearerTokenHandler(); //To be replaced with a mock.
+        var sut = new RestApiOperationRunner(httpClient, authHandler);
+
+        List<RestApiOperationPayloadProperty> payloadProperties = new()
+        {
+            new("value", "string", true, new List<RestApiOperationPayloadProperty>() , "fake-value-description"),
+            new("attributes", "object", false, new List<RestApiOperationPayloadProperty>()
+            {
+                new("enabled", "boolean", false, new List<RestApiOperationPayloadProperty>() , "fake-enabled-description"),
+            })
+        };
+
+        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+
+        var operation = new RestApiOperation(
+            "fake-id",
+            "https://fake-random-test-host",
+            "fake-path",
+            HttpMethod.Post,
+            "fake-description",
+            new List<RestApiOperationParameter>(),
+            payload
+         );
+
+        var arguments = new Dictionary<string, string>();
+        arguments.Add("value", "fake-value");
+        arguments.Add("enabled", "true");
+
+        //Act
+        await sut.RunAsync(operation, arguments);
+
+        //Assert
+        Assert.NotNull(httpMessageHandlerStub.RequestUri);
+        Assert.Equal("https://fake-random-test-host/fake-path", httpMessageHandlerStub.RequestUri.AbsoluteUri);
+
+        Assert.Equal(HttpMethod.Post, httpMessageHandlerStub.Method);
+
+        Assert.NotNull(httpMessageHandlerStub.ContentHeaders);
+        Assert.Contains(httpMessageHandlerStub.ContentHeaders, h => h.Key == "Content-Type" && h.Value.Contains("application/json; charset=utf-8"));
+
+        var messageContent = httpMessageHandlerStub.RequestContent;
+        Assert.NotNull(messageContent);
+        Assert.True(messageContent.Any());
+
+        var deserializedPayload = JsonNode.Parse(new MemoryStream(messageContent));
+        Assert.NotNull(deserializedPayload);
+
+        var valueProperty = deserializedPayload["value"]?.ToString();
+        Assert.Equal("fake-value", valueProperty);
+
+        var attributesProperty = deserializedPayload["attributes"];
+        Assert.NotNull(attributesProperty);
+
+        var enabledProperty = attributesProperty["enabled"]?.AsValue();
+        Assert.NotNull(enabledProperty);
+        Assert.Equal("true", enabledProperty.ToString());
+    }
+
+
+
+    private class HttpMessageHandlerStub : DelegatingHandler
+    {
+        public HttpRequestHeaders? RequestHeaders { get; private set; }
+
+        public HttpContentHeaders? ContentHeaders { get; private set; }
+
+        public byte[]? RequestContent { get; private set; }
+
+        public Uri? RequestUri { get; private set; }
+
+        public HttpMethod? Method { get; private set; }
+
+        public HttpResponseMessage ResponseToReturn { get; set; }
+
+        public HttpMessageHandlerStub()
+        {
+            this.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            this.ResponseToReturn.Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.Method = request.Method;
+            this.RequestUri = request.RequestUri;
+            this.RequestHeaders = request.Headers;
+            this.RequestContent = request.Content == null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            this.ContentHeaders = request.Content?.Headers;
+
+            return await Task.FromResult(this.ResponseToReturn);
+        }
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Skills.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Skills.UnitTests.csproj
@@ -11,6 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="OpenAPI\TestSkills\openapi.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="OpenAPI\TestSkills\v2_0\operation.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
### Motivation and Context

This change adds functionality that creates payload for PUT and POST operations out of metadata provided in OpenAPI document and arguments from SK context. This extends OpenAPI skills capabilities that are currently limited to GET operations. 

### Description
This PR changes/adds the following classes:
- OpenApiDocumentParser is extended to parse OpenAPI document body metadata and convert it into RestApiOperationPayload model.
- New RestApiOperationPayload class is added to represent REST API operation payload.
- RestApiOperation class is extended to include new Payload property. Parameters advertisement (SK pecificlogic) logic is moved out to the RestApiOperationExtensions class to keep the SK logic out of RestApiOperation domain.
- RestApiOperationRunner class is extended to create HTTPContent("application/json; charset=utf-8" Madia Type only) for PUT and POST requests out of RestApiOperation payload   metadata and provided arguments.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
