### PR TITLE
Fix <elseif> prompt error in Integration Tests

### DIFF
--- a/dotnet/src/SemanticKernel/CoreSkills/SemanticFunctionConstants.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/SemanticFunctionConstants.cs
@@ -100,9 +100,10 @@ To create a plan, follow these steps:
 7. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FunctionName} ... appendToResult: ""RESULT__$<UNIQUE_RESULT_KEY>""/>
 8. Only use ""if"" and ""else"" tags
 9. ""if"" and ""else"" tags must be closed
-10. Comparison operators must be literals.
-11. Append an ""END"" XML comment at the end of the plan.
-12. Use only the [AVAILABLE FUNCTIONS].
+10. Don't use <elseif> use <if> instead
+11. Comparison operators must be literals.
+12. Append an ""END"" XML comment at the end of the plan.
+13. Use only the [AVAILABLE FUNCTIONS].
 
 [AVAILABLE FUNCTIONS]
 


### PR DESCRIPTION
### Motivation and Context

GPT-3 Planner was generating elseif tags for the commented Integration Tests "goal"

### Description
Changed planner prompt to avoid GPT-3 generating <elseif> unsupported tags and improved the Integration tests to output what was the plan on failure.

Updated the test also to check for minimum instead of equals.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

