### PR TITLE
Updated Copilot Chat Appsettings.json to default OpenAI

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -36,8 +36,8 @@
     //  - Set Key using dotnet's user secrets (see above) (i.e. dotnet user-secrets set "Completion:Key" "MY_OPENAI")
     //
     "Label": "Completion",
-    "AIService": "AzureOpenAI",
-    "DeploymentOrModelId": "gpt-35-turbo",
+    "AIService": "OpenAI",
+    "DeploymentOrModelId": "gpt-3.5-turbo",
     "Endpoint": "" // ignored when AIService is "OpenAI"
     // "Key": ""
   },
@@ -58,7 +58,7 @@
     //  - Set Key using dotnet's user secrets (see above) (i.e. dotnet user-secrets set "Embedding:Key" "MY_OPENAI")
     //
     "Label": "Embeddings",
-    "AIService": "AzureOpenAI",
+    "AIService": "OpenAI",
     "DeploymentOrModelId": "text-embedding-ada-002",
     "Endpoint": "" // ignored when AIService is "OpenAI"
     // "Key": ""


### PR DESCRIPTION

Updated appsettings.json in Copilot Chat to default with OpenAI settings.  Users can switch to AzureOpenAI by following comments in file.
