### PR TITLE
🛠️Fix a bug in AIException constructor

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/AIException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/AIException.cs
@@ -49,7 +49,7 @@ public class AIException : SKException
     /// <param name="message">A string that describes the error.</param>
     /// <param name="detail">A string that provides additional details about the error.</param>
     public AIException(ErrorCodes errorCode, string? message, string? detail)
-        : this(errorCode, message, detail: null, innerException: null)
+        : this(errorCode, message, detail, innerException: null)
     {
     }
 


### PR DESCRIPTION
The AIException constructor that takes an errorCode, a message, and a detail was incorrectly passing null as the detail parameter to the base constructor. This commit fixes this bug by passing the detail parameter correctly. This ensures that the detail information is preserved and available for error handling.

### Motivation and Context
Bug Introduced: #701
Bug Hidden by: #596 

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
