### PR TITLE
Clean up Embedding{ReadOnly}Span T validation

### DIFF
--- a/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingReadOnlySpan.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingReadOnlySpan.cs
@@ -25,7 +25,7 @@ public ref struct EmbeddingReadOnlySpan<TEmbedding>
     /// </remarks>
     public EmbeddingReadOnlySpan(ReadOnlySpan<TEmbedding> vector, bool isNormalized = false)
     {
-        SupportedTypes.VerifyTypeSupported(typeof(TEmbedding));
+        SupportedTypes.VerifyTypeSupported<TEmbedding>();
 
         this.ReadOnlySpan = vector;
         this.IsNormalized = isNormalized;
@@ -111,5 +111,5 @@ public ref struct EmbeddingReadOnlySpan<TEmbedding>
     /// Gets a value that indicates whether <typeparamref name="TEmbedding"/> is supported.
     /// </summary>
     [SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Following 'IsSupported' pattern of System.Numerics.")]
-    public static bool IsSupported => SupportedTypes.IsSupported(typeof(TEmbedding));
+    public static bool IsSupported => SupportedTypes.IsSupported<TEmbedding>();
 }

--- a/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingSpan.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingSpan.cs
@@ -19,7 +19,7 @@ public ref struct EmbeddingSpan<TEmbedding>
     /// <param name="vector">A a vector of contiguous, unmanaged data.</param>
     public EmbeddingSpan(Span<TEmbedding> vector)
     {
-        SupportedTypes.VerifyTypeSupported(typeof(TEmbedding));
+        SupportedTypes.VerifyTypeSupported<TEmbedding>();
 
         this.Span = vector;
     }
@@ -83,5 +83,5 @@ public ref struct EmbeddingSpan<TEmbedding>
     /// Gets a value that indicates whether <typeparamref name="TEmbedding"/> is supported.
     /// </summary>
     [SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Following 'IsSupported' pattern of System.Numerics.")]
-    public static bool IsSupported => SupportedTypes.IsSupported(typeof(TEmbedding));
+    public static bool IsSupported => SupportedTypes.IsSupported<TEmbedding>();
 }

--- a/dotnet/src/SemanticKernel/AI/Embeddings/SupportedTypes.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/SupportedTypes.cs
@@ -15,12 +15,18 @@ public static class SupportedTypes
     /// <summary>
     /// Determines whether a specified type is supported by the vector operations.
     /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <returns>true if the vector operations support this type.</returns>
+    public static bool IsSupported<T>() =>
+        typeof(T) == typeof(float) || typeof(T) == typeof(double);
+
+    /// <summary>
+    /// Determines whether a specified type is supported by the vector operations.
+    /// </summary>
     /// <param name="type">The <see cref="Type"/> to check.</param>
     /// <returns>true if the vector operations support this type.</returns>
-    public static bool IsSupported(Type type)
-    {
-        return s_types.Contains(type);
-    }
+    public static bool IsSupported(Type type) =>
+        type == typeof(float) || type == typeof(double);
 
     /// <summary>
     /// The collection of types supported by the vector operations.
@@ -30,14 +36,14 @@ public static class SupportedTypes
     /// <summary>
     /// Checks if a specified type is supported by the vector operations.
     /// </summary>
-    /// <param name="type">The type to check.s</param>
-    /// <param name="caller">Caller member name.</param>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <param name="callerName">Caller member name.</param>
     /// <exception cref="NotSupportedException">Throws if type is not supported.</exception>
-    internal static void VerifyTypeSupported(Type type, [CallerMemberName] string caller = "")
+    internal static void VerifyTypeSupported<T>([CallerMemberName] string callerName = "")
     {
-        if (!IsSupported(type))
+        if (!IsSupported<T>())
         {
-            ThrowTypeNotSupported(type, caller);
+            ThrowTypeNotSupported<T>(callerName);
         }
     }
 
@@ -46,12 +52,12 @@ public static class SupportedTypes
     /// <summary>
     /// Throws type not supported exception.
     /// </summary>
-    /// <param name="type">The type to check.s</param>
-    /// <param name="caller">Caller member name.</param>
+    /// <typeparam name="T">The unsupported type.</typeparam>
+    /// <param name="callerName">Caller member name.</param>
     /// <exception cref="NotSupportedException">Throws if type is not supported.</exception>
-    internal static void ThrowTypeNotSupported(Type type, [CallerMemberName] string caller = "")
+    internal static void ThrowTypeNotSupported<T>([CallerMemberName] string callerName = "")
     {
-        throw new NotSupportedException($"Type '{type.Name}' not supported by {caller}. "
+        throw new NotSupportedException($"Type '{typeof(T).Name}' not supported by {callerName}. "
                                         + $"Supported types include: [ {ToString()} ]");
     }
 

--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/CosineSimilarityOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/CosineSimilarityOperation.cs
@@ -35,7 +35,7 @@ public static class CosineSimilarityOperation
             return CosineSimilarityImplementation(doubleSpanX, doubleSpanY);
         }
 
-        SupportedTypes.ThrowTypeNotSupported(typeof(TNumber));
+        SupportedTypes.ThrowTypeNotSupported<TNumber>();
         return default;
     }
 

