### PR TITLE
Remove InternalsVisibleTo dependencies in solution

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Connectors/WebApi/Rest/Model/RestApiOperation.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Connectors/WebApi/Rest/Model/RestApiOperation.cs
@@ -18,17 +18,17 @@ public sealed class RestApiOperation
     /// <summary>
     /// An artificial parameter that is added to be able to override RESP API operation server url.
     /// </summary>
-    internal const string ServerUrlArgumentName = "server-url";
+    public const string ServerUrlArgumentName = "server-url";
 
     /// <summary>
     /// An artificial parameter to be used for operation having "text/plain" payload media type.
     /// </summary>
-    internal const string PayloadArgumentName = "payload";
+    public const string PayloadArgumentName = "payload";
 
     /// <summary>
     /// An artificial parameter to be used for indicate payload media-type if it's missing in payload metadata.
     /// </summary>
-    internal const string ContentTypeArgumentName = "content-type";
+    public const string ContentTypeArgumentName = "content-type";
 
     /// <summary>
     /// The operation identifier.

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.OpenAPI" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -25,7 +25,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.Memory.CosmosDB" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="IntegrationTests" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -25,7 +25,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.OpenAPI" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.Memory.CosmosDB" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -23,8 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="IntegrationTests" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel.Utilities/Diagnostics/HttpStatusCodeType.cs
+++ b/dotnet/src/SemanticKernel.Utilities/Diagnostics/HttpStatusCodeType.cs
@@ -7,8 +7,8 @@ namespace Microsoft.SemanticKernel.Diagnostics;
 /// <summary>
 /// Contains the values of status codes defined for HTTP in the response to an HTTP request.
 /// </summary>
-[SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "<Pending>")]
-internal enum HttpStatusCodeType
+[SuppressMessage("Design", "CA1008:Enums should have zero value", Justification = "There is no HTTP status code with zero value.")]
+public enum HttpStatusCodeType
 {
     /// <summary>
     /// The server has received the request headers and the client should proceed to send the request body.
@@ -83,17 +83,7 @@ internal enum HttpStatusCodeType
     /// <summary>
     /// The requested resource has multiple representations and the client should choose one of them.
     /// </summary>
-    Ambiguous = 300,
-
-    /// <summary>
-    /// The requested resource has multiple representations and the client should choose one of them.
-    /// </summary>
     MultipleChoices = 300,
-
-    /// <summary>
-    /// The requested resource has been permanently moved to a new location and the client should use the new URI.
-    /// </summary>
-    Moved = 301,
 
     /// <summary>
     /// The requested resource has been permanently moved to a new location and the client should use the new URI.
@@ -104,16 +94,6 @@ internal enum HttpStatusCodeType
     /// The requested resource has been temporarily moved to a new location and the client should use the new URI.
     /// </summary>
     Found = 302,
-
-    /// <summary>
-    /// The requested resource has been temporarily moved to a new location and the client should use the new URI.
-    /// </summary>
-    Redirect = 302,
-
-    /// <summary>
-    /// The requested resource can be found at a different URI and the client should use a GET method to retrieve it.
-    /// </summary>
-    RedirectMethod = 303,
 
     /// <summary>
     /// The requested resource can be found at a different URI and the client should use a GET method to retrieve it.
@@ -134,11 +114,6 @@ internal enum HttpStatusCodeType
     /// This status code is no longer used and is reserved for future use.
     /// </summary>
     Unused = 306,
-
-    /// <summary>
-    /// The requested resource has been temporarily moved to a new location and the client should use the same method to access it.
-    /// </summary>
-    RedirectKeepVerb = 307,
 
     /// <summary>
     /// The requested resource has been temporarily moved to a new location and the client should use the same method to access it.

--- a/dotnet/src/SemanticKernel/Orchestration/SKContextExtensions.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/SKContextExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.SemanticKernel.SkillDefinition;
 namespace Microsoft.SemanticKernel.Orchestration;
 #pragma warning restore IDE0130
 
-internal static class SKContextExtensions
+public static class SKContextExtensions
 {
     /// <summary>
     /// Simple extension method to check if a function is registered in the SKContext.
@@ -17,7 +17,7 @@ internal static class SKContextExtensions
     /// <param name="skillName">The skill name</param>
     /// <param name="functionName">The function name</param>
     /// <param name="registeredFunction">The registered function, if found</param>
-    internal static bool IsFunctionRegistered(this SKContext context, string skillName, string functionName, [NotNullWhen(true)] out ISKFunction? registeredFunction)
+    public static bool IsFunctionRegistered(this SKContext context, string skillName, string functionName, [NotNullWhen(true)] out ISKFunction? registeredFunction)
     {
         context.ThrowIfSkillCollectionNotSet();
 
@@ -47,7 +47,7 @@ internal static class SKContextExtensions
     /// Ensures the context has a skill collection available
     /// </summary>
     /// <param name="context">SK execution context</param>
-    internal static void ThrowIfSkillCollectionNotSet(this SKContext context)
+    public static void ThrowIfSkillCollectionNotSet(this SKContext context)
     {
         if (context.Skills == null)
         {

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -20,8 +20,6 @@ Install this package manually only if you are selecting individual Semantic Kern
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.IntegrationTests" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -23,7 +23,6 @@ Install this package manually only if you are selecting individual Semantic Kern
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" PublicKey="$(StongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.OpenAPI" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.IntegrationTests" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -22,7 +22,6 @@ Install this package manually only if you are selecting individual Semantic Kern
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StongNamePublicKey)"/>
     <InternalsVisibleTo Include="SemanticKernel.IntegrationTests" PublicKey="$(StongNamePublicKey)"/>

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -256,7 +256,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
         public string Description { get; set; }
     }
 
-    internal enum DelegateTypes
+    public enum DelegateTypes
     {
         Unknown = 0,
         Void = 1,
@@ -279,7 +279,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
         OutTask = 18
     }
 
-    internal SKFunction(
+    public SKFunction(
         DelegateTypes delegateType,
         Delegate delegateFunction,
         IList<ParameterView> parameters,


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This PR contains changes to remove `InternalsVisibleTo` dependencies between projects with business logic in entire solution. 
Now `InternalsVisibleTo` dependencies exist only for test projects.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Removed following `InternalsVisibleTo` dependencies in `SemanticKernel` and `SemanticKernel.Abstractions` projects:
1. `Microsoft.SemanticKernel.Connectors.AI.OpenAI`
2. `Microsoft.SemanticKernel.Planning.ActionPlanner`
3. `Microsoft.SemanticKernel.Planning.SequentialPlanner`
4. `Microsoft.SemanticKernel.Skills.OpenAPI`
5. `Microsoft.SemanticKernel.Connectors.Memory.CosmosDB`


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
