### PR TITLE
Default the planner to disabled since we just published a how-to video.

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -155,7 +155,7 @@
   //  - Set "Key" using dotnet's user secrets (see above) (i.e. dotnet user-secrets set "Planner:AIService:Key" "MY_OPENAI_KEY")
   //
   "Planner": {
-    "Enabled": true,
+    "Enabled": false,
     "AIService": {
       "AIService": "AzureOpenAI",
       "DeploymentOrModelId": "gpt-35-turbo",


### PR DESCRIPTION
### Motivation and Context
Default the planner to disabled since we just published a how-to video assuming the planner is not enabled.
