### PR TITLE
Some clean up in OpenAIClientBase

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAIClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAIClientBase.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -21,39 +20,34 @@ using Microsoft.SemanticKernel.Text;
 
 namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.CustomClient;
 
-/// <summary>
-/// An abstract OpenAI Client.
-/// </summary>
-[SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "OpenAI users use strings")]
+#pragma warning disable CA1063 // Class isn't publicly extensible and thus doesn't implement the full IDisposable pattern
+#pragma warning disable CA1816 // No derived types implement a finalizer
+
+/// <summary>Base type for OpenAI clients.</summary>
 public abstract class OpenAIClientBase : IDisposable
 {
-    protected readonly static HttpClientHandler DefaultHttpClientHandler = new() { CheckCertificateRevocationList = true };
-
-    /// <summary>
-    /// Logger
-    /// </summary>
-    protected ILogger Log { get; } = NullLogger.Instance;
-
-    /// <summary>
-    /// HTTP client
-    /// </summary>
-    protected HttpClient HTTPClient { get; }
-
-    internal OpenAIClientBase(HttpClient? httpClient = null, ILogger? logger = null)
+    /// <summary>Initialize the client.</summary>
+    private protected OpenAIClientBase(HttpClient? httpClient = null, ILogger? logger = null)
     {
-        this.Log = logger ?? this.Log;
+        this._httpClient = httpClient ?? new HttpClient(s_defaultHttpClientHandler, disposeHandler: false);
+        this._disposeHttpClient = this._httpClient != httpClient; // dispose a non-shared client when this is disposed
 
-        if (httpClient == null)
-        {
-            this.HTTPClient = new HttpClient(DefaultHttpClientHandler, disposeHandler: false);
-            this._disposeHttpClient = true; // If client is created internally, dispose it when done
-        }
-        else
-        {
-            this.HTTPClient = httpClient;
-        }
+        this._log = logger ?? NullLogger.Instance;
+    }
 
-        this.HTTPClient.DefaultRequestHeaders.Add("User-Agent", HTTPUseragent);
+    /// <summary>Clean up resources used by this instance.</summary>
+    public void Dispose()
+    {
+        if (this._disposeHttpClient)
+        {
+            this._httpClient.Dispose();
+        }
+    }
+
+    /// <summary>Adds headers to use for OpenAI HTTP requests.</summary>
+    private protected virtual void AddRequestHeaders(HttpRequestMessage request)
+    {
+        request.Headers.Add("User-Agent", HttpUserAgent);
     }
 
     /// <summary>
@@ -64,29 +58,20 @@ public abstract class OpenAIClientBase : IDisposable
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>List of text embeddings</returns>
     /// <exception cref="AIException">AIException thrown during the request.</exception>
-    protected async Task<IList<Embedding<float>>> ExecuteTextEmbeddingRequestAsync(
+    private protected async Task<IList<Embedding<float>>> ExecuteTextEmbeddingRequestAsync(
         string url,
         string requestBody,
         CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var result = await this.ExecutePostRequestAsync<TextEmbeddingResponse>(url, requestBody, cancellationToken).ConfigureAwait(false);
-            if (result.Embeddings.Count < 1)
-            {
-                throw new AIException(
-                    AIException.ErrorCodes.InvalidResponseContent,
-                    "Embeddings not found");
-            }
-
-            return result.Embeddings.Select(e => new Embedding<float>(e.Values)).ToList();
-        }
-        catch (Exception e) when (e is not AIException)
+        var result = await this.ExecutePostRequestAsync<TextEmbeddingResponse>(url, requestBody, cancellationToken).ConfigureAwait(false);
+        if (result.Embeddings is not { Count: >= 1 })
         {
             throw new AIException(
-                AIException.ErrorCodes.UnknownError,
-                $"Something went wrong: {e.Message}", e);
+                AIException.ErrorCodes.InvalidResponseContent,
+                "Embeddings not found");
         }
+
+        return result.Embeddings.Select(e => new Embedding<float>(e.Values)).ToList();
     }
 
     /// <summary>
