### PR TITLE
Sqlite to netstandard2.0 + bug fix in WebSkill.DownloadToFile

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.SemanticKernel.Connectors.Memory.Sqlite</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Connectors.Memory.Sqlite</RootNamespace>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -29,9 +28,8 @@ internal class Database
 
     public Task CreateTableAsync(SqliteConnection conn, CancellationToken cancel = default)
     {
-        using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
             CREATE TABLE IF NOT EXISTS {TableName}(
                 collection TEXT,
                 key TEXT,
@@ -39,8 +37,7 @@ internal class Database
                 embedding TEXT,
                 timestamp TEXT,
                 PRIMARY KEY(collection, key))";
-            return cmd.ExecuteNonQueryAsync(cancel);
-        }
+        return cmd.ExecuteNonQueryAsync(cancel);
     }
 
     public async Task CreateCollectionAsync(SqliteConnection conn, string collectionName, CancellationToken cancel = default)
@@ -51,50 +48,44 @@ internal class Database
             return;
         }
 
-        await using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              INSERT INTO {TableName}(collection)
              VALUES(@collection); ";
-            cmd.Parameters.AddWithValue("@collection", collectionName);
-            await cmd.ExecuteNonQueryAsync(cancel);
-        }
+        cmd.Parameters.AddWithValue("@collection", collectionName);
+        await cmd.ExecuteNonQueryAsync(cancel);
     }
 
     public async Task UpdateAsync(SqliteConnection conn,
         string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancel = default)
     {
-        await using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              UPDATE {TableName}
              SET metadata=@metadata, embedding=@embedding, timestamp=@timestamp
              WHERE collection=@collection
                 AND key=@key ";
-            cmd.Parameters.AddWithValue("@collection", collection);
-            cmd.Parameters.AddWithValue("@key", key);
-            cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
-            cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
-            cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
-            await cmd.ExecuteNonQueryAsync(cancel);
-        }
+        cmd.Parameters.AddWithValue("@collection", collection);
+        cmd.Parameters.AddWithValue("@key", key);
+        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
+        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
+        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
+        await cmd.ExecuteNonQueryAsync(cancel);
     }
 
     public async Task InsertOrIgnoreAsync(SqliteConnection conn,
         string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancel = default)
     {
-        await using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              INSERT OR IGNORE INTO {TableName}(collection, key, metadata, embedding, timestamp)
              VALUES(@collection, @key, @metadata, @embedding, @timestamp); ";
-            cmd.Parameters.AddWithValue("@collection", collection);
-            cmd.Parameters.AddWithValue("@key", key);
-            cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
-            cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
-            cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
-            await cmd.ExecuteNonQueryAsync(cancel);
-        }
+        cmd.Parameters.AddWithValue("@collection", collection);
+        cmd.Parameters.AddWithValue("@key", key);
+        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
+        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
+        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
+        await cmd.ExecuteNonQueryAsync(cancel);
     }
 
     public async Task<bool> DoesCollectionExistsAsync(SqliteConnection conn,
@@ -108,19 +99,15 @@ internal class Database
     public async IAsyncEnumerable<string> GetCollectionsAsync(SqliteConnection conn,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
-        await using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
             SELECT DISTINCT(collection)
             FROM {TableName}";
 
-            await using (var dataReader = await cmd.ExecuteReaderAsync(cancel))
-            {
-                while (await dataReader.ReadAsync(cancel))
-                {
-                    yield return dataReader.GetFieldValue<string>("collection");
-                }
-            }
+        using var dataReader = await cmd.ExecuteReaderAsync(cancel);
+        while (await dataReader.ReadAsync(cancel))
+        {
+            yield return dataReader.GetString("collection");
         }
     }
 
@@ -128,24 +115,20 @@ internal class Database
         string collectionName,
         [EnumeratorCancellation] CancellationToken cancel = default)
     {
-        await using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
             SELECT * FROM {TableName}
             WHERE collection=@collection";
-            cmd.Parameters.AddWithValue("@collection", collectionName);
+        cmd.Parameters.AddWithValue("@collection", collectionName);
 
-            await using (var dataReader = await cmd.ExecuteReaderAsync(cancel))
-            {
-                while (await dataReader.ReadAsync(cancel))
-                {
-                    string key = dataReader.GetFieldValue<string>("key");
-                    string metadata = dataReader.GetFieldValue<string>("metadata");
-                    string embedding = dataReader.GetFieldValue<string>("embedding");
-                    string timestamp = dataReader.GetFieldValue<string>("timestamp");
-                    yield return new DatabaseEntry() { Key = key, MetadataString = metadata, EmbeddingString = embedding, Timestamp = timestamp };
-                }
-            }
+        using var dataReader = await cmd.ExecuteReaderAsync(cancel);
+        while (await dataReader.ReadAsync(cancel))
+        {
+            string key = dataReader.GetString("key");
+            string metadata = dataReader.GetString("metadata");
+            string embedding = dataReader.GetString("embedding");
+            string timestamp = dataReader.GetString("timestamp");
+            yield return new DatabaseEntry() { Key = key, MetadataString = metadata, EmbeddingString = embedding, Timestamp = timestamp };
         }
     }
 
