### PR TITLE
Fix typos and code style

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
@@ -14,7 +14,8 @@ using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Skills;
 
-namespace Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
+// ReSharper disable once CheckNamespace
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Class for extensions methods for IKernel interface.
@@ -32,7 +33,12 @@ public static class KernelChatGptPluginExtensions
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillFromUrlAsync(
-        this IKernel kernel, string skillName, Uri url, HttpClient? httpClient = null, AuthenticateRequestAsyncCallback? authCallback = null, CancellationToken cancellationToken = default)
+        this IKernel kernel,
+        string skillName,
+        Uri url,
+        HttpClient? httpClient = null,
+        AuthenticateRequestAsyncCallback? authCallback = null,
+        CancellationToken cancellationToken = default)
     {
         Verify.ValidSkillName(skillName);
 
@@ -47,7 +53,7 @@ public static class KernelChatGptPluginExtensions
                 //  log: null);
 
                 //using HttpClient client = new HttpClient(retryHandler, false);
-                using HttpClient client = new HttpClient();
+                using HttpClient client = new();
 
                 response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
             }
@@ -83,7 +89,8 @@ public static class KernelChatGptPluginExtensions
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillFromResourceAsync(
         this IKernel kernel,
-        string skillName, HttpClient? httpClient = null,
+        string skillName,
+        HttpClient? httpClient = null,
         AuthenticateRequestAsyncCallback? authCallback = null,
         CancellationToken cancellationToken = default)
     {
@@ -135,12 +142,10 @@ public static class KernelChatGptPluginExtensions
         var chatGptPluginPath = Path.Join(skillDir, CHATGPT_PLUGIN_FILE);
         if (!File.Exists(chatGptPluginPath))
         {
-            throw new FileNotFoundException($"No ChatGPT plugin for the specified path - {chatGptPluginPath} is found.");
+            throw new FileNotFoundException($"No ChatGPT plugin for the specified path - {chatGptPluginPath} is found");
         }
 
-        kernel.Log.LogTrace("Registering Rest functions from {0} ChatGPT Plugin.", chatGptPluginPath);
-
-        var skill = new Dictionary<string, ISKFunction>();
+        kernel.Log.LogTrace("Registering Rest functions from {0} ChatGPT Plugin", chatGptPluginPath);
 
         using var stream = File.OpenRead(chatGptPluginPath);
 
@@ -153,7 +158,6 @@ public static class KernelChatGptPluginExtensions
     /// <param name="kernel">Semantic Kernel instance.</param>
     /// <param name="skillName">Name of the skill to register.</param>
     /// <param name="filePath">File path to the ChatGPT plugin definition.</param>
-    /// <param name="httpClient">Optional HttpClient to use for the request.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
@@ -161,7 +165,6 @@ public static class KernelChatGptPluginExtensions
         this IKernel kernel,
         string skillName,
         string filePath,
-        HttpClient? httpClient = null,
         AuthenticateRequestAsyncCallback? authCallback = null,
         CancellationToken cancellationToken = default)
     {
@@ -171,8 +174,6 @@ public static class KernelChatGptPluginExtensions
         }
 
         kernel.Log.LogTrace("Registering Rest functions from {0} ChatGPT Plugin.", filePath);
-
-        var skill = new Dictionary<string, ISKFunction>();
 
         using var stream = File.OpenRead(filePath);
 
@@ -186,13 +187,13 @@ public static class KernelChatGptPluginExtensions
         string? apiType = gptPlugin?["api"]?["type"]?.ToString();
         if (string.IsNullOrWhiteSpace(apiType) || apiType != "openapi")
         {
-            throw new InvalidOperationException($"Invalid ChatGPT plugin document. Supported api types are: openapi.");
+            throw new InvalidOperationException($"Invalid ChatGPT plugin document. Supported api types are: openapi");
         }
 
         string? openApiUrl = gptPlugin?["api"]?["url"]?.ToString();
         if (string.IsNullOrWhiteSpace(openApiUrl))
         {
-            throw new InvalidOperationException($"Invalid ChatGPT plugin document. OpenAPI url is missing.");
+            throw new InvalidOperationException($"Invalid ChatGPT plugin document. OpenAPI url is missing");
         }
 
         return openApiUrl;

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/RestApiOperationOpenAPIExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/RestApiOperationOpenAPIExtensions.cs
@@ -3,14 +3,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 
-namespace Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
+// ReSharper disable once CheckNamespace
+namespace Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 
 /// <summary>
 /// Class for extensions methods for the <see cref="RestApiOperation"/> class.
 /// </summary>
