### PR TITLE
fix path to glossary

### DIFF
--- a/samples/notebooks/dotnet/02-running-prompts-from-file.ipynb
+++ b/samples/notebooks/dotnet/02-running-prompts-from-file.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "A Semantic Skill is a collection of Semantic Functions, where each function is defined with natural language that can be provided with a text file. \n",
     "\n",
-    "Refer to our [glossary](../../../GLOSSARY.md) for an in-depth guide to the terms.\n",
+    "Refer to our [glossary](../../../docs/GLOSSARY.md) for an in-depth guide to the terms.\n",
     "\n",
     "The repository includes some examples under the [samples](https://github.com/microsoft/semantic-kernel/tree/main/samples) folder.\n",
     "\n",


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
the path to the glossary was incorrect.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
fixed path to the glossary.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
