### PR TITLE
GitHub OpenAPI skill integration with planner

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -3,6 +3,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Memory;
@@ -11,6 +12,7 @@ using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.SkillDefinition;
 using SemanticKernel.Service.Config;
 using SemanticKernel.Service.Model;
+using SemanticKernel.Service.Skills.OpenApiSkills;
 using SemanticKernel.Service.Storage;
 
 namespace SemanticKernel.Service.Skills;
@@ -209,30 +211,29 @@ public class ChatSkill
 
         // Create a plan and run it.
         Plan plan = await this._planner.CreatePlanAsync(plannerContext.Variables.Input);
-        if (plan.Steps.Count > 0)
+        SKContext planContext = await plan.InvokeAsync(plannerContext);
+
+        int tokenLimit = int.Parse(context["tokenLimit"], new NumberFormatInfo());
+
+        // The result of the plan may be from an OpenAPI skill. Attempt to extract JSON from the response.
+        if (!this.TryExtractJsonFromPlanResult(planContext.Variables.Input, out string planResult))
         {
-            SKContext planContext = await plan.InvokeAsync(plannerContext);
-
-            // The result of the plan may be from an OpenAPI skill. Attempt to extract JSON from the response.
-            if (!this.TryExtractJsonFromPlanResult(planContext.Variables.Input, out string planResult))
-            {
-                // If not, use result of the plan execution result directly.
-                planResult = planContext.Variables.Input;
-            }
-
-            string informationText = $"[START RELATED INFORMATION]\n{planResult.Trim()}\n[END RELATED INFORMATION]\n";
-
-            // Adjust the token limit using the number of tokens in the information text.
-            int tokenLimit = int.Parse(context["tokenLimit"], new NumberFormatInfo());
-            tokenLimit -= Utilities.TokenCount(informationText);
-            context.Variables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
-
-            return informationText;
+            // If not, use result of the plan execution result directly.
+            planResult = planContext.Variables.Input;
         }
         else
         {
-            return string.Empty;
+            int relatedInformationTokenLimit = (int)Math.Floor(tokenLimit * this._promptSettings.RelatedInformationContextWeight);
+            planResult = this.OptimizeOpenApiSkillJson(planResult, relatedInformationTokenLimit, plan);
         }
+
+        string informationText = $"[START RELATED INFORMATION]\n{planResult.Trim()}\n[END RELATED INFORMATION]\n";
+
+        // Adjust the token limit using the number of tokens in the information text.
+        tokenLimit -= Utilities.TokenCount(informationText);
+        context.Variables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
+
+        return informationText;
     }
 
     /// <summary>
@@ -399,6 +400,86 @@ public class ChatSkill
 
         json = string.Empty;
         return false;
