### PR TITLE
Plan,TextMemorySkill improvements and custom planner examples

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -128,7 +128,7 @@ public class SequentialPlanParserTests
 <plan>
     <function.SummarizeSkill.Summarize/>
     <function.WriterSkill.Translate language=""French"" setContextVariable=""TRANSLATED_SUMMARY""/>
-    <function.email.GetEmailAddressAsync input=""John Doe"" setContextVariable=""EMAIL_ADDRESS""/>
+    <function.email.GetEmailAddressAsync input=""John Doe"" setContextVariable=""EMAIL_ADDRESS"" appendToResult=""PLAN_RESULT""/>
     <function.email.SendEmailAsync input=""$TRANSLATED_SUMMARY"" email_address=""$EMAIL_ADDRESS""/>
 </plan>";
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -151,22 +151,22 @@ public class SequentialPlanParserTests
             {
                 Assert.Equal("WriterSkill", step.SkillName);
                 Assert.Equal("Translate", step.Name);
-                Assert.Equal("French", step.NamedParameters["language"]);
-                Assert.True(step.NamedOutputs.ContainsKey("TRANSLATED_SUMMARY"));
+                Assert.Equal("French", step.Parameters["language"]);
+                Assert.True(step.Outputs.Contains("TRANSLATED_SUMMARY"));
             },
             step =>
             {
                 Assert.Equal("email", step.SkillName);
                 Assert.Equal("GetEmailAddressAsync", step.Name);
-                Assert.Equal("John Doe", step.NamedParameters["input"]);
-                Assert.True(step.NamedOutputs.ContainsKey("EMAIL_ADDRESS"));
+                Assert.Equal("John Doe", step.Parameters["input"]);
+                Assert.True(step.Outputs.Contains("EMAIL_ADDRESS"));
             },
             step =>
             {
                 Assert.Equal("email", step.SkillName);
                 Assert.Equal("SendEmailAsync", step.Name);
-                Assert.Equal("$TRANSLATED_SUMMARY", step.NamedParameters["input"]);
-                Assert.Equal("$EMAIL_ADDRESS", step.NamedParameters["email_address"]);
+                Assert.Equal("$TRANSLATED_SUMMARY", step.Parameters["input"]);
+                Assert.Equal("$EMAIL_ADDRESS", step.Parameters["email_address"]);
             }
         );
     }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -66,25 +66,25 @@ internal static class SequentialPlanParser
             var plan = new Plan(goal);
 
             // loop through solution node and add to Steps
-            foreach (XmlNode o in solution)
+            foreach (XmlNode solutionNode in solution)
             {
-                var parentNodeName = o.Name;
+                var parentNodeName = solutionNode.Name;
 
-                foreach (XmlNode o2 in o.ChildNodes)
+                foreach (XmlNode childNode in solutionNode.ChildNodes)
                 {
-                    if (o2.Name == "#text")
+                    if (childNode.Name == "#text")
                     {
-                        if (o2.Value != null)
+                        if (childNode.Value != null)
                         {
-                            plan.AddSteps(new Plan(o2.Value.Trim()));
+                            plan.AddSteps(new Plan(childNode.Value.Trim()));
                         }
 
                         continue;
                     }
 
-                    if (o2.Name.StartsWith(FunctionTag, StringComparison.OrdinalIgnoreCase))
+                    if (childNode.Name.StartsWith(FunctionTag, StringComparison.OrdinalIgnoreCase))
                     {
-                        var skillFunctionName = o2.Name.Split(s_functionTagArray, StringSplitOptions.None)?[1] ?? string.Empty;
+                        var skillFunctionName = childNode.Name.Split(s_functionTagArray, StringSplitOptions.None)?[1] ?? string.Empty;
                         GetSkillFunctionNames(skillFunctionName, out var skillName, out var functionName);
 
                         if (!string.IsNullOrEmpty(functionName) && context.IsFunctionRegistered(skillName, functionName, out var skillFunction))
@@ -101,24 +101,24 @@ internal static class SequentialPlanParser
                                 functionVariables.Set(p.Name, p.DefaultValue);
                             }
 
-                            if (o2.Attributes is not null)
+                            if (childNode.Attributes is not null)
                             {
-                                foreach (XmlAttribute attr in o2.Attributes)
+                                foreach (XmlAttribute attr in childNode.Attributes)
                                 {
                                     context.Log.LogTrace("{0}: processing attribute {1}", parentNodeName, attr.ToString());
                                     if (attr.Name.Equals(SetContextVariableTag, StringComparison.OrdinalIgnoreCase))
                                     {
                                         functionOutputs.Add(attr.InnerText);
-                                        continue;
                                     }
                                     else if (attr.Name.Equals(AppendToResultTag, StringComparison.OrdinalIgnoreCase))
                                     {
                                         functionOutputs.Add(attr.InnerText);
                                         functionResults.Add(attr.InnerText);
-                                        continue;
                                     }
-
-                                    functionVariables.Set(attr.Name, attr.InnerText);
+                                    else
+                                    {
+                                        functionVariables.Set(attr.Name, attr.InnerText);
+                                    }
                                 }
                             }
 
@@ -135,13 +135,13 @@ internal static class SequentialPlanParser
                         else
                         {
                             context.Log.LogTrace("{0}: appending function node {1}", parentNodeName, skillFunctionName);
-                            plan.AddSteps(new Plan(o2.InnerText));
+                            plan.AddSteps(new Plan(childNode.InnerText));
                         }
 
                         continue;
                     }
 
-                    plan.AddSteps(new Plan(o2.InnerText));
+                    plan.AddSteps(new Plan(childNode.InnerText));
                 }
             }
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -92,6 +92,7 @@ internal static class SequentialPlanParser
 
                             var functionVariables = new ContextVariables();
                             var functionOutputs = new ContextVariables();
+                            var functionResults = new ContextVariables();
 
                             var view = skillFunction.Describe();
                             foreach (var p in view.Parameters)
@@ -104,11 +105,14 @@ internal static class SequentialPlanParser
                                 foreach (XmlAttribute attr in o2.Attributes)
                                 {
                                     context.Log.LogTrace("{0}: processing attribute {1}", parentNodeName, attr.ToString());
-                                    if (attr.Name.Equals(SetContextVariableTag, StringComparison.OrdinalIgnoreCase)
-                                        || attr.Name.Equals(AppendToResultTag, StringComparison.OrdinalIgnoreCase))
+                                    if (attr.Name.Equals(SetContextVariableTag, StringComparison.OrdinalIgnoreCase))
                                     {
                                         functionOutputs.Set(attr.InnerText, string.Empty);
                                         continue;
+                                    }
+                                    else if (attr.Name.Equals(AppendToResultTag, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        functionResults.Set(attr.InnerText, string.Empty);
                                     }
 
                                     functionVariables.Set(attr.Name, attr.InnerText);
@@ -118,6 +122,7 @@ internal static class SequentialPlanParser
                             // Plan properties
                             planStep.NamedOutputs = functionOutputs;
                             planStep.NamedParameters = functionVariables;
+                            planStep.NamedResults = functionResults;
                             plan.AddSteps(planStep);
                         }
                         else

--- a/dotnet/src/IntegrationTests/Planning/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/PlanTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -137,7 +138,7 @@ public sealed class PlanTests : IDisposable
         cv.Set("email_address", "$TheEmailFromState");
         var sendEmailPlan = new Plan(emailSkill["SendEmailAsync"])
         {
-            NamedParameters = cv,
+            Parameters = cv,
         };
 
         var plan = new Plan(goal);
@@ -171,7 +172,7 @@ public sealed class PlanTests : IDisposable
         cv.Set("email_address", string.Empty);
         var sendEmailPlan = new Plan(emailSkill["SendEmailAsync"])
         {
-            NamedParameters = cv,
+            Parameters = cv,
         };
 
         var plan = new Plan(goal);
@@ -206,7 +207,7 @@ public sealed class PlanTests : IDisposable
         cv.Set("email_address", "$TheEmailFromState");
         var sendEmailPlan = new Plan(emailSkill["SendEmailAsync"])
         {
-            NamedParameters = cv
+            Parameters = cv
         };
 
         var plan = new Plan(goal);
@@ -240,22 +241,26 @@ public sealed class PlanTests : IDisposable
 
         var cv = new ContextVariables();
         cv.Set("language", inputLanguage);
-        var outputs = new ContextVariables();
-        outputs.Set("TRANSLATED_SUMMARY", string.Empty);
+        var outputs = new List<string>
+        {
+            "TRANSLATED_SUMMARY"
+        };
         var translatePlan = new Plan(writerSkill["Translate"])
         {
-            NamedParameters = cv,
-            NamedOutputs = outputs,
+            Parameters = cv,
+            Outputs = outputs,
         };
 
         cv = new ContextVariables();
         cv.Update(inputName);
-        outputs = new ContextVariables();
-        outputs.Set("TheEmailFromState", string.Empty);
+        outputs = new List<string>
+        {
+            "TheEmailFromState"
+        };
         var getEmailPlan = new Plan(emailSkill["GetEmailAddressAsync"])
         {
-            NamedParameters = cv,
-            NamedOutputs = outputs,
+            Parameters = cv,
+            Outputs = outputs,
         };
 
         cv = new ContextVariables();
@@ -263,7 +268,7 @@ public sealed class PlanTests : IDisposable
         cv.Set("input", "$TRANSLATED_SUMMARY");
         var sendEmailPlan = new Plan(emailSkill["SendEmailAsync"])
         {
-            NamedParameters = cv
+            Parameters = cv
         };
 
         var plan = new Plan(goal);
@@ -309,23 +314,27 @@ public sealed class PlanTests : IDisposable
 
         var cv = new ContextVariables();
         cv.Set("language", inputLanguage);
-        var outputs = new ContextVariables();
-        outputs.Set("TRANSLATED_SUMMARY", string.Empty);
+        var outputs = new List<string>
+        {
+            "TRANSLATED_SUMMARY"
+        };
 
         var translatePlan = new Plan(writerSkill["Translate"])
         {
-            NamedParameters = cv,
-            NamedOutputs = outputs,
+            Parameters = cv,
+            Outputs = outputs,
         };
 
         cv = new ContextVariables();
         cv.Update(inputName);
-        outputs = new ContextVariables();
-        outputs.Set("TheEmailFromState", string.Empty);
+        outputs = new List<string>
+        {
+            "TheEmailFromState"
+        };
         var getEmailPlan = new Plan(emailSkill["GetEmailAddressAsync"])
         {
-            NamedParameters = cv,
-            NamedOutputs = outputs,
+            Parameters = cv,
+            Outputs = outputs,
         };
 
         cv = new ContextVariables();
@@ -333,7 +342,7 @@ public sealed class PlanTests : IDisposable
         cv.Set("input", "$TRANSLATED_SUMMARY");
         var sendEmailPlan = new Plan(emailSkill["SendEmailAsync"])
         {
-            NamedParameters = cv
+            Parameters = cv
         };
 
         var plan = new Plan(goal);
@@ -364,23 +373,27 @@ public sealed class PlanTests : IDisposable
 
         var cv = new ContextVariables();
         cv.Set("language", inputLanguage);
-        var outputs = new ContextVariables();
-        outputs.Set("TRANSLATED_SUMMARY", string.Empty);
+        var outputs = new List<string>
+        {
+            "TRANSLATED_SUMMARY"
+        };
 
         var translatePlan = new Plan(writerSkill["Translate"])
         {
-            NamedParameters = cv,
-            NamedOutputs = outputs,
+            Parameters = cv,
+            Outputs = outputs,
         };
 
         cv = new ContextVariables();
         cv.Update(inputName);
-        outputs = new ContextVariables();
-        outputs.Set("TheEmailFromState", string.Empty);
+        outputs = new List<string>
+        {
+            "TheEmailFromState"
+        };
         var getEmailPlan = new Plan(emailSkill["GetEmailAddressAsync"])
         {
-            NamedParameters = cv,
-            NamedOutputs = outputs,
+            Parameters = cv,
+            Outputs = outputs,
         };
 
         cv = new ContextVariables();
@@ -388,7 +401,7 @@ public sealed class PlanTests : IDisposable
         cv.Set("input", "$TRANSLATED_SUMMARY");
         var sendEmailPlan = new Plan(emailSkill["SendEmailAsync"])
         {
-            NamedParameters = cv
+            Parameters = cv
         };
 
         var plan = new Plan(goal);

--- a/dotnet/src/IntegrationTests/Planning/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/PlanTests.cs
@@ -43,9 +43,8 @@ public sealed class PlanTests : IDisposable
 
         // Assert
         Assert.Equal(prompt, plan.Description);
-        Assert.Equal(prompt, plan.Name);
-        // TODO: avoid hardcoded names, tests shouldn't fail when refactoring code
-        Assert.Equal("Microsoft.SemanticKernel.Planning.Plan", plan.SkillName);
+        Assert.Equal(string.Empty, plan.Name);
+        Assert.Equal(typeof(Plan).FullName, plan.SkillName);
         Assert.Empty(plan.Steps);
     }
 

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -70,22 +70,22 @@ public class SequentialPlanParserTests
             {
                 Assert.Equal("WriterSkill", step.SkillName);
                 Assert.Equal("Translate", step.Name);
-                Assert.Equal("French", step.NamedParameters["language"]);
-                Assert.True(step.NamedOutputs.ContainsKey("TRANSLATED_SUMMARY"));
+                Assert.Equal("French", step.Parameters["language"]);
+                Assert.True(step.Outputs.Contains("TRANSLATED_SUMMARY"));
             },
             step =>
             {
                 Assert.Equal("email", step.SkillName);
                 Assert.Equal("GetEmailAddressAsync", step.Name);
-                Assert.Equal("John Doe", step.NamedParameters["input"]);
-                Assert.True(step.NamedOutputs.ContainsKey("EMAIL_ADDRESS"));
+                Assert.Equal("John Doe", step.Parameters["input"]);
+                Assert.True(step.Outputs.Contains("EMAIL_ADDRESS"));
             },
             step =>
             {
                 Assert.Equal("email", step.SkillName);
                 Assert.Equal("SendEmailAsync", step.Name);
-                Assert.Equal("$TRANSLATED_SUMMARY", step.NamedParameters["input"]);
-                Assert.Equal("$EMAIL_ADDRESS", step.NamedParameters["email_address"]);
+                Assert.Equal("$TRANSLATED_SUMMARY", step.Parameters["input"]);
+                Assert.Equal("$EMAIL_ADDRESS", step.Parameters["email_address"]);
             }
         );
     }

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -71,7 +71,7 @@ public sealed class SequentialPlannerTests : IDisposable
             step =>
                 step.Name.Equals(expectedFunction, StringComparison.OrdinalIgnoreCase) &&
                 step.SkillName.Equals(expectedSkill, StringComparison.OrdinalIgnoreCase) &&
