### PR TITLE
Add support for custom delegates as SKFunctions

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
@@ -247,6 +247,36 @@ public sealed class SKFunctionTests2
     }
 
     [Fact]
+    public async Task ItSupportsAsyncType7Async()
+    {
+        // Arrange
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        async Task<SKContext> TestAsync(SKContext cx)
+        {
+            await Task.Delay(0);
+            s_canary = s_expected;
+            cx.Variables.Update("foo");
+            cx["canary"] = s_expected;
+            return cx;
+        }
+
+        var context = this.MockContext("");
+
+        // Act
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        this.VerifyFunctionTypeMatch(7);
+        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("foo", context.Result);
+    }
+
+    [Fact]
     public async Task ItSupportsType8Async()
     {
         // Arrange

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests3.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests3.cs
@@ -3,10 +3,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
+using Moq;
+using SemanticKernel.UnitTests.XunitHelpers;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.SkillDefinition;
@@ -62,6 +66,43 @@ public sealed class SKFunctionTests3
 
         // Assert
         Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task ItCanImportNativeFunctionsAsync()
+    {
+        // Arrange
+        var variables = new ContextVariables();
+        var skills = new SkillCollection();
+        var logger = TestConsoleLogger.Log;
+        var cancellationToken = default(CancellationToken);
+        var memory = new Mock<ISemanticTextMemory>();
+        var context = new SKContext(variables, memory.Object, skills.ReadOnlySkillCollection, logger, cancellationToken);
+
+        // Note: the function doesn't have any SK attributes
+        async Task<SKContext> ExecuteAsync(SKContext contextIn)
+        {
+            Assert.Equal("NO", contextIn["done"]);
+            contextIn["canary"] = "YES";
+
+            await Task.Delay(0);
+            return contextIn;
+        }
+
+        // Act
+        context["done"] = "NO";
+        ISKFunction function = SKFunction.FromNativeFunction(
+            nativeFunction: ExecuteAsync,
+            parameters: null,
+            description: "description",
+            skillName: "skillName",
+            functionName: "functionName");
+
+        SKContext result = await function.InvokeAsync(context, cancellationToken: cancellationToken);
+
+        // Assert
+        Assert.Equal("YES", context["canary"]);
+        Assert.Equal("YES", result["canary"]);
     }
 
     private sealed class InvalidSkill

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -25,8 +25,6 @@ namespace Microsoft.SemanticKernel.SkillDefinition;
 /// </summary>
 public sealed class SKFunction : ISKFunction, IDisposable
 {
-    public delegate Task<SKContext> CustomFunctionAsync(SKContext context);
-
     /// <inheritdoc/>
     public string Name { get; }
 
@@ -66,7 +64,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     {
         if (string.IsNullOrWhiteSpace(skillName)) { skillName = SkillCollection.GlobalSkill; }
 
-        MethodDetails methodDetails = GetMethodDetails(methodSignature, methodContainerInstance, log);
+        MethodDetails methodDetails = GetMethodDetails(methodSignature, methodContainerInstance, true, log);
 
         // If the given method is not a valid SK function
         if (!methodDetails.HasSkFunctionAttribute)
@@ -83,6 +81,39 @@ public sealed class SKFunction : ISKFunction, IDisposable
             description: methodDetails.Description,
             isSemantic: false,
             log: log);
+    }
+
+    /// <summary>
+    /// Create a native function instance, wrapping a delegate function
+    /// </summary>
+    /// <param name="nativeFunction">Function to invoke</param>
+    /// <param name="skillName">SK skill name</param>
+    /// <param name="functionName">SK function name</param>
+    /// <param name="description">SK function description</param>
+    /// <param name="parameters">SK function parameters</param>
+    /// <param name="log">Application logger</param>
+    /// <returns>SK function instance</returns>
+    public static ISKFunction FromNativeFunction(
+        Delegate nativeFunction,
+        string skillName,
+        string functionName,
+        string description,
+        IEnumerable<ParameterView>? parameters = null,
+        ILogger? log = null)
+    {
+        MethodDetails methodDetails = GetMethodDetails(nativeFunction.Method, null, false, log);
+
+        var function = new SKFunction(
+            delegateType: methodDetails.Type,
+            delegateFunction: methodDetails.Function,
+            parameters: (parameters ?? Enumerable.Empty<ParameterView>()).ToList(),
+            description: description,
+            skillName: skillName,
+            functionName: functionName,
+            isSemantic: false,
+            log: log);
+
+        return function;
     }
 
     /// <summary>
@@ -117,13 +148,15 @@ public sealed class SKFunction : ISKFunction, IDisposable
             }
             catch (AIException ex)
             {
-                const string Message = "Something went wrong while rendering the semantic function or while executing the text completion. Function: {0}.{1}. Error: {2}. Details: {3}";
+                const string Message = "Something went wrong while rendering the semantic function" +
+                                       " or while executing the text completion. Function: {0}.{1}. Error: {2}. Details: {3}";
                 log?.LogError(ex, Message, skillName, functionName, ex.Message, ex.Detail);
                 context.Fail(ex.Message, ex);
             }
             catch (Exception ex) when (!ex.IsCriticalException())
             {
-                const string Message = "Something went wrong while rendering the semantic function or while executing the text completion. Function: {0}.{1}. Error: {2}";
+                const string Message = "Something went wrong while rendering the semantic function" +
+                                       " or while executing the text completion. Function: {0}.{1}. Error: {2}";
                 log?.LogError(ex, Message, skillName, functionName, ex.Message);
                 context.Fail(ex.Message, ex);
             }
