### PR TITLE
Introducing trust checks in the kernel

### DIFF
--- a/dotnet/SK-dotnet.sln.DotSettings
+++ b/dotnet/SK-dotnet.sln.DotSettings
@@ -130,6 +130,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="s_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Property/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="Async" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb_AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CustomTools/CustomToolsData/@EntryValue"></s:String>
 	<s:Int64 x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MsBuildSolutionLoadingNodeCount/@EntryValue">2</s:Int64>
 	<s:Boolean x:Key="/Default/Environment/Hierarchy/Build/SolutionBuilderNext/LogToFile/@EntryValue">False</s:Boolean>

--- a/dotnet/SK-dotnet.sln.DotSettings
+++ b/dotnet/SK-dotnet.sln.DotSettings
@@ -216,6 +216,7 @@ public void It$SOMENAME$()
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xunit_002EXunitTestWithConsoleOutput/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=testsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tldr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Untrust/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=upserted/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upserts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=wellknown/@EntryIndexedValue">True</s:Boolean>

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -8,6 +8,7 @@ using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Planning.Sequential;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Moq;
@@ -85,7 +86,8 @@ public class SequentialPlanParserTests
                 kernelMock.Setup(x => x.RegisterSemanticFunction(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.IsAny<SemanticFunctionConfig>()
+                    It.IsAny<SemanticFunctionConfig>(),
+                    It.IsAny<ITrustService?>()
                 )).Returns(mockFunction.Object);
             }
             else

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Moq;
@@ -103,7 +104,8 @@ public sealed class SequentialPlannerTests
         kernel.Setup(x => x.RegisterSemanticFunction(
             It.IsAny<string>(),
             It.IsAny<string>(),
-            It.IsAny<SemanticFunctionConfig>()
+            It.IsAny<SemanticFunctionConfig>(),
+            It.IsAny<ITrustService?>()
         )).Returns(mockFunctionFlowFunction.Object);
 
         var planner = new Microsoft.SemanticKernel.Planning.SequentialPlanner(kernel.Object);
@@ -190,7 +192,8 @@ public sealed class SequentialPlannerTests
         kernel.Setup(x => x.RegisterSemanticFunction(
             It.IsAny<string>(),
             It.IsAny<string>(),
-            It.IsAny<SemanticFunctionConfig>()
+            It.IsAny<SemanticFunctionConfig>(),
+            It.IsAny<ITrustService?>()
         )).Returns(mockFunctionFlowFunction.Object);
 
         var planner = new Microsoft.SemanticKernel.Planning.SequentialPlanner(kernel.Object);

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
@@ -130,7 +130,7 @@ public static class SKContextSequentialPlannerExtensions
     internal static async Task RememberFunctionsAsync(SKContext context, List<FunctionView> availableFunctions)
     {
         // Check if the functions have already been saved to memory.
-        if (context.Variables.Get(PlanSKFunctionsAreRemembered, out var _))
+        if (context.Variables.Get(PlanSKFunctionsAreRemembered, out string _))
         {
             return;
         }

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -41,10 +41,10 @@
 
   <ItemGroup>
     <None Update="testsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="testsettings.development.json" Condition="Exists('testsettings.development.json')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Content Include="TemplateLanguage\tests.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/dotnet/src/IntegrationTests/Security/TrustServiceTests.cs
+++ b/dotnet/src/IntegrationTests/Security/TrustServiceTests.cs
@@ -1,0 +1,429 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
+using Microsoft.SemanticKernel.SkillDefinition;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Security;
+
+public sealed class TrustServiceTests
+{
+    public TrustServiceTests(ITestOutputHelper output)
+    {
+        this._configuration = new ConfigurationBuilder()
+            .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+            .AddEnvironmentVariables()
+            .AddUserSecrets<TrustServiceTests>()
+            .Build();
+    }
+
+    [Fact]
+    public async void FlowWithUntrustedContentAndNotSensitiveSemanticFunctionShouldSucceed()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI :)";
+        var kernel = this.InitializeKernel();
+
+        var defaultUntrustedEchoFunction = this.CreateSemanticEchoFunction(
+            kernel,
+            functionName: "DefaultUntrustedEchoFunction",
+            isSensitive: false,
+            trustService: TrustService.DefaultUntrusted
+        );
+        var defaultTrustedEchoFunction = this.CreateSemanticEchoFunction(
+            kernel,
+            functionName: "DefaultTrustedEchoFunction",
+            isSensitive: false,
+            trustService: TrustService.DefaultTrusted
+        );
+
+        // Act
+        var result = await kernel.RunAsync(valueToEcho, defaultUntrustedEchoFunction, defaultTrustedEchoFunction);
+
+        // Assert
+        Assert.Equal(valueToEcho, result.Result);
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async void FlowWithUntrustedContentAndSensitiveSemanticFunctionShouldThrow()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI :)";
+
+        var kernel = this.InitializeKernel();
+
+        var notSensitiveEchoFunction = this.CreateSemanticEchoFunction(
+            kernel,
+            functionName: "NotSensitiveEchoFunction",
+            isSensitive: false,
+            trustService: TrustService.DefaultUntrusted
+        );
+        var sensitiveEchoFunction = this.CreateSemanticEchoFunction(
+            kernel,
+            functionName: "SensitiveEchoFunction",
+            isSensitive: true,
+            trustService: TrustService.DefaultTrusted
+        );
+
+        // Act
+        var result = await kernel.RunAsync(valueToEcho, notSensitiveEchoFunction, sensitiveEchoFunction);
+
+        // Assert
+        this.AssertResultHasThrown(result);
+    }
+
+    [Fact]
+    public async void FlowWithUntrustedContentAndNotSensitiveNativeFunctionShouldSucceed()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI :)";
+        var kernel = this.InitializeKernel();
+
+        var defaultUntrustedEchoFunction = this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: false,
+            trustService: TrustService.DefaultUntrusted
+        );
+        var defaultTrustedEchoFunction = this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: false,
+            trustService: TrustService.DefaultTrusted
+        );
+
+        // Act
+        var result = await kernel.RunAsync(valueToEcho, defaultUntrustedEchoFunction, defaultTrustedEchoFunction);
+
+        // Assert
+        Assert.Equal(valueToEcho, result.Result);
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async void FlowWithUntrustedContentAndSensitiveNativeFunctionShouldThrow()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI :)";
+        var kernel = this.InitializeKernel();
+
+        var notSensitiveEchoFunction = this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: false,
+            trustService: TrustService.DefaultUntrusted
+        );
+        var sensitiveEchoFunction = this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: true,
+            trustService: TrustService.DefaultTrusted
+        );
+
+        // Act
+        var result = await kernel.RunAsync(valueToEcho, notSensitiveEchoFunction, sensitiveEchoFunction);
+
+        // Assert
+        this.AssertResultHasThrown(result);
+    }
+
+    [Fact]
+    public async void UntrustedVariableAndNotSensitiveSemanticFunctionShouldSucceed()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI, ";
+        var extraVar = "welcome!";
+        var variables = new ContextVariables(valueToEcho);
+        var kernel = this.InitializeKernel();
+
+        var notSensitiveEchoFunction = this.CreateSemanticEchoFunction(
+            kernel,
+            functionName: "NotSensitiveEchoFunction",
+            isSensitive: false,
+            trustService: null // Use defaults
+        );
+
+        // Make this untrusted
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+
+        // Act
+        var result = await kernel.RunAsync(variables, notSensitiveEchoFunction);
+
+        // Assert
+        Assert.Equal(valueToEcho + extraVar, result.Result);
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async void UntrustedVariableAndSensitiveSemanticFunctionShouldThrow()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI, ";
+        var extraVar = "welcome!";
+        var variables = new ContextVariables(valueToEcho);
+        var kernel = this.InitializeKernel();
+
+        var sensitiveEchoFunction = this.CreateSemanticEchoFunction(
+            kernel,
+            functionName: "SensitiveEchoFunction",
+            isSensitive: true,
+            trustService: null // Use defaults
+        );
+
+        // Make this untrusted
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+
+        // Act
+        var result = await kernel.RunAsync(variables, sensitiveEchoFunction);
+
+        // Assert
+        this.AssertResultHasThrown(result);
+    }
+
+    [Fact]
+    public async void UntrustedVariableAndNotSensitiveNativeFunctionShouldSucceed()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI, ";
+        var extraVar = "welcome!";
+        var variables = new ContextVariables(valueToEcho);
+        var kernel = this.InitializeKernel();
+
+        var notSensitiveEchoFunction = this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: false,
+            trustService: null // Use defaults
+        );
+
+        // Make this untrusted
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+
+        // Act
+        var result = await kernel.RunAsync(variables, notSensitiveEchoFunction);
+
+        // Assert
+        Assert.Equal(valueToEcho + extraVar, result.Result);
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async void UntrustedVariableAndSensitiveNativeFunctionShouldThrow()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI, ";
+        var extraVar = "welcome!";
+        var variables = new ContextVariables(valueToEcho);
+        var kernel = this.InitializeKernel();
+
+        var sensitiveEchoFunction = this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: true,
+            trustService: null // Use defaults
+        );
+
+        // Make this untrusted
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+
+        // Act
+        var result = await kernel.RunAsync(variables, sensitiveEchoFunction);
+
+        // Assert
+        this.AssertResultHasThrown(result);
+    }
+
+    [Fact]
+    public async void NotSensitiveFunctionWithTrustedFunctionCallShouldSucceed()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI :)";
+        var kernel = this.InitializeKernel();
+
+        this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: true,
+            trustService: TrustService.DefaultTrusted
+        );
+
+        var sensitiveEchoWithFunctionCallFunction = this.CreateSemanticEchoWithFunctionCallFunction(
+            kernel,
+            functionName: "SensitiveEchoWithFunctionCallFunction",
+            isSensitive: true,
+            trustService: null // Use defaults
+        );
+
+        // Act
+        var result = await kernel.RunAsync(valueToEcho, sensitiveEchoWithFunctionCallFunction);
+
+        // Assert
+        Assert.Equal(valueToEcho, result.Result);
+        Assert.True(result.IsTrusted);
+    }
+
+    [Fact]
+    public async void SensitiveFunctionWithUntrustedFunctionCallShouldThrow()
+    {
+        // Arrange
+        var valueToEcho = "Hello AI :)";
+        var kernel = this.InitializeKernel();
+
+        this.CreateNativeEchoFunction(
+            kernel,
+            isSensitive: true,
+            trustService: TrustService.DefaultUntrusted // Forces output to be untrusted
+        );
+
+        var sensitiveEchoWithFunctionCallFunction = this.CreateSemanticEchoWithFunctionCallFunction(
+            kernel,
+            functionName: "SensitiveEchoWithFunctionCallFunction",
+            isSensitive: true,
+            trustService: null // Use defaults
+        );
+
+        // Act
+        var result = await kernel.RunAsync(valueToEcho, sensitiveEchoWithFunctionCallFunction);
+
+        // Assert
+        this.AssertResultHasThrown(result);
+    }
+
+    private IKernel InitializeKernel()
+    {
+        AzureOpenAIConfiguration? azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
+        Assert.NotNull(azureOpenAIConfiguration);
+
+        var builder = Kernel.Builder
+            .WithAzureTextCompletionService(
+                deploymentName: azureOpenAIConfiguration.DeploymentName,
+                endpoint: azureOpenAIConfiguration.Endpoint,
+                apiKey: azureOpenAIConfiguration.ApiKey,
+                serviceId: azureOpenAIConfiguration.ServiceId,
+                setAsDefault: true
+            );
+
+        return builder.Build();
+    }
+
+    private ISKFunction CreateSemanticEchoFunction(
+        IKernel kernel,
+        string functionName,
+        bool isSensitive,
+        ITrustService? trustService)
+    {
+        string promptTemplate = TrustServiceTests.SemanticEchoPrompt.Replace(
+            TrustServiceTests.WhatToEcho,
+            $"{{{{$input}}}}{{{{${TrustServiceTests.ExtraVarName}}}}}",
+            System.StringComparison.Ordinal
+        );
+
+        return kernel.CreateSemanticFunction(
+            promptTemplate: promptTemplate,
+            functionName: functionName,
+            skillName: "CustomSkill",
+            isSensitive: isSensitive,
+            trustService: trustService
+        );
+    }
+
+    private ISKFunction CreateSemanticEchoWithFunctionCallFunction(
+        IKernel kernel,
+        string functionName,
+        bool isSensitive,
+        ITrustService? trustService)
+    {
+        string promptTemplate = TrustServiceTests.SemanticEchoPrompt.Replace(
+            TrustServiceTests.WhatToEcho,
+            $"{{{{{nameof(EchoSkill)}.{nameof(EchoSkill.NotSensitiveEcho)} $input}}}}",
+            System.StringComparison.Ordinal
+        );
+
+        return kernel.CreateSemanticFunction(
+            promptTemplate: promptTemplate,
+            functionName: functionName,
+            skillName: "CustomSkill",
+            isSensitive: isSensitive,
+            trustService: trustService
+        );
+    }
+
+    private ISKFunction CreateNativeEchoFunction(
+        IKernel kernel,
+        bool isSensitive,
+        ITrustService? trustService)
+    {
+        var skill = kernel.ImportSkill(
+            new EchoSkill(),
+            nameof(EchoSkill),
+            trustService: trustService
+        );
+
+        return isSensitive ?
+            skill[nameof(EchoSkill.SensitiveEcho)] :
+            skill[nameof(EchoSkill.NotSensitiveEcho)];
+    }
+
+    private void AssertResultHasThrown(SKContext result)
+    {
+        Assert.True(result.ErrorOccurred);
+        Assert.IsType<UntrustedContentException>(result.LastException);
+        Assert.Equal(
+            UntrustedContentException.ErrorCodes.SensitiveFunctionWithUntrustedContent,
+            ((UntrustedContentException)result.LastException).ErrorCode
+        );
+    }
+
+    private readonly IConfigurationRoot _configuration;
+
+    private sealed class EchoSkill
+    {
+        [SKFunction("Echoes a given text", isSensitive: false)]
+        public string NotSensitiveEcho(SKContext context)
+        {
+            context.Variables.Get("extraVar", out string extraVar);
+
+            return context.Variables.Input + extraVar;
+        }
+
+        [SKFunction("Echoes a given text", isSensitive: true)]
+        public string SensitiveEcho(SKContext context)
+        {
+            context.Variables.Get("extraVar", out string extraVar);
+
+            return context.Variables.Input + extraVar;
+        }
+    }
+
+    private const string WhatToEcho = "[WHAT_TO_ECHO]";
+
+    private const string ExtraVarName = "extraVar";
+
+    private const string SemanticEchoPrompt = @$"Your goal is just to echo whatever input is given to you.
+
+[EXAMPLES]
+INPUT
+-------------------
+Hello, how are you?
+
+RESULT
+-------------------
+Hello, how are you?
+
+INPUT
+-------------------
+Hi!
+            
+RESULT
+-------------------
+Hi!
+[END EXAMPLES]
+
+INPUT
+-------------------
+{TrustServiceTests.WhatToEcho}
+
+RESULT
+-------------------
+";
+}

--- a/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.Services;
 using Microsoft.SemanticKernel.SkillDefinition;
@@ -44,14 +45,23 @@ public interface IKernel
     IReadOnlySkillCollection Skills { get; }
 
     /// <summary>
+    /// Default service for trust check events in case a specific one is not provided at function creation.
+    /// Functions directly created through the kernel will use this trust service if no other is provided.
+    /// If null, the created functions will rely on the TrustService.DefaultTrusted implementation.
+    /// </summary>
+    ITrustService? TrustServiceInstance { get; }
+
+    /// <summary>
     /// Build and register a function in the internal skill collection, in a global generic skill.
     /// </summary>
     /// <param name="functionName">Name of the semantic function. The name can contain only alphanumeric chars + underscore.</param>
     /// <param name="functionConfig">Function configuration, e.g. I/O params, AI settings, localization details, etc.</param>
