### PR TITLE
Allow markdown workflow to run against PR branches

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,8 +16,6 @@ jobs:
     # check out the latest version of the code
     steps:
     - uses: actions/checkout@v3
-      with:
-        ref: 'main'
 
     # Checks the status of hyperlinks in .md files in verbose mode
     - name: Check links


### PR DESCRIPTION
### Motivation and Context
Markdown workflow is broken and blockign PRs.

### Description
- Removed ref:main from checkout in markdown check workflow
