### PR TITLE
Make MinHeap internal

### DIFF
--- a/dotnet/src/SemanticKernel/Memory/Collections/MinHeap.cs
+++ b/dotnet/src/SemanticKernel/Memory/Collections/MinHeap.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Memory.Collections;
 /// Implements the classic 'heap' data structure. By default, the item with the lowest value is at the top of the heap.
 /// </summary>
 /// <typeparam name="T">Data type.</typeparam>
-public class MinHeap<T> : IEnumerable<T> where T : IComparable<T>
+internal sealed class MinHeap<T> : IEnumerable<T> where T : IComparable<T>
 {
     private const int DefaultCapacity = 7;
     private const int MinCapacity = 0;
@@ -219,7 +219,7 @@ public class MinHeap<T> : IEnumerable<T> where T : IComparable<T>
         items[i] = item;
     }
 
-    public virtual IEnumerator<T> GetEnumerator()
+    public IEnumerator<T> GetEnumerator()
     {
         // The 0'th item in the queue is a sentinel. i is 1 based.
         for (int i = 1; i <= this._count; ++i)


### PR DESCRIPTION
### Motivation and Context

Fixes https://github.com/microsoft/semantic-kernel/issues/615.  Avoid exposing unnecessary public surface area.

### Description

.NET has a production-grade `PriorityQueue<>`, it's just not available for netstandard2.0.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