-                step.NamedParameters["endMarker"].Equals(expectedDefault, StringComparison.OrdinalIgnoreCase));
+                step.Parameters["endMarker"].Equals(expectedDefault, StringComparison.OrdinalIgnoreCase));
     }
 
     [Theory]

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
@@ -526,10 +526,10 @@ public sealed class PlanSerializationTests
         Assert.NotNull(deserializedPlan);
         Assert.Equal(goal, deserializedPlan.Description);
 
-        Assert.Equal(string.Join(",", plan.NamedOutputs.Select(kv => $"{kv.Key}:{kv.Value}")),
-            string.Join(",", deserializedPlan.NamedOutputs.Select(kv => $"{kv.Key}:{kv.Value}")));
-        Assert.Equal(string.Join(",", plan.NamedParameters.Select(kv => $"{kv.Key}:{kv.Value}")),
-            string.Join(",", deserializedPlan.NamedParameters.Select(kv => $"{kv.Key}:{kv.Value}")));
+        Assert.Equal(string.Join(",", plan.Outputs),
+            string.Join(",", deserializedPlan.Outputs));
+        Assert.Equal(string.Join(",", plan.Parameters.Select(kv => $"{kv.Key}:{kv.Value}")),
+            string.Join(",", deserializedPlan.Parameters.Select(kv => $"{kv.Key}:{kv.Value}")));
         Assert.Equal(string.Join(",", plan.State.Select(kv => $"{kv.Key}:{kv.Value}")),
             string.Join(",", deserializedPlan.State.Select(kv => $"{kv.Key}:{kv.Value}")));
 

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -627,55 +627,58 @@ public sealed class PlanTests
         // - MiscSkill.ElementAtIndex count='3' INPUT='$OUTLINE' index='2' => CHAPTER_3_SYNOPSIS
         // - WriterSkill.NovelChapter chapterIndex='3' previousChapter='$CHAPTER_2_SYNOPSIS' INPUT='$CHAPTER_3_SYNOPSIS' theme='Children's mystery' => RESULT__CHAPTER_3
         var planStep = new Plan(outlineMock.Object);
-        planStep.NamedParameters.Set("input",
-            "A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.");
-        planStep.NamedParameters.Set("chapterCount", "3");
-        planStep.NamedOutputs.Set("OUTLINE", string.Empty);
+        planStep.Parameters.Set("input",
+            "NovelOutline function input.");
+        planStep.Parameters.Set("chapterCount", "3");
+        planStep.Outputs.Add("OUTLINE");
         plan.AddSteps(planStep);
 
         planStep = new Plan(elementAtIndexMock.Object);
-        planStep.NamedParameters.Set("count", "3");
-        planStep.NamedParameters.Set("INPUT", "$OUTLINE");
-        planStep.NamedParameters.Set("index", "0");
-        planStep.NamedOutputs.Set("CHAPTER_1_SYNOPSIS", string.Empty);
+        planStep.Parameters.Set("count", "3");
+        planStep.Parameters.Set("INPUT", "$OUTLINE");
+        planStep.Parameters.Set("index", "0");
+        planStep.Outputs.Add("CHAPTER_1_SYNOPSIS");
         plan.AddSteps(planStep);
 
         planStep = new Plan(novelChapterMock.Object);
-        planStep.NamedParameters.Set("chapterIndex", "1");
-        planStep.NamedParameters.Set("previousChapter", " ");
-        planStep.NamedParameters.Set("INPUT", "$CHAPTER_1_SYNOPSIS");
-        planStep.NamedParameters.Set("theme", "Children's mystery");
-        planStep.NamedResults.Set("RESULT__CHAPTER_1", string.Empty);
+        planStep.Parameters.Set("chapterIndex", "1");
+        planStep.Parameters.Set("previousChapter", " ");
+        planStep.Parameters.Set("INPUT", "$CHAPTER_1_SYNOPSIS");
+        planStep.Parameters.Set("theme", "Children's mystery");
+        planStep.Outputs.Add("RESULT__CHAPTER_1");
+        plan.Outputs.Add("RESULT__CHAPTER_1");
         plan.AddSteps(planStep);
 
         planStep = new Plan(elementAtIndexMock.Object);
-        planStep.NamedParameters.Set("count", "3");
-        planStep.NamedParameters.Set("INPUT", "$OUTLINE");
-        planStep.NamedParameters.Set("index", "1");
-        planStep.NamedOutputs.Set("CHAPTER_2_SYNOPSIS", string.Empty);
+        planStep.Parameters.Set("count", "3");
+        planStep.Parameters.Set("INPUT", "$OUTLINE");
+        planStep.Parameters.Set("index", "1");
+        planStep.Outputs.Add("CHAPTER_2_SYNOPSIS");
         plan.AddSteps(planStep);
 
         planStep = new Plan(novelChapterMock.Object);
-        planStep.NamedParameters.Set("chapterIndex", "2");
-        planStep.NamedParameters.Set("previousChapter", "$CHAPTER_1_SYNOPSIS");
-        planStep.NamedParameters.Set("INPUT", "$CHAPTER_2_SYNOPSIS");
-        planStep.NamedParameters.Set("theme", "Children's mystery");
-        planStep.NamedResults.Set("RESULT__CHAPTER_2", string.Empty);
+        planStep.Parameters.Set("chapterIndex", "2");
+        planStep.Parameters.Set("previousChapter", "$CHAPTER_1_SYNOPSIS");
+        planStep.Parameters.Set("INPUT", "$CHAPTER_2_SYNOPSIS");
+        planStep.Parameters.Set("theme", "Children's mystery");
+        planStep.Outputs.Add("RESULT__CHAPTER_2");
+        plan.Outputs.Add("RESULT__CHAPTER_2");
         plan.AddSteps(planStep);
 
         planStep = new Plan(elementAtIndexMock.Object);
-        planStep.NamedParameters.Set("count", "3");
-        planStep.NamedParameters.Set("INPUT", "$OUTLINE");
-        planStep.NamedParameters.Set("index", "2");
-        planStep.NamedOutputs.Set("CHAPTER_3_SYNOPSIS", string.Empty);
+        planStep.Parameters.Set("count", "3");
+        planStep.Parameters.Set("INPUT", "$OUTLINE");
+        planStep.Parameters.Set("index", "2");
+        planStep.Outputs.Add("CHAPTER_3_SYNOPSIS");
         plan.AddSteps(planStep);
 
         planStep = new Plan(novelChapterMock.Object);
