### PR TITLE
[Fix] Modify Plan class to update context variables with input

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -47,6 +47,42 @@ public sealed class PlanTests
         Assert.Equal("Some input", result.Result);
     }
 
+
+    [Fact]
+    public async Task CanExecutePlanWithContextAsync()
+    {
+        // Arrange
+        var goal = "Write a poem or joke and send it in an e-mail to Kai.";
+        var plan = new Plan(goal);
+        var kernel = new Mock<IKernel>();
+        var log = new Mock<ILogger>();
+        var memory = new Mock<ISemanticTextMemory>();
+        var skills = new Mock<ISkillCollection>();
+
+        var context = new SKContext(
+            new ContextVariables("Some input"),
+            memory.Object,
+            skills.Object,
+            log.Object
+        );
+
+        // Act
+        var result = await plan.InvokeAsync(context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Some input", result.Result);
+
+        plan = new Plan(goal);
+
+        // Act
+        result = await plan.InvokeAsync("other input", context);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("other input", result.Result);
+    }
+
     [Fact]
     public async Task CanExecutePlanWithPlanStepAsync()
     {

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -288,7 +288,10 @@ public sealed class Plan : ISKFunction
     public Task<SKContext> InvokeAsync(string input, SKContext? context = null, CompleteRequestSettings? settings = null, ILogger? log = null,
         CancellationToken? cancel = null)
     {
-        context ??= new SKContext(new ContextVariables(input), null!, null, log ?? NullLogger.Instance, cancel ?? CancellationToken.None);
+        context ??= new SKContext(new ContextVariables(), null!, null, log ?? NullLogger.Instance, cancel ?? CancellationToken.None);
+
+        context.Variables.Update(input);
+
         return this.InvokeAsync(context, settings, log, cancel);
     }
 


### PR DESCRIPTION
### Motivation and Context
Fix issue with invoking plan with both string input and existing context.

### Description
This pull request refactors the Plan class to update the context variables with the input string when invoking a plan. This change allows the plan to use the input as part of the context for executing the plan steps. The pull request also adds a unit test to verify that the plan can execute with a given context and input.

Details:
- In Plan.cs, change the InvokeAsync method to create a new SKContext with empty variables if the context parameter is null, and then update the context variables with the input string.
- In PlanTests.cs, add a new test method called CanExecutePlanWithContextAsync that creates a mock context with some variables, memory, skills, and log, and then invokes a plan with the context and an input string. The test asserts that the plan returns the input string as the result, and that the context variables are updated with the input. The test also invokes the plan again with a different input string and the same context, and asserts that the result and the context variables are updated accordingly.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