+    /// <param name="trustService">Service used for trust checks (if null will use the default registered in the kernel).</param>
     /// <returns>A C# function wrapping AI logic, usually defined with natural language</returns>
     ISKFunction RegisterSemanticFunction(
         string functionName,
-        SemanticFunctionConfig functionConfig);
+        SemanticFunctionConfig functionConfig,
+        ITrustService? trustService = null);
 
     /// <summary>
     /// Build and register a function in the internal skill collection.
@@ -59,11 +69,13 @@ public interface IKernel
     /// <param name="skillName">Name of the skill containing the function. The name can contain only alphanumeric chars + underscore.</param>
     /// <param name="functionName">Name of the semantic function. The name can contain only alphanumeric chars + underscore.</param>
     /// <param name="functionConfig">Function configuration, e.g. I/O params, AI settings, localization details, etc.</param>
+    /// <param name="trustService">Service used for trust checks (if null will use the default registered in the kernel).</param>
     /// <returns>A C# function wrapping AI logic, usually defined with natural language</returns>
     ISKFunction RegisterSemanticFunction(
         string skillName,
         string functionName,
-        SemanticFunctionConfig functionConfig);
+        SemanticFunctionConfig functionConfig,
+        ITrustService? trustService = null);
 
     /// <summary>
     /// Registers a custom function in the internal skill collection.
@@ -79,8 +91,9 @@ public interface IKernel
     /// </summary>
     /// <param name="skillInstance">Instance of a class containing functions</param>
     /// <param name="skillName">Name of the skill for skill collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
+    /// <param name="trustService">Service used for trust checks (if null will use the default registered in the kernel).</param>
     /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
-    IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName = "");
+    IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName = "", ITrustService? trustService = null);
 
     /// <summary>
     /// Set the semantic memory to use

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -60,9 +60,21 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// <param name="content">The new input value, for the next function in the pipeline, or as a result for the user
     /// if the pipeline reached the end.</param>
     /// <returns>The current instance</returns>
-    public ContextVariables Update(string content)
+    public ContextVariables Update(string? content)
     {
         return this.Update(TrustAwareString.Trusted(content));
+    }
+
+    /// <summary>
+    /// Updates the main input text with the new value after a function is complete.
+    /// This will keep the trust state of the current input set.
+    /// </summary>
+    /// <param name="content">The new input value, for the next function in the pipeline, or as a result for the user
+    /// if the pipeline reached the end.</param>
+    /// <returns>The current instance</returns>
+    public ContextVariables UpdateKeepingTrustState(string? content)
+    {
+        return this.Update(new TrustAwareString(content, this.Input.IsTrusted));
     }
 
     /// <summary>
@@ -206,6 +218,14 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
             // Note: we don't use an internal setter for better multi-threading
             this._variables[item.Key] = TrustAwareString.Untrusted(item.Value.Value);
         }
