### PR TITLE
Extending list of retryable codes

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Reliability/HttpRetryConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Reliability/HttpRetryConfig.cs
@@ -59,7 +59,11 @@ public sealed class HttpRetryConfig
         (HttpStatusCode)HttpStatusCodeType.RequestTimeout,
         (HttpStatusCode)HttpStatusCodeType.ServiceUnavailable,
         (HttpStatusCode)HttpStatusCodeType.GatewayTimeout,
-        (HttpStatusCode)HttpStatusCodeType.TooManyRequests
+        (HttpStatusCode)HttpStatusCodeType.TooManyRequests,
+        (HttpStatusCode)HttpStatusCodeType.InternalServerError,
+        (HttpStatusCode)HttpStatusCodeType.NotImplemented,
+        (HttpStatusCode)HttpStatusCodeType.BadGateway,
+        (HttpStatusCode)HttpStatusCodeType.InsufficientStorage
     };
 
     /// <summary>


### PR DESCRIPTION
### Motivation, Context and Description

This change is required to improve SK SDK resilience while working with REST API by extending list of HTTP status codes DefaultHttpRetryHandler retries on.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
