### PR TITLE
Add customizable metadata field to MemoryRecord and memory retrieval with embeddings is optional

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
@@ -119,7 +119,7 @@ public class CosmosMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc />
-    public async Task<MemoryRecord?> GetAsync(string collectionName, string key, CancellationToken cancel = default)
+    public async Task<MemoryRecord?> GetAsync(string collectionName, string key, bool withEmbedding = false, CancellationToken cancel = default)
     {
         var id = this.ToCosmosFriendlyId(key);
         var partitionKey = PartitionKey.None;
@@ -141,7 +141,7 @@ public class CosmosMemoryStore : IMemoryStore
         {
             var result = response.Resource;
 
-            var vector = System.Text.Json.JsonSerializer.Deserialize<float[]>(result.EmbeddingString);
+            float[]? vector = withEmbedding ? System.Text.Json.JsonSerializer.Deserialize<float[]>(result.EmbeddingString) : System.Array.Empty<float>();
 
             if (vector != null)
             {
@@ -157,12 +157,12 @@ public class CosmosMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys,
+    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         foreach (var key in keys)
         {
-            var record = await this.GetAsync(collectionName, key, cancel);
+            var record = await this.GetAsync(collectionName, key, withEmbeddings, cancel);
 
             if (record != null)
             {
@@ -241,6 +241,7 @@ public class CosmosMemoryStore : IMemoryStore
         Embedding<float> embedding,
         int limit,
         double minRelevanceScore = 0,
+        bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         {
@@ -252,15 +253,16 @@ public class CosmosMemoryStore : IMemoryStore
             var collectionMemories = new List<MemoryRecord>();
             TopNCollection<MemoryRecord> embeddings = new(limit);
 
-            await foreach (var entry in this.GetAllAsync(collectionName, cancel))
+            await foreach (var record in this.GetAllAsync(collectionName, cancel))
             {
-                if (entry != null)
+                if (record != null)
                 {
                     double similarity = embedding
                         .AsReadOnlySpan()
-                        .CosineSimilarity(entry.Embedding.AsReadOnlySpan());
+                        .CosineSimilarity(record.Embedding.AsReadOnlySpan());
                     if (similarity >= minRelevanceScore)
                     {
+                        var entry = withEmbeddings ? record : MemoryRecord.FromMetadata(record.Metadata, Embedding<float>.Empty, record.Key, record.Timestamp);
                         embeddings.Add(new(entry, similarity));
                     }
                 }
@@ -276,7 +278,7 @@ public class CosmosMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc/>
-    public async Task<(MemoryRecord, double)?> GetNearestMatchAsync(string collectionName, Embedding<float> embedding, double minRelevanceScore = 0,
+    public async Task<(MemoryRecord, double)?> GetNearestMatchAsync(string collectionName, Embedding<float> embedding, double minRelevanceScore = 0, bool withEmbedding = false,
         CancellationToken cancel = default)
     {
         return await this.GetNearestMatchesAsync(
@@ -284,6 +286,7 @@ public class CosmosMemoryStore : IMemoryStore
             embedding: embedding,
             limit: 1,
             minRelevanceScore: minRelevanceScore,
+            withEmbeddings: withEmbedding,
             cancel: cancel).FirstOrDefaultAsync(cancellationToken: cancel);
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
@@ -66,9 +66,9 @@ internal class GetVectorsRequest
         return this;
     }
 
-    public GetVectorsRequest WithVectors(bool withVectors)
+    public GetVectorsRequest WithVectors(bool withEmbeddings)
     {
-        this.WithVector = withVectors;
+        this.WithVector = withEmbeddings;
         return this;
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
@@ -80,9 +80,9 @@ internal class SearchVectorsRequest : IValidatable
         return this;
     }
 
-    public SearchVectorsRequest IncludeVectorData()
+    public SearchVectorsRequest IncludeVectorData(bool withVector)
     {
-        this.WithVector = true;
+        this.WithVector = withVector;
         return this;
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
@@ -23,7 +23,7 @@ internal class SearchVectorsResponse : QdrantResponse
         public Dictionary<string, object> Payload { get; set; }
 
         [JsonPropertyName("vector")]
-        public IEnumerable<float> Vector { get; }
+        public IEnumerable<float>? Vector { get; }
 
         [JsonConstructor]
         public ScoredPoint(string id, double? score, Dictionary<string, object> payload, IEnumerable<float> vector)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
@@ -63,6 +63,7 @@ public interface IQdrantVectorDbClient
     /// <param name="target">The vector to compare the collection's vectors with.</param>
     /// <param name="threshold">The minimum relevance threshold for returned results.</param>
     /// <param name="top">The maximum number of similarity results to return.</param>
+    /// <param name="withVectors">Whether to include the vector data in the returned results.</param>
     /// <param name="requiredTags">Qdrant tags used to filter the results.</param>
     /// <param name="cancel">Cancellation token.</param>
     public IAsyncEnumerable<(QdrantVectorRecord, double)> FindNearestInCollectionAsync(
@@ -70,6 +71,7 @@ public interface IQdrantVectorDbClient
         IEnumerable<float> target,
         double threshold,
         int top = 1,
+        bool withVectors = false,
         IEnumerable<string>? requiredTags = null,
         CancellationToken cancel = default);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
@@ -16,9 +16,10 @@ public interface IQdrantVectorDbClient
     /// </summary>
     /// <param name="collectionName">The name assigned to the collection of vectors.</param>
     /// <param name="pointIds">The unique IDs used to index Qdrant vector entries.</param>
+    /// <param name="withVectors">Whether to include the vector data in the returned results.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>An asynchronous list of Qdrant vectors records associated with the given IDs</returns>
-    public IAsyncEnumerable<QdrantVectorRecord> GetVectorsByIdAsync(string collectionName, IEnumerable<string> pointIds,
+    public IAsyncEnumerable<QdrantVectorRecord> GetVectorsByIdAsync(string collectionName, IEnumerable<string> pointIds, bool withVectors = false,
         CancellationToken cancel = default);
 
     /// <summary>
@@ -26,9 +27,10 @@ public interface IQdrantVectorDbClient
     /// </summary>
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="metadataId">The unique ID stored in a Qdrant vector entry's metadata.</param>
+    /// <param name="withVector">Whether to include the vector data in the returned result.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>The Qdrant vector record associated with the given ID if found, null if not.</returns>
-    public Task<QdrantVectorRecord?> GetVectorByPayloadIdAsync(string collectionName, string metadataId, CancellationToken cancel = default);
+    public Task<QdrantVectorRecord?> GetVectorByPayloadIdAsync(string collectionName, string metadataId, bool withVector = false, CancellationToken cancel = default);
 
     /// <summary>
     /// Delete vectors by their unique Qdrant IDs.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -180,9 +180,10 @@ public class QdrantMemoryStore : IMemoryStore
     /// <summary>
     /// Get a MemoryRecord from the Qdrant Vector database by pointId.
     /// </summary>
-    /// <param name="collectionName"></param>
-    /// <param name="pointId"></param>
-    /// <param name="cancel"></param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
+    /// <param name="pointId">The unique indexed ID associated with the Qdrant vector record to get.</param>
+    /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
+    /// <param name="cancel">Cancellation token.</param>
     /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
     public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, bool withEmbedding, CancellationToken cancel = default)
@@ -224,9 +225,10 @@ public class QdrantMemoryStore : IMemoryStore
     /// <summary>
     /// Get a MemoryRecord from the Qdrant Vector database by a group of pointIds.
     /// </summary>
-    /// <param name="collectionName"></param>
-    /// <param name="pointIds"></param>
-    /// <param name="cancel"></param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
+    /// <param name="pointIds">The unique indexed IDs associated with Qdrant vector records to get.</param>
+    /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
+    /// <param name="cancel">Cancellation token.</param>
     /// <returns></returns>
     public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, bool withEmbeddings,
         [EnumeratorCancellation] CancellationToken cancel = default)
@@ -268,9 +270,9 @@ public class QdrantMemoryStore : IMemoryStore
     /// <summary>
     /// Remove a MemoryRecord from the Qdrant Vector database by pointId.
     /// </summary>
-    /// <param name="collectionName"></param>
-    /// <param name="pointId"></param>
-    /// <param name="cancel"></param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
+    /// <param name="pointId">The unique indexed ID associated with the Qdrant vector record to remove.</param>
+    /// <param name="cancel">Cancellation token.</param>
     /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
     public async Task RemoveWithPointIdAsync(string collectionName, string pointId, CancellationToken cancel = default)
@@ -291,9 +293,9 @@ public class QdrantMemoryStore : IMemoryStore
     /// <summary>
     /// Remove a MemoryRecord from the Qdrant Vector database by a group of pointIds.
     /// </summary>
-    /// <param name="collectionName"></param>
-    /// <param name="pointIds"></param>
-    /// <param name="cancel"></param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
+    /// <param name="pointIds">The unique indexed IDs associated with the Qdrant vector records to remove.</param>
+    /// <param name="cancel">Cancellation token.</param>
     /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
     public async Task RemoveWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, CancellationToken cancel = default)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -164,12 +164,12 @@ public class QdrantMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys,
+    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, bool withEmbeddings,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         foreach (var key in keys)
         {
-            MemoryRecord? record = await this.GetAsync(collectionName, key, cancel);
+            MemoryRecord? record = await this.GetAsync(collectionName, key, withEmbeddings, cancel);
             if (record != null)
             {
                 yield return record;
@@ -185,7 +185,7 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="cancel"></param>
     /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
-    public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, CancellationToken cancel = default)
+    public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, bool withEmbedding, CancellationToken cancel = default)
     {
         try
         {
@@ -228,7 +228,7 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="pointIds"></param>
     /// <param name="cancel"></param>
     /// <returns></returns>
-    public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds,
+    public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, bool withEmbeddings,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         var vectorDataList = this._qdrantClient
@@ -317,6 +317,7 @@ public class QdrantMemoryStore : IMemoryStore
         Embedding<float> embedding,
         int limit,
         double minRelevanceScore = 0,
+        bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         var results = this._qdrantClient.FindNearestInCollectionAsync(
@@ -341,6 +342,7 @@ public class QdrantMemoryStore : IMemoryStore
         string collectionName,
         Embedding<float> embedding,
         double minRelevanceScore = 0,
+        bool withEmbedding = false,
         CancellationToken cancel = default)
     {
         var results = this.GetNearestMatchesAsync(
@@ -348,6 +350,7 @@ public class QdrantMemoryStore : IMemoryStore
             embedding: embedding,
             minRelevanceScore: minRelevanceScore,
             limit: 1,
+            withEmbeddings: withEmbedding,
             cancel: cancel);
 
         var record = await results.FirstOrDefaultAsync(cancellationToken: cancel);

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -130,11 +130,11 @@ public class QdrantMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc/>
-    public async Task<MemoryRecord?> GetAsync(string collectionName, string key, bool withEmbedding, CancellationToken cancel = default)
+    public async Task<MemoryRecord?> GetAsync(string collectionName, string key, bool withEmbedding = false, CancellationToken cancel = default)
     {
         try
         {
-            var vectorData = await this._qdrantClient.GetVectorByPayloadIdAsync(collectionName, key, cancel: cancel);
+            var vectorData = await this._qdrantClient.GetVectorByPayloadIdAsync(collectionName, key, withEmbedding, cancel: cancel);
             if (vectorData != null)
             {
                 return MemoryRecord.FromJson(
@@ -164,7 +164,7 @@ public class QdrantMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, bool withEmbeddings,
+    public async IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         foreach (var key in keys)
@@ -186,12 +186,12 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="cancel">Cancellation token.</param>
     /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
-    public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, bool withEmbedding, CancellationToken cancel = default)
+    public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, bool withEmbedding = false, CancellationToken cancel = default)
     {
         try
         {
             var vectorDataList = this._qdrantClient
-                .GetVectorsByIdAsync(collectionName, new[] { pointId }, cancel: cancel);
+                .GetVectorsByIdAsync(collectionName, new[] { pointId }, withEmbedding, cancel: cancel);
 
             var vectorData = await vectorDataList.FirstOrDefaultAsync(cancel);
 
@@ -230,11 +230,11 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns></returns>
-    public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, bool withEmbeddings,
+    public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         var vectorDataList = this._qdrantClient
-            .GetVectorsByIdAsync(collectionName, pointIds, cancel: cancel);
+            .GetVectorsByIdAsync(collectionName, pointIds, withEmbeddings, cancel: cancel);
 
         await foreach (var vectorData in vectorDataList)
         {
@@ -327,6 +327,7 @@ public class QdrantMemoryStore : IMemoryStore
             target: embedding.Vector,
             threshold: minRelevanceScore,
             top: limit,
+            withVectors: withEmbeddings,
             cancel: cancel);
 
         await foreach ((QdrantVectorRecord, double) result in results)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -130,7 +130,7 @@ public class QdrantMemoryStore : IMemoryStore
     }
 
     /// <inheritdoc/>
-    public async Task<MemoryRecord?> GetAsync(string collectionName, string key, CancellationToken cancel = default)
+    public async Task<MemoryRecord?> GetAsync(string collectionName, string key, bool withEmbedding, CancellationToken cancel = default)
     {
         try
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -21,178 +21,206 @@ internal struct DatabaseEntry
     public string? Timestamp { get; set; }
 }
 
-internal static class Database
+internal class Database
 {
     private const string TableName = "SKMemoryTable";
 
-    public static async Task<SqliteConnection> CreateConnectionAsync(string filename, CancellationToken cancel = default)
+    public Database() { }
+
+    public async Task CreateConnectionAsync(string connectionString, CancellationToken cancel = default)
     {
-        var connection = new SqliteConnection(@"Data Source={filename};");
-        await connection.OpenAsync(cancel);
-        await CreateTableAsync(connection, cancel);
-        return connection;
+        await using (var connection = new SqliteConnection(connectionString))
+        {
+            await connection.OpenAsync(cancel);
+            await this.CreateTableAsync(connection, cancel);
+        }
     }
 
-    public static async Task CreateCollectionAsync(this SqliteConnection conn, string collectionName, CancellationToken cancel = default)
+    public async Task CreateCollectionAsync(SqliteConnection conn, string collectionName, CancellationToken cancel = default)
     {
-        if (await DoesCollectionExistsAsync(conn, collectionName, cancel))
+        if (await this.DoesCollectionExistsAsync(conn, collectionName, cancel))
         {
             // Collection already exists
             return;
         }
 
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
              INSERT INTO {TableName}(collection)
              VALUES(@collection); ";
-        cmd.Parameters.AddWithValue("@collection", collectionName);
-        await cmd.ExecuteNonQueryAsync(cancel);
+            cmd.Parameters.AddWithValue("@collection", collectionName);
+            await cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 
-    public static async Task UpdateAsync(this SqliteConnection conn,
+    public async Task UpdateAsync(SqliteConnection conn,
         string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
              UPDATE {TableName}
              SET metadata=@metadata, embedding=@embedding, timestamp=@timestamp
              WHERE collection=@collection
                 AND key=@key ";
-        cmd.Parameters.AddWithValue("@collection", collection);
-        cmd.Parameters.AddWithValue("@key", key);
-        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
-        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
-        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
-        await cmd.ExecuteNonQueryAsync(cancel);
+            cmd.Parameters.AddWithValue("@collection", collection);
+            cmd.Parameters.AddWithValue("@key", key);
+            cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
+            cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
+            cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
+            await cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 
-    public static async Task InsertOrIgnoreAsync(this SqliteConnection conn,
+    public async Task InsertOrIgnoreAsync(SqliteConnection conn,
         string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
-             INSERT OR IGNORE INTO {TableName}(collection, key, value, timestamp)
-             VALUES(@collection, @key, @value, @timestamp); ";
-        cmd.Parameters.AddWithValue("@collection", collection);
-        cmd.Parameters.AddWithValue("@key", key);
-        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
-        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
-        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
-        await cmd.ExecuteNonQueryAsync(cancel);
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
+             INSERT OR IGNORE INTO {TableName}(collection, key, metadata, embedding, timestamp)
+             VALUES(@collection, @key, @metadata, @embedding, @timestamp); ";
+            cmd.Parameters.AddWithValue("@collection", collection);
+            cmd.Parameters.AddWithValue("@key", key);
+            cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
+            cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
+            cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
+            await cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 
-    public static async Task<bool> DoesCollectionExistsAsync(this SqliteConnection conn,
+    public async Task<bool> DoesCollectionExistsAsync(SqliteConnection conn,
         string collectionName,
         CancellationToken cancel = default)
     {
-        var collections = await GetCollectionsAsync(conn, cancel).ToListAsync(cancel);
+        var collections = await this.GetCollectionsAsync(conn, cancel).ToListAsync(cancel);
         return collections.Contains(collectionName);
     }
 
-    public static async IAsyncEnumerable<string> GetCollectionsAsync(this SqliteConnection conn,
+    public async IAsyncEnumerable<string> GetCollectionsAsync(SqliteConnection conn,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
             SELECT DISTINCT(collection)
             FROM {TableName}";
 
-        var dataReader = await cmd.ExecuteReaderAsync(cancel);
-        while (await dataReader.ReadAsync(cancel))
-        {
-            yield return dataReader.GetFieldValue<string>("collection");
+            await using (var dataReader = await cmd.ExecuteReaderAsync(cancel))
+            {
+                while (await dataReader.ReadAsync(cancel))
+                {
+                    yield return dataReader.GetFieldValue<string>("collection");
+                }
+            }
         }
     }
-
-    public static async IAsyncEnumerable<DatabaseEntry> ReadAllAsync(this SqliteConnection conn,
+    
+    public async IAsyncEnumerable<DatabaseEntry> ReadAllAsync(SqliteConnection conn,
         string collectionName,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
             SELECT * FROM {TableName}
             WHERE collection=@collection";
-        cmd.Parameters.AddWithValue("@collection", collectionName);
+            cmd.Parameters.AddWithValue("@collection", collectionName);
 
-        var dataReader = await cmd.ExecuteReaderAsync(cancel);
-        while (await dataReader.ReadAsync(cancel))
-        {
-            string key = dataReader.GetFieldValue<string>("key");
-            string metadata = dataReader.GetFieldValue<string>("metadata");
-            string embedding = dataReader.GetFieldValue<string>("embedding");
-            string timestamp = dataReader.GetFieldValue<string>("timestamp");
-            yield return new DatabaseEntry() { Key = key, MetadataString = metadata, EmbeddingString = embedding, Timestamp = timestamp };
+            await using (var dataReader = await cmd.ExecuteReaderAsync(cancel))
+            {
+                while (await dataReader.ReadAsync(cancel))
+                {
+                    string key = dataReader.GetFieldValue<string>("key");
+                    string metadata = dataReader.GetFieldValue<string>("metadata");
+                    string embedding = dataReader.GetFieldValue<string>("embedding");
+                    string timestamp = dataReader.GetFieldValue<string>("timestamp");
+                    yield return new DatabaseEntry() { Key = key, MetadataString = metadata, EmbeddingString = embedding, Timestamp = timestamp };
+                }
+            }
         }
     }
 
-    public static async Task<DatabaseEntry?> ReadAsync(this SqliteConnection conn,
+    public async Task<DatabaseEntry?> ReadAsync(SqliteConnection conn,
         string collectionName,
         string key,
         CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
              SELECT * FROM {TableName}
              WHERE collection=@collection
                 AND key=@key ";
-        cmd.Parameters.AddWithValue("@collection", collectionName);
-        cmd.Parameters.AddWithValue("@key", key);
+            cmd.Parameters.AddWithValue("@collection", collectionName);
+            cmd.Parameters.AddWithValue("@key", key);
 
-        var dataReader = await cmd.ExecuteReaderAsync(cancel);
-        if (await dataReader.ReadAsync(cancel))
-        {
-            string metadata = dataReader.GetString(dataReader.GetOrdinal("metadata"));
-            string embedding = dataReader.GetString(dataReader.GetOrdinal("embedding"));
-            string timestamp = dataReader.GetString(dataReader.GetOrdinal("timestamp"));
-            return new DatabaseEntry()
+            await using (var dataReader = await cmd.ExecuteReaderAsync(cancel))
             {
-                Key = key,
-                MetadataString = metadata,
-                EmbeddingString = embedding,
-                Timestamp = timestamp
-            };
-        }
+                if (await dataReader.ReadAsync(cancel))
+                {
+                    string metadata = dataReader.GetString(dataReader.GetOrdinal("metadata"));
+                    string embedding = dataReader.GetString(dataReader.GetOrdinal("embedding"));
+                    string timestamp = dataReader.GetString(dataReader.GetOrdinal("timestamp"));
+                    return new DatabaseEntry()
+                    {
+                        Key = key,
+                        MetadataString = metadata,
+                        EmbeddingString = embedding,
+                        Timestamp = timestamp
+                    };
+                }
 
-        return null;
+                return null;
+            }
+        }
     }
 
-    public static Task DeleteCollectionAsync(this SqliteConnection conn, string collectionName, CancellationToken cancel = default)
+    public Task DeleteCollectionAsync(SqliteConnection conn, string collectionName, CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
              DELETE FROM {TableName}
              WHERE collection=@collection";
-        cmd.Parameters.AddWithValue("@collection", collectionName);
-        return cmd.ExecuteNonQueryAsync(cancel);
+            cmd.Parameters.AddWithValue("@collection", collectionName);
+            return cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 
-    public static Task DeleteAsync(this SqliteConnection conn, string collectionName, string key, CancellationToken cancel = default)
+    public Task DeleteAsync(SqliteConnection conn, string collectionName, string key, CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
              DELETE FROM {TableName}
              WHERE collection=@collection
                 AND key=@key ";
-        cmd.Parameters.AddWithValue("@collection", collectionName);
-        cmd.Parameters.AddWithValue("@key", key);
-        return cmd.ExecuteNonQueryAsync(cancel);
+            cmd.Parameters.AddWithValue("@collection", collectionName);
+            cmd.Parameters.AddWithValue("@key", key);
+            return cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 
-    public static Task DeleteEmptyAsync(this SqliteConnection conn, string collectionName, CancellationToken cancel = default)
+    public Task DeleteEmptyAsync(SqliteConnection conn, string collectionName, CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
              DELETE FROM {TableName}
              WHERE collection=@collection
                 AND key IS NULL";
-        cmd.Parameters.AddWithValue("@collection", collectionName);
-        return cmd.ExecuteNonQueryAsync(cancel);
+            cmd.Parameters.AddWithValue("@collection", collectionName);
+            return cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 
-    private static Task CreateTableAsync(SqliteConnection conn, CancellationToken cancel = default)
+    private Task CreateTableAsync(SqliteConnection conn, CancellationToken cancel = default)
     {
-        SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
+        using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $@"
             CREATE TABLE IF NOT EXISTS {TableName}(
                 collection TEXT,
                 key TEXT,
@@ -200,6 +228,7 @@ internal static class Database
                 embedding TEXT,
                 timestamp TEXT,
                 PRIMARY KEY(collection, key))";
-        return cmd.ExecuteNonQueryAsync(cancel);
+            return cmd.ExecuteNonQueryAsync(cancel);
+        }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -26,13 +26,20 @@ internal class Database
     private const string TableName = "SKMemoryTable";
 
     public Database() { }
-
-    public async Task CreateConnectionAsync(string connectionString, CancellationToken cancel = default)
+    
+    public Task CreateTableAsync(SqliteConnection conn, CancellationToken cancel = default)
     {
-        await using (var connection = new SqliteConnection(connectionString))
+        using (SqliteCommand cmd = conn.CreateCommand())
         {
-            await connection.OpenAsync(cancel);
-            await this.CreateTableAsync(connection, cancel);
+            cmd.CommandText = $@"
+            CREATE TABLE IF NOT EXISTS {TableName}(
+                collection TEXT,
+                key TEXT,
+                metadata TEXT,
+                embedding TEXT,
+                timestamp TEXT,
+                PRIMARY KEY(collection, key))";
+            return cmd.ExecuteNonQueryAsync(cancel);
         }
     }
 
@@ -212,22 +219,6 @@ internal class Database
              WHERE collection=@collection
                 AND key IS NULL";
             cmd.Parameters.AddWithValue("@collection", collectionName);
-            return cmd.ExecuteNonQueryAsync(cancel);
-        }
-    }
-
-    private Task CreateTableAsync(SqliteConnection conn, CancellationToken cancel = default)
-    {
-        using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
-            CREATE TABLE IF NOT EXISTS {TableName}(
-                collection TEXT,
-                key TEXT,
-                metadata TEXT,
-                embedding TEXT,
-                timestamp TEXT,
-                PRIMARY KEY(collection, key))";
             return cmd.ExecuteNonQueryAsync(cancel);
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -17,7 +17,7 @@ internal struct DatabaseEntry
     public string MetadataString { get; set; }
 
     public string EmbeddingString { get; set; }
-    
+
     public string? Timestamp { get; set; }
 }
 
@@ -116,7 +116,7 @@ internal class Database
             }
         }
     }
-    
+
     public async IAsyncEnumerable<DatabaseEntry> ReadAllAsync(SqliteConnection conn,
         string collectionName,
         [EnumeratorCancellation] CancellationToken cancel = default)

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
@@ -269,11 +269,12 @@ public class SqliteMemoryStore : IMemoryStore, IDisposable
 
         await foreach (DatabaseEntry dbEntry in this._dbConnection.ReadAllAsync(collectionName, cancel))
         {
-            var record = JsonSerializer.Deserialize<MemoryRecord>(dbEntry.ValueString);
-            if (record != null)
-            {
-                yield return record;
-            }
+            float[]? vector = JsonSerializer.Deserialize<float[]>(dbEntry.EmbeddingString);
+            
+            var record = MemoryRecord.FromJson(dbEntry.MetadataString,
+                vector != null ? new Embedding<float>(vector) : Embedding<float>.Empty);
+            
+            yield return record;
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
@@ -53,7 +53,7 @@ public class SqliteMemoryStore : IMemoryStore
     /// <inheritdoc/>
     public async Task<bool> DoesCollectionExistAsync(string collectionName, CancellationToken cancel = default)
     {
-        await using(var connection = new SqliteConnection(this._dbConnectionString))
+        await using (var connection = new SqliteConnection(this._dbConnectionString))
         {
             await connection.OpenAsync(cancel);
             return await this._dbConnector.DoesCollectionExistsAsync(connection, collectionName, cancel);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
@@ -233,9 +233,9 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, false, It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
+            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, false, It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.True(Guid.TryParse(guidString, out _));
@@ -254,7 +254,7 @@ public class QdrantMemoryStoreTests
 
         var qdrantVectorRecord = QdrantVectorRecord.FromJson(
             Guid.NewGuid().ToString(),
-            memoryRecord.Embedding.Vector,
+            Array.Empty<float>(),
             memoryRecord.GetSerializedMetadata());
 
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
@@ -266,11 +266,11 @@ public class QdrantMemoryStoreTests
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), false, It.IsAny<CancellationToken>()))
             .Returns(new[] { qdrantVectorRecord }.ToAsyncEnumerable());
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), false, It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()));
@@ -285,9 +285,9 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, false, It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorsByIdAsync("test_collection", It.IsAny<IEnumerable<string>>(), false, It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
             x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
@@ -309,7 +309,7 @@ public class QdrantMemoryStoreTests
 
         var qdrantVectorRecord = QdrantVectorRecord.FromJson(
             memoryRecord.Key,
-            memoryRecord.Embedding.Vector,
+            Array.Empty<float>(),
             memoryRecord.GetSerializedMetadata());
 
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
@@ -336,9 +336,9 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, false, It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
+            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, false, It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.True(Guid.TryParse(guidString, out _));
@@ -388,11 +388,11 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, false, It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord2.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord2.Metadata.Id, false, It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord3.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord3.Metadata.Id, false, It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
 

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
@@ -141,11 +141,11 @@ public class QdrantMemoryStoreTests
             .Setup<Task<bool>>(x => x.DoesCollectionExistAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()))
@@ -172,11 +172,11 @@ public class QdrantMemoryStoreTests
             .Setup<Task<bool>>(x => x.DoesCollectionExistAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()));
@@ -214,11 +214,11 @@ public class QdrantMemoryStoreTests
             .Setup<Task<bool>>(x => x.DoesCollectionExistAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()));
@@ -233,9 +233,9 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<CancellationToken>()), Times.Never());
+            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.True(Guid.TryParse(guidString, out _));
@@ -262,15 +262,15 @@ public class QdrantMemoryStoreTests
             .Setup<Task<bool>>(x => x.DoesCollectionExistAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(new[] { qdrantVectorRecord }.ToAsyncEnumerable());
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()));
@@ -285,11 +285,11 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorsByIdAsync("test_collection", It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.True(Guid.TryParse(guidString, out _));
@@ -317,11 +317,11 @@ public class QdrantMemoryStoreTests
             .Setup<Task<bool>>(x => x.DoesCollectionExistAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()));
@@ -336,9 +336,9 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<CancellationToken>()), Times.Never());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<CancellationToken>()), Times.Never());
+            x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.True(Guid.TryParse(guidString, out _));
@@ -369,11 +369,11 @@ public class QdrantMemoryStoreTests
         mockQdrantClient
             .Setup<Task>(x => x.CreateCollectionAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()));
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
         mockQdrantClient
             .Setup<Task>(x => x.UpsertVectorsAsync(It.IsAny<string>(), It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()));
@@ -388,18 +388,18 @@ public class QdrantMemoryStoreTests
             .Verify<Task<bool>>(x => x.DoesCollectionExistAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task>(x => x.CreateCollectionAsync("test_collection", It.IsAny<CancellationToken>()), Times.Never());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord2.Metadata.Id, It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord2.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord3.Metadata.Id, It.IsAny<CancellationToken>()), Times.Once());
+            x => x.GetVectorByPayloadIdAsync("test_collection", memoryRecord3.Metadata.Id, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
         mockQdrantClient.Verify<Task>(x => x.UpsertVectorsAsync("test_collection", It.IsAny<IEnumerable<QdrantVectorRecord>>(), It.IsAny<CancellationToken>()),
             Times.Once());
 
         foreach (var guidString in keys)
         {
             mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-                x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<CancellationToken>()), Times.Once());
+                x => x.GetVectorsByIdAsync("test_collection", new[] { guidString }, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
             Assert.True(Guid.TryParse(guidString, out _));
         }
     }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests2.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests2.cs
@@ -43,16 +43,16 @@ public class QdrantMemoryStoreTests2
 
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getResult = await vectorStore.GetAsync("test_collection", this._id);
-
+        var getResult = await vectorStore.GetAsync("test_collection", this._id, false);
+        
         // Assert
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.Null(getResult);
     }
@@ -76,16 +76,16 @@ public class QdrantMemoryStoreTests2
 
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord);
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getResult = await vectorStore.GetAsync("test_collection", this._id);
+        var getResult = await vectorStore.GetAsync("test_collection", this._id, true);
 
         // Assert
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.NotNull(getResult);
         Assert.Equal(memoryRecord.Metadata.Id, getResult.Metadata.Id);
@@ -135,29 +135,29 @@ public class QdrantMemoryStoreTests2
 
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id2, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id2, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord2);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id3, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id3, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord3);
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getBatchResult = await vectorStore.GetBatchAsync("test_collection", new List<string> { this._id, this._id2, this._id3 }).ToListAsync();
+        var getBatchResult = await vectorStore.GetBatchAsync("test_collection", new List<string> { this._id, this._id2, this._id3 }, false).ToListAsync();
 
         // Assert
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            x => x.GetVectorByPayloadIdAsync("test_collection", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Exactly(3));
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id2, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id2, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id3, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id3, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
 
         Assert.NotNull(getBatchResult);
