### PR TITLE
Fix another extraneous JsonSerializerOptions instance

### DIFF
--- a/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
@@ -80,7 +80,7 @@ public class SemanticKernelEndpoint
         HttpRequestData req,
         FunctionContext executionContext)
     {
-        var ask = await JsonSerializer.DeserializeAsync<Ask>(req.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var ask = await JsonSerializer.DeserializeAsync<Ask>(req.Body, s_jsonOptions);
 
         if (ask == null)
         {


### PR DESCRIPTION
### Motivation and Context

JsonSerializerOptions should be cached and reused.

### Description

We already had a cached one with appropriate settings.  Just needs to be used.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
