### PR TITLE
Enable default logging in SKWeApi, add healthprobe url output.

### DIFF
--- a/samples/apps/copilot-chat-app/SKWebApi/Program.cs
+++ b/samples/apps/copilot-chat-app/SKWebApi/Program.cs
@@ -26,10 +26,10 @@ public static class Program
 
         string protocol = "https";
         builder.WebHost.UseUrls($"{protocol}://*:{serverPort}");
-        
+
         // Add services to the DI container
         AddServices(builder.Services, builder.Configuration);
-        
+
         var app = builder.Build();
 
         // Configure the HTTP request pipeline

--- a/samples/apps/copilot-chat-app/SKWebApi/Program.cs
+++ b/samples/apps/copilot-chat-app/SKWebApi/Program.cs
@@ -23,11 +23,13 @@ public static class Program
         {
             serverPort = SKWebApiConstants.DefaultServerPort;
         }
-        builder.WebHost.UseUrls($"https://*:{serverPort}");
 
+        string protocol = "https";
+        builder.WebHost.UseUrls($"{protocol}://*:{serverPort}");
+        
         // Add services to the DI container
         AddServices(builder.Services, builder.Configuration);
-
+        
         var app = builder.Build();
 
         // Configure the HTTP request pipeline
@@ -40,6 +42,10 @@ public static class Program
         app.UseHttpsRedirection();
         app.UseAuthorization();
         app.MapControllers();
+
+        // Log the health probe URL
+        var logger = app.Services.GetService<ILogger>()!;
+        logger.LogInformation("Health probe: https://{0}:{1}/probe", protocol, serverPort);
 
         app.Run();
     }

--- a/samples/apps/copilot-chat-app/SKWebApi/appsettings.json
+++ b/samples/apps/copilot-chat-app/SKWebApi/appsettings.json
@@ -39,7 +39,8 @@
   "SemanticSkillsDirectory": "", // Ex: ".\\SemanticSkills",
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Information"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
### Motivation and Context
Make it more obvious that SKWebApi started as expected as show the user the health probe.

### Description
Bumped the logging level from "Warning" to "Information" in SKWebApi and added a health probe address logging message.