### PR TITLE
Tweak HttpSkill for improved performance

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/CoreSkills/HttpSkillTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/CoreSkills/HttpSkillTests.cs
@@ -55,7 +55,7 @@ public class HttpSkillTests : IDisposable
         using var skill = new HttpSkill(client);
 
         // Act
-        var result = await skill.GetAsync(this._uriString);
+        var result = await skill.GetAsync(this._uriString, this._context);
 
         // Assert
         Assert.Equal(this._content, result);
@@ -105,7 +105,7 @@ public class HttpSkillTests : IDisposable
         using var skill = new HttpSkill(client);
 
         // Act
-        var result = await skill.DeleteAsync(this._uriString);
+        var result = await skill.DeleteAsync(this._uriString, this._context);
 
         // Assert
         Assert.Equal(this._content, result);


### PR DESCRIPTION
### Motivation and Context

Suggested changes to HttpSkill based on code reviewing its implementation.

### Description

- If no HttpClient is provided, use a shared HttpClientHandler singleton so that connections may be pooled under the covers.  Otherwise, every instantiation of the skill would create and teardown a connection for the request.  If there's only ever a single instance of the skill created, it's effectively equivalent.  In the future this could also be changed to use HttpClientFactory and allow it to manage singletons.
- Use GetStringAsync for the GetAsync function: this lets the implementation optimize the operation a bit more than what the consumer can do.
- Use a shared SendRequestAsync to deduplicate the Put/Post/DeleteAsync implementations.
- Use HttpCompletionOption.ResponseHeadersRead to allow the implementation of ReadAsStringAsync to more efficiently create the returned string rather than first buffering the whole response as a byte[].
- Ensure the response message is disposed.
- Add a remark to the HttpSkill ctor accepting an HttpClient that it assumes ownership of that instance such that a caller should expect it to be disposed of when the skill is disposed.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
