### PR TITLE
Tweak VectorOperation/SpanTest exception validation

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/VectorOperations/VectorOperationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/VectorOperations/VectorOperationTests.cs
@@ -56,14 +56,7 @@ public class VectorOperationTests
         var shortVector = new float[] { -1.0F, 4.0F };
 
         // Assert
-        try
-        {
-            shortVector.CosineSimilarity(this._floatV2);
-        }
-        catch (ArgumentException target)
-        {
-            Assert.IsType<ArgumentException>(target);
-        }
+        Assert.Throws<ArgumentException>(() => shortVector.CosineSimilarity(this._floatV2));
     }
 
     [Fact]
@@ -73,14 +66,7 @@ public class VectorOperationTests
         var shortVector = new double[] { -1.0, 4.0 };
 
         // Assert
-        try
-        {
-            shortVector.CosineSimilarity(this._doubleV2);
-        }
-        catch (ArgumentException target)
-        {
-            Assert.IsType<ArgumentException>(target);
-        }
+        Assert.Throws<ArgumentException>(() => shortVector.CosineSimilarity(this._doubleV2));
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/VectorOperations/VectorSpanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/VectorOperations/VectorSpanTests.cs
@@ -71,6 +71,7 @@ public class VectorSpanTests
         try
         {
             vSpan1.CosineSimilarity(vSpan2);
+            Assert.True(false, "No exception thrown");
         }
         catch (ArgumentException target)
         {
@@ -89,6 +90,7 @@ public class VectorSpanTests
         try
         {
             vSpan1.CosineSimilarity(vSpan2);
+            Assert.True(false, "No exception thrown");
         }
         catch (ArgumentException target)
         {
@@ -161,6 +163,7 @@ public class VectorSpanTests
         try
         {
             vSpan1.Dot(vSpan2);
+            Assert.True(false, "No exception thrown");
         }
         catch (ArgumentException target)
         {
@@ -179,6 +182,7 @@ public class VectorSpanTests
         try
         {
             vSpan1.Dot(vSpan2);
+            Assert.True(false, "No exception thrown");
         }
         catch (ArgumentException target)
         {


### PR DESCRIPTION
### Motivation and Context

Fix some unit tests to validate what they intended to validate.

### Description

The validation is ensuring if an exception is thrown that it's of the right type, but it's not actually ensuring that an exception is thrown.

For the array-based validation, we can just use the Assert.Throws helper.

For the ref struct-based validation, we can't capture the ref structs into a lambda, but we can at least assert that the operation throws.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
