### PR TITLE
Improvements/fixes for service registry

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIKernelBuilderExtensions.cs
@@ -16,7 +16,7 @@ using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
 namespace Microsoft.SemanticKernel;
 #pragma warning restore IDE0130
 
-public static class OpenAKernelBuilderExtensions
+public static class OpenAIKernelBuilderExtensions
 {
     #region Text Completion
 
@@ -33,7 +33,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddAzureTextCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureTextCompletionService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         string apiKey,
@@ -67,7 +67,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddAzureTextCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureTextCompletionService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         TokenCredential credentials,
@@ -101,7 +101,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddOpenAITextCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithOpenAITextCompletionService(this KernelBuilder builder,
         string modelId,
         string apiKey,
         string? orgId = null,
@@ -138,7 +138,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddAzureTextEmbeddingGenerationService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureTextEmbeddingGenerationService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         string apiKey,
@@ -171,7 +171,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddAzureTextEmbeddingGenerationService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureTextEmbeddingGenerationService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         TokenCredential credential,
@@ -204,7 +204,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddOpenAITextEmbeddingGenerationService(this KernelBuilder builder,
+    public static KernelBuilder WithOpenAITextEmbeddingGenerationService(this KernelBuilder builder,
         string modelId,
         string apiKey,
         string? orgId = null,
@@ -242,7 +242,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddAzureChatCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureChatCompletionService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         string apiKey,
@@ -284,7 +284,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddAzureChatCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureChatCompletionService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         TokenCredential credentials,
@@ -326,7 +326,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddOpenAIChatCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithOpenAIChatCompletionService(this KernelBuilder builder,
         string modelId,
         string apiKey,
         string? orgId = null,
@@ -369,7 +369,7 @@ public static class OpenAKernelBuilderExtensions
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="logger">Application logger</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder AddOpenAIImageGenerationService(this KernelBuilder builder,
+    public static KernelBuilder WithOpenAIImageGenerationService(this KernelBuilder builder,
         string apiKey,
         string? orgId = null,
         string? serviceId = null,

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace SemanticKernel.Connectors.UnitTests.OpenAI;
 
 /// <summary>
-/// Unit tests of <see cref="OpenAKernelBuilderExtensions"/>.
+/// Unit tests of <see cref="OpenAIKernelBuilderExtensions"/>.
 /// </summary>
 public class AIServicesOpenAIExtensionsTests
 {
@@ -16,8 +16,8 @@ public class AIServicesOpenAIExtensionsTests
     public void ItSucceedsWhenAddingDifferentServiceTypeWithSameId()
     {
         KernelBuilder targetBuilder = Kernel.Builder;
-        targetBuilder.AddAzureTextCompletionService("depl", "https://url", "key", "azure");
-        targetBuilder.AddAzureTextEmbeddingGenerationService("depl2", "https://url", "key", "azure");
+        targetBuilder.WithAzureTextCompletionService("depl", "https://url", "key", "azure");
+        targetBuilder.WithAzureTextEmbeddingGenerationService("depl2", "https://url", "key", "azure");
 
         IKernel targetKernel = targetBuilder.Build();
         Assert.NotNull(targetKernel.GetService<ITextCompletion>("azure"));
@@ -28,10 +28,10 @@ public class AIServicesOpenAIExtensionsTests
     public void ItTellsIfAServiceIsAvailable()
     {
         KernelBuilder targetBuilder = Kernel.Builder;
-        targetBuilder.AddAzureTextCompletionService("depl", "https://url", "key", serviceId: "azure");
-        targetBuilder.AddOpenAITextCompletionService("model", "apikey", serviceId: "oai");
-        targetBuilder.AddAzureTextEmbeddingGenerationService("depl2", "https://url2", "key", serviceId: "azure");
-        targetBuilder.AddOpenAITextEmbeddingGenerationService("model2", "apikey2", serviceId: "oai2");
+        targetBuilder.WithAzureTextCompletionService("depl", "https://url", "key", serviceId: "azure");
+        targetBuilder.WithOpenAITextCompletionService("model", "apikey", serviceId: "oai");
+        targetBuilder.WithAzureTextEmbeddingGenerationService("depl2", "https://url2", "key", serviceId: "azure");
+        targetBuilder.WithOpenAITextEmbeddingGenerationService("model2", "apikey2", serviceId: "oai2");
 
         // Assert
         IKernel targetKernel = targetBuilder.Build();
@@ -48,13 +48,13 @@ public class AIServicesOpenAIExtensionsTests
         KernelBuilder targetBuilder = Kernel.Builder;
 
         // Act - Assert no exception occurs
-        targetBuilder.AddAzureTextCompletionService("dep", "https://localhost", "key", serviceId: "one");
-        targetBuilder.AddAzureTextCompletionService("dep", "https://localhost", "key", serviceId: "one");
-        targetBuilder.AddOpenAITextCompletionService("model", "key, serviceId: \"one\"");
-        targetBuilder.AddOpenAITextCompletionService("model", "key", serviceId: "one");
-        targetBuilder.AddAzureTextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
-        targetBuilder.AddAzureTextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
-        targetBuilder.AddOpenAITextEmbeddingGenerationService("model", "key", serviceId: "one");
-        targetBuilder.AddOpenAITextEmbeddingGenerationService("model", "key", serviceId: "one");
+        targetBuilder.WithAzureTextCompletionService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithAzureTextCompletionService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithOpenAITextCompletionService("model", "key, serviceId: \"one\"");
+        targetBuilder.WithOpenAITextCompletionService("model", "key", serviceId: "one");
+        targetBuilder.WithAzureTextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithAzureTextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithOpenAITextEmbeddingGenerationService("model", "key", serviceId: "one");
+        targetBuilder.WithOpenAITextEmbeddingGenerationService("model", "key", serviceId: "one");
     }
 }

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -44,7 +44,7 @@ public sealed class OpenAICompletionTests : IDisposable
 
         IKernel target = Kernel.Builder
             .WithLogger(this._logger)
-            .AddOpenAITextCompletionService(
+            .WithOpenAITextCompletionService(
                 serviceId: openAIConfiguration.ServiceId,
                 modelId: openAIConfiguration.ModelId,
                 apiKey: openAIConfiguration.ApiKey,
@@ -70,7 +70,7 @@ public sealed class OpenAICompletionTests : IDisposable
 
         IKernel target = Kernel.Builder
             .WithLogger(this._logger)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 serviceId: azureOpenAIConfiguration.ServiceId,
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
@@ -99,7 +99,7 @@ public sealed class OpenAICompletionTests : IDisposable
         Assert.NotNull(openAIConfiguration);
 
         IKernel target = Kernel.Builder
-            .AddOpenAITextCompletionService(
+            .WithOpenAITextCompletionService(
                 serviceId: openAIConfiguration.ServiceId,
                 modelId: openAIConfiguration.ModelId,
                 apiKey: "INVALID_KEY") // Use an invalid API key to force a 401 Unauthorized response
@@ -123,7 +123,7 @@ public sealed class OpenAICompletionTests : IDisposable
 
         // Use an invalid API key to force a 401 Unauthorized response
         IKernel target = Kernel.Builder
-            .AddOpenAITextCompletionService(
+            .WithOpenAITextCompletionService(
                 modelId: openAIConfiguration.ModelId,
                 apiKey: "INVALID_KEY",
                 serviceId: openAIConfiguration.ServiceId)
@@ -149,7 +149,7 @@ public sealed class OpenAICompletionTests : IDisposable
 
         IKernel target = Kernel.Builder
             .WithLogger(this._testOutputHelper)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: "INVALID_KEY",
@@ -176,7 +176,7 @@ public sealed class OpenAICompletionTests : IDisposable
         // Arrange
         IKernel target = Kernel.Builder
             .WithLogger(this._testOutputHelper)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey,

--- a/dotnet/src/IntegrationTests/Planning/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/PlanTests.cs
@@ -458,7 +458,7 @@ public sealed class PlanTests : IDisposable
 
         var builder = Kernel.Builder
             .WithLogger(this._logger)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey,
@@ -468,7 +468,7 @@ public sealed class PlanTests : IDisposable
         if (useEmbeddings)
         {
             builder
-                .AddAzureTextEmbeddingGenerationService(
+                .WithAzureTextEmbeddingGenerationService(
                     deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                     endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
                     apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey)

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -32,7 +32,7 @@ public class SequentialPlanParserTests
         Assert.NotNull(azureOpenAIConfiguration);
 
         IKernel kernel = Kernel.Builder
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey,

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -108,7 +108,7 @@ public sealed class SequentialPlannerTests : IDisposable
 
         var builder = Kernel.Builder
             .WithLogger(this._logger)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey,
@@ -116,7 +116,7 @@ public sealed class SequentialPlannerTests : IDisposable
 
         if (useEmbeddings)
         {
-            builder.AddAzureTextEmbeddingGenerationService(
+            builder.WithAzureTextEmbeddingGenerationService(
                 deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                 endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
                 apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatCompletionServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatCompletionServiceExtensions.cs
@@ -16,9 +16,9 @@ public static class ChatCompletionServiceExtensions
     /// <param name="serviceId">Optional identifier of the desired service.</param>
     /// <returns>The completion service id matching the given id or the default.</returns>
     /// <exception cref="KernelException">Thrown when no suitable service is found.</exception>
-    public static IChatCompletion GetChatCompletionServiceOrDefault(
+    public static IChatCompletion GetChatCompletionService(
         this IAIServiceProvider services,
-        string? serviceId = null) => services.GetNamedServiceOrDefault<IChatCompletion>(serviceId)
+        string? serviceId = null) => services.GetService<IChatCompletion>(serviceId)
             ?? throw new KernelException(KernelException.ErrorCodes.ServiceNotFound, "Chat completion service not found");
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/TextEmbeddingServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/TextEmbeddingServiceExtensions.cs
@@ -16,10 +16,10 @@ public static class TextEmbeddingServiceExtensions
     /// <param name="serviceId">Optional identifier of the desired service.</param>
     /// <returns>The embedding service matching the given id or the default service.</returns>
     /// <exception cref="KernelException">Thrown when no suitable service is found.</exception>
-    public static ITextEmbeddingGeneration GetTextEmbeddingServiceOrDefault(
+    public static ITextEmbeddingGeneration GetTextEmbeddingService(
         this IAIServiceProvider services,
         string? serviceId = null)
-            => services.GetNamedServiceOrDefault<ITextEmbeddingGeneration>(serviceId)
+            => services.GetService<ITextEmbeddingGeneration>(serviceId)
                 ?? throw new KernelException(KernelException.ErrorCodes.ServiceNotFound, "Text embedding service not available");
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ImageGeneration/ImageGenerationServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ImageGeneration/ImageGenerationServiceExtensions.cs
@@ -16,9 +16,9 @@ public static class ImageGenerationServiceExtensions
     /// <param name="serviceId">Optional identifier of the desired service.</param>
     /// <returns>The <see cref="IImageGeneration"/> id matching the given id or the default.</returns>
     /// <exception cref="KernelException">Thrown when no suitable service is found.</exception>
-    public static IImageGeneration GetImageGenerationServiceOrDefault(
+    public static IImageGeneration GetImageGenerationService(
         this IAIServiceProvider services,
-        string? serviceId = null) => services.GetNamedServiceOrDefault<IImageGeneration>(serviceId)
+        string? serviceId = null) => services.GetService<IImageGeneration>(serviceId)
             ?? throw new KernelException(KernelException.ErrorCodes.ServiceNotFound, "Image generation service not found");
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Services/ServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Services/ServiceExtensions.cs
@@ -6,27 +6,6 @@ namespace Microsoft.SemanticKernel.Services;
 internal static class AIServiceProviderExtensions
 {
     /// <summary>
-    /// Get the service matching the given id or the default if an id is not provided or not found.
-    /// </summary>
-    /// <typeparam name="T">The type of the service.</typeparam>
-    /// <param name="serviceProvider">The service provider.</param>
-    /// <param name="serviceId">Optional identifier of the desired service.</param>
-    /// <returns>The service matching the given id, the default service, or null.</returns>
-    public static T? GetNamedServiceOrDefault<T>(
-        this IAIServiceProvider serviceProvider,
-        string? serviceId = null) where T : IAIService
-    {
-        if ((serviceId != null)
-            && serviceProvider.TryGetService<T>(serviceId, out var namedService))
-        {
-            return namedService;
-        }
-
-        return serviceProvider.GetService<T>();
-    }
-
-
-    /// <summary>
     /// Tries to get the service of the specified type and name, and returns a value indicating whether the operation succeeded.
     /// </summary>
     /// <typeparam name="T">The type of the service.</typeparam>

--- a/dotnet/src/SemanticKernel/KernelBuilder.cs
+++ b/dotnet/src/SemanticKernel/KernelBuilder.cs
@@ -146,10 +146,7 @@ public sealed class KernelBuilder
     /// Adds a <typeparamref name="TService"/> instance to the services collection
     /// </summary>
     /// <param name="instance">The <typeparamref name="TService"/> instance.</param>
-    /// <param name="setAsDefault">Optional: set as the default AI service for type <typeparamref name="TService"/></param>
-    public KernelBuilder WithDefaultAIService<TService>(
-        TService instance,
-        bool setAsDefault = false) where TService : IAIService
+    public KernelBuilder WithDefaultAIService<TService>(TService instance) where TService : IAIService
     {
         this._aiServices.SetService<TService>(instance);
         return this;
@@ -174,10 +171,7 @@ public sealed class KernelBuilder
     /// Adds a <typeparamref name="TService"/> factory method to the services collection
     /// </summary>
     /// <param name="factory">The factory method that creates the AI service instances of type <typeparamref name="TService"/>.</param>
-    /// <param name="setAsDefault">Optional: set as the default AI service for type <typeparamref name="TService"/></param>
-    public KernelBuilder WithDefaultAIService<TService>(
-        Func<TService> factory,
-        bool setAsDefault = false) where TService : IAIService
+    public KernelBuilder WithDefaultAIService<TService>(Func<TService> factory) where TService : IAIService
     {
         this._aiServices.SetService<TService>(factory);
         return this;

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -94,7 +94,7 @@ internal static class SemanticKernelExtensions
         switch (config.AIService)
         {
             case AIServiceOptions.AIServiceType.AzureOpenAI:
-                kernelBuilder.AddAzureChatCompletionService(
+                kernelBuilder.WithAzureChatCompletionService(
                     serviceId: config.Label,
                     deploymentName: config.DeploymentOrModelId,
                     endpoint: config.Endpoint,
@@ -103,7 +103,7 @@ internal static class SemanticKernelExtensions
                 break;
 
             case AIServiceOptions.AIServiceType.OpenAI:
-                kernelBuilder.AddOpenAIChatCompletionService(
+                kernelBuilder.WithOpenAIChatCompletionService(
                    serviceId: config.Label,
                    modelId: config.DeploymentOrModelId,
                    apiKey: config.Key,
@@ -127,7 +127,7 @@ internal static class SemanticKernelExtensions
         switch (config.AIService)
         {
             case AIServiceOptions.AIServiceType.AzureOpenAI:
-                kernelBuilder.AddAzureTextEmbeddingGenerationService(
+                kernelBuilder.WithAzureTextEmbeddingGenerationService(
                     serviceId: config.Label,
                     deploymentName: config.DeploymentOrModelId,
                     endpoint: config.Endpoint,
@@ -135,7 +135,7 @@ internal static class SemanticKernelExtensions
                 break;
 
             case AIServiceOptions.AIServiceType.OpenAI:
-                kernelBuilder.AddOpenAITextEmbeddingGenerationService(
+                kernelBuilder.WithOpenAITextEmbeddingGenerationService(
                     serviceId: config.Label,
                     modelId: config.DeploymentOrModelId,
                     apiKey: config.Key);

--- a/samples/dotnet/KernelBuilder/Program.cs
+++ b/samples/dotnet/KernelBuilder/Program.cs
@@ -66,7 +66,7 @@ var kernel3 = new Kernel(skills, aiServiceProvider, templateEngine, memory, conf
 var kernel4 = Kernel.Builder
     .WithLogger(NullLogger.Instance)
     .WithMemory(memory)
-    .AddAzureTextCompletionService("deploymentName", "https://...", "apiKey")
+    .WithAzureTextCompletionService("deploymentName", "https://...", "apiKey")
     .Build();
 
 // Example: how to use a custom memory storage and custom embedding generator
@@ -79,15 +79,15 @@ var kernel5 = Kernel.Builder
 var kernel6 = Kernel.Builder
     .WithLogger(NullLogger.Instance)
     .WithMemoryStorage(memoryStorage) // Custom memory storage
-    .AddAzureTextCompletionService("myName1", "completionDeploymentName", "https://...", "apiKey") // This will be used when using AI completions
-    .AddAzureTextEmbeddingGenerationService("myName2", "embeddingsDeploymentName", "https://...", "apiKey") // This will be used when indexing memory records
+    .WithAzureTextCompletionService("myName1", "completionDeploymentName", "https://...", "apiKey") // This will be used when using AI completions
+    .WithAzureTextEmbeddingGenerationService("myName2", "embeddingsDeploymentName", "https://...", "apiKey") // This will be used when indexing memory records
     .Build();
 
 // ==========================================================================================================
 // The AI services are defined with the builder
 
 var kernel7 = Kernel.Builder
-    .AddAzureTextCompletionService("myName1", "completionDeploymentName", "https://...", "apiKey", true)
+    .WithAzureTextCompletionService("myName1", "completionDeploymentName", "https://...", "apiKey", true)
     .Build();
 
 // ==========================================================================================================

--- a/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
@@ -46,13 +46,13 @@ internal static class SemanticKernelFactory
         switch (config.CompletionConfig.AIService)
         {
             case AIService.OpenAI:
-                builder.AddOpenAITextCompletionService(
+                builder.WithOpenAITextCompletionService(
                     config.CompletionConfig.DeploymentOrModelId,
                     config.CompletionConfig.Key,
                     config.CompletionConfig.ServiceId);
                 break;
             case AIService.AzureOpenAI:
-                builder.AddAzureTextCompletionService(
+                builder.WithAzureTextCompletionService(
                     config.CompletionConfig.DeploymentOrModelId,
                     config.CompletionConfig.Endpoint,
                     config.CompletionConfig.Key,
@@ -67,13 +67,13 @@ internal static class SemanticKernelFactory
             switch (config.EmbeddingConfig.AIService)
             {
                 case AIService.OpenAI:
-                    builder.AddOpenAITextEmbeddingGenerationService(
+                    builder.WithOpenAITextEmbeddingGenerationService(
                         config.EmbeddingConfig.DeploymentOrModelId,
                         config.EmbeddingConfig.Key,
                         serviceId: config.EmbeddingConfig.ServiceId);
                     break;
                 case AIService.AzureOpenAI:
-                    builder.AddAzureTextEmbeddingGenerationService(
+                    builder.WithAzureTextEmbeddingGenerationService(
                         config.EmbeddingConfig.DeploymentOrModelId,
                         config.EmbeddingConfig.Endpoint,
                         config.EmbeddingConfig.Key,

--- a/samples/dotnet/graph-api-skills/Program.cs
+++ b/samples/dotnet/graph-api-skills/Program.cs
@@ -113,7 +113,7 @@ public sealed class Program
             AzureOpenAIConfiguration? azureOpenAIConfiguration = configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
             if (azureOpenAIConfiguration != null)
             {
-                builder.AddAzureTextCompletionService(
+                builder.WithAzureTextCompletionService(
                     deploymentName: azureOpenAIConfiguration.DeploymentName,
                     endpoint: azureOpenAIConfiguration.Endpoint,
                     apiKey: azureOpenAIConfiguration.ApiKey,
@@ -127,7 +127,7 @@ public sealed class Program
             OpenAIConfiguration? openAIConfiguration = configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
             if (openAIConfiguration != null)
             {
-                builder.AddOpenAITextCompletionService(
+                builder.WithOpenAITextCompletionService(
                     modelId: openAIConfiguration.ModelId,
                     apiKey: openAIConfiguration.ApiKey,
                     serviceId: openAIConfiguration.ServiceId,

--- a/samples/dotnet/kernel-syntax-examples/Example04_CombineLLMPromptsAndNativeCode.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example04_CombineLLMPromptsAndNativeCode.cs
@@ -16,8 +16,8 @@ public static class Example04_CombineLLMPromptsAndNativeCode
 
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-002", Env.Var("OPENAI_API_KEY"), serviceId: "text-davinci-002")
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-002", Env.Var("OPENAI_API_KEY"), serviceId: "text-davinci-002")
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         // Load native skill

--- a/samples/dotnet/kernel-syntax-examples/Example05_InlineFunctionDefinition.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example05_InlineFunctionDefinition.cs
@@ -20,7 +20,7 @@ public static class Example05_InlineFunctionDefinition
 
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         // Function defined using few-shot design pattern

--- a/samples/dotnet/kernel-syntax-examples/Example06_TemplateLanguage.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example06_TemplateLanguage.cs
@@ -20,7 +20,7 @@ public static class Example06_TemplateLanguage
 
         IKernel kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         // Load native skill into the kernel skill collection, sharing its functions with prompt templates

--- a/samples/dotnet/kernel-syntax-examples/Example07_BingAndGoogleSkills.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example07_BingAndGoogleSkills.cs
@@ -22,7 +22,7 @@ public static class Example07_BingAndGoogleSkills
     {
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         // Load Bing skill

--- a/samples/dotnet/kernel-syntax-examples/Example08_RetryHandler.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example08_RetryHandler.cs
@@ -47,7 +47,7 @@ public static class Example08_RetryHandler
         kernelBuilder = kernelBuilder.Configure(c => c.DefaultHttpRetryConfig.RetryableStatusCodes.Add(HttpStatusCode.Unauthorized));
 
         // OpenAI settings - you can set the OPENAI_API_KEY to an invalid value to see the retry policy in play
-        kernelBuilder = kernelBuilder.AddOpenAITextCompletionService("text-davinci-003", "BAD_KEY");
+        kernelBuilder = kernelBuilder.WithOpenAITextCompletionService("text-davinci-003", "BAD_KEY");
 
         var kernel = kernelBuilder.Build();
 
@@ -59,7 +59,7 @@ public static class Example08_RetryHandler
         var kernel = Kernel.Builder
             .WithLogger(InfoLogger.Log)
             // OpenAI settings - you can set the OPENAI_API_KEY to an invalid value to see the retry policy in play
-            .AddOpenAITextCompletionService("text-davinci-003", "BAD_KEY")
+            .WithOpenAITextCompletionService("text-davinci-003", "BAD_KEY")
             .Build();
 
         return kernel;
@@ -76,7 +76,7 @@ public static class Example08_RetryHandler
         var kernel = Kernel.Builder.WithLogger(InfoLogger.Log)
             .WithRetryHandlerFactory((Activator.CreateInstance(retryHandlerFactoryType) as IDelegatingHandlerFactory)!)
             // OpenAI settings - you can set the OPENAI_API_KEY to an invalid value to see the retry policy in play
-            .AddOpenAITextCompletionService("text-davinci-003", "BAD_KEY")
+            .WithOpenAITextCompletionService("text-davinci-003", "BAD_KEY")
             .Build();
 
         await ImportAndExecuteSkillAsync(kernel);

--- a/samples/dotnet/kernel-syntax-examples/Example09_FunctionTypes.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example09_FunctionTypes.cs
@@ -21,7 +21,7 @@ public static class Example09_FunctionTypes
 
         var kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         // Load native skill into the kernel skill collection, sharing its functions with prompt templates

--- a/samples/dotnet/kernel-syntax-examples/Example10_DescribeAllSkillsAndFunctions.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example10_DescribeAllSkillsAndFunctions.cs
@@ -21,7 +21,7 @@ public static class Example10_DescribeAllSkillsAndFunctions
         Console.WriteLine("======== Describe all skills and functions ========");
 
         var kernel = Kernel.Builder
-            .AddOpenAITextCompletionService("text-davinci-003", "none")
+            .WithOpenAITextCompletionService("text-davinci-003", "none")
             .Build();
 
         // Import a native skill

--- a/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
@@ -27,7 +27,7 @@ internal static class Example12_SequentialPlanner
         Console.WriteLine("======== Sequential Planner - Create and Execute Poetry Plan ========");
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 Env.Var("AZURE_OPENAI_SERVICE_ID"),
                 Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_ENDPOINT"),
@@ -138,11 +138,11 @@ internal static class Example12_SequentialPlanner
 
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                         Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                         Env.Var("AZURE_OPENAI_ENDPOINT"),
                         Env.Var("AZURE_OPENAI_KEY"))
-            .AddAzureTextEmbeddingGenerationService(
+            .WithAzureTextEmbeddingGenerationService(
                         Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
                         Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
                         Env.Var("AZURE_OPENAI_EMBEDDINGS_KEY"))
@@ -182,7 +182,7 @@ internal static class Example12_SequentialPlanner
     {
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_ENDPOINT"),
                 Env.Var("AZURE_OPENAI_KEY"))

--- a/samples/dotnet/kernel-syntax-examples/Example13_ConversationSummarySkill.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example13_ConversationSummarySkill.cs
@@ -180,7 +180,7 @@ Jane: Goodbye!
     {
         IKernel kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_ENDPOINT"),
                 Env.Var("AZURE_OPENAI_KEY"))

--- a/samples/dotnet/kernel-syntax-examples/Example14_SemanticMemory.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example14_SemanticMemory.cs
@@ -56,7 +56,7 @@ public static class Example14_SemanticMemory
 
         var kernelWithCustomDb = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextEmbeddingGenerationService("ada", "text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextEmbeddingGenerationService("ada", "text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
             .WithMemoryStorage(new VolatileMemoryStore())
             .Build();
 

--- a/samples/dotnet/kernel-syntax-examples/Example15_MemorySkill.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example15_MemorySkill.cs
@@ -16,8 +16,8 @@ public static class Example15_MemorySkill
     {
         var kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
-            .AddOpenAITextEmbeddingGenerationService("text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
             .WithMemoryStorage(new VolatileMemoryStore())
             .Build();
 

--- a/samples/dotnet/kernel-syntax-examples/Example17_ChatGPT.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example17_ChatGPT.cs
@@ -21,7 +21,7 @@ public static class Example17_ChatGPT
 
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAIChatCompletionService("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAIChatCompletionService("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         IChatCompletion chatGPT = kernel.GetService<IChatCompletion>();

--- a/samples/dotnet/kernel-syntax-examples/Example18_DallE.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example18_DallE.cs
@@ -22,9 +22,9 @@ public static class Example18_DallE
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
             // Add your image generation service
-            .AddOpenAIImageGenerationService("dallE", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAIImageGenerationService("dallE", Env.Var("OPENAI_API_KEY"))
             // Add your chat completion service 
-            .AddOpenAIChatCompletionService("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAIChatCompletionService("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"))
             .Build();
 
         IImageGeneration dallE = kernel.GetService<IImageGeneration>();

--- a/samples/dotnet/kernel-syntax-examples/Example19_Qdrant.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example19_Qdrant.cs
@@ -19,8 +19,8 @@ public static class Example19_Qdrant
         QdrantMemoryStore memoryStore = new QdrantMemoryStore(Env.Var("QDRANT_ENDPOINT"), qdrantPort, vectorSize: 1536, ConsoleLogger.Log);
         IKernel kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
-            .AddOpenAITextEmbeddingGenerationService("text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))
+            .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
             .WithMemoryStorage(memoryStore)
             .Build();
 

--- a/samples/dotnet/kernel-syntax-examples/Example26_AADAuth.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example26_AADAuth.cs
@@ -43,7 +43,7 @@ public static class Example26_AADAuth
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
             // Add Azure chat completion service using DefaultAzureCredential AAD auth
-            .AddAzureChatCompletionService(
+            .WithAzureChatCompletionService(
                 "gpt-35-turbo",
                 "https://....openai.azure.com/",
                 new DefaultAzureCredential(authOptions))

--- a/samples/dotnet/kernel-syntax-examples/Example27_SemanticFunctionsUsingChatGPT.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example27_SemanticFunctionsUsingChatGPT.cs
@@ -19,7 +19,7 @@ public static class Example27_SemanticFunctionsUsingChatGPT
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
             // Note: we use Chat Completion and GPT 3.5 Turbo
-            .AddAzureChatCompletionService("gpt-35-turbo", "https://....openai.azure.com/", "...API KEY...")
+            .WithAzureChatCompletionService("gpt-35-turbo", "https://....openai.azure.com/", "...API KEY...")
             .Build();
 
         var func = kernel.CreateSemanticFunction(

--- a/samples/dotnet/kernel-syntax-examples/Example28_ActionPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example28_ActionPlanner.cs
@@ -15,7 +15,7 @@ public static class Example28_ActionPlanner
         Console.WriteLine("======== Action Planner ========");
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-002", Env.Var("OPENAI_API_KEY"))// Note: Action Planner works with old models like text-davinci-002
+            .WithOpenAITextCompletionService("text-davinci-002", Env.Var("OPENAI_API_KEY"))// Note: Action Planner works with old models like text-davinci-002
             .Build();
 
         string folder = RepoFiles.SampleSkillsPath();

--- a/samples/dotnet/kernel-syntax-examples/Example30_ChatWithPrompts.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example30_ChatWithPrompts.cs
@@ -65,7 +65,7 @@ public static class Example30_ChatWithPrompts
         // Usual kernel initialization, with GPT 3.5 Turbo
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAIChatCompletionService("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"), serviceId: "chat")
+            .WithOpenAIChatCompletionService("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"), serviceId: "chat")
             .Build();
 
         // As an example, we import the time skill, which is used in system prompt to read the current date.

--- a/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
@@ -120,11 +120,11 @@ internal static class Example31_CustomPlanner
     {
         return new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_ENDPOINT"),
                 Env.Var("AZURE_OPENAI_KEY"))
-            .AddAzureTextEmbeddingGenerationService(
+            .WithAzureTextEmbeddingGenerationService(
                 Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
                 Env.Var("AZURE_OPENAI_EMBEDDINGS_KEY"))

--- a/samples/dotnet/kernel-syntax-examples/Example32_StreamingCompletion.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example32_StreamingCompletion.cs
@@ -24,7 +24,7 @@ public static class Example32_StreamingCompletion
 
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddAzureTextCompletionService(
+            .WithAzureTextCompletionService(
                 Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_ENDPOINT"),
                 Env.Var("AZURE_OPENAI_KEY"))
@@ -41,7 +41,7 @@ public static class Example32_StreamingCompletion
 
         IKernel kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .AddOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"), serviceId: "text-davinci-003")
+            .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"), serviceId: "text-davinci-003")
             .Build();
 
         ITextCompletion textCompletion = kernel.GetService<ITextCompletion>();


### PR DESCRIPTION
### Description
Series of improvements to align service registration extension methods with the other kernel builder ones and remove the "default" suffix from service provider Get*ServiceOrDefault method name to not expose unnecessary details with code that may use it.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
