### PR TITLE
Remove intermediary collections from Kernel.ImportSkill

### DIFF
--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -109,13 +108,11 @@ public sealed class Kernel : IKernel, IDisposable
             this._log.LogTrace("Importing skill {0}", skillName);
         }
 
-        var skill = new Dictionary<string, ISKFunction>(StringComparer.OrdinalIgnoreCase);
-        IEnumerable<ISKFunction> functions = ImportSkill(skillInstance, skillName, this._log);
-        foreach (ISKFunction f in functions)
+        Dictionary<string, ISKFunction> skill = ImportSkill(skillInstance, skillName, this._log);
+        foreach (KeyValuePair<string, ISKFunction> f in skill)
         {
-            f.SetDefaultSkillCollection(this.Skills);
-            this._skillCollection.AddNativeFunction(f);
-            skill.Add(f.Name, f);
+            f.Value.SetDefaultSkillCollection(this.Skills);
+            this._skillCollection.AddNativeFunction(f.Value);
         }
 
         return skill;
@@ -337,27 +334,31 @@ public sealed class Kernel : IKernel, IDisposable
     /// <param name="skillInstance">Skill class instance</param>
     /// <param name="skillName">Skill name, used to group functions under a shared namespace</param>
     /// <param name="log">Application logger</param>
-    /// <returns>List of functions imported from the given class instance</returns>
-    private static List<ISKFunction> ImportSkill(object skillInstance, string skillName, ILogger log)
+    /// <returns>Dictionary of functions imported from the given class instance, case-insensitively indexed by name.</returns>
+    private static Dictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName, ILogger log)
     {
         log.LogTrace("Importing skill name: {0}", skillName);
         MethodInfo[] methods = skillInstance.GetType()
-            .GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod);
+            .GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
         log.LogTrace("Methods found {0}", methods.Length);
 
-        // Filter out null functions
-        IEnumerable<ISKFunction> functions = from method in methods select SKFunction.FromNativeMethod(method, skillInstance, skillName, log);
-        List<ISKFunction> result = (from function in functions where function != null select function).ToList();
-        log.LogTrace("Methods imported {0}", result.Count);
-
-        // Fail if two functions have the same name
-        var uniquenessCheck = new HashSet<string>(from x in result select x.Name, StringComparer.OrdinalIgnoreCase);
-        if (result.Count > uniquenessCheck.Count)
+        // Filter out null functions and fail if two functions have the same name
+        Dictionary<string, ISKFunction> result = new Dictionary<string, ISKFunction>(StringComparer.OrdinalIgnoreCase);
+        foreach (MethodInfo method in methods)
         {
-            throw new KernelException(
-                KernelException.ErrorCodes.FunctionOverloadNotSupported,
-                "Function overloads are not supported, please differentiate function names");
+            if (SKFunction.FromNativeMethod(method, skillInstance, skillName, log) is ISKFunction function)
+            {
+                if (result.ContainsKey(function.Name))
+                {
+                    throw new KernelException(
+                        KernelException.ErrorCodes.FunctionOverloadNotSupported,
+                        "Function overloads are not supported, please differentiate function names");
+                }
+
+                result.Add(function.Name, function);
+            }
         }
+        log.LogTrace("Methods imported {0}", result.Count);
 
         return result;
     }


### PR DESCRIPTION
### Motivation and Context

Simplify/streamline ImportSkill

### Description

`ImportSkill(object skillInstance, string skillName, ILogger log)` uses Enumerable.Select to enumerate a MethodInfo[], then uses Enumerable.Where to filter out nulls, then populates a `List<ISKFunction>` with those results, then uses Enumerable.Select to get an enumerable of the names of those functions, then populates a HashSet with those names to ensure they're all unique, and then returns the list.  The sole consumer of this then immediately creates a `Dictionary<string, ISKFunction>` from that list.

We can avoid that `List<>` and that `HashSet<>` as well as three LINQ enumerables just by creating the dictionary directly.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
