### PR TITLE
Carry over changes from RefApp_SpeechInput into this branch; Minus ch…

### DIFF
--- a/samples/apps/copilot-chat-app/README.md
+++ b/samples/apps/copilot-chat-app/README.md
@@ -67,10 +67,10 @@ and these components are functional:
               option is appropriate for your instance.    
             * Set your Azure endpoint key using the following command: dotnet user-secrets set "Embedding:Key" "MY_EMBEDDING_KEY"
 
-         * If you are using speech-to-text as input option then under the `AzureSpeechConfig` block, make sure the following configuration matches your instance:
+         * If you are using speech-to-text as input option then under the `AzureSpeech` block, make sure the following configuration matches your instance:
             * `"Region": "westus2",` or whichever region is appropriate
               for your speech sdk instance.
-            * Set your azure speech key using the following command: dotnet user-secrets set "AzureSpeechConfig:Key" "MY_AZURE_SPEECH_KEY"
+            * Set your azure speech key using the following command: dotnet user-secrets set "AzureSpeech:Key" "MY_AZURE_SPEECH_KEY"
             
 4. Build the back-end API server by following these instructions:
     1. In the terminal navigate to  `\samples\apps\copilot-chat-app\webapi`

--- a/samples/apps/copilot-chat-app/README.md
+++ b/samples/apps/copilot-chat-app/README.md
@@ -49,17 +49,15 @@ and these components are functional:
             you may change `"UseHttp": false,` to `True` to overide the default
             use of https.
 
-          * Under the `“Completion”` block, make the following configuration
+         * Under the `“Completion”` block, make the following configuration
             changes to match your instance:
-
             * `“AIService”: “AzureOpenAI”`, or whichever option is appropriate for
               your instance.
             * `“DeploymentOrModelID”: “text-davinci-003”,` or whichever option is
               appropriate for your instance.  
             * `“Endpoint”:` “Your Azure Endpoint address, i.e. `http://contoso.openai.azure.com`”.
               If you are using OpenAI, leave this blank.
-            * You will insert your Azure endpoint key during build of the backend
-              API Server
+            * Set your Azure endpoint key using the following command: dotnet user-secrets set "Completion:Key" "MY_COMPLETION_KEY"
 
         * Under the `“Embedding”` block, make sure the following configuration
           changes to match your instance:
@@ -67,8 +65,12 @@ and these components are functional:
               for your instance.
             * `“DeploymentOrModelID”: “text-embedding-ada-002”,` or whichever
               option is appropriate for your instance.    
-            * You will insert your Azure endpoint key during build of the backend
-              API Server
+            * Set your Azure endpoint key using the following command: dotnet user-secrets set "Embedding:Key" "MY_EMBEDDING_KEY"
+
+         * If you are using speech-to-text as input option then under the `AzureSpeechConfig` block, make sure the following configuration matches your instance:
+            * `"Region": "westus2",` or whichever region is appropriate
+              for your speech sdk instance.
+            * Set your azure speech key using the following command: dotnet user-secrets set "AzureSpeechConfig:Key" "MY_AZURE_SPEECH_KEY"
             
 4. Build the back-end API server by following these instructions:
     1. In the terminal navigate to  `\samples\apps\copilot-chat-app\webapi`

--- a/samples/apps/copilot-chat-app/WebApp/package.json
+++ b/samples/apps/copilot-chat-app/WebApp/package.json
@@ -24,6 +24,7 @@
     "@fluentui/react-northstar": "^0.66.4",
     "@reduxjs/toolkit": "^1.9.1",
     "debug": "^4.3.4",
+    "microsoft-cognitiveservices-speech-sdk": "^1.27.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/samples/apps/copilot-chat-app/WebApp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/WebApp/src/components/chat/ChatInput.tsx
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import { Button, makeStyles, shorthands, Textarea, tokens } from '@fluentui/react-components';
-import { SendRegular } from '@fluentui/react-icons';
+import { MicRegular, SendRegular } from '@fluentui/react-icons';
 import debug from 'debug';
 import React from 'react';