@@ -94,82 +79,22 @@ public abstract class OpenAIClientBase : IDisposable
     /// </summary>
     /// <param name="url">URL for the image generation request API</param>
     /// <param name="requestBody">Request payload</param>
+    /// <param name="extractResponseFunc">Function to invoke to extract the desired portion of the image generation response.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>List of image URLs</returns>
     /// <exception cref="AIException">AIException thrown during the request.</exception>
-    protected async Task<IList<string>> ExecuteImageUrlGenerationRequestAsync(
+    private protected async Task<IList<string>> ExecuteImageGenerationRequestAsync(
         string url,
         string requestBody,
+        Func<ImageGenerationResponse.Image, string> extractResponseFunc,
         CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var result = await this.ExecutePostRequestAsync<ImageGenerationResponse>(url, requestBody, cancellationToken).ConfigureAwait(false);
-            return result.Images.Select(x => x.Url).ToList();
-        }
-        catch (Exception e) when (e is not AIException)
-        {
-            throw new AIException(
-                AIException.ErrorCodes.UnknownError,
-                $"Something went wrong: {e.Message}", e);
-        }
+        var result = await this.ExecutePostRequestAsync<ImageGenerationResponse>(url, requestBody, cancellationToken).ConfigureAwait(false);
+        return result.Images.Select(extractResponseFunc).ToList();
     }
 
-    /// <summary>
-    /// Run the HTTP request to generate a list of images
-    /// </summary>
-    /// <param name="url">URL for the image generation request API</param>
-    /// <param name="requestBody">Request payload</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>List of images serialized in base64</returns>
-    /// <exception cref="AIException">AIException thrown during the request.</exception>
-    protected async Task<IList<string>> ExecuteImageBase64GenerationRequestAsync(
-        string url,
-        string requestBody,
-        CancellationToken cancellationToken = default)
+    private protected virtual string? GetErrorMessageFromResponse(string jsonResponsePayload)
     {
-        try
-        {
-            var result = await this.ExecutePostRequestAsync<ImageGenerationResponse>(url, requestBody, cancellationToken).ConfigureAwait(false);
-            return result.Images.Select(x => x.AsBase64).ToList();
-        }
-        catch (Exception e) when (e is not AIException)
-        {
-            throw new AIException(
-                AIException.ErrorCodes.UnknownError,
-                $"Something went wrong: {e.Message}", e);
-        }
-    }
-
-    /// <summary>
-    /// Explicit finalizer called by IDisposable
-    /// </summary>
-    public void Dispose()
-    {
-        this.Dispose(true);
-        // Request CL runtime not to call the finalizer - reduce cost of GC
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Overridable finalizer for concrete classes
-    /// </summary>
-    /// <param name="disposing"></param>
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing & this._disposeHttpClient)
-        {
-            this.HTTPClient.Dispose();
-        }
-    }
-
-    protected virtual string? GetErrorMessageFromResponse(string? jsonResponsePayload)
-    {
-        if (jsonResponsePayload is null)
-        {
-            return null;
-        }
-
         try
         {
             JsonNode? root = JsonSerializer.Deserialize<JsonNode>(jsonResponsePayload);
@@ -178,36 +103,48 @@ public abstract class OpenAIClientBase : IDisposable
         }
         catch (Exception ex) when (ex is NotSupportedException or JsonException)
         {
-            this.Log.LogTrace("Unable to extract error from response body content. Exception: {0}:{1}", ex.GetType(), ex.Message);
-            return null;
+            this._log.LogTrace("Unable to extract error from response body content. Exception: {0}:{1}", ex.GetType(), ex.Message);
         }
+
+        return null;
     }
 
     #region private ================================================================================
 
+    // Shared singleton HttpClientHandler used when an existing HttpClient isn't provided
+    private readonly static HttpClientHandler s_defaultHttpClientHandler = new() { CheckCertificateRevocationList = true };
+
     // HTTP user agent sent to remote endpoints
