### PR TITLE
Rename TextChunker from SemanticTextPartitioner

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -2,12 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.SemanticKernel.SemanticFunctions.Partitioning;
+using Microsoft.SemanticKernel.Text;
 using Xunit;
 
-namespace SemanticKernel.UnitTests.SemanticFunctions.Partitioning;
+namespace SemanticKernel.UnitTests.Text;
 
-public sealed class SemanticTextPartitionerTests
+public sealed class TextChunkerTests
 {
     [Fact]
     public void CanSplitPlainTextLines()
@@ -19,7 +19,7 @@ public sealed class SemanticTextPartitionerTests
             "This is only a test."
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextLines(input, 15);
+        var result = TextChunker.SplitPlainTextLines(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -39,7 +39,7 @@ public sealed class SemanticTextPartitionerTests
             "We repeat, this is only a test. A unit test."
         };
 
-        var result = SemanticTextPartitioner.SplitMarkdownParagraphs(input, 13);
+        var result = TextChunker.SplitMarkdownParagraphs(input, 13);
 
         Assert.Equal(expected, result);
     }
@@ -60,7 +60,7 @@ public sealed class SemanticTextPartitionerTests
             "We repeat, this is only a test. A unit test."
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 13);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 13);
 
         Assert.Equal(expected, result);
     }
@@ -75,7 +75,7 @@ public sealed class SemanticTextPartitionerTests
             "This is only a test."
         };
 
-        var result = SemanticTextPartitioner.SplitMarkDownLines(input, 15);
+        var result = TextChunker.SplitMarkDownLines(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -87,7 +87,7 @@ public sealed class SemanticTextPartitionerTests
 
         var expected = new List<string>();
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 13);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 13);
 
         Assert.Equal(expected, result);
     }
@@ -99,7 +99,7 @@ public sealed class SemanticTextPartitionerTests
 
         var expected = new List<string>();
 
-        var result = SemanticTextPartitioner.SplitMarkdownParagraphs(input, 13);
+        var result = TextChunker.SplitMarkdownParagraphs(input, 13);
 
         Assert.Equal(expected, result);
     }
@@ -124,7 +124,7 @@ public sealed class SemanticTextPartitionerTests
             "Seriously, this is the end. We're finished. All set. Bye. Done."
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -150,7 +150,7 @@ public sealed class SemanticTextPartitionerTests
             "Seriously this is the end\nWe're finished\nAll set\nBye Done",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -177,7 +177,7 @@ public sealed class SemanticTextPartitionerTests
             $"We're finished. All set. Bye.{Environment.NewLine}Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -203,7 +203,7 @@ public sealed class SemanticTextPartitionerTests
             "Seriously, this is the end; We're finished; All set; Bye. Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -229,7 +229,7 @@ public sealed class SemanticTextPartitionerTests
             "Seriously, this is the end: We're finished: All set: Bye. Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -255,7 +255,7 @@ public sealed class SemanticTextPartitionerTests
             $"this is the end, We're finished, All set, Bye.{Environment.NewLine}Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -281,7 +281,7 @@ public sealed class SemanticTextPartitionerTests
             "Seriously this is the end} We're finished} All set} Bye. Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -307,7 +307,7 @@ public sealed class SemanticTextPartitionerTests
             $"this is the end We're finished All set Bye.{Environment.NewLine}Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -333,7 +333,7 @@ public sealed class SemanticTextPartitionerTests
             $"this is the end-We're finished-All set-Bye.{Environment.NewLine}Done.",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -360,7 +360,7 @@ public sealed class SemanticTextPartitionerTests
             "tByeDoneThisOneWillBeSplitToMeetTheLimit",
         };
 
-        var result = SemanticTextPartitioner.SplitPlainTextParagraphs(input, 15);
+        var result = TextChunker.SplitPlainTextParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }
@@ -402,7 +402,7 @@ public sealed class SemanticTextPartitionerTests
             "Seriously_this_is_the_end\nWe're_finished\nAll_set\nBye Done",
         };
 
-        var result = SemanticTextPartitioner.SplitMarkdownParagraphs(input, 15);
+        var result = TextChunker.SplitMarkdownParagraphs(input, 15);
 
         Assert.Equal(expected, result);
     }

--- a/dotnet/src/SemanticKernel/CoreSkills/ConversationSummarySkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/ConversationSummarySkill.cs
@@ -3,8 +3,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SemanticFunctions.Partitioning;
 using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.Text;
 
 namespace Microsoft.SemanticKernel.CoreSkills;
 