+import * as speechSdk from 'microsoft-cognitiveservices-speech-sdk';
 import { Constants } from '../../Constants';
 import { AlertType } from '../../libs/models/AlertType';
 import { useAppDispatch } from '../../redux/app/hooks';
 import { addAlert } from '../../redux/features/app/appSlice';
 import { TypingIndicatorRenderer } from './typing-indicator/TypingIndicatorRenderer';
+import { useSKSpeechService } from './../../libs/semantic-kernel/useSKSpeech';
 
 const log = debug(Constants.debug.root).extend('chat-input');
 
@@ -53,6 +55,30 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
     const dispatch = useAppDispatch();
     const [value, setValue] = React.useState('');
     const [previousValue, setPreviousValue] = React.useState('');
+    const [recognizer, setRecognizer] = React.useState<speechSdk.SpeechRecognizer>();
+    const [isListening, setIsListening] = React.useState(false);
+    const speechService = useSKSpeechService(process.env.REACT_APP_BACKEND_URI as string);
+
+    React.useEffect(() => {
+        if (recognizer) return;
+        void (async () => {
+            const newRecognizer = await speechService.getSpeechRecognizerAsync();
+            setRecognizer(newRecognizer);
+        })();
+    }, [recognizer, speechService]);
+
+    const handleSpeech = () => {
+        setIsListening(true);
+
+        recognizer?.recognizeOnceAsync((result) => {
+            if (result.reason === speechSdk.ResultReason.RecognizedSpeech) {
+                if (result.text && result.text.length > 0) {
+                    handleSubmit(result.text);
+                }
+            }
+            setIsListening(false);
+        });
+    };
 
     const handleSubmit = (data: string) => {
         try {
@@ -105,6 +131,9 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
                     }}
                 />
                 <div className={classes.controls}>
+                    {recognizer && (
+                            <Button disabled={isListening} icon={<MicRegular />} onClick={() => handleSpeech()} />
+                    )}
                     <Button icon={<SendRegular />} onClick={() => handleSubmit(value)} />
                 </div>
             </div>

