### PR TITLE
Reducing SK core to minimum viable dependency packages

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -5,13 +5,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.3" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Net.Primitives" Version="4.3.1" />
     <PackageVersion Include="System.Text.Json" Version="7.0.2" />
     
     <!-- Microsoft.Extensions.Logging -->

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -31,12 +31,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="System.Linq.Async" />
-    <PackageReference Include="System.Net.Primitives" />
-    <PackageReference Include="System.Text.Json" />
+    <!--Setting version overrides to miniumum supported version, to maxiumize compatability.-->
+    <PackageReference Include="Microsoft.Bcl.HashCode" VersionOverride="[1.1.0, )" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="[6.0.0, )" />
+    <PackageReference Include="System.Linq.Async" VersionOverride="[6.0.1, )" />
+    <PackageReference Include="System.Text.Json" VersionOverride="[6.0.0, )" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation and Context
Maximizing compatibility with hosting apps, supporting the widest version range of dependency packages.

### Description
Reducing the SK core project's dependencies to the minimum needed set, and the minimum supported version for each. Explicitly using the [minversion, ) syntax, normally implicit, to make it clear that this is a deliberate min version, and not take automatically suggested updates.

Note: we may be able to remove 1 or 2 more with a few minor code changes.

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
