### PR TITLE
Enable CA1852 ("Type '...' can be sealed...)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -105,7 +105,6 @@ dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visi
 dotnet_diagnostic.CA1805.severity = none # Member is explicitly initialized to its default value
 dotnet_diagnostic.CA1822.severity = none # Member does not access instance data and can be marked as static
 dotnet_diagnostic.CA1848.severity = none # For improved performance, use the LoggerMessage delegates
-dotnet_diagnostic.CA1852.severity = none # Type '...' can be sealed because it has no subtypes in its containing assembly and is not externally visible
 dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
 dotnet_diagnostic.CA2225.severity = none # Operator overloads have named alternates
 dotnet_diagnostic.CA2227.severity = none # Change to be read-only by removing the property setter

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/AddHeaderRequestPolicy.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/AddHeaderRequestPolicy.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
 /// <summary>
 /// Helper class to inject headers into Azure SDK HTTP pipeline
 /// </summary>
-internal class AddHeaderRequestPolicy : HttpPipelineSynchronousPolicy
+internal sealed class AddHeaderRequestPolicy : HttpPipelineSynchronousPolicy
 {
     private readonly string _headerName;
     private readonly string _headerValue;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/CreateCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/CreateCollectionRequest.cs
@@ -33,7 +33,7 @@ internal sealed class CreateCollectionRequest
             payload: this);
     }
 
