### PR TITLE
Improve function availability and planning skill template

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Planning/SKContextExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/SKContextExtensionsTests.cs
@@ -86,7 +86,7 @@ public class SKContextExtensionsTests
         var semanticQuery = "test";
 
         // Act
-        var result = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true);
+        var result = (await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true)).ToList();
 
         //Assert
         Assert.NotNull(result);
@@ -97,7 +97,7 @@ public class SKContextExtensionsTests
         config.IncludedFunctions.UnionWith(new List<string> { "nativeFunctionName" });
 
         // Act
-        result = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true);
+        result = (await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true)).ToList();
 
         // Assert
         Assert.NotNull(result);
@@ -148,7 +148,7 @@ public class SKContextExtensionsTests
         var semanticQuery = "test";
 
         // Act
-        var result = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true);
+        var result = (await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true)).ToList();
 
         //Assert
         Assert.NotNull(result);
@@ -159,7 +159,7 @@ public class SKContextExtensionsTests
         config.IncludedFunctions.UnionWith(new List<string> { "nativeFunctionName" });
 
         // Act
-        result = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true);
+        result = (await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(true)).ToList();
 
         // Assert
         Assert.NotNull(result);

--- a/dotnet/src/SemanticKernel/CoreSkills/SemanticFunctionConstants.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/SemanticFunctionConstants.cs
@@ -6,6 +6,7 @@ internal static class SemanticFunctionConstants
 {
     internal const string FunctionFlowFunctionDefinition =
         @"[EXAMPLE FUNCTIONS]
+
   AuthorAbility.Summarize:
     description: summarizes the input text
     inputs:
@@ -24,6 +25,7 @@ internal static class SemanticFunctionConstants
     inputs:
     - input: the text to email
     - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
+
 [END EXAMPLE FUNCTIONS]
 
 <goal>Summarize an input, translate to french, and e-mail to John Doe</goal>
@@ -35,6 +37,7 @@ internal static class SemanticFunctionConstants
 </plan><!-- END -->
 
 [EXAMPLE FUNCTIONS]
+
   Everything.Summarize:
     description: summarize input text
     inputs:
@@ -102,7 +105,9 @@ To create a plan, follow these steps:
 12. Use only the [AVAILABLE FUNCTIONS].
 
 [AVAILABLE FUNCTIONS]
+
 {{$available_functions}}
+
 [END AVAILABLE FUNCTIONS]
 
 <goal>{{$input}}</goal>

--- a/dotnet/src/SemanticKernel/Planning/SKContextPlanningExtensions.cs
+++ b/dotnet/src/SemanticKernel/Planning/SKContextPlanningExtensions.cs
@@ -9,8 +9,10 @@ using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.SkillDefinition;
 using static Microsoft.SemanticKernel.CoreSkills.PlannerSkill;
 
+#pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace // Extension methods
 namespace Microsoft.SemanticKernel.Orchestration;
+#pragma warning restore IDE0130
 
 internal static class SKContextPlanningExtensions
 {
@@ -43,7 +45,7 @@ internal static class SKContextPlanningExtensions
     /// <param name="config">The planner skill config.</param>
     /// <param name="semanticQuery">The semantic query for finding relevant registered functions</param>
     /// <returns>A list of functions that are available to the user based on the semantic query and the excluded skills and functions.</returns>
-    internal static async Task<List<FunctionView>> GetAvailableFunctionsAsync(
+    internal static async Task<IOrderedEnumerable<FunctionView>> GetAvailableFunctionsAsync(
         this SKContext context,
         PlannerSkillConfig config,
         string? semanticQuery = null)
@@ -91,7 +93,9 @@ internal static class SKContextPlanningExtensions
             result.AddRange(missingFunctions);
         }
 
-        return result;
+        return result
+            .OrderBy(x => x.SkillName)
+            .ThenBy(x => x.Name);
     }
 
     internal static async Task<IEnumerable<FunctionView>> GetRelevantFunctionsAsync(SKContext context, IEnumerable<FunctionView> availableFunctions,


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
Today, planner can create different plans for the same goal and function input. This is undesirable, as it'd be best to have consistent plan generation as temperature is 0. The reason for these difference, is because the use of ConcurrentDictionary would result in non-deterministic function manual ordering. This change adds sorting to local manual retrieval to ensure consistent plan generation. Additionally, issues have been raised showing DV3 being unable to use available functions without additional whitespace in the prompt, so adding that as well.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
      - Order the available functions by skill name and function name for better readability
      - Add blank lines to the planning skill template for better formatting
      - Add a pragma directive to suppress a warning for the namespace of the extension methods
      -[Test] Convert the result of GetAvailableFunctionsAsync to a list to avoid multiple enumerations

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