+    }
+
+    /// <summary>
+    /// Make the input variable untrusted.
+    /// </summary>
+    public void UntrustInput()
+    {
+        this.Update(TrustAwareString.Untrusted(this.Input.Value));
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -5,7 +5,9 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Security;
 
 namespace Microsoft.SemanticKernel.Orchestration;
 
@@ -15,32 +17,52 @@ namespace Microsoft.SemanticKernel.Orchestration;
 /// </summary>
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 [DebuggerTypeProxy(typeof(ContextVariables.TypeProxy))]
-public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
+public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwareString>>
 {
     /// <summary>
     /// In the simplest scenario, the data is an input string, stored here.
     /// </summary>
-    public string Input => this._variables[MainKey];
+    public TrustAwareString Input => this._variables[MainKey];
 
     /// <summary>
     /// Constructor for context variables.
     /// </summary>
-    /// <param name="content">Optional value for the main variable of the context.</param>
-    public ContextVariables(string? content = null)
+    /// <param name="trustAwareContent">Optional value for the main variable of the context including trust information.</param>
+    public ContextVariables(TrustAwareString? trustAwareContent = null)
     {
-        this._variables[MainKey] = content ?? string.Empty;
+        this._variables[MainKey] = trustAwareContent ?? TrustAwareString.Empty;
+    }
+
+    /// <summary>
+    /// Constructor for context variables.
+    /// By default the content will be trusted.
+    /// </summary>
+    /// <param name="content">Optional value for the main variable of the context.</param>
+    public ContextVariables(string? content) : this(TrustAwareString.Trusted(content)) { }
+
+    /// <summary>
+    /// Updates the main input text with the new value after a function is complete.
+    /// The string includes trust information and will overwrite the trust state of the input.
+    /// </summary>
+    /// <param name="trustAwareContent">The new input value, for the next function in the pipeline, or as a result for the user
+    /// if the pipeline reached the end.</param>
+    /// <returns>The current instance</returns>
+    public ContextVariables Update(TrustAwareString? trustAwareContent)
+    {
+        this._variables[MainKey] = trustAwareContent ?? TrustAwareString.Empty;
+        return this;
     }
 
     /// <summary>
     /// Updates the main input text with the new value after a function is complete.
+    /// By default the content will be trusted.
     /// </summary>
     /// <param name="content">The new input value, for the next function in the pipeline, or as a result for the user
     /// if the pipeline reached the end.</param>
     /// <returns>The current instance</returns>
-    public ContextVariables Update(string? content)
+    public ContextVariables Update(string content)
     {
-        this._variables[MainKey] = content ?? string.Empty;
-        return this;
+        return this.Update(TrustAwareString.Trusted(content));
     }
 
     /// <summary>
@@ -57,7 +79,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
             // If requested, discard old data and keep only the new one.
             if (!merge) { this._variables.Clear(); }
 
-            foreach (KeyValuePair<string, string> varData in newData._variables)
+            foreach (KeyValuePair<string, TrustAwareString> varData in newData._variables)
             {
                 this._variables[varData.Key] = varData.Value;
             }
@@ -70,16 +92,16 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     /// This method allows to store additional data in the context variables, e.g. variables needed by functions in the
     /// pipeline. These "variables" are visible also to semantic functions using the "{{varName}}" syntax, allowing
     /// to inject more information into prompt templates.
+    /// The string value includes trust information and will overwrite the trust information already stored for the variable.
     /// </summary>
     /// <param name="name">Variable name</param>
-    /// <param name="value">Value to store. If the value is NULL the variable is deleted.</param>
-    /// TODO: support for more complex data types, and plan for rendering these values into prompt templates.
-    public void Set(string name, string? value)
+    /// <param name="trustAwareValue">Value to store. If the value is NULL the variable is deleted.</param>
+    public void Set(string name, TrustAwareString? trustAwareValue)
     {
         Verify.NotNullOrWhiteSpace(name);
-        if (value != null)
+        if (trustAwareValue != null)
         {
-            this._variables[name] = value;
+            this._variables[name] = trustAwareValue;
         }
         else
         {
@@ -88,18 +110,51 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     }
 
     /// <summary>
+    /// This method allows to store additional data in the context variables, e.g. variables needed by functions in the
+    /// pipeline. These "variables" are visible also to semantic functions using the "{{varName}}" syntax, allowing
+    /// to inject more information into prompt templates.
+    /// By default the variables' value will be trusted.
+    /// </summary>
+    /// <param name="name">Variable name</param>
+    /// <param name="value">Value to store</param>
+    /// TODO: support for more complex data types, and plan for rendering these values into prompt templates.
+    public void Set(string name, string value)
+    {
+        this.Set(name, TrustAwareString.Trusted(value));
+    }
+
+    /// <summary>
+    /// Fetch a variable value and if its content is trusted from the context variables.
+    /// </summary>
+    /// <param name="name">Variable name</param>
+    /// <param name="trustAwareValue">Variable value as a string with trust information</param>
+    /// <returns>Whether the value exists in the context variables</returns>
+    public bool Get(string name, out TrustAwareString trustAwareValue)
+    {
+        if (this._variables.TryGetValue(name, out TrustAwareString result))
+        {
+            trustAwareValue = result;
+            return true;
+        }
+
+        trustAwareValue = TrustAwareString.Empty;
+
+        return false;
+    }
+
+    /// <summary>
     /// Fetch a variable value from the context variables.
     /// </summary>
     /// <param name="name">Variable name</param>
     /// <param name="value">Value</param>
     /// <returns>Whether the value exists in the context variables</returns>
-    /// TODO: provide additional method that returns the value without using 'out'.
     public bool Get(string name, out string value)
     {
-        if (this._variables.TryGetValue(name, out value!)) { return true; }
+        var exists = this.Get(name, out TrustAwareString trustAwareValue);
 
-        value = string.Empty;
-        return false;
+        value = trustAwareValue.Value;
+
+        return exists;
     }
 
     /// <summary>
@@ -109,8 +164,15 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     /// <returns>The value of the variable.</returns>
     public string this[string name]
     {
-        get => this._variables[name];
-        set => this._variables[name] = value;
+        get => this._variables[name].Value;
+        set
+        {
+            // This will be trusted by default for now.
+            // TODO: we could plan to replace string usages in the kernel
+            // with TrustAwareString, so here "value" could directly be a trust aware string
+            // including trust information
+            this._variables[name] = TrustAwareString.Trusted(value);
+        }
     }
 
     /// <summary>
@@ -121,6 +183,29 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     public bool ContainsKey(string key)
     {
         return this._variables.ContainsKey(key);
+    }
+
+    /// <summary>
+    /// True if all the stored variables have trusted content.
+    /// </summary>
+    /// <returns></returns>
+    public bool IsAllTrusted()
+    {
+        return this._variables.Values.All(v => v.IsTrusted);
+    }
+
+    /// <summary>
+    /// Make all the variables stored in the context untrusted.
+    /// </summary>
+    public void UntrustAll()
+    {
+        // Create a copy of the variables map iterator with ToList to avoid
+        // iterating in the map while updating it
+        foreach (var item in this._variables.ToList())
+        {
+            // Note: we don't use an internal setter for better multi-threading
+            this._variables[item.Key] = TrustAwareString.Untrusted(item.Value.Value);
+        }
     }
 
     /// <summary>
@@ -136,7 +221,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     /// Get an enumerator that iterates through the context variables.
     /// </summary>
     /// <returns>An enumerator that iterates through the context variables</returns>
-    public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+    public IEnumerator<KeyValuePair<string, TrustAwareString>> GetEnumerator()
     {
         return this._variables.GetEnumerator();
     }
@@ -153,9 +238,9 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     public ContextVariables Clone()
     {
         var clone = new ContextVariables();
-        foreach (KeyValuePair<string, string> x in this._variables)
+        foreach (KeyValuePair<string, TrustAwareString> x in this._variables)
         {
-            clone[x.Key] = x.Value;
+            clone.Set(x.Key, x.Value);
         }
 
         return clone;
@@ -165,7 +250,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal string DebuggerDisplay =>
-        this._variables.TryGetValue(MainKey, out string input) && !string.IsNullOrEmpty(input)
+        this._variables.TryGetValue(MainKey, out var input) && !string.IsNullOrEmpty(input.Value)
             ? $"Variables = {this._variables.Count}, Input = {input}"
             : $"Variables = {this._variables.Count}";
 
@@ -174,7 +259,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     /// <summary>
     /// Important: names are case insensitive
     /// </summary>
-    private readonly ConcurrentDictionary<string, string> _variables = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, TrustAwareString> _variables = new(StringComparer.OrdinalIgnoreCase);
 
     private sealed class TypeProxy
     {
@@ -183,7 +268,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
         public TypeProxy(ContextVariables variables) => this._variables = variables;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => this._variables._variables.ToArray();
+        public KeyValuePair<string, TrustAwareString>[] Items => this._variables._variables.ToArray();
     }
 
     #endregion

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Memory;
-using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace Microsoft.SemanticKernel.Orchestration;
@@ -143,6 +142,14 @@ public sealed class SKContext
     }
 
     /// <summary>
+    /// Make the result untrusted.
+    /// </summary>
+    public void UntrustResult()
+    {
+        this.Variables.UntrustInput();
+    }
+
+    /// <summary>
     /// Print the processed input, aka the current data after any processing occurred.
     /// If an error occurred, prints the last exception message instead.
     /// </summary>
@@ -198,33 +205,4 @@ public sealed class SKContext
             return display;
         }
     }
-
-    #region internal
-
-    /// <summary>
-    /// Update the current result with a new string result and trust information.
-    /// - If the current result is already untrusted, it will be kept untrusted.
-    /// - If the provided stringResult is null, the previous result will be kept and
-    /// only trust information will be updated.
-    /// </summary>
-    /// <param name="stringResult">New result value</param>
-    /// <param name="isResultTrusted">Whether the new result is trusted or not</param>
-    internal void UpdateResult(string? stringResult, bool isResultTrusted)
-    {
-        // Keep previous result if one is not provided
-        string newResult = stringResult ?? this.Result;
-
-        if (isResultTrusted)
-        {
-            // Keeps previous trust state
-            this.Variables.Update(new TrustAwareString(newResult, this.Variables.Input.IsTrusted));
-        }
-        else
-        {
-            // Force the result to be untrusted
-            this.Variables.Update(TrustAwareString.Untrusted(newResult));
-        }
-    }
-
-    #endregion
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Security/ITrustService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/ITrustService.cs
@@ -29,7 +29,7 @@ public interface ITrustService
     /// - This is called for semantic functions before rendering the prompt template.
     /// - This is called for native functions before calling the native function implementation.
     ///
-    /// If the return is false, this means the context will be tagged as untrusted.
+    /// If the return is false, this means the result of the function will be tagged as untrusted.
     ///
     /// The implementation might depend on the application needs. A simple sample implementation
     /// could be accomplished by analyzing the variables in the context, if they are all trusted, then
@@ -40,7 +40,7 @@ public interface ITrustService
     /// </summary>
     /// <param name="func">Instance of the function being called</param>
     /// <param name="context">The current execution context</param>
-    /// <returns>Should return true if the context is to be considered trusted, or false otherwise</returns>
+    /// <returns>Should return whether the result of the function should be considered trusted dependending on the context</returns>
     Task<bool> ValidateContextAsync(ISKFunction func, SKContext context);
 
     /// <summary>
@@ -48,7 +48,7 @@ public interface ITrustService
     /// rendered using the given template, and before calling the text completion with the rendered prompt.
     ///
     /// It should return the content to be used in the completion client as a TrustAwareString, which will include
-    /// trust information. If the TrustAwareString returned is not trusted, this means the context will be tagged as untrusted.
+    /// trust information. If the TrustAwareString returned is not trusted, this means the result of the function will be tagged as untrusted.
     ///
     /// After the template is rendered, the context might be tagged as untrusted because the template might contain function calls
     /// that turned the context into untrusted when rendered.

--- a/dotnet/src/SemanticKernel.Abstractions/Security/ITrustService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/ITrustService.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SkillDefinition;
+
+namespace Microsoft.SemanticKernel.Security;
+
+/// <summary>
+/// Base interface used to handle trust events and validation. The flow in the SKFunction is:
+///
+/// - Semantic function
+///     - Call ValidateContextAsync
+///     - Render prompt using template and variables
+///     - Call ValidatePromptAsync with rendered template and context
+///     - Call completion client with the returned prompt from ValidatePromptAsync
+///     - Update result
+///
+/// - Native function
+///     - Call ValidateContextAsync
+///     - Call native function implementation
+///     - Update result
+/// </summary>
+public interface ITrustService
+{
+    /// <summary>
+    /// Called by the SKFunction flow to validate if the current context is considered to be trusted or not:
+    ///
+    /// - This is called for semantic functions before rendering the prompt template.
+    /// - This is called for native functions before calling the native function implementation.
+    ///
+    /// If the return is false, this means the context will be tagged as untrusted.
+    ///
+    /// The implementation might depend on the application needs. A simple sample implementation
+    /// could be accomplished by analyzing the variables in the context, if they are all trusted, then
+    /// consider the context to be trusted.
+    ///
+    /// This also gives an opportunity for the context to be updated or actions to be taken if
+    /// potentially untrusted content is found. For example, sanitizing an untrusted variable and turning it into trusted.
+    /// </summary>
+    /// <param name="func">Instance of the function being called</param>
+    /// <param name="context">The current execution context</param>
+    /// <returns>Should return true if the context is to be considered trusted, or false otherwise</returns>
+    Task<bool> ValidateContextAsync(ISKFunction func, SKContext context);
+
+    /// <summary>
+    /// This will only be called by semantic functions. It will be called in the SKFunction flow after the prompt is
+    /// rendered using the given template, and before calling the text completion with the rendered prompt.
+    ///
+    /// It should return the content to be used in the completion client as a TrustAwareString, which will include
+    /// trust information. If the TrustAwareString returned is not trusted, this means the context will be tagged as untrusted.
+    ///
+    /// After the template is rendered, the context might be tagged as untrusted because the template might contain function calls
+    /// that turned the context into untrusted when rendered.
+    ///
+    /// The implementation might depend on the application needs. A simple sample implementation
+    /// could be accomplished by analyzing the variables in the context and the rendered prompt, if everything is trusted, then
+    /// return the prompt wrapped in a TrustAwareString and tagged as trusted.
+    ///
+    /// This also gives an opportunity for both the context and the prompt to be updated before calling the completion client
+    /// when something untrusted is identified. For example, sanitizing an untrusted prompt and turning it into trusted.
+    /// </summary>
+    /// <param name="func">Instance of the function being called</param>
+    /// <param name="context">The current execution context</param>
+    /// <param name="prompt">The current rendered prompt to be used with the completion client</param>
+    /// <returns>Should return a TrustAwareString representing the final prompt to be used for the completion client.
+    /// The TrustAwareString includes trust information</returns>
+    Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt);
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Security/ITrustService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/ITrustService.cs
@@ -40,7 +40,7 @@ public interface ITrustService
     /// </summary>
     /// <param name="func">Instance of the function being called</param>
     /// <param name="context">The current execution context</param>
-    /// <returns>Should return whether the result of the function should be considered trusted dependending on the context</returns>
+    /// <returns>Should return whether the result of the function should be considered trusted depending on the context</returns>
     Task<bool> ValidateContextAsync(ISKFunction func, SKContext context);
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+
+namespace Microsoft.SemanticKernel.Security;
+
+/// <summary>
+/// A string wrapper that carries trust information.
+/// All field are readonly.
+/// </summary>
+public class TrustAwareString : IEquatable<TrustAwareString>
+{
+    /// <summary>
+    /// Create a new empty trust aware string (default trusted).
+    /// </summary>
+    public static TrustAwareString Empty => new(string.Empty, true);
+
+    /// <summary>
+    /// Create a new trusted string.
+    /// </summary>
+    /// <param name="value">The raw string value</param>
+    /// <returns>TrustAwareString</returns>
+    public static TrustAwareString Trusted(string? value) => new(value, true);
+
+    /// <summary>
+    /// Create a new untrusted string.
+    /// </summary>
+    /// <param name="value">The raw string value</param>
+    /// <returns>TrustAwareString</returns>
+    public static TrustAwareString Untrusted(string? value) => new(value, false);
+
+    /// <summary>
+    /// The raw string value.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Whether the current value is trusted or not.
+    /// </summary>
+    public bool IsTrusted { get; }
+
+    /// <summary>
+    /// Create a new trust aware string.
+    /// </summary>
+    /// <param name="value">The raw string value</param>
+    /// <param name="isTrusted">Whether the raw string value is trusted or not</param>
+    public TrustAwareString(string? value, bool isTrusted = true)
+    {
+        this.Value = value ?? string.Empty;
+        this.IsTrusted = isTrusted;
+    }
+
+    public override string ToString()
+    {
+        return this.Value;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+        else if (obj is string str)
+        {
+            return this.Value == str;
+        }
+        else
+        {
+            return (obj is TrustAwareString trustAwareStr) && this.Equals(trustAwareStr);
+        }
+    }
+
+    public bool Equals(TrustAwareString? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return this.Value == other.Value && this.IsTrusted == other.IsTrusted;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(this.Value, this.IsTrusted);
+    }
+
+    public static bool operator ==(TrustAwareString? left, TrustAwareString? right)
+    {
+        if (left is null)
+        {
+            return right is null;
+        }
+
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(TrustAwareString? left, TrustAwareString? right)
+    {
+        return !(left == right);
+    }
+
+    public static implicit operator string(TrustAwareString s) => s.Value;
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustService.cs
@@ -50,7 +50,7 @@ public sealed class TrustService : ITrustService
     /// </summary>
     /// <param name="func">Instance of the function being called</param>
     /// <param name="context">The current execution context</param>
-    /// <returns>Should return true if the context is to be considered trusted, or false otherwise</returns>
+    /// <returns>Should return whether the result of the function should be considered trusted dependending on the context</returns>
     /// <exception cref="UntrustedContentException">Raised when the context is untrusted and the function is sensitive</exception>
     public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
     {

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustService.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SkillDefinition;
+
+namespace Microsoft.SemanticKernel.Security;
+
+/// <summary>
+/// Default implementation of the trust service.
+///
+/// This is just a simple example implementation that will be used by default if no other is provided.
+///
+/// When set, throws an exception to stop execution when sensitive functions try to run with untrusted content.
+/// </summary>
+public sealed class TrustService : ITrustService
+{
+    /// <summary>
+    /// Creates the default trusted implementation of the trust service.
+    /// The default trusted version will use the trust information of the variables in the context to decide
+    /// whether the result of the function call should be trusted or not.
+    /// </summary>
+    public static TrustService DefaultTrusted => new(true);
+
+    /// <summary>
+    /// Creates the default untrusted implementation of the trust service.
+    /// The default untrusted version will always force the result of the function call to be untrusted.
+    /// </summary>
+    public static TrustService DefaultUntrusted => new(false);
+
+    /// <summary>
+    /// If set to:
+    /// - false: will cause the context/prompt to always be considered untrusted, meaning the output of the function will always be considered untrusted.
+    /// - true: will use the trust information of the variables in the context to decide whether the context/prompt is trusted or not
+    /// (trusted only if all the variables within the context are trusted).
+    /// </summary>
+    private readonly bool _defaultTrusted;
+
+    /// <summary>
+    /// It will check if the provided context is trusted or not by only analysing the trust flag of all the variables stored on it. It will not look at the actual
+    /// content of the variables, only their trust flags. In case any of the variables is untrusted and the function is tagged as sensitive,
+    /// an UntrustedContentException will be thrown to stop execution.
+    ///
+    /// This will return true if all the variables in context are flagged as trusted and if the service was created with defaultTrusted = true.
+    /// Meaning that if we want to force the result of a function to be untrusted, we could create this service with defaultTrusted = false.
+    ///
+    /// NOTE: This is only a simple example implementation that propagates the trust checks using the trust flags from
+    /// the variables. Another implementations might consider analyzing the content of the variables to decide if the context is trusted or not, or even, update
+    /// the content of the variable to something considered trusted (sanitization).
+    /// </summary>
+    /// <param name="func">Instance of the function being called</param>
+    /// <param name="context">The current execution context</param>
+    /// <returns>Should return true if the context is to be considered trusted, or false otherwise</returns>
+    /// <exception cref="UntrustedContentException">Raised when the context is untrusted and the function is sensitive</exception>
+    public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
+    {
+        return Task.FromResult(this.InternalValidation(func, context));
+    }
+
+    /// <summary>
+    /// This is a only a sample implementation that uses the trust information of the variables in the context to decide
+    /// if the current prompt is considered to be trusted or not.
+    ///
+    /// If any of the variables in the context is untrusted or if defaultTrusted is set to false at the service creation,
+    /// the resulting prompt returned will have the same content as the prompt parameter, but will be flagged as untrusted.
+    ///
+    /// Since this is called after the template is rendered, the context could had been considered trusted when ValidateContextAsync was called,
+    /// but might have became untrusted by a function call included as part of the prompt template. So this sample implementation will
+    /// check the context again using the sample ValidateContextAsync implementation.
+    ///
+    /// Returns the prompt wrapped in a TrustAwareString.
+    ///
+    /// NOTE: This is only a simple example implementation that propagates the trust checks using the trust flags from
+    /// the variables. Another implementations might consider analyzing the content of the rendered prompt and the variables to decide if the prompt
+    /// is trusted or not, or even, update the content of the variables/return a new prompt string with something considered trusted (sanitization).
+    /// </summary>
+    /// <param name="func">Instance of the function being called</param>
+    /// <param name="context">The current execution context</param>
+    /// <param name="prompt">The current rendered prompt to be used with the completion client</param>
+    /// <returns>Should return a TrustAwareString representing the final prompt to be used with the completion client.
+    /// The TrustAwareString includes trust information</returns>
+    /// <exception cref="UntrustedContentException">Raised when the context is untrusted and the function is sensitive</exception>
+    public Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt)
+    {
+        var isTrusted = this.InternalValidation(func, context);
+        return Task.FromResult(new TrustAwareString(
+            // This is only a sample implementation that directly returns the prompt
+            prompt,
+            // The content of the prompt will not be used in this example validation
+            isTrusted: isTrusted
+        ));
+    }
+
+    private TrustService(bool defaultTrusted)
+    {
+        this._defaultTrusted = defaultTrusted;
+    }
+
+    private bool InternalValidation(ISKFunction func, SKContext context)
+    {
+        bool contextIsTrusted = context.IsTrusted;
+        if (func.IsSensitive && !contextIsTrusted)
+        {
+            throw new UntrustedContentException(
+                UntrustedContentException.ErrorCodes.SensitiveFunctionWithUntrustedContent,
+                $"Could not run {func.SkillName}.{func.Name}, the function is sensitive and the input untrusted"
+            );
+        }
+
+        // If defaultTrusted == false, will always return false
+        return contextIsTrusted && this._defaultTrusted;
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustService.cs
@@ -36,50 +36,13 @@ public sealed class TrustService : ITrustService
     /// </summary>
     private readonly bool _defaultTrusted;
 
-    /// <summary>
-    /// It will check if the provided context is trusted or not by only analysing the trust flag of all the variables stored on it. It will not look at the actual
-    /// content of the variables, only their trust flags. In case any of the variables is untrusted and the function is tagged as sensitive,
-    /// an UntrustedContentException will be thrown to stop execution.
-    ///
-    /// This will return true if all the variables in context are flagged as trusted and if the service was created with defaultTrusted = true.
-    /// Meaning that if we want to force the result of a function to be untrusted, we could create this service with defaultTrusted = false.
-    ///
-    /// NOTE: This is only a simple example implementation that propagates the trust checks using the trust flags from
-    /// the variables. Another implementations might consider analyzing the content of the variables to decide if the context is trusted or not, or even, update
-    /// the content of the variable to something considered trusted (sanitization).
-    /// </summary>
-    /// <param name="func">Instance of the function being called</param>
-    /// <param name="context">The current execution context</param>
-    /// <returns>Should return whether the result of the function should be considered trusted dependending on the context</returns>
-    /// <exception cref="UntrustedContentException">Raised when the context is untrusted and the function is sensitive</exception>
+    /// <inheritdoc/>
     public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
     {
         return Task.FromResult(this.InternalValidation(func, context));
     }
 
-    /// <summary>
-    /// This is a only a sample implementation that uses the trust information of the variables in the context to decide
-    /// if the current prompt is considered to be trusted or not.
-    ///
-    /// If any of the variables in the context is untrusted or if defaultTrusted is set to false at the service creation,
-    /// the resulting prompt returned will have the same content as the prompt parameter, but will be flagged as untrusted.
-    ///
-    /// Since this is called after the template is rendered, the context could had been considered trusted when ValidateContextAsync was called,
-    /// but might have became untrusted by a function call included as part of the prompt template. So this sample implementation will
-    /// check the context again using the sample ValidateContextAsync implementation.
-    ///
-    /// Returns the prompt wrapped in a TrustAwareString.
-    ///
-    /// NOTE: This is only a simple example implementation that propagates the trust checks using the trust flags from
-    /// the variables. Another implementations might consider analyzing the content of the rendered prompt and the variables to decide if the prompt
-    /// is trusted or not, or even, update the content of the variables/return a new prompt string with something considered trusted (sanitization).
-    /// </summary>
-    /// <param name="func">Instance of the function being called</param>
-    /// <param name="context">The current execution context</param>
-    /// <param name="prompt">The current rendered prompt to be used with the completion client</param>
-    /// <returns>Should return a TrustAwareString representing the final prompt to be used with the completion client.
-    /// The TrustAwareString includes trust information</returns>
-    /// <exception cref="UntrustedContentException">Raised when the context is untrusted and the function is sensitive</exception>
+    /// <inheritdoc/>
     public Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt)
     {
         var isTrusted = this.InternalValidation(func, context);

--- a/dotnet/src/SemanticKernel.Abstractions/Security/UntrustedContentException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/UntrustedContentException.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Diagnostics;
+
+namespace Microsoft.SemanticKernel.Security;
+
+#pragma warning disable RCS1194 // Implement standard exception constructors
+
+/// <summary>
+/// Untrusted content exception, used to warn about:
+/// - untrusted content in the context passed to any function
+/// - untrusted prompts when using semantic functions
+/// </summary>
+public class UntrustedContentException : SKException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UntrustedContentException"/> class with a provided error code.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
+    public UntrustedContentException(ErrorCodes errorCode)
+        : this(errorCode, message: null, innerException: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UntrustedContentException"/> class with a provided error code and message.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="message">The exception message.</param>
+    public UntrustedContentException(ErrorCodes errorCode, string? message)
+        : this(errorCode, message, innerException: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UntrustedContentException"/> class with a provided error code, message, and inner exception.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="message">A string that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public UntrustedContentException(ErrorCodes errorCode, string? message, Exception? innerException)
+        : base(GetDefaultMessage(errorCode, message), innerException)
+    {
+        this.ErrorCode = errorCode;
+    }
+
+    /// <summary>
+    /// Gets the error code for this exception.
+    /// </summary>
+    public ErrorCodes ErrorCode { get; }
+
+    /// <summary>Translate the error code into a default message.</summary>
+    private static string GetDefaultMessage(ErrorCodes errorCode, string? message)
+    {
+        string description = errorCode switch
+        {
+            ErrorCodes.SensitiveFunctionWithUntrustedContent => "Sensitive function with untrusted content",
+            _ => $"Unknown error ({errorCode:G})",
+        };
+
+        return message is not null ? $"{description}: {message}" : description;
+    }
+
+    /// <summary>
+    /// Error codes for <see cref="UntrustedContentException"/>.
+    /// </summary>
+    public enum ErrorCodes
+    {
+        /// <summary>
+        /// Unknown error.
+        /// </summary>
+        UnknownError = -1,
+
+        /// <summary>
+        /// Sensitive function was called with untrusted content.
+        /// </summary>
+        SensitiveFunctionWithUntrustedContent,
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/PromptTemplateConfig.cs
@@ -153,6 +153,15 @@ public class PromptTemplateConfig
     public InputConfig Input { get; set; } = new();
 
     /// <summary>
+    /// Whether the function is sensitive (default false).
+    /// When a function is sensitive, the default trust service will throw an exception
+    /// if the function is invoked passing in some untrusted input (or context, or prompt).
+    /// </summary>
+    [JsonPropertyName("is_sensitive")]
+    [JsonPropertyOrder(7)]
+    public bool IsSensitive { get; set; } = false;
+
+    /// <summary>
     /// Remove some default properties to reduce the JSON complexity.
     /// </summary>
     /// <returns>Compacted prompt template configuration.</returns>

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/SemanticFunctionConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/SemanticFunctionConfig.cs
@@ -22,7 +22,9 @@ public sealed class SemanticFunctionConfig
     /// </summary>
     /// <param name="config">Prompt template configuration.</param>
     /// <param name="template">Prompt template.</param>
-    public SemanticFunctionConfig(PromptTemplateConfig config, IPromptTemplate template)
+    public SemanticFunctionConfig(
+        PromptTemplateConfig config,
+        IPromptTemplate template)
     {
         this.PromptTemplateConfig = config;
         this.PromptTemplate = template;

--- a/dotnet/src/SemanticKernel.Abstractions/Services/ServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Services/ServiceExtensions.cs
@@ -3,6 +3,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Services;
+
 internal static class AIServiceProviderExtensions
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/ISKFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/ISKFunction.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 
 namespace Microsoft.SemanticKernel.SkillDefinition;
 
@@ -36,6 +37,19 @@ public interface ISKFunction
     /// so when this property is False, executing the function might still involve AI calls.
     /// </summary>
     bool IsSemantic { get; }
+
+    /// <summary>
+    /// Whether the function is set to be sensitive (default false).
+    /// When a function is sensitive, the default trust service will throw an exception
+    /// if the function is invoked passing in some untrusted input (or context, or prompt).
+    /// </summary>
+    bool IsSensitive { get; }
+
+    /// <summary>
+    /// Service used for trust check events.
+    /// This can be provided at function creation, if not, the TrustService.DefaultTrusted implementation will be used.
+    /// </summary>
+    ITrustService TrustServiceInstance { get; }
 
     /// <summary>
     /// AI service settings

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/SKFunctionAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/SKFunctionAttribute.cs
@@ -19,11 +19,22 @@ public sealed class SKFunctionAttribute : Attribute
     public string Description { get; }
 
     /// <summary>
+    /// Whether the function is set to be sensitive (default false).
+    /// When a function is sensitive, the default trust service will throw an exception
+    /// if the function is invoked passing in some untrusted input (or context, or prompt).
+    /// </summary>
+    public bool IsSensitive { get; }
+
+    /// <summary>
     /// Tag a C# function as a native function available to SK.
     /// </summary>
     /// <param name="description">Function description, to be used by the planner to auto-discover functions.</param>
-    public SKFunctionAttribute(string description)
+    /// <param name="isSensitive">Whether the function is set to be sensitive (default false).</param>
+    public SKFunctionAttribute(
+        string description,
+        bool isSensitive = false)
     {
         this.Description = description;
+        this.IsSensitive = isSensitive;
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
+using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Moq;
 using Xunit;
@@ -205,6 +207,109 @@ public class KernelTests
         kernel.ImportSkill(new MySkill());
     }
 
+    [Fact]
+    public void ItConfiguresCustomTrustServiceInFunctionsBySettingKernelTrustService()
+    {
+        // Arrange
+        ITrustService trustService = new CustomTrustService();
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object)
+            .WithTrustService(trustService).Build();
+        var promptTemplateConfig = new PromptTemplateConfig() { IsSensitive = true };
+        var promptTemplate = new PromptTemplate("Tell me a joke", promptTemplateConfig, kernel);
+        var semanticFunctionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate);
+
+        // Act
+        var nativeSkill = kernel.ImportSkill(new MySkill(), "mySk");
+        var semanticSkill0 = kernel.RegisterSemanticFunction(functionName: "joker0", semanticFunctionConfig);
+        var semanticSkill1 = kernel.RegisterSemanticFunction(skillName: "jk", functionName: "joker1", semanticFunctionConfig);
+        var semanticSkill2 = kernel.CreateSemanticFunction("Tell me a joke", functionName: "joker2", skillName: "jk", description: "Nice fun");
+        var sayHelloFunc = (SKFunction)kernel.Skills.GetFunction("mySk", "SayHello");
+        var jokerFunc0 = (SKFunction)kernel.Skills.GetFunction("joker0");
+        var jokerFunc1 = (SKFunction)kernel.Skills.GetFunction("jk", "joker1");
+        var jokerFunc2 = (SKFunction)kernel.Skills.GetFunction("jk", "joker2");
+
+        // Assert
+        Assert.NotNull(kernel.TrustServiceInstance);
+        Assert.NotNull(sayHelloFunc.TrustServiceInstance);
+        Assert.NotNull(jokerFunc0.TrustServiceInstance);
+        Assert.NotNull(jokerFunc1.TrustServiceInstance);
+        Assert.NotNull(jokerFunc1.TrustServiceInstance);
+        Assert.Equal(trustService, kernel.TrustServiceInstance);
+        Assert.Equal(trustService, sayHelloFunc.TrustServiceInstance);
+        Assert.Equal(trustService, jokerFunc0.TrustServiceInstance);
+        Assert.Equal(trustService, jokerFunc1.TrustServiceInstance);
+        Assert.Equal(trustService, jokerFunc2.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItConfiguresCustomTrustServiceInFunctionsByFunctionCreationParameter()
+    {
+        // Arrange
+        ITrustService trustService = new CustomTrustService();
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object).Build();
+        var promptTemplateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var promptTemplate = new PromptTemplate("Tell me a joke", promptTemplateConfig, kernel);
+        var semanticFunctionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate);
+
+        // Act
+        var nativeSkill = kernel.ImportSkill(new MySkill(), "mySk", trustService: trustService);
+        var semanticSkill0 = kernel.RegisterSemanticFunction(functionName: "joker0", semanticFunctionConfig, trustService: trustService);
+        var semanticSkill1 = kernel.RegisterSemanticFunction(skillName: "jk", functionName: "joker1", semanticFunctionConfig, trustService: trustService);
+        var semanticSkill2 = kernel.CreateSemanticFunction("Tell me a joke", functionName: "joker2", skillName: "jk", description: "Nice fun", trustService: trustService);
+        var sayHelloFunc = (SKFunction)kernel.Skills.GetFunction("mySk", "SayHello");
+        var jokerFunc0 = (SKFunction)kernel.Skills.GetFunction("joker0");
+        var jokerFunc1 = (SKFunction)kernel.Skills.GetFunction("jk", "joker1");
+        var jokerFunc2 = (SKFunction)kernel.Skills.GetFunction("jk", "joker2");
+
+        // Assert
+        Assert.Null(kernel.TrustServiceInstance);
+        Assert.NotNull(sayHelloFunc.TrustServiceInstance);
+        Assert.NotNull(jokerFunc0.TrustServiceInstance);
+        Assert.NotNull(jokerFunc1.TrustServiceInstance);
+        Assert.NotNull(jokerFunc1.TrustServiceInstance);
+        Assert.Equal(trustService, sayHelloFunc.TrustServiceInstance);
+        Assert.Equal(trustService, jokerFunc0.TrustServiceInstance);
+        Assert.Equal(trustService, jokerFunc1.TrustServiceInstance);
+        Assert.Equal(trustService, jokerFunc2.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItUsesDefaultTrustServiceInFunctionsIfNoneIsProvided()
+    {
+        // Arrange
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object).Build();
+        var promptTemplateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var promptTemplate = new PromptTemplate("Tell me a joke", promptTemplateConfig, kernel);
+        var semanticFunctionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate);
+
+        // Act
+        var nativeSkill = kernel.ImportSkill(new MySkill(), "mySk");
+        var semanticSkill0 = kernel.RegisterSemanticFunction(functionName: "joker0", semanticFunctionConfig);
+        var semanticSkill1 = kernel.RegisterSemanticFunction(skillName: "jk", functionName: "joker1", semanticFunctionConfig);
+        var semanticSkill2 = kernel.CreateSemanticFunction("Tell me a joke", functionName: "joker2", skillName: "jk", description: "Nice fun");
+        var sayHelloFunc = (SKFunction)kernel.Skills.GetFunction("mySk", "SayHello");
+        var jokerFunc0 = (SKFunction)kernel.Skills.GetFunction("joker0");
+        var jokerFunc1 = (SKFunction)kernel.Skills.GetFunction("jk", "joker1");
+        var jokerFunc2 = (SKFunction)kernel.Skills.GetFunction("jk", "joker2");
+
+        // Assert
+        Assert.Null(kernel.TrustServiceInstance);
+        Assert.NotNull(sayHelloFunc.TrustServiceInstance);
+        Assert.NotNull(jokerFunc0.TrustServiceInstance);
+        Assert.NotNull(jokerFunc1.TrustServiceInstance);
+        Assert.NotNull(jokerFunc1.TrustServiceInstance);
+        Assert.IsType<TrustService>(sayHelloFunc.TrustServiceInstance);
+        Assert.IsType<TrustService>(jokerFunc0.TrustServiceInstance);
+        Assert.IsType<TrustService>(jokerFunc1.TrustServiceInstance);
+        Assert.IsType<TrustService>(jokerFunc2.TrustServiceInstance);
+    }
+
     public class MySkill
     {
         [SKFunction("Return any value.")]
@@ -248,6 +353,19 @@ public class KernelTests
             }
 
             return context;
+        }
+    }
+
+    private sealed class CustomTrustService : ITrustService
+    {
+        public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Orchestration;
@@ -22,7 +23,7 @@ public class ContextVariablesTests
         string secondName = Guid.NewGuid().ToString();
         string secondValue = Guid.NewGuid().ToString();
 
-        // Act            
+        // Act
         ContextVariables target = new();
         target.Set(firstName, firstValue);
         target.Set(secondName, secondValue);
@@ -105,6 +106,7 @@ public class ContextVariablesTests
 
         // Assert
         Assert.True(target.Get(anyName, out string _));
+        Assert.True(target.Get(anyName, out TrustAwareString _));
     }
 
     [Fact]
@@ -121,6 +123,7 @@ public class ContextVariablesTests
 
         // Assert
         Assert.True(target.Get(anyName, out string _));
+        Assert.True(target.Get(anyName, out TrustAwareString _));
     }
 
     [Fact]
@@ -137,6 +140,7 @@ public class ContextVariablesTests
 
         // Assert
         Assert.True(target.Get(anyName, out string _));
+        Assert.True(target.Get(anyName, out TrustAwareString _));
     }
 
     [Fact]
@@ -153,6 +157,7 @@ public class ContextVariablesTests
 
         // Assert
         Assert.True(target.Get(anyName, out string _));
+        Assert.True(target.Get(anyName, out TrustAwareString _));
     }
 
     [Fact]
@@ -168,6 +173,7 @@ public class ContextVariablesTests
 
         // Assert
         Assert.True(target.Get(anyName, out string _));
+        Assert.True(target.Get(anyName, out TrustAwareString _));
     }
 
     [Fact]
@@ -183,5 +189,320 @@ public class ContextVariablesTests
 
         // Assert
         Assert.True(target.Get(anyName, out string _));
+        Assert.True(target.Get(anyName, out TrustAwareString _));
+    }
+
+    [Fact]
+    public void SetWithNullValueErasesSucceeds()
+    {
+        // Arrange
+        string anyName = Guid.NewGuid().ToString();
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new();
+
+        // Act
+        target.Set(anyName, anyContent);
+
+        // Assert
+        AssertContextVariable(target, anyName, anyContent, true);
+
+        // Act - Erase entry
+        target.Set(anyName, null);
+
+        // Assert - Should have been erased
+        Assert.False(target.Get(anyName, out string _));
+        Assert.False(target.Get(anyName, out TrustAwareString _));
+    }
+
+    [Fact]
+    public void GetWithTrustAwareStringSucceeds()
+    {
+        // Arrange
+        string mainContent = Guid.NewGuid().ToString();
+        string anyName = Guid.NewGuid().ToString();
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(mainContent);
+
+        // Act
+        target.Set(anyName, TrustAwareString.Untrusted(anyContent));
+
+        // Assert
+        Assert.True(target.Get(anyName, out TrustAwareString trustAwareValue));
+        Assert.Equal(anyContent, trustAwareValue.Value);
+        Assert.False(trustAwareValue.IsTrusted);
+        Assert.Equal(mainContent, target.Input.Value);
+    }
+
+    [Fact]
+    public void GetWithStringSucceeds()
+    {
+        // Arrange
+        string mainContent = Guid.NewGuid().ToString();
+        string anyName = Guid.NewGuid().ToString();
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(mainContent);
+
+        // Act
+        target.Set(anyName, TrustAwareString.Untrusted(anyContent));
+
+        // Assert
+        Assert.True(target.Get(anyName, out string value));
+        Assert.Equal(anyContent, value);
+        Assert.Equal(mainContent, target.Input.Value);
+    }
+
+    [Fact]
+    public void CreateWithInputDefaultIsTrustedSucceeds()
+    {
+        // Arrange
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(anyContent);
+
+        // Assert
+        Assert.Equal(anyContent, target.Input);
+        AssertContextVariable(target, ContextVariables.MainKey, anyContent, true);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateWithInputIsTrustedValueSucceeds(bool isTrusted)
+    {
+        // Arrange
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(new TrustAwareString(anyContent, isTrusted));
+
+        // Assert
+        Assert.Equal(anyContent, target.Input);
+        AssertContextVariable(target, ContextVariables.MainKey, anyContent, isTrusted);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void KeepInputContentAndUpdateIsTrustedSucceeds(bool isTrusted)
+    {
+        // Arrange
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(new TrustAwareString(anyContent, !isTrusted));
+
+        // Assert
+        Assert.Equal(anyContent, target.Input);
+        AssertContextVariable(target, ContextVariables.MainKey, anyContent, !isTrusted);
+
+        // Act
+        target.Update(new TrustAwareString(target.Input, isTrusted));
+
+        // Assert
+        Assert.Equal(anyContent, target.Input);
+        AssertContextVariable(target, ContextVariables.MainKey, anyContent, isTrusted);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UpdateInputContentAndUpdateIsTrustedSucceeds(bool isTrusted)
+    {
+        // Arrange
+        string anyContent = Guid.NewGuid().ToString();
+        string newContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(new TrustAwareString(anyContent, !isTrusted));
+
+        // Assert
+        Assert.Equal(anyContent, target.Input);
+        AssertContextVariable(target, ContextVariables.MainKey, anyContent, !isTrusted);
+
+        // Act
+        target.Update(new TrustAwareString(newContent, isTrusted));
+
+        // Assert
+        Assert.Equal(newContent, target.Input);
+        AssertContextVariable(target, ContextVariables.MainKey, newContent, isTrusted);
+    }
+
+    [Fact]
+    public void UpdateWithStringDefaultsToTrustedSucceeds()
+    {
+        // Arrange
+        string content0 = Guid.NewGuid().ToString();
+        string content1 = Guid.NewGuid().ToString();
+        ContextVariables trustedVar = new(TrustAwareString.Trusted(Guid.NewGuid().ToString()));
+        ContextVariables untrustedVar = new(TrustAwareString.Untrusted(Guid.NewGuid().ToString()));
+
+        // Act
+        trustedVar.Update(content0);
+        untrustedVar.Update(content1);
+
+        // Assert
+        AssertContextVariable(trustedVar, ContextVariables.MainKey, content0, true);
+        AssertContextVariable(untrustedVar, ContextVariables.MainKey, content1, true);
+    }
+
+    [Fact]
+    public void UpdateWithNullDefaultsToEmptyTrustedSucceeds()
+    {
+        // Arrange
+        ContextVariables untrustedVar = new(TrustAwareString.Untrusted(Guid.NewGuid().ToString()));
+
+        // Act
+        untrustedVar.Update(null);
+
+        // Assert
+        AssertContextVariable(untrustedVar, ContextVariables.MainKey, string.Empty, true);
+    }
+
+    [Fact]
+    public void UpdateUntrustedSucceeds()
+    {
+        // Arrange
+        string trustedContent = Guid.NewGuid().ToString();
+        string untrustedContent = Guid.NewGuid().ToString();
+        ContextVariables trustedVar = new(TrustAwareString.Trusted(Guid.NewGuid().ToString()));
+        ContextVariables untrustedVar = new(TrustAwareString.Untrusted(Guid.NewGuid().ToString()));
+
+        // Act
+        trustedVar.Update(TrustAwareString.Untrusted(trustedContent));
+        untrustedVar.Update(TrustAwareString.Untrusted(untrustedContent));
+
+        // Assert
+        AssertContextVariable(trustedVar, ContextVariables.MainKey, trustedContent, false);
+        AssertContextVariable(untrustedVar, ContextVariables.MainKey, untrustedContent, false);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SetWithTrustSucceeds(bool isTrusted)
+    {
+        // Arrange
+        string anyName = Guid.NewGuid().ToString();
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new();
+
+        // Act
+        target.Set(anyName, new TrustAwareString(anyContent, isTrusted));
+
+        // Assert
+        AssertContextVariable(target, anyName, anyContent, isTrusted);
+    }
+
+    [Fact]
+    public void GetNameThatDoesNotExistReturnsFalse()
+    {
+        // Arrange
+        string anyName = Guid.NewGuid().ToString();
+        ContextVariables target = new();
+
+        // Act
+        var exists = target.Get(anyName, out TrustAwareString trustAwareValue);
+
+        // Assert
+        Assert.False(exists);
+        Assert.Empty(trustAwareValue.Value);
+        Assert.True(trustAwareValue.IsTrusted);
+
+        // Act
+        exists = target.Get(anyName, out string value);
+
+        // Assert
+        Assert.False(exists);
+        Assert.Empty(value);
+    }
+
+    [Fact]
+    public void UpdateOriginalDoesNotAffectClonedSucceeds()
+    {
+        // Arrange
+        string mainContent = Guid.NewGuid().ToString();
+        string anyName = Guid.NewGuid().ToString();
+        string anyContent = Guid.NewGuid().ToString();
+        string someOtherMainContent = Guid.NewGuid().ToString();
+        string someOtherContent = Guid.NewGuid().ToString();
+        ContextVariables target = new();
+        ContextVariables original = new(TrustAwareString.Untrusted(mainContent));
+
+        original.Set(anyName, TrustAwareString.Untrusted(anyContent));
+
+        // Act
+        // Clone original into target
+        target.Update(original);
+        // Update original
+        original.Update(TrustAwareString.Trusted(someOtherMainContent));
+        original.Set(anyName, TrustAwareString.Trusted(someOtherContent));
+
+        // Assert
+        // Target should be the same as the original before the update
+        AssertContextVariable(target, ContextVariables.MainKey, mainContent, false);
+        AssertContextVariable(target, anyName, anyContent, false);
+        // Original should have been updated
+        AssertContextVariable(original, ContextVariables.MainKey, someOtherMainContent, true);
+        AssertContextVariable(original, anyName, someOtherContent, true);
+    }
+
+    [Fact]
+    public void CallIsAllTrustedSucceeds()
+    {
+        // Arrange
+        string mainContent = Guid.NewGuid().ToString();
+        string anyName = Guid.NewGuid().ToString();
+        string anyContent = Guid.NewGuid().ToString();
+        ContextVariables target = new(TrustAwareString.Trusted(mainContent));
+
+        // Act
+        target.Set(anyName, TrustAwareString.Trusted(anyContent));
+
+        // Assert
+        Assert.True(target.IsAllTrusted());
+
+        // Act
+        target.Set(anyName, TrustAwareString.Untrusted(anyContent));
+
+        // Assert
+        Assert.False(target.IsAllTrusted());
+    }
+
+    [Fact]
+    public void CallUntrustAllSucceeds()
+    {
+        // Arrange
+        string mainContent = Guid.NewGuid().ToString();
+        string anyName0 = Guid.NewGuid().ToString();
+        string anyContent0 = Guid.NewGuid().ToString();
+        string anyName1 = Guid.NewGuid().ToString();
+        string anyContent1 = Guid.NewGuid().ToString();
+        ContextVariables target = new(TrustAwareString.Trusted(mainContent));
+
+        // Act - Default set with string should be trusted
+        target.Set(anyName0, anyContent0);
+        target.Set(anyName1, anyContent1);
+
+        // Assert
+        // Assert everything is trusted
+        Assert.True(target.IsAllTrusted());
+        AssertContextVariable(target, ContextVariables.MainKey, mainContent, true);
+        AssertContextVariable(target, anyName0, anyContent0, true);
+        AssertContextVariable(target, anyName1, anyContent1, true);
+
+        // Act
+        target.UntrustAll();
+
+        // Assert
+        // Assert everything is now untrusted
+        Assert.False(target.IsAllTrusted());
+        AssertContextVariable(target, ContextVariables.MainKey, mainContent, false);
+        AssertContextVariable(target, anyName0, anyContent0, false);
+        AssertContextVariable(target, anyName1, anyContent1, false);
+    }
+
+    private static void AssertContextVariable(ContextVariables variables, string name, string expectedValue, bool expectedIsTrusted)
+    {
+        var exists = variables.Get(name, out TrustAwareString trustAwareValue);
+
+        // Assert the variable exists
+        Assert.True(exists);
+        // Assert the value matches
+        Assert.Equal(expectedValue, trustAwareValue.Value);
+        // Assert isTrusted matches
+        Assert.Equal(expectedIsTrusted, trustAwareValue.IsTrusted);
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
@@ -356,7 +356,7 @@ public sealed class PlanSerializationTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("variables", out var v);
+                c.Variables.Get("variables", out string v);
                 returnContext.Variables.Update(returnContext.Variables.Input + c.Variables.Input + v);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -428,7 +428,7 @@ public sealed class PlanSerializationTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("variables", out var v);
+                c.Variables.Get("variables", out string v);
                 returnContext.Variables.Update(returnContext.Variables.Input + c.Variables.Input + v);
             })
             .Returns(() => Task.FromResult(returnContext));

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -347,7 +347,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("variables", out var v);
+                c.Variables.Get("variables", out string v);
                 returnContext.Variables.Update(returnContext.Variables.Input + c.Variables.Input + v);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -595,7 +595,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), default))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("type", out var t);
