### PR TITLE
Python: remove extra comma from summarize skill json

### DIFF
--- a/samples/skills/SummarizeSkill/Summarize/config.json
+++ b/samples/skills/SummarizeSkill/Summarize/config.json
@@ -14,7 +14,7 @@
       {
         "name": "input",
         "description": "Text to summarize",
-        "defaultValue": "",
+        "defaultValue": ""
       }
     ]
   }


### PR DESCRIPTION
### Motivation and Context
Right now this command would fail in Python
```
skills_directory = "../../skills/"
kernel.import_semantic_skill_from_directory(skills_directory, "SummarizeSkill")
```

This is because there is an extra comma specifically in the `Summarize` skill. This PR fixes that. 

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
