### PR TITLE
Add .editorconfig suppressions for test projects

### DIFF
--- a/dotnet/.editorconfig
+++ b/dotnet/.editorconfig
@@ -1,4 +1,4 @@
 # Setting errors for SDK projects under dotnet folder
 [*.cs]
 dotnet_diagnostic.CA2007.severity = error # Do not directly await a Task
-dotnet_diagnostic.VSTHRD111.severity = error # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+dotnet_diagnostic.VSTHRD111.severity = error # Use .ConfigureAwait(bool)

--- a/dotnet/src/Connectors/Connectors.UnitTests/.editorconfig
+++ b/dotnet/src/Connectors/Connectors.UnitTests/.editorconfig
@@ -1,0 +1,5 @@
+# Suppressing errors for Test projects under dotnet folder
+[*.cs]
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+

--- a/dotnet/src/IntegrationTests/.editorconfig
+++ b/dotnet/src/IntegrationTests/.editorconfig
@@ -1,0 +1,5 @@
+# Suppressing errors for Test projects under dotnet folder
+[*.cs]
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+

--- a/dotnet/src/SemanticKernel.UnitTests/.editorconfig
+++ b/dotnet/src/SemanticKernel.UnitTests/.editorconfig
@@ -1,0 +1,5 @@
+# Suppressing errors for Test projects under dotnet folder
+[*.cs]
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+

--- a/dotnet/src/Skills/Skills.UnitTests/.editorconfig
+++ b/dotnet/src/Skills/Skills.UnitTests/.editorconfig
@@ -1,0 +1,5 @@
+# Suppressing errors for Test projects under dotnet folder
+[*.cs]
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+


### PR DESCRIPTION
This commit adds .editorconfig files to the test projects under the dotnet folder, to suppress the errors for CA2007 and VSTHRD111 rules. These rules are enforced for the SDK projects, but not necessary for the test projects. The .editorconfig files inherit the settings from the parent folder, and override the severity for the two rules to none. This prevents the IDE from changing the code on autosave, and avoids false positives in the code analysis. The commit also removes the redundant comment for VSTHRD111 in the dotnet/.editorconfig file.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
