### PR TITLE
Fix nuget, include tokenizer data files into the output dir

### DIFF
--- a/dotnet/src/SemanticKernel/Memory/Collections/ScoredValue.cs
+++ b/dotnet/src/SemanticKernel/Memory/Collections/ScoredValue.cs
@@ -92,7 +92,6 @@ public struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredVal
         return left.CompareTo(right) >= 0;
     }
 
-
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Min value convenience method")]
     public static ScoredValue<T> Min()
     {

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -48,10 +48,12 @@
     <None Remove="Connectors\OpenAI\Tokenizers\Settings\encoder.json" />
     <Content Include="Connectors\OpenAI\Tokenizers\Settings\encoder.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
     <None Remove="Connectors\OpenAI\Tokenizers\Settings\vocab.bpe" />
     <Content Include="Connectors\OpenAI\Tokenizers\Settings\vocab.bpe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
   </ItemGroup>
 </Project>

--- a/samples/dotnet/FileCompression/FileCompressionSkill.cs
+++ b/samples/dotnet/FileCompression/FileCompressionSkill.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
 
-namespace Microsoft.SemanticKernel.Skills.FileCompression;
+namespace FileCompression;
 
 /// <summary>
 /// Skill for compressing and decompressing files.
@@ -67,11 +67,11 @@ public class FileCompressionSkill
     [SKFunctionContextParameter(Name = Parameters.DestinationFilePath, Description = "Path of compressed file to create")]
     public async Task<string?> CompressFileAsync(string sourceFilePath, SKContext context)
     {
-        this._logger.LogTrace($"{nameof(CompressFileAsync)} got called");
+        this._logger.LogTrace($"{nameof(this.CompressFileAsync)} got called");
 
         if (!context.Variables.Get(Parameters.DestinationFilePath, out string destinationFilePath))
         {
-            const string errorMessage = $"Missing context variable {Parameters.DestinationFilePath} in {nameof(CompressFileAsync)}";
+            const string errorMessage = $"Missing context variable {Parameters.DestinationFilePath} in {nameof(this.CompressFileAsync)}";
             this._logger.LogError(errorMessage);
             context.Fail(errorMessage);
 
@@ -79,8 +79,8 @@ public class FileCompressionSkill
         }
 
         await this._fileCompressor.CompressFileAsync(Environment.ExpandEnvironmentVariables(sourceFilePath),
-                                                     Environment.ExpandEnvironmentVariables(destinationFilePath),
-                                                     context.CancellationToken);
+            Environment.ExpandEnvironmentVariables(destinationFilePath),
+            context.CancellationToken);
 
         return destinationFilePath;
     }
@@ -97,11 +97,11 @@ public class FileCompressionSkill
     [SKFunctionContextParameter(Name = Parameters.DestinationFilePath, Description = "Path of compressed file to create")]
     public async Task<string?> CompressDirectoryAsync(string sourceDirectoryPath, SKContext context)
     {
-        this._logger.LogTrace($"{nameof(CompressDirectoryAsync)} got called");
+        this._logger.LogTrace($"{nameof(this.CompressDirectoryAsync)} got called");
 
         if (!context.Variables.Get(Parameters.DestinationFilePath, out string destinationFilePath))
         {
-            const string errorMessage = $"Missing context variable {Parameters.DestinationFilePath} in {nameof(CompressDirectoryAsync)}";
+            const string errorMessage = $"Missing context variable {Parameters.DestinationFilePath} in {nameof(this.CompressDirectoryAsync)}";
             this._logger.LogError(errorMessage);
             context.Fail(errorMessage);
 
@@ -109,8 +109,8 @@ public class FileCompressionSkill
         }
 
         await this._fileCompressor.CompressDirectoryAsync(Environment.ExpandEnvironmentVariables(sourceDirectoryPath),
-                                                          Environment.ExpandEnvironmentVariables(destinationFilePath),
-                                                          context.CancellationToken);
+            Environment.ExpandEnvironmentVariables(destinationFilePath),
+            context.CancellationToken);
 
         return destinationFilePath;
     }
@@ -127,11 +127,11 @@ public class FileCompressionSkill
     [SKFunctionContextParameter(Name = Parameters.DestinationDirectoryPath, Description = "Directory into which to extract the decompressed content")]
     public async Task<string?> DecompressFileAsync(string sourceFilePath, SKContext context)
     {
-        this._logger.LogTrace($"{nameof(DecompressFileAsync)} got called");
+        this._logger.LogTrace($"{nameof(this.DecompressFileAsync)} got called");
 
         if (!context.Variables.Get(Parameters.DestinationDirectoryPath, out string destinationDirectoryPath))
         {
-            const string errorMessage = $"Missing context variable {Parameters.DestinationDirectoryPath} in {nameof(DecompressFileAsync)}";
+            const string errorMessage = $"Missing context variable {Parameters.DestinationDirectoryPath} in {nameof(this.DecompressFileAsync)}";
             this._logger.LogError(errorMessage);
             context.Fail(errorMessage);
 
@@ -144,8 +144,8 @@ public class FileCompressionSkill
         }
 
         await this._fileCompressor.DecompressFileAsync(Environment.ExpandEnvironmentVariables(sourceFilePath),
-                                                       Environment.ExpandEnvironmentVariables(destinationDirectoryPath),
-                                                       context.CancellationToken);
+            Environment.ExpandEnvironmentVariables(destinationDirectoryPath),
+            context.CancellationToken);
 
         return destinationDirectoryPath;
     }

--- a/samples/dotnet/FileCompression/IFileCompressor.cs
+++ b/samples/dotnet/FileCompression/IFileCompressor.cs
@@ -3,7 +3,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.SemanticKernel.Skills.FileCompression;
+namespace FileCompression;
 
 /// <summary>
 /// Interface for file compression / decompression.

--- a/samples/dotnet/FileCompression/ZipFileCompressor.cs
+++ b/samples/dotnet/FileCompression/ZipFileCompressor.cs
@@ -5,7 +5,7 @@ using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.SemanticKernel.Skills.FileCompression;
+namespace FileCompression;
 
 /// <summary>
 /// Implementation of <see cref="IFileCompressor"/> that uses the Zip format.


### PR DESCRIPTION
### Motivation and Context

SK nuget is not deploying the tokenizer data files (encoder.json and vocab.bpe) into the app build folder, only showing the files in the explorer. As a result the tokenizer doesn't work, throwing a FileNotFoundException.

### Description

* Updated csproj file so that the auto-generated nuspec file has `copyToOutput="true"`
* Improved the code to use the assembly location, supporting also the scenario where the tokenizer might be in a different assembly.