### PR TITLE
Fix issue with casting custom functions in plan.InvokeAsync

### DIFF
--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -25,8 +25,6 @@ namespace Microsoft.SemanticKernel.SkillDefinition;
 /// </summary>
 public sealed class SKFunction : ISKFunction, IDisposable
 {
-    public delegate Task<SKContext> CustomFunctionAsync(SKContext context);
-
     /// <inheritdoc/>
     public string Name { get; }
 
@@ -153,7 +151,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     /// <param name="log">Application logger</param>
     /// <returns>SK function instance</returns>
     public static ISKFunction FromCustomMethod(
-        CustomFunctionAsync customFunction,
+        Func<SKContext, Task<SKContext>> customFunction,
         string skillName,
         string functionName,
         string description,


### PR DESCRIPTION
### Motivation and Context
plan.InvokeAsync is failing with `Unable to cast object of type 'CustomFunctionAsync' to type 'System.Func`2[Microsoft.SemanticKernel.Orchestration.SKContext,System.Threading.Tasks.Task`1[Microsoft.SemanticKernel.Orchestration.SKContext]]'.`


### Description
Replaced CustomFunctionAsync delegate with Func base type.