### PR TITLE
Introduce new meta package to install core packages

### DIFF
--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -71,6 +71,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Connectors.AI.OpenAI", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticKernel.Abstractions", "src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj", "{627742DB-1E52-468A-99BD-6FF1A542D25B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticKernel.MetaPackage", "src\SemanticKernel.MetaPackage\SemanticKernel.MetaPackage.csproj", "{E3299033-EB81-4C4C-BCD9-E8DC40937969}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +167,10 @@ Global
 		{627742DB-1E52-468A-99BD-6FF1A542D25B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{627742DB-1E52-468A-99BD-6FF1A542D25B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{627742DB-1E52-468A-99BD-6FF1A542D25B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3299033-EB81-4C4C-BCD9-E8DC40937969}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3299033-EB81-4C4C-BCD9-E8DC40937969}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3299033-EB81-4C4C-BCD9-E8DC40937969}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3299033-EB81-4C4C-BCD9-E8DC40937969}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -195,6 +201,7 @@ Global
 		{EA61C289-7928-4B78-A9C1-7AAD61F907CD} = {0247C2C9-86C3-45BA-8873-28B0948EDC0C}
 		{AFA81EB7-F869-467D-8A90-744305D80AAC} = {0247C2C9-86C3-45BA-8873-28B0948EDC0C}
 		{627742DB-1E52-468A-99BD-6FF1A542D25B} = {831DDCA2-7D2C-4C31-80DB-6BDB3E1F7AE0}
+		{E3299033-EB81-4C4C-BCD9-E8DC40937969} = {831DDCA2-7D2C-4C31-80DB-6BDB3E1F7AE0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBDC56A3-86AD-4323-AA0F-201E59123B83}

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Connectors.AI.OpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Connectors.AI.OpenAI.csproj
@@ -9,12 +9,14 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.AI.OpenAI</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Connectors.AI.OpenAI</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Connectors.AI.OpenAI</PackageId>
     <Title>Semantic Kernel - OpenAI and Azure OpenAI connectors</Title>
+    <Description>Semantic Kernel connectors for OpenAI and Azure OpenAI. Contains clients for text completion, chat completion, embedding and DALL-E image generation.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/Connectors.Memory.CosmosDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/Connectors.Memory.CosmosDB.csproj
@@ -5,15 +5,16 @@
   <!--<Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />-->
 
   <PropertyGroup>
-    <AssemblyName>Microsoft.SemanticKernel.Connectors.Memory.Cosmos</AssemblyName>
-    <RootNamespace>Microsoft.SemanticKernel.Connectors.Memory.Cosmos</RootNamespace>
+    <AssemblyName>Microsoft.SemanticKernel.Connectors.Memory.AzureCosmosDb</AssemblyName>
+    <RootNamespace>Microsoft.SemanticKernel.Connectors.Memory.AzureCosmosDb</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->
-    <PackageId>Microsoft.SemanticKernel.Connectors.Memory.Cosmos</PackageId>
-    <Title>Semantic Kernel - Qdrant Connector</Title>
+    <PackageId>Microsoft.SemanticKernel.Connectors.Memory.AzureCosmosDb</PackageId>
+    <Title>Semantic Kernel - Azure Cosmos Db Connector</Title>
+    <Description>Azure Cosmos Db connector for Semantic Kernel skills and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryRecord.cs
@@ -4,7 +4,7 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace Microsoft.SemanticKernel.Connectors.Memory.Cosmos;
+namespace Microsoft.SemanticKernel.Connectors.Memory.AzureCosmosDb;
 
 /// <summary>
 /// A Cosmos memory record.

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
@@ -14,7 +14,7 @@ using Microsoft.SemanticKernel.AI.Embeddings.VectorOperations;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Memory.Collections;
 
-namespace Microsoft.SemanticKernel.Connectors.Memory.Cosmos;
+namespace Microsoft.SemanticKernel.Connectors.Memory.AzureCosmosDb;
 
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> for Azure Cosmos DB.
@@ -297,7 +297,7 @@ public class CosmosMemoryStore : IMemoryStore
 
         var iterator = container.GetItemQueryIterator<CosmosMemoryRecord>(query);
 