-    internal class VectorSettings : IValidatable
+    internal sealed class VectorSettings : IValidatable
     {
         [JsonPropertyName("size")]
         public int? Size { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteCollectionRequest.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class DeleteCollectionRequest : IValidatable
+internal sealed class DeleteCollectionRequest : IValidatable
 {
     public static DeleteCollectionRequest Create(string collectionName)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class DeleteVectorsRequest : IValidatable
+internal sealed class DeleteVectorsRequest : IValidatable
 {
     [JsonPropertyName("points")]
     public List<string> Ids { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetCollectionRequest.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class GetCollectionsRequest
+internal sealed class GetCollectionsRequest
 {
     /// <summary>
     /// Name of the collection to request vectors from

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class GetVectorsRequest
+internal sealed class GetVectorsRequest
 {
     /// <summary>
     /// Name of the collection to request vectors from

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsResponse.cs
@@ -6,9 +6,9 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-internal class GetVectorsResponse : QdrantResponse
+internal sealed class GetVectorsResponse : QdrantResponse
 {
-    internal class Record
+    internal sealed class Record
     {
         [JsonPropertyName("id")]
         public string Id { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class ListCollectionsRequest
+internal sealed class ListCollectionsRequest
 {
     public static ListCollectionsRequest Create()
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
 internal sealed class ListCollectionsResponse : QdrantResponse
 {
-    internal class CollectionResult
+    internal sealed class CollectionResult
     {
         internal sealed class CollectionDescription
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class SearchVectorsRequest : IValidatable
+internal sealed class SearchVectorsRequest : IValidatable
 {
     [JsonPropertyName("vector")]
     public IEnumerable<float> StartingVector { get; set; } = System.Array.Empty<float>();
@@ -119,9 +119,9 @@ internal class SearchVectorsRequest : IValidatable
             payload: this);
     }
 
-    internal class Filter : IValidatable
+    internal sealed class Filter : IValidatable
     {
-        internal class Match : IValidatable
+        internal sealed class Match : IValidatable
         {
             [JsonPropertyName("value")]
             public object Value { get; set; }
@@ -136,7 +136,7 @@ internal class SearchVectorsRequest : IValidatable
             }
         }
 
-        internal class Must : IValidatable
+        internal sealed class Must : IValidatable
         {
             [JsonPropertyName("key")]
             public string Key { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
@@ -6,9 +6,9 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-internal class SearchVectorsResponse : QdrantResponse
+internal sealed class SearchVectorsResponse : QdrantResponse
 {
-    internal class ScoredPoint
+    internal sealed class ScoredPoint
     {
         [JsonPropertyName("id")]
         public string Id { get; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
-internal class UpsertVectorRequest
+internal sealed class UpsertVectorRequest
 {
     public static UpsertVectorRequest Create(string collectionName)
     {
@@ -34,7 +34,7 @@ internal class UpsertVectorRequest
     [JsonPropertyName("batch")]
     public BatchRequest Batch { get; set; }
 
-    internal class BatchRequest
+    internal sealed class BatchRequest
     {
         [JsonPropertyName("ids")]
         public IList<string> Ids { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-internal class UpsertVectorResponse : QdrantResponse
+internal sealed class UpsertVectorResponse : QdrantResponse
 {
     /// <summary>
     /// Upsert result information object
@@ -23,7 +23,7 @@ internal class UpsertVectorResponse : QdrantResponse
         this.Result = result;
     }
 
-    internal class UpdateResult
+    internal sealed class UpdateResult
     {
         /// <summary>
         /// Sequential Number of the Operation

--- a/dotnet/src/SemanticKernel.IntegrationTests/Fakes/EmailSkillFake.cs
+++ b/dotnet/src/SemanticKernel.IntegrationTests/Fakes/EmailSkillFake.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace SemanticKernel.IntegrationTests.Fakes;
 
-internal class EmailSkillFake
+internal sealed class EmailSkillFake
 {
     [SKFunction("Given an email address and message body, send an email")]
     [SKFunctionInput(Description = "The body of the email message to send.")]

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/TestSkills/ResourceSkillsProvider.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/OpenAPI/TestSkills/ResourceSkillsProvider.cs
@@ -5,7 +5,7 @@ using System.Resources;
 
 namespace SemanticKernel.Skills.UnitTests.OpenAPI.TestSkills;
 
-internal class ResourceSkillsProvider
+internal static class ResourceSkillsProvider
 {
     /// <summary>
     /// Loads OpenApi document from assembly resource.

--- a/dotnet/src/SemanticKernel.UnitTests/Connectors/WebApi/Rest/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Connectors/WebApi/Rest/RestApiOperationRunnerTests.cs
@@ -153,7 +153,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpClient.Dispose();
     }
 
-    private class HttpMessageHandlerStub : DelegatingHandler
+    private sealed class HttpMessageHandlerStub : DelegatingHandler
     {
         public HttpRequestHeaders? RequestHeaders { get; private set; }
 

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/SKContextTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/SKContextTests.cs
@@ -64,7 +64,7 @@ public class SKContextTests
         Assert.Equal("ciao", result.Result);
     }
 
-    private class Parrot
+    private sealed class Parrot
     {
         [SKFunction("say something")]
         // ReSharper disable once UnusedMember.Local

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/SKFunctionTests3.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/SKFunctionTests3.cs
@@ -64,7 +64,7 @@ public sealed class SKFunctionTests3
         Assert.Equal(3, count);
     }
 
-    private class InvalidSkill
+    private sealed class InvalidSkill
     {
         [SKFunction("one")]
         public void Invalid1(string x, string y)
@@ -82,7 +82,7 @@ public sealed class SKFunctionTests3
         }
     }
 
-    private class LocalExampleSkill
+    private sealed class LocalExampleSkill
     {
         [SKFunction("one")]
         public void Type01()

--- a/dotnet/src/SemanticKernel.UnitTests/Services/ServiceConfigTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Services/ServiceConfigTests.cs
@@ -30,7 +30,7 @@ public class ServiceConfigTests
         Assert.Equal(ValidationException.ErrorCodes.EmptyValue, exception?.ErrorCode);
     }
 
-    private class FakeAIServiceConfig : ServiceConfig
+    private sealed class FakeAIServiceConfig : ServiceConfig
     {
         public FakeAIServiceConfig(string serviceId) : base(serviceId)
         {

--- a/samples/apps/copilot-chat-app/webapi/Config/AIServiceConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/AIServiceConfig.cs
@@ -6,7 +6,7 @@
 namespace SemanticKernel.Service.Config;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes - Instantiated by deserializing JSON
-internal class AIServiceConfig
+internal sealed class AIServiceConfig
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
     public const string OpenAI = "OPENAI";

--- a/samples/apps/copilot-chat-app/webapi/Config/AzureSpeechConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/AzureSpeechConfig.cs
@@ -3,7 +3,7 @@
 namespace SemanticKernel.Service.Config;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes - Instantiated by deserializing JSON
-internal class AzureSpeechConfig
+internal sealed class AzureSpeechConfig
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
     public string Label { get; set; } = string.Empty;

--- a/samples/apps/copilot-chat-app/webapi/Skills/SemanticMemoryExtractor.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/SemanticMemoryExtractor.cs
@@ -5,10 +5,7 @@ using Microsoft.SemanticKernel.Orchestration;
 
 namespace SemanticKernel.Service.Skills;
 
-/// <summary>
-///
-/// </summary>
-internal class SemanticMemoryExtractor
+internal static class SemanticMemoryExtractor
 {
     /// <summary>
     /// Returns the name of the semantic text memory collection that stores chat semantic memory.

--- a/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
+++ b/samples/apps/copilot-chat-app/webapi/Storage/FileSystemContext.cs
@@ -96,7 +96,7 @@ public class FileSystemContext<T> : IStorageContext<T> where T : IStorageEntity
     /// <summary>
     /// A concurrent dictionary to store entities in memory.
     /// </summary>
-    private class EntityDictionary : ConcurrentDictionary<string, T>
+    private sealed class EntityDictionary : ConcurrentDictionary<string, T>
     {
     }
 

--- a/samples/dotnet/KernelHttpServer/Config/Constants.cs
+++ b/samples/dotnet/KernelHttpServer/Config/Constants.cs
@@ -2,9 +2,9 @@
 
 namespace KernelHttpServer.Config;
 
-internal class Constants
+internal static class Constants
 {
-    public class SKHttpHeaders
+    public static class SKHttpHeaders
     {
         public const string CompletionModel = "x-ms-sk-completion-model";
         public const string CompletionEndpoint = "x-ms-sk-completion-endpoint";

--- a/samples/dotnet/kernel-syntax-examples/Example23_ReadOnlyMemoryStore.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example23_ReadOnlyMemoryStore.cs
@@ -41,7 +41,7 @@ public static class Example23_ReadOnlyMemoryStore
         }
     }
 
-    private class ReadOnlyMemoryStore : IMemoryStore
+    private sealed class ReadOnlyMemoryStore : IMemoryStore
     {
         private IEnumerable<MemoryRecord>? _memoryRecords = null;
         private int _vectorSize = 3;

--- a/samples/dotnet/kernel-syntax-examples/RepoUtils/Env.cs
+++ b/samples/dotnet/kernel-syntax-examples/RepoUtils/Env.cs
@@ -5,7 +5,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace RepoUtils;
 
-internal class Env
+#pragma warning disable CA1812 // instantiated by AddUserSecrets
+internal sealed class Env
+#pragma warning restore CA1812
 {
     /// <summary>
     /// Simple helper used to load env vars and secrets like credentials,

--- a/samples/dotnet/kernel-syntax-examples/Skills/EmailSkill.cs
+++ b/samples/dotnet/kernel-syntax-examples/Skills/EmailSkill.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace Skills;
 
-internal class EmailSkill
+internal sealed class EmailSkill
 {
     [SKFunction("Given an e-mail and message body, send an email")]
     [SKFunctionInput(Description = "The body of the email message to send.")]


### PR DESCRIPTION
### Motivation and Context

Sealed types enables better perf. For internal/private types, there's no downside.

### Description

Stop suppressing the analyzer rule and fix all resulting warnings.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
