### PR TITLE
Include Connectors.AI.OpenAI as dependency of the SK main nuget

### DIFF
--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -52,6 +52,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Connectors\Connectors.AI.OpenAI\Connectors.AI.OpenAI.csproj">
+      <PrivateAssets>none</PrivateAssets>
+    </ProjectReference>
     <ProjectReference Include="..\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Motivation and Context
When users install the "Microsoft.SemanticKernel" nuget package, it should have a fully working path without requiring them to seek additional nugets explicitly.

### Description
Adds the SemanticKernel.Connectors.AI.OpenAI nuget package as a dependency of the main nuget package, so that users installing the main package will get this too.

Note: <PrivateAssets>none</> tells the hosting package to include all assets of the OpenAI package. The default value of PrivateAssets is "contentfiles;analyzers;build", so content files are considered "private" and hidden from the host project. 
