### PR TITLE
Invoke chatSkill from frontend

### DIFF
--- a/samples/apps/copilot-chat-app/WebApp/src/libs/useChat.ts
+++ b/samples/apps/copilot-chat-app/WebApp/src/libs/useChat.ts
@@ -45,10 +45,9 @@ export const useChat = () => {
     };
 
     const getResponse = async (value: string, chatId: string) => {
-        // TODO: generate reply instead of simple ask
-        const ask = { input: value, variables: [{ key: 'style', value: 'Bill & Ted' }] };
+        const ask = { input: value, variables: [{ key: 'audience', value: account?.name ?? 'Unknown User' }] };
         try {
-            var result = await sk.invokeAsync(ask, 'funskill', 'joke');
+            var result = await sk.invokeAsync(ask, 'ChatSkill', 'Chat');
             const messageResult = {
                 timestamp: new Date().getTime(),
                 sender: 'bot',


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
Currently the frontend invokes the FunSkill Joke function which is just a placeholder.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
Invoke the ChatSkill Chat function to actually get a response. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
