### PR TITLE
Remove unnecessary finalizer of the OpenAIClientAbstract class.

### DIFF
--- a/dotnet/src/SemanticKernel/Connectors/OpenAI/OpenAIClientAbstract.cs
+++ b/dotnet/src/SemanticKernel/Connectors/OpenAI/OpenAIClientAbstract.cs
@@ -346,13 +346,5 @@ public abstract class OpenAIClientAbstract : IDisposable
         }
     }
 
-    /// <summary>
-    /// C# finalizer
-    /// </summary>
-    ~OpenAIClientAbstract()
-    {
-        this.Dispose(false);
-    }
-
     #endregion
 }


### PR DESCRIPTION
This change removes unnecessary destructor/finalizer declared by OpenAIClientAbstract class and inherited by the backend classes implementing it. 

Finalizers are usually used to release/clean **unmanaged** resources referenced directly through OS handles. Taking into account that neither of SK SDK backends is using any unmanaged resource directly, the finalizer is not really needed and having the IDisposable.Dispose method is enough to release **managed** resources. 

There's also a needless loss of performance associated with class finalizers - every instance of the class that implements the finalizer will be put into a special Finalize queue by garbage collector (GC), then the queue got processed by GC, and only on the next GC cycle the instances will be removed from RAM.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