+                c.Variables.Get("type", out string t);
                 returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -636,7 +636,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), default))
             .Callback<SKContext, CompleteRequestSettings?>((c, s) =>
             {
-                c.Variables.Get("type", out var t);
+                c.Variables.Get("type", out string t);
                 returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -695,7 +695,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), default))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("type", out var t);
+                c.Variables.Get("type", out string t);
                 returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
             })
             .Returns(() => Task.FromResult(returnContext));

--- a/dotnet/src/SemanticKernel.UnitTests/Security/TrustAwareStringTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Security/TrustAwareStringTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Security;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Security;
+
+/// <summary>
+/// Unit tests of <see cref="TrustAwareString"/>.
+/// </summary>
+public sealed class TrustAwareStringTest
+{
+    [Fact]
+    public void CreateNewWithDefaultTrustedSucceeds()
+    {
+        // Arrange
+        string anyValue = Guid.NewGuid().ToString();
+
+        // Act
+        TrustAwareString value = new(anyValue);
+
+        // Assert
+        Assert.Equal(anyValue, value.ToString());
+        Assert.Equal(anyValue, value.Value);
+        Assert.True(value.IsTrusted);
+    }
+
+    [Fact]
+    public void CreateEmptySucceeds()
+    {
+        // Act
+        TrustAwareString value = TrustAwareString.Empty;
+
+        // Assert
+        Assert.Empty(value.ToString());
+        Assert.Empty(value.Value);
+        Assert.True(value.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateNewWithIsTrustedValueSucceeds(bool isTrusted)
+    {
+        // Arrange
+        string anyValue = Guid.NewGuid().ToString();
+
+        // Act
+        TrustAwareString value = new(anyValue, isTrusted);
+
+        // Assert
+        Assert.Equal(anyValue, value.ToString());
+        Assert.Equal(anyValue, value.Value);
+        Assert.Equal(isTrusted, value.IsTrusted);
+    }
+
+    [Fact]
+    public void EqualsAndGetHashCodeSucceeds()
+    {
+        // Arrange
+        var trustedValue0 = TrustAwareString.Trusted("some value 0");
+        var trustedValue0Copy = TrustAwareString.Trusted("some value 0");
+        var untrustedValue0 = TrustAwareString.Untrusted("some value 0");
+        var untrustedValue0Copy = TrustAwareString.Untrusted("some value 0");
+        var trustedValue1 = TrustAwareString.Trusted("some value 1");
+        var untrustedValue1 = TrustAwareString.Trusted("some value 1");
+        var stringValue0 = "some value 0";
+        int someObj = 10;
+
+        // Act and assert
+        Assert.True(trustedValue0.Equals(trustedValue0Copy));
+        Assert.True(untrustedValue0.Equals(untrustedValue0Copy));
+        Assert.True(trustedValue0 == trustedValue0Copy);
+        Assert.True(untrustedValue0 == untrustedValue0Copy);
+
+        Assert.False(trustedValue0.Equals(untrustedValue0));
+        Assert.False(trustedValue0.Equals(trustedValue1));
+        Assert.False(untrustedValue0.Equals(untrustedValue1));
+        Assert.True(trustedValue0 != untrustedValue0);
+        Assert.True(trustedValue0 != trustedValue1);
+        Assert.True(untrustedValue0 != untrustedValue1);
+
+        // Uses override with object
+        // Comparison with string should work
+        Assert.True(trustedValue0.Equals(stringValue0));
+        // Comparison with int should not work
+        Assert.False(trustedValue0.Equals(someObj));
+
+        // Uses the implicit conversion
+        Assert.True(trustedValue0 == stringValue0);
+        Assert.True(stringValue0 == trustedValue0);
+
+        Assert.Equal(trustedValue0.GetHashCode(), trustedValue0Copy.GetHashCode());
+        Assert.NotEqual(trustedValue0.GetHashCode(), untrustedValue0.GetHashCode());
+        Assert.NotEqual(trustedValue0.GetHashCode(), trustedValue1.GetHashCode());
+    }
+
+    [Fact]
+    public void EqualsWithNullsSucceeds()
+    {
+        // Arrange
+        TrustAwareString? null1 = null;
+        TrustAwareString? null2 = null;
+        TrustAwareString value = new("value");
+
+        // Act and assert
+#pragma warning disable CA1508 // Avoid dead conditional code
+        Assert.True(null1 == null2);
+        Assert.False(null1 != null2);
+        Assert.False(value.Equals(null1));
+        Assert.False(value == null1);
+        Assert.True(value != null1);
+
+        Assert.True(null1 == null);
+        Assert.False(null1 != null);
+        Assert.False(value.Equals(null));
+        Assert.False(value == null);
+        Assert.True(value != null);
+#pragma warning restore CA1508 // Avoid dead conditional code
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Security/TrustServiceTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Security/TrustServiceTests.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
+using Microsoft.SemanticKernel.SemanticFunctions;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Security;
+
+/// <summary>
+/// Unit tests of <see cref="TrustService"/>.
+/// </summary>
+public sealed class TrustServiceTests
+{
+    [Fact]
+    public async Task SemanticSensitiveFunctionShouldNotFailWithTrustedInputAsync()
+    {
+        // Arrange
+        ITrustService trustService = TrustService.DefaultTrusted;
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object)
+            .WithTrustService(trustService).Build();
+        var aiService = MockAIService();
+        var context = new ContextVariables("my input");
+
+        factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
+
+        var func = kernel.CreateSemanticFunction(
+            "Tell me a joke",
+            functionName: "joker",
+            skillName: "jk",
+            description: "Nice fun",
+            isSensitive: true
+        );
+
+        // Act
+        var result = await kernel.RunAsync(context, func);
+
+        // Assert
+        Assert.Empty(result.LastErrorDescription);
+        Assert.False(result.ErrorOccurred);
+        Assert.Null(result.LastException);
+    }
+
+    [Fact]
+    public async Task SemanticSensitiveFunctionShouldFailWithUntrustedInputAsync()
+    {
+        // Arrange
+        ITrustService trustService = TrustService.DefaultTrusted;
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object)
+            .WithTrustService(trustService).Build();
+        var aiService = MockAIService();
+        // The input here is set as untrusted
+        var context = new ContextVariables(TrustAwareString.Untrusted("my input"));
+
+        factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
+
+        var func = kernel.CreateSemanticFunction(
+            "Tell me a joke",
+            functionName: "joker",
+            skillName: "jk",
+            description: "Nice fun",
+            isSensitive: true
+        );
+
+        // Act
+        var result = await kernel.RunAsync(context, func);
+
+        // Assert
+        // We expect the UntrustedContentException to be thrown using the TrustService.DefaultTrusted
+        Assert.True(result.ErrorOccurred);
+        Assert.IsType<UntrustedContentException>(result.LastException);
+        Assert.Equal(
+            UntrustedContentException.ErrorCodes.SensitiveFunctionWithUntrustedContent,
+            ((UntrustedContentException)result.LastException).ErrorCode
+        );
+    }
+
+    [Fact]
+    public async Task SemanticSensitiveFunctionWithDefaultUntrustedFlagAsync()
+    {
+        // Arrange
+        // Here we are forcing the output of the function to always be untrusted with
+        // defaultTrusted = false
+        ITrustService trustService = TrustService.DefaultUntrusted;
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object)
+            .WithTrustService(trustService).Build();
+        var aiService = MockAIService();
+        var context = new ContextVariables("my input");
+
+        factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
+
+        var func = kernel.CreateSemanticFunction(
+            "Tell me a joke",
+            functionName: "joker",
+            skillName: "jk",
+            description: "Nice fun",
+            isSensitive: true
+        );
+
+        // Act
+        var result = await kernel.RunAsync(context, func);
+
+        // Assert
+        Assert.Null(result.LastException);
+        Assert.Empty(result.LastErrorDescription);
+        Assert.False(result.ErrorOccurred);
+        // The output of the function is expected to be untrusted
+        // but in this case no exception was thrown (the output was not used
+        // by a sensitive function yet)
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task SemanticSensitiveFunctionShouldFailWithUntrustedTemplateRenderAsync()
+    {
+        // Arrange
+        var trustService = TrustService.DefaultTrusted;
+        var promptTemplateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var promptTemplate = new Mock<IPromptTemplate>();
+
+        // Mock this to make the context untrusted when the template is rendered
+        promptTemplate.Setup(x => x.RenderAsync(It.IsAny<SKContext>()))
+            .Callback<SKContext>(ctx => ctx.Variables.Update(TrustAwareString.Untrusted("some untrusted content")))
+            .ReturnsAsync("unsafe prompt");
+
+        promptTemplate
+            .Setup(x => x.GetParameters())
+            .Returns(new List<ParameterView>());
+
+        var functionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate.Object);
+        var func = SKFunction.FromSemanticConfig(
+            "exampleSkill",
+            "exampleFunction",
+            functionConfig,
+            trustService
+        );
+        var aiService = new Mock<ITextCompletion>();
+
+        func.SetAIService(() => aiService.Object);
+
+        // Act
+        var result = await func.InvokeAsync();
+
+        // Assert
+        // Since the context was tagged an untrusted, the DefaultTrustHandler should throw
+        Assert.True(result.ErrorOccurred);
+        Assert.IsType<UntrustedContentException>(result.LastException);
+        Assert.Equal(
+            UntrustedContentException.ErrorCodes.SensitiveFunctionWithUntrustedContent,
+            ((UntrustedContentException)result.LastException).ErrorCode
+        );
+    }
+
+    [Fact]
+    public async Task NativeSensitiveFunctionShouldNotFailWithTrustedInputAsync()
+    {
+        // Arrange
+        ITrustService trustService = TrustService.DefaultTrusted;
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object)
+            .WithTrustService(trustService).Build();
+        var aiService = MockAIService();
+        var context = new ContextVariables("my input");
+
+        factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
+
+        var func = kernel.ImportSkill(new MySkill(), nameof(MySkill))["Function1"];
+
+        // Act
+        var result = await kernel.RunAsync(context, func);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+    }
+
+    [Fact]
+    public async Task NativeSensitiveFunctionShouldFailWithUntrustedInputAsync()
+    {
+        // Arrange
+        ITrustService trustService = TrustService.DefaultTrusted;
+        var factory = new Mock<Func<(ILogger, KernelConfig), ITextCompletion>>();
+        var kernel = Kernel.Builder
+            .WithAIService<ITextCompletion>("x", factory.Object)
+            .WithTrustService(trustService).Build();
+        var aiService = MockAIService();
+        // Here the input is untrusted
+        var context = new ContextVariables(TrustAwareString.Untrusted("my input"));
+
+        factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
+
+        var func = kernel.ImportSkill(new MySkill(), nameof(MySkill))["Function1"];
+
+        // Act
+        var result = await kernel.RunAsync(context, func);
+
+        // Assert
+        // We expect the TrustService.DefaultTrusted to throw because the context became untrusted
+        Assert.True(result.ErrorOccurred);
+        Assert.IsType<UntrustedContentException>(result.LastException);
+        Assert.Equal(
+            UntrustedContentException.ErrorCodes.SensitiveFunctionWithUntrustedContent,
+            ((UntrustedContentException)result.LastException).ErrorCode
+        );
+    }
+
+    private sealed class MySkill
+    {
+        [SKFunction("Function1", isSensitive: true)]
+        public void Function1()
+        {
+        }
+    }
+
+    private static Mock<ITextCompletion> MockAIService()
+    {
+        var aiService = new Mock<ITextCompletion>();
+        var textCompletionResult = new Mock<ITextCompletionResult>();
+
+        textCompletionResult
+            .Setup(x => x.GetCompletionAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("some string");
+
+        aiService
+            .Setup(x => x.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<CompleteRequestSettings>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ITextCompletionResult> { textCompletionResult.Object });
+
+        return aiService;
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKContextTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKContextTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Moq;
 using Xunit;
@@ -85,74 +84,20 @@ public class SKContextTests
     }
 
     [Fact]
-    public void UpdateResultWithUntrustedContentMakesTheContextUntrusted()
+    public void ItCanUntrustResult()
     {
         // Arrange
-        string newResult = Guid.NewGuid().ToString();
-        string someOtherResult = Guid.NewGuid().ToString();
         var variables = new ContextVariables();
         var target = new SKContext(variables);
 
         // Assert
-        Assert.Empty(target.Result);
         Assert.True(target.IsTrusted);
         AssertIsInputTrusted(target.Variables, true);
 
         // Act
-        // Update with new result as untrusted
-        target.UpdateResult(newResult, false);
+        target.UntrustResult();
 
         // Assert
-        Assert.Equal(newResult, target.Result);
-        Assert.False(target.IsTrusted);
-        AssertIsInputTrusted(target.Variables, false);
-    }
-
-    [Fact]
-    public void UpdateResultInAlreadyUntrustedContextKeepsTheContextUntrusted()
-    {
-        // Arrange
-        string originalResult = Guid.NewGuid().ToString();
-        string newResult = Guid.NewGuid().ToString();
-        var variables = new ContextVariables(TrustAwareString.Untrusted(originalResult));
-        var target = new SKContext(variables);
-
-        // Assert
-        Assert.Equal(originalResult, target.Result);
-        Assert.False(target.IsTrusted);
-        AssertIsInputTrusted(target.Variables, false);
-
-        // Act
-        // Update with new result as trusted, although
-        // the context should be kept untrusted because of the previous result
-        target.UpdateResult(newResult, true);
-
-        // Assert
-        Assert.Equal(newResult, target.Result);
-        // Should be kept false because the previous result it already false
-        Assert.False(target.IsTrusted);
-        AssertIsInputTrusted(target.Variables, false);
-    }
-
-    [Fact]
-    public void UpdateResultWithNullContentKeepsPreviousResult()
-    {
-        // Arrange
-        string originalResult = Guid.NewGuid().ToString();
-        var variables = new ContextVariables(TrustAwareString.Trusted(originalResult));
-        var target = new SKContext(variables);
-
-        // Assert
-        Assert.Equal(originalResult, target.Result);
-        Assert.True(target.IsTrusted);
-        AssertIsInputTrusted(target.Variables, true);
-
-        // Act
-        // Update with null result should keep previous value
-        target.UpdateResult(null, false);
-
-        // Assert
-        Assert.Equal(originalResult, target.Result);
         Assert.False(target.IsTrusted);
         AssertIsInputTrusted(target.Variables, false);
     }

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests1.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Orchestration;
@@ -107,7 +108,7 @@ public sealed class SKFunctionTests1
         // Arrange
         var templateConfig = new PromptTemplateConfig();
         var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
-        var trustService = new CustomTrustService();
+        var trustService = new CustomTrustService(false, false);
 
         // Act
         var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig, trustService: trustService);
@@ -117,16 +118,143 @@ public sealed class SKFunctionTests1
         Assert.Equal(trustService, skFunction.TrustServiceInstance);
     }
 
