### PR TITLE
Fix support for blocking/non-blocking storage contexts (allow CosmosDB and InMemory storage contexts to coexist)

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
 using SemanticKernel.Service.Skills;
 
 namespace SemanticKernel.Service.Storage;
@@ -23,6 +25,12 @@ public class ChatMessageRepository : Repository<ChatMessage>
     /// </summary>
     public Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
     {
+        if (base.StorageContext.IsQueryBlocking)
+        {
+            return Task.Run<IEnumerable<ChatMessage>>(
+                () => base.StorageContext.QueryableEntities.Where(e => e.ChatId == chatId).AsEnumerable());
+        }
+
         return Task.FromResult(base.StorageContext.QueryableEntities.Where(e => e.ChatId == chatId).AsEnumerable());
     }
 

--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
@@ -25,6 +25,12 @@ public class ChatSessionRepository : Repository<ChatSession>
     /// <returns>A list of chat sessions.</returns>
     public Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
     {
+        if (base.StorageContext.IsQueryBlocking)
+        {
+            return Task.Run<IEnumerable<ChatSession>>(
+                () => base.StorageContext.QueryableEntities.Where(e => e.UserId == userId).AsEnumerable());
+        }
+
         return Task.FromResult(base.StorageContext.QueryableEntities.Where(e => e.UserId == userId).AsEnumerable());
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/Storage/CosmosDbContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/CosmosDbContext.cs
@@ -40,10 +40,10 @@ public class CosmosDbContext<T> : IStorageContext<T>, IDisposable where T : ISto
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
             },
-            
+
         };
         this._client = new CosmosClient(connectionString, options);
-        this._container = this._client.GetContainer(database, container);        
+        this._container = this._client.GetContainer(database, container);
     }
 
     /// <inheritdoc/>

--- a/samples/apps/copilot-chat-app/webapi/Storage/CosmosDbContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/CosmosDbContext.cs
@@ -11,6 +11,7 @@ namespace SemanticKernel.Service.Storage;
 /// </summary>
 public class CosmosDbContext<T> : IStorageContext<T>, IDisposable where T : IStorageEntity
 {
+    ///<inheritdoc />
     public bool IsQueryBlocking => true;
 
 

--- a/samples/apps/copilot-chat-app/webapi/Storage/IStorageContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/IStorageContext.cs
@@ -16,7 +16,7 @@ public interface IStorageContext<T> where T : IStorageEntity
     /// When true, the consumer of this storage context should handle queryable entities
     /// that are retrieved via a blocking operation with a Task.Run (or similar)
     /// </summary>
-    bool IsQueryBlocking {get;}
+    bool IsQueryBlocking { get; }
 
     /// <summary>
     /// Read an entity from the storage context by id.

--- a/samples/apps/copilot-chat-app/webapi/Storage/IStorageContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/IStorageContext.cs
@@ -13,6 +13,12 @@ public interface IStorageContext<T> where T : IStorageEntity
     IQueryable<T> QueryableEntities { get; }
 
     /// <summary>
+    /// When true, the consumer of this storage context should handle queryable entities
+    /// that are retrieved via a blocking operation with a Task.Run (or similar)
+    /// </summary>
+    bool IsQueryBlocking {get;}
+
+    /// <summary>
     /// Read an entity from the storage context by id.
     /// </summary>
     /// <param name="entityId">The entity id.</param>

--- a/samples/apps/copilot-chat-app/webapi/Storage/InMemoryContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/InMemoryContext.cs
@@ -9,6 +9,9 @@ namespace SemanticKernel.Service.Storage;
 /// </summary>
 public class InMemoryContext<T> : IStorageContext<T> where T : IStorageEntity
 {
+    public bool IsQueryBlocking => false;
+    
+
     /// <summary>
     /// Using a concurrent dictionary to store entities in memory.
     /// </summary>

--- a/samples/apps/copilot-chat-app/webapi/Storage/InMemoryContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/InMemoryContext.cs
@@ -9,6 +9,7 @@ namespace SemanticKernel.Service.Storage;
 /// </summary>
 public class InMemoryContext<T> : IStorageContext<T> where T : IStorageEntity
 {
+    ///<inheritdoc />
     public bool IsQueryBlocking => false;
     
 

--- a/samples/apps/copilot-chat-app/webapi/Storage/InMemoryContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/InMemoryContext.cs
@@ -11,7 +11,7 @@ public class InMemoryContext<T> : IStorageContext<T> where T : IStorageEntity
 {
     ///<inheritdoc />
     public bool IsQueryBlocking => false;
-    
+
 
     /// <summary>
     /// Using a concurrent dictionary to store entities in memory.


### PR DESCRIPTION
### Motivation and Context
The CosmosDB v3 SDK does not support async LINQ enumerations, preferring the ToFeedIterator() pattern. There is an overload that does make requests blocking which we can handle by wrapping the blocking operation in a Task. While I don't love this and it is a bit messy, it does unblock the CosmosDB implementation without leaking into the repository.


### Description
* Add a property to IStorageContext<T> ```IsQueryBlocking```
* During queries, repository implementers must check ```if (base.StorageContext.IsQueryBlocking)```, running the query in a Task if true.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
