### PR TITLE
fixed error notebboks pyhon 4 when useAzureOpenAI equals True

### DIFF
--- a/samples/notebooks/python/04-context-variables-chat.ipynb
+++ b/samples/notebooks/python/04-context-variables-chat.ipynb
@@ -44,8 +44,8 @@
     "\n",
     "# Configure AI backend used by the kernel\n",
     "if useAzureOpenAI:\n",
-    "    api_key, endpoint = sk.azure_openai_settings_from_dot_env()\n",
-    "    kernel.config.add_text_backend(\"dv\", AzureTextCompletion(\"text-davinci-003\", api_key, endpoint))\n",
+    "    deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()\n",
+    "    kernel.config.add_text_backend(\"dv\", AzureTextCompletion(deployment, endpoint, api_key))\n",
     "else:\n",
     "    api_key, org_id = sk.openai_settings_from_dot_env()\n",
     "    kernel.config.add_text_backend(\"dv\", OpenAITextCompletion(\"text-davinci-003\", api_key, org_id))"


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
I fixed error `useAzureOpenAI = True` on `samples/notebooks/python/04-context-variables-chat.ipynb`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

before:
![image](https://user-images.githubusercontent.com/875216/233800808-69edecc7-9233-4fcb-9e40-3a20a173a972.png)

after:
![image](https://user-images.githubusercontent.com/875216/233800826-894bbc75-7272-4cd0-900e-8ab0b770ca75.png)


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
