### PR TITLE
Enable xml docs for all nugets

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -15,4 +15,18 @@
     <!-- Disable NuGet packaging by default. Projects can override. -->
     <IsPackable>disable</IsPackable>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+
 </Project>

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -3,7 +3,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <!-- Central version prefix - applies to all nuget packages -->
-    <Version>0.12</Version>
+    <Version>0.13</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
-    </PropertyGroup>
-    <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
+  </PropertyGroup>
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
 
-    <PropertyGroup>
-        <AssemblyName>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</AssemblyName>
-        <RootNamespace>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</RootNamespace>
-        <TargetFramework>netstandard2.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyName>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</AssemblyName>
+    <RootNamespace>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
 
-    <PropertyGroup>
-      <!-- NuGet Package Settings -->
-        <PackageId>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</PackageId>
-        <Title>Semantic Kernel - Qdrant Connector</Title>
-        <Description>Qdrant connector for Semantic Kernel skills and semantic memory</Description>
-    </PropertyGroup>
+  <PropertyGroup>
+    <!-- NuGet Package Settings -->
+    <PackageId>Microsoft.SemanticKernel.Connectors.Memory.Qdrant</PackageId>
+    <Title>Semantic Kernel - Qdrant Connector</Title>
+    <Description>Qdrant connector for Semantic Kernel skills and semantic memory</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Text.Json" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\SemanticKernel\SemanticKernel.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\SemanticKernel\SemanticKernel.csproj" />
+  </ItemGroup>
 </Project>

--- a/dotnet/src/SemanticKernel.Skills/Skills.MsGraph/Skills.MsGraph.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.MsGraph/Skills.MsGraph.csproj
@@ -17,13 +17,13 @@
     <Title>Semantic Kernel - Microsoft Graph Connector</Title>
     <Description>Semantic Kernel Microsoft Graph Skill: access your tenant data, schedule meetings, send emails, etc.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Graph" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\SemanticKernel\SemanticKernel.csproj" />
   </ItemGroup>

--- a/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Skills.OpenAPI.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.OpenAPI/Skills.OpenAPI.csproj
@@ -4,7 +4,7 @@
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-  
+
   <PropertyGroup>
     <AssemblyName>Microsoft.SemanticKernel.Skills.OpenAPI</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Skills.OpenAPI</RootNamespace>
@@ -26,9 +26,6 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>KernelSyntaxExamples</_Parameter1>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>SemanticKernel.Skills.UnitTests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
@@ -46,5 +43,5 @@
   <ItemGroup>
     <EmbeddedResource Include="Skills\AzureKeyVaultSkill\openapi.json" />
   </ItemGroup>
-  
+
 </Project>

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -22,17 +22,6 @@ This package is automatically installed by 'Microsoft.SemanticKernel' package wi
 Install this package manually only if you are selecting individual Semantic Kernel components.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <DocumentationFile>bin\Release\netstandard2.0\Microsoft.SemanticKernel.Core.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DebugType>portable</DebugType>
-    <DocumentationFile>bin\Debug\netstandard2.0\Microsoft.SemanticKernel.Core.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Microsoft.SemanticKernel.Connectors.OpenAI</_Parameter1>

--- a/samples/apps/copilot-chat-app/webapi/Config/ConfigExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/ConfigExtensions.cs
@@ -104,14 +104,14 @@ internal static class ConfigExtensions
         return serviceConfig.AIService.ToUpperInvariant() switch
         {
             AIServiceConfig.AzureOpenAI => new AzureTextEmbeddingGeneration(
-                                serviceConfig.DeploymentOrModelId,
-                                serviceConfig.Endpoint,
-                                serviceConfig.Key,
-                                handlerFactory: handlerFactory,
-                                log: logger),
+                serviceConfig.DeploymentOrModelId,
+                serviceConfig.Endpoint,
+                serviceConfig.Key,
+                handlerFactory: handlerFactory,
+                log: logger),
 
             AIServiceConfig.OpenAI => new OpenAITextEmbeddingGeneration(
-                                serviceConfig.DeploymentOrModelId, serviceConfig.Key, handlerFactory: handlerFactory, log: logger),
+                serviceConfig.DeploymentOrModelId, serviceConfig.Key, handlerFactory: handlerFactory, log: logger),
 
             _ => throw new ArgumentException("Invalid AIService value in embeddings backend settings"),
         };

--- a/samples/apps/copilot-chat-app/webapi/Config/CosmosConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/CosmosConfig.cs
@@ -26,5 +26,4 @@ public class CosmosConfig
     /// Gets or sets the Cosmos container for chat messages.
     /// </summary>
     public string ChatMessagesContainer { get; set; } = string.Empty;
-
 }