--- a/samples/apps/copilot-chat-app/WebApp/src/libs/semantic-kernel/SKSpeech.ts
+++ b/samples/apps/copilot-chat-app/WebApp/src/libs/semantic-kernel/SKSpeech.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+import * as speechSdk from 'microsoft-cognitiveservices-speech-sdk';
+
+interface TokenResponse {
+    token: string;
+    region: string;
+}
+
+interface SpeechServiceRequest {
+    commandPath: string;
+    method?: string;
+}
+
+export class SKSpeechService {
+    constructor(private readonly serviceUrl: string) {}
+
+    getSpeechRecognizerAsync = async () => {
+        const response = await this.invokeTokenAsync();
+        const { token, region } = response;
+        const speechConfig = speechSdk.SpeechConfig.fromAuthorizationToken(token, region);
+        speechConfig.speechRecognitionLanguage = 'en-US';
+        const audioConfig = speechSdk.AudioConfig.fromDefaultMicrophoneInput();
+        return new speechSdk.SpeechRecognizer(speechConfig, audioConfig);
+    };
+
+    private invokeTokenAsync = async (): Promise<TokenResponse> => {
+        const result = await this.getAzureSpeechTokenAsync<TokenResponse>({
+            commandPath: `speechToken`,
+            method: 'GET',
+        });
+        return result;
+    };
+
+    private readonly getAzureSpeechTokenAsync = async <TokenResponse>(
+        request: SpeechServiceRequest,
+    ): Promise<TokenResponse> => {
+        const { commandPath, method } = request;
+
+        try {
+            const requestUrl = new URL(commandPath, this.serviceUrl);
+            const response = await fetch(requestUrl, {
+                method: method ?? 'GET',
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            if (!response.ok) {
+                throw Object.assign(new Error(response.statusText + ' => ' + (await response.text())));
+            }
+
+            return (await response.json()) as TokenResponse;
+        } catch (e) {
+            var additional_error_msg = '';
+            if (e instanceof TypeError) {
+                // fetch() will reject with a TypeError when a network error is encountered.
+                additional_error_msg =
+                    '\n\nPlease check that your backend is running and that it is accessible by the app';
+            }
+            throw Object.assign(new Error(e + additional_error_msg));
+        }
+    };
+}

--- a/samples/apps/copilot-chat-app/WebApp/src/libs/semantic-kernel/useSKSpeech.ts
+++ b/samples/apps/copilot-chat-app/WebApp/src/libs/semantic-kernel/useSKSpeech.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+import React from 'react';
+import { SKSpeechService } from './SKSpeech';
+
+export const useSKSpeechService = (uri: string) => {
+    const [skSpeechService] = React.useState(new SKSpeechService(uri));
+    return skSpeechService;
+};

--- a/samples/apps/copilot-chat-app/webapi/Config/AzureSpeechConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/AzureSpeechConfig.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace SemanticKernel.Service.Config;
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes - Instantiated by deserializing JSON
+internal class AzureSpeechServiceConfig
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+{
+    public string Label { get; set; } = string.Empty;
+    public string Region { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+
+    public bool IsValid()
+    {
+        return
+            !string.IsNullOrEmpty(this.Label) &&
+            !string.IsNullOrEmpty(this.Region) &&
+            !string.IsNullOrEmpty(this.Key);
+    }
+}

--- a/samples/apps/copilot-chat-app/webapi/Config/AzureSpeechConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/AzureSpeechConfig.cs
@@ -3,7 +3,7 @@
 namespace SemanticKernel.Service.Config;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes - Instantiated by deserializing JSON
-internal class AzureSpeechServiceConfig
+internal class AzureSpeechConfig
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
     public string Label { get; set; } = string.Empty;

--- a/samples/apps/copilot-chat-app/webapi/Controllers/SpeechTokenController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SpeechTokenController.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.AspNetCore.Mvc;
+using SemanticKernel.Service.Config;
+
+namespace SemanticKernel.Service.Controllers;
+
+/// <summary>
+/// Token Response is a simple wrapper around the token and region
+/// </summary>
+public class SpeechTokenResponse
+{
+    public string? token { get; set; }
+    public string? region { get; set; }
+}
+
+[ApiController]
+public class SpeechTokenController : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<SpeechTokenController> _logger;
+
+    public SpeechTokenController(IConfiguration configuration, ILogger<SpeechTokenController> logger)
+    {
+        this._configuration = configuration;
+        this._logger = logger;
+    }
+
+    /// <summary>
+    /// Use the Azure Speech Config key to return an authorization token and region as a Token Response.
+    /// </summary>
+    [Route("speechToken")]
+    [HttpGet]
+    public ActionResult<SpeechTokenResponse> Get()
+    {
+        AzureSpeechServiceConfig azureSpeechConfig = this._configuration.GetSection("AzureSpeechConfig").Get<AzureSpeechServiceConfig>();
+
+        string FetchTokenUri = "https://" + azureSpeechConfig.Region + ".api.cognitive.microsoft.com/sts/v1.0/issueToken";
+        string subscriptionKey = azureSpeechConfig.Key;
+
+        var token = this.FetchTokenAsync(FetchTokenUri, subscriptionKey).Result;
+
+        return new SpeechTokenResponse { token = token, region = azureSpeechConfig.Region };
+    }
+
+    private async Task<string> FetchTokenAsync(string fetchUri, string subscriptionKey)
+    {
+        // TODO: get the HttpClient from the DI container
+        using (var client = new HttpClient())
+        {
+            client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+            UriBuilder uriBuilder = new UriBuilder(fetchUri);
+
+            var result = await client.PostAsync(uriBuilder.Uri, null);
+            result.EnsureSuccessStatusCode();
+            this._logger.LogDebug("Token Uri: {0}", uriBuilder.Uri.AbsoluteUri);
+            return await result.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/samples/apps/copilot-chat-app/webapi/Controllers/SpeechTokenController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SpeechTokenController.cs
@@ -33,14 +33,14 @@ public class SpeechTokenController : ControllerBase
     [HttpGet]
     public ActionResult<SpeechTokenResponse> Get()
     {
-        AzureSpeechServiceConfig azureSpeechConfig = this._configuration.GetSection("AzureSpeechConfig").Get<AzureSpeechServiceConfig>();
+        AzureSpeechConfig AzureSpeech = this._configuration.GetSection("AzureSpeech").Get<AzureSpeechConfig>();
 
-        string FetchTokenUri = "https://" + azureSpeechConfig.Region + ".api.cognitive.microsoft.com/sts/v1.0/issueToken";
-        string subscriptionKey = azureSpeechConfig.Key;
+        string FetchTokenUri = "https://" + AzureSpeech.Region + ".api.cognitive.microsoft.com/sts/v1.0/issueToken";
+        string subscriptionKey = AzureSpeech.Key;
 
         var token = this.FetchTokenAsync(FetchTokenUri, subscriptionKey).Result;
 
-        return new SpeechTokenResponse { token = token, region = azureSpeechConfig.Region };
+        return new SpeechTokenResponse { token = token, region = AzureSpeech.Region };
     }
 
     private async Task<string> FetchTokenAsync(string fetchUri, string subscriptionKey)

--- a/samples/apps/copilot-chat-app/webapi/CopilotChatApi.csproj
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChatApi.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.14" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.3" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.27.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.16.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -25,10 +25,10 @@
     /* "Key": // dotnet user-secrets set "Embedding:Key" "MY_EMBEDDING_KEY" */
   },
 
-  "AzureSpeechConfig": {
+  "AzureSpeech": {
     "Label": "AzureSpeech",
     "Region": "" // Your Speech SDK subscription's region(e.g. westus2)
-    /* "Key": // dotnet user-secrets set "AzureSpeechConfig:Key" "MY_AZURE_SPEECH_KEY" */
+    /* "Key": // dotnet user-secrets set "AzureSpeech:Key" "MY_AZURE_SPEECH_KEY" */
   },
 
   "ChatStore": {

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -25,6 +25,12 @@
     /* "Key": // dotnet user-secrets set "Embedding:Key" "MY_EMBEDDING_KEY" */
   },
 
+  "AzureSpeechConfig": {
+    "Label": "AzureSpeech",
+    "Region": "westus2" // Your Speech SDK subscription's region(e.g. westus2)
+    /* "Key": // dotnet user-secrets set "AzureSpeechConfig:Key" "MY_AZURE_SPEECH_KEY" */
+  },
+
   "ChatStore": {
     "Type": "volatile", // Which type of chat store to use - supported values are "volatile", "filesystem", or "cosmos".
     "Filesystem": {

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -27,7 +27,7 @@
 
   "AzureSpeechConfig": {
     "Label": "AzureSpeech",
-    "Region": "westus2" // Your Speech SDK subscription's region(e.g. westus2)
+    "Region": "" // Your Speech SDK subscription's region(e.g. westus2)
     /* "Key": // dotnet user-secrets set "AzureSpeechConfig:Key" "MY_AZURE_SPEECH_KEY" */
   },
 


### PR DESCRIPTION
Carry over changes from RefApp_SpeechInput into this branch; Minus changes to yarn.lock

### Motivation and Context
Provide a reference implementation for speech to text input for communicating with the AI model.

### Description
Added UI to the frontend (visible as a microphone symbol) that you can click on to provide speech input.
Hooked up the backend to communicate with the speech SDK via the Microsoft.CognitiveServices.Speech package.
The backend loads the subscription key and region to generate a authorization token. This token is requested by the frontend whenever speech input is needed. The token allows the front end to generate a speech config and use the speech sdk to process the speech input to text. This text input is then passed along to the app as usual.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
