### PR TITLE
Fix state handling for plan execution

### DIFF
--- a/dotnet/src/SemanticKernel/Orchestration/Plan.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/Plan.cs
@@ -293,7 +293,7 @@ public sealed class Plan : ISKFunction
     public async Task<SKContext> InvokeAsync(SKContext? context = null, CompleteRequestSettings? settings = null, ILogger? log = null,
         CancellationToken? cancel = null)
     {
-        context ??= new SKContext(new ContextVariables(), null!, null, log ?? NullLogger.Instance, cancel ?? CancellationToken.None);
+        context ??= new SKContext(this.State, null!, null, log ?? NullLogger.Instance, cancel ?? CancellationToken.None);
 
         if (this.Function is not null)
         {


### PR DESCRIPTION
### Motivation and Context
Fix bug with plans that have single function as root and respect Plan State.

### Description
This commit adds a new unit test for the Plan class, which tests the ability to execute a plan with one step and a state variable. It also modifies the Plan.InvokeAsync method to use the plan's state as the default context variables, instead of an empty one. This allows the plan to pass state information to the function it invokes.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
