### PR TITLE
Functionality to register RestApiOperationRunner in kernel config

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
@@ -29,7 +29,6 @@ public static class KernelChatGptPluginExtensions
     /// <param name="skillName">Skill name.</param>
     /// <param name="url">Url to in which to retrieve the ChatGPT plugin.</param>
     /// <param name="httpClient">Optional HttpClient to use for the request.</param>
-    /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillFromUrlAsync(
@@ -37,7 +36,6 @@ public static class KernelChatGptPluginExtensions
         string skillName,
         Uri url,
         HttpClient? httpClient = null,
-        AuthenticateRequestAsyncCallback? authCallback = null,
         CancellationToken cancellationToken = default)
     {
         Verify.ValidSkillName(skillName);
@@ -67,7 +65,7 @@ public static class KernelChatGptPluginExtensions
             string gptPluginJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             string? openApiUrl = ParseOpenApiUrl(gptPluginJson);
 
-            return await kernel.ImportOpenApiSkillFromUrlAsync(skillName, new Uri(openApiUrl), httpClient, authCallback, cancellationToken).ConfigureAwait(false);
+            return await kernel.ImportOpenApiSkillFromUrlAsync(skillName, new Uri(openApiUrl), httpClient, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -84,14 +82,12 @@ public static class KernelChatGptPluginExtensions
     /// <param name="kernel">Semantic Kernel instance.</param>
     /// <param name="skillName">Skill name.</param>
     /// <param name="httpClient">Optional HttpClient to use for the request.</param>
-    /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static async Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillFromResourceAsync(
         this IKernel kernel,
         string skillName,
         HttpClient? httpClient = null,
-        AuthenticateRequestAsyncCallback? authCallback = null,
         CancellationToken cancellationToken = default)
     {
         Verify.ValidSkillName(skillName);
@@ -111,7 +107,7 @@ public static class KernelChatGptPluginExtensions
 
         string? openApiUrl = ParseOpenApiUrl(gptPluginJson);
 
-        return await kernel.ImportOpenApiSkillFromUrlAsync(skillName, new Uri(openApiUrl), httpClient, authCallback, cancellationToken).ConfigureAwait(false);
+        return await kernel.ImportOpenApiSkillFromUrlAsync(skillName, new Uri(openApiUrl), httpClient, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -121,7 +117,6 @@ public static class KernelChatGptPluginExtensions
     /// <param name="parentDirectory">Directory containing the skill directory.</param>
     /// <param name="skillDirectoryName">Name of the directory containing the selected skill.</param>
     /// <param name="httpClient">Optional HttpClient to use for the request.</param>
-    /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public async static Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillSkillFromDirectoryAsync(
@@ -129,7 +124,6 @@ public static class KernelChatGptPluginExtensions
         string parentDirectory,
         string skillDirectoryName,
         HttpClient? httpClient = null,
-        AuthenticateRequestAsyncCallback? authCallback = null,
         CancellationToken cancellationToken = default)
     {
         const string CHATGPT_PLUGIN_FILE = "ai-plugin.json";
@@ -149,7 +143,7 @@ public static class KernelChatGptPluginExtensions
 
         using var stream = File.OpenRead(chatGptPluginPath);
 
-        return await kernel.RegisterOpenApiSkillAsync(stream, skillDirectoryName, authCallback, cancellationToken);
+        return await kernel.RegisterOpenApiSkillAsync(stream, skillDirectoryName, cancellationToken);
     }
 
     /// <summary>
@@ -158,14 +152,12 @@ public static class KernelChatGptPluginExtensions
     /// <param name="kernel">Semantic Kernel instance.</param>
     /// <param name="skillName">Name of the skill to register.</param>
     /// <param name="filePath">File path to the ChatGPT plugin definition.</param>
-    /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public async static Task<IDictionary<string, ISKFunction>> ImportChatGptPluginSkillSkillFromFileAsync(
         this IKernel kernel,
         string skillName,
         string filePath,
-        AuthenticateRequestAsyncCallback? authCallback = null,
         CancellationToken cancellationToken = default)
     {
         if (!File.Exists(filePath))
@@ -177,7 +169,7 @@ public static class KernelChatGptPluginExtensions
 
         using var stream = File.OpenRead(filePath);
 
-        return await kernel.RegisterOpenApiSkillAsync(stream, skillName, authCallback, cancellationToken);
+        return await kernel.RegisterOpenApiSkillAsync(stream, skillName, cancellationToken);
     }
 
     private static string ParseOpenApiUrl(string gptPluginJson)

--- a/samples/dotnet/kernel-syntax-examples/Example21_ChatGPTPlugins.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example21_ChatGPTPlugins.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
@@ -16,7 +17,12 @@ public static class Example21_ChatGptPlugins
 
     private static async Task RunChatGptPluginAsync()
     {
-        var kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
+        using var httpClient = new HttpClient();
+
+        var kernel = new KernelBuilder()
+            .WithLogger(ConsoleLogger.Log)
+            .Configure((kc) => kc.SetRestApiOperationRunner(httpClient))
+            .Build();
 
         //Import a ChatGPT plugin using one of the following Kernel extension methods
         //kernel.ImportChatGptPluginSkillFromResourceAsync
@@ -38,7 +44,12 @@ public static class Example21_ChatGptPlugins
 
         //--------------- Example of using Klarna ChatGPT plugin ------------------------
 
-        //var kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
+        //using var httpClient = new HttpClient();
+
+        //var kernel = new KernelBuilder()
+        //    .WithLogger(ConsoleLogger.Log)
+        //    .Configure((kc) => kc.SetRestApiOperationRunner(httpClient))
+        //    .Build();
 
         //var skill = await kernel.ImportChatGptPluginSkillFromUrlAsync("Klarna", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"));
 

--- a/samples/dotnet/kernel-syntax-examples/Example22_OpenApiSkill.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example22_OpenApiSkill.cs
@@ -21,7 +21,12 @@ public static class Example22_OpenApiSkill
 
     public static async Task GetSecretFromAzureKeyVaultAsync()
     {
-        var kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
+        using var httpClient = new HttpClient();
+
+        var kernel = new KernelBuilder()
+            .WithLogger(ConsoleLogger.Log)
+            .Configure((kc) => kc.SetRestApiOperationRunner(httpClient, AuthenticateWithBearerToken))
+            .Build();
 
         //Import a OpenApi skill using one of the following Kernel extension methods
         //kernel.ImportOpenApiSkillFromResource
@@ -29,7 +34,7 @@ public static class Example22_OpenApiSkill
         //kernel.ImportOpenApiSkillFromFile
         //kernel.ImportOpenApiSkillFromUrlAsync
         //kernel.RegisterOpenApiSkill
-        var skill = await kernel.ImportOpenApiSkillFromResourceAsync(SkillResourceNames.AzureKeyVault, AuthenticateWithBearerToken);
+        var skill = await kernel.ImportOpenApiSkillFromResourceAsync(SkillResourceNames.AzureKeyVault);
 
         //Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();
@@ -45,7 +50,12 @@ public static class Example22_OpenApiSkill
 
     public static async Task AddSecretToAzureKeyVaultAsync()
     {
-        var kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
+        using var httpClient = new HttpClient();
+
+        var kernel = new KernelBuilder()
+            .WithLogger(ConsoleLogger.Log)
+            .Configure((kc) => kc.SetRestApiOperationRunner(httpClient.SendAsync, AuthenticateWithBearerToken))
+            .Build();
 
         //Import a OpenApi skill using one of the following Kernel extension methods
         //kernel.ImportOpenApiSkillFromResource
@@ -53,7 +63,7 @@ public static class Example22_OpenApiSkill
         //kernel.ImportOpenApiSkillFromFile
         //kernel.ImportOpenApiSkillFromUrlAsync
         //kernel.RegisterOpenApiSkill
-        var skill = await kernel.ImportOpenApiSkillFromResourceAsync(SkillResourceNames.AzureKeyVault, AuthenticateWithBearerToken);
+        var skill = await kernel.ImportOpenApiSkillFromResourceAsync(SkillResourceNames.AzureKeyVault);
 
         //Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();


### PR DESCRIPTION
### Motivation and Context

This PR introduces a few changes:
1. An instance of the RestApiOperationRunner needs to be registered through kernel config so that it can be reused by any skill that uses RestApiOperation functionality.
2. RestApiOperationRunner doesn't create HttpClient instance anymore and requires a hosting app to provide the instance instead. SK SDK can't make assumptions about the way hosting apps create/manage HttpClient objects/instances - whether they use HttpClientFactory to create an instance of HttpClient instance per request, or an HttpClient instance is created using the new operator and stored as singleton, or maybe an instance per host?

These changes add more flexibility to SK SDK to support different scenarios a hosting app may require:
- Working with OpenAPI skills that are run against same host. In this case, the same set of Http handlers can be used for all the skills and only one HttpClient instance will be created.
- Working with OpenAPI skills that are run against different hosts. This case may require a set of Http handlers unique to each host and more than one insnance of HttpClient. 

### Description
This PR introduces the following changes:
* Two overloads of a new SetRestApiOperationRunner method are added to the KernalConfiguration class allowing a hosting app to supply either an instance of HttpClient or a callback that will be called when the RestApiOperationRunner sends Http requests. The callback can be used by the hosting app to route the Http requests to a dedicated HttpClient instance based on the host, header, url string parameter, etc...
* The RegisterRestApiFunction is changed to access the instance of the RestApiOperationRunner class from the Kernal config rather than creating the instance itself.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
