### PR TITLE
Add logging to auth handlers

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Auth/PassThroughAuthenticationHandler.cs
+++ b/samples/apps/copilot-chat-app/webapi/Auth/PassThroughAuthenticationHandler.cs
@@ -14,6 +14,8 @@ public class PassThroughAuthenticationHandler : AuthenticationHandler<Authentica
 {
     public const string AuthenticationScheme = "PassThrough";
 
+    private readonly ILogger<PassThroughAuthenticationHandler> _logger;
+
     /// <summary>
     /// Constructor
     /// </summary>
@@ -23,10 +25,13 @@ public class PassThroughAuthenticationHandler : AuthenticationHandler<Authentica
         UrlEncoder encoder,
         ISystemClock clock) : base(options, logger, encoder, clock)
     {
+        this._logger = logger.CreateLogger<PassThroughAuthenticationHandler>();
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        this._logger.LogInformation("Allowing request to pass through");
+
         var principal = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationScheme));
         var ticket = new AuthenticationTicket(principal, this.Scheme.Name);
 


### PR DESCRIPTION
### Motivation and Context
We want visibility on our auth handling.

### Description
Added logging in our own auth handlers.

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
