### PR TITLE
fix the service registration method in the python README document

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -33,11 +33,11 @@ kernel = sk.Kernel()
 
 # Prepare OpenAI service using credentials stored in the `.env` file
 api_key, org_id = sk.openai_settings_from_dot_env()
-kernel.config.add_text_service("dv", OpenAITextCompletion("text-davinci-003", api_key, org_id))
+kernel.config.add_text_backend("dv", OpenAITextCompletion("text-davinci-003", api_key, org_id))
 
 # Alternative using Azure:
 # deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()
-# kernel.config.add_text_service("dv", AzureTextCompletion(deployment, endpoint, api_key))
+# kernel.config.add_text_backend("dv", AzureTextCompletion(deployment, endpoint, api_key))
 
 # Wrap your prompt in a function
 prompt = kernel.create_semantic_function("""


### PR DESCRIPTION
### Motivation and Context
Semantic Kernel newbee here, trying to walk through the simple guide in `python/README.md`. An out-of-date function from `kernel_config.py` found in the doc.

The doc uses `add_text_service` to load the default text completion service, which is replaced by `add_text_method` in new version.

### Description
1. fix python/README.md: use `add_text_backend` method for text completion service to match the current implementation

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
