### PR TITLE
Use head ref instead of main in markdown-link-check workflow

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: 'main'
+        ref: ${{ github.head_ref }}
 
     # Checks the status of hyperlinks in .md files in verbose mode
     - name: Check links


### PR DESCRIPTION
This change modifies the markdown-link-check workflow to use the head ref instead of the main branch when checking out the repository. This ensures that the workflow runs on the correct branch and checks the links in the pull request. This avoids false positives or negatives when the main branch is not up to date with the pull request branch.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