--- a/samples/apps/copilot-chat-app/webapi/Config/FileSystemConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/FileSystemConfig.cs
@@ -11,5 +11,4 @@ public class FileSystemConfig
     /// Gets or sets the file path for persistent file system storage.
     /// </summary>
     public string FilePath { get; set; } = string.Empty;
-
 }

--- a/samples/apps/copilot-chat-app/webapi/Config/QdrantConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/QdrantConfig.cs
@@ -21,5 +21,4 @@ public class QdrantConfig
     /// Gets or sets the vector size.
     /// </summary>
     public int VectorSize { get; set; }
-
 }

--- a/samples/apps/copilot-chat-app/webapi/Config/ServiceConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/ServiceConfig.cs
@@ -8,6 +8,7 @@ public class ServiceConfig
 {
     [Range(0, 65535, ErrorMessage = "Service port out of range.")]
     public int Port { get; set; }
+
     public bool UseHttp { get; set; }
 #pragma warning disable CA1056 // URI-like properties should not be strings
     public string KeyVaultUri { get; set; } = string.Empty;

--- a/samples/apps/copilot-chat-app/webapi/Controllers/SpeechTokenController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SpeechTokenController.cs
@@ -10,8 +10,8 @@ namespace SemanticKernel.Service.Controllers;
 /// </summary>
 public class SpeechTokenResponse
 {
-    public string? token { get; set; }
-    public string? region { get; set; }
+    public string? Token { get; set; }
+    public string? Region { get; set; }
 }
 
 [ApiController]
@@ -33,14 +33,14 @@ public class SpeechTokenController : ControllerBase
     [HttpGet]
     public ActionResult<SpeechTokenResponse> Get()
     {
-        AzureSpeechConfig AzureSpeech = this._configuration.GetSection("AzureSpeech").Get<AzureSpeechConfig>();
+        AzureSpeechConfig azureSpeech = this._configuration.GetSection("AzureSpeech").Get<AzureSpeechConfig>();
 
-        string FetchTokenUri = "https://" + AzureSpeech.Region + ".api.cognitive.microsoft.com/sts/v1.0/issueToken";
-        string subscriptionKey = AzureSpeech.Key;
+        string fetchTokenUri = "https://" + azureSpeech.Region + ".api.cognitive.microsoft.com/sts/v1.0/issueToken";
+        string subscriptionKey = azureSpeech.Key;
 
-        var token = this.FetchTokenAsync(FetchTokenUri, subscriptionKey).Result;
+        var token = this.FetchTokenAsync(fetchTokenUri, subscriptionKey).Result;
 
-        return new SpeechTokenResponse { token = token, region = AzureSpeech.Region };
+        return new SpeechTokenResponse { Token = token, Region = azureSpeech.Region };
     }
 
     private async Task<string> FetchTokenAsync(string fetchUri, string subscriptionKey)

--- a/samples/apps/copilot-chat-app/webapi/Program.cs
+++ b/samples/apps/copilot-chat-app/webapi/Program.cs
@@ -60,7 +60,7 @@ public static class Program
 
         if (useHttp)
         {
-            logger.LogWarning("Server is using HTTP instead of HTTPS. Do not use HTTP in production." +
+            logger.LogWarning("Server is using HTTP instead of HTTPS. Do not use HTTP in production. " +
                               "All tokens and secrets sent to the server can be intercepted over the network.");
         }
 
@@ -105,7 +105,7 @@ public static class Program
         {
             string promptsConfigPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "prompts.json");
             PromptsConfig promptsConfig = JsonSerializer.Deserialize<PromptsConfig>(File.ReadAllText(promptsConfigPath)) ??
-                throw new InvalidOperationException($"Failed to load '{promptsConfigPath}'.");
+                                          throw new InvalidOperationException($"Failed to load '{promptsConfigPath}'.");
             promptsConfig.Validate();
             return promptsConfig;
         });
@@ -128,11 +128,12 @@ public static class Program
                     {
                         throw new InvalidOperationException("MemoriesStore:Qdrant is required when MemoriesStore:Type is 'Qdrant'");
                     }
+
                     services.AddSingleton<IMemoryStore>(sp => new QdrantMemoryStore(
-                            host: memoriesStoreConfig.Qdrant.Host,
-                            port: memoriesStoreConfig.Qdrant.Port,
-                            vectorSize: memoriesStoreConfig.Qdrant.VectorSize,
-                            logger: sp.GetRequiredService<ILogger<QdrantMemoryStore>>()));
+                        host: memoriesStoreConfig.Qdrant.Host,
+                        port: memoriesStoreConfig.Qdrant.Port,
+                        vectorSize: memoriesStoreConfig.Qdrant.VectorSize,
+                        logger: sp.GetRequiredService<ILogger<QdrantMemoryStore>>()));
                     break;
 
                 default:
@@ -195,6 +196,7 @@ public static class Program
                 {
                     throw new InvalidOperationException("ChatStore:Filesystem is required when ChatStore:Type is 'Filesystem'");
                 }
+
                 string fullPath = Path.GetFullPath(chatStoreConfig.Filesystem.FilePath);
                 string directory = Path.GetDirectoryName(fullPath) ?? string.Empty;
                 chatSessionInMemoryContext = new FileSystemContext<ChatSession>(
@@ -217,7 +219,8 @@ public static class Program
                 break;
 
             default:
-                throw new InvalidOperationException($"Invalid 'ChatStore' setting 'chatStoreConfig.Type'. Value must be 'volatile', 'filesystem', or 'cosmos'.");
+                throw new InvalidOperationException(
+                    $"Invalid 'ChatStore' setting 'chatStoreConfig.Type'. Value must be 'volatile', 'filesystem', or 'cosmos'.");
         }
 
         services.AddSingleton<ChatSessionRepository>(new ChatSessionRepository(chatSessionInMemoryContext));

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -131,6 +131,7 @@ public class ChatSkill
                 relevantMemories.Add(memory);
             }
         }
+
         relevantMemories = relevantMemories.OrderByDescending(m => m.Relevance).ToList();
 
         string memoryText = "";
@@ -429,4 +430,3 @@ public class ChatSkill
 
     # endregion
 }
-

--- a/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
@@ -5,7 +5,7 @@ using SemanticKernel.Service.Config;
 namespace SemanticKernel.Service.Skills;
 
 /// <summary>
-/// Settings for semantic function prompts. 
+/// Settings for semantic function prompts.
 /// </summary>
 public class PromptSettings
 {
@@ -42,6 +42,7 @@ public class PromptSettings
         "{{ChatSkill.ExtractChatHistory}}",
         this.SystemIntentContinuationPrompt
     };
+
     internal string SystemIntentExtractionPrompt => string.Join("\n", this.SystemIntentPromptComponents);
 
     // Memory extraction commands
@@ -53,6 +54,7 @@ public class PromptSettings
     // Long-term memory
     internal string LongTermMemoryName => this._promptsConfig.LongTermMemoryName;
     internal string LongTermMemoryExtractionPrompt => this._promptsConfig.LongTermMemoryExtraction;
+
     internal string[] LongTermMemoryPromptComponents => new string[]
     {
         this.SystemCognitivePrompt,
@@ -62,11 +64,13 @@ public class PromptSettings
         "{{ChatSkill.ExtractChatHistory}}",
         this.MemoryContinuationPrompt
     };
+
     internal string LongTermMemoryPrompt => string.Join("\n", this.LongTermMemoryPromptComponents);
 
     // Working memory
     internal string WorkingMemoryName => this._promptsConfig.WorkingMemoryName;
     internal string WorkingMemoryExtractionPrompt => this._promptsConfig.WorkingMemoryExtraction;
+
     internal string[] WorkingMemoryPromptComponents => new string[]
     {
         this.SystemCognitivePrompt,
@@ -76,6 +80,7 @@ public class PromptSettings
         "{{ChatSkill.ExtractChatHistory}}",
         this.MemoryContinuationPrompt
     };
+
     internal string WorkingMemoryPrompt => string.Join("\n", this.WorkingMemoryPromptComponents);
 
     // Memory map
@@ -97,6 +102,7 @@ public class PromptSettings
         "{{ChatSkill.ExtractChatHistory}}",
         this.SystemChatContinuationPrompt
     };
+
     internal string SystemChatPrompt => string.Join("\n", this.SystemChatPromptComponents);
 
     internal double ResponseTemperature { get; } = 0.7;

--- a/samples/apps/copilot-chat-app/webapi/Skills/SemanticChatMemory.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/SemanticChatMemory.cs
@@ -47,6 +47,7 @@ public class SemanticChatMemory
         {
             throw new ArgumentException("Failed to deserialize chat memory to json.");
         }
+
         return result;
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Concurrent;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Concurrent;
 using System.Text.Json;
 
 namespace SemanticKernel.Service.Storage;
@@ -94,7 +96,9 @@ public class FileSystemContext<T> : IStorageContext<T> where T : IStorageEntity
     /// <summary>
     /// A concurrent dictionary to store entities in memory.
     /// </summary>
-    private class EntityDictionary : ConcurrentDictionary<string, T> { }
+    private class EntityDictionary : ConcurrentDictionary<string, T>
+    {
+    }
 
     /// <summary>
     /// Using a concurrent dictionary to store entities in memory.


### PR DESCRIPTION
### Motivation and Context

* XML docs/intellisense is currently used only for the main nuget. This change enables the same for all nugets.
* Some codestyle fixes
* Bump version to 0.13 for the next release, and people using code from the repo - this makes it also easier testing new nugets locally, ahead of the next release