### PR TITLE
Add error propagation for invalid completion configuration

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
@@ -85,15 +85,9 @@ public class SemanticKernelController : ControllerBase
         SKContext result = await kernel.RunAsync(contextVariables, function!);
         if (result.ErrorOccurred)
         {
-            // TODO latest NuGets don't have the Detail property on AIException
-            //if (result.LastException is AIException aiException && aiException.Detail is not null)
-            //{
-            //    return this.BadRequest(string.Concat(aiException.Message, " - Detail: " + aiException.Detail));
-            //}
-
-            if (result.LastException is AIException aiException)
+            if (result.LastException is AIException aiException && aiException.Detail is not null)
             {
-                return this.BadRequest(aiException.Message);
+                return this.BadRequest(string.Concat(aiException.Message, " - Detail: " + aiException.Detail));
             }
 
             return this.BadRequest(result.LastErrorDescription);

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -91,7 +91,7 @@ public class ChatSkill
             context.Fail(result.LastErrorDescription, result.LastException);
             return string.Empty;
         }
-        
+
         return $"User intent: {result}";
     }
 
@@ -249,7 +249,7 @@ public class ChatSkill
         {
             return chatContext;
         }
-        
+
         chatContext.Variables.Set("userIntent", userIntent);
         remainingToken -= this.EstimateTokenCount(userIntent);
 

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -86,6 +86,12 @@ public class ChatSkill
             settings: this.CreateIntentCompletionSettings()
         );
 
+        if (result.ErrorOccurred)
+        {
+            context.Fail(result.LastErrorDescription, result.LastException);
+            return string.Empty;
+        }
+        
         return $"User intent: {result}";
     }
 
@@ -239,6 +245,11 @@ public class ChatSkill
 
         // Extract user intent and update remaining token count
         var userIntent = await this.ExtractUserIntentAsync(chatContext);
+        if (chatContext.ErrorOccurred)
+        {
+            return chatContext;
+        }
+        
         chatContext.Variables.Set("userIntent", userIntent);
         remainingToken -= this.EstimateTokenCount(userIntent);
 
@@ -251,6 +262,11 @@ public class ChatSkill
             context: chatContext,
             settings: this.CreateChatResponseCompletionSettings()
         );
+
+        if (chatContext.ErrorOccurred)
+        {
+            return chatContext;
+        }
 
         // Save this response to memory such that subsequent chat responses can use it
         try


### PR DESCRIPTION
### Motivation and Context
When the Completion config is invalid, we end up repeating the user's message back to them instead of showing an error.


### Description
- Added propagation of a failed SK invoke back to the top-level controller call.
- Enabled AI exception detail messages
