### PR TITLE
Method name is added to exception message.

### DIFF
--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -513,7 +513,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         if (!result.HasSkFunctionAttribute || skFunctionAttribute == null)
         {
-            log?.LogTrace("Method {0} doesn't have SKFunctionAttribute", result.Name);
+            log?.LogTrace("Method '{0}' doesn't have SKFunctionAttribute", result.Name);
             return result;
         }
 
@@ -554,9 +554,8 @@ public sealed class SKFunction : ISKFunction, IDisposable
         else if (skMainParam != null)
         {
             // The developer used [SKFunctionInput] on a function that doesn't support a string input
-            throw new KernelException(
-                KernelException.ErrorCodes.InvalidFunctionDescription,
-                "The function doesn't have a string parameter, do not use " + typeof(SKFunctionInputAttribute));
+            var message = $"The method '{methodSignature.Name}' doesn't have a string parameter, do not use '{typeof(SKFunctionInputAttribute).Name}' attribute.";
+            throw new KernelException(KernelException.ErrorCodes.InvalidFunctionDescription, message);
         }
 
         // Handle named arg passed via the SKContext object
@@ -570,7 +569,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         result.Description = skFunctionAttribute.Description ?? "";
 
-        log?.LogTrace("Method {0} found", result.Name);
+        log?.LogTrace("Method '{0}' found", result.Name);
 
         return result;
     }

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -513,7 +513,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         if (!result.HasSkFunctionAttribute || skFunctionAttribute == null)
         {
-            log?.LogTrace("Method '{0}' doesn't have SKFunctionAttribute", result.Name);
+            log?.LogTrace("Method '{0}' doesn't have '{1}' attribute.", result.Name, typeof(SKFunctionAttribute).Name);
             return result;
         }
 
@@ -554,7 +554,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
         else if (skMainParam != null)
         {
             // The developer used [SKFunctionInput] on a function that doesn't support a string input
-            var message = $"The method '{methodSignature.Name}' doesn't have a string parameter, do not use '{typeof(SKFunctionInputAttribute).Name}' attribute.";
+            var message = $"The method '{result.Name}' doesn't have a string parameter, do not use '{typeof(SKFunctionInputAttribute).Name}' attribute.";
             throw new KernelException(KernelException.ErrorCodes.InvalidFunctionDescription, message);
         }
 
@@ -569,7 +569,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         result.Description = skFunctionAttribute.Description ?? "";
 
-        log?.LogTrace("Method '{0}' found", result.Name);
+        log?.LogTrace("Method '{0}' found.", result.Name);
 
         return result;
     }
@@ -677,13 +677,13 @@ public sealed class SKFunction : ISKFunction, IDisposable
         {
             throw new KernelException(
                 KernelException.ErrorCodes.FunctionTypeNotSupported,
-                $"Function {method.Name} has an invalid signature 'Func<SKContext, SKContext>'. " +
+                $"Function '{method.Name}' has an invalid signature 'Func<SKContext, SKContext>'. " +
                 "Please use 'Func<SKContext, Task<SKContext>>' instead.");
         }
 
         throw new KernelException(
             KernelException.ErrorCodes.FunctionTypeNotSupported,
-            $"Function {method.Name} has an invalid signature not supported by the kernel");
+            $"Function '{method.Name}' has an invalid signature not supported by the kernel.");
     }
 
     [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "Delegate.CreateDelegate result can be null")]


### PR DESCRIPTION
### Motivation, Context and Description

This PR adds function/method name into exception message that is thrown if a native function, marked with SKFunctionInputAttribute, doesn't have an input parameter of string type. The method name can be useful for debugging and troubleshooting.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
