### PR TITLE
Give the possibility to use HTTP

### DIFF
--- a/samples/apps/copilot-chat-app/SKWebApi/Program.cs
+++ b/samples/apps/copilot-chat-app/SKWebApi/Program.cs
@@ -26,12 +26,8 @@ public static class Program
         }
 
         // Set the protocol to use
-        string protocol = "https";
         bool useHttp = builder.Configuration.GetSection("UseHttp").Get<bool>();
-        if (useHttp)
-        {
-            protocol = "http";
-        }
+        string protocol = useHttp ? "http" : "https";
 
         builder.WebHost.UseUrls($"{protocol}://*:{serverPort}");
 
@@ -58,8 +54,8 @@ public static class Program
 
         if (useHttp)
         {
-            logger.LogWarning("Server is using HTTP instead of HTTPS. Do not use HTTP in production.\n" +
-                              "All tokens and secrets sent to the server can be intercepted over the network!");
+            logger.LogWarning("Server is using HTTP instead of HTTPS. Do not use HTTP in production." +
+                              "All tokens and secrets sent to the server can be intercepted over the network.");
         }
 
         app.Run();

--- a/samples/apps/copilot-chat-app/SKWebApi/appsettings.json
+++ b/samples/apps/copilot-chat-app/SKWebApi/appsettings.json
@@ -5,6 +5,8 @@
 
   "ServicePort": "40443",
 
+  "UseHttp": false, // Set to true to use HTTP instead of HTTPS - Only for development purposes
+
   "CompletionConfig": {
     "Label": "Completion",
     "AIService": "AzureOpenAI", // Or "OpenAI" when using OpenAI directly
@@ -39,8 +41,10 @@
 
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Information"
+      "Default": "Warning",
+      "Microsoft.AspNetCore.Hosting": "Information",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.SemanticKernel": "Information"
     }
   }
 }


### PR DESCRIPTION
### Motivation and Context
Give the possibility to use HTTP so that people just trying out the service don't have to deal with cert issues (self-signed or otherwise)

### Description
Added flag to toggle HTTP / HTTPS
### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
