### PR TITLE
Avoid constructing unnecessary JsonSerializerOptions

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/Settings/GPT3Settings.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/Settings/GPT3Settings.cs
@@ -38,7 +38,7 @@ internal static class GPT3Settings
     private static Dictionary<string, int> BuildEncoder()
     {
         string json = EmbeddedResource.ReadEncodingTable();
-        var encoder = JsonSerializer.Deserialize<Dictionary<string, int>>(json, new JsonSerializerOptions());
+        var encoder = JsonSerializer.Deserialize<Dictionary<string, int>>(json);
 
         return encoder
                ?? throw new AIException(AIException.ErrorCodes.InvalidConfiguration,

--- a/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
@@ -15,6 +15,7 @@ namespace KernelHttpServer;
 
 public class SemanticKernelEndpoint
 {
+    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     private readonly IMemoryStore _memoryStore;
 
     public SemanticKernelEndpoint(IMemoryStore memoryStore)
@@ -32,7 +33,7 @@ public class SemanticKernelEndpoint
         // once created, we feed the kernel the ask received via POST from the client
         // and attempt to invoke the function with the given name
 
-        var ask = await JsonSerializer.DeserializeAsync<Ask>(req.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var ask = await JsonSerializer.DeserializeAsync<Ask>(req.Body, s_jsonOptions);
 
         if (ask == null)
         {
@@ -77,7 +78,7 @@ public class SemanticKernelEndpoint
         HttpRequestData req,
         FunctionContext executionContext, int? maxSteps = 10)
     {
-        var ask = await JsonSerializer.DeserializeAsync<Ask>(req.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var ask = await JsonSerializer.DeserializeAsync<Ask>(req.Body, s_jsonOptions);
 
         if (ask == null)
         {


### PR DESCRIPTION
### Motivation and Context

Avoid creating new JsonSerializerOptions per operation.

### Description

They're deceptively expensive. For the default, there's no need to specify one at all. And for other non-default options, it's best to create a singleton and reuse it. (The cost is cheaper in .NET 7, but there's still cost.)

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
