### PR TITLE
Copilotchat: Don't call the planner if there are no functions available

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -197,11 +197,8 @@ public class ChatSkill
     [SKFunctionContextParameter(Name = "tokenLimit", Description = "Maximum number of tokens")]
     public async Task<string> AcquireExternalInformationAsync(SKContext context)
     {
-        FunctionsView plannerFunctionsView = this._planner.Kernel.Skills.GetFunctionsView(true, true);
-        if (!this._plannerOptions.Enabled ||
-            (plannerFunctionsView.NativeFunctions.IsEmpty && plannerFunctionsView.SemanticFunctions.IsEmpty))
+        if (!this._plannerOptions.Enabled)
         {
-            // Planner is disabled or there are no SK functions registered with the planner.
             return string.Empty;
         }
 

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -197,8 +197,11 @@ public class ChatSkill
     [SKFunctionContextParameter(Name = "tokenLimit", Description = "Maximum number of tokens")]
     public async Task<string> AcquireExternalInformationAsync(SKContext context)
     {
-        if (!this._plannerOptions.Enabled)
+        FunctionsView plannerFunctionsView = this._planner.Kernel.Skills.GetFunctionsView(true, true);
+        if (!this._plannerOptions.Enabled ||
+            (plannerFunctionsView.NativeFunctions.IsEmpty && plannerFunctionsView.SemanticFunctions.IsEmpty))
         {
+            // Planner is disabled or there are no SK functions registered with the planner.
             return string.Empty;
         }
 

--- a/samples/apps/copilot-chat-app/webapi/Skills/CopilotChatPlanner.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/CopilotChatPlanner.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Planning;
+using Microsoft.SemanticKernel.SkillDefinition;
 using SemanticKernel.Service.Config;
 
 namespace SemanticKernel.Service.Skills;
@@ -38,5 +39,14 @@ public class CopilotChatPlanner
     /// </summary>
     /// <param name="goal">The goal to create a plan for.</param>
     /// <returns>The plan.</returns>
-    public Task<Plan> CreatePlanAsync(string goal) => new ActionPlanner(this.Kernel).CreatePlanAsync(goal);
+    public Task<Plan> CreatePlanAsync(string goal)
+    {
+        FunctionsView plannerFunctionsView = this.Kernel.Skills.GetFunctionsView(true, true);
+        if (plannerFunctionsView.NativeFunctions.IsEmpty && plannerFunctionsView.SemanticFunctions.IsEmpty)
+        {
+            // No functions are available - return an empty plan.
+            return Task.FromResult(new Plan(goal));
+        }
+        return new ActionPlanner(this.Kernel).CreatePlanAsync(goal);
+    }
 }


### PR DESCRIPTION
### Motivation and Context
The planner should not get called if there are no functions available to it.

### Description
CopilotChatPlanner now checks if there are functions available before attempting to create a plan. If there are no functions available it returns an empty plan without interacting with the AI.