@@ -69,8 +69,8 @@ public class ConversationSummarySkill
     [SKFunctionInput(Description = "A long conversation transcript.")]
     public Task<SKContext> SummarizeConversationAsync(string input, SKContext context)
     {
-        List<string> lines = SemanticTextPartitioner.SplitPlainTextLines(input, MaxTokens);
-        List<string> paragraphs = SemanticTextPartitioner.SplitPlainTextParagraphs(lines, MaxTokens);
+        List<string> lines = TextChunker.SplitPlainTextLines(input, MaxTokens);
+        List<string> paragraphs = TextChunker.SplitPlainTextParagraphs(lines, MaxTokens);
 
         return this._summarizeConversationFunction
             .AggregatePartitionedResultsAsync(paragraphs, context);
@@ -86,8 +86,8 @@ public class ConversationSummarySkill
     [SKFunctionInput(Description = "A long conversation transcript.")]
     public Task<SKContext> GetConversationActionItemsAsync(string input, SKContext context)
     {
-        List<string> lines = SemanticTextPartitioner.SplitPlainTextLines(input, MaxTokens);
-        List<string> paragraphs = SemanticTextPartitioner.SplitPlainTextParagraphs(lines, MaxTokens);
+        List<string> lines = TextChunker.SplitPlainTextLines(input, MaxTokens);
+        List<string> paragraphs = TextChunker.SplitPlainTextParagraphs(lines, MaxTokens);
 
         return this._conversationActionItemsFunction
             .AggregatePartitionedResultsAsync(paragraphs, context);
@@ -103,8 +103,8 @@ public class ConversationSummarySkill
     [SKFunctionInput(Description = "A long conversation transcript.")]
     public Task<SKContext> GetConversationTopicsAsync(string input, SKContext context)
     {
-        List<string> lines = SemanticTextPartitioner.SplitPlainTextLines(input, MaxTokens);
-        List<string> paragraphs = SemanticTextPartitioner.SplitPlainTextParagraphs(lines, MaxTokens);
+        List<string> lines = TextChunker.SplitPlainTextLines(input, MaxTokens);
+        List<string> paragraphs = TextChunker.SplitPlainTextParagraphs(lines, MaxTokens);
 
         return this._conversationTopicsFunction
             .AggregatePartitionedResultsAsync(paragraphs, context);

--- a/dotnet/src/SemanticKernel/Text/FunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel/Text/FunctionExtensions.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
 
-namespace Microsoft.SemanticKernel.SemanticFunctions.Partitioning;
+namespace Microsoft.SemanticKernel.Text;
 
 /// <summary>
 /// Class with extension methods for semantic functions.

--- a/dotnet/src/SemanticKernel/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel/Text/TextChunker.cs
@@ -4,16 +4,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
-using Microsoft.SemanticKernel.Text;
 
-namespace Microsoft.SemanticKernel.SemanticFunctions.Partitioning;
+namespace Microsoft.SemanticKernel.Text;
 
 /// <summary>
 /// Split text in chunks, attempting to leave meaning intact.
 /// For plain text, split looking at new lines first, then periods, and so on.
 /// For markdown, split looking at punctuation first, and so on.
 /// </summary>
-public static class SemanticTextPartitioner
+public static class TextChunker
 {
     private static readonly char[] s_spaceChar = new[] { ' ' };
     private static readonly string?[] s_plaintextSplitOptions = new[] { "\n\r", ".", "?!", ";", ":", ",", ")]}", " ", "-", null };
@@ -51,8 +50,10 @@ public static class SemanticTextPartitioner
     /// <param name="lines">Lines of text.</param>
     /// <param name="maxTokensPerParagraph">Maximum number of tokens per paragraph.</param>
     /// <returns>List of paragraphs.</returns>
-    public static List<string> SplitPlainTextParagraphs(List<string> lines, int maxTokensPerParagraph) =>
-        InternalSplitTextParagraphs(lines, maxTokensPerParagraph, (text, result) => InternalSplitLines(text, maxTokensPerParagraph, trim: false, s_plaintextSplitOptions, result));
+    public static List<string> SplitPlainTextParagraphs(List<string> lines, int maxTokensPerParagraph)
+    {
+        return InternalSplitTextParagraphs(lines, maxTokensPerParagraph, (text, result) => InternalSplitLines(text, maxTokensPerParagraph, trim: false, s_plaintextSplitOptions, result));
+    }
 
     /// <summary>
     /// Split markdown text into paragraphs.
@@ -60,8 +61,10 @@ public static class SemanticTextPartitioner
     /// <param name="lines">Lines of text.</param>
     /// <param name="maxTokensPerParagraph">Maximum number of tokens per paragraph.</param>
     /// <returns>List of paragraphs.</returns>
-    public static List<string> SplitMarkdownParagraphs(List<string> lines, int maxTokensPerParagraph) =>
-        InternalSplitTextParagraphs(lines, maxTokensPerParagraph, (text, result) => InternalSplitLines(text, maxTokensPerParagraph, trim: false, s_markdownSplitOptions, result));
+    public static List<string> SplitMarkdownParagraphs(List<string> lines, int maxTokensPerParagraph)
+    {
+        return InternalSplitTextParagraphs(lines, maxTokensPerParagraph, (text, result) => InternalSplitLines(text, maxTokensPerParagraph, trim: false, s_markdownSplitOptions, result));
+    }
 
     private static List<string> InternalSplitTextParagraphs(List<string> lines, int maxTokensPerParagraph, Action<string, List<string>> longLinesSplitter)
     {

--- a/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.SemanticFunctions.Partitioning;
+using Microsoft.SemanticKernel.Text;
 using SemanticKernel.Service.Config;
 using SemanticKernel.Service.Model;
 using SemanticKernel.Service.Skills;
@@ -146,8 +146,8 @@ public class DocumentImportController : ControllerBase
 
         // Split the document into lines of text and then combine them into paragraphs.
         // NOTE that this is only one of the strategies to chunk documents. Feel free to experiment with other strategies.
-        var lines = SemanticTextPartitioner.SplitPlainTextLines(content, this._options.DocumentLineSplitMaxTokens);
-        var paragraphs = SemanticTextPartitioner.SplitPlainTextParagraphs(lines, this._options.DocumentParagraphSplitMaxLines);
+        var lines = TextChunker.SplitPlainTextLines(content, this._options.DocumentLineSplitMaxTokens);
+        var paragraphs = TextChunker.SplitPlainTextParagraphs(lines, this._options.DocumentParagraphSplitMaxLines);
 
         foreach (var paragraph in paragraphs)
         {

--- a/samples/apps/github-qna-webapp-react/README.md
+++ b/samples/apps/github-qna-webapp-react/README.md
@@ -25,7 +25,7 @@ The GitHub Repo Q&A Bot sample allows you to pull in data from a public GitHub
 repo into a local memory store in order to ask questions about the project and
 to get answers about it. The sample highlights how [memory](https://aka.ms/sk/memories)
 and [embeddings](https://aka.ms/sk/embeddings) work along with the
-[SemanticTextPartitioner](../../../dotnet/src/SemanticKernel/SemanticFunctions/Partitioning/SemanticTextPartitioner.cs)
+[TextChunker](../../../dotnet/src/SemanticKernel/Text/TextChunker.cs)
 when the size of the data is larger than the allowed token limited.
 Each SK function will call Open AI to perform the tasks you ask about.
 

--- a/samples/dotnet/github-skills/GitHubSkill.cs
+++ b/samples/dotnet/github-skills/GitHubSkill.cs
@@ -10,9 +10,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SemanticFunctions.Partitioning;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.Skills.Web;
+using Microsoft.SemanticKernel.Text;
 
 namespace GitHubSkills;
 
@@ -177,15 +177,15 @@ BEGIN SUMMARY:
                 {
                     case ".md":
                     {
-                        lines = SemanticTextPartitioner.SplitMarkDownLines(code, MaxTokens);
-                        paragraphs = SemanticTextPartitioner.SplitMarkdownParagraphs(lines, MaxTokens);
+                        lines = TextChunker.SplitMarkDownLines(code, MaxTokens);
+                        paragraphs = TextChunker.SplitMarkdownParagraphs(lines, MaxTokens);
 
                         break;
                     }
                     default:
                     {
-                        lines = SemanticTextPartitioner.SplitPlainTextLines(code, MaxTokens);
-                        paragraphs = SemanticTextPartitioner.SplitPlainTextParagraphs(lines, MaxTokens);
+                        lines = TextChunker.SplitPlainTextLines(code, MaxTokens);
+                        paragraphs = TextChunker.SplitPlainTextParagraphs(lines, MaxTokens);
 
                         break;
                     }


### PR DESCRIPTION
### Motivation and Context
To match changes in #450 

### Description
This pull request renames the SemanticTextPartitioner class to TextChunker, and updates all references to this class in the code and documentation. The TextChunker class is responsible for splitting text into smaller chunks based on tokens and paragraphs, which is useful for processing large texts or code files. The new name TextChunker reflects the functionality of the class more clearly and avoids confusion with the SemanticPartitioner class, which is a different concept that splits text into semantic segments based on embeddings.

Details:
- Rename SemanticTextPartitioner.cs to TextChunker.cs and update the class name and namespace accordingly. The TextChunker class is now in the Text namespace, which is more consistent with its purpose and the other classes in the namespace.
- Update all references to SemanticTextPartitioner in the code and documentation to use TextChunker instead. This includes the ConversationSummarySkill and the DocumentImportController classes, which use the TextChunker class to split text into sentences and paragraphs for summarization and import.
- Update the README.md file for the GitHub Repo Q&A Bot sample to explain how the TextChunker class works with memory and embeddings.
- Make some minor formatting changes to the TextChunker class, such as adding line breaks and spaces for readability, and removing an unused using directive.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
