### PR TITLE
Add CORS to SKWebApi

### DIFF
--- a/samples/apps/copilot-chat-app/SKWebApi/Program.cs
+++ b/samples/apps/copilot-chat-app/SKWebApi/Program.cs
@@ -36,6 +36,7 @@ public static class Program
             app.UseSwagger();
             app.UseSwaggerUI();
         }
+        app.UseCors();
         app.UseHttpsRedirection();
         app.UseAuthorization();
         app.MapControllers();
@@ -45,6 +46,20 @@ public static class Program
 
     private static void AddServices(IServiceCollection services, ConfigurationManager configuration)
     {
+        string[] allowedOrigins = configuration.GetSection("AllowedOrigins").Get<string[]>();
+        if (allowedOrigins is not null && allowedOrigins.Length > 0)
+        {
+            services.AddCors(options =>
+            {
+                options.AddDefaultPolicy(
+                    policy =>
+                    {
+                        policy.WithOrigins(allowedOrigins)
+                              .AllowAnyHeader();
+                    });
+            });
+        }
+
         services.AddControllers();
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         services.AddEndpointsApiExplorer();

--- a/samples/apps/copilot-chat-app/SKWebApi/appsettings.json
+++ b/samples/apps/copilot-chat-app/SKWebApi/appsettings.json
@@ -1,34 +1,33 @@
 {
+  // Consider populating secrets, such as "Key" properties, from dotnet's user secrets when running locally.
+  // https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-7.0&tabs=windows#secret-manager
+  // Ex: dotnet user-secrets set "CompletionConfig:Key" "MY_SECRET_VALUE"
+  // Values in user secrets take precedence over those in this file
+
   "ServicePort": "40443",
   "CompletionConfig": {
     "Label": "Completion",
-    "AIService": "", // "AzureOpenAI" or "OpenAI"
-    "DeploymentOrModelId": "text-davinci-003",
-    "Endpoint": "", // Ex: "https://YOUR-INSTANCE.openai.azure.com/"
-    // Consider populating the value below from user secrets when running locally.
-    // Ex: dotnet user-secrets set "CompletionConfig:Key" "MY_SECRET_VALUE"
-    // Values in user secrets take precedence over those in this file
-    "Key": "**DO NOT CHECK IN**"
+    "AIService": "[Enter 'AzureOpenAI', or 'OpenAI']",
+    "DeploymentOrModelId": "[Enter the Azure OpenAI deployment name or OpenAI model, e.g. 'text-davinci-003']",
+    "Endpoint": "[Enter the endpoint of your Azure OpenAI instance, e.g. https://contoso.openai.azure.com]",
+    "Key": "[DO NOT CHECK IN - Enter the key to your Azure OpenAI instance.]"
   },
   // Remove or comment out EmbeddingConfig if no embedding backend is required
   "EmbeddingConfig": {
     "Label": "Embeddings",
-    "AIService": "", // "AzureOpenAI" or "OpenAI"
-    "DeploymentOrModelId": "text-embedding-ada-002",
-    "Endpoint": "", // Ex: "https://YOUR-INSTANCE.openai.azure.com/"
-    // Consider populating the value below from user secrets when running locally.
-    // Ex: dotnet user-secrets set "EmbeddingConfig:Key" "MY_SECRET_VALUE"
-    // Values in user secrets take precedence over those in this file
-    "Key": "**DO NOT CHECK IN**"
+    "AIService": "[Enter 'AzureOpenAI', or 'OpenAI']",
+    "DeploymentOrModelId": "[Enter the Azure OpenAI deployment name or OpenAI model, e.g. 'text-embedding-ada-002']",
+    "Endpoint": "[Enter the endpoint of your Azure OpenAI instance, e.g. https://contoso.openai.azure.com]",
+    "Key": "[DO NOT CHECK IN - Enter the key to your Azure OpenAI instance.]"
   },
   /* The following identity settings need to be configured
      before the project can be successfully executed.
      For more info see https://aka.ms/dotnet-template-ms-identity-platform */
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/", // Or whichever instance you use
-    "Domain": "", // Ex: "yourqualified.domain.name"
-    "TenantId": "", // Ex: "11111111-1111-1111-11111111111111111"
-    "ClientId": "", // Ex: "22222222-2222-2222-2222-222222222222"
+    "Domain": "[Enter the domain of your tenant, e.g. contoso.onmicrosoft.com]",
+    "TenantId": "[Enter 'common', or 'organizations' or the Tenant Id (Obtained from the Azure portal. Select 'Endpoints' from the 'App registrations' blade and use the GUID in any of the URLs), e.g. da41245a5-11b3-996c-00a8-4d99re19f292]",
+    "ClientId": "[Enter the Client Id (Application ID obtained from the Azure portal), e.g. ba74781c2-53c2-442a-97c2-3d60re42f403]",
     "Scopes": "access_as_user",
     "CallbackPath": "/signin-oidc"
   },
@@ -38,5 +37,8 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AllowedOrigins": [
+    "http://localhost:3000"
+  ]
 }


### PR DESCRIPTION
### Motivation and Context
Enable CORS so that we can call the SKWebApi from frontends running on different ports/servers

### Description
Added CORS support for API and in appsettings.