### PR TITLE
Use delegate type for authentication callback

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Authentication/AuthenticateRequestAsyncCallback.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Authentication/AuthenticateRequestAsyncCallback.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
+
+public delegate Task AuthenticateRequestAsyncCallback(HttpRequestMessage request);

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Skills;
 
 namespace Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
@@ -29,7 +30,7 @@ public static class KernelChatGptPluginExtensions
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillFromUrlAsync(
-        this IKernel kernel, string skillName, Uri url, HttpClient? httpClient = null, Func<HttpRequestMessage, Task>? authCallback = null)
+        this IKernel kernel, string skillName, Uri url, HttpClient? httpClient = null, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         Verify.ValidSkillName(skillName);
 
@@ -77,7 +78,7 @@ public static class KernelChatGptPluginExtensions
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillFromResourceAsync(
-        this IKernel kernel, string skillName, HttpClient? httpClient = null, Func<HttpRequestMessage, Task>? authCallback = null)
+        this IKernel kernel, string skillName, HttpClient? httpClient = null, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         Verify.ValidSkillName(skillName);
 
@@ -109,7 +110,7 @@ public static class KernelChatGptPluginExtensions
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static IDictionary<string, ISKFunction> ImportChatGptPluginSkillSkillFromDirectory(
-        this IKernel kernel, string parentDirectory, string skillDirectoryName, HttpClient? httpClient = null, Func<HttpRequestMessage, Task>? authCallback = null)
+        this IKernel kernel, string parentDirectory, string skillDirectoryName, HttpClient? httpClient = null, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         const string CHATGPT_PLUGIN_FILE = "ai-plugin.json";
 
@@ -142,7 +143,7 @@ public static class KernelChatGptPluginExtensions
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static IDictionary<string, ISKFunction> ImportChatGptPluginSkillSkillFromFile(
-        this IKernel kernel, string skillName, string filePath, HttpClient? httpClient = null, Func<HttpRequestMessage, Task>? authCallback = null)
+        this IKernel kernel, string skillName, string filePath, HttpClient? httpClient = null, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         if (!File.Exists(filePath))
         {

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 using Microsoft.SemanticKernel.Skills.OpenAPI.OpenApi;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Rest;
@@ -34,7 +35,7 @@ public static class KernelOpenApiExtensions
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportOpenApiSkillFromUrlAsync(
-        this IKernel kernel, string skillName, Uri url, HttpClient? httpClient = null, Func<HttpRequestMessage, Task>? authCallback = null)
+        this IKernel kernel, string skillName, Uri url, HttpClient? httpClient = null, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         Verify.ValidSkillName(skillName);
 
@@ -83,7 +84,7 @@ public static class KernelOpenApiExtensions
     /// <param name="skillName">Skill name.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
-    public static IDictionary<string, ISKFunction> ImportOpenApiSkillFromResource(this IKernel kernel, string skillName, Func<HttpRequestMessage, Task>? authCallback = null)
+    public static IDictionary<string, ISKFunction> ImportOpenApiSkillFromResource(this IKernel kernel, string skillName, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         Verify.ValidSkillName(skillName);
 
@@ -109,7 +110,7 @@ public static class KernelOpenApiExtensions
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static IDictionary<string, ISKFunction> ImportOpenApiSkillFromDirectory(
-        this IKernel kernel, string parentDirectory, string skillDirectoryName, Func<HttpRequestMessage, Task>? authCallback = null)
+        this IKernel kernel, string parentDirectory, string skillDirectoryName, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         const string OPENAPI_FILE = "openapi.json";
 
@@ -140,7 +141,7 @@ public static class KernelOpenApiExtensions
     /// <param name="filePath">File path to the OpenAPI document.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
-    public static IDictionary<string, ISKFunction> ImportOpenApiSkillFromFile(this IKernel kernel, string skillName, string filePath, Func<HttpRequestMessage, Task>? authCallback = null)
+    public static IDictionary<string, ISKFunction> ImportOpenApiSkillFromFile(this IKernel kernel, string skillName, string filePath, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         if (!File.Exists(filePath))
         {
@@ -163,7 +164,7 @@ public static class KernelOpenApiExtensions
     /// <param name="skillName">Skill name.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
-    public static IDictionary<string, ISKFunction> RegisterOpenApiSkill(this IKernel kernel, Stream documentStream, string skillName, Func<HttpRequestMessage, Task>? authCallback = null)
+    public static IDictionary<string, ISKFunction> RegisterOpenApiSkill(this IKernel kernel, Stream documentStream, string skillName, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         Verify.NotNull(kernel, nameof(kernel));
         Verify.ValidSkillName(skillName);
@@ -203,7 +204,7 @@ public static class KernelOpenApiExtensions
     /// <param name="operation">The REST API operation.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <returns>An instance of <see cref="SKFunction"/> class.</returns>
-    private static ISKFunction RegisterRestApiFunction(this IKernel kernel, string skillName, RestApiOperation operation, Func<HttpRequestMessage, Task>? authCallback = null)
+    private static ISKFunction RegisterRestApiFunction(this IKernel kernel, string skillName, RestApiOperation operation, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         var restOperationParameters = operation.GetParameters();
 

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Rest/RestApiOperationRunner.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Rest/RestApiOperationRunner.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 
 namespace Microsoft.SemanticKernel.Skills.OpenAPI.Rest;
@@ -25,14 +26,14 @@ internal class RestApiOperationRunner : IRestApiOperationRunner
     /// <summary>
     /// Delegate for authorizing the HTTP request.
     /// </summary>
-    private readonly Func<HttpRequestMessage, Task> _authCallback;
+    private readonly AuthenticateRequestAsyncCallback _authCallback;
 
     /// <summary>
     /// Creates an instance of a <see cref="RestApiOperationRunner"/> class.
     /// </summary>
     /// <param name="httpClient">An instance of the HttpClient class.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
-    public RestApiOperationRunner(HttpClient httpClient, Func<HttpRequestMessage, Task>? authCallback = null)
+    public RestApiOperationRunner(HttpClient httpClient, AuthenticateRequestAsyncCallback? authCallback = null)
     {
         this._httpClient = httpClient;
 

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Rest/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Rest/RestApiOperationRunnerTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Rest;
 using Moq;
@@ -26,7 +27,7 @@ public class RestApiOperationRunnerTests
         //Arrange
         using var httpMessageHandlerStub = new HttpMessageHandlerStub();
         using var httpClient = new HttpClient(httpMessageHandlerStub);
-        var authCallbackMock = new Mock<Func<HttpRequestMessage, Task>>();
+        var authCallbackMock = new Mock<AuthenticateRequestAsyncCallback>();
         var sut = new RestApiOperationRunner(httpClient, authCallbackMock.Object);
 
         List<RestApiOperationPayloadProperty> payloadProperties = new()


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
Although the .NET coding conventions suggest using Func<> instead of defining a delegate type, it makes more sense to define a delegate for the auth callback due to the broad usage across the OpenAPI feature. If the signature of this callback needs to change in the future, we will be able to change it in just one place instead of many.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
Define AuthenticateRequestAsyncCallback delegate type and replace all instances of Func<HttpRequestMessage, Task> authCallback with it.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
