### PR TITLE
Update CopilotChat to use only Chat APIs for completions, by default.

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Config/ConfigExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/ConfigExtensions.cs
@@ -47,13 +47,20 @@ internal static class ConfigExtensions
         switch (serviceConfig.AIService.ToUpperInvariant())
         {
             case AIServiceConfig.AzureOpenAI:
-                kernelConfig.AddAzureTextCompletionService(serviceConfig.Label, serviceConfig.DeploymentOrModelId,
-                    serviceConfig.Endpoint, serviceConfig.Key);
+                kernelConfig.AddAzureChatCompletionService(
+                    serviceId: serviceConfig.Label,
+                    deploymentName: serviceConfig.DeploymentOrModelId,
+                    endpoint: serviceConfig.Endpoint,
+                    apiKey: serviceConfig.Key,
+                    alsoAsTextCompletion: true);
                 break;
 
             case AIServiceConfig.OpenAI:
-                kernelConfig.AddOpenAITextCompletionService(serviceConfig.Label, serviceConfig.DeploymentOrModelId,
-                    serviceConfig.Key);
+                kernelConfig.AddOpenAIChatCompletionService(
+                    serviceId: serviceConfig.Label,
+                    modelId: serviceConfig.DeploymentOrModelId,
+                    apiKey: serviceConfig.Key,
+                    alsoAsTextCompletion: true);
                 break;
 
             default:

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -405,3 +405,4 @@ public class ChatSkill
 
     # endregion
 }
+

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -10,7 +10,7 @@
   "Completion": {
     "Label": "Completion",
     "AIService": "AzureOpenAI", // Or "OpenAI" when using OpenAI directly
-    "DeploymentOrModelId": "text-davinci-003", // Azure OpenAI deployment name or OpenAI model to use
+    "DeploymentOrModelId": "gpt-35-turbo", // Azure OpenAI deployment name or OpenAI model to use - Chat completion models only (e.g., 'gpt-3.5-turbo' or 'gpt-4').
     "Endpoint": "" // Your Azure OpenAI endpoint (e.g. https://contoso.openai.azure.com) - Leave blank when using OpenAI.
     // "Key": // dotnet user-secrets set "Completion:Key" "MY_COMPLETION_KEY"
   },


### PR DESCRIPTION
### Motivation and Context
Chat completion (gpt-3.5-turbo/gpt-4) models are the future, let's optimize for those.

### Description
Updated CopilotChat to use Chat completions instead of Text completions.