### PR TITLE
Add feature* branches to dotnet workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", experimental ]
+    branches: [ "main", experimental, "feature*" ]
   schedule:
     - cron: '17 11 * * 2'
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -7,7 +7,7 @@ name: dotnet-ci
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "feature*" ]
     paths:
       - "dotnet/**"
       - "samples/dotnet/**"
@@ -52,7 +52,7 @@ jobs:
         echo "$allProjectFiles"
 
         propsFile="./dotnet/nuget/nuget-package.props"
-        
+
         buildAndRevisionNumber="${{ github.run_number }}.${{ github.run_attempt }}"
         echo "buildAndRevisionNumber: $buildAndRevisionNumber"
 
@@ -95,12 +95,12 @@ jobs:
         name: dotnet-testresults-${{ matrix.configuration }}
         path: ./TestResults
       if: ${{ always() }}
-    
+
     - name: Stage artifacts
       shell: bash
       run: mkdir ./out; find . | grep "/bin/" | xargs cp -r --parents -t ./out
       if: ${{ github.event_name == 'push' }}
-    
+
     - name: Archive artifacts ${{ matrix.os }}-${{ matrix.configuration }}
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -7,7 +7,7 @@ name: dotnet-integration-tests
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "feature*" ]
     paths:
       - "dotnet/**"
 

--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -7,7 +7,7 @@ name: dotnet-pr
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "feature*" ]
     paths:
       - "dotnet/**"
       - "samples/dotnet/**"


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
PR/CI workflows are now required to be run on feature branches.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
This commit updates the dotnet workflows to run on feature* branches as well as main and experimental. This allows the workflows to be triggered by pull requests and pushes to feature branches, which are used for developing new features or enhancements. The workflows affected are codeql-analysis, dotnet-ci, and dotnet-integration-tests.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
