### PR TITLE
Add support for custom context in plan execution

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -155,9 +155,9 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
         return clone;
     }
 
-    #region private ================================================================================
-
     internal const string MainKey = "INPUT";
+
+    #region private ================================================================================
 
     // Important: names are case insensitive
     private readonly ConcurrentDictionary<string, string> _variables = new(StringComparer.OrdinalIgnoreCase);

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -157,7 +157,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
 
     #region private ================================================================================
 
-    private const string MainKey = "INPUT";
+    internal const string MainKey = "INPUT";
 
     // Important: names are case insensitive
     private readonly ConcurrentDictionary<string, string> _variables = new(StringComparer.OrdinalIgnoreCase);

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -636,6 +636,86 @@ public sealed class PlanTests
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Exactly(2));
     }
 
+
+    [Fact]
+    public async Task CanExecutePlanWithCustomStateAsync()
+    {
+        // Arrange
+        var kernel = new Mock<IKernel>();
+        var log = new Mock<ILogger>();
+        var memory = new Mock<ISemanticTextMemory>();
+        var skills = new Mock<ISkillCollection>();
+
+        var returnContext = new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            log.Object
+        );
+
+        var mockFunction = new Mock<ISKFunction>();
+        mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default))
+            .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
+            {
+                c.Variables.Get("type", out var t);
+                returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
+            })
+            .Returns(() => Task.FromResult(returnContext));
+
+        var planStep = new Plan(mockFunction.Object);
+        planStep.Parameters.Set("type", string.Empty);
+        var plan = new Plan("A plan");
+        plan.State.Set("input", "Medusa");
+        plan.State.Set("type", "joke");
+        plan.AddSteps(planStep);
+
+        // Act
+        var result = await plan.InvokeAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal($"Here is a joke about Medusa", result.Result);
+        mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Once);
+
+        planStep = new Plan(mockFunction.Object);
+        plan = new Plan("A plan");
+        planStep.Parameters.Set("input", "Medusa");
+        planStep.Parameters.Set("type", "joke");
+        plan.State.Set("input", "Cleopatra"); // state input will not override parameter
+        plan.State.Set("type", "poem");
+        plan.AddSteps(planStep);
+
+        // Act
+        result = await plan.InvokeAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal($"Here is a poem about Medusa", result.Result);
+        mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Exactly(2));
+
+        planStep = new Plan(mockFunction.Object);
+        plan = new Plan("A plan");
+        planStep.Parameters.Set("input", "Cleopatra");
+        planStep.Parameters.Set("type", "poem");
+        plan.AddSteps(planStep);
+        var contextOverride = new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            log.Object
+        );
+        contextOverride.Variables.Set("type", "joke");
+        contextOverride.Variables.Update("Medusa"); // context input will not override parameters
+
+        // Act
+        result = await plan.InvokeAsync(contextOverride);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal($"Here is a joke about Cleopatra", result.Result);
+        mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Exactly(3));
+    }
+
     [Fact]
     public async Task CanExecutePlanWithJoinedResultAsync()
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -636,7 +636,6 @@ public sealed class PlanTests
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Exactly(2));
     }
 
-
     [Fact]
     public async Task CanExecutePlanWithCustomStateAsync()
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -578,6 +578,65 @@ public sealed class PlanTests
     }
 
     [Fact]
