### PR TITLE
Allow to use chat models for semantic functions

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/AzureChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/AzureChatCompletion.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
 using Microsoft.SemanticKernel.Reliability;
 
@@ -14,7 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
 /// Azure OpenAI chat completion client.
 /// TODO: forward ETW logging to ILogger, see https://learn.microsoft.com/en-us/dotnet/azure/sdk/logging
 /// </summary>
-public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion
+public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion, ITextCompletion
 {
     /// <summary>
     /// Create an instance of the Azure OpenAI chat completion connector with API key auth
@@ -63,5 +64,14 @@ public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion
     public ChatHistory CreateNewChat(string instructions = "")
     {
         return this.InternalCreateNewChat(instructions);
+    }
+
+    /// <inheritdoc/>
+    public Task<string> CompleteAsync(
+        string text,
+        CompleteRequestSettings requestSettings,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InternalCompleteTextUsingChatAsync(text, requestSettings, cancellationToken);
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
 using Microsoft.SemanticKernel.Reliability;
 
@@ -13,7 +14,7 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
 /// OpenAI chat completion client.
 /// TODO: forward ETW logging to ILogger, see https://learn.microsoft.com/en-us/dotnet/azure/sdk/logging
 /// </summary>
-public sealed class OpenAIChatCompletion : OpenAIClientBase, IChatCompletion
+public sealed class OpenAIChatCompletion : OpenAIClientBase, IChatCompletion, ITextCompletion
 {
     /// <summary>
     /// Create an instance of the OpenAI chat completion connector
@@ -46,5 +47,14 @@ public sealed class OpenAIChatCompletion : OpenAIClientBase, IChatCompletion
     public ChatHistory CreateNewChat(string instructions = "")
     {
         return this.InternalCreateNewChat(instructions);
+    }
+
+    /// <inheritdoc/>
+    public Task<string> CompleteAsync(
+        string text,
+        CompleteRequestSettings requestSettings,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InternalCompleteTextUsingChatAsync(text, requestSettings, cancellationToken);
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/KernelConfigOpenAIExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/KernelConfigOpenAIExtensions.cs
@@ -173,9 +173,10 @@ public static class KernelConfigOpenAIExtensions
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="alsoAsTextCompletion">Whether to use the service also for text completion, if supported</param>
     /// <returns>Self instance</returns>
     public static KernelConfig AddAzureChatCompletionService(this KernelConfig config,
-        string serviceId, string deploymentName, string endpoint, string apiKey)
+        string serviceId, string deploymentName, string endpoint, string apiKey, bool alsoAsTextCompletion = true)
     {
         Verify.NotEmpty(serviceId, "The service Id provided is empty");
 
@@ -183,6 +184,15 @@ public static class KernelConfigOpenAIExtensions
             deploymentName, endpoint, apiKey, kernel.Config.HttpHandlerFactory, kernel.Log);
 
         config.AddChatCompletionService(serviceId, Factory);
+
+        // If the class implements the text completion interface, allow to use it also for semantic functions
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletion)))
+        {
+            ITextCompletion TextServiceFactory(IKernel kernel) => new AzureChatCompletion(
+                deploymentName, endpoint, apiKey, kernel.Config.HttpHandlerFactory, kernel.Log);
+
+            config.AddTextCompletionService(serviceId, TextServiceFactory);
+        }
 
         return config;
     }
@@ -196,9 +206,10 @@ public static class KernelConfigOpenAIExtensions
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="credentials">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="alsoAsTextCompletion">Whether to use the service also for text completion, if supported</param>
     /// <returns>Self instance</returns>
     public static KernelConfig AddAzureChatCompletionService(this KernelConfig config,
-        string serviceId, string deploymentName, string endpoint, TokenCredential credentials)
+        string serviceId, string deploymentName, string endpoint, TokenCredential credentials, bool alsoAsTextCompletion = true)
     {
         Verify.NotEmpty(serviceId, "The service Id provided is empty");
 
@@ -206,6 +217,15 @@ public static class KernelConfigOpenAIExtensions
             deploymentName, endpoint, credentials, kernel.Config.HttpHandlerFactory, kernel.Log);
 
         config.AddChatCompletionService(serviceId, Factory);
