### PR TITLE
Update Recall to asynchonously access memories

### DIFF
--- a/samples/dotnet/kernel-syntax-examples/Example15_MemorySkill.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example15_MemorySkill.cs
@@ -63,12 +63,12 @@ public static class Example15_MemorySkill
 
         context[TextMemorySkill.LimitParam] = "2";
         string ask = "where did I grow up?";
-        answer = memorySkill.Recall(ask, context);
+        answer = await memorySkill.RecallAsync(ask, context);
         Console.WriteLine("Ask: {0}", ask);
         Console.WriteLine("Answer:\n{0}", answer);
 
         ask = "where do I live?";
-        answer = memorySkill.Recall(ask, context);
+        answer = await memorySkill.RecallAsync(ask, context);
         Console.WriteLine("Ask: {0}", ask);
         Console.WriteLine("Answer:\n{0}", answer);
 


### PR DESCRIPTION
I opened #671 about a bug that I noticed when working with the semantic kernel locally. I created a patched version of the TextMemorySkill locally and found a small change that allowed it to work as expected. This PR is for that change.


### Description
Updated `TextMemorySkill.Recall` to asynchronously access memories. This means `Recall` becomes `RecalAsync`.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