+    }
+
+    /// <summary>
+    /// Try to optimize json from the planner response
+    /// based on token limit
+    /// </summary>
+    private string OptimizeOpenApiSkillJson(string jsonContent, int tokenLimit, Plan plan)
+    {
+        int jsonTokenLimit = (int)(tokenLimit * 0.8);
+
+        // Remove all new line characters + leading and trailing white space
+        jsonContent = Regex.Replace(jsonContent.Trim(), @"[\n\r]", string.Empty);
+        var document = JsonDocument.Parse(jsonContent);
+        string lastSkillInvoked = plan.Steps[^1].SkillName;
+
+        // Check if the last skill invoked was GitHubSkill and deserialize the JSON content accordingly
+        if (string.Equals(lastSkillInvoked, "GitHubSkill", StringComparison.Ordinal))
+        {
+            var pullRequestType = document.RootElement.ValueKind == JsonValueKind.Array ? typeof(PullRequest[]) : typeof(PullRequest);
+
+            // Deserializing limits the json content to only the fields defined in the GitHubSkill/Model classes
+            var pullRequest = JsonSerializer.Deserialize(jsonContent, pullRequestType);
+            jsonContent = pullRequest != null ? JsonSerializer.Serialize(pullRequest) : string.Empty;
+            document = JsonDocument.Parse(jsonContent);
+        }
+
+        int jsonContentTokenCount = Utilities.TokenCount(jsonContent);
+
+        // Return the JSON content if it does not exceed the token limit
+        if (jsonContentTokenCount < jsonTokenLimit)
+        {
+            return jsonContent;
+        }
+
+        // if (jsonContentTokenCount < jsonTokenLimit * 1.2)
+        // {
+        List<object> itemList = new();
+
+        // Summary (List) Object
+        if (document.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in document.RootElement.EnumerateArray())
+            {
+                int itemTokenCount = Utilities.TokenCount(item.ToString());
+
+                if (jsonTokenLimit - itemTokenCount > 0)
+                {
+                    itemList.Add(item);
+                    jsonTokenLimit -= itemTokenCount;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        // Detail Object
+        if (document.RootElement.ValueKind == JsonValueKind.Object)
+        {
+            foreach (JsonProperty property in document.RootElement.EnumerateObject())
+            {
+                int propertyTokenCount = Utilities.TokenCount(property.ToString());
+
+                if (jsonTokenLimit - propertyTokenCount > 0)
+                {
+                    itemList.Add(property);
+                    jsonTokenLimit -= propertyTokenCount;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        return itemList.Count > 0 ? JsonSerializer.Serialize(itemList) : JsonSerializer.Serialize(jsonContent);
+        //}
+
+        // return string.Empty;
     }
 
     /// <summary>

--- a/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/Label.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/Label.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace SemanticKernel.Service.Skills.OpenApiSkills;
+
+/// <summary>
+/// Represents a label.
+/// </summary>
+public class Label
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Label"/> class.
+    /// </summary>
+    /// <param name="id">The ID of the label.</param>
+    /// <param name="name">The name of the label.</param>
+    /// <param name="description">The description of the label.</param>
+    public Label(long id, string name, string description)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
+
+    /// <summary>
+    /// Gets or sets the ID of the label.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the label.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the label.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
+}

--- a/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/PullRequest.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/PullRequest.cs
@@ -1,0 +1,78 @@
+using System.Text.Json.Serialization;
+
+namespace SemanticKernel.Service.Skills.OpenApiSkills;
+
+public class PullRequest
+{
+    // The URL of the pull request
+    [JsonPropertyName("url")]
+    public string Url { get; set; }
+
+    // The unique identifier of the pull request
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    // The number of the pull request
+    [JsonPropertyName("number")]
+    public int Number { get; set; }
+
+    // The state of the pull request
+    [JsonPropertyName("state")]
+    public string State { get; set; }
+
+    // Whether the pull request is locked
+    [JsonPropertyName("locked")]
+    public bool Locked { get; set; }
+
+    // The title of the pull request
+    [JsonPropertyName("title")]
+    public string Title { get; set; }
+
+    // The user who created the pull request
+    [JsonPropertyName("user")]
+    public GitHubUser User { get; set; }
+
+    // The labels associated with the pull request
+    [JsonPropertyName("labels")]
+    public List<Label> Labels { get; set; }
+
+    // The date and time when the pull request was last updated
+    [JsonPropertyName("updated_at")]
+    public DateTime UpdatedAt { get; set; }
+
+    // The date and time when the pull request was closed
+    [JsonPropertyName("closed_at")]
+    public DateTime? ClosedAt { get; set; }
+
+    // The date and time when the pull request was merged
+    [JsonPropertyName("merged_at")]
+    public DateTime? MergedAt { get; set; }
+
+    // Constructor
+    public PullRequest(
+        string url,
+        int id,
+        int number,
+        string state,
+        bool locked,
+        string title,
+        GitHubUser user,
+        List<Label> labels,
+        DateTime updatedAt,
+        DateTime? closedAt,
+        DateTime? mergedAt
+    )
+    {
+        Url = url;
+        Id = id;
+        Number = number;
+        State = state;
+        Locked = locked;
+        Title = title;
+        User = user;
+        Labels = labels;
+        UpdatedAt = updatedAt;
+        ClosedAt = closedAt;
+        MergedAt = mergedAt;
+    }
+}

--- a/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/Repo.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/Repo.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace SemanticKernel.Service.Skills.OpenApiSkills;
+
+public class Repo
+{
+    // The name of the repo
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    // The full name of the repo
+    [JsonPropertyName("full_name")]
+    public string FullName { get; set; }
+
+    public Repo(string name, string fullName)
+    {
+        Name = name;
+        FullName = fullName;
+    }
+
+}

--- a/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/User.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/Model/User.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Serialization;
+
+namespace SemanticKernel.Service.Skills.OpenApiSkills;
+
+/// <summary>
+/// Represents a user on GitHub.
+/// </summary>
+public class GitHubUser
+{
+    /// <summary>
+    /// The user's name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The user's email address.
+    /// </summary>
+    [JsonPropertyName("email")]
+    public string Email { get; set; }
+
+    /// <summary>
+    /// The user's numeric ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The user's type, e.g. User or Organization.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Whether the user is a site admin.
+    /// </summary>
+    [JsonPropertyName("site_admin")]
+    public bool SiteAdmin { get; set; }
+
+    /// <summary>
+    /// Creates a new instance of the User class.
+    /// </summary>
+    /// <param name="name">The user's name.</param>
+    /// <param name="email">The user's email address.</param>
+    /// <param name="id">The user's numeric ID.</param>
+    /// <param name="type">The user's type.</param>
+    /// <param name="siteAdmin">Whether the user is a site admin.</param>
+    public GitHubUser(string name, string email, int id, string type, bool siteAdmin)
+    {
+        Name = name;
+        Email = email;
+        Id = id;
+        Type = type;
+        SiteAdmin = siteAdmin;
+    }
+}

--- a/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
@@ -35,6 +35,13 @@ public class PromptSettings
     internal double DocumentContextWeight { get; } = 0.3;
 
     /// <summary>
+    /// Weight of information returned from planner (i.e., responses from OpenAPI skills).
+    /// Percentage of the remaining token limit after memories response and document context have already been allocated.
+    /// Contextual prompt excludes all the system commands.
+    /// </summary>
+    internal double RelatedInformationContextWeight { get; } = 0.75;
+
+    /// <summary>
     /// Maximum number of tokens per line that will be used to split a document into lines.
     /// Setting this to a low value will result in higher context granularity, but
     /// takes longer to process the entire document into embeddings.

--- a/samples/apps/copilot-chat-app/webapp/src/components/open-api-plugins/PluginConnector.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/open-api-plugins/PluginConnector.tsx
@@ -40,6 +40,12 @@ const useClasses = makeStyles({
     error: {
         color: '#d13438',
     },
+    section: {
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        rowGap: '10px',
+    },
 });
 
 interface PluginConnectorProps {
@@ -147,7 +153,7 @@ export const PluginConnector: React.FC<PluginConnectorProps> = ({
                         </DialogTitle>
                         <DialogContent className={classes.content}>
                             {errorMessage && <Body1 className={classes.error}>{errorMessage}</Body1>}
-                            You are about to connect to {name}.
+                            You are about to connect to {name}.{' '}
                             {authRequirements.scopes && (
                                 <>
                                     To continue, you will authorize the following:{' '}
@@ -222,35 +228,41 @@ export const PluginConnector: React.FC<PluginConnectorProps> = ({
                                     <Body1Strong> Configuration </Body1Strong>
                                     <Body1>Some additional information is required to enable {name}'s REST APIs.</Body1>
                                     {Object.keys(apiRequirements).map((requirement) => {
+                                        const requirementDetails = apiRequirementsInput![requirement];
                                         return (
-                                            <>
+                                            <div className={classes.section} key={requirement}>
                                                 <Input
+                                                    key={requirement}
                                                     required
                                                     type="text"
-                                                    id={'plugin-additional-info'}
+                                                    id={'plugin-additional-info' + requirement}
                                                     onChange={(_e, input) => {
                                                         setApiRequirmentsInput({
                                                             ...apiRequirementsInput,
                                                             [requirement]: {
-                                                                ...apiRequirementsInput![requirement],
+                                                                ...requirementDetails,
                                                                 value: input.value,
                                                             },
                                                         });
                                                     }}
-                                                    placeholder={`Enter the ${requirement} for ${name}.`}
+                                                    placeholder={`Enter the ${
+                                                        requirementDetails.description ?? requirement
+                                                    }`}
                                                 />
-                                                <Body1>
-                                                    For more details on obtaining the {requirement.toLocaleLowerCase()},{' '}
-                                                    <a
-                                                        href={apiRequirements[requirement].helpLink}
-                                                        target="_blank"
-                                                        rel="noreferrer noopener"
-                                                    >
-                                                        click here
-                                                    </a>
-                                                    .
-                                                </Body1>
-                                            </>
+                                                {requirementDetails.helpLink && (
+                                                    <Body1>
+                                                        For more details on obtaining this information,{' '}
+                                                        <a
+                                                            href={requirementDetails.helpLink}
+                                                            target="_blank"
+                                                            rel="noreferrer noopener"
+                                                        >
+                                                            click here
+                                                        </a>
+                                                        .
+                                                    </Body1>
+                                                )}
+                                            </div>
                                         );
                                     })}
                                 </>

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/BaseService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/BaseService.ts
@@ -32,12 +32,6 @@ export class BaseService {
             for (var idx in enabledPlugins) {
                 var plugin = enabledPlugins[idx];
                 headers.append(`x-sk-copilot-${plugin.headerTag}-auth`, plugin.authData);
-                if (plugin.apiRequirements) {
-                    const apiRequirments = plugin.apiRequirements;
-                    for (var property in apiRequirments) {
-                        headers.append(`x-sk-copilot-${plugin.headerTag}-${property}`, apiRequirments[property].value!);
-                    }
-                }
             }
         }
 
@@ -51,7 +45,8 @@ export class BaseService {
 
             if (!response.ok) {
                 const responseText = await response.text();
-                const errorMessage = `${response.status}: ${response.statusText}` + (responseText ? ` => ${responseText}` : '');
+                const errorMessage =
+                    `${response.status}: ${response.statusText}` + (responseText ? ` => ${responseText}` : '');
 
                 throw Object.assign(new Error(errorMessage));
             }

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/plugins/PluginsState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/plugins/PluginsState.ts
@@ -29,13 +29,14 @@ export type PluginAuthRequirements = {
     helpLink?: string;
 };
 
-// additional information required to enable requests, i.e., server-url
+// Additional information required to enable requests, i.e., server-url
 export type AdditionalApiRequirements = {
+    // Key should be the property name and in kebab case (valid format for request header),
+    // make sure it matches exactly with the property name the API requires
     [key: string]: {
-        // key should be the property name and
-        // kebab case (property-name), required for valid request header
-        helpLink: string;
+        helpLink?: string;
         value?: string;
+        description?: string;
     };
 };
 
@@ -96,11 +97,21 @@ export const initialState: PluginsState = {
         enabled: false,
         authRequirements: {
             personalAccessToken: true,
+            scopes: ['Read and Write access to pull requests'],
             helpLink:
                 'https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token',
         },
         icon: GithubIcon,
         headerTag: AuthHeaderTags.GitHub,
+        apiRequirements: {
+            owner: {
+                description: 'account owner of repository. i.e., "microsoft"',
+            },
+            repo: {
+                description: 'name of repository. i.e., "semantic-kernel"',
+                helpLink: 'https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests',
+            },
+        },
     },
 };
 


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR enables GitHub integration with Copilot Planner. 


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Server-side
- Added C# classes for GitHub schema objects
- Adds tokenLimit for Planner response content. Currently, it's set at 75% of the remaining limit after memories response and document context have already been allocated.
- Added `OptimizeOpenApiSkillJson` method that is called on Planner completion. This method:
     - removes all new line characters (huge token suck) from API response
     - truncates the API response by object until it's under the relatedInformationTokenLimit. 
     - If the request can't be truncated, error message added to bot context
     - For GitHub skills specifically, the API response is deserialized into `PullRequest` or `PullRequest[]` objects to filter noisy properties.

Web app side
- If plugins require additional api requirements, these are added to the ask variables (rather than headers in http request) -- this allows the kernel/planner to directly consume these without any additional handling server side
- `repo` and `owner` added as additional GitHub api requirements

![image](https://user-images.githubusercontent.com/125500434/236005717-14016432-b5de-47b3-a128-e38418c267e3.png)
