### PR TITLE
CopilotChat: Only allow submit when chat message is not empty

### DIFF
--- a/samples/apps/copilot-chat-app/WebApp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/WebApp/src/components/chat/ChatInput.tsx
@@ -82,6 +82,9 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
 
     const handleSubmit = (data: string) => {
         try {
+            if (data.trim() === '') {
+                return; // only submit if data is not empty
+            }
             onSubmit(data);
             setPreviousValue(data);
             setValue('');

--- a/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
@@ -56,6 +56,11 @@ public class SemanticKernelController : ControllerBase
     {
         this._logger.LogDebug("Received call to invoke {SkillName}/{FunctionName}", skillName, functionName);
 
+        if (string.IsNullOrWhiteSpace(ask.Input))
+        {
+            return this.BadRequest("Input is required.");
+        }
+
         string semanticSkillsDirectory = this._configuration.GetSection(CopilotChatApiConstants.SemanticSkillsDirectoryConfigKey).Get<string>();
         if (!string.IsNullOrWhiteSpace(semanticSkillsDirectory))
         {


### PR DESCRIPTION
### Motivation and Context
Submitting empty chat messages confuses the AI.

### Description
- CopilotChat WebApp won't submit if there is not text to submit
- CopilotChat WebApi will successfully return nothing when nothing is submitted