### PR TITLE
Some behavioral / perf fixes for Embedding<T>

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAIClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAIClientBase.cs
@@ -78,7 +78,7 @@ public abstract class OpenAIClientBase : IDisposable
                     "Embeddings not found");
             }
 
-            return result.Embeddings.Select(e => new Embedding<float>(e.Values.ToArray())).ToList();
+            return result.Embeddings.Select(e => new Embedding<float>(e.Values)).ToList();
         }
         catch (Exception e) when (e is not AIException)
         {

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/IMemoryStore.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/IMemoryStore.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -100,10 +101,10 @@ public interface IMemoryStore
     Task RemoveBatchAsync(string collectionName, IEnumerable<string> keys, CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets the nearest matches to the <see cref="Embedding"/> of type <see cref="float"/>. Does not guarantee that the collection exists.
+    /// Gets the nearest matches to the <see cref="Embedding{Single}"/> of type <see cref="float"/>. Does not guarantee that the collection exists.
     /// </summary>
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
-    /// <param name="embedding">The <see cref="Embedding"/> to compare the collection's embeddings with.</param>
+    /// <param name="embedding">The <see cref="Embedding{Single}"/> to compare the collection's embeddings with.</param>
     /// <param name="limit">The maximum number of similarity results to return.</param>
     /// <param name="minRelevanceScore">The minimum relevance threshold for returned results.</param>
     /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
@@ -118,10 +119,10 @@ public interface IMemoryStore
         CancellationToken cancel = default);
 
     /// <summary>
-    /// Gets the nearest match to the <see cref="Embedding"/> of type <see cref="float"/>. Does not guarantee that the collection exists.
+    /// Gets the nearest match to the <see cref="Embedding{Single}"/> of type <see cref="float"/>. Does not guarantee that the collection exists.
     /// </summary>
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
-    /// <param name="embedding">The <see cref="Embedding"/> to compare the collection's embeddings with.</param>
+    /// <param name="embedding">The <see cref="Embedding{Single}"/> to compare the collection's embeddings with.</param>
     /// <param name="minRelevanceScore">The minimum relevance threshold for returned results.</param>
     /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
     /// <param name="cancel">Cancellation token</param>

--- a/dotnet/src/SemanticKernel.UnitTests/AI/Embeddings/EmbeddingTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/Embeddings/EmbeddingTests.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -14,6 +16,54 @@ public class EmbeddingTests
     // Vector has length of 3, magnitude of 5
     private readonly float[] _vector = new float[] { 0, 3, -4 };
     private readonly float[] _empty = Array.Empty<float>();
+
+    [Fact]
+    public void ItTreatsDefaultEmbeddingAsEmpty()
+    {
+        // Arrange
+        Embedding<float> target = default;
+
+        // Assert
+        Assert.True(target.IsEmpty);
+        Assert.Equal(0, target.Count);
+        Assert.Empty(target.Vector);
+        Assert.Same(Array.Empty<float>(), target.Vector);
+        Assert.Same(Array.Empty<float>(), (float[])target);
+        Assert.True(target.AsReadOnlySpan().IsEmpty);
+        Assert.True(((ReadOnlySpan<float>)target).IsEmpty);
+        Assert.True(target.Equals(Embedding<float>.Empty));
+        Assert.True(target.Equals(new Embedding<float>()));
+        Assert.True(target == Embedding<float>.Empty);
+        Assert.True(target == new Embedding<float>());
+        Assert.False(target != Embedding<float>.Empty);
+        Assert.Equal(0, target.GetHashCode());
+    }
+
+    [Fact]
+    public void ItThrowsFromCtorWithUnsupportedType()
+    {
+        // Assert
+        Assert.Throws<NotSupportedException>(() => new Embedding<int>(new int[] { 1, 2, 3 }));
+        Assert.Throws<NotSupportedException>(() => new Embedding<int>(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void ItThrowsFromEmptyWithUnsupportedType()
+    {
+        // Assert
+        Assert.Throws<NotSupportedException>(() => Embedding<int>.Empty);
+    }
+
+    [Fact]
+    public void ItAllowsUnsupportedTypesOnEachOperation()
+    {
+        // Arrange
+        Embedding<int> target = default;
+
+        // Act
+        Assert.True(target.IsEmpty);
+        Assert.Equal(0, target.Count);
+    }
 
     [Fact]
     public void ItThrowsWithNullVector()
@@ -31,6 +81,7 @@ public class EmbeddingTests
         // Assert
         Assert.Empty(target.Vector);
         Assert.Equal(0, target.Count);
+        Assert.False(Embedding<int>.IsSupported);
     }
 
     [Fact]
@@ -38,10 +89,6 @@ public class EmbeddingTests
     {
         // Arrange
         var target = new Embedding<float>(this._vector);
-
-        // Act
-        // TODO: copy is never used - bug?
-        var copy = target;
 
         // Assert
         Assert.True(target.Vector.SequenceEqual(this._vector));
@@ -59,5 +106,20 @@ public class EmbeddingTests
 
         // Assert
         Assert.True(copy.Vector.SequenceEqual(this._vector));
+    }
+
+    [Fact]
+    public void ItDoesntCopyVectorWhenCastingToSpan()
+    {
+        // Arrange
+        var target = new Embedding<float>(this._vector);
+
+        // Act
+        ReadOnlySpan<float> span1 = target.AsReadOnlySpan();
+        ReadOnlySpan<float> span2 = (ReadOnlySpan<float>)target;
+
+        // Assert
+        Assert.False(Unsafe.AreSame(ref MemoryMarshal.GetReference(span1), ref MemoryMarshal.GetArrayDataReference(this._vector)));
+        Assert.True(Unsafe.AreSame(ref MemoryMarshal.GetReference(span1), ref MemoryMarshal.GetReference(span2)));
     }
 }

--- a/dotnet/src/SemanticKernel/Connectors/HuggingFace/TextEmbedding/HuggingFaceTextEmbeddingGeneration.cs
+++ b/dotnet/src/SemanticKernel/Connectors/HuggingFace/TextEmbedding/HuggingFaceTextEmbeddingGeneration.cs
@@ -107,7 +107,7 @@ public sealed class HuggingFaceTextEmbeddingGeneration : IEmbeddingGeneration<st
 
             var embeddingResponse = JsonSerializer.Deserialize<TextEmbeddingResponse>(body);
 
-            return embeddingResponse?.Embeddings?.Select(l => new Embedding<float>(l.Embedding.ToArray())).ToList()!;
+            return embeddingResponse?.Embeddings?.Select(l => new Embedding<float>(l.Embedding!)).ToList()!;
         }
         catch (Exception e) when (e is not AIException && !e.IsCriticalException())
         {


### PR DESCRIPTION
### Motivation and Context

Clean up some `Embedding<T>` behaviors / perf issues.

### Description

- IsSupported was more expensive than it needs to be: if it's changed to just compare the types directly rather than searching a list, the JIT can turn the entire operation into a JIT-time constant.
- The explicit cast to `ReadOnlySpan<T>` was cloning the array. It doesn't need to do that.
- `default(Embedding<T>)` results in a struct that fails on a bunch of operations with NullReferenceExceptions if you try to use it.  We've learned from experience with `ImmutableArray<T>` this is suboptimal.  I've made it functional and behave equivalent to Empty... in fact, Empty is now just `default`.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