@@ -200,29 +200,29 @@ public class QdrantMemoryStoreTests2
 
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id2, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id2, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(qdrantVectorRecord2);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id3, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id3, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getBatchResult = await vectorStore.GetBatchAsync("test_collection", new List<string> { this._id, this._id2, this._id3 }).ToListAsync();
+        var getBatchResult = await vectorStore.GetBatchAsync("test_collection", new List<string> { this._id, this._id2, this._id3 }, false).ToListAsync();
 
         // Assert
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            x => x.GetVectorByPayloadIdAsync("test_collection", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Exactly(3));
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id2, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id2, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id3, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id3, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.NotNull(getBatchResult);
         Assert.NotEmpty(getBatchResult);
@@ -239,29 +239,29 @@ public class QdrantMemoryStoreTests2
         // Arrange
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id2, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id2, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
         mockQdrantClient
-            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id3, It.IsAny<CancellationToken>()))
+            .Setup<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync(It.IsAny<string>(), this._id3, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QdrantVectorRecord?)null);
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getBatchResult = await vectorStore.GetBatchAsync("test_collection", new List<string> { this._id, this._id2, this._id3 }).ToListAsync();
+        var getBatchResult = await vectorStore.GetBatchAsync("test_collection", new List<string> { this._id, this._id2, this._id3 }, false).ToListAsync();
 
         // Assert
         mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(
-            x => x.GetVectorByPayloadIdAsync("test_collection", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            x => x.GetVectorByPayloadIdAsync("test_collection", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Exactly(3));
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id2, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id2, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
-        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id3, It.IsAny<CancellationToken>()),
+        mockQdrantClient.Verify<Task<QdrantVectorRecord?>>(x => x.GetVectorByPayloadIdAsync("test_collection", this._id3, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.NotNull(getBatchResult);
         Assert.Empty(getBatchResult);
@@ -276,17 +276,17 @@ public class QdrantMemoryStoreTests2
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getResult = await vectorStore.GetWithPointIdAsync("test_collection", key);
+        var getResult = await vectorStore.GetWithPointIdAsync("test_collection", key, false);
 
         // Assert
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { key }, It.IsAny<CancellationToken>()),
+            x => x.GetVectorsByIdAsync("test_collection", new[] { key }, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
         Assert.Null(getResult);
     }
@@ -311,17 +311,17 @@ public class QdrantMemoryStoreTests2
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(new[] { qdrantVectorRecord }.ToAsyncEnumerable());
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getResult = await vectorStore.GetWithPointIdAsync("test_collection", memoryRecord.Key);
+        var getResult = await vectorStore.GetWithPointIdAsync("test_collection", memoryRecord.Key, true);
 
         // Assert
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(
-            x => x.GetVectorsByIdAsync("test_collection", new[] { memoryRecord.Key }, It.IsAny<CancellationToken>()),
+            x => x.GetVectorsByIdAsync("test_collection", new[] { memoryRecord.Key }, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once());
 
         Assert.NotNull(getResult);
@@ -373,17 +373,17 @@ public class QdrantMemoryStoreTests2
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(new[] { qdrantVectorRecord, qdrantVectorRecord2, qdrantVectorRecord3 }.ToAsyncEnumerable());
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getBatchResult = await vectorStore.GetWithPointIdBatchAsync("test_collection", new List<string> { key, key2, key3 }).ToListAsync();
+        var getBatchResult = await vectorStore.GetWithPointIdBatchAsync("test_collection", new List<string> { key, key2, key3 }, false).ToListAsync();
 
         // Assert
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-            x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Once());
+            x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
 
         Assert.NotNull(getBatchResult);
         Assert.NotEmpty(getBatchResult);
@@ -407,17 +407,17 @@ public class QdrantMemoryStoreTests2
         var mockQdrantClient = new Mock<IQdrantVectorDbClient>();
         mockQdrantClient
             .Setup<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<QdrantVectorRecord>());
 
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var getBatchResult = await vectorStore.GetWithPointIdBatchAsync("test_collection", new List<string> { key, key2, key3 }).ToListAsync();
+        var getBatchResult = await vectorStore.GetWithPointIdBatchAsync("test_collection", new List<string> { key, key2, key3 }, false).ToListAsync();
 
         // Assert
         mockQdrantClient.Verify<IAsyncEnumerable<QdrantVectorRecord>>(x =>
-            x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Once());
+            x.GetVectorsByIdAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once());
 
         Assert.Empty(getBatchResult);
     }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests3.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests3.cs