+    [Fact]
+    public async Task SemanticFunctionWithValidateContextFalseShouldTagResultAsUntrusted()
+    {
+        // Arrange
+        var expectedResultString = "some result";
+        var trustService = new CustomTrustService(false, true);
+        var promptTemplateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var promptTemplate = MockPromptTemplate();
+        var functionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate.Object);
+        var func = SKFunction.FromSemanticConfig(
+            "exampleSkill",
+            "exampleFunction",
+            functionConfig,
+            trustService
+        );
+        var aiService = MockAIService(expectedResultString);
+
+        func.SetAIService(() => aiService.Object);
+
+        // Act
+        var result = await func.InvokeAsync();
+
+        // Assert
+        // Since CustomTrustService will return false for ValidateContext, the result should be tagged as untrusted
+        Assert.Equal(expectedResultString, result.Result);
+        Assert.False(result.Variables.Input.IsTrusted);
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task SemanticFunctionWithValidatePromptFalseShouldTagResultAsUntrusted()
+    {
+        // Arrange
+        var expectedResultString = "some result";
+        var trustService = new CustomTrustService(true, false);
+        var promptTemplateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var promptTemplate = MockPromptTemplate();
+        var functionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate.Object);
+        var func = SKFunction.FromSemanticConfig(
+            "exampleSkill",
+            "exampleFunction",
+            functionConfig,
+            trustService
+        );
+        var aiService = MockAIService(expectedResultString);
+
+        func.SetAIService(() => aiService.Object);
+
+        // Act
+        var result = await func.InvokeAsync();
+
+        // Assert
+        // Since CustomTrustService will return false for ValidatePrompt, the result should be tagged as untrusted
+        Assert.Equal(expectedResultString, result.Result);
+        Assert.False(result.Variables.Input.IsTrusted);
+        Assert.False(result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task SemanticFunctionWithValidateContentAndPromptTrueShouldKeepResultTrusted()
+    {
+        // Arrange
+        var expectedResultString = "some result";
+        var trustService = new CustomTrustService(true, true);
+        var promptTemplateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var promptTemplate = MockPromptTemplate();
+        var functionConfig = new SemanticFunctionConfig(promptTemplateConfig, promptTemplate.Object);
+        var func = SKFunction.FromSemanticConfig(
+            "exampleSkill",
+            "exampleFunction",
+            functionConfig,
+            trustService
+        );
+        var aiService = MockAIService(expectedResultString);
+
+        func.SetAIService(() => aiService.Object);
+
+        // Act
+        var result = await func.InvokeAsync();
+
+        // Assert
+        // Since CustomTrustService will return true for ValidateContext/ValidatePrompt,
+        // the result should be kept trusted
+        Assert.Equal(expectedResultString, result.Result);
+        Assert.True(result.Variables.Input.IsTrusted);
+        Assert.True(result.IsTrusted);
+    }
+
+    private static Mock<IPromptTemplate> MockPromptTemplate()
+    {
+        var promptTemplate = new Mock<IPromptTemplate>();
+
+        promptTemplate.Setup(x => x.RenderAsync(It.IsAny<SKContext>()))
+            .ReturnsAsync("some prompt");
+
+        promptTemplate
+            .Setup(x => x.GetParameters())
+            .Returns(new List<ParameterView>()); ;
+
+        return promptTemplate;
+    }
+
+    private static Mock<ITextCompletion> MockAIService(string result)
+    {
+        var aiService = new Mock<ITextCompletion>();
+        var textCompletionResult = new Mock<ITextCompletionResult>();
+
+        textCompletionResult
+            .Setup(x => x.GetCompletionAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        aiService
+            .Setup(x => x.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<CompleteRequestSettings>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ITextCompletionResult> { textCompletionResult.Object });
+
+        return aiService;
+    }
+
     private sealed class CustomTrustService : ITrustService
     {
+        private bool _validateContextResult;
+        private bool _validatePromptResult;
+
+        public CustomTrustService(bool validateContextResult, bool validatePromptResult)
+        {
+            this._validateContextResult = validateContextResult;
+            this._validatePromptResult = validatePromptResult;
+        }
+
         public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
         {
-            return Task.FromResult(context.IsTrusted);
+            return Task.FromResult(this._validateContextResult);
         }
 
         public Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt)
         {
-            return Task.FromResult(new TrustAwareString(prompt, context.IsTrusted));
+            return Task.FromResult(new TrustAwareString(prompt, this._validatePromptResult));
         }
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests1.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Moq;
@@ -34,6 +36,21 @@ public sealed class SKFunctionTests1
         // Assert
         Assert.Equal(0, skFunction.RequestSettings.Temperature);
         Assert.Equal(256, skFunction.RequestSettings.MaxTokens);
+    }
+
+    [Fact]
+    public void ItHasDefaultTrustSettings()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig();
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+
+        // Act
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig);
+
+        // Assert
+        Assert.False(skFunction.IsSensitive);
+        Assert.IsType<TrustService>(skFunction.TrustServiceInstance);
     }
 
     [Fact]
