### PR TITLE
Import gRPC skills

### DIFF
--- a/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Extensions/GrpcOperationExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Extensions/GrpcOperationExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.Skills.Grpc.Model;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.SemanticKernel.Skills.Grpc.Extensions;
+
+/// <summary>
+/// Class for extensions methods for the <see cref="GrpcOperationExtensions"/> class.
+/// </summary>
+internal static class GrpcOperationExtensions
+{
+    /// <summary>
+    /// Returns list of gRPC operation parameters.
+    /// </summary>
+    /// <returns>The list of parameters.</returns>
+    public static IReadOnlyList<ParameterView> GetParameters(this GrpcOperation operation)
+    {
+        var parameters = new List<ParameterView>();
+
+        //Register the "address" parameter so that it's possible to override it if needed.
+        parameters.Add(new ParameterView(GrpcOperation.AddressArgumentName, "Address for gRPC channel to use.", string.Empty));
+
+        //Register the "payload" parameter to be used as gRPC operation request message.
+        parameters.Add(new ParameterView(GrpcOperation.PayloadArgumentName, "gRPC request message.", string.Empty));
+
+        return parameters;
+    }
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Orchestration;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.SemanticKernel.Skills.Grpc.Model;
+using System.Linq;
+using Microsoft.SemanticKernel.Diagnostics;
+using System.IO;
+using Microsoft.SemanticKernel.Skills.Grpc.Protobuf;
+
+namespace Microsoft.SemanticKernel.Skills.Grpc.Extensions;
+
+/// <summary>
+/// <see cref="IKernel"/> extensions methods for gRPC functionality.
+/// </summary>
+public static class KernelGrpcExtensions
+{
+    /// <summary>
+    /// Imports gRPC document from a directory.
+    /// </summary>
+    /// <param name="kernel">Semantic Kernel instance.</param>
+    /// <param name="parentDirectory">Directory containing the skill directory.</param>
+    /// <param name="skillDirectoryName">Name of the directory containing the selected skill.</param>
+    /// <returns>A list of all the semantic functions representing the skill.</returns>
+    public static IDictionary<string, ISKFunction> ImportGrpcSkillFromDirectory(this IKernel kernel, string parentDirectory, string skillDirectoryName)
+    {
+        const string PROTO_FILE = "grpc.proto";
+
+        Verify.ValidSkillName(skillDirectoryName);
+
+        var skillDir = Path.Combine(parentDirectory, skillDirectoryName);
+        Verify.DirectoryExists(skillDir);
+
+        var filePath = Path.Combine(skillDir, PROTO_FILE);
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"No .proto document for the specified path - {filePath} is found.");
+        }
+
+        kernel.Log.LogTrace("Registering gRPC functions from {0} .proto document.", filePath);
+
+        using var stream = File.OpenRead(filePath);
+
+        return kernel.RegisterGrpcSkill(stream, skillDirectoryName);
+    }
+
+    /// <summary>
+    /// Imports gRPC document from a file.
+    /// </summary>
+    /// <param name="kernel">Semantic Kernel instance.</param>
+    /// <param name="skillName">Name of the skill to register.</param>
+    /// <param name="filePath">File path to .proto document.</param>
+    /// <returns>A list of all the semantic functions representing the skill.</returns>
+    public static IDictionary<string, ISKFunction> ImportGrpcSkillFromFile(
+        this IKernel kernel,
+        string skillName,
+        string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"No .proto document for the specified path - {filePath} is found.");
+        }
+
+        kernel.Log.LogTrace("Registering gRPC functions from {0} .proto document.", filePath);
+
+        using var stream = File.OpenRead(filePath);
+
+        return kernel.RegisterGrpcSkill(stream, skillName);
+    }
+
+    /// <summary>
+    /// Registers an gRPC skill.
+    /// </summary>
+    /// <param name="kernel">Semantic Kernel instance.</param>
+    /// <param name="documentStream">.proto document stream.</param>
+    /// <param name="skillName">Skill name.</param>
+    /// <returns>A list of all the semantic functions representing the skill.</returns>
+    public static IDictionary<string, ISKFunction> RegisterGrpcSkill(
+        this IKernel kernel,
+        Stream documentStream,
+        string skillName)
+    {
+        Verify.NotNull(kernel, nameof(kernel));
+        Verify.ValidSkillName(skillName);
+
+        // Parse
+        var parser = new ProtoDocumentParser();
+
+        var operations = parser.Parse(documentStream, skillName);
+
+        var skill = new Dictionary<string, ISKFunction>();
+
+        foreach (var operation in operations)
+        {
+            try
+            {
+                kernel.Log.LogTrace("Registering gRPC function {0}.{1}", skillName, operation.Name);
+                var function = kernel.RegisterGrpcFunction(skillName, operation);
+                skill[function.Name] = function;
+            }
+            catch (Exception ex) when (!ex.IsCriticalException())
+            {
+                //Logging the exception and keep registering other gRPC functions
+                kernel.Log.LogWarning(ex, "Something went wrong while rendering the gRPC function. Function: {0}.{1}. Error: {2}",
+                    skillName, operation.Name, ex.Message);
+            }
+        }
+
+        return skill;
+    }
+
+    #region private
+
+    /// <summary>
+    /// Registers SKFunction for a gRPC operation.
+    /// </summary>
+    /// <param name="kernel">Semantic Kernel instance.</param>
+    /// <param name="skillName">Skill name.</param>
+    /// <param name="operation">The gRPC operation.</param>
+    /// <returns>An instance of <see cref="SKFunction"/> class.</returns>
+    private static ISKFunction RegisterGrpcFunction(
+        this IKernel kernel,
+        string skillName,
+        GrpcOperation operation)
+    {
+        var operationParameters = operation.GetParameters();
+
+        async Task<SKContext> ExecuteAsync(SKContext context)
+        {
+            try
+            {
+                var arguments = new Dictionary<string, string>();
+
+                //Extract function arguments from context
+                foreach (var parameter in operationParameters)
+                {
+                    //A try to resolve argument parameter name.
+                    if (context.Variables.Get(parameter.Name, out var value))
+                    {
+                        arguments.Add(parameter.Name, value);
+                        continue;
+                    }
+
+                    throw new KeyNotFoundException($"No variable found in context to use as an argument for the '{parameter.Name}' parameter of the '{skillName}.{operation.Name}' gRPC function.");
+                }
+
+                var runner = new GrpcOperationRunner(new HttpClient());
+
+                //SKFunction should be extended to pass cancellation token for delegateFunction calls.
+                var result = await runner.RunAsync(operation, arguments, CancellationToken.None).ConfigureAwait(false);
+
+                if (result != null)
+                {
+                    context.Variables.Update(result.ToString());
+                }
+            }
+            catch (Exception ex) when (!ex.IsCriticalException())
+            {
+                kernel.Log.LogWarning(ex, "Something went wrong while rendering the gRPC function. Function: {0}.{1}. Error: {2}", skillName, operation.Name,
+                    ex.Message);
+                context.Fail(ex.Message, ex);
+            }
+
+            return context;
+        }
+
+        // TODO: to be fixed later
+#pragma warning disable CA2000 // Dispose objects before losing scope.
+        var function = new SKFunction(
+            delegateType: SKFunction.DelegateTypes.ContextSwitchInSKContextOutTaskSKContext,
+            delegateFunction: ExecuteAsync,
+            parameters: operationParameters.ToList(),
+            description: operation.Name,
+            skillName: skillName,
+            functionName: operation.Name,
+            isSemantic: false,
+            log: kernel.Log);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+        return kernel.RegisterCustomFunction(skillName, function);
+    }
+
+    #endregion
+}

