### PR TITLE
[SequentialPlanner] Add default values to function manual

### DIFF
--- a/dotnet/src/IntegrationTests/Planning/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlannerTests.cs
@@ -43,12 +43,35 @@ public sealed class SequentialPlannerTests : IDisposable
 
         // Act
         var plan = await planner.CreatePlanAsync(prompt);
+
         // Assert
         Assert.Contains(
             plan.Steps,
             step =>
                 step.Name.Equals(expectedFunction, StringComparison.OrdinalIgnoreCase) &&
                 step.SkillName.Equals(expectedSkill, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("Write a novel about software development that is 3 chapters long.", "NovelOutline", "WriterSkill", "<!--===ENDPART===-->")]
+    public async Task CreatePlanWithDefaultsAsync(string prompt, string expectedFunction, string expectedSkill, string expectedDefault)
+    {
+        // Arrange
+        IKernel kernel = this.InitializeKernel();
+        TestHelpers.GetSkill("WriterSkill", kernel);
+
+        var planner = new SequentialPlanner(kernel);
+
+        // Act
+        var plan = await planner.CreatePlanAsync(prompt);
+
+        // Assert
+        Assert.Contains(
+            plan.Steps,
+            step =>
+                    step.Name.Equals(expectedFunction, StringComparison.OrdinalIgnoreCase) &&
+                    step.SkillName.Equals(expectedSkill, StringComparison.OrdinalIgnoreCase) &&
+                    step.NamedParameters["endMarker"].Equals(expectedDefault, StringComparison.OrdinalIgnoreCase));
     }
 
     [Theory]

--- a/dotnet/src/SemanticKernel/Planning/FunctionViewExtensions.cs
+++ b/dotnet/src/SemanticKernel/Planning/FunctionViewExtensions.cs
@@ -16,7 +16,7 @@ internal static class FunctionViewExtensions
     /// <returns>A manual-friendly string for a function.</returns>
     internal static string ToManualString(this FunctionView function)
     {
-        var inputs = string.Join("\n", function.Parameters.Select(p => $"    - {p.Name}: {p.Description}"));
+        var inputs = string.Join("\n", function.Parameters.Select(p => $"    - {p.Name}: {p.Description} (default value: {p.DefaultValue}))"));
         return $"  {function.ToFullyQualifiedName()}:\n    description: {function.Description}\n    inputs:\n{inputs}";
     }
 


### PR DESCRIPTION
### Motivation and Context
SequentialPlanner was not respecting default values for inputs.

### Description
This commit modifies the ToManualString extension method for FunctionView to include the default value of each parameter in the generated string. This makes the manual more informative and helpful for LLM to know the default behavior of a function. The default value is shown in parentheses after the parameter description.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