@@ -69,5 +86,47 @@ public sealed class SKFunctionTests1
         // Assert
         Assert.Equal(settings.Temperature, skFunction.RequestSettings.Temperature);
         Assert.Equal(settings.MaxTokens, skFunction.RequestSettings.MaxTokens);
+    }
+
+    [Fact]
+    public void ItAllowsFunctionToBeSensitive()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig);
+
+        // Assert
+        Assert.True(functionConfig.PromptTemplateConfig.IsSensitive);
+        Assert.True(skFunction.IsSensitive);
+    }
+
+    [Fact]
+    public void ItCanSetCustomTrustService()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig();
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+        var trustService = new CustomTrustService();
+
+        // Act
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig, trustService: trustService);
+
+        // Assert
+        Assert.IsType<CustomTrustService>(skFunction.TrustServiceInstance);
+        Assert.Equal(trustService, skFunction.TrustServiceInstance);
+    }
+
+    private sealed class CustomTrustService : ITrustService
+    {
+        public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
+        {
+            return Task.FromResult(context.IsTrusted);
+        }
+
+        public Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt)
+        {
+            return Task.FromResult(new TrustAwareString(prompt, context.IsTrusted));
+        }
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
@@ -1,0 +1,1220 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
+using Microsoft.SemanticKernel.SemanticFunctions;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.SkillDefinition;
+
+public class SKFunctionTests4
+{
+    private readonly Mock<ILogger> _log;
+    private readonly Mock<IReadOnlySkillCollection> _skills;
+    private readonly Mock<IPromptTemplate> _promptTemplate;
+    private static string s_expected = string.Empty;
+    private static string s_actual = string.Empty;
+
+    public SKFunctionTests4()
+    {
+        this._promptTemplate = new Mock<IPromptTemplate>();
+        this._promptTemplate.Setup(x => x.RenderAsync(It.IsAny<SKContext>())).ReturnsAsync("foo");
+        this._promptTemplate.Setup(x => x.GetParameters()).Returns(new List<ParameterView>());
+
+        this._log = new Mock<ILogger>();
+        this._skills = new Mock<IReadOnlySkillCollection>();
+
+        s_expected = Guid.NewGuid().ToString("D");
+    }
+
+    [Fact]
+    public void ItHasDefaultTrustSettings()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig();
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+
+        // Act
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig);
+
+        // Assert
+        Assert.False(skFunction.IsSensitive);
+        Assert.IsType<TrustService>(skFunction.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItHasDefaultTrustSettings2()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static void Test()
+        {
+        }
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+
+        // Assert
+        Assert.NotNull(function);
+        Assert.False(function.IsSensitive);
+        Assert.IsType<TrustService>(function.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItSetsTrustSettings()
+    {
+        // Arrange
+        [SKFunction("Test", isSensitive: true)]
+        [SKFunctionName("Test")]
+        static void Test()
+        {
+        }
+
+        var trustService = new CustomTrustService();
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object, trustService: trustService);
+
+        // Assert
+        Assert.NotNull(function);
+        Assert.True(function.IsSensitive);
+        Assert.IsType<CustomTrustService>(function.TrustServiceInstance);
+        Assert.Equal(trustService, function.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItSetsTrustSettings2()
+    {
+        // Arrange
+        var context = Kernel.Builder.Build().CreateNewContext();
+
+        async Task<SKContext> ExecuteAsync(SKContext contextIn)
+        {
+            await Task.Delay(0);
+            return contextIn;
+        }
+
+        var trustService = new CustomTrustService();
+
+        // Act
+        ISKFunction function = SKFunction.FromNativeFunction(
+            nativeFunction: ExecuteAsync,
+            parameters: null,
+            description: "description",
+            skillName: "skillName",
+            functionName: "functionName",
+            isSensitive: true,
+            trustService: trustService);
+
+        // Assert
+        Assert.NotNull(function);
+        Assert.True(function.IsSensitive);
+        Assert.IsType<CustomTrustService>(function.TrustServiceInstance);
+        Assert.Equal(trustService, function.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItAllowsFunctionToBeSensitive()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig { IsSensitive = true };
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig);
+
+        // Assert
+        Assert.True(functionConfig.PromptTemplateConfig.IsSensitive);
+        Assert.True(skFunction.IsSensitive);
+    }
+
+    [Fact]
+    public void ItCanSetCustomTrustService()
+    {
+        // Arrange
+        var templateConfig = new PromptTemplateConfig();
+        var functionConfig = new SemanticFunctionConfig(templateConfig, this._promptTemplate.Object);
+        var trustService = new CustomTrustService();
+
+        // Act
+        var skFunction = SKFunction.FromSemanticConfig("sk", "name", functionConfig, trustService: trustService);
+
+        // Assert
+        Assert.IsType<CustomTrustService>(skFunction.TrustServiceInstance);
+        Assert.Equal(trustService, skFunction.TrustServiceInstance);
+    }
+
+    [Fact]
+    public void ItCanImportNativeFunctionsWithTrustService()
+    {
+        // Arrange
+        var context = Kernel.Builder.Build().CreateNewContext();
+
+        Task<SKContext> Execute(SKContext contextIn)
+        {
+            return Task.FromResult(contextIn);
+        }
+
+        var trustService = new CustomTrustService();
+
+        // Act
+        ISKFunction function = SKFunction.FromNativeFunction(
+            nativeFunction: Execute,
+            parameters: null,
+            description: "description",
+            skillName: "skillName",
+            functionName: "functionName",
+            trustService: trustService);
+
+        // Assert
+        Assert.IsType<CustomTrustService>(function.TrustServiceInstance);
+        Assert.Equal(trustService, function.TrustServiceInstance);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType1Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static void Test()
+        {
+            s_actual = s_expected;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType2Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static string Test()
+        {
+            s_actual = s_expected;
+            return s_expected;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, result.Result);
+        Assert.Equal(s_expected, context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType3Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task<string> Test()
+        {
+            s_actual = s_expected;
+            return Task.FromResult(s_expected);
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context.Result);
+        Assert.Equal(s_expected, result.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType4Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static void Test(SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+        }
+
+        var context = this.MockContext("xy", isTrusted);
+        context["someVar"] = "qz";
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType4Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static void Test(SKContext cx)
+        {
+            s_actual = s_expected;
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted(cx.Variables.Input));
+            cx["canary"] = s_expected;
+        }
+
+        var context = this.MockContext("xy");
+        context["someVar"] = "qz";
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType5Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static string Test(SKContext cx)
+        {
+            s_actual = cx["someVar"];
+            return "abc";
+        }
+
+        var context = this.MockContext("", isTrusted);
+        context["someVar"] = s_expected;
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal("abc", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType5Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static string Test(SKContext cx)
+        {
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted("some value"));
+            s_actual = cx["someVar"];
+            return "abc";
+        }
+
+        var context = this.MockContext("");
+        context["someVar"] = s_expected;
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal("abc", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType5NullableAsync(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        string? Test(SKContext cx)
+        {
+            s_actual = cx["someVar"];
+            return "abc";
+        }
+
+        var context = this.MockContext("", isTrusted);
+        context["someVar"] = s_expected;
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal("abc", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType6Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        Task<string> Test(SKContext cx)
+        {
+            s_actual = s_expected;
+            cx.Variables["canary"] = s_expected;
+            return Task.FromResult(s_expected);
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_actual, context.Result);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType6Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        Task<string> Test(SKContext cx)
+        {
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted(cx.Variables.Input));
+            s_actual = s_expected;
+            cx.Variables["canary"] = s_expected;
+            return Task.FromResult(s_expected);
+        }
+
+        var context = this.MockContext("");
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_actual, context.Result);
+        Assert.Equal(s_expected, context["canary"]);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType7Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        Task<SKContext> Test(SKContext cx)
+        {
+            s_actual = s_expected;
+            cx.Variables.Update("foo");
+            cx["canary"] = s_expected;
+            return Task.FromResult(cx);
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("foo", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType7Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        Task<SKContext> Test(SKContext cx)
+        {
+            s_actual = s_expected;
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted("foo"));
+            cx["canary"] = s_expected;
+            return Task.FromResult(cx);
+        }
+
+        var context = this.MockContext("");
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("foo", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsAsyncType7Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        async Task<SKContext> TestAsync(SKContext cx)
+        {
+            await Task.Delay(0);
+            s_actual = s_expected;
+            cx.Variables.Update("foo");
+            cx["canary"] = s_expected;
+            return cx;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("foo", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType8Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        void Test(string input)
+        {
+            s_actual = s_expected + input;
+        }
+
+        var context = this.MockContext(".blah", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected + ".blah", s_actual);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType9Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        string Test(string input)
+        {
+            s_actual = s_expected;
+            return "foo-bar";
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal("foo-bar", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType10Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        Task<string> Test(string input)
+        {
+            s_actual = s_expected;
+            return Task.FromResult("hello there");
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal("hello there", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType11Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        void Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx.Variables.Update("x y z");
+            cx["canary"] = s_expected;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("x y z", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType11Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        void Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx.Variables.Update("x y z");
+            cx["canary"] = s_expected;
+            // Make all variables untrusted
+            cx.UntrustAll();
+        }
+
+        var context = this.MockContext("");
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("x y z", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType12Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static string Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            cx.Variables.Update("x y z");
+            // This value should overwrite "x y z"
+            return "new data";
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("new data", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType12Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static string Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted("x y z"));
+
+            // This value should overwrite "x y z"
+            return "new data";
+        }
+
+        var context = this.MockContext("");
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("new data", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType13Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task<string> Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            cx.Variables.Update("x y z");
+            // This value should overwrite "x y z"
+            return Task.FromResult("new data");
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("new data", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType13Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task<string> Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted("x y z"));
+            // This value should overwrite "x y z"
+            return Task.FromResult("new data");
+        }
+
+        var context = this.MockContext("");
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("new data", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType14Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task<SKContext> Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            cx.Variables.Update("x y z");
+            // This value should overwrite "x y z". Contexts are merged.
+            var newCx = new SKContext(
+                new ContextVariables(input),
+                skills: new Mock<IReadOnlySkillCollection>().Object);
+            newCx.Variables.Update("new data");
+            newCx["canary2"] = "222";
+            return Task.FromResult(newCx);
+        }
+
+        var oldContext = this.MockContext("", isTrusted);
+        oldContext["legacy"] = "something";
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext newContext = await function.InvokeAsync(oldContext);
+
+        // Assert
+        Assert.False(oldContext.ErrorOccurred);
+        Assert.False(newContext.ErrorOccurred);
+
+        Assert.Equal(s_expected, s_actual);
+
+        Assert.True(oldContext.Variables.ContainsKey("canary"));
+        Assert.False(oldContext.Variables.ContainsKey("canary2"));
+
+        Assert.False(newContext.Variables.ContainsKey("canary"));
+        Assert.True(newContext.Variables.ContainsKey("canary2"));
+
+        Assert.Equal(s_expected, oldContext["canary"]);
+        Assert.Equal("222", newContext["canary2"]);
+
+        Assert.True(oldContext.Variables.ContainsKey("legacy"));
+        Assert.False(newContext.Variables.ContainsKey("legacy"));
+
+        Assert.Equal("x y z", oldContext.Result);
+        Assert.Equal("new data", newContext.Result);
+        Assert.Equal(expectedTrustResult, newContext.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType14Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task<SKContext> Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            cx.Variables.Update("x y z");
+
+            // This value should overwrite "x y z". Contexts are merged.
+            var newCx = new SKContext(
+                new ContextVariables(input),
+                skills: new Mock<IReadOnlySkillCollection>().Object);
+
+            // Setting the trust of the input to be false
+            newCx.Variables.Update(TrustAwareString.Untrusted("new data"));
+            newCx["canary2"] = "222";
+
+            return Task.FromResult(newCx);
+        }
+
+        var oldContext = this.MockContext("");
+        oldContext["legacy"] = "something";
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext newContext = await function.InvokeAsync(oldContext);
+        // Assert
+        Assert.False(oldContext.ErrorOccurred);
+        Assert.False(newContext.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.True(oldContext.Variables.ContainsKey("canary"));
+        Assert.False(oldContext.Variables.ContainsKey("canary2"));
+        Assert.False(newContext.Variables.ContainsKey("canary"));
+        Assert.True(newContext.Variables.ContainsKey("canary2"));
+        Assert.Equal(s_expected, oldContext["canary"]);
+        Assert.Equal("222", newContext["canary2"]);
+        Assert.True(oldContext.Variables.ContainsKey("legacy"));
+        Assert.False(newContext.Variables.ContainsKey("legacy"));
+
+        Assert.Equal("x y z", oldContext.Result);
+        Assert.Equal("new data", newContext.Result);
+        // Check if the trust of the input is still false
+        Assert.False(newContext.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType15Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task TestAsync(string input)
+        {
+            s_actual = s_expected;
+            return Task.CompletedTask;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType16Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task TestAsync(SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            cx.Variables.Update("x y z");
+            return Task.CompletedTask;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("x y z", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType16Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task Test(SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted("x y z"));
+            return Task.CompletedTask;
+        }
+
+        var context = this.MockContext("");
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("x y z", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType17Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task TestAsync(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            cx.Variables.Update(input + "x y z");
+            return Task.CompletedTask;
+        }
+
+        var context = this.MockContext("input:", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("input:x y z", context.Result);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItKeepsContextTrustType17Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task Test(string input, SKContext cx)
+        {
+            s_actual = s_expected;
+            cx["canary"] = s_expected;
+            // Set this variable as untrusted
+            cx.Variables.Update(TrustAwareString.Untrusted(input + "x y z"));
+            return Task.CompletedTask;
+        }
+
+        var context = this.MockContext("input:");
+
+        var trustService = TrustService.DefaultTrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(Test), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("input:x y z", context.Result);
+        // This should result in an untrusted output
+        Assert.False(result.IsTrusted);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public async Task ItSupportsType18Async(bool isTrusted, bool defaultTrusted, bool expectedTrustResult)
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        static Task TestAsync()
+        {
+            s_actual = s_expected;
+            return Task.CompletedTask;
+        }
+
+        var context = this.MockContext("", isTrusted);
+
+        var trustService = defaultTrusted ? TrustService.DefaultTrusted : TrustService.DefaultUntrusted;
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), trustService: trustService, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(expectedTrustResult, result.IsTrusted);
+    }
+
+    private static MethodInfo Method(Delegate method)
+    {
+        return method.Method;
+    }
+
+    private SKContext MockContext(string input, bool isTrusted = true)
+    {
+        return new SKContext(
+            new ContextVariables(new TrustAwareString(input, isTrusted)),
+            skills: this._skills.Object,
+            logger: this._log.Object);
+    }
+
+    private sealed class CustomTrustService : ITrustService
+    {
+        public Task<bool> ValidateContextAsync(ISKFunction func, SKContext context)
+        {
+            return Task.FromResult(context.IsTrusted);
+        }
+
+        public Task<TrustAwareString> ValidatePromptAsync(ISKFunction func, SKContext context, string prompt)
+        {
+            return Task.FromResult(new TrustAwareString(prompt, context.IsTrusted));
+        }
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.TemplateEngine;
 using Microsoft.SemanticKernel.TemplateEngine.Blocks;
@@ -296,5 +297,101 @@ public class CodeBlockTests
         // Assert
         Assert.Equal(Value, result);
         Assert.Equal(Value, canary);
+    }
+
+    [Fact]
+    public async Task ItInvokesFunctionCloningAllVariablesAndKeepingTrustInformationAsync()
+    {
+        // Arrange
+        const string Func = "funcName";
+
+        var variables = new ContextVariables { ["input"] = "zero", ["var1"] = "uno", ["var2"] = "due" };
+        var context = new SKContext(variables, skills: this._skills.Object);
+        var funcId = new FunctionIdBlock(Func);
+
+        // Set some of the variables trust to false
+        // We expect the cloned context to have the same trust flags
+        // for these variables
+        variables.Set("input", TrustAwareString.Untrusted("zero"));
+        variables.Set("var2", TrustAwareString.Untrusted("due"));
+
+        TrustAwareString canary0 = TrustAwareString.Empty;
+        TrustAwareString canary1 = TrustAwareString.Empty;
+        TrustAwareString canary2 = TrustAwareString.Empty;
+        var function = new Mock<ISKFunction>();
+        function
+            .Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), It.IsAny<CompleteRequestSettings?>()))
+            .Callback<SKContext, CompleteRequestSettings?>((ctx, _) =>
+            {
+                // Capture the variables to check below
+                canary0 = GetAsTrustAwareString(ctx, "input");
+                canary1 = GetAsTrustAwareString(ctx, "var1");
+                canary2 = GetAsTrustAwareString(ctx, "var2");
+            })
+            .ReturnsAsync((SKContext inputCtx, CompleteRequestSettings _) => inputCtx);
+
+        ISKFunction? outFunc = function.Object;
+        this._skills.Setup(x => x.TryGetFunction(Func, out outFunc)).Returns(true);
+        this._skills.Setup(x => x.GetFunction(Func)).Returns(function.Object);
+
+        // Act
+        var codeBlock = new CodeBlock(new List<Block> { funcId }, "", NullLogger.Instance);
+        string result = await codeBlock.RenderCodeAsync(context);
+
+        // Assert - Values are received
+        Assert.Equal("zero", canary0.Value);
+        Assert.Equal("uno", canary1.Value);
+        Assert.Equal("due", canary2.Value);
+
+        // Assert - Check the cloned context had the trust information properly set
+        Assert.False(canary0.IsTrusted);
+        Assert.True(canary1.IsTrusted);
+        Assert.False(canary2.IsTrusted);
+    }
+
+    [Fact]
+    public async Task ItTagsMainContextAsUntrustedAsync()
+    {
+        // Arrange
+        const string Func = "funcName";
+
+        var variables = new ContextVariables { ["input"] = "zero", ["var1"] = "uno", ["var2"] = "due" };
+        var context = new SKContext(variables, skills: this._skills.Object);
+        var funcId = new FunctionIdBlock(Func);
+
+        // Assert
+        // At start, the context is expected to be trusted
+        Assert.True(context.IsTrusted);
+
+        var function = new Mock<ISKFunction>();
+        function
+            .Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), It.IsAny<CompleteRequestSettings?>()))
+            .Callback<SKContext, CompleteRequestSettings?>((ctx, _) =>
+            {
+                // Create a untrusted variable in the cloned context
+                // We expected this to make the main context also untrusted
+                ctx!.Variables.Set("untrusted key", TrustAwareString.Untrusted("unstrusted content"));
+            })
+            .ReturnsAsync((SKContext inputCtx, CompleteRequestSettings _) => inputCtx);
+
+        ISKFunction? outFunc = function.Object;
+        this._skills.Setup(x => x.TryGetFunction(Func, out outFunc)).Returns(true);
+        this._skills.Setup(x => x.GetFunction(Func)).Returns(function.Object);
+
+        // Act
+        var codeBlock = new CodeBlock(new List<Block> { funcId }, "", NullLogger.Instance);
+        string result = await codeBlock.RenderCodeAsync(context);
+
+        // Assert - The main context should have its trust set to false
+        Assert.False(context.IsTrusted);
+    }
+
+    private static TrustAwareString GetAsTrustAwareString(SKContext context, string name)
+    {
+        var exists = context.Variables.Get(name, out TrustAwareString trustAwareValue);
+
+        Assert.True(exists);
+
+        return trustAwareValue;
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/PromptTemplateEngineTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/PromptTemplateEngineTests.cs
@@ -190,7 +190,7 @@ public sealed class PromptTemplateEngineTests
         {
             // Input value should be "BAR" because the variable $myVar is passed in
             this._logger.WriteLine("MyFunction call received, input: {0}", cx.Variables.Input);
-            return Task.FromResult(cx.Variables.Input);
+            return Task.FromResult(cx.Variables.Input.Value);
         }
 
         ISKFunction? func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);

--- a/dotnet/src/SemanticKernel/KernelBuilder.cs
+++ b/dotnet/src/SemanticKernel/KernelBuilder.cs
@@ -7,6 +7,7 @@ using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Reliability;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.Services;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.TemplateEngine;
@@ -26,6 +27,7 @@ public sealed class KernelBuilder
     private IDelegatingHandlerFactory? _httpHandlerFactory = null;
     private IPromptTemplateEngine? _promptTemplateEngine;
     private readonly AIServiceCollection _aiServices = new();
+    private ITrustService? _trustService = null;
 
     /// <summary>
     /// Create a new kernel instance
@@ -54,7 +56,8 @@ public sealed class KernelBuilder
             this._promptTemplateEngine ?? new PromptTemplateEngine(this._logger),
             this._memory,
             this._config,
-            this._logger
+            this._logger,
+            this._trustService
         );
 
         // TODO: decouple this from 'UseMemory' kernel extension
@@ -150,6 +153,19 @@ public sealed class KernelBuilder
     {
         Verify.NotNull(config);
         this._config = config;
+        return this;
+    }
+
+    /// <summary>
+    /// Use the given default trust service with the kernel to be built.
+    /// Functions directly created through the kernel will use this trust service.
+    /// If null, the created functions will rely on the TrustService.DefaultTrusted implementation.
+    /// </summary>
+    /// <param name="trustService">Trust service to use.</param>
+    /// <returns>Updated kernel builder including the given service.</returns>
+    public KernelBuilder WithTrustService(ITrustService? trustService)
+    {
+        this._trustService = trustService;
         return this;
     }
 

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace Microsoft.SemanticKernel.Planning;
@@ -79,6 +80,14 @@ public sealed class Plan : ISKFunction
     /// <inheritdoc/>
     [JsonIgnore]
     public bool IsSemantic { get; private set; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public bool IsSensitive { get; private set; } = false;
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public ITrustService TrustServiceInstance { get; private set; } = TrustService.DefaultTrusted;
 
     /// <inheritdoc/>
     [JsonIgnore]
@@ -267,14 +276,14 @@ public sealed class Plan : ISKFunction
             // Update Plan Result in State with matching outputs (if any)
             if (this.Outputs.Intersect(step.Outputs).Any())
             {
-                this.State.Get(DefaultResultKey, out var currentPlanResult);
+                this.State.Get(DefaultResultKey, out string currentPlanResult);
                 this.State.Set(DefaultResultKey, string.Join("\n", currentPlanResult.Trim(), resultValue));
             }
 
             // Update state with outputs (if any)
             foreach (var item in step.Outputs)
             {
-                if (result.Variables.Get(item, out var val))
+                if (result.Variables.Get(item, out string val))
                 {
                     this.State.Set(item, val);
                 }
@@ -397,7 +406,7 @@ public sealed class Plan : ISKFunction
 
         foreach (var varName in orderedMatches)
         {
-            result = variables.Get(varName, out var value)
+            result = variables.Get(varName, out string value)
                 ? result.Replace($"${varName}", value)
                 : this.State.Get(varName, out value)
                     ? result.Replace($"${varName}", value)
@@ -462,13 +471,13 @@ public sealed class Plan : ISKFunction
     /// <returns>The updated context.</returns>
     private SKContext UpdateContextWithOutputs(SKContext context)
     {
-        var resultString = this.State.Get(DefaultResultKey, out var result) ? result : this.State.ToString();
+        var resultString = this.State.Get(DefaultResultKey, out string result) ? result : this.State.ToString();
         context.Variables.Update(resultString);
 
         // copy previous step's variables to the next step
         foreach (var item in this._steps[this.NextStepIndex - 1].Outputs)
         {
-            if (this.State.Get(item, out var val))
+            if (this.State.Get(item, out string val))
             {
                 context.Variables.Set(item, val);
             }
@@ -531,7 +540,7 @@ public sealed class Plan : ISKFunction
                 continue;
             }
 
-            if (variables.Get(param.Name, out var value))
+            if (variables.Get(param.Name, out string value))
             {
                 stepVariables.Set(param.Name, value);
             }
@@ -544,7 +553,7 @@ public sealed class Plan : ISKFunction
         foreach (var item in step.Parameters)
         {
             // Don't overwrite variable values that are already set
-            if (stepVariables.Get(item.Key, out _))
+            if (stepVariables.Get(item.Key, out string _))
             {
                 continue;
             }
@@ -554,7 +563,7 @@ public sealed class Plan : ISKFunction
             {
                 stepVariables.Set(item.Key, expandedValue);
             }
-            else if (variables.Get(item.Key, out var value))
+            else if (variables.Get(item.Key, out string value))
             {
                 stepVariables.Set(item.Key, value);
             }
@@ -578,6 +587,8 @@ public sealed class Plan : ISKFunction
         this.SkillName = function.SkillName;
         this.Description = function.Description;
         this.IsSemantic = function.IsSemantic;
+        this.IsSensitive = function.IsSensitive;
+        this.TrustServiceInstance = function.TrustServiceInstance;
         this.RequestSettings = function.RequestSettings;
     }
 

--- a/dotnet/src/SemanticKernel/Services/AIServiceCollection.cs
+++ b/dotnet/src/SemanticKernel/Services/AIServiceCollection.cs
@@ -86,7 +86,7 @@ public class AIServiceCollection
 
         // Register the factory with the given name
         namedServices[name ?? DefaultKey] = objectFactory
-            ?? throw new InvalidOperationException("Service factory is an invalid format");
+                                            ?? throw new InvalidOperationException("Service factory is an invalid format");
     }
 
     /// <summary>
@@ -112,5 +112,5 @@ public class AIServiceCollection
 
     private bool HasDefault<T>() where T : IAIService
         => this._defaultIds.TryGetValue(typeof(T), out var defaultName)
-            && !string.IsNullOrEmpty(defaultName);
+           && !string.IsNullOrEmpty(defaultName);
 }

--- a/dotnet/src/SemanticKernel/Services/AIServiceProvider.cs
+++ b/dotnet/src/SemanticKernel/Services/AIServiceProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.SemanticKernel.Services;
+
 public class AIServiceProvider : NamedServiceProvider<IAIService>, IAIServiceProvider
 {
     public AIServiceProvider(Dictionary<Type, Dictionary<string, Func<object>>> services, Dictionary<Type, string> defaultIds)

--- a/dotnet/src/SemanticKernel/Services/NamedServiceProvider.cs
+++ b/dotnet/src/SemanticKernel/Services/NamedServiceProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.SemanticKernel.Services;
+
 public class NamedServiceProvider<TService> : INamedServiceProvider<TService>
 {
     // A dictionary that maps a service type to a nested dictionary of names and service instances or factories

--- a/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 
@@ -32,6 +33,8 @@ public static class InlineFunctionsDefinitionExtension
     /// <param name="topP">Top P parameter passed to LLM</param>
     /// <param name="presencePenalty">Presence Penalty parameter passed to LLM</param>
     /// <param name="frequencyPenalty">Frequency Penalty parameter passed to LLM</param>
+    /// <param name="isSensitive">Whether the function is set to be sensitive or not (default false)</param>
+    /// <param name="trustService">Service used for trust checks (if null will use the default registered in the kernel)</param>
     /// <param name="stopSequences">Strings the LLM will detect to stop generating (before reaching max tokens)</param>
     /// <returns>A function ready to use</returns>
     public static ISKFunction CreateSemanticFunction(
@@ -45,6 +48,8 @@ public static class InlineFunctionsDefinitionExtension
         double topP = 0,
         double presencePenalty = 0,
         double frequencyPenalty = 0,
+        bool isSensitive = false,
+        ITrustService? trustService = null,
         IEnumerable<string>? stopSequences = null)
     {
         functionName ??= RandomFunctionName();
@@ -53,6 +58,7 @@ public static class InlineFunctionsDefinitionExtension
         {
             Description = description ?? "Generic function, unknown purpose",
             Type = "completion",
+            IsSensitive = isSensitive,
             Completion = new PromptTemplateConfig.CompletionConfig
             {
                 Temperature = temperature,
@@ -68,7 +74,8 @@ public static class InlineFunctionsDefinitionExtension
             promptTemplate: promptTemplate,
             config: config,
             functionName: functionName,
-            skillName: skillName);
+            skillName: skillName,
+            trustService: trustService);
     }
 
     /// <summary>
@@ -80,13 +87,15 @@ public static class InlineFunctionsDefinitionExtension
     /// <param name="functionName">A name for the given function. The name can be referenced in templates and used by the pipeline planner.</param>
     /// <param name="skillName">An optional skill name, e.g. to namespace functions with the same name. When empty,
     /// the function is added to the global namespace, overwriting functions with the same name</param>
+    /// <param name="trustService">Service used for trust checks (if null will use the default registered in the kernel)</param>
     /// <returns>A function ready to use</returns>
     public static ISKFunction CreateSemanticFunction(
         this IKernel kernel,
         string promptTemplate,
         PromptTemplateConfig config,
         string? functionName = null,
-        string skillName = "")
+        string skillName = "",
+        ITrustService? trustService = null)
     {
         functionName ??= RandomFunctionName();
         Verify.ValidFunctionName(functionName);
@@ -99,8 +108,8 @@ public static class InlineFunctionsDefinitionExtension
 
         // TODO: manage overwrites, potentially error out
         return string.IsNullOrEmpty(skillName)
-            ? kernel.RegisterSemanticFunction(functionName, functionConfig)
-            : kernel.RegisterSemanticFunction(skillName, functionName, functionConfig);
+            ? kernel.RegisterSemanticFunction(functionName, functionConfig, trustService)
+            : kernel.RegisterSemanticFunction(skillName, functionName, functionConfig, trustService);
     }
 
     private static string RandomFunctionName() => "func" + Guid.NewGuid().ToString("N");

--- a/dotnet/src/SemanticKernel/TemplateEngine/Blocks/CodeBlock.cs
+++ b/dotnet/src/SemanticKernel/TemplateEngine/Blocks/CodeBlock.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Security;
 using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace Microsoft.SemanticKernel.TemplateEngine.Blocks;
@@ -122,7 +123,8 @@ internal sealed class CodeBlock : Block, ICodeRendering
             // TODO: PII
             this.Log.LogTrace("Passing variable/value: `{0}`", this._tokens[1].Content);
             string input = ((ITextRendering)this._tokens[1]).Render(contextClone.Variables);
-            contextClone.Variables.Update(input);
+            // Keep previous trust information when updating the input
+            contextClone.Variables.Update(new TrustAwareString(input, contextClone.Variables.IsAllTrusted()));
         }
 
         try
@@ -134,6 +136,19 @@ internal sealed class CodeBlock : Block, ICodeRendering
             this.Log.LogError(ex, "Something went wrong when invoking function with custom input: {0}.{1}. Error: {2}",
                 function.SkillName, function.Name, ex.Message);
             contextClone.Fail(ex.Message, ex);
+        }
+
+        // If the output of the function is not trusted, tag the main context as untrusted as well.
+        // This is important for cases where there is a function call within a prompt template and
+        // the result of the function call is untrusted. In such cases, we need to propagate the
+        // untrusted tag back to the main context.
+        // TODO: we might want to evaluate updating the template engine to rely on TrustAwareStrings that already
+        // include trust information. This way, the rendered prompt will be a TrustAwareString that already
+        // carries trust information, so this won't be needed.
+        // (e.g. concatenating strings A (trusted) and B (untrusted), will result in a string that is untrusted)
+        if (!contextClone.IsTrusted)
+        {
+            context.UntrustAll();
         }
 
         if (contextClone.ErrorOccurred)

--- a/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -145,7 +145,7 @@ public static class KernelGrpcExtensions
                 foreach (var parameter in operationParameters)
                 {
                     //A try to resolve argument parameter name.
-                    if (context.Variables.Get(parameter.Name, out var value))
+                    if (context.Variables.Get(parameter.Name, out string value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;
@@ -178,6 +178,7 @@ public static class KernelGrpcExtensions
             description: operation.Name,
             skillName: skillName,
             functionName: operation.Name,
+            isSensitive: false,
             log: kernel.Log);
 
         return kernel.RegisterCustomFunction(skillName, function);

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -273,7 +273,7 @@ public static class KernelOpenApiExtensions
                 foreach (var parameter in restOperationParameters)
                 {
                     // A try to resolve argument by alternative parameter name
-                    if (!string.IsNullOrEmpty(parameter.AlternativeName) && context.Variables.Get(parameter.AlternativeName!, out var value))
+                    if (!string.IsNullOrEmpty(parameter.AlternativeName) && context.Variables.Get(parameter.AlternativeName!, out string value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;
@@ -324,6 +324,7 @@ public static class KernelOpenApiExtensions
             description: operation.Description,
             skillName: skillName,
             functionName: operation.Id,
+            isSensitive: false,
             log: kernel.Log);
 
         return kernel.RegisterCustomFunction(skillName, function);

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/TaskListSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/TaskListSkillTests.cs
@@ -43,7 +43,7 @@ public class TaskListSkillTests
         TaskListSkill target = new(connectorMock.Object);
 
         // Verify no reminder is set
-        Assert.False(this._context.Variables.Get(Parameters.Reminder, out _));
+        Assert.False(this._context.Variables.Get(Parameters.Reminder, out string _));
 
         // Act
         await target.AddTaskAsync(anyTitle, this._context);

--- a/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
@@ -140,7 +140,7 @@ public class MarkupSkill
     [SKFunctionName("RunMarkup")]
     public async Task<SKContext> RunMarkupAsync(SKContext context)
     {
-        var docString = context.Variables.Input;
+        string docString = context.Variables.Input;
         var plan = docString.FromMarkup("Run a piece of xml markup", context);
 
         Console.WriteLine("Markup plan:");


### PR DESCRIPTION
### Motivation and Context

Prompt injection attacks can fool the LLMs into doing not intended actions. This happens when untrusted input is injected into the prompt, fooling the LLM into doing something that is not intended.

To help identifying and handling such cases, we can start by tracking the trust of: (i) input variables; (ii) prompts; and (iii) function outputs. This way, if a potential sensitive function tries to run with untrusted content of any kind, the desired action can be taken (e.g. prevent the function from running and throwing an exception).

### Description

The main idea behind this PR is to update the context to keep track of the trust state of its variables. So if the kernel identifies that an user defined sensitive function is trying to run with untrusted input, an action can be taken. Currently, the trust is defined as a boolean flag.

The main changes are:

- Update `ContextVariables` to store not only a single string, but an abstraction of a string called `TrustAwareString` that also has a boolean flag about the trust of its content
- Update the kernel to add a service for trust events. This service is currently named `TrustService`, for which there is an interface definition: `ITrustService`. The user can implement this interface and set an instance of it in the kernel and/or for a specific function. 
    - For now the interface includes two events that gets called to validate the input context and rendered prompt (semantic functions). They should return if the context/prompt is currently trusted or not. This can also be used for validation, sanitization and other tasks.
    - There is a default implementation called `DefaultTrustService` that when configured in the kernel, throws a `UntrustedContentException`
- Update semantic and native functions to include the following information:
    - `bool IsSensitive`: when set to true, configures the function to be sensitive (e.g. should not run with untrusted input) [default false]
- Implemented unit tests

The trust checks are also chained across multiple function calls. For example, imagine that we have 4 functions running like below:

```mermaid
flowchart LR
   A["Function A"] --> B["Function B"] == output becomes untrusted ==> C["Function C"]  --> D["Function D\n(SENSITIVE)"] 
```

If the `DefaultTrustService` is used, function D will not execute, this happens because its input comes from Function C, that then comes from Function B, which is untrusted.

### Further ideas (not implemented)

The idea of replacing the string usage within the Kernel with the `TrustAwareString` (that includes trust information) could be extended to other places in the kernel, making it easier to track provenance of the inputs and string operations. This has not been implemented in this PR because this would result in a bigger number of changes.

### What's currently missing

- Currently the planner has not been updated to also track trust. This can be tackled as part of another PR if desired.
- Currently, if any of the variables stored in the context is untrusted, the entire context becomes untrusted, regardless if the variable has been used or not. This has been implemented this way for now to simplify the PR, since updating the template engine to track trust through the `TrustAwareString` would result in a bigger number of changes.

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
