### PR TITLE
Configure CosmosDB SDK to serialize JSON with camel case

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Azure.Cosmos.Linq;
 using SemanticKernel.Service.Skills;
 
 namespace SemanticKernel.Service.Storage;
@@ -21,9 +22,10 @@ public class ChatMessageRepository : Repository<ChatMessage>
     /// <summary>
     /// Finds chat messages by chat id.
     /// </summary>
-    public Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
+    public async Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
     {
-        return Task.FromResult(base.StorageContext.QueryableEntities.Where(e => e.ChatId == chatId).AsEnumerable());
+        var matches = base.StorageContext.QueryableEntities.Where(e => e.ChatId == chatId).ToFeedIterator();
+        return await matches.ReadNextAsync();
     }
 
     public async Task<ChatMessage> FindLastByChatIdAsync(string chatId)

--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Azure.Cosmos.Linq;
 using SemanticKernel.Service.Skills;
 
 namespace SemanticKernel.Service.Storage;
@@ -23,8 +24,9 @@ public class ChatSessionRepository : Repository<ChatSession>
     /// </summary>
     /// <param name="userId">The user id.</param>
     /// <returns>A list of chat sessions.</returns>
-    public Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
+    public async Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
     {
-        return Task.FromResult(base.StorageContext.QueryableEntities.Where(e => e.UserId == userId).AsEnumerable());
+        var matches = base.StorageContext.QueryableEntities.Where(e => e.UserId == userId).ToFeedIterator();
+        return await matches.ReadNextAsync();
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/Storage/CosmosDbContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/CosmosDbContext.cs
@@ -28,12 +28,20 @@ public class CosmosDbContext<T> : IStorageContext<T>, IDisposable where T : ISto
     /// <param name="container">The CosmosDB container name.</param>
     public CosmosDbContext(string connectionString, string database, string container)
     {
-        this._client = new CosmosClient(connectionString);
+        // Configure JsonSerializerOptions
+        var options = new CosmosClientOptions
+        {
+            SerializerOptions = new CosmosSerializationOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            },
+        };
+        this._client = new CosmosClient(connectionString, options);
         this._container = this._client.GetContainer(database, container);
     }
 
     /// <inheritdoc/>
-    public IQueryable<T> QueryableEntities => this._container.GetItemLinqQueryable<T>().AsQueryable();
+    public IQueryable<T> QueryableEntities => this._container.GetItemLinqQueryable<T>();
 
     /// <inheritdoc/>
     public async Task CreateAsync(T entity)


### PR DESCRIPTION
### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->
The CosmosDb SDK serializes entities into Json using the same property names. We would like it to serialize the entities to Json with the property names in camel case.

### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->
Configure the CosmosDb client to use camel case for serialization.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