@@ -140,37 +173,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
             functionName: functionName,
             isSemantic: true,
             log: log);
-    }
-
-    /// <summary>
-    /// Create a native function instance, wrapping a native object method
-    /// </summary>
-    /// <param name="customFunction">Signature of the method to invoke</param>
-    /// <param name="skillName">SK skill name</param>
-    /// <param name="functionName">SK function name</param>
-    /// <param name="description">SK function description</param>
-    /// <param name="parameters">SK function parameters</param>
-    /// <param name="log">Application logger</param>
-    /// <returns>SK function instance</returns>
-    public static ISKFunction FromCustomMethod(
-        CustomFunctionAsync customFunction,
-        string skillName,
-        string functionName,
-        string description,
-        IEnumerable<ParameterView>? parameters = null,
-        ILogger? log = null)
-    {
-        var function = new SKFunction(
-            delegateType: SKFunction.DelegateTypes.ContextSwitchInSKContextOutTaskSKContext,
-            delegateFunction: customFunction,
-            parameters: (parameters ?? Enumerable.Empty<ParameterView>()).ToList(),
-            description: description,
-            skillName: skillName,
-            functionName: functionName,
-            isSemantic: false,
-            log: log);
-
-        return function;
     }
 
     /// <inheritdoc/>
@@ -526,7 +528,11 @@ public sealed class SKFunction : ISKFunction, IDisposable
         context.Skills ??= this._skillCollection;
     }
 
-    private static MethodDetails GetMethodDetails(MethodInfo methodSignature, object? methodContainerInstance, ILogger? log = null)
+    private static MethodDetails GetMethodDetails(
+        MethodInfo methodSignature,
+        object? methodContainerInstance,
+        bool skAttributesRequired = true,
+        ILogger? log = null)
     {
         Verify.NotNull(methodSignature);
 
@@ -546,11 +552,13 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         if (!result.HasSkFunctionAttribute || skFunctionAttribute == null)
         {
-            log?.LogTrace("Method '{0}' doesn't have '{1}' attribute.", result.Name, typeof(SKFunctionAttribute).Name);
-            return result;
+            log?.LogTrace("Method '{0}' doesn't have '{1}' attribute", result.Name, typeof(SKFunctionAttribute).Name);
+            if (skAttributesRequired) { return result; }
         }
-
-        result.HasSkFunctionAttribute = true;
+        else
+        {
+            result.HasSkFunctionAttribute = true;
+        }
 
         (result.Type, result.Function, bool hasStringParam) = GetDelegateInfo(methodContainerInstance, methodSignature);
 
@@ -600,9 +608,9 @@ public sealed class SKFunction : ISKFunction, IDisposable
         // Note: the name "input" is reserved for the main parameter
         Verify.ParametersUniqueness(result.Parameters);
 
-        result.Description = skFunctionAttribute.Description ?? "";
+        result.Description = skFunctionAttribute?.Description ?? "";
 
-        log?.LogTrace("Method '{0}' found.", result.Name);
+        log?.LogTrace("Method '{0}' found, type `{1}`", result.Name, result.Type.ToString("G"));
 
         return result;
     }

--- a/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -172,8 +172,8 @@ public static class KernelGrpcExtensions
             return context;
         }
 
-        var function = SKFunction.FromCustomMethod(
-            customFunction: ExecuteAsync,
+        var function = SKFunction.FromNativeFunction(
+            nativeFunction: ExecuteAsync,
             parameters: operationParameters.ToList(),
             description: operation.Name,
             skillName: skillName,

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -318,8 +318,8 @@ public static class KernelOpenApiExtensions
             })
             .ToList();
 
-        var function = SKFunction.FromCustomMethod(
-            customFunction: ExecuteAsync,
+        var function = SKFunction.FromNativeFunction(
+            nativeFunction: ExecuteAsync,
             parameters: parameters,
             description: operation.Description,
             skillName: skillName,

--- a/samples/apps/copilot-chat-app/webapi/Skills/CopilotChatPlanner.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/CopilotChatPlanner.cs
@@ -47,6 +47,7 @@ public class CopilotChatPlanner
             // No functions are available - return an empty plan.
             return Task.FromResult(new Plan(goal));
         }
+
         return new ActionPlanner(this.Kernel).CreatePlanAsync(goal);
     }
 }


### PR DESCRIPTION
### Motivation and Context

In some scenarios like RPC and OpenAPI it can be useful turning native code into SK Functions allowing to pass signature details (name, description, params) without the use of SK* attributes. For example, loading these details from OpenAPI docs or config files, rather than using reflection.


### Description

Add a new `FromNativeFunction` factory method to `SKFunction` to pass a custom delegate. The custom delegate must use one of the supported signatures, but doesn't need the "SK*[...]" attributes.

Example:

```
async Task<SKContext> MyFunctionAsync(SKContext contextIn)
{
    await Task.Delay(0);
    return contextIn;
}
```

```
ISKFunction function = SKFunction.FromNativeFunction(
            nativeFunction: MyFunctionAsync,
            skillName: "Test",
            functionName: "HelloWorld"
            description: "This is a test");
```