### PR TITLE
Python: Making SKFunction.RunThread an outer class

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ "main", "feature*" ]
+    paths:
+      - 'python/**'
 
 jobs:
   build:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,30 @@
+name: Python tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "main", "feature*" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install poetry pytest
+        cd python && poetry install
+    - name: Test with pytest
+      run: |
+        cd python && poetry run pytest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,12 +4,33 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ "main", "feature*" ]
-    paths:
-      - 'python/**'
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.filter.outputs.python}}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          python:
+            - 'python/**'
+    # run only if 'python' files were changed
+    - name: python tests
+      if: steps.filter.outputs.python == 'true'
+      run: echo "Python file"
+    # run only if not 'python' files were changed
+    - name: not python tests
+      if: steps.filter.outputs.python != 'true'
+      run: echo "NOT python file"
+
   build:
     runs-on: ${{ matrix.os }}
+    needs: paths-filter
+    if: needs.paths-filter.outputs.output1 == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/python/semantic_kernel/orchestration/sk_function.py
+++ b/python/semantic_kernel/orchestration/sk_function.py
@@ -431,6 +431,7 @@ class SKFunction(SKFunctionBase):
     Async code wrapper to allow running async code inside external
     event loops such as Jupyter notebooks.
     """
+
     def _runThread(self, code: Callable):
         result = []
         thread = threading.Thread(target=self._runCode, args=(code, result))

--- a/python/semantic_kernel/orchestration/sk_function.py
+++ b/python/semantic_kernel/orchestration/sk_function.py
@@ -287,15 +287,11 @@ class SKFunction(SKFunctionBase):
         # Handle "asyncio.run() cannot be called from a running event loop"
         if loop and loop.is_running():
             if self.is_semantic:
-                thread = RunThread(self._invoke_semantic_async(context, settings))
-                thread.start()
-                thread.join()
-                return thread.result
+                return RunThread(
+                    self._invoke_semantic_async(context, settings)
+                ).runThread()
             else:
-                thread = RunThread(self._invoke_native_async(context))
-                thread.start()
-                thread.join()
-                return thread.result
+                return RunThread(self._invoke_semantic_async(context)).runThread()
         else:
             if self.is_semantic:
                 return asyncio.run(self._invoke_semantic_async(context, settings))
@@ -438,6 +434,7 @@ class RunThread(threading.Thread):
     """
     Async code wrapper to allow running async code inside external
     event loops such as Jupyter notebooks.
+    Call runThread to run and get the result of the async code
     """
 
     def __init__(self, code):
@@ -447,3 +444,8 @@ class RunThread(threading.Thread):
 
     def run(self):
         self.result = asyncio.run(self.code)
+
+    def runThread(self):
+        self.start()
+        self.join()
+        return self.result


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
It's better to avoid nested classes in Python, so in SKFunction, I move RunThread out of the class. RunThread is needed because we need to wait for the result of an async function that's being run in an existing event loop, and subclassing Thread seems to be the best way to do that.
This also adds python-test.yml to the github workflows. 
### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- Move RunThread out of SKFunction since flat hierarchy is more desirable than nested hierarchy in python. 
- Tried using a local method instead, but to no avail
  - I had to invoke `_invoke_semantic_async` with await or async.run, but that could only be done within a Thread because the jupyter notebook spawns an event loop. To wait for the result, you need to use `join()` but it doesn't return the result, so the local method needed an output parameter that I could mutate. That is, I passed in a list and modified the list inside the method I pass into the Thread. I didn't like that
  - I tried creating a task inside the existing event loop but couldn't wait for the result without a callback
- Ran tests, pre-commit hooks, and notebooks


For python-test.yml:
- In this PR, the checks were run because python files were changed. 
- In this test PR: https://github.com/mkarle/semantic-kernel/pull/2, the python tests were skipped because files in the python directory were not changed.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
