### PR TITLE
Build and style fixes in OpenAPI skill

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameter.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Model/RestApiOperationParameter.cs
@@ -10,7 +10,7 @@ internal class RestApiOperationParameter
     /// <summary>
     /// The parameter name.
     /// </summary>
-    public string Name { get;  }
+    public string Name { get; }
 
     /// <summary>
     /// The property alternative name. It can be used as an alternative name in contexts where the original name can't be used.

--- a/samples/dotnet/FileCompression/FileCompressionSkill.cs
+++ b/samples/dotnet/FileCompression/FileCompressionSkill.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
-using Microsoft.SemanticKernel.Skills.FileCompression;
 
 namespace FileCompression;
 


### PR DESCRIPTION
- Removed non-existent namespace reference
- Fixed whitespace violation in RestApiOperationParameter.cs