-        while (iterator.HasMoreResults) //read all result in batch 
+        while (iterator.HasMoreResults) //read all result in batch
         {
             var items = await iterator.ReadNextAsync(cancel).ConfigureAwait(false);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -14,6 +14,7 @@
       <!-- NuGet Package Settings -->
         <PackageId>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</PackageId>
         <Title>Semantic Kernel - Qdrant Connector</Title>
+        <Description>Qdrant connector for Semantic Kernel skills and semantic memory</Description>
     </PropertyGroup>
 
     <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
@@ -15,6 +15,7 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Connectors.Memory.Sqlite</PackageId>
     <Title>Semantic Kernel - SQLite Connector</Title>
+    <Description>SQLite connector for Semantic Kernel skills and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteExtensions.cs
@@ -3,6 +3,7 @@
 using Microsoft.Data.Sqlite;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Sqlite;
+
 internal static class SqliteExtensions
 {
     public static T GetFieldValue<T>(this SqliteDataReader reader, string fieldName)

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -15,6 +15,7 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Abstractions</PackageId>
     <Title>Semantic Kernel - Abstractions</Title>
+    <Description>Semantic Kernel interfaces and abstractions. This package is automatically installed by Semantic Kernel packages if needed.</Description>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +28,7 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>Microsoft.SemanticKernel</_Parameter1>
+      <_Parameter1>Microsoft.SemanticKernel.Core</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Microsoft.SemanticKernel.Connectors.AI.OpenAI</_Parameter1>

--- a/dotnet/src/SemanticKernel.MetaPackage/SemanticKernel.MetaPackage.csproj
+++ b/dotnet/src/SemanticKernel.MetaPackage/SemanticKernel.MetaPackage.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
+  </PropertyGroup>
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <PropertyGroup>
+    <AssemblyName>Microsoft.SemanticKernel</AssemblyName>
+    <RootNamespace>Microsoft.SemanticKernel</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Settings -->
+    <PackageId>Microsoft.SemanticKernel</PackageId>
+    <Title>Semantic Kernel</Title>
+    <Description>Semantic Kernel common package collection, including SK Core, OpenAI, Azure OpenAI, DALL-E 2.
+Empowers app owners to integrate cutting-edge LLM technology quickly and easily into their apps.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SemanticKernel\SemanticKernel.csproj" />
+    <ProjectReference Include="..\Connectors\Connectors.AI.OpenAI\Connectors.AI.OpenAI.csproj" PrivateAssets="none"/>
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/SemanticKernel.Skills/Skills.Document/Skills.Document.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Document/Skills.Document.csproj
@@ -15,6 +15,7 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.Document</PackageId>
     <Title>Semantic Kernel - Document Skill</Title>
+    <Description>Semantic Kernel Document Skill: Word processing, OpenXML, etc.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.MsGraph/Skills.MsGraph.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.MsGraph/Skills.MsGraph.csproj
@@ -15,6 +15,7 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.MsGraph</PackageId>
     <Title>Semantic Kernel - Microsoft Graph Connector</Title>
+    <Description>Semantic Kernel Microsoft Graph Skill: access your tenant data, schedule meetings, send emails, etc.</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Skills.OpenAPI.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Skills.OpenAPI.csproj
@@ -15,6 +15,7 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.OpenAPI</PackageId>
     <Title>Semantic Kernel - OpenAPI Skills</Title>
+    <Description>Semantic Kernel OpenAPI Skill</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.Web/Skills.Web.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Web/Skills.Web.csproj
@@ -15,6 +15,7 @@
     <!-- NuGet Package Settings -->
     <PackageId>Microsoft.SemanticKernel.Skills.Web</PackageId>
     <Title>Semantic Kernel - Microsoft Bing Connector</Title>
+    <Description>Semantic Kernel Web Skill: search the web, download files, etc.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingReadOnlySpan.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingReadOnlySpan.cs
@@ -19,7 +19,7 @@ public ref struct EmbeddingReadOnlySpan<TEmbedding>
     /// <param name="vector">A a vector of contiguous, unmanaged data.</param>
     /// <param name="isNormalized">Indicates whether the data was pre-normalized.</param>
     /// <remarks>
-    /// This does not verified that the data is normalized, nor make any guarantees that it remains so,
+    /// This does not verify that the data is normalized, nor make any guarantees that it remains so,
     /// as the data can be modified at its source. The <paramref name="isNormalized"/> parameter simply
     /// directs these operations to perform faster if the data is known to be normalized.
     /// </remarks>
@@ -37,7 +37,7 @@ public ref struct EmbeddingReadOnlySpan<TEmbedding>
     /// <param name="vector">A vector of contiguous, unmanaged data.</param>
     /// <param name="isNormalized">Indicates whether the data was pre-normalized.</param>
     /// <remarks>
-    /// This does not verified that the data is normalized, nor make any guarantees that it remains so,
+    /// This does not verify that the data is normalized, nor make any guarantees that it remains so,
     /// as the data can be modified at its source. The <paramref name="isNormalized"/> parameter simply
     /// directs these operations to perform faster if the data is known to be normalized.
     /// </remarks>
@@ -52,7 +52,7 @@ public ref struct EmbeddingReadOnlySpan<TEmbedding>
     /// <param name="span">A vector of contiguous, unmanaged data.</param>
     /// <param name="isNormalized">Indicates whether the data was pre-normalized.</param>
     /// <remarks>
-    /// This does not verified that the data is normalized, nor make any guarantees that it remains so,
+    /// This does not verify that the data is normalized, nor make any guarantees that it remains so,
     /// as the data can be modified at its source. The <paramref name="isNormalized"/> parameter simply
     /// directs these operations to perform faster if the data is known to be normalized.
     /// </remarks>

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
 
   <PropertyGroup>
-    <AssemblyName>Microsoft.SemanticKernel</AssemblyName>
+    <AssemblyName>Microsoft.SemanticKernel.Core</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -15,8 +15,11 @@
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->
-    <PackageId>Microsoft.SemanticKernel</PackageId>
-    <Title>Semantic Kernel</Title>
+    <PackageId>Microsoft.SemanticKernel.Core</PackageId>
+    <Title>Semantic Kernel Core</Title>
+    <Description>Semantic Kernel core orchestration, runtime and skills.
+This package is automatically installed by 'Microsoft.SemanticKernel' package with other useful packages.
+Install this package manually only if you are selecting individual Semantic Kernel components.</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Change **Microsoft.SemanticKernel** to be a metapackage that installs 2 packages:
* Microsoft.SemanticKernel.Core: core code (previously named Microsoft.SemanticKernel) + abstractions
* Microsoft.SemanticKernel.Connectors.AI.OpenAI: OpenAI clients, depending on Azure OpenAI SDK and Azure Core

Benefits:
* Users installing Microsoft.SemanticKernel have all the code like before to use OpenAI
* Users can install the core kernel without OpenAI if they need to, e.g. when working with other AI providers
* We can use the metapackage to include more useful dependencies if needed, without having to put all in the same package
