### PR TITLE
Tweak Score and ScoredValue

### DIFF
--- a/dotnet/src/SemanticKernel/Memory/Collections/Score.cs
+++ b/dotnet/src/SemanticKernel/Memory/Collections/Score.cs
@@ -8,15 +8,20 @@ namespace Microsoft.SemanticKernel.Memory.Collections;
 /// <summary>
 /// Structure for storing score value.
 /// </summary>
-public struct Score : IComparable<Score>, IEquatable<Score>
+public readonly struct Score : IComparable<Score>, IEquatable<Score>
 {
-    public double Value { get; set; }
+    public double Value { get; }
 
-    public static Score Min => double.MinValue;
+    public Score(double value)
+    {
+        this.Value = value;
+    }
+
+    internal static Score Min => double.MinValue;
 
     public static implicit operator Score(double score)
     {
-        return new Score { Value = score };
+        return new Score(score);
     }
 
     public static implicit operator double(Score src)

--- a/dotnet/src/SemanticKernel/Memory/Collections/ScoredValue.cs
+++ b/dotnet/src/SemanticKernel/Memory/Collections/ScoredValue.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Memory.Collections;
 /// Structure for storing data which can be scored.
 /// </summary>
 /// <typeparam name="T">Data type.</typeparam>
-public struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredValue<T>>
+public readonly struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredValue<T>>
 {
     public ScoredValue(T item, double score)
     {
@@ -17,8 +17,8 @@ public struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredVal
         this.Score = score;
     }
 
-    public T Value { get; private set; }
-    public Score Score { get; private set; }
+    public T Value { get; }
+    public Score Score { get; }
 
     public int CompareTo(ScoredValue<T> other)
     {
@@ -30,12 +30,12 @@ public struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredVal
         return $"{this.Score}, {this.Value}";
     }
 
-    public static implicit operator double(ScoredValue<T> src)
+    public static explicit operator double(ScoredValue<T> src)
     {
         return src.Score;
     }
 
-    public static implicit operator T(ScoredValue<T> src)
+    public static explicit operator T(ScoredValue<T> src)
     {
         return src.Value;
     }
@@ -52,9 +52,8 @@ public struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredVal
 
     public bool Equals(ScoredValue<T> other)
     {
-        return (other != null)
-               && (this.Value?.Equals(other.Value) == true)
-               && (this.Score.Equals(other.Score));
+        return EqualityComparer<T>.Default.Equals(other.Value) &&
+               this.Score.Equals(other.Score);
     }
 
     public override int GetHashCode()
@@ -92,9 +91,7 @@ public struct ScoredValue<T> : IComparable<ScoredValue<T>>, IEquatable<ScoredVal
         return left.CompareTo(right) >= 0;
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types",
-        Justification = "Min value convenience method")]
-    public static ScoredValue<T> Min()
+    internal static ScoredValue<T> Min()
     {
         return new ScoredValue<T>(default!, Score.Min);
     }


### PR DESCRIPTION
### Motivation and Context

A bit of cleanup for the `Score` and `ScoredValue` types.

### Description

- Make them both readonly, removing the setters from properties
- Give Score a public ctor
- Make the Min static properties internal (it doesn't really make sense on ScoredValue, and it's strange to have a Min but no Max)
- Make ScoredValue's implicit operators for casting to T or double to instead be explicit; implicit operators shouldn't be lossy, but by definition throwing away half of the state is lossy
- Remove unnecessary null checks

I also opened https://github.com/microsoft/semantic-kernel/issues/616.

And, do we need `Score` at all?  It's really just giving a unit of measure to a `double`.  Could we delete it and just let `ScoredValue<T>` wrap `T` and a `double`?

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