-        planStep.NamedParameters.Set("chapterIndex", "3");
-        planStep.NamedParameters.Set("previousChapter", "$CHAPTER_2_SYNOPSIS");
-        planStep.NamedParameters.Set("INPUT", "$CHAPTER_3_SYNOPSIS");
-        planStep.NamedParameters.Set("theme", "Children's mystery");
-        planStep.NamedResults.Set("CHAPTER_3", string.Empty);
+        planStep.Parameters.Set("chapterIndex", "3");
+        planStep.Parameters.Set("previousChapter", "$CHAPTER_2_SYNOPSIS");
+        planStep.Parameters.Set("INPUT", "$CHAPTER_3_SYNOPSIS");
+        planStep.Parameters.Set("theme", "Children's mystery");
+        planStep.Outputs.Add("CHAPTER_3");
+        plan.Outputs.Add("CHAPTER_3");
         plan.AddSteps(planStep);
 
         // Act
@@ -687,15 +690,15 @@ public sealed class PlanTests
         ));
 
         var expected =
-            @"Chapter #1: Outline section #0 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+            @"Chapter #1: Outline section #0 of 3: Here is a 3 chapter outline about NovelOutline function input.
 Theme:Children's mystery
 Previously:
-Chapter #2: Outline section #1 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+Chapter #2: Outline section #1 of 3: Here is a 3 chapter outline about NovelOutline function input.
 Theme:Children's mystery
-Previously:Outline section #0 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
-Chapter #3: Outline section #2 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+Previously:Outline section #0 of 3: Here is a 3 chapter outline about NovelOutline function input.
+Chapter #3: Outline section #2 of 3: Here is a 3 chapter outline about NovelOutline function input.
 Theme:Children's mystery
-Previously:Outline section #1 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.";
+Previously:Outline section #1 of 3: Here is a 3 chapter outline about NovelOutline function input.";
 
         // Assert
         Assert.Equal(expected, result.Result);

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -576,4 +576,129 @@ public sealed class PlanTests
         Assert.Equal($"Here is a poem about Cleopatra", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Once);
     }
+
+
+
+    [Fact]
+    public async Task CanExecutePlanWithJoinedResultAsync()
+    {
+        // Arrange
+        var kernel = new Mock<IKernel>();
+        var log = new Mock<ILogger>();
+        var memory = new Mock<ISemanticTextMemory>();
+        var skills = new Mock<ISkillCollection>();
+
+        var returnContext = new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            log.Object
+        );
+
+        var outlineMock = new Mock<ISKFunction>();
+        outlineMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
+            .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
+                returnContext.Variables.Update($"Here is a {c.Variables["chapterCount"]} chapter outline about " + c.Variables.Input))
+            .Returns(() => Task.FromResult(returnContext));
+
+        var elementAtIndexMock = new Mock<ISKFunction>();
+        elementAtIndexMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
+            .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
+            {
+                returnContext.Variables.Update($"Outline section #{c.Variables["index"]} of {c.Variables["count"]}: " + c.Variables.Input);
+            })
+            .Returns(() => Task.FromResult(returnContext));
+
+        var novelChapterMock = new Mock<ISKFunction>();
+        novelChapterMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
+            .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
+            {
+                returnContext.Variables.Update($"Chapter #{c.Variables["chapterIndex"]}: {c.Variables.Input}\nTheme:{c.Variables["theme"]}\nPreviously:{c.Variables["previousChapter"]}");
+            })
+            .Returns(() => Task.FromResult(returnContext));
+
+
+        var plan = new Plan("A plan with steps that alternate appending to the plan result.");
+
+        // Steps:
+        // - WriterSkill.NovelOutline chapterCount='3' INPUT='A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.' endMarker='<!--===ENDPART===-->' => OUTLINE
+        // - MiscSkill.ElementAtIndex count='3' INPUT='$OUTLINE' index='0' => CHAPTER_1_SYNOPSIS
+        // - WriterSkill.NovelChapter chapterIndex='1' previousChapter='' INPUT='$CHAPTER_1_SYNOPSIS' theme='Children's mystery' => RESULT__CHAPTER_1
+        // - MiscSkill.ElementAtIndex count='3' INPUT='$OUTLINE' index='1' => CHAPTER_2_SYNOPSIS
+        // - WriterSkill.NovelChapter chapterIndex='2' previousChapter='$CHAPTER_1_SYNOPSIS' INPUT='$CHAPTER_2_SYNOPSIS' theme='Children's mystery' => RESULT__CHAPTER_2
+        // - MiscSkill.ElementAtIndex count='3' INPUT='$OUTLINE' index='2' => CHAPTER_3_SYNOPSIS
+        // - WriterSkill.NovelChapter chapterIndex='3' previousChapter='$CHAPTER_2_SYNOPSIS' INPUT='$CHAPTER_3_SYNOPSIS' theme='Children's mystery' => RESULT__CHAPTER_3
+        var planStep = new Plan(outlineMock.Object);
+        planStep.NamedParameters.Set("input", "A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.");
+        planStep.NamedParameters.Set("chapterCount", "3");
+        planStep.NamedOutputs.Set("OUTLINE", string.Empty);
+        plan.AddSteps(planStep);
+
+        planStep = new Plan(elementAtIndexMock.Object);
+        planStep.NamedParameters.Set("count", "3");
+        planStep.NamedParameters.Set("INPUT", "$OUTLINE");
+        planStep.NamedParameters.Set("index", "0");
+        planStep.NamedOutputs.Set("CHAPTER_1_SYNOPSIS", string.Empty);
+        plan.AddSteps(planStep);
+
+        planStep = new Plan(novelChapterMock.Object);
+        planStep.NamedParameters.Set("chapterIndex", "1");
+        planStep.NamedParameters.Set("previousChapter", " ");
+        planStep.NamedParameters.Set("INPUT", "$CHAPTER_1_SYNOPSIS");
+        planStep.NamedParameters.Set("theme", "Children's mystery");
+        planStep.NamedResults.Set("RESULT__CHAPTER_1", string.Empty);
+        plan.AddSteps(planStep);
+
+        planStep = new Plan(elementAtIndexMock.Object);
+        planStep.NamedParameters.Set("count", "3");
+        planStep.NamedParameters.Set("INPUT", "$OUTLINE");
+        planStep.NamedParameters.Set("index", "1");
+        planStep.NamedOutputs.Set("CHAPTER_2_SYNOPSIS", string.Empty);
+        plan.AddSteps(planStep);
+
+        planStep = new Plan(novelChapterMock.Object);
+        planStep.NamedParameters.Set("chapterIndex", "2");
+        planStep.NamedParameters.Set("previousChapter", "$CHAPTER_1_SYNOPSIS");
+        planStep.NamedParameters.Set("INPUT", "$CHAPTER_2_SYNOPSIS");
+        planStep.NamedParameters.Set("theme", "Children's mystery");
+        planStep.NamedResults.Set("RESULT__CHAPTER_2", string.Empty);
+        plan.AddSteps(planStep);
+
+        planStep = new Plan(elementAtIndexMock.Object);
+        planStep.NamedParameters.Set("count", "3");
+        planStep.NamedParameters.Set("INPUT", "$OUTLINE");
+        planStep.NamedParameters.Set("index", "2");
+        planStep.NamedOutputs.Set("CHAPTER_3_SYNOPSIS", string.Empty);
+        plan.AddSteps(planStep);
+
+        planStep = new Plan(novelChapterMock.Object);
+        planStep.NamedParameters.Set("chapterIndex", "3");
+        planStep.NamedParameters.Set("previousChapter", "$CHAPTER_2_SYNOPSIS");
+        planStep.NamedParameters.Set("INPUT", "$CHAPTER_3_SYNOPSIS");
+        planStep.NamedParameters.Set("theme", "Children's mystery");
+        planStep.NamedResults.Set("CHAPTER_3", string.Empty);
+        plan.AddSteps(planStep);
+
+        // Act
+        var result = await plan.InvokeAsync(new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            log.Object
+        ));
+
+        var expected =
+@"Chapter #1: Outline section #0 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+Theme:Children's mystery
+Previously:
+Chapter #2: Outline section #1 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+Theme:Children's mystery
+Previously:Outline section #0 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+Chapter #3: Outline section #2 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+Theme:Children's mystery
+Previously:Outline section #1 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.";
+
+        // Assert
+        Assert.Equal(expected, result.Result);
+    }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -577,8 +577,6 @@ public sealed class PlanTests
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Once);
     }
 
-
-
     [Fact]
     public async Task CanExecutePlanWithJoinedResultAsync()
     {
@@ -613,10 +611,10 @@ public sealed class PlanTests
         novelChapterMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
             .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
             {
-                returnContext.Variables.Update($"Chapter #{c.Variables["chapterIndex"]}: {c.Variables.Input}\nTheme:{c.Variables["theme"]}\nPreviously:{c.Variables["previousChapter"]}");
+                returnContext.Variables.Update(
+                    $"Chapter #{c.Variables["chapterIndex"]}: {c.Variables.Input}\nTheme:{c.Variables["theme"]}\nPreviously:{c.Variables["previousChapter"]}");
             })
             .Returns(() => Task.FromResult(returnContext));
-
 
         var plan = new Plan("A plan with steps that alternate appending to the plan result.");
 
@@ -629,7 +627,8 @@ public sealed class PlanTests
         // - MiscSkill.ElementAtIndex count='3' INPUT='$OUTLINE' index='2' => CHAPTER_3_SYNOPSIS
         // - WriterSkill.NovelChapter chapterIndex='3' previousChapter='$CHAPTER_2_SYNOPSIS' INPUT='$CHAPTER_3_SYNOPSIS' theme='Children's mystery' => RESULT__CHAPTER_3
         var planStep = new Plan(outlineMock.Object);
-        planStep.NamedParameters.Set("input", "A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.");
+        planStep.NamedParameters.Set("input",
+            "A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.");
         planStep.NamedParameters.Set("chapterCount", "3");
         planStep.NamedOutputs.Set("OUTLINE", string.Empty);
         plan.AddSteps(planStep);
@@ -688,7 +687,7 @@ public sealed class PlanTests
         ));
 
         var expected =
-@"Chapter #1: Outline section #0 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
+            @"Chapter #1: Outline section #0 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.
 Theme:Children's mystery
 Previously:
 Chapter #2: Outline section #1 of 3: Here is a 3 chapter outline about A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic.

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -594,13 +594,13 @@ public sealed class PlanTests
         );
 
         var outlineMock = new Mock<ISKFunction>();
