### PR TITLE
Python: delegate_inference should show appropriate error message

### DIFF
--- a/python/semantic_kernel/orchestration/delegate_inference.py
+++ b/python/semantic_kernel/orchestration/delegate_inference.py
@@ -223,7 +223,7 @@ class DelegateInference:
 
     @staticmethod
     @_infers(DelegateTypes.Unknown)
-    def infer_unknown(signature: Signature) -> NoReturn:
+    def infer_unknown(signature: Signature, awaitable: bool) -> NoReturn:
         raise KernelException(
             KernelException.ErrorCodes.FunctionTypeNotSupported,
             "Invalid function type detected, unable to infer DelegateType.",


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
#624 

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Error message should be delivered appropriately.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
