### PR TITLE
Fix two build warnings

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Connectors/WebApi/Rest/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Connectors/WebApi/Rest/RestApiOperationRunnerTests.cs
@@ -159,7 +159,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var messageContent = this._httpMessageHandlerStub.RequestContent;
         Assert.NotNull(messageContent);
-        Assert.True(messageContent.Any());
+        Assert.True(messageContent.Length != 0);
 
         var payloadText = System.Text.Encoding.UTF8.GetString(messageContent, 0, messageContent.Length);
         Assert.Equal("fake-input-value", payloadText);

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -94,7 +94,7 @@ internal static class SemanticKernelExtensions
         services.AddScoped<PlannerFactoryAsync>(sp => async (IKernel kernel) =>
         {
             // Create a kernel for the planner with the same contexts as the chat's kernel but with only skills we want available to the planner.
-            IKernel plannerKernel = new Kernel(new SkillCollection(), kernel.PromptTemplateEngine, kernel.Memory, kernel.Config, kernel.Log);
+            var plannerKernel = new Kernel(new SkillCollection(), kernel.PromptTemplateEngine, kernel.Memory, kernel.Config, kernel.Log);
 
             //
             // Add skills to the planner here.


### PR DESCRIPTION
### Motivation and Context

Fix two analyzer warnings issued during the build.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