-        outlineMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
+        outlineMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default))
             .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
                 returnContext.Variables.Update($"Here is a {c.Variables["chapterCount"]} chapter outline about " + c.Variables.Input))
             .Returns(() => Task.FromResult(returnContext));
 
         var elementAtIndexMock = new Mock<ISKFunction>();
-        elementAtIndexMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
+        elementAtIndexMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default))
             .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
             {
                 returnContext.Variables.Update($"Outline section #{c.Variables["index"]} of {c.Variables["count"]}: " + c.Variables.Input);
@@ -608,7 +608,7 @@ public sealed class PlanTests
             .Returns(() => Task.FromResult(returnContext));
 
         var novelChapterMock = new Mock<ISKFunction>();
-        novelChapterMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, null))
+        novelChapterMock.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default))
             .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
             {
                 returnContext.Variables.Update(

--- a/dotnet/src/SemanticKernel/CoreSkills/TextMemorySkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/TextMemorySkill.cs
@@ -49,9 +49,9 @@ public class TextMemorySkill
     /// <summary>
     /// Creates a new instance of the TextMemorySkill
     /// </summary>
-    /// <param name="collection">The default collection for Recall</param>
-    /// <param name="relevance">The default relevance value for Recall</param>
-    /// <param name="limit">The default limit for Recall</param>
+    /// <param name="collection">The default collection for Recall. Memories collection to search.</param>
+    /// <param name="relevance">The default relevance value for Recall. The relevance score, from 0.0 to 1.0, where 1.0 means perfect match.</param>
+    /// <param name="limit">The default limit for Recall. The maximum number of relevant memories to recall.</param>
     public TextMemorySkill(string collection = DefaultCollection, string relevance = DefaultRelevance, string limit = DefaultLimit)
     {
         this._collection = collection;

--- a/dotnet/src/SemanticKernel/CoreSkills/TextMemorySkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/TextMemorySkill.cs
@@ -43,7 +43,7 @@ public class TextMemorySkill
     public const string LimitParam = "limit";
 
     private const string DefaultCollection = "generic";
-    private const string DefaultRelevance = "0.75";
+    private const string DefaultRelevance = "0.0";
     private const string DefaultLimit = "1";
 
     /// <summary>
@@ -118,9 +118,9 @@ public class TextMemorySkill
 
         // TODO: support locales, e.g. "0.7" and "0,7" must both work
         var limitInt = int.Parse(limit, CultureInfo.InvariantCulture);
-        var relevanceScore = float.Parse(relevance, CultureInfo.InvariantCulture);
+        var relevanceThreshold = float.Parse(relevance, CultureInfo.InvariantCulture);
         var memories = context.Memory
-            .SearchAsync(collection, text, limitInt, relevanceScore)
+            .SearchAsync(collection, text, limitInt, relevanceThreshold)
             .ToEnumerable();
 
         context.Log.LogTrace("Done looking for memories in collection '{0}')", collection);

--- a/dotnet/src/SemanticKernel/CoreSkills/TextMemorySkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/TextMemorySkill.cs
@@ -51,7 +51,7 @@ public class TextMemorySkill
     /// </summary>
     /// <param name="collection">The default collection for Recall</param>
     /// <param name="relevance">The default relevance value for Recall</param>
-    /// <param name="limit">The default limit for Recall </param>
+    /// <param name="limit">The default limit for Recall</param>
     public TextMemorySkill(string collection = DefaultCollection, string relevance = DefaultRelevance, string limit = DefaultLimit)
     {
         this._collection = collection;

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -260,18 +260,10 @@ public sealed class Plan : ISKFunction
             this.State.Update(resultValue);
 
             // Update Plan Result in State with matching outputs (if any)
-            bool resultAppended = false;
-            foreach (var item in this.Outputs.Intersect(step.Outputs))
+            if (this.Outputs.Intersect(step.Outputs).Any())
             {
-                if (resultAppended)
-                {
-                    continue;
-                }
-
                 this.State.Get(DefaultResultKey, out var currentPlanResult);
                 this.State.Set(DefaultResultKey, string.Join("\n", currentPlanResult.Trim(), resultValue));
-                resultAppended = true;
-                continue;
             }
 
             // Update state with outputs (if any)

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -263,6 +263,12 @@ public sealed class Plan : ISKFunction
             // TODO Assuming there is one today -- multiple results may not be ordered correctly.
             foreach (var item in step.NamedResults)
             {
+                // ignore the input key
+                if (item.Key.ToUpperInvariant() == "INPUT")
+                {
+                    continue;
+                }
+
                 this.State.Get(DefaultResultKey, out var currentPlanResult);
                 this.State.Set(DefaultResultKey, currentPlanResult.Trim() + "\n" + result.Result.Trim());
             }

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -93,7 +93,6 @@ public sealed class Plan : ISKFunction
     {
         this.Description = goal;
         this.SkillName = this.GetType().FullName;
-        this.Name = goal;
     }
 
     /// <summary>
@@ -252,7 +251,14 @@ public sealed class Plan : ISKFunction
             #region Update State
 
             // Update state with result
-            this.State.Update(result.Result.Trim());
+            if (this.NextStepIndex == 0 || step.NamedOutputs.Count() <= 1)
+            {
+                this.State.Update(result.Result.Trim());
+            }
+            else
+            {
+                this.State.Update(this.State.Input + Environment.NewLine + result.Result.Trim());
+            }
 
             // Update state with named outputs (if any)
             foreach (var item in step.NamedOutputs)

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -260,7 +260,8 @@ public sealed class Plan : ISKFunction
             // Update state with result
             this.State.Update(result.Result.Trim());
 
-            // TODO Assuming there is one today -- multiple results may not be ordered correctly.
+            // Update state with name results (if any)
+            bool resultAppended = false;
             foreach (var item in step.NamedResults)
             {
                 // ignore the input key
@@ -269,8 +270,18 @@ public sealed class Plan : ISKFunction
                     continue;
                 }
 
+                // Also set the named result in the state for other steps to use
+                this.State.Set(item.Key, result.Result.Trim());
+
+                if (resultAppended)
+                {
+                    continue;
+                }
+
+                // Additionally, append to current plan result
                 this.State.Get(DefaultResultKey, out var currentPlanResult);
-                this.State.Set(DefaultResultKey, currentPlanResult.Trim() + "\n" + result.Result.Trim());
+                this.State.Set(DefaultResultKey, string.Join("\n", currentPlanResult.Trim(), result.Result.Trim()));
+                resultAppended = true;
             }
 
             // Update state with named outputs (if any)

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -36,25 +36,17 @@ public sealed class Plan : ISKFunction
     public IReadOnlyList<Plan> Steps => this._steps.AsReadOnly();
 
     /// <summary>
-    /// Named parameters for the function
+    ///  parameters for the plan, used to pass information to the next step
     /// </summary>
-    [JsonPropertyName("named_parameters")]
+    [JsonPropertyName("parameters")]
     [JsonConverter(typeof(ContextVariablesConverter))]
-    public ContextVariables NamedParameters { get; set; } = new();
+    public ContextVariables Parameters { get; set; } = new();
 
     /// <summary>
-    /// Named outputs for the function -- these are used within a plan.
+    ///  outputs for the plan, used to pass information to the caller
     /// </summary>
-    [JsonPropertyName("named_outputs")]
-    [JsonConverter(typeof(ContextVariablesConverter))]
-    public ContextVariables NamedOutputs { get; set; } = new();
-
-    /// <summary>
-    /// Named results for the function -- these are used to return results from a plan.
-    /// </summary>
-    [JsonPropertyName("named_results")]
-    [JsonConverter(typeof(ContextVariablesConverter))]
-    public ContextVariables NamedResults { get; set; } = new();
+    [JsonPropertyName("outputs")]
+    public IList<string> Outputs { get; set; } = new List<string>();
 
     /// <summary>
     /// Gets whether the plan has a next step.
@@ -139,12 +131,18 @@ public sealed class Plan : ISKFunction
     /// <param name="description">The description of the plan.</param>
     /// <param name="nextStepIndex">The index of the next step.</param>
     /// <param name="state">The state of the plan.</param>
-    /// <param name="namedParameters">The named parameters of the plan.</param>
-    /// <param name="namedOutputs">The named outputs of the plan.</param>
+    /// <param name="parameters">The parameters of the plan.</param>
+    /// <param name="outputs">The outputs of the plan.</param>
     /// <param name="steps">The steps of the plan.</param>
     [JsonConstructor]
-    public Plan(string name, string skillName, string description, int nextStepIndex, ContextVariables state, ContextVariables namedParameters,
-        ContextVariables namedOutputs,
+    public Plan(
+        string name,
+        string skillName,
+        string description,
+        int nextStepIndex,
+        ContextVariables state,
+        ContextVariables parameters,
+        IList<string> outputs,
         IReadOnlyList<Plan> steps)
     {
         this.Name = name;
@@ -152,8 +150,8 @@ public sealed class Plan : ISKFunction
         this.Description = description;
         this.NextStepIndex = nextStepIndex;
         this.State = state;
-        this.NamedParameters = namedParameters;
-        this.NamedOutputs = namedOutputs;
+        this.Parameters = parameters;
+        this.Outputs = outputs;
         this._steps.Clear();
         this.AddSteps(steps.ToArray());
     }
@@ -248,6 +246,7 @@ public sealed class Plan : ISKFunction
             // Execute the step
             var functionContext = new SKContext(functionVariables, context.Memory, context.Skills, context.Log, context.CancellationToken);
             var result = await step.InvokeAsync(functionContext).ConfigureAwait(false);
+            var resultValue = result.Result.Trim();
 
             if (result.ErrorOccurred)
             {
@@ -258,48 +257,33 @@ public sealed class Plan : ISKFunction
             #region Update State
 
             // Update state with result
-            this.State.Update(result.Result.Trim());
+            this.State.Update(resultValue);
 
-            // Update state with name results (if any)
+            // Update Plan Result in State with matching outputs (if any)
             bool resultAppended = false;
-            foreach (var item in step.NamedResults)
+            foreach (var item in this.Outputs.Intersect(step.Outputs))
             {
-                // ignore the input key
-                if (item.Key.ToUpperInvariant() == "INPUT")
-                {
-                    continue;
-                }
-
-                // Also set the named result in the state for other steps to use
-                this.State.Set(item.Key, result.Result.Trim());
-
                 if (resultAppended)
                 {
                     continue;
                 }
 
-                // Additionally, append to current plan result
                 this.State.Get(DefaultResultKey, out var currentPlanResult);
-                this.State.Set(DefaultResultKey, string.Join("\n", currentPlanResult.Trim(), result.Result.Trim()));
+                this.State.Set(DefaultResultKey, string.Join("\n", currentPlanResult.Trim(), resultValue));
                 resultAppended = true;
+                continue;
             }
 
-            // Update state with named outputs (if any)
-            foreach (var item in step.NamedOutputs)
+            // Update state with outputs (if any)
+            foreach (var item in step.Outputs)
             {
-                // ignore the input key
-                if (item.Key.ToUpperInvariant() == "INPUT")
+                if (result.Variables.Get(item, out var val))
                 {
-                    continue;
-                }
-
-                if (result.Variables.Get(item.Key, out var val))
-                {
-                    this.State.Set(item.Key, val);
+                    this.State.Set(item, val);
                 }
                 else
                 {
-                    this.State.Set(item.Key, result.Result.Trim());
+                    this.State.Set(item, resultValue);
                 }
             }
 
@@ -471,21 +455,15 @@ public sealed class Plan : ISKFunction
         context.Variables.Update(resultString);
 
         // copy previous step's variables to the next step
-        foreach (var item in this._steps[this.NextStepIndex - 1].NamedOutputs)
+        foreach (var item in this._steps[this.NextStepIndex - 1].Outputs)
         {
-            // ignore the input key
-            if (item.Key.ToUpperInvariant() == "INPUT")
+            if (this.State.Get(item, out var val))
             {
-                continue;
-            }
-
-            if (this.State.Get(item.Key, out var val))
-            {
-                context.Variables.Set(item.Key, val);
+                context.Variables.Set(item, val);
             }
             else
             {
-                context.Variables.Set(item.Key, resultString);
+                context.Variables.Set(item, resultString);
             }
         }
 
@@ -509,7 +487,7 @@ public sealed class Plan : ISKFunction
         var stepVariables = new ContextVariables(stepInput);
 
         // Priority for remaining stepVariables is:
-        // - NamedParameters (pull from State by a key value)
+        // - Parameters (pull from State by a key value)
         // - Parameters (from context)
         // - Parameters (from State)
         var functionParameters = step.Describe();
@@ -525,7 +503,7 @@ public sealed class Plan : ISKFunction
             }
         }
 
-        foreach (var item in step.NamedParameters)
+        foreach (var item in step.Parameters)
         {
             if (!string.IsNullOrEmpty(item.Value))
             {

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -36,14 +36,14 @@ public sealed class Plan : ISKFunction
     public IReadOnlyList<Plan> Steps => this._steps.AsReadOnly();
 
     /// <summary>
-    ///  parameters for the plan, used to pass information to the next step
+    /// Parameters for the plan, used to pass information to the next step
     /// </summary>
     [JsonPropertyName("parameters")]
     [JsonConverter(typeof(ContextVariablesConverter))]
     public ContextVariables Parameters { get; set; } = new();
 
     /// <summary>
-    ///  outputs for the plan, used to pass information to the caller
+    /// Outputs for the plan, used to pass information to the caller
     /// </summary>
     [JsonPropertyName("outputs")]
     public IList<string> Outputs { get; set; } = new List<string>();

--- a/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
@@ -50,7 +48,7 @@ internal static class Example12_SequentialPlanner
         // - WriterSkill.Translate language='Italian' INPUT='' =>
 
         Console.WriteLine("Original plan:");
-        Console.WriteLine(PlanToString(plan));
+        Console.WriteLine(plan.ToPlanString());
 
         var result = await kernel.RunAsync(plan);
 
@@ -82,7 +80,7 @@ internal static class Example12_SequentialPlanner
         // - email.SendEmail INPUT='$TRANSLATED_SUMMARY' email_address='$EMAIL_ADDRESS' =>
 
         Console.WriteLine("Original plan:");
-        Console.WriteLine(PlanToString(plan));
+        Console.WriteLine(plan.ToPlanString());
 
         var input =
             "Once upon a time, in a faraway kingdom, there lived a kind and just king named Arjun. " +
@@ -124,28 +122,11 @@ internal static class Example12_SequentialPlanner
         // - WriterSkill.NovelChapter chapterIndex='3' previousChapter='$CHAPTER_2_SYNOPSIS' INPUT='$CHAPTER_3_SYNOPSIS' theme='Children's mystery' => RESULT__CHAPTER_3
 
         Console.WriteLine("Original plan:");
-        Console.WriteLine(PlanToString(originalPlan));
+        Console.WriteLine(originalPlan.ToPlanString());
 
         Stopwatch sw = new();
         sw.Start();
         await ExecutePlanAsync(kernel, originalPlan);
-    }
-
-    private static string PlanToString(Plan originalPlan, string indent = " ")
-    {
-        var sb = new StringBuilder($"{indent}Goal: {originalPlan.Description}\n\n{indent}Steps:\n");
-
-        foreach (var step in originalPlan.Steps)
-        {
-            sb.Append(step.Steps.Count switch
-            {
-                0 =>
-                    $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
-                _ => PlanToString(step, indent + indent)
-            });
-        }
-
-        return sb.ToString();
     }
 
     private static async Task MemorySampleAsync()
@@ -196,7 +177,7 @@ internal static class Example12_SequentialPlanner
         var plan = await planner.CreatePlanAsync(goal);
 
         Console.WriteLine("Original plan:");
-        Console.WriteLine(PlanToString(plan));
+        Console.WriteLine(plan.ToPlanString());
     }
 
     private static IKernel InitializeKernelAndPlanner(out SequentialPlanner planner, int maxTokens = 1024)

--- a/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
@@ -139,14 +139,14 @@ internal static class Example12_SequentialPlanner
         {
             sb.Append(step.Steps.Count switch
             {
-                0 => $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
+                0 =>
+                    $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
                 _ => PlanToString(step, indent + indent)
             });
         }
 
         return sb.ToString();
     }
-
 
     private static async Task MemorySampleAsync()
     {

--- a/samples/dotnet/kernel-syntax-examples/Example29_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example29_CustomPlanner.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.XPath;
@@ -153,29 +151,12 @@ public class MarkupSkill
         var plan = docString.FromMarkup("Run a piece of xml markup", context);
 
         Console.WriteLine("Markup plan:");
-        Console.WriteLine(PlanToString(plan));
+        Console.WriteLine(plan.ToPlanString());
         Console.WriteLine();
 
         var result = await plan.InvokeAsync();
         context.Variables.Update(result.Result);
         return context;
-    }
-
-    private static string PlanToString(Plan originalPlan, string indent = " ")
-    {
-        var sb = new StringBuilder($"{indent}Goal: {originalPlan.Description}\n\n{indent}Steps:\n");
-
-        foreach (var step in originalPlan.Steps)
-        {
-            sb.Append(step.Steps.Count switch
-            {
-                0 =>
-                    $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
-                _ => PlanToString(step, indent + indent)
-            });
-        }
-
-        return sb.ToString();
     }
 }
 

--- a/samples/dotnet/kernel-syntax-examples/Example29_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example29_CustomPlanner.cs
@@ -1,0 +1,380 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.XPath;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.CoreSkills;
+using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Planning;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.Skills.Web;
+using Microsoft.SemanticKernel.Skills.Web.Bing;
+using RepoUtils;
+
+// ReSharper disable CommentTypo
+// ReSharper disable once InconsistentNaming
+internal static class Example29_CustomPlanner
+{
+    public static async Task RunAsync()
+    {
+        Console.WriteLine("======== Custom Planner - Create and Execute Markup Plan ========");
+        IKernel kernel = InitializeKernel();
+
+        // ContextQuery is part of the QASkill
+        IDictionary<string, ISKFunction> skills = LoadQASkill(kernel);
+        SKContext context = CreateContextQueryContext(kernel);
+
+        // Setup defined memories for recall
+        await RememberFactsAsync(kernel);
+
+        // MarkupSkill named "markup"
+        var markup = kernel.ImportSkill(new MarkupSkill(), "markup");
+
+        // contextQuery "Who is my president? Who was president 3 years ago? What should I eat for dinner" | markup
+        // Create a plan to execute the ContextQuery and then run the markup skill on the output
+        var plan = new Plan("Execute ContextQuery and then RunMarkup");
+        plan.AddSteps(skills["ContextQuery"], markup["RunMarkup"]);
+
+        // Execute plan
+        var result = await plan.InvokeAsync("Who is my president? Who was president 3 years ago? What should I eat for dinner", context);
+
+        Console.WriteLine("Result:");
+        Console.WriteLine(result.Result);
+        Console.WriteLine();
+    }
+    /* Example Output
+    ======== Custom Planner - Create and Execute Markup Plan ========
+    Markup:
+    <response><lookup>Who is United States President</lookup><fact>Joe Biden was president 3 years ago</fact><opinion>For dinner, you might enjoy some sushi with your partner, since you both like it and you only ate it once this month</opinion></response>
+
+    Original plan:
+        Goal: Run a piece of xml markup
+
+        Steps:
+        Goal: response
+
+        Steps:
+        - bing.SearchAsync INPUT='Who is United States President' => markup.SearchAsync.result    - Microsoft.SemanticKernel.Planning.Plan. INPUT='Joe Biden was president 3 years ago' => markup.fact.result    - Microsoft.SemanticKernel.Planning.Plan. INPUT='For dinner, you might enjoy some sushi with your partner, since you both like it and you only ate it once this month' => markup.opinion.result
+
+    Result:
+    The president of the United States ( POTUS) [A] is the head of state and head of government of the United States of America. The president directs the executive branch of the federal government and is the commander-in-chief of the United States Armed Forces .
+    Joe Biden was president 3 years ago
+    For dinner, you might enjoy some sushi with your partner, since you both like it and you only ate it once this month
+    */
+
+    private static SKContext CreateContextQueryContext(IKernel kernel)
+    {
+        var context = kernel.CreateNewContext();
+        context.Variables.Set("firstname", "Jamal");
+        context.Variables.Set("lastname", "Williams");
+        context.Variables.Set("city", "Tacoma");
+        context.Variables.Set("state", "WA");
+        context.Variables.Set("country", "USA");
+        return context;
+    }
+
+    private static async Task RememberFactsAsync(IKernel kernel)
+    {
+        kernel.ImportSkill(new TextMemorySkill("contextQueryMemories", "0.3", "5"), "memory");
+
+        List<string> memoriesToSave = new()
+        {
+            "I like pizza and chicken wings.",
+            "I ate pizza 10 times this month.",
+            "I ate chicken wings 3 time this month.",
+            "I ate sushi 1 time this month.",
+            "My partner likes sushi and chicken wings.",
+            "I like to eat dinner with my partner.",
+            "I am a software engineer.",
+            "I live in Tacoma, WA.",
+            "I have a dog named Tully.",
+            "I have a cat named Butters.",
+        };
+
+        foreach (var memoryToSave in memoriesToSave)
+        {
+            await kernel.Memory.SaveInformationAsync("contextQueryMemories", memoryToSave, Guid.NewGuid().ToString());
+        }
+    }
+
+    // ContextQuery is part of the QASkill
+    // DependsOn: TimeSkill named "time"
+    // DependsOn: BingSkill named "bing"
+    private static IDictionary<string, ISKFunction> LoadQASkill(IKernel kernel)
+    {
+        string folder = RepoFiles.SampleSkillsPath();
+        kernel.ImportSkill(new TimeSkill(), "time");
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        var bing = new WebSearchEngineSkill(new BingConnector(Env.Var("BING_API_KEY")));
+#pragma warning restore CA2000 // Dispose objects before losing scope
+        var search = kernel.ImportSkill(bing, "bing");
+
+        return kernel.ImportSemanticSkillFromDirectory(folder, "QASkill");
+    }
+
+    private static IKernel InitializeKernel()
+    {
+        return new KernelBuilder()
+                    .WithLogger(ConsoleLogger.Log)
+                    .Configure(
+                        config =>
+                        {
+                            config.AddAzureTextCompletionService(
+                                Env.Var("AZURE_OPENAI_SERVICE_ID"),
+                                Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
+                                Env.Var("AZURE_OPENAI_ENDPOINT"),
+                                Env.Var("AZURE_OPENAI_KEY"));
+
+                            config.AddAzureTextEmbeddingGenerationService(
+                                Env.Var("AZURE_OPENAI_EMBEDDINGS_SERVICE_ID"),
+                                Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
+                                Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
+                                Env.Var("AZURE_OPENAI_EMBEDDINGS_KEY"));
+                        })
+                    .WithMemoryStorage(new VolatileMemoryStore())
+                    .Build();
+    }
+}
+
+// Example Skill that can process XML Markup created by ContextQuery
+public class MarkupSkill
+{
+    [SKFunction("Run Markup")]
+    [SKFunctionName("RunMarkup")]
+    public async Task<SKContext> RunMarkupAsync(SKContext context)
+    {
+        var docString = context.Variables.Input;
+        var plan = docString.FromMarkup("Run a piece of xml markup", context);
+
+        Console.WriteLine("Markup plan:");
+        Console.WriteLine(PlanToString(plan));
+        Console.WriteLine();
+
+        var result = await plan.InvokeAsync();
+        context.Variables.Update(result.Result);
+        return context;
+    }
+
+    private static string PlanToString(Plan originalPlan, string indent = " ")
+    {
+        var sb = new StringBuilder($"{indent}Goal: {originalPlan.Description}\n\n{indent}Steps:\n");
+
+        foreach (var step in originalPlan.Steps)
+        {
+            sb.Append(step.Steps.Count switch
+            {
+                0 => $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
+                _ => PlanToString(step, indent + indent)
+            });
+        }
+
+        return sb.ToString();
+    }
+}
+
+public static class XmlMarkupPlanParser
+{
+    private static readonly Dictionary<string, KeyValuePair<string, string>> s_skillMapping = new()
+    {
+        {"lookup", new KeyValuePair<string, string>("bing", "SearchAsync")},
+    };
+
+    public static Plan FromMarkup(this string markup, string goal, SKContext context)
+    {
+        Console.WriteLine("Markup:");
+        Console.WriteLine(markup);
+        Console.WriteLine();
+
+        var doc = new XmlMarkup(markup);
+        var nodes = doc.SelectElements();
+        return nodes.Count == 0 ? new Plan(goal) : NodeListToPlan(nodes, context, goal);
+    }
+
+    private static Plan NodeListToPlan(XmlNodeList nodes, SKContext context, string description)
+    {
+        Plan plan = new(description);
+        for (var i = 0; i < nodes.Count; ++i)
+        {
+            var node = nodes[i];
+            var functionName = node!.LocalName;
+            var skillName = string.Empty;
+
+            if (s_skillMapping.TryGetValue(node!.LocalName, out KeyValuePair<string, string> value))
+            {
+                functionName = value.Value;
+                skillName = value.Key;
+            }
+
+            var hasChildElements = node.HasChildElements();
+
+            if (hasChildElements)
+            {
+                plan.AddSteps(NodeListToPlan(node.ChildNodes, context, functionName));
+            }
+            else
+            {
+                if (
+                    string.IsNullOrEmpty(skillName) ? !context.Skills!.HasFunction(functionName) : !context.Skills!.HasFunction(skillName, functionName))
+                {
+                    var planStep = new Plan(node.InnerText);
+                    planStep.NamedParameters.Update(node.InnerText);
+                    planStep.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
+                    plan.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
+                    plan.AddSteps(planStep);
+                }
+                else
+                {
+                    var command = string.IsNullOrEmpty(skillName) ? context.Skills.GetFunction(functionName) : context.Skills.GetFunction(skillName, functionName);
+                    var planStep = new Plan(command);
+                    planStep.NamedParameters.Update(node.InnerText);
+                    planStep.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
+                    plan.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
+                    plan.AddSteps(planStep);
+                }
+            }
+        }
+
+        return plan;
+    }
+}
+
+#region Utility Classes
+public class XmlMarkup
+{
+    public XmlMarkup(string response, string? wrapperTag = null)
+    {
+        if (!string.IsNullOrEmpty(wrapperTag))
+        {
+            response = $"<{wrapperTag}>{response}</{wrapperTag}>";
+        }
+
+        this.Document = new XmlDocument();
+        this.Document.LoadXml(response);
+    }
+
+    public XmlDocument Document { get; }
+
+    public XmlNodeList SelectAllElements()
+    {
+        return this.Document.SelectNodes("//*")!;
+    }
+
+    public XmlNodeList SelectElements()
+    {
+        return this.Document.SelectNodes("/*")!;
+    }
+}
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+public struct XmlNodeInfo
+{
+    public int StackDepth { get; set; }
+    public XmlNode Parent { get; set; }
+    public XmlNode Node { get; set; }
+
+    public static implicit operator XmlNode(XmlNodeInfo info)
+    {
+        return info.Node;
+    }
+}
+#pragma warning restore CA1815
+
+
+#pragma warning disable CA1711
+public static class XmlEx
+{
+    public static bool HasChildElements(this XmlNode elt)
+    {
+        if (!elt.HasChildNodes)
+        {
+            return false;
+        }
+
+        var childNodes = elt.ChildNodes;
+        for (int i = 0, count = childNodes.Count; i < count; ++i)
+        {
+            if (childNodes[i]?.NodeType == XmlNodeType.Element)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Walks the Markup DOM using an XPathNavigator, allowing recursive descent WITHOUT requiring a Stack Hit
+    ///     This is safe for very large and highly nested documents.
+    /// </summary>
+    public static IEnumerable<XmlNodeInfo> EnumerateNodes(this XmlNode node, int maxStackDepth = 32)
+    {
+        var nav = node.CreateNavigator();
+        return EnumerateNodes(nav!, maxStackDepth);
+    }
+
+    public static IEnumerable<XmlNodeInfo> EnumerateNodes(this XmlDocument doc, int maxStackDepth = 32)
+    {
+        var nav = doc.CreateNavigator();
+        nav!.MoveToRoot();
+        return EnumerateNodes(nav, maxStackDepth);
+    }
+
+    public static IEnumerable<XmlNodeInfo> EnumerateNodes(this XPathNavigator nav, int maxStackDepth = 32)
+    {
+        var info = new XmlNodeInfo
+        {
+            StackDepth = 0
+        };
+        var hasChildren = nav.HasChildren;
+        while (true)
+        {
+            info.Parent = (XmlNode)nav.UnderlyingObject!;
+            if (hasChildren && info.StackDepth < maxStackDepth)
+            {
+                nav.MoveToFirstChild();
+                info.StackDepth++;
+            }
+            else
+            {
+                var hasParent = false;
+                while (hasParent = nav.MoveToParent())
+                {
+                    info.StackDepth--;
+                    if (info.StackDepth == 0)
+                    {
+                        hasParent = false;
+                        break;
+                    }
+
+                    if (nav.MoveToNext())
+                    {
+                        break;
+                    }
+                }
+
+                if (!hasParent)
+                {
+                    break;
+                }
+            }
+
+            do
+            {
+                info.Node = (XmlNode)nav.UnderlyingObject!;
+                yield return info;
+                if (hasChildren = nav.HasChildren)
+                {
+                    break;
+                }
+            } while (nav.MoveToNext());
+        }
+    }
+}
+#pragma warning restore CA1711
+#endregion Utility Classes

--- a/samples/dotnet/kernel-syntax-examples/Example29_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example29_CustomPlanner.cs
@@ -121,24 +121,24 @@ internal static class Example29_CustomPlanner
     private static IKernel InitializeKernel()
     {
         return new KernelBuilder()
-                    .WithLogger(ConsoleLogger.Log)
-                    .Configure(
-                        config =>
-                        {
-                            config.AddAzureTextCompletionService(
-                                Env.Var("AZURE_OPENAI_SERVICE_ID"),
-                                Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
-                                Env.Var("AZURE_OPENAI_ENDPOINT"),
-                                Env.Var("AZURE_OPENAI_KEY"));
+            .WithLogger(ConsoleLogger.Log)
+            .Configure(
+                config =>
+                {
+                    config.AddAzureTextCompletionService(
+                        Env.Var("AZURE_OPENAI_SERVICE_ID"),
+                        Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
+                        Env.Var("AZURE_OPENAI_ENDPOINT"),
+                        Env.Var("AZURE_OPENAI_KEY"));
 
-                            config.AddAzureTextEmbeddingGenerationService(
-                                Env.Var("AZURE_OPENAI_EMBEDDINGS_SERVICE_ID"),
-                                Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
-                                Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
-                                Env.Var("AZURE_OPENAI_EMBEDDINGS_KEY"));
-                        })
-                    .WithMemoryStorage(new VolatileMemoryStore())
-                    .Build();
+                    config.AddAzureTextEmbeddingGenerationService(
+                        Env.Var("AZURE_OPENAI_EMBEDDINGS_SERVICE_ID"),
+                        Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
+                        Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
+                        Env.Var("AZURE_OPENAI_EMBEDDINGS_KEY"));
+                })
+            .WithMemoryStorage(new VolatileMemoryStore())
+            .Build();
     }
 }
 
@@ -169,7 +169,8 @@ public class MarkupSkill
         {
             sb.Append(step.Steps.Count switch
             {
-                0 => $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
+                0 =>
+                    $"{indent}{indent}- {string.Join(".", step.SkillName, step.Name)} {string.Join(" ", step.NamedParameters.Select(p => $"{p.Key}='{p.Value}'"))}{(step.NamedOutputs.Where(s => s.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT").Select(p => $"{p.Key}").FirstOrDefault() is var namedOutputs ? $" => {namedOutputs}" : "")}",
                 _ => PlanToString(step, indent + indent)
             });
         }
