### PR TITLE
Semantic Kernel Python README document fix

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -27,13 +27,16 @@ AZURE_OPENAI_API_KEY=""
 
 ```python
 import semantic_kernel as sk
-from semantic_kernel.connectors.ai.open_ai import OpenAITextCompletion, AzureTextCompletion
+from semantic_kernel.ai.open_ai import OpenAITextCompletion, AzureTextCompletion
 
 kernel = sk.Kernel()
 
 # Prepare OpenAI service using credentials stored in the `.env` file
 api_key, org_id = sk.openai_settings_from_dot_env()
 kernel.config.add_text_backend("dv", OpenAITextCompletion("text-davinci-003", api_key, org_id))
+
+# `org_id` is not required
+# kernel.config.add_text_backend("dv", OpenAITextCompletion("text-davinci-003", api_key))
 
 # Alternative using Azure:
 # deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()

--- a/python/README.md
+++ b/python/README.md
@@ -27,7 +27,7 @@ AZURE_OPENAI_API_KEY=""
 
 ```python
 import semantic_kernel as sk
-from semantic_kernel.ai.open_ai import OpenAITextCompletion, AzureTextCompletion
+from semantic_kernel.connectors.ai.open_ai import OpenAITextCompletion, AzureTextCompletion
 
 kernel = sk.Kernel()
 

--- a/python/README.md
+++ b/python/README.md
@@ -33,11 +33,11 @@ kernel = sk.Kernel()
 
 # Prepare OpenAI service using credentials stored in the `.env` file
 api_key, org_id = sk.openai_settings_from_dot_env()
-kernel.config.add_text_service("dv", OpenAITextCompletion("text-davinci-003", api_key, org_id))
+kernel.config.add_text_backend("dv", OpenAITextCompletion("text-davinci-003", api_key, org_id))
 
 # Alternative using Azure:
 # deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()
-# kernel.config.add_text_service("dv", AzureTextCompletion(deployment, endpoint, api_key))
+# kernel.config.add_text_backend("dv", AzureTextCompletion(deployment, endpoint, api_key))
 
 # Wrap your prompt in a function
 prompt = kernel.create_semantic_function("""


### PR DESCRIPTION
### Motivation and Context
Semantic Kernel newbee here, trying to walk through the simple guide in python/README.md. Out-of-date implementations from `kernel_config.py` and `OpenAITextCompletion` and are found in the document.

To go through the guide in the document, one should do the following modifications:
* new path to import text completion service: `from semantic_kernel.ai.open_ai import OpenAITextCompletion, AzureTextCompletion`
* change `add_text_service` to `add_text_method` to register the text completion service
* `org_id` is not required for initializing the text completion service

### Description
fix python/README.md:
* change the path to import `OpenAITextCompletion`, `AzureTextCompletion` to `semantic_kernel.ai.open_ai`
* use `add_text_backend` method for text completion service to match the current implementation
* add a tip that `org_id` is not required for initializing the text completion service