--- a/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -2,15 +2,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.Orchestration;
-using System.Threading.Tasks;
-using System.Threading;
-using Microsoft.SemanticKernel.Skills.Grpc.Model;
-using System.Linq;
-using Microsoft.SemanticKernel.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.Skills.Grpc.Model;
 using Microsoft.SemanticKernel.Skills.Grpc.Protobuf;
 
 namespace Microsoft.SemanticKernel.Skills.Grpc.Extensions;

--- a/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Model/GrpcOperation.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Model/GrpcOperation.cs
@@ -8,6 +8,16 @@ namespace Microsoft.SemanticKernel.Skills.Grpc.Model;
 internal class GrpcOperation
 {
     /// <summary>
+    /// Name of 'address' argument used as override for the address provided by gRPC operation.
+    /// </summary>
+    internal const string AddressArgumentName = "address";
+
+    /// <summary>
+    /// Name of 'payload' argument that represents gRPC operation request message.
+    /// </summary>
+    internal const string PayloadArgumentName = "payload";
+
+    /// <summary>
     /// Creates an instance of a <see cref="GrpcOperation"/> class.
     /// <param name="serviceName">The service name.</param>
     /// <param name="name">The operation name.</param>

--- a/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Skills.Grpc.csproj
+++ b/dotnet/src/SemanticKernel.Skills/Skills.Grpc/Skills.Grpc.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
+    <ProjectReference Include="..\..\SemanticKernel\SemanticKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Grpc/Extensions/GrpcOperationExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.Skills/Skills.UnitTests/Grpc/Extensions/GrpcOperationExtensionsTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Skills.Grpc.Extensions;
+using Microsoft.SemanticKernel.Skills.Grpc.Model;
+using Xunit;
+
+namespace SemanticKernel.Skills.UnitTests.Grpc.Extensions;
+public class GrpcOperationExtensionsTests
+{
+    private readonly GrpcOperationDataContractType _request;
+
+    private readonly GrpcOperationDataContractType _response;
+
+    private readonly GrpcOperation _operation;
+
+    public GrpcOperationExtensionsTests()
+    {
+        this._request = new GrpcOperationDataContractType("fake-name", new List<GrpcOperationDataContractTypeFiled>());
+
+        this._response = new GrpcOperationDataContractType("fake-name", new List<GrpcOperationDataContractTypeFiled>());
+
+        this._operation = new GrpcOperation("fake-service-name", "fake-operation-name", this._response, this._response);
+    }
+
+    [Fact]
+    public void ThereShouldBeAddressParameter()
+    {
+        // Act
+        var parameters = this._operation.GetParameters();
+
+        // Assert
+        Assert.NotNull(parameters);
+        Assert.True(parameters.Any());
+
+        var addressParameter = parameters.SingleOrDefault(p => p.Name == "address");
+        Assert.NotNull(addressParameter);
+        Assert.Equal("Address for gRPC channel to use.", addressParameter.Description);
+    }
+
+    [Fact]
+    public void ThereShouldBePayloadParameter()
+    {
+        // Act
+        var parameters = this._operation.GetParameters();
+
+        // Assert
+        Assert.NotNull(parameters);
+        Assert.True(parameters.Any());
+
+        var payloadPrameter = parameters.SingleOrDefault(p => p.Name == "payload");
+        Assert.NotNull(payloadPrameter);
+        Assert.Equal("gRPC request message.", payloadPrameter.Description);
+    }
+}

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -26,6 +26,9 @@ Install this package manually only if you are selecting individual Semantic Kern
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Microsoft.SemanticKernel.Skills.OpenAPI</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Microsoft.SemanticKernel.Skills.Grpc</_Parameter1>
+    </AssemblyAttribute>
     <!-- Testing -->
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>SemanticKernel.UnitTests</_Parameter1>

--- a/samples/dotnet/kernel-syntax-examples/Example27_GrpcSkills.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example27_GrpcSkills.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Orchestration;
+using RepoUtils;
+using Microsoft.SemanticKernel.Skills.Grpc.Extensions;
+using System.Threading.Tasks;
+
+/**
+ * This example shows how to use gRPC skills.
+ */
+
+public static class Example27_GrpcSkills
+{
+    public static async Task RunAsync()
+    {
+        var kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
+
+        // Import a gRPC skill using one of the following Kernel extension methods
+        // kernel.RegisterGrpcSkill
+        // kernel.ImportGrpcSkillFromDirectory
+        var skill = kernel.ImportGrpcSkillFromFile("<skill-name>", "<path-to-.proto-file>");
+
+        // Add arguments for required parameters, arguments for optional ones can be skipped.
+        var contextVariables = new ContextVariables();
+        contextVariables.Set("address", "<gRPC-server-address>");
+        contextVariables.Set("payload", "<gRPC-request-message-as-json>");
+
+        // Run
+        var result = await kernel.RunAsync(contextVariables, skill["<operation-name>"]);
+
+        Console.WriteLine("Skill response: {0}", result);
+    }
+}

--- a/samples/dotnet/kernel-syntax-examples/Example27_GrpcSkills.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example27_GrpcSkills.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
-using RepoUtils;
 using Microsoft.SemanticKernel.Skills.Grpc.Extensions;
-using System.Threading.Tasks;
+using RepoUtils;
 
 /**
  * This example shows how to use gRPC skills.

--- a/samples/dotnet/kernel-syntax-examples/KernelSyntaxExamples.csproj
+++ b/samples/dotnet/kernel-syntax-examples/KernelSyntaxExamples.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\dotnet\src\Connectors\Connectors.AI.OpenAI\Connectors.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\dotnet\src\SemanticKernel.Skills\Skills.Grpc\Skills.Grpc.csproj" />
     <ProjectReference Include="..\..\..\dotnet\src\SemanticKernel.Skills\Skills.OpenAPI\Skills.OpenAPI.csproj" />
     <ProjectReference Include="..\..\..\dotnet\src\Connectors\Connectors.Memory.Qdrant\Connectors.Memory.Qdrant.csproj" />
     <ProjectReference Include="..\..\..\dotnet\src\SemanticKernel.Skills\Skills.Web\Skills.Web.csproj" />

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -85,5 +85,8 @@ public static class Program
 
         await Example26_SemanticFunctionsUsingChatGPT.RunAsync();
         Console.WriteLine("== DONE ==");
+
+        await Example27_GrpcSkills.RunAsync();
+        Console.WriteLine("== DONE ==");
     }
 }


### PR DESCRIPTION
### Motivation and Context

This change adds functionality required for gRPC skills import to Kernel allowing SK SDK client code to register and use gRPC skills in SK SDK.

### Description
This change adds a few ImportGrpc* Kernel extension methods that can import gRPC skills from a folder or a file. Additionality, GrpcOperationRunner is changed to accept gRPC request message as JSON and return the gRPC method result as JSON as well.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