+    public async Task CanExecutePlanWithCustomContextAsync()
+    {
+        // Arrange
+        var kernel = new Mock<IKernel>();
+        var log = new Mock<ILogger>();
+        var memory = new Mock<ISemanticTextMemory>();
+        var skills = new Mock<ISkillCollection>();
+
+        var returnContext = new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            log.Object
+        );
+
+        var mockFunction = new Mock<ISKFunction>();
+        mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default))
+            .Callback<SKContext, CompleteRequestSettings, ILogger, CancellationToken?>((c, s, l, ct) =>
+            {
+                c.Variables.Get("type", out var t);
+                returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
+            })
+            .Returns(() => Task.FromResult(returnContext));
+
+        var plan = new Plan(mockFunction.Object);
+        plan.State.Set("input", "Cleopatra");
+        plan.State.Set("type", "poem");
+
+        // Act
+        var result = await plan.InvokeAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal($"Here is a poem about Cleopatra", result.Result);
+        mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Once);
+
+        plan = new Plan(mockFunction.Object);
+        plan.State.Set("input", "Cleopatra");
+        plan.State.Set("type", "poem");
+
+        var contextOverride = new SKContext(
+            new ContextVariables(),
+            memory.Object,
+            skills.Object,
+            log.Object
+        );
+        contextOverride.Variables.Set("type", "joke");
+        contextOverride.Variables.Update("Medusa");
+
+        // Act
+        result = await plan.InvokeAsync(contextOverride);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal($"Here is a joke about Medusa", result.Result);
+        mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null, null, default), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task CanExecutePlanWithJoinedResultAsync()
     {
         // Arrange

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -508,7 +508,7 @@ public sealed class Plan : ISKFunction
         var functionParameters = step.Describe();
         foreach (var param in functionParameters.Parameters)
         {
-            if (param.Name.Equals("INPUT", StringComparison.OrdinalIgnoreCase))
+            if (param.Name.Equals(ContextVariables.MainKey, StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -501,7 +501,6 @@ public sealed class Plan : ISKFunction
 
         var stepVariables = new ContextVariables(input);
 
-
         // Priority for remaining stepVariables is:
         // - Function Parameters (pull from variables or state by a key value)
         // - Step Parameters (pull from variables or state by a key value)

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -497,6 +497,12 @@ public sealed class Plan : ISKFunction
 
         foreach (var item in step.Parameters)
         {
+            // Don't overwrite variable values that are already set except for INPUT
+            if (!item.Key.Equals("INPUT", StringComparison.OrdinalIgnoreCase) && stepVariables.Get(item.Key, out var val))
+            {
+                continue;
+            }
+
             if (!string.IsNullOrEmpty(item.Value))
             {
                 var value = this.ExpandFromVariables(variables, item.Value);

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -525,7 +525,7 @@ public sealed class Plan : ISKFunction
         foreach (var item in step.Parameters)
         {
             // Don't overwrite variable values that are already set
-            if (stepVariables.Get(item.Key, out var val))
+            if (stepVariables.Get(item.Key, out _))
             {
                 continue;
             }

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -512,11 +512,11 @@ public sealed class Plan : ISKFunction
                 continue;
             }
 
-            if (variables.Get(param.Name, out var value) && !string.IsNullOrEmpty(value))
+            if (variables.Get(param.Name, out var value))
             {
                 stepVariables.Set(param.Name, value);
             }
-            else if (this.State.Get(param.Name, out value) && !string.IsNullOrEmpty(value))
+            else if (this.State.Get(param.Name, out value))
             {
                 stepVariables.Set(param.Name, value);
             }
@@ -531,19 +531,19 @@ public sealed class Plan : ISKFunction
             }
 
             var expandedValue = this.ExpandFromVariables(variables, item.Value);
-            if (!string.IsNullOrEmpty(item.Value) && !expandedValue.Equals(item.Value, StringComparison.OrdinalIgnoreCase))
+            if (!expandedValue.Equals(item.Value, StringComparison.OrdinalIgnoreCase))
             {
                 stepVariables.Set(item.Key, expandedValue);
             }
-            else if (variables.Get(item.Key, out var value) && !string.IsNullOrEmpty(value))
+            else if (variables.Get(item.Key, out var value))
             {
                 stepVariables.Set(item.Key, value);
             }
-            else if (this.State.Get(item.Key, out value) && !string.IsNullOrEmpty(value))
+            else if (this.State.Get(item.Key, out value))
             {
                 stepVariables.Set(item.Key, value);
             }
-            else if (!string.IsNullOrEmpty(expandedValue) && !stepVariables.Get(item.Key, out var _))
+            else
             {
                 stepVariables.Set(item.Key, expandedValue);
             }


### PR DESCRIPTION
This commit fixes a bug that allows users to pass a custom SKContext object to a plan invocation, which can override or augment the default context variables. This enables more flexibility and control over the plan execution and the output. The commit also adds a unit test to verify the functionality of the new feature.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
