### PR TITLE
Rename Timestamp to CreateOn in ChatSession

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Model/ChatSession.cs
+++ b/samples/apps/copilot-chat-app/webapi/Model/ChatSession.cs
@@ -29,16 +29,16 @@ public class ChatSession : IStorageEntity
     public string Title { get; set; }
 
     /// <summary>
-    /// Timestamp of the message.
+    /// Timestamp of the chat creation.
     /// </summary>
-    [JsonPropertyName("timestamp")]
-    public DateTimeOffset Timestamp { get; set; }
+    [JsonPropertyName("createdOn")]
+    public DateTimeOffset CreatedOn { get; set; }
 
     public ChatSession(string userId, string title)
     {
         this.Id = Guid.NewGuid().ToString();
         this.UserId = userId;
         this.Title = title;
-        this.Timestamp = DateTimeOffset.Now;
+        this.CreatedOn = DateTimeOffset.Now;
     }
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The name CreatedOn is much more descriptive than Timestamp in the context of a chat session.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Rename Timestamp to CreateOn in ChatSession.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
