### PR TITLE
Specify the version of SkiaSharp to use in the notebooks

### DIFF
--- a/samples/notebooks/dotnet/7-DALL-E-2.ipynb
+++ b/samples/notebooks/dotnet/7-DALL-E-2.ipynb
@@ -44,7 +44,7 @@
     "// Usual setup: importing Semantic Kernel SDK and SkiaSharp, used to display images inline.\n",
     "\n",
     "#r \"nuget: Microsoft.SemanticKernel, 0.10.72.1-preview\"\n",
-    "#r \"nuget: SkiaSharp\"\n",
+    "#r \"nuget: SkiaSharp, 2.88.3\"\n",
     "\n",
     "#!import config/Settings.cs\n",
     "#!import config/Utils.cs\n",

--- a/samples/notebooks/dotnet/8-chatGPT-with-DALL-E-2.ipynb
+++ b/samples/notebooks/dotnet/8-chatGPT-with-DALL-E-2.ipynb
@@ -66,7 +66,7 @@
     "// Usual setup: importing Semantic Kernel SDK and SkiaSharp, used to display images inline.\n",
     "\n",
     "#r \"nuget: Microsoft.SemanticKernel, 0.10.72.1-preview\"\n",
-    "#r \"nuget: SkiaSharp\"\n",
+    "#r \"nuget: SkiaSharp, 2.88.3\"\n",
     "\n",
     "#!import config/Settings.cs\n",
     "#!import config/Utils.cs\n",


### PR DESCRIPTION
### Motivation and Context

Some users are reporting errors with the new notebooks that use SkiaSharp, because the nuget version is not explicitly stated in the code.

### Description

Specify which version of SkiaSharp to use.