### PR TITLE
Tweak MathSkill to avoid unnecessary tasks

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/CoreSkills/MathSkillTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/CoreSkills/MathSkillTests.cs
@@ -110,14 +110,14 @@ public class MathSkillTests
         var target = new MathSkill();
 
         // Act
-        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
         {
             await target.AddAsync(initialValue, context);
         });
 
         // Assert
         Assert.NotNull(exception);
-        Assert.IsType<ArgumentException>(exception);
+        Assert.Equal(initialValue, exception.ActualValue);
         Assert.Equal("initialValueText", exception.ParamName);
     }
 
@@ -145,14 +145,14 @@ public class MathSkillTests
         var target = new MathSkill();
 
         // Act
-        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
         {
             await target.AddAsync("1", context);
         });
 
         // Assert
         Assert.NotNull(exception);
-        Assert.IsType<ArgumentException>(exception);
+        Assert.Equal(amount, exception.ActualValue);
         Assert.Equal("context", exception.ParamName);
     }
 
@@ -180,14 +180,14 @@ public class MathSkillTests
         var target = new MathSkill();
 
         // Act
-        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
         {
             await target.SubtractAsync(initialValue, context);
         });
 
         // Assert
         Assert.NotNull(exception);
-        Assert.IsType<ArgumentException>(exception);
+        Assert.Equal(initialValue, exception.ActualValue);
         Assert.Equal("initialValueText", exception.ParamName);
     }
 
@@ -215,14 +215,14 @@ public class MathSkillTests
         var target = new MathSkill();
 
         // Act
-        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
         {
             await target.SubtractAsync("1", context);
         });
 
         // Assert
         Assert.NotNull(exception);
-        Assert.IsType<ArgumentException>(exception);
+        Assert.Equal(amount, exception.ActualValue);
         Assert.Equal("context", exception.ParamName);
     }
 }


### PR DESCRIPTION
### Motivation and Context

Make MathSkill's operations a bit more efficient and make them more debuggable

### Description

These methods were using `await Task.FromResult(...)`, which is usually an indication that the method isn't actually asynchronous but is trying to silence a warning about having an async method without any awaits.  The net result of this is we end up actually incurring the overhead of an extra task unnecessarily, and can instead just use Tasks directly rather than using async/await.  These two Add/Subtract methods are also identical other than for a +/-, so we can just loop them into a shared method and avoid the duplication.

I also changed the exceptions from ArgumentException to ArgumentOutOfRangeException (which derives from ArgumentException) and included the actual value in the exception; that should help with debugging, as the resulting exception will inform a consumer of what the invalid input was.  The tests were also unnecessarily double-validating the exception type... Assert.ThrowsAsync does that validation.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
