### PR TITLE
Change kernel.add_text_completion_service to kernel.config.add_text_completion_service

### DIFF
--- a/samples/notebooks/python/00-getting-started.ipynb
+++ b/samples/notebooks/python/00-getting-started.ipynb
@@ -53,7 +53,7 @@
         "\n",
         "api_key, org_id = sk.openai_settings_from_dot_env()\n",
         "\n",
-        "kernel.add_text_completion_service(\"dv\", OpenAITextCompletion(\"text-davinci-003\", api_key, org_id))"
+        "kernel.config.add_text_completion_service(\"dv\", OpenAITextCompletion(\"text-davinci-003\", api_key, org_id))"
       ]
     },
     {
@@ -84,7 +84,7 @@
         "\n",
         "deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()\n",
         "\n",
-        "kernel.add_text_completion_service(\"dv\", AzureTextCompletion(deployment, endpoint, api_key))"
+        "kernel.config.add_text_completion_service(\"dv\", AzureTextCompletion(deployment, endpoint, api_key))"
       ]
     },
     {


### PR DESCRIPTION
Change kernel.add_text_completion_service to kernel.config.add_text_completion_service

To solve the following error:
Traceback (most recent call last):
  File "/home/hwaking/experiment/semantic-kernel/python/tests/mytest/test_prompt.py", line 13, in <module>
    kernel.add_text_completion_service("dv", AzureTextCompletion(deployment, endpoint, api_key))
AttributeError: 'Kernel' object has no attribute 'add_text_completion_service'

### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
