### PR TITLE
Vectorize CosineSimilarityImplementation with Vector<T>

### DIFF
--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/CosineSimilarityOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/CosineSimilarityOperation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.SemanticKernel.AI.Embeddings.VectorOperations;
@@ -72,34 +73,48 @@ public static class CosineSimilarityOperation
             throw new ArgumentException("Array lengths must be equal");
         }
 
-        double dotSum = 0;
-        double lenXSum = 0;
-        double lenYSum = 0;
-        fixed (double* pxBuffer = x)
+        fixed (double* pxBuffer = x, pyBuffer = y)
         {
-            fixed (double* pyBuffer = y)
-            {
-                double* px = pxBuffer;
-                double* pxMax = px + x.Length;
-                double* py = pyBuffer;
-                while (px < pxMax)
-                {
-                    double xVal = *px;
-                    double yVal = *py;
-                    // Dot product
-                    dotSum += xVal * yVal;
-                    // For magnitude of x
-                    lenXSum += xVal * xVal;
-                    // For magnitude of y
-                    lenYSum += yVal * yVal;
-                    ++px;
-                    ++py;
-                }
+            double dotSum = 0, lenXSum = 0, lenYSum = 0;
 
-                // Cosine Similarity of X, Y
-                // Sum(X * Y) / |X| * |Y|
-                return dotSum / (Math.Sqrt(lenXSum) * Math.Sqrt(lenYSum));
+            double* px = pxBuffer, py = pyBuffer;
+            double* pxEnd = px + x.Length;
+
+            if (Vector.IsHardwareAccelerated &&
+                x.Length >= Vector<double>.Count)
+            {
+                double* pxOneVectorFromEnd = pxEnd - Vector<double>.Count;
+                do
+                {
+                    Vector<double> xVec = *(Vector<double>*)px;
+                    Vector<double> yVec = *(Vector<double>*)py;
+
+                    dotSum += Vector.Dot(xVec, yVec); // Dot product
+                    lenXSum += Vector.Dot(xVec, xVec); // For magnitude of x
+                    lenYSum += Vector.Dot(yVec, yVec); // For magnitude of y
+
+                    px += Vector<double>.Count;
+                    py += Vector<double>.Count;
+                }
+                while (px <= pxOneVectorFromEnd);
             }
+
+            while (px < pxEnd)
+            {
+                double xVal = *px;
+                double yVal = *py;
+
+                dotSum += xVal * yVal; // Dot product
+                lenXSum += xVal * xVal; // For magnitude of x
+                lenYSum += yVal * yVal; // For magnitude of y
+
+                ++px;
+                ++py;
+            }
+
+            // Cosine Similarity of X, Y
+            // Sum(X * Y) / |X| * |Y|
+            return dotSum / (Math.Sqrt(lenXSum) * Math.Sqrt(lenYSum));
         }
     }
 
@@ -110,34 +125,48 @@ public static class CosineSimilarityOperation
             throw new ArgumentException("Array lengths must be equal");
         }
 
-        double dotSum = 0;
-        double lenXSum = 0;
-        double lenYSum = 0;
-        fixed (float* pxBuffer = x)
+        fixed (float* pxBuffer = x, pyBuffer = y)
         {
-            fixed (float* pyBuffer = y)
-            {
-                float* px = pxBuffer;
-                float* pxMax = px + x.Length;
-                float* py = pyBuffer;
-                while (px < pxMax)
-                {
-                    float xVal = *px;
-                    float yVal = *py;
-                    // Dot product
-                    dotSum += xVal * yVal;
-                    // For magnitude of x
-                    lenXSum += xVal * xVal;
-                    // For magnitude of y
-                    lenYSum += yVal * yVal;
-                    ++px;
-                    ++py;
-                }
+            double dotSum = 0, lenXSum = 0, lenYSum = 0;
 
-                // Cosine Similarity of X, Y
-                // Sum(X * Y) / |X| * |Y|
-                return dotSum / (Math.Sqrt(lenXSum) * Math.Sqrt(lenYSum));
+            float* px = pxBuffer, py = pyBuffer;
+            float* pxEnd = px + x.Length;
+
+            if (Vector.IsHardwareAccelerated &&
+                x.Length >= Vector<float>.Count)
+            {
+                float* pxOneVectorFromEnd = pxEnd - Vector<float>.Count;
+                do
+                {
+                    Vector<float> xVec = *(Vector<float>*)px;
+                    Vector<float> yVec = *(Vector<float>*)py;
+
+                    dotSum += Vector.Dot(xVec, yVec);  // Dot product
+                    lenXSum += Vector.Dot(xVec, xVec); // For magnitude of x
+                    lenYSum += Vector.Dot(yVec, yVec); // For magnitude of y
+
+                    px += Vector<float>.Count;
+                    py += Vector<float>.Count;
+                }
+                while (px <= pxOneVectorFromEnd);
             }
+
+            while (px < pxEnd)
+            {
+                float xVal = *px;
+                float yVal = *py;
+
+                dotSum += xVal * yVal;  // Dot product
+                lenXSum += xVal * xVal; // For magnitude of x
+                lenYSum += yVal * yVal; // For magnitude of y
+
+                ++px;
+                ++py;
+            }
+
+            // Cosine Similarity of X, Y
+            // Sum(X * Y) / |X| * |Y|
+            return dotSum / (Math.Sqrt(lenXSum) * Math.Sqrt(lenYSum));
         }
     }
 


### PR DESCRIPTION
### Motivation and Context

Accelerate the CosineSimilarityImplementation for floats and doubles using SIMD.

### Description

Employ `Vector<T>` to accelerate CosineSimilarityImplementation.  If the hardware supports acceleration, a vector's worth of data is processed at a time until there isn't a vector's worth remaining.  Then it falls back to the scalar path that's also used if hardware acceleration isn't available.  It's a fairly simplistic implementation that maintains a clean parallel with the scalar code and achieves a reasonable speedup.  As with anything that impacts the order in which floating-point operations are performed, this can impact the precise resulting answer.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

On my machine:

```C#
private float[] _values1, _values2;

[Params(10, 100, 1_000, 10_000)]
public int Length { get; set; }

[Params(false, true)]
public bool Vectorized { get; set; }

[GlobalSetup]
public void Setup()
{
    _values1 = Enumerable.Range(0, Length).Select(_ => Random.Shared.NextSingle()).ToArray();
    _values2 = Enumerable.Range(0, Length).Select(_ => Random.Shared.NextSingle()).ToArray();
}

[Benchmark] public double CosineSimilarity() => CosineSimilarityImplementation(_values1, _values2, Vectorized);
```

|           Method | Length | Vectorized |         Mean |
|----------------- |------- |----------- |-------------:|
| CosineSimilarity |     10 |      False |     17.80 ns |
| CosineSimilarity |     10 |       True |     12.97 ns |
| CosineSimilarity |    100 |      False |    117.07 ns |
| CosineSimilarity |    100 |       True |     52.06 ns |
| CosineSimilarity |   1000 |      False |  1,078.35 ns |
| CosineSimilarity |   1000 |       True |    384.26 ns |
| CosineSimilarity |  10000 |      False | 10,702.32 ns |
| CosineSimilarity |  10000 |       True |  3,799.04 ns |

cc: @tannergooding