### PR TITLE
Chat stream

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
@@ -189,6 +189,7 @@ public abstract class ClientBase
     /// </summary>
     /// <param name="chat">Chat history</param>
     /// <param name="requestSettings">AI request settings</param>
+    /// <param name="onDataReceived">Delegate function called on each data received</param>
     /// <param name="cancellationToken">Async cancellation token</param>
     /// <returns>Generated chat message in string format</returns>
     protected async Task<string> InternalGenerateChatMessageStreamAsync(

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
@@ -47,6 +47,8 @@ public sealed class OpenAIChatCompletion : OpenAIClientBase, IChatCompletion, IT
 
         return this.InternalGenerateChatMessageAsync(chat, requestSettings, cancellationToken);
     }
+
+    /// <inheritdoc/>
     public Task<string> GenerateMessageStreamAsync(
         ChatHistory chat,
         Func<string, Task> onDataReceived, // Add delegate parameter here

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
 
@@ -45,6 +46,16 @@ public sealed class OpenAIChatCompletion : OpenAIClientBase, IChatCompletion, IT
         requestSettings ??= new ChatRequestSettings();
 
         return this.InternalGenerateChatMessageAsync(chat, requestSettings, cancellationToken);
+    }
+    public Task<string> GenerateMessageStreamAsync(
+        ChatHistory chat,
+        Func<string, Task> onDataReceived, // Add delegate parameter here
+        ChatRequestSettings? requestSettings = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (requestSettings == null) { requestSettings = new ChatRequestSettings(); }
+
+        return this.InternalGenerateChatMessageStreamAsync(chat, requestSettings,onDataReceived, cancellationToken);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

1. This change is required to add OpenAI chat stream capabilities to the Semantic Kernel, making it more versatile and useful in real-time chat applications.
2. The problem it solves is the inability to process and handle chat data in real-time, leading to a less interactive and responsive user experience.
3. This contributes to a scenario where developers can now integrate the Semantic Kernel with chat applications that require real-time processing and streaming of chat data.
4. This PR does not fix an open issue but improves the overall functionality and usability of the Semantic Kernel. might be duplicate of this https://github.com/microsoft/semantic-kernel/issues/378

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->  
This PR adds OpenAI chat stream capabilities to the Semantic Kernel. The changes include modifications to the existing code to enable handling of real-time chat data and sending partial responses to the client as the data is received. The overall approach focuses on maintaining the existing architecture while extending its functionality. This update enhances the Semantic Kernel's ability to work with chat applications requiring real-time interactions and responsiveness.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x ] The code builds clean without any errors or warnings
- [x ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x ] All unit tests pass, and I have added new tests where possible
- [x ] I didn't break anyone :smile:
