### PR TITLE
Addressing comments

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -217,14 +217,14 @@ public static class KernelOpenApiExtensions
                 foreach (var parameter in restOperationParameters)
                 {
                     //A try to resolve argument by alternative parameter name
-                    if (context.Variables.Get(parameter.AlternativeName!, out var value))
+                    if (!string.IsNullOrEmpty(parameter.AlternativeName) && context.Variables.Get(parameter.AlternativeName, out var value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;
                     }
 
                     //A try to resolve argument by original parameter name
-                    if (context.Variables.Get(parameter.Name!, out value))
+                    if (context.Variables.Get(parameter.Name, out value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;
@@ -256,7 +256,7 @@ public static class KernelOpenApiExtensions
         var function = new SKFunction(
             delegateType: SKFunction.DelegateTypes.ContextSwitchInSKContextOutTaskSKContext,
             delegateFunction: ExecuteAsync,
-            parameters: restOperationParameters.Select(p => new ParameterView() { Name = p.AlternativeName!, Description = p.Name, DefaultValue = p.DefaultValue ?? string.Empty }).ToList(), //functionConfig.PromptTemplate.GetParameters(),
+            parameters: restOperationParameters.Select(p => new ParameterView() { Name = p.AlternativeName ?? p.Name, Description = p.Name, DefaultValue = p.DefaultValue ?? string.Empty }).ToList(), //functionConfig.PromptTemplate.GetParameters(),
             description: operation.Description,
             skillName: skillName,
             functionName: operation.Id,

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/RestApiOperationExtensions.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 
 namespace Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
@@ -24,6 +25,12 @@ internal static class RestApiOperationExtensions
 
         //Add Payload properties.
         parameters.AddRange(CreateParametersFromPayloadProperties(operation.Payload));
+
+        //Create a property alternative name without special symbols that are not supported by SK template language.
+        foreach (var parameter in parameters)
+        {
+            parameter.AlternativeName = Regex.Replace(parameter.Name, @"[^0-9A-Za-z_]+", "_");
+        }
 
         return parameters;
     }

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameter.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameter.cs
@@ -10,7 +10,12 @@ internal class RestApiOperationParameter
     /// <summary>
     /// The parameter name.
     /// </summary>
-    public string Name { get; }
+    public string Name { get;  }
+
+    /// <summary>
+    /// The property alternative name. It can be used as an alternative name in contexts where the original name can't be used.
+    /// </summary>
+    public string? AlternativeName { get; set; }
 
     /// <summary>
     /// The parameter type - string, integer, number, boolean, array and object.

--- a/dotnet/src/SemanticKernel/Diagnostics/Verify.cs
+++ b/dotnet/src/SemanticKernel/Diagnostics/Verify.cs
@@ -58,7 +58,7 @@ internal static class Verify
     internal static void ValidFunctionParamName([NotNull] string? functionParamName)
     {
         NotEmpty(functionParamName, "The function parameter name cannot be empty");
-        Regex pattern = new("^[0-9A-Za-z_-]*$");
+        Regex pattern = new("^[0-9A-Za-z_]*$");
         if (!pattern.IsMatch(functionParamName))
         {
             throw new KernelException(

--- a/dotnet/src/SemanticKernel/IKernel.cs
+++ b/dotnet/src/SemanticKernel/IKernel.cs
@@ -70,7 +70,7 @@ public interface IKernel
     /// <param name="skillName">Name of the skill containing the function. The name can contain only alphanumeric chars + underscore.</param>
     /// <param name="customFunction">The custom function to register.</param>
     /// <returns>A C# function wrapping the function execution logic.</returns>
-    ISKFunction RegisterCustomFunction(string skillName, SKFunction customFunction);
+    ISKFunction RegisterCustomFunction(string skillName, ISKFunction customFunction);
 
     /// <summary>
     /// Import a set of functions from the given skill. The functions must have the `SKFunction` attribute.

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -123,7 +123,7 @@ public sealed class Kernel : IKernel, IDisposable
     }
 
     /// <inheritdoc/>
-    public ISKFunction RegisterCustomFunction(string skillName, SKFunction customFunction)
+    public ISKFunction RegisterCustomFunction(string skillName, ISKFunction customFunction)
     {
         // Future-proofing the name not to contain special chars
         Verify.ValidSkillName(skillName);

--- a/samples/dotnet/FileCompression/FileCompressionSkill.cs
+++ b/samples/dotnet/FileCompression/FileCompressionSkill.cs
@@ -8,8 +8,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.Skills.FileCompression;
 
-namespace Microsoft.SemanticKernel.Skills.FileCompression;
+namespace FileCompression;
 
 /// <summary>
 /// Skill for compressing and decompressing files.
@@ -79,8 +80,8 @@ public class FileCompressionSkill
         }
 
         await this._fileCompressor.CompressFileAsync(Environment.ExpandEnvironmentVariables(sourceFilePath),
-                                                     Environment.ExpandEnvironmentVariables(destinationFilePath),
-                                                     context.CancellationToken);
+            Environment.ExpandEnvironmentVariables(destinationFilePath),
+            context.CancellationToken);
 
         return destinationFilePath;
     }
@@ -109,8 +110,8 @@ public class FileCompressionSkill
         }
 
         await this._fileCompressor.CompressDirectoryAsync(Environment.ExpandEnvironmentVariables(sourceDirectoryPath),
-                                                          Environment.ExpandEnvironmentVariables(destinationFilePath),
-                                                          context.CancellationToken);
+            Environment.ExpandEnvironmentVariables(destinationFilePath),
+            context.CancellationToken);
 
         return destinationFilePath;
     }
@@ -144,8 +145,8 @@ public class FileCompressionSkill
         }
 
         await this._fileCompressor.DecompressFileAsync(Environment.ExpandEnvironmentVariables(sourceFilePath),
-                                                       Environment.ExpandEnvironmentVariables(destinationDirectoryPath),
-                                                       context.CancellationToken);
+            Environment.ExpandEnvironmentVariables(destinationDirectoryPath),
+            context.CancellationToken);
 
         return destinationDirectoryPath;
     }

--- a/samples/dotnet/FileCompression/IFileCompressor.cs
+++ b/samples/dotnet/FileCompression/IFileCompressor.cs
@@ -3,7 +3,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.SemanticKernel.Skills.FileCompression;
+namespace FileCompression;
 
 /// <summary>
 /// Interface for file compression / decompression.

--- a/samples/dotnet/FileCompression/ZipFileCompressor.cs
+++ b/samples/dotnet/FileCompression/ZipFileCompressor.cs
@@ -5,7 +5,7 @@ using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.SemanticKernel.Skills.FileCompression;
+namespace FileCompression;
 
 /// <summary>
 /// Implementation of <see cref="IFileCompressor"/> that uses the Zip format.


### PR DESCRIPTION
### Motivation and Context

The change is addressing comments regarding dashes in function parameter names and a few other minor comments. 
Taking into account that JSON standard allows dashes in property names and SK function parameters don't allow them, a solution was put in place to temporarily replace all dashes and other not supported by SK function symbols by underscore symbol - "_".

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x]  The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
