### PR TITLE
CopilotChat: Have storage context to handle query

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
@@ -21,9 +21,9 @@ public class ChatMessageRepository : Repository<ChatMessage>
     /// <summary>
     /// Finds chat messages by chat id.
     /// </summary>
-    public async Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
+    public Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
     {
-        return await base.StorageContext.QueryEntitiesAsync(e => e.ChatId == chatId);
+        return base.StorageContext.QueryEntitiesAsync(e => e.ChatId == chatId);
     }
 
     public async Task<ChatMessage> FindLastByChatIdAsync(string chatId)

--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatMessageRepository.cs
@@ -21,9 +21,9 @@ public class ChatMessageRepository : Repository<ChatMessage>
     /// <summary>
     /// Finds chat messages by chat id.
     /// </summary>
-    public Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
+    public async Task<IEnumerable<ChatMessage>> FindByChatIdAsync(string chatId)
     {
-        return Task.FromResult(base.StorageContext.QueryableEntities.Where(e => e.ChatId == chatId).AsEnumerable());
+        return await base.StorageContext.QueryEntitiesAsync(e => e.ChatId == chatId);
     }
 
     public async Task<ChatMessage> FindLastByChatIdAsync(string chatId)

--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
@@ -23,8 +23,8 @@ public class ChatSessionRepository : Repository<ChatSession>
     /// </summary>
     /// <param name="userId">The user id.</param>
     /// <returns>A list of chat sessions.</returns>
-    public async Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
+    public Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
     {
-        return await base.StorageContext.QueryEntitiesAsync(e => e.UserId == userId);
+        return base.StorageContext.QueryEntitiesAsync(e => e.UserId == userId);
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/ChatSessionRepository.cs
@@ -23,8 +23,8 @@ public class ChatSessionRepository : Repository<ChatSession>
     /// </summary>
     /// <param name="userId">The user id.</param>
     /// <returns>A list of chat sessions.</returns>
-    public Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
+    public async Task<IEnumerable<ChatSession>> FindByUserIdAsync(string userId)
     {
-        return Task.FromResult(base.StorageContext.QueryableEntities.Where(e => e.UserId == userId).AsEnumerable());
+        return await base.StorageContext.QueryEntitiesAsync(e => e.UserId == userId);
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
@@ -20,7 +20,10 @@ public class FileSystemContext<T> : IStorageContext<T> where T : IStorageEntity
     }
 
     /// <inheritdoc/>
-    public IQueryable<T> QueryableEntities => this._entities.Values.AsQueryable();
+    public Task<IEnumerable<T>> QueryEntitiesAsync(Func<T, bool> predicate)
+    {
+        return Task.FromResult(this._entities.Values.Where(predicate));
+    }
 
     /// <inheritdoc/>
     public Task CreateAsync(T entity)

--- a/samples/apps/copilot-chat-app/webapi/Storage/IStorageContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/IStorageContext.cs
@@ -8,9 +8,9 @@ namespace SemanticKernel.Service.Storage;
 public interface IStorageContext<T> where T : IStorageEntity
 {
     /// <summary>
-    /// Queryable entities.
+    /// Query entities in the storage context.
     /// </summary>
-    IQueryable<T> QueryableEntities { get; }
+    Task<IEnumerable<T>> QueryEntitiesAsync(Func<T, bool> predicate);
 
     /// <summary>
     /// Read an entity from the storage context by id.

--- a/samples/apps/copilot-chat-app/webapi/Storage/VolatileContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/VolatileContext.cs
@@ -25,7 +25,10 @@ public class VolatileContext<T> : IStorageContext<T> where T : IStorageEntity
     }
 
     /// <inheritdoc/>
-    public IQueryable<T> QueryableEntities => this._entities.Values.AsQueryable();
+    public Task<IEnumerable<T>> QueryEntitiesAsync(Func<T, bool> predicate)
+    {
+        return Task.FromResult(this._entities.Values.Where(predicate));
+    }
 
     /// <inheritdoc/>
     public Task CreateAsync(T entity)


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
1. A ComsoDb storage context exposing an IQueryable to repositories will not allow queries to be processed asynchronously, unless the repository takes dependency on Microsoft.Azure.Cosmos.Linq, which will violate the principles of the repository data access pattern and cause problems when using other storage context other than CosmosDb.
2. The CosmosDb SDK serializes entities into Json using the same property names that are pascal case. We would like it to serialize the entities to Json with the property names in camel case.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

1. Create an API named QueryEntitiesAsync that accept a predicate for Linq query and have the storage contexts handle the internal.
2. Configure the CosmosDb client to use camel case for serialization.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
