### PR TITLE
Simplify labeler rules for kernel label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,8 @@
 # Add 'kernel' label to any change within the 'dotnet/src' that's not 'SemanticKernel' or 'SemanticKernel.Abstractions' directory
 kernel:
-  - any:
+  - any: ["dotnet/src/**/*", "dotnet/src/*"]
+  - all:
       [
-        "dotnet/src/**/*",
-        "dotnet/src/*",
         "!dotnet/src/SemanticKernel/*",
         "!dotnet/src/SemanticKernel/**/*",
         "!dotnet/src/SemanticKernel.Abstractions/*",


### PR DESCRIPTION
This commit simplifies the labeler rules for the kernel label by using the any and all operators instead of a list of patterns. This makes the rules more readable and easier to maintain and ensures `kernel` label is used as appropriate. The logic of the rules still exclude the SemanticKernel and SemanticKernel.Abstractions projects from the kernel label but will now include if only non-core kernel changes are made.

https://github.com/lemillermicrosoft/semantic-kernel/pull/7
https://github.com/lemillermicrosoft/semantic-kernel/pull/8
https://github.com/lemillermicrosoft/semantic-kernel/pull/9

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
