### PR TITLE
Fix variable name reporting in exception messages

### DIFF
--- a/dotnet/src/Skills/Skills.Web/Bing/BingConnector.cs
+++ b/dotnet/src/Skills/Skills.Web/Bing/BingConnector.cs
@@ -36,7 +36,7 @@ public sealed class BingConnector : IWebSearchEngineConnector, IDisposable
     {
         if (count <= 0) { throw new ArgumentOutOfRangeException(nameof(count)); }
 
-        if (count >= 50) { throw new ArgumentOutOfRangeException(nameof(count), "{nameof(count)} value must be less than 50."); }
+        if (count >= 50) { throw new ArgumentOutOfRangeException(nameof(count), $"{nameof(count)} value must be less than 50."); }
 
         if (offset < 0) { throw new ArgumentOutOfRangeException(nameof(offset)); }
 

--- a/dotnet/src/Skills/Skills.Web/Google/GoogleConnector.cs
+++ b/dotnet/src/Skills/Skills.Web/Google/GoogleConnector.cs
@@ -46,7 +46,7 @@ public sealed class GoogleConnector : IWebSearchEngineConnector, IDisposable
     {
         if (count <= 0) { throw new ArgumentOutOfRangeException(nameof(count)); }
 
-        if (count > 10) { throw new ArgumentOutOfRangeException(nameof(count), "{nameof(count)} value must be between 0 and 10, inclusive."); }
+        if (count > 10) { throw new ArgumentOutOfRangeException(nameof(count), $"{nameof(count)} value must be between 0 and 10, inclusive."); }
 
         if (offset < 0) { throw new ArgumentOutOfRangeException(nameof(offset)); }
 


### PR DESCRIPTION
### Motivation and Context
Add string interpolation prefix so that {nameof(count)} is interpreted rather than treated as a literal.