@@ -34,6 +34,7 @@ public class QdrantMemoryStoreTests3
                 It.IsAny<IEnumerable<float>>(),
                 It.IsAny<double>(),
                 It.IsAny<int>(),
+                It.IsAny<bool>(),
                 null,
                 It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<(QdrantVectorRecord, double)>());
@@ -52,6 +53,7 @@ public class QdrantMemoryStoreTests3
                 It.IsAny<IEnumerable<float>>(),
                 It.IsAny<double>(),
                 It.IsAny<int>(),
+                It.IsAny<bool>(),
                 null,
                 It.IsAny<CancellationToken>()),
             Times.Once());
@@ -84,6 +86,7 @@ public class QdrantMemoryStoreTests3
                 It.IsAny<IEnumerable<float>>(),
                 It.IsAny<double>(),
                 It.IsAny<int>(),
+                It.IsAny<bool>(),
                 null,
                 It.IsAny<CancellationToken>()))
             .Returns(new[] { (qdrantVectorRecord, 0.5) }.ToAsyncEnumerable());
@@ -102,6 +105,7 @@ public class QdrantMemoryStoreTests3
                 It.IsAny<IEnumerable<float>>(),
                 It.IsAny<double>(),
                 It.IsAny<int>(),
+                It.IsAny<bool>(),
                 null,
                 It.IsAny<CancellationToken>()),
             Times.Once());
