### PR TITLE
Improve performance of SemanticTextPartitioner

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Text/StringExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Text/StringExtensions.cs
@@ -12,16 +12,6 @@ internal static class StringExtensions
         return src.Replace("\r\n", "\n");
     }
 
-    internal static string[] SplitEx(this string src, char separator, StringSplitOptions options = StringSplitOptions.None)
-    {
-        return src.Split(new[] { separator }, options);
-    }
-
-    internal static string[] SplitEx(this string src, string separator, StringSplitOptions options = StringSplitOptions.None)
-    {
-        return src.Split(new[] { separator }, options);
-    }
-
     public static bool IsNullOrEmpty([NotNullWhen(false)] this string? data)
     {
         return string.IsNullOrEmpty(data);

--- a/dotnet/src/SemanticKernel/Planning/FunctionFlowRunner.cs
+++ b/dotnet/src/SemanticKernel/Planning/FunctionFlowRunner.cs
@@ -63,6 +63,8 @@ internal class FunctionFlowRunner
 
     private readonly ConditionalFlowHelper _conditionalFlowHelper;
 
+    private static readonly string[] s_functionTagArray = new string[] { FunctionTag };
+
     public FunctionFlowRunner(IKernel kernel, ITextCompletion? completionBackend = null)
     {
         this._kernel = kernel;
@@ -245,7 +247,7 @@ internal class FunctionFlowRunner
 
                 if (o2.Name.StartsWith(FunctionTag, StringComparison.OrdinalIgnoreCase))
                 {
-                    var splits = o2.Name.SplitEx(FunctionTag);
+                    var splits = o2.Name.Split(s_functionTagArray, StringSplitOptions.None);
                     string skillFunctionName = (splits.Length > 1) ? splits[1] : string.Empty;
                     context.Log.LogTrace("{0}: found skill node {1}", parentNodeName, skillFunctionName);
                     GetSkillFunctionNames(skillFunctionName, out var skillName, out var functionName);


### PR DESCRIPTION
### Motivation and Context

SemanticTextPartitioner can be made a lot faster.

### Description

Without fundamentally changing the algorithm or approach, we can tweak how data is handled in order to significantly improve the performance of this type.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

```C#
private static readonly string s_input = new HttpClient().GetStringAsync("https://www.gutenberg.org/cache/epub/3200/pg3200.txt").Result; // complete works of Mark Twain

private const int MaxTokensPerLine = 100;
private const int MaxTokensPerParagraph = 1024;

[Benchmark(Baseline = true)]
public List<string> Old()
{
    List<string> lines = SemanticTextPartitioner_Old.SplitPlainTextLines(s_input, MaxTokensPerLine);
    return SemanticTextPartitioner_Old.SplitPlainTextParagraphs(lines, MaxTokensPerParagraph);
}

[Benchmark]
public List<string> New()
{
    List<string> lines = SemanticTextPartitioner_New.SplitPlainTextLines(s_input, MaxTokensPerLine);
    return SemanticTextPartitioner_New.SplitPlainTextParagraphs(lines, MaxTokensPerParagraph);
}
```

| Method |       Mean |    Error |   StdDev | Ratio |  Allocated | Alloc Ratio |
|------- |-----------:|---------:|---------:|------:|-----------:|------------:|
|    Old | 1,709.4 ms | 21.86 ms | 18.26 ms |  1.00 | 1259.78 MB |        1.00 |
|    New |   115.9 ms |  1.82 ms |  1.70 ms |  0.07 |  123.03 MB |        0.10 |