-    private const string HTTPUseragent = "Microsoft Semantic Kernel";
+    private const string HttpUserAgent = "Microsoft Semantic Kernel";
 
     // Set to true to dispose of HttpClient when disposing. If HttpClient was passed in, then the caller can manage.
-    private readonly bool _disposeHttpClient = false;
+    private readonly bool _disposeHttpClient;
+
+    /// <summary>
+    /// Logger
+    /// </summary>
+    private readonly ILogger _log;
+
+    /// <summary>
+    /// The <see cref="_httpClient"/> to use for issuing requests.
+    /// </summary>
+    private readonly HttpClient _httpClient;
 
     private async Task<T> ExecutePostRequestAsync<T>(string url, string requestBody, CancellationToken cancellationToken = default)
     {
-        string responseJson;
-
+        HttpResponseMessage? response = null;
         try
         {
-            using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await this.HTTPClient.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
-
-            if (response == null)
+            using (var request = new HttpRequestMessage(HttpMethod.Post, url))
             {
-                throw new AIException(AIException.ErrorCodes.NoResponse);
+                this.AddRequestHeaders(request);
+                request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                response = await this._httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
 
-            this.Log.LogTrace("HTTP response: {0} {1}", (int)response.StatusCode, response.StatusCode.ToString("G"));
+            this._log.LogTrace("HTTP response: {0} {1}", (int)response.StatusCode, response.StatusCode.ToString("G"));
 
-            responseJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            string responseJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             string? errorDetail = this.GetErrorMessageFromResponse(responseJson);
 
             if (!response.IsSuccessStatusCode)
@@ -279,28 +216,26 @@ public abstract class OpenAIClientBase : IDisposable
                             errorDetail);
                 }
             }
-        }
-        catch (Exception e) when (e is not AIException)
-        {
-            throw new AIException(
-                AIException.ErrorCodes.UnknownError,
-                $"Something went wrong: {e.Message}", e);
-        }
 
-        try
-        {
             var result = Json.Deserialize<T>(responseJson);
-            if (result != null) { return result; }
-
-            throw new AIException(
+            if (result is null)
+            {
+                throw new AIException(
                 AIException.ErrorCodes.InvalidResponseContent,
                 "Response JSON parse error");
+            }
+
+            return result;
         }
         catch (Exception e) when (e is not AIException)
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,
                 $"Something went wrong: {e.Message}", e);