@@ -124,6 +128,7 @@ public class QdrantMemoryStoreTests3
                 It.IsAny<IEnumerable<float>>(),
                 It.IsAny<double>(),
                 It.IsAny<int>(),
+                It.IsAny<bool>(),
                 null,
                 It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<(QdrantVectorRecord, double)>());

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Sqlite/SqliteMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Sqlite/SqliteMemoryStoreTests.cs
@@ -20,7 +20,7 @@ namespace SemanticKernel.Connectors.UnitTests.Memory.Sqlite;
 public class SqliteMemoryStoreTests : IDisposable
 {
     private const string DatabaseFile = "SqliteMemoryStoreTests.db";
-    
+
     public SqliteMemoryStoreTests()
     {
         if (File.Exists(DatabaseFile))
@@ -70,7 +70,7 @@ public class SqliteMemoryStoreTests : IDisposable
     [Fact]
     public async Task InitializeDbConnectionSucceedsAsync()
     {
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         // Assert
         Assert.NotNull(db);
     }
@@ -79,7 +79,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanCreateAndGetCollectionAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
 
@@ -96,7 +96,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanCheckIfCollectionExistsAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string collection = "my_collection";
         this._collectionNum++;
 
@@ -112,7 +112,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task CreatingDuplicateCollectionDoesNothingAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
 
@@ -130,7 +130,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task CollectionsCanBeDeletedAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
         await db.CreateCollectionAsync(collection);
@@ -152,7 +152,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanInsertIntoNonExistentCollectionAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         MemoryRecord testRecord = MemoryRecord.LocalRecord(
             id: "test",
             text: "text",
@@ -180,7 +180,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task GetAsyncReturnsEmptyEmbeddingUnlessSpecifiedAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         MemoryRecord testRecord = MemoryRecord.LocalRecord(
             id: "test",
             text: "text",
@@ -208,7 +208,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanUpsertAndRetrieveARecordWithNoTimestampAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         MemoryRecord testRecord = MemoryRecord.LocalRecord(
             id: "test",
             text: "text",
@@ -239,7 +239,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanUpsertAndRetrieveARecordWithTimestampAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         MemoryRecord testRecord = MemoryRecord.LocalRecord(
             id: "test",
             text: "text",
@@ -270,7 +270,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task UpsertReplacesExistingRecordWithSameIdAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string commonId = "test";
         MemoryRecord testRecord = MemoryRecord.LocalRecord(
             id: commonId,
@@ -305,7 +305,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ExistingRecordCanBeRemovedAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         MemoryRecord testRecord = MemoryRecord.LocalRecord(
             id: "test",
             text: "text",
@@ -328,7 +328,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task RemovingNonExistingRecordDoesNothingAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
 
@@ -345,7 +345,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanListAllDatabaseCollectionsAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string[] testCollections = { "random_collection1", "random_collection2", "random_collection3" };
         this._collectionNum += 3;
         await db.CreateCollectionAsync(testCollections[0]);
@@ -378,7 +378,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task GetNearestMatchesReturnsAllResultsWithNoMinScoreAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         var compareEmbedding = new Embedding<float>(new float[] { 1, 1, 1 });
         int topN = 4;
         string collection = "test_collection" + this._collectionNum;
@@ -441,7 +441,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task GetNearestMatchAsyncReturnsEmptyEmbeddingUnlessSpecifiedAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         var compareEmbedding = new Embedding<float>(new float[] { 1, 1, 1 });
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -502,7 +502,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task GetNearestMatchAsyncReturnsExpectedAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         var compareEmbedding = new Embedding<float>(new float[] { 1, 1, 1 });
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -561,7 +561,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task GetNearestMatchesDifferentiatesIdenticalVectorsByKeyAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         var compareEmbedding = new Embedding<float>(new float[] { 1, 1, 1 });
         int topN = 4;
         string collection = "test_collection" + this._collectionNum;
@@ -597,7 +597,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanBatchUpsertRecordsAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         int numRecords = 10;
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -618,7 +618,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanBatchGetRecordsAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         int numRecords = 10;
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -639,7 +639,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task ItCanBatchRemoveRecordsAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         int numRecords = 10;
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -667,7 +667,7 @@ public class SqliteMemoryStoreTests : IDisposable
     public async Task DeletingNonExistentCollectionDoesNothingAsync()
     {
         // Arrange
-        SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
+        using SqliteMemoryStore db = await SqliteMemoryStore.ConnectAsync(DatabaseFile);
         string collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
 

--- a/dotnet/src/SemanticKernel.UnitTests/Memory/MemoryRecordTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/MemoryRecordTests.cs
@@ -15,6 +15,7 @@ public class MemoryRecordTests
     private readonly string _text = "text";
     private readonly string _description = "description";
     private readonly string _externalSourceName = "externalSourceName";
+    private readonly string _valueString = "value";
     private readonly Embedding<float> _embedding = new Embedding<float>(new float[] { 1, 2, 3 });
 
     [Fact]
@@ -26,7 +27,8 @@ public class MemoryRecordTests
             id: this._id,
             text: this._text,
             description: this._description,
-            externalSourceName: this._externalSourceName);
+            externalSourceName: this._externalSourceName,
+            valueString: this._valueString);
 
         // Act
         var memoryRecord = new MemoryRecord(metadata, this._embedding, "key", DateTimeOffset.Now);
@@ -87,7 +89,8 @@ public class MemoryRecordTests
             ""id"": ""Id"",
             ""text"": ""text"",
             ""description"": ""description"",
-            ""external_source_name"": ""externalSourceName""
+            ""external_source_name"": ""externalSourceName"",
+            ""value_string"": ""value""
         }";
 
         // Act
@@ -99,6 +102,7 @@ public class MemoryRecordTests
         Assert.Equal(this._text, memoryRecord.Metadata.Text);
         Assert.Equal(this._description, memoryRecord.Metadata.Description);
         Assert.Equal(this._externalSourceName, memoryRecord.Metadata.ExternalSourceName);
+        Assert.Equal(this._valueString, memoryRecord.Metadata.ValueString);
         Assert.Equal(this._embedding.Vector, memoryRecord.Embedding.Vector);
     }
 
@@ -112,7 +116,8 @@ public class MemoryRecordTests
                 ""id"": ""Id"",
                 ""text"": ""text"",
                 ""description"": ""description"",
-                ""external_source_name"": ""externalSourceName""
+                ""external_source_name"": ""externalSourceName"",
+                ""value_string"": ""value""
             },
             ""embedding"": {
                 ""vector"": [
@@ -132,6 +137,7 @@ public class MemoryRecordTests
         Assert.Equal(this._id, memoryRecord.Metadata.Id);
         Assert.Equal(this._text, memoryRecord.Metadata.Text);
         Assert.Equal(this._description, memoryRecord.Metadata.Description);
+        Assert.Equal(this._externalSourceName, memoryRecord.Metadata.ExternalSourceName);
         Assert.Equal(this._externalSourceName, memoryRecord.Metadata.ExternalSourceName);
         Assert.Equal(this._embedding.Vector, memoryRecord.Embedding.Vector);
     }
@@ -153,7 +159,8 @@ public class MemoryRecordTests
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"": ""value""
             },
             ""key"": ""key"",
             ""timestamp"": null
@@ -163,7 +170,8 @@ public class MemoryRecordTests
             id: this._id,
             text: this._text,
             description: this._description,
-            externalSourceName: this._externalSourceName);
+            externalSourceName: this._externalSourceName,
+            valueString: this._valueString);
         var memoryRecord = new MemoryRecord(metadata, this._embedding, "key");
 
         // Act
@@ -184,7 +192,8 @@ public class MemoryRecordTests
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"": ""value""
             }";
 
         var metadata = new MemoryRecordMetadata(
@@ -192,7 +201,8 @@ public class MemoryRecordTests
             id: this._id,
             text: this._text,
             description: this._description,
-            externalSourceName: this._externalSourceName);
+            externalSourceName: this._externalSourceName,
+            valueString: this._valueString);
         var memoryRecord = new MemoryRecord(metadata, this._embedding, "key");
 
         // Act

