### PR TITLE
Allow to replace functions (fix regression)

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -3,7 +3,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <!-- Central version prefix - applies to all nuget packages -->
-    <Version>0.13</Version>
+    <Version>0.14</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SkillCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SkillCollectionTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.SkillDefinition;
+
+public class SkillCollectionTests
+{
+    [Fact]
+    public void ItAllowsToReplaceFunctions()
+    {
+        // Arrange
+        var functionOne = new Mock<ISKFunction>();
+        functionOne.SetupGet(x => x.Name).Returns("fName");
+        functionOne.SetupGet(x => x.SkillName).Returns("sName");
+        functionOne.SetupGet(x => x.Description).Returns("ONE");
+        functionOne.SetupGet(x => x.IsSemantic).Returns(false);
+        functionOne.SetupGet(x => x.RequestSettings).Returns(new CompleteRequestSettings());
+
+        var functionTwo = new Mock<ISKFunction>();
+        functionTwo.SetupGet(x => x.Name).Returns("fName");
+        functionTwo.SetupGet(x => x.SkillName).Returns("sName");
+        functionTwo.SetupGet(x => x.Description).Returns("TWO");
+        functionTwo.SetupGet(x => x.IsSemantic).Returns(false);
+        functionTwo.SetupGet(x => x.RequestSettings).Returns(new CompleteRequestSettings());
+
+        var target = new SkillCollection();
+
+        // Act
+        target.AddFunction(functionOne.Object);
+
+        // Assert
+        Assert.True(target.TryGetFunction("sName", "fName", out var func));
+        Assert.Equal("ONE", func.Description);
+
+        // Act
+        target.AddFunction(functionTwo.Object);
+
+        // Assert
+        Assert.True(target.TryGetFunction("sName", "fName", out func));
+        Assert.Equal("TWO", func.Description);
+    }
+}

--- a/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
@@ -38,7 +38,7 @@ public class SkillCollection : ISkillCollection
         Verify.NotNull(functionInstance, "The function is NULL");
 
         ConcurrentDictionary<string, ISKFunction> skill = this._skillCollection.GetOrAdd(functionInstance.SkillName, static _ => new(StringComparer.OrdinalIgnoreCase));
-        skill.TryAdd(functionInstance.Name, functionInstance);
+        skill[functionInstance.Name] = functionInstance;
 
         return this;
     }


### PR DESCRIPTION
### Motivation and Context

* Functions stored in a skill can be replaced, fix regression introduced in the last release
* Bump version to 0.14