@@ -154,72 +137,62 @@ internal class Database
         string key,
         CancellationToken cancel = default)
     {
-        await using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              SELECT * FROM {TableName}
              WHERE collection=@collection
                 AND key=@key ";
-            cmd.Parameters.AddWithValue("@collection", collectionName);
-            cmd.Parameters.AddWithValue("@key", key);
+        cmd.Parameters.AddWithValue("@collection", collectionName);
+        cmd.Parameters.AddWithValue("@key", key);
 
-            await using (var dataReader = await cmd.ExecuteReaderAsync(cancel))
+        using var dataReader = await cmd.ExecuteReaderAsync(cancel);
+        if (await dataReader.ReadAsync(cancel))
+        {
+            string metadata = dataReader.GetString(dataReader.GetOrdinal("metadata"));
+            string embedding = dataReader.GetString(dataReader.GetOrdinal("embedding"));
+            string timestamp = dataReader.GetString(dataReader.GetOrdinal("timestamp"));
+            return new DatabaseEntry()
             {
-                if (await dataReader.ReadAsync(cancel))
-                {
-                    string metadata = dataReader.GetString(dataReader.GetOrdinal("metadata"));
-                    string embedding = dataReader.GetString(dataReader.GetOrdinal("embedding"));
-                    string timestamp = dataReader.GetString(dataReader.GetOrdinal("timestamp"));
-                    return new DatabaseEntry()
-                    {
-                        Key = key,
-                        MetadataString = metadata,
-                        EmbeddingString = embedding,
-                        Timestamp = timestamp
-                    };
-                }
-
-                return null;
-            }
+                Key = key,
+                MetadataString = metadata,
+                EmbeddingString = embedding,
+                Timestamp = timestamp
+            };
         }
+
+        return null;
     }
 
     public Task DeleteCollectionAsync(SqliteConnection conn, string collectionName, CancellationToken cancel = default)
     {
-        using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              DELETE FROM {TableName}
              WHERE collection=@collection";
-            cmd.Parameters.AddWithValue("@collection", collectionName);
-            return cmd.ExecuteNonQueryAsync(cancel);
-        }
+        cmd.Parameters.AddWithValue("@collection", collectionName);
+        return cmd.ExecuteNonQueryAsync(cancel);
     }
 
     public Task DeleteAsync(SqliteConnection conn, string collectionName, string key, CancellationToken cancel = default)
     {
-        using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              DELETE FROM {TableName}
              WHERE collection=@collection
                 AND key=@key ";
-            cmd.Parameters.AddWithValue("@collection", collectionName);
-            cmd.Parameters.AddWithValue("@key", key);
-            return cmd.ExecuteNonQueryAsync(cancel);
-        }
+        cmd.Parameters.AddWithValue("@collection", collectionName);
+        cmd.Parameters.AddWithValue("@key", key);
+        return cmd.ExecuteNonQueryAsync(cancel);
     }
 
     public Task DeleteEmptyAsync(SqliteConnection conn, string collectionName, CancellationToken cancel = default)
     {
-        using (SqliteCommand cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = $@"
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
              DELETE FROM {TableName}
              WHERE collection=@collection
                 AND key IS NULL";
-            cmd.Parameters.AddWithValue("@collection", collectionName);
-            return cmd.ExecuteNonQueryAsync(cancel);
-        }
+        cmd.Parameters.AddWithValue("@collection", collectionName);
+        return cmd.ExecuteNonQueryAsync(cancel);
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Data.Sqlite;
+
+namespace Microsoft.SemanticKernel.Connectors.Memory.Sqlite;
+internal static class SqliteExtensions
+{
+    public static T GetFieldValue<T>(this SqliteDataReader reader, string fieldName)
+    {
+        int ordinal = reader.GetOrdinal(fieldName);
+        return reader.GetFieldValue<T>(ordinal);
+    }
+
+    public static string GetString(this SqliteDataReader reader, string fieldName)
+    {
+        int ordinal = reader.GetOrdinal(fieldName);
+        return reader.GetString(ordinal);
+    }
+}

--- a/dotnet/src/SemanticKernel.IntegrationTests/RedirectOutput.cs
+++ b/dotnet/src/SemanticKernel.IntegrationTests/RedirectOutput.cs
@@ -29,7 +29,7 @@ public class RedirectOutput : TextWriter, ILogger
 
     public IDisposable BeginScope<TState>(TState state)
     {
-        return null;
+        return null!;
     }
 
     public bool IsEnabled(LogLevel logLevel)

--- a/dotnet/src/SemanticKernel.Skills/Skills.Web/WebFileDownloadSkill.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Web/WebFileDownloadSkill.cs
@@ -76,7 +76,7 @@ public class WebFileDownloadSkill : IDisposable
         using Stream webStream = await response.Content.ReadAsStreamAsync();
         using FileStream outputFileStream = new(Environment.ExpandEnvironmentVariables(filePath), FileMode.Create);
 
-        await webStream.CopyToAsync(outputFileStream, (int)outputFileStream.Length, cancellationToken: context.CancellationToken);
+        await webStream.CopyToAsync(outputFileStream, (int)webStream.Length, cancellationToken: context.CancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
### Description
Converting the Connectors.Sqlite package to netstandard2.0. 
Added some extension methods to make up for the gap in overloads in the netstandard2.0 sqlite implementation.
Converted usings to single line syntax and removed the "async using" since this version does not implement IAsyncDisposable.

Also included:
 - a single-line bug fix in WebSkill.DownloadToFileAsync() -- was using the destination stream length (always 0) instead of the source stream length.
 - a nullable warning fix in integration tests that has been showing up in recent PRs.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
