### PR TITLE
Fix cosmos memory store to return all results, not just the first batch

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
@@ -297,19 +297,22 @@ public class CosmosMemoryStore : IMemoryStore
 
         var iterator = container.GetItemQueryIterator<CosmosMemoryRecord>(query);
 
-        var items = await iterator.ReadNextAsync(cancel).ConfigureAwait(false);
-
-        foreach (var item in items)
+        while (iterator.HasMoreResults) //read all result in batch 
         {
-            var vector = System.Text.Json.JsonSerializer.Deserialize<float[]>(item.EmbeddingString);
+            var items = await iterator.ReadNextAsync(cancel).ConfigureAwait(false);
 
-            if (vector != null)
+            foreach (var item in items)
             {
-                yield return MemoryRecord.FromJsonMetadata(
-                    item.MetadataString,
-                    new Embedding<float>(vector),
-                    item.Id,
-                    item.Timestamp);
+                var vector = System.Text.Json.JsonSerializer.Deserialize<float[]>(item.EmbeddingString);
+
+                if (vector != null)
+                {
+                    yield return MemoryRecord.FromJsonMetadata(
+                        item.MetadataString,
+                        new Embedding<float>(vector),
+                        item.Id,
+                        item.Timestamp);
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation and Context

GetAllAsync() in CosmosDB connector does not return all records.
This issue also impacts GetNearestMatchAsync() as it does not count all the records in the comparation.

Closes https://github.com/microsoft/semantic-kernel/issues/437

### Description
Updated `CosmosMemoryStore` to iterate over all batches of results from `GetItemQueryIterator`, not just the first batch of results. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
