### PR TITLE
refactor(AIServiceOptions.cs): remove [NotEmptyOrWhitespace] attribute from Endpoint property validation because it throws error when using OpenAI

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Config/AIServiceOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/AIServiceOptions.cs
@@ -40,7 +40,6 @@ public sealed class AIServiceOptions
     /// (Azure OpenAI only) Azure OpenAI endpoint.
     /// </summary>
     [RequiredOnPropertyValue(nameof(AIService), AIServiceType.AzureOpenAI)]
-    [NotEmptyOrWhitespace]
     public string Endpoint { get; set; } = string.Empty;
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? Throws error when running app using OpenAI
  2. What problem does it solve? The app can run without inputing a value for endpoint
  3. What scenario does it contribute to? Chat App API
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
In the appsettings.json the comments say the Endpoint property will be ignored if using OpenAI but it's not. Removing the attribute fixes that

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
