### PR TITLE
Adding Detailed Message for AIException Scenarios

### DIFF
--- a/dotnet/src/SemanticKernel/AI/AIException.cs
+++ b/dotnet/src/SemanticKernel/AI/AIException.cs
@@ -77,6 +77,11 @@ public class AIException : Exception<AIException.ErrorCodes>
     public ErrorCodes ErrorCode { get; set; }
 
     /// <summary>
+    /// The exception's detail.
+    /// </summary>
+    public string? Detail { get; set; }
+
+    /// <summary>
     /// Construct an exception with an error code and message.
     /// </summary>
     /// <param name="errCode">Error code of the exception.</param>
@@ -95,6 +100,17 @@ public class AIException : Exception<AIException.ErrorCodes>
     public AIException(ErrorCodes errCode, string message, Exception? e) : base(errCode, message, e)
     {
         this.ErrorCode = errCode;
+    }
+
+    /// <summary>
+    /// Construct an exception with an error code, message, and existing exception.
+    /// </summary>
+    /// <param name="errCode">Error code of the exception.</param>
+    /// <param name="message">Message of the exception.</param>
+    /// <param name="detail">More details about the exception</param>
+    public AIException(ErrorCodes errCode, string message, string? detail) : this(errCode, message)
+    {
+        this.Detail = detail;
     }
 
     #region private ================================================================================

--- a/dotnet/src/SemanticKernel/Connectors/OpenAI/AzureOpenAIClientAbstract.cs
+++ b/dotnet/src/SemanticKernel/Connectors/OpenAI/AzureOpenAIClientAbstract.cs
@@ -110,14 +110,15 @@ public abstract class AzureOpenAIClientAbstract : OpenAIClientAbstract
     {
         var url = $"{this.Endpoint}/openai/deployments?api-version={this.AzureOpenAIApiVersion}";
         HttpResponseMessage response = await this.HTTPClient.GetAsync(url);
+        string json = await response.Content.ReadAsStringAsync();
+
         if (!response.IsSuccessStatusCode)
         {
             throw new AIException(
                 AIException.ErrorCodes.ModelNotAvailable,
-                $"Unable to fetch the list of model deployments from Azure. Status code: {response.StatusCode}");
+                $"Unable to fetch the list of model deployments from Azure. Status code: {response.StatusCode}",
+                this.GetErrorMessageFromResponse(json));
         }
-
-        string json = await response.Content.ReadAsStringAsync();
 
         lock (s_deploymentToModel)
         {

--- a/samples/apps/auth-api-webapp-react/src/components/YourInfo.tsx
+++ b/samples/apps/auth-api-webapp-react/src/components/YourInfo.tsx
@@ -8,7 +8,7 @@ import signInLogo from '../../src/ms-symbollockup_signin_light.svg';
 const YourInfo: FC = () => {
     const { instance } = useMsal();
     const loginRequest = {
-        scopes: (process.env.REACT_APP_GRAPH_SCOPES as string).split(','),
+        scopes: (process.env.REACT_APP_GRAPH_SCOPES as string)?.split(','),
     };
 
     return (

--- a/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Orchestration;
 using SemanticKernel.Service.Model;
 
@@ -74,6 +76,11 @@ public class SemanticKernelController : ControllerBase
         SKContext result = await kernel.RunAsync(contextVariables, function!);
         if (result.ErrorOccurred)
         {
+            if (result.LastException is AIException aiException && aiException.Detail is not null)
+            {
+                return this.BadRequest(string.Concat(aiException.Message, " - Detail: " + aiException.Detail));
+            }
+
             return this.BadRequest(result.LastErrorDescription);
         }
 


### PR DESCRIPTION
### Motivation and Context

OpenAI when reaches quota limit gives a TooManyRequests Http Status which is unclear and many times lead to think it was related to Throttling instead of a hard quota limit error.

![image](https://user-images.githubusercontent.com/19890735/231898339-b3de9dc5-deb3-4ef7-838c-37a93261c300.png)

### Description

This change allow us to retrieve the detail of the exception regarding what was the underlyning error from the AI Provider.

To get more details on the error if that error is AIException, you now can get it using the `Detail` property

This change brings more clarity to the actual error when that happens for OpenAI and AzureOpenAI completion requests.

![image](https://user-images.githubusercontent.com/19890735/231894369-7ccf43ee-ac2b-4c74-a895-547aa14c65d1.png)

![image](https://user-images.githubusercontent.com/19890735/231894481-fb290a36-6cec-4e90-b4c5-7a1363790df5.png)

![image](https://user-images.githubusercontent.com/19890735/231894609-a698276f-d1c2-4617-8342-6b7c532bc11a.png)

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