--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/DivideOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/DivideOperation.cs
@@ -31,7 +31,7 @@ public static class DivideOperation
         }
         else
         {
-            SupportedTypes.ThrowTypeNotSupported(typeof(TNumber));
+            SupportedTypes.ThrowTypeNotSupported<TNumber>();
         }
     }
 

--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/DotProductOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/DotProductOperation.cs
@@ -36,7 +36,7 @@ public static class DotProductOperation
             return DotProductImplementation(doubleSpanX, doubleSpanY);
         }
 
-        SupportedTypes.ThrowTypeNotSupported(typeof(TNumber));
+        SupportedTypes.ThrowTypeNotSupported<TNumber>();
         return default;
     }
 

--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/MultiplyOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/MultiplyOperation.cs
@@ -32,7 +32,7 @@ public static class MultiplyOperation
         }
         else
         {
-            SupportedTypes.ThrowTypeNotSupported(typeof(TNumber));
+            SupportedTypes.ThrowTypeNotSupported<TNumber>();
         }
     }
 


### PR DESCRIPTION
### Motivation and Context

Make it cheaper to create EmbeddingReadOnlySpan and EmbeddingSpan instances.

### Description

The EmbeddingReadOnlySpan and EmbeddingSpan type ctors call SupportedTypes.VerifyTypeSupported.  This method is passed a Type that it then looks up in an array using a linear search.  But there's only two types that are valid, float and double, and if more are added in the future, the number that are added will either be very limited or will have some other mechanism for determining validaty.  By instead making it generic and just doing the type comparison inline, for supported types we can enable the JIT to eliminate the entire check.

Note that this does add a public `IsSupported<T>` overload.  I'm not sure of the rules about that.  If that's an issue it can be made internal for now.  However, in general we'd recommend a generic be used in such situations.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

```C#
private float[] _values = new float[16];

[Benchmark] public EmbeddedSpanOld<float> Old() => new EmbeddedSpanOld<float>(_values);
[Benchmark] public EmbeddedSpanNew<float> New() => new EmbeddedSpanNew<float>(_values);

public ref struct EmbeddedSpanOld<T>
{
    public Span<T> Span { get; }
    public EmbeddedSpanOld(Span<T> span)
    {
        if (!SupportedTypes.IsSupportedOld(typeof(T))) SupportedTypes.ThrowNotSupported(typeof(T));
        Span = span;
    }
}

public ref struct EmbeddedSpanNew<T>
{
    public Span<T> Span { get; }
    public EmbeddedSpanNew(Span<T> span)
    {
        if (!SupportedTypes.IsSupportedNew<T>()) SupportedTypes.ThrowNotSupported(typeof(T));
        Span = span;
    }
}

public static class SupportedTypes
{
    public static bool IsSupportedNew<T>() =>
        typeof(T) == typeof(float) || typeof(T) == typeof(double);

    public static bool IsSupportedOld(Type type) => s_types.Contains(type);

    private static readonly Type[] s_types = new[] { typeof(float), typeof(double) };

    internal static void ThrowNotSupported(Type type) => throw new NotSupportedException($"Type {type} is not supported");
}
```

| Method |       Mean |
|------- |-----------:|
|    Old | 12.9307 ns |
|    New |  0.2407 ns |