### PR TITLE
CopilotChat: Minor refactor of token limits and reduce to 4096 for gpt-3.5-turbo.

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Config/PromptsConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/PromptsConfig.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using SemanticKernel.Service.Skills.OpenApiSkills.GitHubSkill.Model;
+
 namespace SemanticKernel.Service.Config;
 
 /// <summary>
@@ -7,6 +9,17 @@ namespace SemanticKernel.Service.Config;
 /// </summary>
 public class PromptsConfig
 {
+    /// <summary>
+    /// Token limit of the chat model.
+    /// </summary>
+    /// <remarks>https://platform.openai.com/docs/models/overview for token limits.</remarks>
+    public int CompletionTokenLimit { get; set; }
+
+    /// <summary>
+    /// The token count left for the model to generate text after the prompt.
+    /// </summary>
+    public int ResponseTokenLimit { get; set; }
+    
     // System
     public string KnowledgeCutoffDate { get; set; } = string.Empty;
     public string InitialBotMessage { get; set; } = string.Empty;
@@ -33,6 +46,16 @@ public class PromptsConfig
 
     public void Validate()
     {
+        if (this.CompletionTokenLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.CompletionTokenLimit), $"{nameof(this.CompletionTokenLimit)} is not valid: '{this.CompletionTokenLimit}' is not greater than 0.");
+        }
+
+        if (this.ResponseTokenLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.ResponseTokenLimit), $"{nameof(this.ResponseTokenLimit)} is not valid: '{this.ResponseTokenLimit}' is not greater than 0.");
+        }
+        
         Validate(this.KnowledgeCutoffDate, nameof(this.KnowledgeCutoffDate));
         Validate(this.InitialBotMessage, nameof(this.InitialBotMessage));
         Validate(this.SystemDescription, nameof(this.SystemDescription));

--- a/samples/apps/copilot-chat-app/webapi/Config/PromptsConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/PromptsConfig.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using SemanticKernel.Service.Skills.OpenApiSkills.GitHubSkill.Model;
-
 namespace SemanticKernel.Service.Config;
 
 /// <summary>
@@ -19,7 +17,7 @@ public class PromptsConfig
     /// The token count left for the model to generate text after the prompt.
     /// </summary>
     public int ResponseTokenLimit { get; set; }
-    
+
     // System
     public string KnowledgeCutoffDate { get; set; } = string.Empty;
     public string InitialBotMessage { get; set; } = string.Empty;
@@ -55,7 +53,7 @@ public class PromptsConfig
         {
             throw new ArgumentOutOfRangeException(nameof(this.ResponseTokenLimit), $"{nameof(this.ResponseTokenLimit)} is not valid: '{this.ResponseTokenLimit}' is not greater than 0.");
         }
-        
+
         Validate(this.KnowledgeCutoffDate, nameof(this.KnowledgeCutoffDate));
         Validate(this.InitialBotMessage, nameof(this.InitialBotMessage));
         Validate(this.SystemDescription, nameof(this.SystemDescription));

--- a/samples/apps/copilot-chat-app/webapi/Config/PromptsConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/PromptsConfig.cs
@@ -54,6 +54,11 @@ public class PromptsConfig
             throw new ArgumentOutOfRangeException(nameof(this.ResponseTokenLimit), $"{nameof(this.ResponseTokenLimit)} is not valid: '{this.ResponseTokenLimit}' is not greater than 0.");
         }
 
+        if (this.ResponseTokenLimit > this.CompletionTokenLimit)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.ResponseTokenLimit), $"{nameof(this.ResponseTokenLimit)} is not valid: '{this.ResponseTokenLimit}' is greater than '{this.CompletionTokenLimit}'.");
+        }
+
         Validate(this.KnowledgeCutoffDate, nameof(this.KnowledgeCutoffDate));
         Validate(this.InitialBotMessage, nameof(this.InitialBotMessage));
         Validate(this.SystemDescription, nameof(this.SystemDescription));

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -27,8 +27,9 @@ internal static class SemanticKernelExtensions
         services.AddSingleton<PromptsConfig>(sp =>
         {
             string promptsConfigPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "prompts.json");
-            PromptsConfig promptsConfig = JsonSerializer.Deserialize<PromptsConfig>(File.ReadAllText(promptsConfigPath)) ??
-                                          throw new InvalidOperationException($"Failed to load '{promptsConfigPath}'.");
+            PromptsConfig promptsConfig = JsonSerializer.Deserialize<PromptsConfig>(
+                File.ReadAllText(promptsConfigPath), new JsonSerializerOptions() { ReadCommentHandling = JsonCommentHandling.Skip })
+                ?? throw new InvalidOperationException($"Failed to load '{promptsConfigPath}'.");
             promptsConfig.Validate();
             return promptsConfig;
         });

--- a/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/PromptSettings.cs
@@ -19,8 +19,16 @@ public class PromptSettings
         this._promptsConfig = promptsConfig;
     }
 
-    internal int ResponseTokenLimit { get; } = 1024;
-    internal int CompletionTokenLimit { get; } = 8192;
+    /// <summary>
+    /// The token count left for the model to generate text after the prompt.
+    /// </summary>
+    internal int ResponseTokenLimit => this._promptsConfig.ResponseTokenLimit;
+
+    /// <summary>
+    /// Token limit of the chat model.
+    /// </summary>
+    /// <remarks>https://platform.openai.com/docs/models/overview for token limits.</remarks>
+    internal int CompletionTokenLimit => this._promptsConfig.CompletionTokenLimit;
 
     /// <summary>
     /// Weight of memories in the contextual part of the final prompt.

--- a/samples/apps/copilot-chat-app/webapi/prompts.json
+++ b/samples/apps/copilot-chat-app/webapi/prompts.json
@@ -1,4 +1,11 @@
 {
+  // Token limit of the chat model.
+  // see https://platform.openai.com/docs/models/overview for each model's token limits.
+  "CompletionTokenLimit": 4096,
+
+  // The token count left for the model to generate text after the prompt.
+  "ResponseTokenLimit": 1024,
+
   "SystemDescription": "This is a chat between an intelligent AI bot named Copilot and {{$audience}}. SK stands for Semantic Kernel, the AI platform used to build the bot. The AI was trained on data through 2021 and is not aware of events that have occurred since then. It also has no ability to access data on the Internet, so it should not claim that it can or say that it will go and look things up. Try to be concise with your answers, though it is not required. Knowledge cutoff: {{$knowledgeCutoff}} / Current date: {{TimeSkill.Now}}.",
   "SystemResponse": "Provide a response to the last message. Do not provide a list of possible responses or completions, just a single response. If it appears the last message was for another user, send [silence] as the bot response.",
   "InitialBotMessage": "Hello, nice to meet you! How can I help you today?",


### PR DESCRIPTION
### Motivation and Context
CopilotChat is blowing out token limits.

### Description
- Reduced default token limit to 4096 to match gpt-3.5-turbo
- Elevated token limits to prompts.json so they can be adjusted along with other configuration values, like models.
