### PR TITLE
Fix Python unit tests for Windows

### DIFF
--- a/python/DEV_SETUP.md
+++ b/python/DEV_SETUP.md
@@ -69,7 +69,7 @@ running samples in the repo and developing apps using Python SK.
 
     poetry shell
 
-To run the same checks that are run during the Azure Pipelines build, you can run:
+To run style checks, you can run:
 
     poetry run pre-commit run -c .conf/.pre-commit-config.yaml -a
 

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/python/tests/integration/template_engine/test_prompt_template_e2e.py
+++ b/python/tests/integration/template_engine/test_prompt_template_e2e.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from typing import List, Tuple
+import os
+import pathlib
 
 from pytest import mark, raises
 
@@ -11,9 +13,9 @@ from semantic_kernel.template_engine.prompt_template_engine import PromptTemplat
 
 def _get_template_language_tests() -> List[Tuple[str, str]]:
     path = __file__
-    path = path[: path.rfind("/")]
+    path = os.path.dirname(path)
 
-    with open(f"{path}/tests.txt", "r") as file:
+    with open(os.path.join(path, "tests.txt"), "r") as file:
         content = file.readlines()
 
     key = ""

--- a/python/tests/integration/template_engine/test_prompt_template_e2e.py
+++ b/python/tests/integration/template_engine/test_prompt_template_e2e.py
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from typing import List, Tuple
 import os
-import pathlib
+from typing import List, Tuple
 
 from pytest import mark, raises
 

--- a/python/tests/unit/core_skills/test_file_io_skill.py
+++ b/python/tests/unit/core_skills/test_file_io_skill.py
@@ -23,12 +23,19 @@ def test_can_be_imported():
 @pytest.mark.asyncio
 async def test_can_read_async():
     skill = FileIOSkill()
-    with tempfile.NamedTemporaryFile(mode="w", delete=True) as fp:
-        fp.write("Hello, world!")
-        fp.flush()
 
-        content = await skill.read_async(fp.name)
-        assert content == "Hello, world!"
+    # Note: On Windows, we must use delete=False, otherwise the skill cannot open the file
+    fp = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
+            fp.write("Hello, world!")
+            fp.flush()
+
+            content = await skill.read_async(fp.name)
+            assert content == "Hello, world!"
+    finally:
+        if fp is not None:
+            os.remove(fp.name)
 
 
 @pytest.mark.asyncio
@@ -46,34 +53,46 @@ async def test_cannot_read_async():
 @pytest.mark.asyncio
 async def test_can_write():
     skill = FileIOSkill()
-    with tempfile.NamedTemporaryFile(mode="r", delete=True) as fp:
-        context_variables = ContextVariables()
 
-        context_variables.set("path", fp.name)
-        context_variables.set("content", "Hello, world!")
+    fp = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="r", delete=False) as fp:
+            context_variables = ContextVariables()
 
-        context = SKContext(context_variables, None, None, None)
+            context_variables.set("path", fp.name)
+            context_variables.set("content", "Hello, world!")
 
-        await skill.write_async(context)
+            context = SKContext(context_variables, None, None, None)
 
-        content = fp.read()
+            await skill.write_async(context)
 
-        assert content == "Hello, world!"
+            content = fp.read()
+
+            assert content == "Hello, world!"
+    finally:
+        if fp is not None:
+            os.remove(fp.name)
 
 
 @pytest.mark.asyncio
 async def test_cannot_write():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        skill = FileIOSkill()
-        os.chmod(temp_dir, 0o500)
+    fp = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="r", delete=False) as fp:
+            skill = FileIOSkill()
+            os.chmod(fp.name, 0o500)
 
-        temp_file = os.path.join(temp_dir, "test.txt")
-        context_variables = ContextVariables()
+            context_variables = ContextVariables()
 
-        context_variables.set("path", temp_file)
-        context_variables.set("content", "Hello, world!")
+            context_variables.set("path", fp.name)
+            context_variables.set("content", "Hello, world!")
 
-        context = SKContext(context_variables, None, None, None)
+            context = SKContext(context_variables, None, None, None)
 
-        with pytest.raises(PermissionError):
-            await skill.write_async(context)
+            with pytest.raises(PermissionError):
+                await skill.write_async(context)
+
+            os.chmod(fp.name, 0o777)
+    finally:
+        if fp is not None:
+            os.remove(fp.name)

--- a/python/tests/unit/core_skills/test_file_io_skill.py
+++ b/python/tests/unit/core_skills/test_file_io_skill.py
@@ -24,7 +24,7 @@ def test_can_be_imported():
 async def test_can_read_async():
     skill = FileIOSkill()
 
-    # Note: On Windows, we must use delete=False, otherwise the skill cannot open the file
+    # Note: On Windows, we must use delete=False, or the skill cannot open the file
     fp = None
     try:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->

Some unit tests were broken on Windows. This fixes them to ensure cross-platform compatibility. 
I also added the LICENSE file to the python directory so it will be packaged up with pip.
### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
- In `test_prompt_template_e2e`, needed to use os.path.join instead of concatenation strings for a path
- In `test_file_io_skill`, using delete=True on NamedTemporaryFiles doesn't work on Windows when the skill tries to open the file, so we have to delete it manually
- In `test_file_io_skill.test_cannot_write_async`, I wasn't getting a permission error because the file the skill created was created with 666 file permissions instead of 500 like its parent directory. Instead I create a file with the proper (or rather, improper) permissions.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
