### PR TITLE
Copilot chat: Interactively ask permissions

### DIFF
--- a/samples/apps/copilot-chat-app/WebApp/src/App.tsx
+++ b/samples/apps/copilot-chat-app/WebApp/src/App.tsx
@@ -60,9 +60,13 @@ const App: FC = () => {
     useEffect(() => {
         if (isAuthenticated && account && appState === AppState.LoadingChats) {            
             // Load all chats from memory
-            chat.loadChats().then(() => {
-                setAppState(AppState.Chat);
-            });
+            async function loadChats() {
+                if (await chat.loadChats()) {
+                    setAppState(AppState.Chat);
+                }
+            }
+
+            loadChats();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [instance, inProgress, isAuthenticated, appState]);

--- a/samples/apps/copilot-chat-app/WebApp/src/libs/auth/AuthHelper.ts
+++ b/samples/apps/copilot-chat-app/WebApp/src/libs/auth/AuthHelper.ts
@@ -85,7 +85,7 @@ const getSKaaSAccessToken = async (instance: IPublicClientApplication) => {
             return token.accessToken;
         }
     }
-    throw new Error('Unable to get SKaaS access token');
+    throw new Error('Failed to get access token for web service.');
 };
 
 export const AuthHelper = {

--- a/samples/apps/copilot-chat-app/WebApp/src/libs/auth/AuthHelper.ts
+++ b/samples/apps/copilot-chat-app/WebApp/src/libs/auth/AuthHelper.ts
@@ -4,6 +4,7 @@ import {
     Configuration,
     EndSessionRequest,
     IPublicClientApplication,
+    InteractionRequiredAuthError,
     LogLevel
 } from '@azure/msal-browser';
 import debug from 'debug';
@@ -75,9 +76,16 @@ const logoutAsync = async (instance: IPublicClientApplication) => {
 // SKaaS = Semantic Kernel as a Service
 // Gets token with scopes to authorize SKaaS specifically
 const getSKaaSAccessToken = async (instance: IPublicClientApplication) => {
-    return instance.acquireTokenSilent({ scopes: Constants.msal.skScopes, account: instance.getAllAccounts()[0] }).then((token) => {
+    try {
+        const token = await instance.acquireTokenSilent({ scopes: Constants.msal.skScopes, account: instance.getAllAccounts()[0] });
         return token.accessToken;
-    });
+    } catch (ex: any) {
+        if (ex instanceof InteractionRequiredAuthError) {
+            const token = await instance.acquireTokenPopup({ scopes: Constants.msal.skScopes, account: instance.getAllAccounts()[0] });
+            return token.accessToken;
+        }
+    }
+    throw new Error('Unable to get SKaaS access token');
 };
 
 export const AuthHelper = {

--- a/samples/apps/copilot-chat-app/WebApp/src/libs/useChat.ts
+++ b/samples/apps/copilot-chat-app/WebApp/src/libs/useChat.ts
@@ -197,9 +197,11 @@ export const useChat = () => {
                 // No chats exist, create first chat window
                 await createChat();
             }
+            return true;
         } catch (e: any) {
             const errorMessage = `Unable to load chats. Details: ${e.message ?? e}`;
             dispatch(addAlert({ message: errorMessage, type: AlertType.Error }));
+            return false;
         }
     };
 


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The Copilot Chat App will enter an error state when a user doesn't not have permissions to the scopes the app requests.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Interactively ask users permissions if users don't have the requested once when acquiring tokens.
2. Prevent the app from entering the Chat state if errors occur in LoadingChats state.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