--- a/dotnet/src/SemanticKernel.UnitTests/Memory/VolatileMemoryStoreTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/VolatileMemoryStoreTests.cs
@@ -107,6 +107,34 @@ public class VolatileMemoryStoreTests
     }
 
     [Fact]
+    public async Task GetRecordReturnsEmptyEmbeddingUnlessSpecifiedAsync()
+    {
+        // Arrange
+        MemoryRecord testRecord = MemoryRecord.LocalRecord(
+            id: "test",
+            text: "text",
+            description: "description",
+            embedding: new Embedding<float>(new float[] { 1, 2, 3 }),
+            key: null,
+            timestamp: null);
+        string collection = "test_collection" + this._collectionNum;
+        this._collectionNum++;
+
+        // Act
+        await this._db.CreateCollectionAsync(collection);
+        var key = await this._db.UpsertAsync(collection, testRecord);
+        var actualDefault = await this._db.GetAsync(collection, key);
+        var actualWithEmbedding = await this._db.GetAsync(collection, key, true);
+
+        // Assert
+        Assert.NotNull(actualDefault);
+        Assert.NotNull(actualWithEmbedding);
+        Assert.Empty(actualDefault.Embedding.Vector);
+        Assert.NotEqual(testRecord, actualDefault);
+        Assert.Equal(testRecord, actualWithEmbedding);
+    }
+
+    [Fact]
     public async Task ItCanUpsertAndRetrieveARecordWithNoTimestampAsync()
     {
         // Arrange
@@ -123,7 +151,7 @@ public class VolatileMemoryStoreTests
         // Act
         await this._db.CreateCollectionAsync(collection);
         var key = await this._db.UpsertAsync(collection, testRecord);
-        var actual = await this._db.GetAsync(collection, key);
+        var actual = await this._db.GetAsync(collection, key, true);
 
         // Assert
         Assert.NotNull(actual);
@@ -147,7 +175,7 @@ public class VolatileMemoryStoreTests
         // Act
         await this._db.CreateCollectionAsync(collection);
         var key = await this._db.UpsertAsync(collection, testRecord);
-        var actual = await this._db.GetAsync(collection, key);
+        var actual = await this._db.GetAsync(collection, key, true);
 
         // Assert
         Assert.NotNull(actual);
@@ -176,7 +204,7 @@ public class VolatileMemoryStoreTests
         await this._db.CreateCollectionAsync(collection);
         var key = await this._db.UpsertAsync(collection, testRecord);
         var key2 = await this._db.UpsertAsync(collection, testRecord2);
-        var actual = await this._db.GetAsync(collection, key);
+        var actual = await this._db.GetAsync(collection, key, true);
 
         // Assert
         Assert.NotNull(actual);

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/SKContextExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/SKContextExtensionsTests.cs
@@ -29,7 +29,7 @@ public class SKContextExtensionsTests
         var memory = new Mock<ISemanticTextMemory>();
         var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", "id", "description", "text"), 0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
-        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(asyncEnumerable);
 
         // Arrange GetAvailableFunctionsAsync parameters
@@ -42,7 +42,7 @@ public class SKContextExtensionsTests
 
         // Assert
         Assert.NotNull(result);
-        memory.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
+        memory.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -69,7 +69,7 @@ public class SKContextExtensionsTests
             0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
         var memory = new Mock<ISemanticTextMemory>();
-        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(asyncEnumerable);
 
         skills.Setup(x => x.HasFunction(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
@@ -131,7 +131,7 @@ public class SKContextExtensionsTests
                     externalSourceName: "sourceName"), relevance: 0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
         var memory = new Mock<ISemanticTextMemory>();
-        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(asyncEnumerable);
 
         skills.Setup(x => x.HasFunction(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
@@ -334,7 +334,7 @@ public class SKContextExtensionsTests
         var memory = new Mock<ISemanticTextMemory>();
         var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", "id", "description", "text"), 0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
-        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+        memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(asyncEnumerable);
 
         // Arrange GetAvailableFunctionsAsync parameters
@@ -347,7 +347,7 @@ public class SKContextExtensionsTests
 
         // Assert
         Assert.NotNull(result);
-        memory.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
+        memory.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/SKContextExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/SKContextExtensionsTests.cs
@@ -27,7 +27,7 @@ public class SKContextExtensionsTests
 
         // Arrange Mock Memory and Result
         var memory = new Mock<ISemanticTextMemory>();
-        var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", "id", "description", "text"), 0.8);
+        var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", "id", "description", "text", "value"), 0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
         memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(asyncEnumerable);
@@ -65,7 +65,7 @@ public class SKContextExtensionsTests
 
         // Arrange Mock Memory and Result
         var skills = new Mock<ISkillCollection>();
-        var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", functionView.ToFullyQualifiedName(), "description", "text"),
+        var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", functionView.ToFullyQualifiedName(), "description", "text", "value"),
             0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
         var memory = new Mock<ISemanticTextMemory>();
@@ -128,7 +128,7 @@ public class SKContextExtensionsTests
         var memoryQueryResult =
             new MemoryQueryResult(
                 new MemoryRecordMetadata(isReference: false, id: functionView.ToFullyQualifiedName(), text: "text", description: "description",
-                    externalSourceName: "sourceName"), relevance: 0.8);
+                    externalSourceName: "sourceName", valueString: "value"), relevance: 0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
         var memory = new Mock<ISemanticTextMemory>();
         memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
@@ -332,7 +332,7 @@ public class SKContextExtensionsTests
 
         // Arrange Mock Memory and Result
         var memory = new Mock<ISemanticTextMemory>();
-        var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", "id", "description", "text"), 0.8);
+        var memoryQueryResult = new MemoryQueryResult(new MemoryRecordMetadata(false, "sourceName", "id", "description", "text", "value"), 0.8);
         var asyncEnumerable = new[] { memoryQueryResult }.ToAsyncEnumerable();
         memory.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(asyncEnumerable);

--- a/dotnet/src/SemanticKernel/Memory/IMemoryStore.cs
+++ b/dotnet/src/SemanticKernel/Memory/IMemoryStore.cs
@@ -66,7 +66,7 @@ public interface IMemoryStore
     /// <summary>
     /// Gets a memory record from the data store. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of embedding.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="key">The unique id associated with the memory record to get.</param>
     /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
     /// <param name="cancel">Cancellation token.</param>

--- a/dotnet/src/SemanticKernel/Memory/IMemoryStore.cs
+++ b/dotnet/src/SemanticKernel/Memory/IMemoryStore.cs
@@ -8,52 +8,52 @@ using Microsoft.SemanticKernel.AI.Embeddings;
 namespace Microsoft.SemanticKernel.Memory;
 
 /// <summary>
-/// An interface for storing and retrieving indexed <see cref="MemoryRecord"/> objects in a datastore.
+/// An interface for storing and retrieving indexed <see cref="MemoryRecord"/> objects in a data store.
 /// </summary>
 public interface IMemoryStore
 {
     /// <summary>
-    /// Creates a new collection in the datastore.
+    /// Creates a new collection in the data store.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="cancel">Cancellation token.</param>
     Task CreateCollectionAsync(string collectionName, CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets all collection names in the datastore.
+    /// Gets all collection names in the data store.
     /// </summary>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>A group of collection names.</returns>
     IAsyncEnumerable<string> GetCollectionsAsync(CancellationToken cancel = default);
 
     /// <summary>
-    /// Determines if a collection exists in the datastore.
+    /// Determines if a collection exists in the data store.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>True if given collection exists, false if not.</returns>
     Task<bool> DoesCollectionExistAsync(string collectionName, CancellationToken cancel = default);
 
     /// <summary>
-    /// Deletes a collection from the datastore.
+    /// Deletes a collection from the data store.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="cancel">Cancellation token.</param>
     Task DeleteCollectionAsync(string collectionName, CancellationToken cancel = default);
 
     /// <summary>
-    /// Upserts a memory record into the datastore. Does not guarantee that the collection exists.
+    /// Upserts a memory record into the data store. Does not guarantee that the collection exists.
     ///     If the record already exists, it will be updated.
     ///     If the record does not exist, it will be created.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="record">The memory record to upsert.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>The unique identifier for the memory record.</returns>
     Task<string> UpsertAsync(string collectionName, MemoryRecord record, CancellationToken cancel = default);
 
     /// <summary>
-    /// Upserts a group of memory records into the datastore. Does not guarantee that the collection exists.
+    /// Upserts a group of memory records into the data store. Does not guarantee that the collection exists.
     ///     If the record already exists, it will be updated.
     ///     If the record does not exist, it will be created.
     /// </summary>
@@ -64,35 +64,37 @@ public interface IMemoryStore
     IAsyncEnumerable<string> UpsertBatchAsync(string collectionName, IEnumerable<MemoryRecord> records, CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets a memory record from the datastore. Does not guarantee that the collection exists.
+    /// Gets a memory record from the data store. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embedding.</param>
     /// <param name="key">The unique id associated with the memory record to get.</param>
+    /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>The memory record if found, otherwise null.</returns>
-    Task<MemoryRecord?> GetAsync(string collectionName, string key, CancellationToken cancel = default);
+    Task<MemoryRecord?> GetAsync(string collectionName, string key, bool withEmbedding = false, CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets a batch of memory records from the datastore. Does not guarantee that the collection exists.
+    /// Gets a batch of memory records from the data store. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embedding.</param>
     /// <param name="keys">The unique ids associated with the memory record to get.</param>
+    /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>The memory records associated with the unique keys provided.</returns>
-    IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, CancellationToken cancel = default);
+    IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, bool withEmbeddings = false, CancellationToken cancel = default);
 
     /// <summary>
-    /// Removes a memory record from the datastore. Does not guarantee that the collection exists.
+    /// Removes a memory record from the data store. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="key">The unique id associated with the memory record to remove.</param>
     /// <param name="cancel">Cancellation token.</param>
     Task RemoveAsync(string collectionName, string key, CancellationToken cancel = default);
 
     /// <summary>
-    /// Removes a batch of memory records from the datastore. Does not guarantee that the collection exists.
+    /// Removes a batch of memory records from the data store. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="keys">The unique ids associated with the memory record to remove.</param>
     /// <param name="cancel">Cancellation token.</param>
     Task RemoveBatchAsync(string collectionName, IEnumerable<string> keys, CancellationToken cancel = default);
@@ -100,10 +102,11 @@ public interface IMemoryStore
     /// <summary>
     /// Gets the nearest matches to the <see cref="Embedding"/> of type <see cref="float"/>. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
-    /// <param name="embedding">The <see cref="Embedding"/> to compare the collection's vectors with.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
+    /// <param name="embedding">The <see cref="Embedding"/> to compare the collection's embeddings with.</param>
     /// <param name="limit">The maximum number of similarity results to return.</param>
     /// <param name="minRelevanceScore">The minimum relevance threshold for returned results.</param>
+    /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
     /// <param name="cancel">Cancellation token.</param>
     /// <returns>A group of tuples where item1 is a <see cref="MemoryRecord"/> and item2 is its similarity score as a <see cref="double"/>.</returns>
     IAsyncEnumerable<(MemoryRecord, double)> GetNearestMatchesAsync(
@@ -111,19 +114,22 @@ public interface IMemoryStore
         Embedding<float> embedding,
         int limit,
         double minRelevanceScore = 0.0,
+        bool withEmbeddings = false,
         CancellationToken cancel = default);
 
     /// <summary>
     /// Gets the nearest match to the <see cref="Embedding"/> of type <see cref="float"/>. Does not guarantee that the collection exists.
     /// </summary>
-    /// <param name="collectionName">The name associated with a collection of vectors.</param>
-    /// <param name="embedding">The vector to compare the collection's vectors with.</param>
+    /// <param name="collectionName">The name associated with a collection of embeddings.</param>
+    /// <param name="embedding">The <see cref="Embedding"/> to compare the collection's embeddings with.</param>
     /// <param name="minRelevanceScore">The minimum relevance threshold for returned results.</param>
+    /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
     /// <param name="cancel">Cancellation token</param>
     /// <returns>A tuple consisting of the <see cref="MemoryRecord"/> and the similarity score as a <see cref="double"/>. Null if no nearest match found.</returns>
     Task<(MemoryRecord, double)?> GetNearestMatchAsync(
         string collectionName,
         Embedding<float> embedding,
         double minRelevanceScore = 0.0,
+        bool withEmbedding = false,
         CancellationToken cancel = default);
 }

--- a/dotnet/src/SemanticKernel/Memory/ISemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/ISemanticTextMemory.cs
@@ -20,7 +20,8 @@ public interface ISemanticTextMemory
     /// <param name="description">Optional description.</param>
     /// <param name="valueString">Optional value string for saving custom metadata.</param>
     /// <param name="cancel">Cancellation token.</param>
-    public Task SaveInformationAsync(
+    /// <returns>Unique identifier of the saved memory record.</returns>
+    public Task<string> SaveInformationAsync(
         string collection,
         string text,
         string id,
@@ -38,7 +39,8 @@ public interface ISemanticTextMemory
     /// <param name="description">Optional description.</param>
     /// <param name="valueString">Optional value string for saving custom metadata.</param>
     /// <param name="cancel">Cancellation token</param>
-    public Task SaveReferenceAsync(
+    /// <returns>Unique identifier of the saved memory record.</returns>
+    public Task<string> SaveReferenceAsync(
         string collection,
         string text,
         string externalId,

--- a/dotnet/src/SemanticKernel/Memory/ISemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/ISemanticTextMemory.cs
@@ -14,26 +14,29 @@ public interface ISemanticTextMemory
     /// <summary>
     /// Save some information into the semantic memory, keeping a copy of the source information.
     /// </summary>
-    /// <param name="collection">Collection where to save the information</param>
-    /// <param name="id">Unique identifier</param>
-    /// <param name="text">Information to save</param>
-    /// <param name="description">Optional description</param>
-    /// <param name="cancel">Cancellation token</param>
+    /// <param name="collection">Collection where to save the information.</param>
+    /// <param name="id">Unique identifier.</param>
+    /// <param name="text">Information to save.</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="valueString">Optional value string for saving custom metadata.</param>
+    /// <param name="cancel">Cancellation token.</param>
     public Task SaveInformationAsync(
         string collection,
         string text,
         string id,
         string? description = null,
+        string? valueString = null,
         CancellationToken cancel = default);
 
     /// <summary>
     /// Save some information into the semantic memory, keeping only a reference to the source information.
     /// </summary>
-    /// <param name="collection">Collection where to save the information</param>
-    /// <param name="text">Information to save</param>
-    /// <param name="externalId">Unique identifier, e.g. URL or GUID to the original source</param>
+    /// <param name="collection">Collection where to save the information.</param>
+    /// <param name="text">Information to save.</param>
+    /// <param name="externalId">Unique identifier, e.g. URL or GUID to the original source.</param>
     /// <param name="externalSourceName">Name of the external service, e.g. "MSTeams", "GitHub", "WebSite", "Outlook IMAP", etc.</param>
-    /// <param name="description">Optional description</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="valueString">Optional value string for saving custom metadata.</param>
     /// <param name="cancel">Cancellation token</param>
     public Task SaveReferenceAsync(
         string collection,
@@ -41,6 +44,7 @@ public interface ISemanticTextMemory
         string externalId,
         string externalSourceName,
         string? description = null,
+        string? valueString = null,
         CancellationToken cancel = default);
 
     /// <summary>
@@ -48,20 +52,21 @@ public interface ISemanticTextMemory
     /// For local memories the key is the "id" used when saving the record.
     /// For external reference, the key is the "URI" used when saving the record.
     /// </summary>
-    /// <param name="collection">Collection to search</param>
-    /// <param name="key">Unique memory record identifier</param>
-    /// <param name="cancel">Cancellation token</param>
+    /// <param name="collection">Collection to search.</param>
+    /// <param name="key">Unique memory record identifier.</param>
+    /// <param name="withEmbedding">Whether to return the embedding of the memory found.</param>
+    /// <param name="cancel">Cancellation token.</param>
     /// <returns>Memory record, or null when nothing is found</returns>
-    public Task<MemoryQueryResult?> GetAsync(string collection, string key, CancellationToken cancel = default);
+    public Task<MemoryQueryResult?> GetAsync(string collection, string key, bool withEmbedding = false, CancellationToken cancel = default);
 
     /// <summary>
     /// Remove a memory by key.
     /// For local memories the key is the "id" used when saving the record.
     /// For external reference, the key is the "URI" used when saving the record.
     /// </summary>
-    /// <param name="collection">Collection to search</param>
-    /// <param name="key">Unique memory record identifier</param>
-    /// <param name="cancel">Cancellation token</param>
+    /// <param name="collection">Collection to search.</param>
+    /// <param name="key">Unique memory record identifier.</param>
+    /// <param name="cancel">Cancellation token.</param>
     public Task RemoveAsync(string collection, string key, CancellationToken cancel = default);
 
     /// <summary>
@@ -71,13 +76,15 @@ public interface ISemanticTextMemory
     /// <param name="query">What to search for</param>
     /// <param name="limit">How many results to return</param>
     /// <param name="minRelevanceScore">Minimum relevance score, from 0 to 1, where 1 means exact match.</param>
-    /// <param name="cancel">Cancellation token</param>
+    /// <param name="withEmbeddings">Whether to return the embeddings of the memories found.</param>
+    /// <param name="cancel">Cancellation token.</param>
     /// <returns>Memories found</returns>
     public IAsyncEnumerable<MemoryQueryResult> SearchAsync(
         string collection,
         string query,
         int limit = 1,
         double minRelevanceScore = 0.7,
+        bool withEmbeddings = false,
         CancellationToken cancel = default);
 
     /// <summary>

--- a/dotnet/src/SemanticKernel/Memory/MemoryRecord.cs
+++ b/dotnet/src/SemanticKernel/Memory/MemoryRecord.cs
@@ -42,18 +42,20 @@ public class MemoryRecord : DataEntryBase
     /// Prepare an instance about a memory which source is stored externally.
     /// The universal resource identifies points to the URL (or equivalent) to find the original source.
     /// </summary>
-    /// <param name="externalId">URL (or equivalent) to find the original source</param>
+    /// <param name="externalId">URL (or equivalent) to find the original source.</param>
     /// <param name="sourceName">Name of the external service, e.g. "MSTeams", "GitHub", "WebSite", "Outlook IMAP", etc.</param>
     /// <param name="description">Optional description of the record. Note: the description is not indexed.</param>
-    /// <param name="embedding">Source content embeddings</param>
-    /// <param name="key">Optional existing database key</param>
-    /// <param name="timestamp">optional timestamp</param>
+    /// <param name="embedding">Source content embedding.</param>
+    /// <param name="valueString">Optional value string for saving custom metadata.</param>
+    /// <param name="key">Optional existing database key.</param>
+    /// <param name="timestamp">optional timestamp.</param>
     /// <returns>Memory record</returns>
     public static MemoryRecord ReferenceRecord(
         string externalId,
         string sourceName,
         string? description,
         Embedding<float> embedding,
+        string? valueString = null,
         string? key = null,
         DateTimeOffset? timestamp = null)
     {
@@ -64,7 +66,8 @@ public class MemoryRecord : DataEntryBase
                 externalSourceName: sourceName,
                 id: externalId,
                 description: description ?? string.Empty,
-                text: string.Empty
+                text: string.Empty,
+                valueString: valueString ?? string.Empty
             ),
             embedding,
             key,
@@ -76,17 +79,19 @@ public class MemoryRecord : DataEntryBase
     /// Prepare an instance for a memory stored in the internal storage provider.
     /// </summary>
     /// <param name="id">Resource identifier within the storage provider, e.g. record ID/GUID/incremental counter etc.</param>
-    /// <param name="text">Full text used to generate the embeddings</param>
+    /// <param name="text">Full text used to generate the embeddings.</param>
     /// <param name="description">Optional description of the record. Note: the description is not indexed.</param>
-    /// <param name="embedding">Source content embeddings</param>
-    /// <param name="key">Optional existing database key</param>
-    /// <param name="timestamp">optional timestamp</param>
+    /// <param name="embedding">Source content embedding.</param>
+    /// <param name="valueString">Optional value string for saving custom metadata.</param>
+    /// <param name="key">Optional existing database key.</param>
+    /// <param name="timestamp">optional timestamp.</param>
     /// <returns>Memory record</returns>
     public static MemoryRecord LocalRecord(
         string id,
         string text,
         string? description,
         Embedding<float> embedding,
+        string? valueString = null,
         string? key = null,
         DateTimeOffset? timestamp = null)
     {
@@ -98,7 +103,8 @@ public class MemoryRecord : DataEntryBase
                 id: id,
                 text: text,
                 description: description ?? string.Empty,
-                externalSourceName: string.Empty
+                externalSourceName: string.Empty,
+                valueString: valueString ?? string.Empty
             ),
             embedding,
             key,
@@ -110,26 +116,43 @@ public class MemoryRecord : DataEntryBase
     /// Create a memory record from a serialized metadata string.
     /// </summary>
     /// <param name="json">Json string representing a memory record's metadata.</param>
-    /// <param name="embedding">The embedding associated with a memory record.</param>
-    /// <param name="key">Optional existing database key</param>
-    /// <param name="timestamp">optional timestamp</param>
+    /// <param name="embedding">Optional embedding associated with a memory record.</param>
+    /// <param name="key">Optional existing database key.</param>
+    /// <param name="timestamp">optional timestamp.</param>
     /// <returns></returns>
     /// <exception cref="MemoryException"></exception>
     public static MemoryRecord FromJson(
         string json,
-        Embedding<float> embedding,
+        Embedding<float>? embedding,
         string? key = null,
         DateTimeOffset? timestamp = null)
     {
         var metadata = JsonSerializer.Deserialize<MemoryRecordMetadata>(json);
         if (metadata != null)
         {
-            return new MemoryRecord(metadata, embedding, key, timestamp);
+            return new MemoryRecord(metadata, embedding ?? Embedding<float>.Empty, key, timestamp);
         }
 
         throw new MemoryException(
             MemoryException.ErrorCodes.UnableToDeserializeMetadata,
             "Unable to create memory record from serialized metadata");
+    }
+
+    /// <summary>
+    /// Create a memory record from a memory record's metadata.
+    /// </summary>
+    /// <param name="metadata">Metadata associated with a memory.</param>
+    /// <param name="embedding">Optional embedding associated with a memory record.</param>
+    /// <param name="key">Optional existing database key.</param>
+    /// <param name="timestamp">optional timestamp.</param>
+    /// <returns></returns>
+    public static MemoryRecord FromMetadata(
+        MemoryRecordMetadata metadata,
+        Embedding<float>? embedding,
+        string? key = null,
+        DateTimeOffset? timestamp = null)
+    {
+        return new MemoryRecord(metadata, embedding ?? Embedding<float>.Empty, key, timestamp);
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel/Memory/MemoryRecordMetadata.cs
+++ b/dotnet/src/SemanticKernel/Memory/MemoryRecordMetadata.cs
@@ -48,6 +48,13 @@ public class MemoryRecordMetadata : ICloneable
     public string Text { get; }
 
     /// <summary>
+    /// Field for saving custom metadata with a memory.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("value_string")]
+    public string ValueString { get; }
+
+    /// <summary>
     /// Constructor.
     /// </summary>
     /// <param name="isReference">True if source data is local, false if source data comes from an external service</param>
@@ -55,13 +62,15 @@ public class MemoryRecordMetadata : ICloneable
     /// <param name="text">Local source data associated with a <see cref="MemoryRecord"/> embedding.</param>
     /// <param name="description"><see cref="MemoryRecord"/> description.</param>
     /// <param name="externalSourceName">Name of the external source if isReference is true.</param>
+    /// <param name="valueString">Field for saving custom metadata with a memory.</param>
     [JsonConstructor]
     public MemoryRecordMetadata(
         bool isReference,
         string id,
         string text,
         string description,
-        string externalSourceName
+        string externalSourceName,
+        string valueString
     )
     {
         this.IsReference = isReference;
@@ -69,6 +78,7 @@ public class MemoryRecordMetadata : ICloneable
         this.Id = id;
         this.Text = text;
         this.Description = description;
+        this.ValueString = valueString;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel/Memory/NullMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/NullMemory.cs
@@ -23,6 +23,7 @@ public sealed class NullMemory : ISemanticTextMemory
         string text,
         string id,
         string? description = null,
+        string? valueString = null,
         CancellationToken cancel = default)
     {
         return Task.CompletedTask;
@@ -35,6 +36,7 @@ public sealed class NullMemory : ISemanticTextMemory
         string externalId,
         string externalSourceName,
         string? description = null,
+        string? valueString = null,
         CancellationToken cancel = default)
     {
         return Task.CompletedTask;
@@ -44,6 +46,7 @@ public sealed class NullMemory : ISemanticTextMemory
     public Task<MemoryQueryResult?> GetAsync(
         string collection,
         string key,
+        bool withEmbedding = false,
         CancellationToken cancel = default)
     {
         return Task.FromResult(null as MemoryQueryResult);
@@ -64,6 +67,7 @@ public sealed class NullMemory : ISemanticTextMemory
         string query,
         int limit = 1,
         double minRelevanceScore = 0.7,
+        bool withEmbeddings = false,
         CancellationToken cancel = default)
     {
         return AsyncEnumerable.Empty<MemoryQueryResult>();

--- a/dotnet/src/SemanticKernel/Memory/NullMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/NullMemory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -18,7 +19,7 @@ public sealed class NullMemory : ISemanticTextMemory
     public static NullMemory Instance { get; } = new();
 
     /// <inheritdoc/>
-    public Task SaveInformationAsync(
+    public Task<string> SaveInformationAsync(
         string collection,
         string text,
         string id,
@@ -26,11 +27,11 @@ public sealed class NullMemory : ISemanticTextMemory
         string? valueString = null,
         CancellationToken cancel = default)
     {
-        return Task.CompletedTask;
+        return Task.FromResult(string.Empty);
     }
 
     /// <inheritdoc/>
-    public Task SaveReferenceAsync(
+    public Task<string> SaveReferenceAsync(
         string collection,
         string text,
         string externalId,
@@ -39,7 +40,7 @@ public sealed class NullMemory : ISemanticTextMemory
         string? valueString = null,
         CancellationToken cancel = default)
     {
-        return Task.CompletedTask;
+        return Task.FromResult(string.Empty);
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/SemanticKernel/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/SemanticTextMemory.cs
@@ -27,7 +27,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task SaveInformationAsync(
+    public async Task<string> SaveInformationAsync(
         string collection,
         string text,
         string id,
@@ -43,11 +43,11 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
             await this._storage.CreateCollectionAsync(collection, cancel);
         }
 
-        await this._storage.UpsertAsync(collection, record: data, cancel: cancel);
+        return await this._storage.UpsertAsync(collection, record: data, cancel: cancel);
     }
 
     /// <inheritdoc/>
-    public async Task SaveReferenceAsync(
+    public async Task<string> SaveReferenceAsync(
         string collection,
         string text,
         string externalId,
@@ -64,7 +64,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
             await this._storage.CreateCollectionAsync(collection, cancel);
         }
 
-        await this._storage.UpsertAsync(collection, record: data, cancel: cancel);
+        return await this._storage.UpsertAsync(collection, record: data, cancel: cancel);
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/SemanticKernel/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/SemanticTextMemory.cs
@@ -32,6 +32,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         string text,
         string id,
         string? description = null,
+        string? valueString = null,
         CancellationToken cancel = default)
     {
         var embeddings = await this._embeddingGenerator.GenerateEmbeddingAsync(text);
@@ -52,6 +53,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         string externalId,
         string externalSourceName,
         string? description = null,
+        string? valueString = null,
         CancellationToken cancel = default)
     {
         var embedding = await this._embeddingGenerator.GenerateEmbeddingAsync(text);
@@ -69,9 +71,10 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
     public async Task<MemoryQueryResult?> GetAsync(
         string collection,
         string key,
+        bool withEmbedding = false,
         CancellationToken cancel = default)
     {
-        MemoryRecord? record = await this._storage.GetAsync(collection, key, cancel);
+        MemoryRecord? record = await this._storage.GetAsync(collection, key, withEmbedding, cancel);
 
         if (record == null) { return null; }
 
@@ -93,6 +96,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         string query,
         int limit = 1,
         double minRelevanceScore = 0.7,
+        bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
         Embedding<float> queryEmbedding = await this._embeddingGenerator.GenerateEmbeddingAsync(query);
@@ -102,6 +106,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
             embedding: queryEmbedding,
             limit: limit,
             minRelevanceScore: minRelevanceScore,
+            withEmbeddings: withEmbeddings,
             cancel: cancel);
 
         await foreach ((MemoryRecord, double) result in results.WithCancellation(cancel))

--- a/dotnet/src/SemanticKernel/Planning/SKContextPlanningExtensions.cs
+++ b/dotnet/src/SemanticKernel/Planning/SKContextPlanningExtensions.cs
@@ -79,7 +79,7 @@ internal static class SKContextPlanningExtensions
             await RememberFunctionsAsync(context, availableFunctions);
 
             // Search for functions that match the semantic query.
-            var memories = context.Memory.SearchAsync(PlannerMemoryCollectionName, semanticQuery!, config.MaxRelevantFunctions, config.RelevancyThreshold.Value,
+            var memories = context.Memory.SearchAsync(PlannerMemoryCollectionName, semanticQuery!, config.MaxRelevantFunctions, config.RelevancyThreshold.Value, false,
                 context.CancellationToken);
 
             // Add functions that were found in the search results.
@@ -135,13 +135,13 @@ internal static class SKContextPlanningExtensions
             var key = string.IsNullOrEmpty(function.Description) ? functionName : function.Description;
 
             // It'd be nice if there were a saveIfNotExists method on the memory interface
-            var memoryEntry = await context.Memory.GetAsync(PlannerMemoryCollectionName, key, context.CancellationToken);
+            var memoryEntry = await context.Memory.GetAsync(PlannerMemoryCollectionName, key, false, context.CancellationToken);
             if (memoryEntry == null)
             {
                 // TODO It'd be nice if the minRelevanceScore could be a parameter for each item that was saved to memory
                 // As folks may want to tune their functions to be more or less relevant.
                 await context.Memory.SaveInformationAsync(PlannerMemoryCollectionName, key, functionName, function.ToManualString(),
-                    context.CancellationToken);
+                    string.Empty, context.CancellationToken);
             }
         }
 

--- a/samples/dotnet/kernel-syntax-examples/Example19_Qdrant.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example19_Qdrant.cs
@@ -36,9 +36,9 @@ public static class Example19_Qdrant
 
         Console.WriteLine("== Adding Memories ==");
 
-        await kernel.Memory.SaveInformationAsync(MemoryCollectionName, id: "cat1", text: "british short hair");
-        await kernel.Memory.SaveInformationAsync(MemoryCollectionName, id: "cat2", text: "orange tabby");
-        await kernel.Memory.SaveInformationAsync(MemoryCollectionName, id: "cat3", text: "norwegian forest cat");
+        var key1 = await kernel.Memory.SaveInformationAsync(MemoryCollectionName, id: "cat1", text: "british short hair");
+        var key2 = await kernel.Memory.SaveInformationAsync(MemoryCollectionName, id: "cat2", text: "orange tabby");
+        var key3 = await kernel.Memory.SaveInformationAsync(MemoryCollectionName, id: "cat3", text: "norwegian forest cat");
 
         Console.WriteLine("== Printing Collections in DB ==");
         collections = memoryStore.GetCollectionsAsync();
@@ -47,9 +47,20 @@ public static class Example19_Qdrant
             Console.WriteLine(collection);
         }
 
-        Console.WriteLine("== Retrieving Memories ==");
+        Console.WriteLine("== Retrieving Memories Through the Kernel ==");
         MemoryQueryResult? lookup = await kernel.Memory.GetAsync(MemoryCollectionName, "cat1");
         Console.WriteLine(lookup != null ? lookup.Metadata.Text : "ERROR: memory not found");
+
+        // TODO: Verified that the record exists. Also verified that the request being sent to Qdrant is valid according to
+        //  https://qdrant.github.io/qdrant/redoc/index.html#tag/points/operation/get_points
+        //  but the response is always 404.
+        //Console.WriteLine("== Retrieving Memories Directly From the Store ==");
+        //var memory1 = await memoryStore.GetWithPointIdAsync(MemoryCollectionName, key1);
+        //var memory2 = await memoryStore.GetWithPointIdAsync(MemoryCollectionName, key2);
+        //var memory3 = await memoryStore.GetWithPointIdAsync(MemoryCollectionName, key3);
+        //Console.WriteLine(memory1 != null ? memory1.Metadata.Text : "ERROR: memory not found");
+        //Console.WriteLine(memory2 != null ? memory2.Metadata.Text : "ERROR: memory not found");
+        //Console.WriteLine(memory3 != null ? memory3.Metadata.Text : "ERROR: memory not found");
 
         Console.WriteLine("== Similarity Searching Memories: My favorite color is orange ==");
         var searchResults = kernel.Memory.SearchAsync(MemoryCollectionName, "My favorite color is orange", limit: 3, minRelevanceScore: 0.8);

--- a/samples/dotnet/kernel-syntax-examples/Example23_ReadOnlyMemoryStore.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example23_ReadOnlyMemoryStore.cs
@@ -76,12 +76,12 @@ public static class Example23_ReadOnlyMemoryStore
             throw new System.NotImplementedException();
         }
 
-        public Task<MemoryRecord?> GetAsync(string collectionName, string key, CancellationToken cancel = default)
+        public Task<MemoryRecord?> GetAsync(string collectionName, string key, bool withEmbedding = true, CancellationToken cancel = default)
         {
             return Task.FromResult(this._memoryRecords?.FirstOrDefault(x => x.Key == key));
         }
 
-        public IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, CancellationToken cancel = default)
+        public IAsyncEnumerable<MemoryRecord> GetBatchAsync(string collectionName, IEnumerable<string> keys, bool withEmbeddings = true, CancellationToken cancel = default)
         {
             return this._memoryRecords?.Where(x => keys.Contains(x.Key)).ToAsyncEnumerable() ?? AsyncEnumerable.Empty<MemoryRecord>();
         }
@@ -92,18 +92,19 @@ public static class Example23_ReadOnlyMemoryStore
         }
 
         public async Task<(MemoryRecord, double)?> GetNearestMatchAsync(string collectionName, Embedding<float> embedding, double minRelevanceScore = 0,
-            CancellationToken cancel = default)
+            bool withEmbedding = true, CancellationToken cancel = default)
         {
             return await this.GetNearestMatchesAsync(
                 collectionName: collectionName,
                 embedding: embedding,
                 limit: 1,
                 minRelevanceScore: minRelevanceScore,
+                withEmbeddings: withEmbedding,
                 cancel: cancel).FirstOrDefaultAsync(cancellationToken: cancel);
         }
 
         public IAsyncEnumerable<(MemoryRecord, double)> GetNearestMatchesAsync(string collectionName, Embedding<float> embedding, int limit,
-            double minRelevanceScore = 0, CancellationToken cancel = default)
+            double minRelevanceScore = 0, bool withEmbeddings = true, CancellationToken cancel = default)
         {
             if (this._memoryRecords == null || !this._memoryRecords.Any())
             {
@@ -166,7 +167,8 @@ public static class Example23_ReadOnlyMemoryStore
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id1"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"" : ""value:""
             },
             ""key"": ""key1"",
             ""timestamp"": null
@@ -180,7 +182,8 @@ public static class Example23_ReadOnlyMemoryStore
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id2"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"" : ""value:""
             },
             ""key"": ""key2"",
             ""timestamp"": null
@@ -194,7 +197,8 @@ public static class Example23_ReadOnlyMemoryStore
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id3"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"" : ""value:""
             },
             ""key"": ""key3"",
             ""timestamp"": null
@@ -208,7 +212,8 @@ public static class Example23_ReadOnlyMemoryStore
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id4"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"" : ""value:""
             },
             ""key"": ""key4"",
             ""timestamp"": null
@@ -222,7 +227,8 @@ public static class Example23_ReadOnlyMemoryStore
                 ""external_source_name"": ""externalSourceName"",
                 ""id"": ""Id5"",
                 ""description"": ""description"",
-                ""text"": ""text""
+                ""text"": ""text"",
+                ""value_string"" : ""value:""
             },
             ""key"": ""key5"",
             ""timestamp"": null


### PR DESCRIPTION
### Motivation and Context
This PR addresses 3 issues. 

1. MemoryRecord now has a ValueString field - this is to support customizable metadata from the user. It is up to the user to serialize and deserialize this information. 
2. Retrieving the embedding from an IMemoryStore is optional and defaults to false. In the vast majority of cases, it is unnecessary and wasteful to pass the vector around the application, especially over a network. It is primarily used for similarity comparison which performed server-side for vector optimized data stores (ex: Qdrant).
3. Refactored SqliteMemoryStore so that connections are disposed better. There were multiple cases of residual connections causing intermittent, unexpected unit test behavior. 

### Description
- `IMemoryStore` `Get` and `GetNearest` calls have a new boolean parameter called `withEmbedding`. This indicates whether or not the response should include the vector associated with the memory. For all existing memory connectors, this defaults to false. This boolean is propagated to `ISemanticTextMemory` `Get` and `Search` calls as well.
- `MemoryRecord` has an optional field called `valueString` to allow the user to supply a custom metadata string. This is field is added to `ISemanticTextMemory` record creation as well. 
- Connectors.Sqlite.Memory `Database` is no longer a static class. The connection is supplied by the `SqliteMemoryStore` which also ensures its proper disposal.
- Added a few missing XML docs where necessary. 
- Added tests for `valueString` and `withEmbeddings`.
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
