### PR TITLE
Switch default memoriesstore to volatile

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -40,7 +40,7 @@
 
   // Memories stores are used for storing new memories and retrieving semantically similar memories.
   "MemoriesStore": {
-    "Type": "qdrant", // Which type of memory store to use - supported values are "volatile" or "qdrant"
+    "Type": "volatile", // Which type of memory store to use - supported values are "volatile" or "qdrant"
     "Qdrant": {
       "Host": "http://localhost", // Endpoint of the Qdrant server
       "Port": "6333", // Port of the Qdrant server


### PR DESCRIPTION
appsettings defaults should be set to "volatile" - this was an accidental change in a previous merge.