### PR TITLE
Improve labeler rules for kernel label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,34 +1,21 @@
-# Add 'kernel' label to any change within the 'dotnet/src' that's not 'SemanticKernel' or 'SemanticKernel.Abstractions' directory
+# Add 'kernel' label to any change within the 'dotnet' directory that's not under 'dotnet/src/SemanticKernel' or 'dotnet/src/SemanticKernel.Abstractions'
 kernel:
-  - any: ["dotnet/src/**/*", "dotnet/src/*"]
-  - all:
-      [
-        "!dotnet/src/SemanticKernel/*",
-        "!dotnet/src/SemanticKernel/**/*",
-        "!dotnet/src/SemanticKernel.Abstractions/*",
-        "!dotnet/src/SemanticKernel.Abstractions/**/*",
-      ]
+  - any:["dotnet/**/*", "!dotnet/src/SemanticKernel/**/*", "!dotnet/src/SemanticKernel.Abstractions/**/*"]
 
 # Add 'kernel.core' label to any change within the 'SemanticKernel' or 'SemanticKernel.Abstractions' directory
 kernel.core:
-  - dotnet/src/SemanticKernel/*
   - dotnet/src/SemanticKernel/**/*
-  - dotnet/src/SemanticKernel.Abstractions/*
   - dotnet/src/SemanticKernel.Abstractions/**/*
 
 # Add 'python' label to any change within the 'python' directory
 python:
-  - python/*
   - python/**/*
 
 # Add 'samples' label to any change within the 'samples' directory
 samples:
-  - samples/*
   - samples/**/*
 
 # Add '.NET' label to any change within samples or kernel 'dotnet' directories.
 .NET:
-  - dotnet/src/*
   - dotnet/src/**/*
   - samples/**/dotnet/**/*
-  - samples/**/dotnet/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,10 @@
 # Add 'kernel' label to any change within the 'dotnet' directory that's not under 'dotnet/src/SemanticKernel' or 'dotnet/src/SemanticKernel.Abstractions'
 kernel:
-  - any:
-      - "dotnet/src/Connectors/**/*"
-      - "dotnet/src/Extensions/**/*"
-      - "dotnet/src/Skills/**/*"
-      - "dotnet/src/IntegrationTests/**/*"
-      - "dotnet/src/SemanticKernel.UnitTests/**/*"
+  - "dotnet/src/Connectors/**/*"
+  - "dotnet/src/Extensions/**/*"
+  - "dotnet/src/Skills/**/*"
+  - "dotnet/src/IntegrationTests/**/*"
+  - "dotnet/src/SemanticKernel.UnitTests/**/*"
 
 # Add 'kernel.core' label to any change within the 'SemanticKernel' or 'SemanticKernel.Abstractions' directory
 kernel.core:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 # Add 'kernel' label to any change within the 'dotnet' directory that's not under 'dotnet/src/SemanticKernel' or 'dotnet/src/SemanticKernel.Abstractions'
 kernel:
-  - any:["dotnet/**/*", "!dotnet/src/SemanticKernel/**/*", "!dotnet/src/SemanticKernel.Abstractions/**/*"]
+  - any:
+      - "dotnet/**/*"
+      - "!dotnet/src/SemanticKernel/**/*"
+      - "!dotnet/src/SemanticKernel.Abstractions/**/*"
 
 # Add 'kernel.core' label to any change within the 'SemanticKernel' or 'SemanticKernel.Abstractions' directory
 kernel.core:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,17 @@
 # Add 'kernel' label to any change within the 'dotnet' directory that's not under 'dotnet/src/SemanticKernel' or 'dotnet/src/SemanticKernel.Abstractions'
 kernel:
   - any:
-      - "dotnet/**/*"
-      - "!dotnet/src/SemanticKernel/**/*"
-      - "!dotnet/src/SemanticKernel.Abstractions/**/*"
+      - "dotnet/src/Connectors/**/*"
+      - "dotnet/src/Extensions/**/*"
+      - "dotnet/src/Skills/**/*"
+      - "dotnet/src/IntegrationTests/**/*"
+      - "dotnet/src/SemanticKernel.UnitTests/**/*"
 
 # Add 'kernel.core' label to any change within the 'SemanticKernel' or 'SemanticKernel.Abstractions' directory
 kernel.core:
   - dotnet/src/SemanticKernel/**/*
   - dotnet/src/SemanticKernel.Abstractions/**/*
+  - dotnet/src/SemanticKernel.MetaPackage/**/*
 
 # Add 'python' label to any change within the 'python' directory
 python:


### PR DESCRIPTION
### Motivation and Context
#710 tried to enable the `kernel` tag but accidentally applied to too many changes.

### Description
 The best way to resolve this was specify directories under `dotnet` to be considered for `kernel`.
 
 https://github.com/lemillermicrosoft/semantic-kernel/pull/7
 https://github.com/lemillermicrosoft/semantic-kernel/pull/8
 https://github.com/lemillermicrosoft/semantic-kernel/pull/10
https://github.com/lemillermicrosoft/semantic-kernel/pull/9 This one was missed before.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
