### PR TITLE
Fix: Check for absence, not presence of API key header

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Auth/ApiKeyAuthenticationHandler .cs
+++ b/samples/apps/copilot-chat-app/webapi/Auth/ApiKeyAuthenticationHandler .cs
@@ -37,7 +37,7 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthentic
             return Task.FromResult(AuthenticateResult.Fail("API key not configured on server"));
         }
 
-        if (this.Request.Headers.TryGetValue(ApiKeyHeaderName, out StringValues apiKeyFromHeader))
+        if (!this.Request.Headers.TryGetValue(ApiKeyHeaderName, out StringValues apiKeyFromHeader))
         {
             return Task.FromResult(AuthenticateResult.Fail("No API key provided"));
         }


### PR DESCRIPTION
### Motivation and Context
A negation bug was introduced when making a change to the API key authenticator. Fixing it.


### Description
Negate the condition where the authenticator looks for an x-api-key header

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
