### PR TITLE
Remove duplicative extension methods on KernelPlanExtensions

### DIFF
--- a/dotnet/src/SemanticKernel/Planning/KernelPlanExtensions.cs
+++ b/dotnet/src/SemanticKernel/Planning/KernelPlanExtensions.cs
@@ -20,17 +20,6 @@ public static class KernelPlanExtensions
     /// </summary>
     /// <param name="kernel">Kernel instance to use</param>
     /// <param name="plan">Plan to run</param>
-    /// <returns>Result of the plan execution</returns>
-    public static Task<Plan> StepAsync(this IKernel kernel, Plan plan)
-    {
-        return kernel.StepAsync(plan.State, plan, CancellationToken.None);
-    }
-
-    /// <summary>
-    /// Run the next step in a plan asynchronously
-    /// </summary>
-    /// <param name="kernel">Kernel instance to use</param>
-    /// <param name="plan">Plan to run</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Result of the plan execution</returns>
     public static Task<Plan> StepAsync(this IKernel kernel, Plan plan, CancellationToken cancellationToken = default)
@@ -44,34 +33,10 @@ public static class KernelPlanExtensions
     /// <param name="kernel">Kernel instance to use</param>
     /// <param name="input">Input to use</param>
     /// <param name="plan">Plan to run</param>
-    /// <returns>Result of the plan execution</returns>
-    public static Task<Plan> StepAsync(this IKernel kernel, string input, Plan plan)
-    {
-        return kernel.StepAsync(input, plan, CancellationToken.None);
-    }
-
-    /// <summary>
-    /// Run the next step in a plan asynchronously
-    /// </summary>
-    /// <param name="kernel">Kernel instance to use</param>
-    /// <param name="input">Input to use</param>
-    /// <param name="plan">Plan to run</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public static Task<Plan> StepAsync(this IKernel kernel, string input, Plan plan, CancellationToken cancellationToken = default)
     {
         return kernel.StepAsync(new ContextVariables(input), plan, cancellationToken);
-    }
-
-    /// <summary>
-    /// Run the next step in a plan asynchronously
-    /// </summary>
-    /// <param name="kernel">Kernel instance to use</param>
-    /// <param name="variables">Input to process</param>
-    /// <param name="plan">Plan to run</param>
-    /// <returns>Result of the plan execution</returns>
-    public static Task<Plan> StepAsync(this IKernel kernel, ContextVariables variables, Plan plan)
-    {
-        return kernel.StepAsync(variables, plan, CancellationToken.None);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

Remove unnecessary overloads

### Description

These are all handled by the corresponding overload that takes an optional CancellationToken. Their presence also means the optionality of the tokens in the other overloads would never actually be used.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

cc: @shawncal, @dluc 