+
+        // If the class implements the text completion interface, allow to use it also for semantic functions
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletion)))
+        {
+            ITextCompletion TextServiceFactory(IKernel kernel) => new AzureChatCompletion(
+                deploymentName, endpoint, credentials, kernel.Config.HttpHandlerFactory, kernel.Log);
+
+            config.AddTextCompletionService(serviceId, TextServiceFactory);
+        }
 
         return config;
     }
@@ -219,9 +239,10 @@ public static class KernelConfigOpenAIExtensions
     /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
     /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
     /// <param name="orgId">OpenAI organization id. This is usually optional unless your account belongs to multiple organizations.</param>
+    /// <param name="alsoAsTextCompletion">Whether to use the service also for text completion, if supported</param>
     /// <returns>Self instance</returns>
     public static KernelConfig AddOpenAIChatCompletionService(this KernelConfig config,
-        string serviceId, string modelId, string apiKey, string? orgId = null)
+        string serviceId, string modelId, string apiKey, string? orgId = null, bool alsoAsTextCompletion = true)
     {
         Verify.NotEmpty(serviceId, "The service Id provided is empty");
 
@@ -229,6 +250,15 @@ public static class KernelConfigOpenAIExtensions
             modelId, apiKey, orgId, kernel.Config.HttpHandlerFactory, kernel.Log);
 
         config.AddChatCompletionService(serviceId, Factory);
+
+        // If the class implements the text completion interface, allow to use it also for semantic functions
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(OpenAIChatCompletion)))
+        {
+            ITextCompletion TextServiceFactory(IKernel kernel) => new OpenAIChatCompletion(
+                modelId, apiKey, orgId, kernel.Config.HttpHandlerFactory, kernel.Log);
+
+            config.AddTextCompletionService(serviceId, TextServiceFactory);
+        }
 
         return config;
     }

--- a/samples/dotnet/kernel-syntax-examples/Example25_AADAuth.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example25_AADAuth.cs
@@ -45,7 +45,7 @@ public static class Example25_AADAuth
         // Add Azure chat completion service using DefaultAzureCredential AAD auth
         kernel.Config.AddAzureChatCompletionService("chat",
             "gpt-35-turbo",
-            "https://lightspeed-team-shared-openai.openai.azure.com/",
+            "https://....openai.azure.com/",
             new DefaultAzureCredential(authOptions));
 
         IChatCompletion chatGPT = kernel.GetService<IChatCompletion>();

--- a/samples/dotnet/kernel-syntax-examples/Example26_SemanticFunctionsUsingChatGPT.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example26_SemanticFunctionsUsingChatGPT.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using RepoUtils;
+
+/**
+ * This example shows how to use GPT3.5 Chat model for prompts and semantic functions.
+ */
+
+// ReSharper disable once InconsistentNaming
+public static class Example26_SemanticFunctionsUsingChatGPT
+{
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("======== Using Chat GPT model for text completion ========");
+
+        IKernel kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
+
+        // Note: we use Chat Completion and GPT 3.5 Turbo
+        kernel.Config.AddAzureChatCompletionService("id", "gpt-35-turbo", "https://....openai.azure.com/", "...API KEY...");
+
+        var func = kernel.CreateSemanticFunction(
+            "List the two planets closest to '{{$input}}', excluding moons, using bullet points.");
+
+        var result = await func.InvokeAsync("Jupiter");
+        Console.WriteLine(result);
+
+        /*
+        Output:
+           - Saturn
+           - Uranus
+        */
+    }
+}

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -82,5 +82,8 @@ public static class Program
 
         await Example25_AADAuth.RunAsync();
         Console.WriteLine("== DONE ==");
+
+        await Example26_SemanticFunctionsUsingChatGPT.RunAsync();
+        Console.WriteLine("== DONE ==");
     }
 }


### PR DESCRIPTION
### Motivation and Context

Chat models are (currently) less expensive and can be used like text completion models also for semantic functions and prompt completion.

### Description

Extend OpenAI chat clients to simulate text completion over the chat protocol. This behavior is enabled by default, but can also be disabled passing a boolean parameter when registering an AI service.