### PR TITLE
fix implementation to return embedding

### DIFF
--- a/python/semantic_kernel/memory/memory_record.py
+++ b/python/semantic_kernel/memory/memory_record.py
@@ -50,7 +50,7 @@ class MemoryRecord:
 
     @property
     def embedding(self) -> ndarray:
-        return self.embedding
+        return self._embedding
 
     @staticmethod
     def reference_record(


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

1. Why is this change required?
   because calling the memory record's embedding property throws `RecursionError: maximum recursion depth exceeded`
3. What problem does it solve?
    calling the memory record's embedding property throws `RecursionError: maximum recursion depth exceeded`
4. What scenario does it contribute to?
    people calling the embedding attribute of a memory memory record
5. If it fixes an open issue, please link to the issue here.
    NA
### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

return the attribute instead of the property


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
