### PR TITLE
Add namespace warning suppression to KernelPlanningExtensions.cs

### DIFF
--- a/dotnet/src/SemanticKernel/Planning/KernelPlanningExtensions.cs
+++ b/dotnet/src/SemanticKernel/Planning/KernelPlanningExtensions.cs
@@ -3,9 +3,12 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Planning;
 
+#pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace // Extension methods
 namespace Microsoft.SemanticKernel;
+#pragma warning restore IDE0130
 
 /// <summary>
 /// Extension methods for running plans using a kernel


### PR DESCRIPTION
### Motivation and Context
Fix the build

### Description
This commit adds a pragma directive to suppress the IDE0130 warning that suggests using the file name as the namespace for the KernelPlanningExtensions.cs file. This warning is not applicable for extension methods, as they need to be in the same namespace as the type they are extending. The commit also adds a using directive for the Microsoft.SemanticKernel.Planning namespace, which is needed for the extension methods.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
