### PR TITLE
Fix context generation order in chat skill

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
@@ -126,8 +126,8 @@ public class PromptSettings
         this.SystemResponsePrompt,
         "{{$userIntent}}",
         "{{ChatSkill.ExtractUserMemories}}",
-        "{{ChatSkill.ExtractChatHistory}}",
         "{{DocumentMemorySkill.QueryDocuments $INPUT}}",
+        "{{ChatSkill.ExtractChatHistory}}",
         this.SystemChatContinuationPrompt
     };
 


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The chat function generates the final prompt by populating it with multiple contexts. Each context is constrained by a token limit except the last one, which is chat history. The chat function will fill up the prompt with chat history to reach the token limit. 

A bug was discovered that the chat history context was not the last context.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Move chat history to the end of the prompt.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
