### PR TITLE
Update tasks.json to use IntegrationTests.csproj

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -147,7 +147,7 @@
         "XPlat Code Coverage;Format=lcov",
         "--filter",
         "${input:filter}",
-        "SemanticKernel.IntegrationTests.csproj"
+        "IntegrationTests.csproj"
       ],
       "problemMatcher": "$msCompile",
       "group": "test",
@@ -156,7 +156,7 @@
         "panel": "shared"
       },
       "options": {
-        "cwd": "${workspaceFolder}/dotnet/src/SemanticKernel.IntegrationTests/"
+        "cwd": "${workspaceFolder}/dotnet/src/IntegrationTests/"
       }
     },
     {


### PR DESCRIPTION

### Motivation and Context
Fix the VSCode tasks for integration tests.

### Description
This commit changes the tasks.json file to use the IntegrationTests.csproj file instead of the SemanticKernel.IntegrationTests.csproj file. This is because the SemanticKernel project has been renamed to IntegrationTests, and the tasks.json file needs to reflect this change. This affects the test coverage task, which runs the integration tests and generates a lcov report. The commit also updates the cwd option to point to the new project folder.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
