### PR TITLE
Run linter for pull requests only if python files have changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,39 @@
-name: Lint
-on: push
-# concurrency:
-#   group: lint-${{ github.ref }}
-#   cancel-in-progress: true
+name: Python Lint
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "main", "feature*" ]
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.filter.outputs.python}}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          python:
+            - 'python/**'
+    # run only if 'python' files were changed
+    - name: python tests
+      if: steps.filter.outputs.python == 'true'
+      run: echo "Python file"
+    # run only if not 'python' files were changed
+    - name: not python tests
+      if: steps.filter.outputs.python != 'true'
+      run: echo "NOT python file"
+
   ruff:
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8"]
     runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.output1 == 'true'
     timeout-minutes: 5
     steps:
       - run: echo "/root/.local/bin" >> $GITHUB_PATH
@@ -32,6 +55,8 @@ jobs:
       matrix:
         python-version: ["3.8"]
     runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.output1 == 'true'
     timeout-minutes: 5
     steps:
       - run: echo "/root/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This will run the linter on pull requests when python files have changed.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- Skip linting if python files haven't changed, similar to this action https://github.com/microsoft/semantic-kernel/actions/workflows/python-test.yml

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