+        }
+        finally
+        {
+            response?.Dispose();
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/OpenAIImageGeneration.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/OpenAIImageGeneration.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Linq;
+using System;
+using System.Diagnostics;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.ImageGeneration;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.CustomClient;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -16,8 +15,20 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ImageGeneration;
 
 public class OpenAIImageGeneration : OpenAIClientBase, IImageGeneration
 {
-    // 3P OpenAI REST API endpoint
+    /// <summary>
+    /// OpenAI REST API endpoint
+    /// </summary>
     private const string OpenAIEndpoint = "https://api.openai.com/v1/images/generations";
+
+    /// <summary>
+    /// Optional value for the OpenAI-Organization header.
+    /// </summary>
+    private readonly string? _organizationHeaderValue;
+
+    /// <summary>
+    /// Value for the authorization header.
+    /// </summary>
+    private readonly string _authorizationHeaderValue;
 
     /// <summary>
     /// Create a new instance of OpenAI image generation service
@@ -34,50 +45,55 @@ public class OpenAIImageGeneration : OpenAIClientBase, IImageGeneration
     ) : base(httpClient, logger)
     {
         Verify.NotNullOrWhiteSpace(apiKey);
-        this.HTTPClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        this._authorizationHeaderValue = $"Bearer {apiKey}";
+        this._organizationHeaderValue = organization;
+    }
 
-        if (!string.IsNullOrEmpty(organization))
+    /// <summary>Adds headers to use for OpenAI HTTP requests.</summary>
+    private protected override void AddRequestHeaders(HttpRequestMessage request)
+    {
+        base.AddRequestHeaders(request);
+
+        request.Headers.Add("Authorization", this._authorizationHeaderValue);
+        if (!string.IsNullOrEmpty(this._organizationHeaderValue))
         {
-            this.HTTPClient.DefaultRequestHeaders.Add("OpenAI-Organization", organization);
+            request.Headers.Add("OpenAI-Organization", this._organizationHeaderValue);
         }
     }
 
     /// <inheritdoc/>
     public Task<string> GenerateImageAsync(string description, int width, int height, CancellationToken cancellationToken = default)
     {
+        Verify.NotNull(description);
         if (width != height || (width != 256 && width != 512 && width != 1024))
         {
-            throw new AIException(AIException.ErrorCodes.InvalidRequest, "OpenAI can generate only square images 256x256, 512x512, 1024x1024");
+            throw new ArgumentOutOfRangeException(nameof(width), width, "OpenAI can generate only square images of size 256x256, 512x512, or 1024x1024.");
         }
 
-        return this.GenerateImageUrlAsync(description, width, height, cancellationToken);
+        return this.GenerateImageAsync(description, width, height, 1, "url", x => x.Url, cancellationToken);
     }
 
-    private async Task<string> GenerateImageUrlAsync(string description, int width, int height, CancellationToken cancellationToken = default)
+    private async Task<string> GenerateImageAsync(
+        string description,
+        int width, int height,
+        int count, string format, Func<ImageGenerationResponse.Image, string> extractResponse,
+        CancellationToken cancellationToken)
     {
+        Debug.Assert(width == height);
+        Debug.Assert(width is 256 or 512 or 1024);
+        Debug.Assert(count > 0);
+        Debug.Assert(format is "url" or "b64_json");
+        Debug.Assert(extractResponse is not null);
+
         var requestBody = Json.Serialize(new ImageGenerationRequest
         {
             Prompt = description,
             Size = $"{width}x{height}",
-            Count = 1,
-            Format = "url",
+            Count = count,
+            Format = format,
         });
 
-        var list = await this.ExecuteImageUrlGenerationRequestAsync(OpenAIEndpoint, requestBody, cancellationToken).ConfigureAwait(false);
-        return list.First();
-    }
-
-    private async Task<string> GenerateImageBase64Async(string description, int width, int height, CancellationToken cancellationToken = default)
-    {
-        var requestBody = Json.Serialize(new ImageGenerationRequest
-        {
-            Prompt = description,
-            Size = $"{width}x{height}",
-            Count = 1,
-            Format = "b64_json",
-        });
-
-        var list = await this.ExecuteImageBase64GenerationRequestAsync(OpenAIEndpoint, requestBody, cancellationToken).ConfigureAwait(false);
-        return list.First();
+        var list = await this.ExecuteImageGenerationRequestAsync(OpenAIEndpoint, requestBody, extractResponse!, cancellationToken).ConfigureAwait(false);
+        return list[0];
     }
 }


### PR DESCRIPTION
### Motivation and Context

Fix some possible functional issues as well as remove unnecessary code.

### Description

- The type accepts an HttpClient instance that it'll use.  It shouldn't then mutate that instance, as it might be shared with other consumers.  But it's adding to its DefaultRequestHeaders collection, which will impact all other users of that instance (DefaultRequestHeaders also isn't thread-safe and should only ever be added to while it's not being used for issuing requests).  I've removed the interaction with DefaultRequestHeaders and instead added the relevant headers to each message being sent.
- The base is exposing a lot of protected surface area, but it's not actually extensible outside of the assembly.  I've changed all of its internal and protected members to instead be "private protected" or just "private", reflecting their actual usage and ensuring the surface area doesn't show up in public documentation (which protected members would).
- As it's not actually extensible publicly, and as no derived types are finalizable, it needn't implement the full IDisposable pattern nor use GC.SuppressFinalize.
- Both the base and the derived image generation client had duplicated APIs for url vs base64 image generation.  I've consolidated that via arguments to just have one copy of the code. Note that the base64 image generation was private and unused, so I've deleted that unused member, but the functionality can be exposed easily if desired based on the shared routines now in place.
- Removed some unnecessary null checking for things that'll never be null.
- Ensured the HttpClient response message is disposed.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
