### PR TITLE
Add unit tests for core exception types

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/AI/AIExceptionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/AIExceptionTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.AI;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.AI;
+
+public class AIExceptionTests
+{
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeCtor()
+    {
+        // Arrange
+        var e = new AIException(AIException.ErrorCodes.InvalidRequest);
+
+        // Assert
+        Assert.Equal(AIException.ErrorCodes.InvalidRequest, e.ErrorCode);
+        Assert.Contains("Invalid request", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.Detail);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var e = new AIException(AIException.ErrorCodes.InvalidRequest, Message);
+
+        // Assert
+        Assert.Equal(AIException.ErrorCodes.InvalidRequest, e.ErrorCode);
+        Assert.Contains("Invalid request", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.Detail);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var inner = new FormatException();
+        var e = new AIException(AIException.ErrorCodes.InvalidRequest, Message, inner);
+
+        // Assert
+        Assert.Equal(AIException.ErrorCodes.InvalidRequest, e.ErrorCode);
+        Assert.Contains("Invalid request", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.Detail);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageDetailCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        const string Detail = "so is this";
+        var e = new AIException(AIException.ErrorCodes.InvalidRequest, Message, Detail);
+
+        // Assert
+        Assert.Equal(AIException.ErrorCodes.InvalidRequest, e.ErrorCode);
+        Assert.Contains("Invalid request", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Equal(Detail, e.Detail);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageDetailExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        const string Detail = "so is this";
+        var inner = new FormatException();
+        var e = new AIException(AIException.ErrorCodes.InvalidRequest, Message, Detail, inner);
+
+        // Assert
+        Assert.Equal(AIException.ErrorCodes.InvalidRequest, e.ErrorCode);
+        Assert.Contains("Invalid request", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Equal(Detail, e.Detail);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItAllowsNullMessageAndInnerExceptionInCtors()
+    {
+        // Arrange
+        var e = new AIException(AIException.ErrorCodes.AccessDenied, null, null, null);
+
+        // Assert
+        Assert.Equal(AIException.ErrorCodes.AccessDenied, e.ErrorCode);
+        Assert.Contains("Access denied", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.Detail);
+        Assert.Null(e.InnerException);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Diagnostics/ValidationExceptionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Diagnostics/ValidationExceptionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Diagnostics;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Diagnostics;
+
+public class ValidationExceptionTests
+{
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeCtor()
+    {
+        // Arrange
+        var e = new ValidationException(ValidationException.ErrorCodes.DirectoryNotFound);
+
+        // Assert
+        Assert.Equal(ValidationException.ErrorCodes.DirectoryNotFound, e.ErrorCode);
+        Assert.Contains("Directory not found", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var e = new ValidationException(ValidationException.ErrorCodes.DirectoryNotFound, Message);
+
+        // Assert
+        Assert.Equal(ValidationException.ErrorCodes.DirectoryNotFound, e.ErrorCode);
+        Assert.Contains("Directory not found", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var inner = new FormatException();
+        var e = new ValidationException(ValidationException.ErrorCodes.DirectoryNotFound, Message, inner);
+
+        // Assert
+        Assert.Equal(ValidationException.ErrorCodes.DirectoryNotFound, e.ErrorCode);
+        Assert.Contains("Directory not found", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItAllowsNullMessageAndInnerExceptionInCtors()
+    {
+        // Arrange
+        var e = new ValidationException(ValidationException.ErrorCodes.DirectoryNotFound, null, null);
+
+        // Assert
+        Assert.Equal(ValidationException.ErrorCodes.DirectoryNotFound, e.ErrorCode);
+        Assert.Contains("Directory not found", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/KernelExceptionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelExceptionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel;
+using Xunit;
+
+namespace SemanticKernel.UnitTests;
+
+public class KernelExceptionTests
+{
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeCtor()
+    {
+        // Arrange
+        var e = new KernelException(KernelException.ErrorCodes.FunctionNotAvailable);
+
+        // Assert
+        Assert.Equal(KernelException.ErrorCodes.FunctionNotAvailable, e.ErrorCode);
+        Assert.Contains("Function not available", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var e = new KernelException(KernelException.ErrorCodes.FunctionNotAvailable, Message);
+
+        // Assert
+        Assert.Equal(KernelException.ErrorCodes.FunctionNotAvailable, e.ErrorCode);
+        Assert.Contains("Function not available", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var inner = new FormatException();
+        var e = new KernelException(KernelException.ErrorCodes.FunctionNotAvailable, Message, inner);
+
+        // Assert
+        Assert.Equal(KernelException.ErrorCodes.FunctionNotAvailable, e.ErrorCode);
+        Assert.Contains("Function not available", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItAllowsNullMessageAndInnerExceptionInCtors()
+    {
+        // Arrange
+        var e = new KernelException(KernelException.ErrorCodes.FunctionNotAvailable, null, null);
+
+        // Assert
+        Assert.Equal(KernelException.ErrorCodes.FunctionNotAvailable, e.ErrorCode);
+        Assert.Contains("Function not available", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Memory/MemoryExceptionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/MemoryExceptionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Memory;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Memory;
+
+public class MemoryExceptionTests
+{
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeCtor()
+    {
+        // Arrange
+        var e = new MemoryException(MemoryException.ErrorCodes.FailedToCreateCollection);
+
+        // Assert
+        Assert.Equal(MemoryException.ErrorCodes.FailedToCreateCollection, e.ErrorCode);
+        Assert.Contains("Failed to create collection", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var e = new MemoryException(MemoryException.ErrorCodes.FailedToCreateCollection, Message);
+
+        // Assert
+        Assert.Equal(MemoryException.ErrorCodes.FailedToCreateCollection, e.ErrorCode);
+        Assert.Contains("Failed to create collection", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var inner = new FormatException();
+        var e = new MemoryException(MemoryException.ErrorCodes.FailedToCreateCollection, Message, inner);
+
+        // Assert
+        Assert.Equal(MemoryException.ErrorCodes.FailedToCreateCollection, e.ErrorCode);
+        Assert.Contains("Failed to create collection", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItAllowsNullMessageAndInnerExceptionInCtors()
+    {
+        // Arrange
+        var e = new MemoryException(MemoryException.ErrorCodes.FailedToCreateCollection, null, null);
+
+        // Assert
+        Assert.Equal(MemoryException.ErrorCodes.FailedToCreateCollection, e.ErrorCode);
+        Assert.Contains("Failed to create collection", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanningExceptionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanningExceptionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Planning;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Planning;
+
+public class PlanningExceptionTests
+{
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeCtor()
+    {
+        // Arrange
+        var e = new PlanningException(PlanningException.ErrorCodes.InvalidGoal);
+
+        // Assert
+        Assert.Equal(PlanningException.ErrorCodes.InvalidGoal, e.ErrorCode);
+        Assert.Contains("Invalid goal", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var e = new PlanningException(PlanningException.ErrorCodes.InvalidGoal, Message);
+
+        // Assert
+        Assert.Equal(PlanningException.ErrorCodes.InvalidGoal, e.ErrorCode);
+        Assert.Contains("Invalid goal", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var inner = new FormatException();
+        var e = new PlanningException(PlanningException.ErrorCodes.InvalidGoal, Message, inner);
+
+        // Assert
+        Assert.Equal(PlanningException.ErrorCodes.InvalidGoal, e.ErrorCode);
+        Assert.Contains("Invalid goal", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItAllowsNullMessageAndInnerExceptionInCtors()
+    {
+        // Arrange
+        var e = new PlanningException(PlanningException.ErrorCodes.InvalidGoal, null, null);
+
+        // Assert
+        Assert.Equal(PlanningException.ErrorCodes.InvalidGoal, e.ErrorCode);
+        Assert.Contains("Invalid goal", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/TemplateExceptionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/TemplateExceptionTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.TemplateEngine;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.TemplateEngine;
+
+public class TemplateExceptionTests
+{
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeCtor()
+    {
+        // Arrange
+        var e = new TemplateException(TemplateException.ErrorCodes.RuntimeError);
+
+        // Assert
+        Assert.Equal(TemplateException.ErrorCodes.RuntimeError, e.ErrorCode);
+        Assert.Contains("Runtime error", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var e = new TemplateException(TemplateException.ErrorCodes.RuntimeError, Message);
+
+        // Assert
+        Assert.Equal(TemplateException.ErrorCodes.RuntimeError, e.ErrorCode);
+        Assert.Contains("Runtime error", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+
+    [Fact]
+    public void ItRoundtripsArgsToErrorCodeMessageExceptionCtor()
+    {
+        // Arrange
+        const string Message = "this is a test";
+        var inner = new FormatException();
+        var e = new TemplateException(TemplateException.ErrorCodes.RuntimeError, Message, inner);
+
+        // Assert
+        Assert.Equal(TemplateException.ErrorCodes.RuntimeError, e.ErrorCode);
+        Assert.Contains("Runtime error", e.Message, StringComparison.Ordinal);
+        Assert.Contains(Message, e.Message, StringComparison.Ordinal);
+        Assert.Same(inner, e.InnerException);
+    }
+
+    [Fact]
+    public void ItAllowsNullMessageAndInnerExceptionInCtors()
+    {
+        // Arrange
+        var e = new TemplateException(TemplateException.ErrorCodes.RuntimeError, null, null);
+
+        // Assert
+        Assert.Equal(TemplateException.ErrorCodes.RuntimeError, e.ErrorCode);
+        Assert.Contains("Runtime error", e.Message, StringComparison.Ordinal);
+        Assert.Null(e.InnerException);
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Fill unit test gaps.

### Description

Simple unit tests for the core exception types.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

cc: @lemillermicrosoft 