-internal static class RestApiOperationExtensions
+internal static class RestApiOperationOpenAPIExtensions
 {
     /// <summary>
     /// Returns list of REST API operation parameters.

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/OpenApi/OpenApiDocumentParser.cs
@@ -28,7 +28,7 @@ internal class OpenApiDocumentParser : IOpenApiDocumentParser
     /// <inheritdoc/>
     public async Task<IList<RestApiOperation>> ParseAsync(Stream stream, CancellationToken cancellationToken = default)
     {
-        var jsonObject = await this.DowngradeDocumentVersionToSuportedOneAsync(stream, cancellationToken).ConfigureAwait(false);
+        var jsonObject = await this.DowngradeDocumentVersionToSupportedOneAsync(stream, cancellationToken).ConfigureAwait(false);
 
         using var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(jsonObject.ToJson()));
 
@@ -54,7 +54,7 @@ internal class OpenApiDocumentParser : IOpenApiDocumentParser
     /// <param name="stream">The original OpenAPI document stream.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>OpenAPI document with downgraded document version.</returns>
-    private async Task<JsonObject> DowngradeDocumentVersionToSuportedOneAsync(Stream stream, CancellationToken cancellationToken)
+    private async Task<JsonObject> DowngradeDocumentVersionToSupportedOneAsync(Stream stream, CancellationToken cancellationToken)
     {
         var jsonObject = await ConvertContentToJsonAsync(stream, cancellationToken);
         if (jsonObject == null)
@@ -63,7 +63,7 @@ internal class OpenApiDocumentParser : IOpenApiDocumentParser
             throw new OpenApiDocumentParsingException($"Parsing of OpenAPI document failed.");
         }
 
-        if (!jsonObject.TryGetPropertyValue(OpenApiVersionPropetyName, out var propertyNode))
+        if (!jsonObject.TryGetPropertyValue(OpenApiVersionPropertyName, out var propertyNode))
         {
             //The document is either malformed or has 2.x version that specifies document version in the 'swagger' property rather than in the 'openapi' one.
             return jsonObject;
@@ -83,7 +83,7 @@ internal class OpenApiDocumentParser : IOpenApiDocumentParser
 
         if (version > s_latestSupportedVersion)
         {
-            jsonObject[OpenApiVersionPropetyName] = s_latestSupportedVersion.ToString();
+            jsonObject[OpenApiVersionPropertyName] = s_latestSupportedVersion.ToString();
         }
 
         return jsonObject;
@@ -91,10 +91,10 @@ internal class OpenApiDocumentParser : IOpenApiDocumentParser
 
     /// <summary>
     /// Converts YAML content to JSON content.
-    /// The method uses SharpYaml library that comes as a not-direct dependency of Microsoft.AopenAPI.NET library.
+    /// The method uses SharpYaml library that comes as a not-direct dependency of Microsoft.OpenAPI.NET library.
     /// Should be replaced later when there's more convenient way to convert YAML content to JSON one.
     /// </summary>
-    /// <param name="stream">The JAML/JSON content stream.</param>
+    /// <param name="stream">The YAML/JSON content stream.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>JSON content stream.</returns>
     private static async Task<JsonObject?> ConvertContentToJsonAsync(Stream stream, CancellationToken cancellationToken = default)
@@ -371,7 +371,7 @@ internal class OpenApiDocumentParser : IOpenApiDocumentParser
     /// <summary>
     /// Name of property that contains OpenAPI document version.
     /// </summary>
-    private const string OpenApiVersionPropetyName = "openapi";
+    private const string OpenApiVersionPropertyName = "openapi";
 
     #endregion
 }

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 using Microsoft.SemanticKernel.Skills.OpenAPI.OpenApi;
 using SemanticKernel.Skills.UnitTests.OpenAPI.TestSkills;

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 using Microsoft.SemanticKernel.Skills.OpenAPI.OpenApi;
 using SemanticKernel.Skills.UnitTests.OpenAPI.TestSkills;

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Model;
 using Microsoft.SemanticKernel.Skills.OpenAPI.OpenApi;
 using SemanticKernel.Skills.UnitTests.OpenAPI.TestSkills;

--- a/samples/dotnet/kernel-syntax-examples/Example21_ChatGPTPlugins.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example21_ChatGPTPlugins.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using RepoUtils;
 
 // ReSharper disable once InconsistentNaming

--- a/samples/dotnet/kernel-syntax-examples/Example22_OpenApiSkill.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example22_OpenApiSkill.cs
@@ -6,7 +6,6 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Skills;
 using RepoUtils;
 


### PR DESCRIPTION
* Extension methods: use the same namespace of the class being extended
* Fix typos
* Removed unused vars and params
* Use correct cancellation token