### PR TITLE
CosmosDBMemoryStore can replace others in KernelSyntaxExamples

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosDBMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosDBMemoryRecord.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Memory;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -31,33 +30,13 @@ public class CosmosDBMemoryRecord
     public DateTimeOffset? Timestamp { get; set; }
 
     /// <summary>
-    /// The embedding data.
-    /// </summary>
-    [JsonIgnore]
-    public IEnumerable<float> Embedding { get; set; } = Array.Empty<float>();
-
-    /// <summary>
     /// The embedding data as a string.
     /// </summary>
     public string EmbeddingString { get; set; } = string.Empty;
 
     /// <summary>
-    /// Metadata associated with a Semantic Kernel memory.
-    /// </summary>
-    [JsonIgnore]
-    public MemoryRecordMetadata? Metadata { get; set; }
-
-    /// <summary>
     /// Metadata as a string.
     /// </summary>
     public string MetadataString { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Metadata serialized as a JSON string.
-    /// </summary>
-    public string GetSerializedMetadata()
-    {
-        return JsonConvert.SerializeObject(this.Metadata);
-    }
 }
 

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosDBMemoryStore.cs
@@ -29,11 +29,11 @@ public class CosmosDBMemoryStore : IMemoryStore
     private string _databaseName;
     private ILogger _log;
 
-    [SuppressMessage("Performance", "CS8618:Non-nullable field is uninitialized. Consider declaring as nullable.",
-        Justification = "Class instance is created and populated via factor method.")]
+#pragma warning disable CS8618 // Non-nullable field is uninitialized: Class instance is created and populated via factory method.
     private CosmosDBMemoryStore()
     {
     }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized
 
     /// <summary>
     /// Factory method to initialize a new instance of the <see cref="CosmosDBMemoryStore"/> class.

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosDBMemoryStore.cs
@@ -43,12 +43,12 @@ public class CosmosDBMemoryStore : IMemoryStore
     /// <param name="log">Optional logger.</param>
     /// <param name="cancel">Optional cancellation token.</param>
     /// <exception cref="CosmosException"></exception>
-    public async Task<CosmosDBMemoryStore> CreateAsync(CosmosClient client, string databaseName, ILogger? log = null, CancellationToken cancel = default)
+    public static async Task<CosmosDBMemoryStore> CreateAsync(CosmosClient client, string databaseName, ILogger? log = null, CancellationToken cancel = default)
     {
         var newStore = new CosmosDBMemoryStore();
 
         newStore._databaseName = databaseName;
-        this._log = log ?? NullLogger<CosmosDBMemoryStore>.Instance;
+        newStore._log = log ?? NullLogger<CosmosDBMemoryStore>.Instance;
         var response = await client.CreateDatabaseIfNotExistsAsync(newStore._databaseName, cancellationToken: cancel);
 
         if (response.StatusCode == HttpStatusCode.Created)


### PR DESCRIPTION
Removed dependency of CosmosDBMemoryRecord on Kernel Embedding struct and improved CosmosDB Queries and deserialization. 