### PR TITLE
Validate goal and handle plan parsing errors in SequentialPlanner

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Moq;
@@ -142,6 +143,73 @@ public sealed class SequentialPlannerTests
                 plan.Steps,
                 step => step.SkillName == expectedSkill);
         }
+    }
+
+    [Fact]
+    public async Task EmptyGoalThrowsAsync()
+    {
+        // Arrange
+        var kernel = new Mock<IKernel>();
+        // kernel.Setup(x => x.Log).Returns(new Mock<ILogger>().Object);
+
+        var planner = new Microsoft.SemanticKernel.Planning.SequentialPlanner(kernel.Object);
+
+        // Act
+        await Assert.ThrowsAsync<PlanningException>(async () => await planner.CreatePlanAsync(""));
+    }
+
+    [Fact]
+    public async Task InvalidXMLThrowsAsync()
+    {
+        // Arrange
+        var kernel = new Mock<IKernel>();
+        // kernel.Setup(x => x.Log).Returns(new Mock<ILogger>().Object);
+        var memory = new Mock<ISemanticTextMemory>();
+        var skills = new Mock<ISkillCollection>();
+
+        var functionsView = new FunctionsView();
+        skills.Setup(x => x.GetFunctionsView(It.IsAny<bool>(), It.IsAny<bool>())).Returns(functionsView);
+
+        var planString =
+            @"<plan>notvalid<</plan>";
+        var returnContext = new SKContext(
+            new ContextVariables(planString),
+            memory.Object,
+            skills.Object,
+            new Mock<ILogger>().Object
+        );
+
+        var context = new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            new Mock<ILogger>().Object
+        );
+
+        var mockFunctionFlowFunction = new Mock<ISKFunction>();
+        mockFunctionFlowFunction.Setup(x => x.InvokeAsync(
+            It.IsAny<SKContext>(),
+            null,
+            null,
+            null
+        )).Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>(
+            (c, s, l, ct) => c.Variables.Update("Hello world!")
+        ).Returns(() => Task.FromResult(returnContext));
+
+        // Mock Skills
+        kernel.Setup(x => x.Skills).Returns(skills.Object);
+        kernel.Setup(x => x.CreateNewContext()).Returns(context);
+
+        kernel.Setup(x => x.RegisterSemanticFunction(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<SemanticFunctionConfig>()
+        )).Returns(mockFunctionFlowFunction.Object);
+
+        var planner = new Microsoft.SemanticKernel.Planning.SequentialPlanner(kernel.Object);
+
+        // Act
+        await Assert.ThrowsAsync<PlanningException>(async () => await planner.CreatePlanAsync("goal"));
     }
 
     // Method to create Mock<ISKFunction> objects

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
@@ -55,6 +56,11 @@ public sealed class SequentialPlanner
     /// <returns>The plan.</returns>
     public async Task<Plan> CreatePlanAsync(string goal)
     {
+        if (string.IsNullOrEmpty(goal))
+        {
+            throw new PlanningException(PlanningException.ErrorCodes.InvalidGoal, "The goal specified is empty");
+        }
+
         string relevantFunctionsManual = await this._context.GetFunctionsManualAsync(goal, this.Config).ConfigureAwait(false);
         this._context.Variables.Set("available_functions", relevantFunctionsManual);
 
@@ -64,9 +70,15 @@ public sealed class SequentialPlanner
 
         string planResultString = planResult.Result.Trim();
 
-        var plan = planResultString.ToPlanFromXml(goal, this._context);
-
-        return plan;
+        try
+        {
+            var plan = planResultString.ToPlanFromXml(goal, this._context);
+            return plan;
+        }
+        catch (Exception e)
+        {
+            throw new PlanningException(PlanningException.ErrorCodes.InvalidPlan, "Plan parsing error, invalid XML", e);
+        }
     }
 
     private SequentialPlannerConfig Config { get; }


### PR DESCRIPTION
Added a check for empty goal in CreatePlanAsync method and threw a PlanningException with appropriate error code. Wrapped the plan parsing logic in a try-catch block and re-threw any exceptions as PlanningExceptions with a different error code. This improves the robustness and usability of the SequentialPlanner class.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
