### PR TITLE
Remove a few unnecessary internal setters

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ISKFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ISKFunction.cs
@@ -34,12 +34,12 @@ public interface ISKFunction
     /// IMPORTANT: native functions might use semantic functions internally,
     /// so when this property is False, executing the function might still involve AI calls.
     /// </summary>
-    public bool IsSemantic { get; }
+    bool IsSemantic { get; }
 
     /// <summary>
     /// AI service settings
     /// </summary>
-    public CompleteRequestSettings RequestSettings { get; }
+    CompleteRequestSettings RequestSettings { get; }
 
     /// <summary>
     /// Returns a description of the function, including parameters.

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
@@ -78,7 +78,7 @@ public sealed class SKContext
     /// <summary>
     /// Semantic memory
     /// </summary>
-    public ISemanticTextMemory Memory { get; internal set; }
+    public ISemanticTextMemory Memory { get; }
 
     /// <summary>
     /// Read only skills collection

--- a/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingReadOnlySpan.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingReadOnlySpan.cs
@@ -64,12 +64,12 @@ public ref struct EmbeddingReadOnlySpan<TEmbedding>
     /// <summary>
     /// Gets the underlying <see cref="ReadOnlySpan{T}"/> of unmanaged data.
     /// </summary>
-    public ReadOnlySpan<TEmbedding> ReadOnlySpan { get; internal set; }
+    public ReadOnlySpan<TEmbedding> ReadOnlySpan { get; }
 
     /// <summary>
     /// True if the data was specified to be normalized at construction.
     /// </summary>
-    public bool IsNormalized { get; internal set; }
+    public bool IsNormalized { get; }
 
     /// <summary>
     /// Calculates the dot product of this vector with another.

--- a/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingSpan.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/EmbeddingSpan.cs
@@ -36,7 +36,7 @@ public ref struct EmbeddingSpan<TEmbedding>
     /// <summary>
     /// Gets the underlying <see cref="Span{T}"/> of unmanaged data.
     /// </summary>
-    public Span<TEmbedding> Span { get; internal set; }
+    public Span<TEmbedding> Span { get; }
 
     /// <summary>
     /// Normalizes the underlying vector in-place, such that the Euclidean length is 1.

--- a/dotnet/src/SemanticKernel/Orchestration/Plan.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/Plan.cs
@@ -59,7 +59,7 @@ public sealed class Plan : ISKFunction
     /// Gets the next step index.
     /// </summary>
     [JsonPropertyName("next_step_index")]
-    public int NextStepIndex { get; internal set; } = 0;
+    public int NextStepIndex { get; private set; }
 
     #region ISKFunction implementation
 
@@ -77,11 +77,11 @@ public sealed class Plan : ISKFunction
 
     /// <inheritdoc/>
     [JsonIgnore]
-    public bool IsSemantic { get; internal set; } = false;
+    public bool IsSemantic { get; private set; }
 
     /// <inheritdoc/>
     [JsonIgnore]
-    public CompleteRequestSettings RequestSettings { get; internal set; } = new();
+    public CompleteRequestSettings RequestSettings { get; private set; } = new();
 
     #endregion ISKFunction implementation
 


### PR DESCRIPTION
### Motivation and Context

Minor cleanup.

### Description

These are unnecessary.  As I was reviewing through the code I happened to notice they were unused or had greater than required visibility.  Also removed a few unnecessary `public` visibility annotations from an interface (they were nops and were inconsistent with the rest of the interface), as well as a few initializers that were initializing to the default value and thus were duplicative.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
