### PR TITLE
Simplify IKernel interface

### DIFF
--- a/dotnet/SK-dotnet.sln.DotSettings
+++ b/dotnet/SK-dotnet.sln.DotSettings
@@ -190,6 +190,7 @@ public void It$SOMENAME$()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ctors/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=davinci/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ENDPART/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=fareweller/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=greaterthan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Joinable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keyvault/@EntryIndexedValue">True</s:Boolean>

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -82,7 +82,7 @@ public class SequentialPlanParserTests
 
             if (string.IsNullOrEmpty(name))
             {
-                kernelMock.Setup(x => x.RegisterSemanticFunction(
+                kernelMock.Setup(x => x.ImportSemanticFunction(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<SemanticFunctionConfig>()

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -102,7 +102,7 @@ public sealed class SequentialPlannerTests
         kernel.Setup(x => x.Skills).Returns(skills.Object);
         kernel.Setup(x => x.CreateNewContext()).Returns(context);
 
-        kernel.Setup(x => x.RegisterSemanticFunction(
+        kernel.Setup(x => x.ImportSemanticFunction(
             It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<SemanticFunctionConfig>()
@@ -192,7 +192,7 @@ public sealed class SequentialPlannerTests
         kernel.Setup(x => x.Skills).Returns(skills.Object);
         kernel.Setup(x => x.CreateNewContext()).Returns(context);
 
-        kernel.Setup(x => x.RegisterSemanticFunction(
+        kernel.Setup(x => x.ImportSemanticFunction(
             It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<SemanticFunctionConfig>()

--- a/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.TemplateEngine;
 
@@ -43,26 +42,13 @@ public interface IKernel
     IReadOnlySkillCollection Skills { get; }
 
     /// <summary>
-    /// Build and register a function in the internal skill collection, in a global generic skill.
+    /// Import a set of functions from the given skill. The functions must have the `SKFunction` attribute.
+    /// Once these functions are imported, the prompt templates can use functions to import content at runtime.
     /// </summary>
-    /// <param name="functionName">Name of the semantic function. The name can contain only alphanumeric chars + underscore.</param>
-    /// <param name="functionConfig">Function configuration, e.g. I/O params, AI settings, localization details, etc.</param>
-    /// <returns>A C# function wrapping AI logic, usually defined with natural language</returns>
-    ISKFunction RegisterSemanticFunction(
-        string functionName,
-        SemanticFunctionConfig functionConfig);
-
-    /// <summary>
-    /// Build and register a function in the internal skill collection.
-    /// </summary>
-    /// <param name="skillName">Name of the skill containing the function. The name can contain only alphanumeric chars + underscore.</param>
-    /// <param name="functionName">Name of the semantic function. The name can contain only alphanumeric chars + underscore.</param>
-    /// <param name="functionConfig">Function configuration, e.g. I/O params, AI settings, localization details, etc.</param>
-    /// <returns>A C# function wrapping AI logic, usually defined with natural language</returns>
-    ISKFunction RegisterSemanticFunction(
-        string skillName,
-        string functionName,
-        SemanticFunctionConfig functionConfig);
+    /// <param name="skillInstance">Instance of a class containing functions</param>
+    /// <param name="skillName">Name of the skill for skill collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
+    /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
+    IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string? skillName = null);
 
     /// <summary>
     /// Registers a custom function in the internal skill collection.
@@ -70,16 +56,7 @@ public interface IKernel
     /// <param name="skillName">Name of the skill containing the function. The name can contain only alphanumeric chars + underscore.</param>
     /// <param name="customFunction">The custom function to register.</param>
     /// <returns>A C# function wrapping the function execution logic.</returns>
-    ISKFunction RegisterCustomFunction(string skillName, ISKFunction customFunction);
-
-    /// <summary>
-    /// Import a set of functions from the given skill. The functions must have the `SKFunction` attribute.
-    /// Once these functions are imported, the prompt templates can use functions to import content at runtime.
-    /// </summary>
-    /// <param name="skillInstance">Instance of a class containing functions</param>
-    /// <param name="skillName">Name of the skill for skill collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
-    /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
-    IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName = "");
+    ISKFunction ImportFunction(string skillName, ISKFunction customFunction);
 
     /// <summary>
     /// Set the semantic memory to use

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.AI.ImageGeneration;
@@ -14,7 +13,6 @@ using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SemanticFunctions;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.TemplateEngine;
 
@@ -77,26 +75,7 @@ public sealed class Kernel : IKernel, IDisposable
     }
 
     /// <inheritdoc/>
-    public ISKFunction RegisterSemanticFunction(string functionName, SemanticFunctionConfig functionConfig)
-    {
-        return this.RegisterSemanticFunction(SkillCollection.GlobalSkill, functionName, functionConfig);
-    }
-
-    /// <inheritdoc/>
-    public ISKFunction RegisterSemanticFunction(string skillName, string functionName, SemanticFunctionConfig functionConfig)
-    {
-        // Future-proofing the name not to contain special chars
-        Verify.ValidSkillName(skillName);
-        Verify.ValidFunctionName(functionName);
-
-        ISKFunction function = this.CreateSemanticFunction(skillName, functionName, functionConfig);
-        this._skillCollection.AddFunction(function);
-
-        return function;
-    }
-
-    /// <inheritdoc/>
-    public IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName = "")
+    public IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string? skillName = null)
     {
         if (string.IsNullOrWhiteSpace(skillName))
         {
@@ -108,7 +87,7 @@ public sealed class Kernel : IKernel, IDisposable
             this._log.LogTrace("Importing skill {0}", skillName);
         }
 
-        Dictionary<string, ISKFunction> skill = ImportSkill(skillInstance, skillName, this._log);
+        Dictionary<string, ISKFunction> skill = ImportSkill(skillInstance, skillName!, this._log);
         foreach (KeyValuePair<string, ISKFunction> f in skill)
         {
             f.Value.SetDefaultSkillCollection(this.Skills);
@@ -119,7 +98,7 @@ public sealed class Kernel : IKernel, IDisposable
     }
 
     /// <inheritdoc/>
-    public ISKFunction RegisterCustomFunction(string skillName, ISKFunction customFunction)
+    public ISKFunction ImportFunction(string skillName, ISKFunction customFunction)
     {
         // Future-proofing the name not to contain special chars
         Verify.ValidSkillName(skillName);
@@ -300,32 +279,6 @@ public sealed class Kernel : IKernel, IDisposable
     private readonly ISkillCollection _skillCollection;
     private ISemanticTextMemory _memory;
     private readonly IPromptTemplateEngine _promptTemplateEngine;
-
-    private ISKFunction CreateSemanticFunction(
-        string skillName,
-        string functionName,
-        SemanticFunctionConfig functionConfig)
-    {
-        if (!functionConfig.PromptTemplateConfig.Type.Equals("completion", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new AIException(
-                AIException.ErrorCodes.FunctionTypeNotSupported,
-                $"Function type not supported: {functionConfig.PromptTemplateConfig}");
-        }
-
-        ISKFunction func = SKFunction.FromSemanticConfig(skillName, functionName, functionConfig, this._log);
-
-        // Connect the function to the current kernel skill collection, in case the function
-        // is invoked manually without a context and without a way to find other functions.
-        func.SetDefaultSkillCollection(this.Skills);
-
-        func.SetAIConfiguration(CompleteRequestSettings.FromCompletionConfig(functionConfig.PromptTemplateConfig.Completion));
-
-        // Note: the service is instantiated using the kernel configuration state when the function is invoked
-        func.SetAIService(() => this.GetService<ITextCompletion>());
-
-        return func;
-    }
 
     /// <summary>
     /// Import a skill into the kernel skill collection, so that semantic functions and pipelines can consume its functions.

--- a/dotnet/src/SemanticKernel/SemanticFunctions/KernelSemanticFunctionsExtensions.cs
+++ b/dotnet/src/SemanticKernel/SemanticFunctions/KernelSemanticFunctionsExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.AI;
+using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.SemanticFunctions;
+using Microsoft.SemanticKernel.SkillDefinition;
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace - Using NS of IKernel
+namespace Microsoft.SemanticKernel;
+#pragma warning restore IDE0130
+
+public static class KernelSemanticFunctionsExtensions
+{
+    /// <summary>
+    /// Build and register a semantic function in the kernel skill collection, in a global generic skill.
+    /// </summary>
+    /// /// <param name="kernel">Kernel instance to extend</param>
+    /// <param name="functionName">Name of the semantic function. The name can contain only alphanumeric chars + underscore.</param>
+    /// <param name="functionConfig">Function configuration, e.g. I/O params, AI settings, localization details, etc.</param>
+    /// <returns>A C# function wrapping AI logic, usually defined with natural language</returns>
+    public static ISKFunction ImportSemanticFunction(this IKernel kernel,
+        string functionName,
+        SemanticFunctionConfig functionConfig)
+    {
+        return ImportSemanticFunction(kernel, SkillCollection.GlobalSkill, functionName, functionConfig);
+    }
+
+    /// <summary>
+    /// Build and register a semantic function in the kernel skill collection.
+    /// </summary>
+    /// <param name="kernel">Kernel instance to extend</param>
+    /// <param name="skillName">Name of the skill containing the function. The name can contain only alphanumeric chars + underscore.</param>
+    /// <param name="functionName">Name of the semantic function. The name can contain only alphanumeric chars + underscore.</param>
+    /// <param name="functionConfig">Function configuration, e.g. I/O params, AI settings, localization details, etc.</param>
+    /// <returns>A C# function wrapping AI logic, usually defined with natural language</returns>
+    public static ISKFunction ImportSemanticFunction(this IKernel kernel,
+        string skillName,
+        string functionName,
+        SemanticFunctionConfig functionConfig)
+    {
+        // Future-proofing the name not to contain special chars
+        Verify.ValidSkillName(skillName);
+        Verify.ValidFunctionName(functionName);
+
+        ISKFunction function = CreateSemanticFunction(kernel, skillName, functionName, functionConfig);
+        kernel.ImportFunction(skillName, function);
+
+        return function;
+    }
+
+    private static ISKFunction CreateSemanticFunction(IKernel kernel,
+        string skillName,
+        string functionName,
+        SemanticFunctionConfig functionConfig)
+    {
+        if (!functionConfig.PromptTemplateConfig.Type.Equals("completion", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new AIException(
+                AIException.ErrorCodes.FunctionTypeNotSupported,
+                $"Function type not supported: {functionConfig.PromptTemplateConfig}");
+        }
+
+        ISKFunction func = SKFunction.FromSemanticConfig(skillName, functionName, functionConfig, kernel.Log);
+
+        // Connect the function to the current kernel skill collection, in case the function
+        // is invoked manually without a context and without a way to find other functions.
+        func.SetDefaultSkillCollection(kernel.Skills);
+
+        func.SetAIConfiguration(CompleteRequestSettings.FromCompletionConfig(functionConfig.PromptTemplateConfig.Completion));
+
+        // Note: the service is instantiated using the kernel configuration state when the function is invoked
+        func.SetAIService(() => kernel.GetService<ITextCompletion>());
+
+        return func;
+    }
+}

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -22,15 +22,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.OpenAPI" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.Grpc" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="SemanticKernel.IntegrationTests" PublicKey="$(StrongNamePublicKey)"/>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="$(StrongNamePublicKey)"/> <!-- Moq -->
+    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.ActionPlanner" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.OpenAPI" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.SemanticKernel.Skills.Grpc" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="SemanticKernel.UnitTests" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="SemanticKernel.Skills.UnitTests" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="SemanticKernel.IntegrationTests" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="$(StrongNamePublicKey)" /> <!-- Moq -->
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel/SkillDefinition/ImportSemanticSkillFromDirectory.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/ImportSemanticSkillFromDirectory.cs
@@ -97,7 +97,7 @@ public static class ImportSemanticSkillFromDirectoryExtension
                 var functionConfig = new SemanticFunctionConfig(config, template);
 
                 kernel.Log.LogTrace("Registering function {0}.{1} loaded from {2}", skillDirectoryName, functionName, dir);
-                skill[functionName] = kernel.RegisterSemanticFunction(skillDirectoryName, functionName, functionConfig);
+                skill[functionName] = kernel.ImportSemanticFunction(skillDirectoryName, functionName, functionConfig);
             }
         }
 

--- a/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
@@ -99,8 +99,8 @@ public static class InlineFunctionsDefinitionExtension
 
         // TODO: manage overwrites, potentially error out
         return string.IsNullOrEmpty(skillName)
-            ? kernel.RegisterSemanticFunction(functionName, functionConfig)
-            : kernel.RegisterSemanticFunction(skillName, functionName, functionConfig);
+            ? kernel.ImportSemanticFunction(functionName, functionConfig)
+            : kernel.ImportSemanticFunction(skillName, functionName, functionConfig);
     }
 
     private static string RandomFunctionName() => "func" + Guid.NewGuid().ToString("N");

--- a/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
@@ -37,7 +37,8 @@ public class SkillCollection : ISkillCollection
     {
         Verify.NotNull(functionInstance, "The function is NULL");
 
-        ConcurrentDictionary<string, ISKFunction> skill = this._skillCollection.GetOrAdd(functionInstance.SkillName, static _ => new(StringComparer.OrdinalIgnoreCase));
+        ConcurrentDictionary<string, ISKFunction> skill =
+            this._skillCollection.GetOrAdd(functionInstance.SkillName, static _ => new(StringComparer.OrdinalIgnoreCase));
         skill.TryAdd(functionInstance.Name, functionInstance);
 
         return this;

--- a/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -30,20 +30,20 @@ public static class KernelGrpcExtensions
     /// <returns>A list of all the semantic functions representing the skill.</returns>
     public static IDictionary<string, ISKFunction> ImportGrpcSkillFromDirectory(this IKernel kernel, string parentDirectory, string skillDirectoryName)
     {
-        const string PROTO_FILE = "grpc.proto";
+        const string ProtoFile = "grpc.proto";
 
         Verify.ValidSkillName(skillDirectoryName);
 
         var skillDir = Path.Combine(parentDirectory, skillDirectoryName);
         Verify.DirectoryExists(skillDir);
 
-        var filePath = Path.Combine(skillDir, PROTO_FILE);
+        var filePath = Path.Combine(skillDir, ProtoFile);
         if (!File.Exists(filePath))
         {
             throw new FileNotFoundException($"No .proto document for the specified path - {filePath} is found.");
         }
 
-        kernel.Log.LogTrace("Registering gRPC functions from {0} .proto document.", filePath);
+        kernel.Log.LogTrace("Registering gRPC functions from {0} .proto document", filePath);
 
         using var stream = File.OpenRead(filePath);
 
@@ -67,7 +67,7 @@ public static class KernelGrpcExtensions
             throw new FileNotFoundException($"No .proto document for the specified path - {filePath} is found.");
         }
 
-        kernel.Log.LogTrace("Registering gRPC functions from {0} .proto document.", filePath);
+        kernel.Log.LogTrace("Registering gRPC functions from {0} .proto document", filePath);
 
         using var stream = File.OpenRead(filePath);
 
@@ -184,7 +184,7 @@ public static class KernelGrpcExtensions
             log: kernel.Log);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        return kernel.RegisterCustomFunction(skillName, function);
+        return kernel.ImportFunction(skillName, function);
     }
 
     #endregion

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -331,7 +331,7 @@ public static class KernelOpenApiExtensions
             log: kernel.Log);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        return kernel.RegisterCustomFunction(skillName, function);
+        return kernel.ImportFunction(skillName, function);
     }
 
     #endregion

--- a/dotnet/src/Skills/Skills.UnitTests/Grpc/Extensions/GrpcOperationExtensionsTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/Grpc/Extensions/GrpcOperationExtensionsTests.cs
@@ -7,6 +7,7 @@ using Microsoft.SemanticKernel.Skills.Grpc.Model;
 using Xunit;
 
 namespace SemanticKernel.Skills.UnitTests.Grpc.Extensions;
+
 public class GrpcOperationExtensionsTests
 {
     private readonly GrpcOperationDataContractType _request;
@@ -49,8 +50,8 @@ public class GrpcOperationExtensionsTests
         Assert.NotNull(parameters);
         Assert.True(parameters.Any());
 
-        var payloadPrameter = parameters.SingleOrDefault(p => p.Name == "payload");
-        Assert.NotNull(payloadPrameter);
-        Assert.Equal("gRPC request message.", payloadPrameter.Description);
+        var payloadParameter = parameters.SingleOrDefault(p => p.Name == "payload");
+        Assert.NotNull(payloadParameter);
+        Assert.Equal("gRPC request message.", payloadParameter.Description);
     }
 }

--- a/dotnet/src/Skills/Skills.UnitTests/Grpc/Protobuf/ProtoDocumentParserV30Tests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/Grpc/Protobuf/ProtoDocumentParserV30Tests.cs
@@ -98,11 +98,11 @@ public sealed class ProtoDocumentParserV30Tests
         Assert.Equal("greet.HelloReply", response.Name);
         Assert.NotNull(response.Fields);
 
-        var messageFeld = response.Fields.SingleOrDefault(f => f.Name == "message");
-        Assert.NotNull(messageFeld);
+        var messageField = response.Fields.SingleOrDefault(f => f.Name == "message");
+        Assert.NotNull(messageField);
 
-        Assert.Equal(1, messageFeld.Number);
-        Assert.Equal("TYPE_STRING", messageFeld.TypeName);
+        Assert.Equal(1, messageField.Number);
+        Assert.Equal("TYPE_STRING", messageField.TypeName);
     }
 }
 

--- a/samples/dotnet/kernel-extension-load-prompts-from-cloud/SampleExtension.cs
+++ b/samples/dotnet/kernel-extension-load-prompts-from-cloud/SampleExtension.cs
@@ -54,7 +54,7 @@ public static class SemanticKernelExtensions
 
             // Wrap AI logic into a function and store it
             var functionConfig = new SemanticFunctionConfig(config, template);
-            skill[functionName] = kernel.RegisterSemanticFunction(skillName, functionName, functionConfig);
+            skill[functionName] = kernel.ImportSemanticFunction(skillName, functionName, functionConfig);
         }
 
         return skill;

--- a/samples/dotnet/kernel-syntax-examples/Example35_GrpcSkills.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example35_GrpcSkills.cs
@@ -11,6 +11,7 @@ using RepoUtils;
  * This example shows how to use gRPC skills.
  */
 
+// ReSharper disable once InconsistentNaming
 public static class Example35_GrpcSkills
 {
     public static async Task RunAsync()


### PR DESCRIPTION
### Motivation and Context

* Move semantic methods out of IKernel, since they can be delivered using more generic code.
* Fix #726

### Description

* `RegisterCustomFunction` -> `ImportFunction`, consistent with `ImportSkill`
* `RegisterSemanticFunction` -> `ImportSemanticFunction` kernel extension 