@@ -182,7 +183,7 @@ public static class XmlMarkupPlanParser
 {
     private static readonly Dictionary<string, KeyValuePair<string, string>> s_skillMapping = new()
     {
-        {"lookup", new KeyValuePair<string, string>("bing", "SearchAsync")},
+        { "lookup", new KeyValuePair<string, string>("bing", "SearchAsync") },
     };
 
     public static Plan FromMarkup(this string markup, string goal, SKContext context)
@@ -230,7 +231,9 @@ public static class XmlMarkupPlanParser
                 }
                 else
                 {
-                    var command = string.IsNullOrEmpty(skillName) ? context.Skills.GetFunction(functionName) : context.Skills.GetFunction(skillName, functionName);
+                    var command = string.IsNullOrEmpty(skillName)
+                        ? context.Skills.GetFunction(functionName)
+                        : context.Skills.GetFunction(skillName, functionName);
                     var planStep = new Plan(command);
                     planStep.NamedParameters.Update(node.InnerText);
                     planStep.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
@@ -245,6 +248,7 @@ public static class XmlMarkupPlanParser
 }
 
 #region Utility Classes
+
 public class XmlMarkup
 {
     public XmlMarkup(string response, string? wrapperTag = null)
@@ -284,7 +288,6 @@ public struct XmlNodeInfo
     }
 }
 #pragma warning restore CA1815
-
 
 #pragma warning disable CA1711
 public static class XmlEx
@@ -377,4 +380,5 @@ public static class XmlEx
     }
 }
 #pragma warning restore CA1711
+
 #endregion Utility Classes

--- a/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
@@ -199,8 +199,9 @@ public static class XmlMarkupPlanParser
             }
             else
             {
-                if (
-                    string.IsNullOrEmpty(skillName) ? !context.Skills!.HasFunction(functionName) : !context.Skills!.HasFunction(skillName, functionName))
+                if (string.IsNullOrEmpty(skillName) ?
+                    !context.Skills!.TryGetFunction(functionName, out var _) :
+                    !context.Skills!.TryGetFunction(skillName, functionName, out var _))
                 {
                     var planStep = new Plan(node.InnerText);
                     planStep.Parameters.Update(node.InnerText);

--- a/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
@@ -17,7 +17,7 @@ using RepoUtils;
 
 // ReSharper disable CommentTypo
 // ReSharper disable once InconsistentNaming
-internal static class Example29_CustomPlanner
+internal static class Example31_CustomPlanner
 {
     public static async Task RunAsync()
     {
@@ -79,7 +79,7 @@ internal static class Example29_CustomPlanner
 
     private static async Task RememberFactsAsync(IKernel kernel)
     {
-        kernel.ImportSkill(new TextMemorySkill("contextQueryMemories", "0.3", "5"), "memory");
+        kernel.ImportSkill(new TextMemorySkill("contextQueryMemories", "0.3", "5"));
 
         List<string> memoriesToSave = new()
         {
@@ -124,13 +124,11 @@ internal static class Example29_CustomPlanner
                 config =>
                 {
                     config.AddAzureTextCompletionService(
-                        Env.Var("AZURE_OPENAI_SERVICE_ID"),
                         Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                         Env.Var("AZURE_OPENAI_ENDPOINT"),
                         Env.Var("AZURE_OPENAI_KEY"));
 
                     config.AddAzureTextEmbeddingGenerationService(
-                        Env.Var("AZURE_OPENAI_EMBEDDINGS_SERVICE_ID"),
                         Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
                         Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
                         Env.Var("AZURE_OPENAI_EMBEDDINGS_KEY"));

--- a/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
@@ -203,9 +203,9 @@ public static class XmlMarkupPlanParser
                     string.IsNullOrEmpty(skillName) ? !context.Skills!.HasFunction(functionName) : !context.Skills!.HasFunction(skillName, functionName))
                 {
                     var planStep = new Plan(node.InnerText);
-                    planStep.NamedParameters.Update(node.InnerText);
-                    planStep.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
-                    plan.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
+                    planStep.Parameters.Update(node.InnerText);
+                    planStep.Outputs.Add($"markup.{functionName}.result");
+                    plan.Outputs.Add($"markup.{functionName}.result");
                     plan.AddSteps(planStep);
                 }
                 else
@@ -214,9 +214,9 @@ public static class XmlMarkupPlanParser
                         ? context.Skills.GetFunction(functionName)
                         : context.Skills.GetFunction(skillName, functionName);
                     var planStep = new Plan(command);
-                    planStep.NamedParameters.Update(node.InnerText);
-                    planStep.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
-                    plan.NamedOutputs.Set($"markup.{functionName}.result", string.Empty);
+                    planStep.Parameters.Update(node.InnerText);
+                    planStep.Outputs.Add($"markup.{functionName}.result");
+                    plan.Outputs.Add($"markup.{functionName}.result");
                     plan.AddSteps(planStep);
                 }
             }

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -8,95 +8,95 @@ public static class Program
     // ReSharper disable once InconsistentNaming
     public static async Task Main()
     {
-        // Example01_NativeFunctions.Run();
-        // Console.WriteLine("== DONE ==");
+        Example01_NativeFunctions.Run();
+        Console.WriteLine("== DONE ==");
 
-        // await Example02_Pipeline.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example02_Pipeline.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example03_Variables.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example03_Variables.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example04_CombineLLMPromptsAndNativeCode.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example04_CombineLLMPromptsAndNativeCode.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example05_InlineFunctionDefinition.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example05_InlineFunctionDefinition.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example06_TemplateLanguage.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example06_TemplateLanguage.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example07_BingAndGoogleSkills.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example07_BingAndGoogleSkills.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example08_RetryHandler.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example08_RetryHandler.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example09_FunctionTypes.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example09_FunctionTypes.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // Example10_DescribeAllSkillsAndFunctions.Run();
-        // Console.WriteLine("== DONE ==");
+        Example10_DescribeAllSkillsAndFunctions.Run();
+        Console.WriteLine("== DONE ==");
 
-        // await Example11_WebSearchQueries.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example11_WebSearchQueries.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example12_SequentialPlanner.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example12_SequentialPlanner.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example13_ConversationSummarySkill.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example13_ConversationSummarySkill.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example14_SemanticMemory.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example14_SemanticMemory.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example15_MemorySkill.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example15_MemorySkill.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example16_CustomLLM.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example16_CustomLLM.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example17_ChatGPT.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example17_ChatGPT.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example18_DallE.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example18_DallE.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example19_Qdrant.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example19_Qdrant.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example20_HuggingFace.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example20_HuggingFace.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example21_ChatGptPlugins.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example21_ChatGptPlugins.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example22_OpenApiSkill_AzureKeyVault.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example22_OpenApiSkill_AzureKeyVault.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example23_OpenApiSkill_GitHub.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example23_OpenApiSkill_GitHub.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example24_OpenApiSkill_Jira.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example24_OpenApiSkill_Jira.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example25_ReadOnlyMemoryStore.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example25_ReadOnlyMemoryStore.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example26_AADAuth.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example26_AADAuth.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example27_SemanticFunctionsUsingChatGPT.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example27_SemanticFunctionsUsingChatGPT.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // await Example28_ActionPlanner.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example28_ActionPlanner.RunAsync();
+        Console.WriteLine("== DONE ==");
 
-        // Example29_Tokenizer.Run();
-        // Console.WriteLine("== DONE ==");
+        Example29_Tokenizer.Run();
+        Console.WriteLine("== DONE ==");
 
-        // await Example30_ChatWithPrompts.RunAsync();
-        // Console.WriteLine("== DONE ==");
+        await Example30_ChatWithPrompts.RunAsync();
+        Console.WriteLine("== DONE ==");
 
         await Example31_CustomPlanner.RunAsync();
         Console.WriteLine("== DONE ==");

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -8,95 +8,95 @@ public static class Program
     // ReSharper disable once InconsistentNaming
     public static async Task Main()
     {
-        Example01_NativeFunctions.Run();
-        Console.WriteLine("== DONE ==");
+        // Example01_NativeFunctions.Run();
+        // Console.WriteLine("== DONE ==");
 
-        await Example02_Pipeline.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example02_Pipeline.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example03_Variables.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example03_Variables.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example04_CombineLLMPromptsAndNativeCode.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example04_CombineLLMPromptsAndNativeCode.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example05_InlineFunctionDefinition.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example05_InlineFunctionDefinition.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example06_TemplateLanguage.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example06_TemplateLanguage.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example07_BingAndGoogleSkills.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example07_BingAndGoogleSkills.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example08_RetryHandler.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example08_RetryHandler.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example09_FunctionTypes.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example09_FunctionTypes.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        Example10_DescribeAllSkillsAndFunctions.Run();
-        Console.WriteLine("== DONE ==");
+        // Example10_DescribeAllSkillsAndFunctions.Run();
+        // Console.WriteLine("== DONE ==");
 
-        await Example11_WebSearchQueries.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example11_WebSearchQueries.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example12_SequentialPlanner.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example12_SequentialPlanner.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example13_ConversationSummarySkill.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example13_ConversationSummarySkill.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example14_SemanticMemory.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example14_SemanticMemory.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example15_MemorySkill.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example15_MemorySkill.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example16_CustomLLM.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example16_CustomLLM.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example17_ChatGPT.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example17_ChatGPT.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example18_DallE.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example18_DallE.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example19_Qdrant.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example19_Qdrant.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example20_HuggingFace.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example20_HuggingFace.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example21_ChatGptPlugins.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example21_ChatGptPlugins.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example22_OpenApiSkill_AzureKeyVault.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example22_OpenApiSkill_AzureKeyVault.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example23_OpenApiSkill_GitHub.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example23_OpenApiSkill_GitHub.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example24_OpenApiSkill_Jira.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example24_OpenApiSkill_Jira.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example25_ReadOnlyMemoryStore.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example25_ReadOnlyMemoryStore.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example26_AADAuth.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example26_AADAuth.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example27_SemanticFunctionsUsingChatGPT.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example27_SemanticFunctionsUsingChatGPT.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        await Example28_ActionPlanner.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example28_ActionPlanner.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
-        Example29_Tokenizer.Run();
-        Console.WriteLine("== DONE ==");
+        // Example29_Tokenizer.Run();
+        // Console.WriteLine("== DONE ==");
 
-        await Example30_ChatWithPrompts.RunAsync();
-        Console.WriteLine("== DONE ==");
+        // await Example30_ChatWithPrompts.RunAsync();
+        // Console.WriteLine("== DONE ==");
 
         await Example31_CustomPlanner.RunAsync();
         Console.WriteLine("== DONE ==");

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -97,5 +97,8 @@ public static class Program
 
         await Example30_ChatWithPrompts.RunAsync();
         Console.WriteLine("== DONE ==");
+
+        await Example29_CustomPlanner.RunAsync();
+        Console.WriteLine("== DONE ==");
     }
 }

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -98,7 +98,7 @@ public static class Program
         await Example30_ChatWithPrompts.RunAsync();
         Console.WriteLine("== DONE ==");
 
-        await Example29_CustomPlanner.RunAsync();
+        await Example31_CustomPlanner.RunAsync();
         Console.WriteLine("== DONE ==");
     }
 }

--- a/samples/dotnet/kernel-syntax-examples/RepoUtils/PlanExtensions.cs
+++ b/samples/dotnet/kernel-syntax-examples/RepoUtils/PlanExtensions.cs
@@ -18,19 +18,19 @@ internal static class PlanExtensions
                 string skillName = step.SkillName;
                 string stepName = step.Name;
 
-                string namedParams = string.Join(" ", step.Parameters.Select(param => $"{param.Key}='{param.Value}'"));
-                if (!string.IsNullOrEmpty(namedParams))
+                string parameters = string.Join(" ", step.Parameters.Select(param => $"{param.Key}='{param.Value}'"));
+                if (!string.IsNullOrEmpty(parameters))
                 {
-                    namedParams = $" {namedParams}";
+                    parameters = $" {parameters}";
                 }
 
-                string? namedOutputs = step.Outputs?.Select(output => output).FirstOrDefault();
-                if (!string.IsNullOrEmpty(namedOutputs))
+                string? outputs = step.Outputs.FirstOrDefault();
+                if (!string.IsNullOrEmpty(outputs))
                 {
-                    namedOutputs = $" => {namedOutputs}";
+                    outputs = $" => {outputs}";
                 }
 
-                return $"{indent}{indent}- {string.Join(".", skillName, stepName)}{namedParams}{namedOutputs}";
+                return $"{indent}{indent}- {string.Join(".", skillName, stepName)}{parameters}{outputs}";
             }
             else
             {

--- a/samples/dotnet/kernel-syntax-examples/RepoUtils/PlanExtensions.cs
+++ b/samples/dotnet/kernel-syntax-examples/RepoUtils/PlanExtensions.cs
@@ -18,15 +18,13 @@ internal static class PlanExtensions
                 string skillName = step.SkillName;
                 string stepName = step.Name;
 
-                string namedParams = string.Join(" ", step.NamedParameters.Select(param => $"{param.Key}='{param.Value}'"));
+                string namedParams = string.Join(" ", step.Parameters.Select(param => $"{param.Key}='{param.Value}'"));
                 if (!string.IsNullOrEmpty(namedParams))
                 {
                     namedParams = $" {namedParams}";
                 }
 
-                string? namedOutputs = step.NamedOutputs?
-                    .Where(output => output.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT")
-                    .Select(output => output.Key).FirstOrDefault();
+                string? namedOutputs = step.Outputs?.Select(output => output).FirstOrDefault();
                 if (!string.IsNullOrEmpty(namedOutputs))
                 {
                     namedOutputs = $" => {namedOutputs}";

--- a/samples/dotnet/kernel-syntax-examples/RepoUtils/PlanExtensions.cs
+++ b/samples/dotnet/kernel-syntax-examples/RepoUtils/PlanExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using Microsoft.SemanticKernel.Planning;
+
+namespace RepoUtils;
+
+internal static class PlanExtensions
+{
+    internal static string ToPlanString(this Plan originalPlan, string indent = " ")
+    {
+        string goalHeader = $"{indent}Goal: {originalPlan.Description}\n\n{indent}Steps:\n";
+
+        string stepItems = string.Join("\n", originalPlan.Steps.Select(step =>
+        {
+            if (step.Steps.Count == 0)
+            {
+                string skillName = step.SkillName;
+                string stepName = step.Name;
+
+                string namedParams = string.Join(" ", step.NamedParameters.Select(param => $"{param.Key}='{param.Value}'"));
+                if (!string.IsNullOrEmpty(namedParams))
+                {
+                    namedParams = $" {namedParams}";
+                }
+
+                string? namedOutputs = step.NamedOutputs?
+                    .Where(output => output.Key.ToUpper(System.Globalization.CultureInfo.CurrentCulture) != "INPUT")
+                    .Select(output => output.Key).FirstOrDefault();
+                if (!string.IsNullOrEmpty(namedOutputs))
+                {
+                    namedOutputs = $" => {namedOutputs}";
+                }
+
+                return $"{indent}{indent}- {string.Join(".", skillName, stepName)}{namedParams}{namedOutputs}";
+            }
+            else
+            {
+                string nestedSteps = step.ToPlanString(indent + indent);
+                return nestedSteps;
+            }
+        }));
+
+        return goalHeader + stepItems;
+    }
+}

--- a/samples/skills/QASkill/ContextQuery/skprompt.txt
+++ b/samples/skills/QASkill/ContextQuery/skprompt.txt
@@ -20,7 +20,7 @@ LAST NAME: {{$lastname}}
 CITY: {{$city}}
 STATE: {{$state}}
 COUNTRY: {{$country}}
-{{recall $input}}
+{{memory.recall $input}}
 [END CONTEXT]
 
 EMIT WELL FORMED XML ALWAYS. Any code you write should be CDATA.

--- a/samples/skills/QASkill/ContextQuery/skprompt.txt
+++ b/samples/skills/QASkill/ContextQuery/skprompt.txt
@@ -17,7 +17,7 @@ essay: longer answers. You can have sub-elements such as fact and fiction
 TODAY is {{time.Date}}
 FIRST NAME: {{$firstname}}
 LAST NAME: {{$lastname}}
-CITYl {{$city}}
+CITY: {{$city}}
 STATE: {{$state}}
 COUNTRY: {{$country}}
 {{memory.recall $input}}

--- a/samples/skills/QASkill/ContextQuery/skprompt.txt
+++ b/samples/skills/QASkill/ContextQuery/skprompt.txt
@@ -1,4 +1,4 @@
-ONLY USE XML TAGS IN THIS LIST: 
+ONLY USE XML TAGS IN THIS LIST:
 [XML TAG LIST]
 lookup: lookup information from outside
 unsure: low confidence
@@ -20,24 +20,24 @@ LAST NAME: {{$lastname}}
 CITYl {{$city}}
 STATE: {{$state}}
 COUNTRY: {{$country}}
-{{recall $input}}
+{{memory.recall $input}}
 [END CONTEXT]
 
-EMIT WELL FORMED XML ALWAYS. Any code you write should be CDATA. 
-BE BRIEF AND TO THE POINT, BUT WHEN SUPPLYING OPINION, IF YOU SEE THE NEED, YOU CAN BE LONGER.  
+EMIT WELL FORMED XML ALWAYS. Any code you write should be CDATA.
+BE BRIEF AND TO THE POINT, BUT WHEN SUPPLYING OPINION, IF YOU SEE THE NEED, YOU CAN BE LONGER.
 USE [CONTEXT] TO LEARN ABOUT ME.
 WHEN ANSWERING QUESTIONS, GIVING YOUR OPINION OR YOUR RECOMMENDATIONS, BE CONTEXTUAL.
 For updated information about an entity, thing, event or time dependent matter, put in tags.
 If you don't know, ask.
-If you are not sure, ask. 
-If information is out of date, ask. 
-Don't give me old information that is out of date. 
+If you are not sure, ask.
+If information is out of date, ask.
+Don't give me old information that is out of date.
 Based on calculates from TODAY, if the answer in the past, emit a fact. Otherwise emit a lookup tag.
 
 
 Who is the current president of the United States? Who was president in 2012? Who was CEO of Microsoft 30 years ago?
 <response><lookup>Who is United States President</lookup><fact>Barack Obama was president in 2012</fact><fact>Bill Gates was CEO 30 years ago</fact></response>
-[done] 
+[done]
 
 Give me a short overview of Jupiter. What are NASA's latest spacecraft around it? What was the first spacecraft to do so?
 <response><fact>Jupiter is the largest planet in the solar system</fact> <lookup>NASA missions Jupiter now</lookup><fact>Galileo was the first spacecraft to orbit Jupiter</fact><fiction>invaders from Jupiter attacked Saturn</fiction></response>[done]

--- a/samples/skills/QASkill/ContextQuery/skprompt.txt
+++ b/samples/skills/QASkill/ContextQuery/skprompt.txt
@@ -20,7 +20,7 @@ LAST NAME: {{$lastname}}
 CITY: {{$city}}
 STATE: {{$state}}
 COUNTRY: {{$country}}
-{{memory.recall $input}}
+{{recall $input}}
 [END CONTEXT]
 
 EMIT WELL FORMED XML ALWAYS. Any code you write should be CDATA.


### PR DESCRIPTION
### Motivation and Context
The motivation of the PR is to demonstrate custom planning capabilities, specifically for the markup returned by `ContextQuery` function. 

In creating this example, some gaps were found in the Plan object and TextMemorySkill. This PR proposes some changes to those objects.

### Description

#### Plan
- Plan now updates its state with the result of each step, appending the result to the previous result if the step has more than one named output. This allows the plan to keep track of the context and the intermediate results of each step, and to pass them to the next step as input.

#### Example Custom|Markup Planner
- A new example for using a custom planner to create and execute a plan using the Markup Skill, which can process XML markup created by the ContextQuery skill, which can generate natural language queries from a context. 
- A new example of using a custom planner to generate plans from XML markup, using a simple markup language that supports lookup, echo, and concat functions, as well as nested elements.
- Some minor fixes and improvements to the plan execution logic, the plan parser, the plan invocation logic, and the PlanToString method.

#### TextMemorySkill improvements (for the example).
- TextMemorySkill now has a constructor that allows customizing the default parameters for the Recall function, such as the collection, relevance, and limit. By default, getting a single memory for ContextQuery was not interesting. This change makes it easier to demonstrate more interesting capabilities.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
- [x] Integration Tests pass https://github.com/lemillermicrosoft/semantic-kernel/actions/runs/4831594273