### PR TITLE
CopilotChat: Add instructions for Planner:AIService in READMEs

### DIFF
--- a/samples/apps/copilot-chat-app/README.md
+++ b/samples/apps/copilot-chat-app/README.md
@@ -30,7 +30,7 @@ First, let’s set up and verify the back-end API server is running.
    > **Note:** It is recommended you close all instances of your web browser after installing the developer certificates.
 
 1. Navigate to `samples/apps/copilot-chat-app/webapi` and open `appsettings.json`
-   - Update the `Completion` and `Embedding` configuration sections:
+   - Update the `Completion`, `Embedding`, and `Planner:AIService` (if enabled) configuration sections:
      - Update `AIService` to the AI service you will be using (i.e., `AzureOpenAI` or `OpenAI`).
      - If your are using Azure OpenAI, update `Endpoint` to your Azure OpenAI resource Endpoint address (e.g.,  
        `http://contoso.openai.azure.com`).
@@ -40,9 +40,10 @@ First, let’s set up and verify the back-end API server is running.
        cd semantic-kernel/samples/apps/copilot-chat-app/webapi
        dotnet user-secrets set "Completion:Key" "MY_AZUREOPENAI_OR_OPENAI_KEY"
        dotnet user-secrets set "Embedding:Key" "MY_AZUREOPENAI_OR_OPENAI_KEY"
+       dotnet user-secrets set "Planner:AIService:Key" "MY_AZUREOPENAI_OR_OPENAI_KEY"
        ```
      - Update `DeploymentOrModelID` to the Azure OpenAI deployment or OpenAI models you want to use. 
-       - For `Completion`, CopilotChat is optimized for Chat completion models, such as gpt-3.5-turbo and gpt-4
+       - For `Completion` and `Planner:AIService`, CopilotChat is optimized for Chat completion models, such as gpt-3.5-turbo and gpt-4.
          > **Important:** gpt-3.5-turbo is normally labelled as "`gpt-35-turbo`" (no period) in Azure OpenAI and "`gpt-3.5-turbo`" (with a period) in OpenAI.
        - For `Embedding`, `text-embedding-ada-002` is sufficient and cost-effect for generating embeddings.
    
@@ -118,15 +119,7 @@ to the back end while waiting for your permission to connect. To resolve this, t
    - Acknowledge, continue, and navigate until you see the message Semantic Kernel service is up and running
 1. Navigate to `https://localhost:3000` or refresh the page to use the Copilot Chat application.
 
-### 2. Configuration issues after updating your repo/fork.
-As of [PR #470](https://github.com/microsoft/semantic-kernel/pull/470), we have updated some of the top-level
-configuration keys. Most notably, 
-  - `CompletionConfig` is now `Completion` 
-  - `EmbeddingConfig` is now `Embedding`
-  
-You may also need to update the keys used for any secrets set with `dotnet user-secrets set` 
-
-### 3. Issues using text completion models, such as `text-davinci-003`
+### 2. Issues using text completion models, such as `text-davinci-003`
 As of [PR #499](https://github.com/microsoft/semantic-kernel/pull/499), CopilotChat now focuses support on chat completion models, such as `gpt-3.5-*` and `gpt-4-*`
 See [OpenAI's model compatiblity](https://platform.openai.com/docs/models/model-endpoint-compatibility) for
 the complete list of current models supporting chat completions.


### PR DESCRIPTION
### Motivation and Context
Missed adding instructions for setting Planner:AIService configuration settings.

### Description
Updated README to include Planner:AIService when setting configuration settings.