### PR TITLE
Add property model to CompleteRequestSettings.cs

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextCompletion/CompleteRequestSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextCompletion/CompleteRequestSettings.cs
@@ -48,6 +48,11 @@ public class CompleteRequestSettings
     public IList<string> StopSequences { get; set; } = Array.Empty<string>();
 
     /// <summary>
+    /// The name of the model to use for the completion.
+    /// </summary>
+    public string Model { get; set; } = "text-davinci-003";
+
+    /// <summary>
     /// Create a new settings object with the values from another settings object.
     /// </summary>
     /// <param name="config"></param>
@@ -62,6 +67,7 @@ public class CompleteRequestSettings
             FrequencyPenalty = config.FrequencyPenalty,
             MaxTokens = config.MaxTokens,
             StopSequences = config.StopSequences,
+            Model = config.Model
         };
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/PromptTemplateConfig.cs
@@ -66,6 +66,12 @@ public class PromptTemplateConfig
         [JsonPropertyOrder(6)]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string> StopSequences { get; set; } = new();
+
+        /// <summary>
+        /// The name of the model to use for the completion.
+        /// </summary>
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = "text-davinci-003";
     }
 
     /// <summary>


### PR DESCRIPTION
Summary:

This pull request adds a new "Model" property to the CompleteRequestSettings class, which allows clients to specify the name of the GPT model to use for text generation.

Details:

The CompleteRequestSettings class previously included properties for controlling various aspects of the text generation process, such as temperature, top-p, and penalty values. However, it did not include a property for specifying the GPT model to use for generating text. I'd like to specify whether i'm using `text-davinci-003` or `gpt-3.5-turbo`

This pull request addresses this issue by adding a new Model property to the CompleteRequestSettings class. By default, this property is set to`text-davinci-003`, but clients can set it to the name of any available GPT model.

Additionally, the FromCompletionConfig method has been updated to set the Model property based on the config.Model value.