### PR TITLE
Clean up a few uses of Tasks

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.Document/FileSystem/LocalFileSystemConnector.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Document/FileSystem/LocalFileSystemConnector.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Skills.Document.FileSystem;
 
+#pragma warning disable CA1031 // Exceptions are caught and returned in a task
+
 /// <summary>
 /// Connector for local filesystem
 /// </summary>
@@ -28,7 +30,14 @@ public class LocalFileSystemConnector : IFileSystemConnector
     /// <exception cref="NotSupportedException"></exception>
     public Task<Stream> GetFileContentStreamAsync(string filePath, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult<Stream>(File.Open(Environment.ExpandEnvironmentVariables(filePath), FileMode.Open, FileAccess.Read));
+        try
+        {
+            return Task.FromResult<Stream>(File.Open(Environment.ExpandEnvironmentVariables(filePath), FileMode.Open, FileAccess.Read));
+        }
+        catch (Exception e)
+        {
+            return Task.FromException<Stream>(e);
+        }
     }
 
     /// <summary>
@@ -47,7 +56,14 @@ public class LocalFileSystemConnector : IFileSystemConnector
     /// <exception cref="NotSupportedException"></exception>
     public Task<Stream> GetWriteableFileStreamAsync(string filePath, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult<Stream>(File.Open(Environment.ExpandEnvironmentVariables(filePath), FileMode.Open, FileAccess.ReadWrite));
+        try
+        {
+            return Task.FromResult<Stream>(File.Open(Environment.ExpandEnvironmentVariables(filePath), FileMode.Open, FileAccess.ReadWrite));
+        }
+        catch (Exception e)
+        {
+            return Task.FromException<Stream>(e);
+        }
     }
 
     /// <summary>
@@ -64,12 +80,26 @@ public class LocalFileSystemConnector : IFileSystemConnector
     /// <exception cref="NotSupportedException"></exception>
     public Task<Stream> CreateFileAsync(string filePath, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult<Stream>(File.Create(Environment.ExpandEnvironmentVariables(filePath)));
+        try
+        {
+            return Task.FromResult<Stream>(File.Create(Environment.ExpandEnvironmentVariables(filePath)));
+        }
+        catch (Exception e)
+        {
+            return Task.FromException<Stream>(e);
+        }
     }
 
     /// <inheritdoc/>
     public Task<bool> FileExistsAsync(string filePath, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(File.Exists(Environment.ExpandEnvironmentVariables(filePath)));
+        try
+        {
+            return Task.FromResult(File.Exists(Environment.ExpandEnvironmentVariables(filePath)));
+        }
+        catch (Exception e)
+        {
+            return Task.FromException<bool>(e);
+        }
     }
 }

--- a/dotnet/src/SemanticKernel/Memory/NullMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/NullMemory.cs
@@ -12,6 +12,8 @@ namespace Microsoft.SemanticKernel.Memory;
 /// </summary>
 public sealed class NullMemory : ISemanticTextMemory
 {
+    private static readonly Task<string> s_emptyStringTask = Task.FromResult(string.Empty);
+
     /// <summary>
     /// Singleton instance
     /// </summary>
@@ -26,7 +28,7 @@ public sealed class NullMemory : ISemanticTextMemory
         string? additionalMetadata = null,
         CancellationToken cancel = default)
     {
-        return Task.FromResult(string.Empty);
+        return s_emptyStringTask;
     }
 
     /// <inheritdoc/>
@@ -39,7 +41,7 @@ public sealed class NullMemory : ISemanticTextMemory
         string? additionalMetadata = null,
         CancellationToken cancel = default)
     {
-        return Task.FromResult(string.Empty);
+        return s_emptyStringTask;
     }
 
     /// <inheritdoc/>
@@ -49,7 +51,7 @@ public sealed class NullMemory : ISemanticTextMemory
         bool withEmbedding = false,
         CancellationToken cancel = default)
     {
-        return Task.FromResult(null as MemoryQueryResult);
+        return Task.FromResult<MemoryQueryResult?>(null);
     }
 
     /// <inheritdoc/>
@@ -77,7 +79,7 @@ public sealed class NullMemory : ISemanticTextMemory
     public Task<IList<string>> GetCollectionsAsync(
         CancellationToken cancel = default)
     {
-        return Task.FromResult(new List<string>() as IList<string>);
+        return Task.FromResult<IList<string>>(new List<string>());
     }
 
     private NullMemory()

--- a/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
@@ -73,7 +73,7 @@ public class FileSystemContext<T> : IStorageContext<T> where T : IStorageEntity
         }
         else
         {
-            throw new KeyNotFoundException($"Entity with id {entityId} not found.");
+            return Task.FromException<T>(new KeyNotFoundException($"Entity with id {entityId} not found."));
         }
     }
 

--- a/samples/dotnet/github-skills/GitHubSkill.cs
+++ b/samples/dotnet/github-skills/GitHubSkill.cs
@@ -214,7 +214,7 @@ BEGIN SUMMARY:
     /// </summary>
     private async Task SummarizeCodeDirectoryAsync(string directoryPath, string searchPattern, string repositoryUri, string repositoryBranch, SKContext context)
     {
-        string[] filePaths = await Task.FromResult(Directory.GetFiles(directoryPath, searchPattern, SearchOption.AllDirectories));
+        string[] filePaths = Directory.GetFiles(directoryPath, searchPattern, SearchOption.AllDirectories);
 
         if (filePaths != null && filePaths.Length > 0)
         {


### PR DESCRIPTION
### Motivation and Context

Minor tweaks to use Tasks more efficiently or more compliantly in a few places.

### Description

- Task.FromResult on .NET Core does cache a Task for null, but not for the empty string, so change NullMemory to use its own cached empty string task.
- Other than for argument exceptions, Task-returning methods should return exceptions out via the returned task rather than throwing them, so add in some use of Task.FromException.
- Rather than await'ing a WhenAll that's the entirety of a method, we can just return its Task
- `await Task.FromResult` is an expensive nop, so remove such occurrences.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
