### PR TITLE
CopilotChat: Slim down error messages in WebApp

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -120,7 +120,7 @@ public class ChatSkill
 
         if (result.ErrorOccurred)
         {
-            this._logger.LogWarning("{0}: {1}", result.LastErrorDescription, result.LastException);
+            context.Log.LogError("{0}: {1}", result.LastErrorDescription, result.LastException);
             context.Fail(result.LastErrorDescription);
             return string.Empty;
         }
@@ -224,7 +224,7 @@ public class ChatSkill
             this._logger.LogWarning("{0}: {1}", planContext.LastErrorDescription, planContext.LastException);
             return string.Empty;
         }
-        
+
         int tokenLimit = int.Parse(context["tokenLimit"], new NumberFormatInfo());
 
         // The result of the plan may be from an OpenAPI skill. Attempt to extract JSON from the response.
@@ -300,14 +300,14 @@ public class ChatSkill
     [SKFunctionContextParameter(Name = "chatId", Description = "Unique and persistent identifier for the chat")]
     public async Task<SKContext> ChatAsync(string message, SKContext context)
     {
-        // Log full error and strip the full exception from the context, leaving the error description.
+        // Log exception and strip it from the context, leaving the error description.
         SKContext RemoveExceptionFromContext(SKContext chatContext)
         {
             chatContext.Log.LogError("{0}: {1}", chatContext.LastErrorDescription, chatContext.LastException);
             chatContext.Fail(chatContext.LastErrorDescription);
             return chatContext;
         }
-        
+
         var tokenLimit = this._promptSettings.CompletionTokenLimit;
         var remainingToken =
             tokenLimit -
@@ -390,8 +390,6 @@ public class ChatSkill
         context.Variables.Update(chatContext.Result);
         context.Variables.Set("userId", "Bot");
         return context;
-
-        
     }
 
     #region Private

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -120,7 +120,8 @@ public class ChatSkill
 
         if (result.ErrorOccurred)
         {
-            context.Fail(result.LastErrorDescription, result.LastException);
+            this._logger.LogWarning("{0}: {1}", result.LastErrorDescription, result.LastException);
+            context.Fail(result.LastErrorDescription);
             return string.Empty;
         }
 
@@ -212,34 +213,40 @@ public class ChatSkill
 
         // Create a plan and run it.
         Plan plan = await this._planner.CreatePlanAsync(plannerContext.Variables.Input);
-        if (plan.Steps.Count > 0)
+        if (plan.Steps.Count <= 0)
         {
-            SKContext planContext = await plan.InvokeAsync(plannerContext);
-            int tokenLimit = int.Parse(context["tokenLimit"], new NumberFormatInfo());
-
-            // The result of the plan may be from an OpenAPI skill. Attempt to extract JSON from the response.
-            bool extractJsonFromOpenApi = this.TryExtractJsonFromOpenApiPlanResult(planContext.Variables.Input, out string planResult);
-            if (extractJsonFromOpenApi)
-            {
-                int relatedInformationTokenLimit = (int)Math.Floor(tokenLimit * this._promptSettings.RelatedInformationContextWeight);
-                planResult = this.OptimizeOpenApiSkillJson(planResult, relatedInformationTokenLimit, plan);
-            }
-            else
-            {
-                // If not, use result of the plan execution result directly.
-                planResult = planContext.Variables.Input;
-            }
-
-            string informationText = $"[START RELATED INFORMATION]\n{planResult.Trim()}\n[END RELATED INFORMATION]\n";
-
-            // Adjust the token limit using the number of tokens in the information text.
-            tokenLimit -= Utilities.TokenCount(informationText);
-            context.Variables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
-
-            return informationText;
+            return string.Empty;
         }
 
-        return string.Empty;
+        SKContext planContext = await plan.InvokeAsync(plannerContext);
+        if (planContext.ErrorOccurred)
+        {
+            this._logger.LogWarning("{0}: {1}", planContext.LastErrorDescription, planContext.LastException);
+            return string.Empty;
+        }
+        
+        int tokenLimit = int.Parse(context["tokenLimit"], new NumberFormatInfo());
+
+        // The result of the plan may be from an OpenAPI skill. Attempt to extract JSON from the response.
+        bool extractJsonFromOpenApi = this.TryExtractJsonFromOpenApiPlanResult(planContext.Variables.Input, out string planResult);
+        if (extractJsonFromOpenApi)
+        {
+            int relatedInformationTokenLimit = (int)Math.Floor(tokenLimit * this._promptSettings.RelatedInformationContextWeight);
+            planResult = this.OptimizeOpenApiSkillJson(planResult, relatedInformationTokenLimit, plan);
+        }
+        else
+        {
+            // If not, use result of the plan execution result directly.
+            planResult = planContext.Variables.Input;
+        }
+
+        string informationText = $"[START RELATED INFORMATION]\n{planResult.Trim()}\n[END RELATED INFORMATION]\n";
+
+        // Adjust the token limit using the number of tokens in the information text.
+        tokenLimit -= Utilities.TokenCount(informationText);
+        context.Variables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
+
+        return informationText;
     }
 
     /// <summary>
@@ -293,6 +300,14 @@ public class ChatSkill
     [SKFunctionContextParameter(Name = "chatId", Description = "Unique and persistent identifier for the chat")]
     public async Task<SKContext> ChatAsync(string message, SKContext context)
     {
+        // Log full error and strip the full exception from the context, leaving the error description.
+        SKContext RemoveExceptionFromContext(SKContext chatContext)
+        {
+            chatContext.Log.LogError("{0}: {1}", chatContext.LastErrorDescription, chatContext.LastException);
+            chatContext.Fail(chatContext.LastErrorDescription);
+            return chatContext;
+        }
+        
         var tokenLimit = this._promptSettings.CompletionTokenLimit;
         var remainingToken =
             tokenLimit -
@@ -332,7 +347,7 @@ public class ChatSkill
         var userIntent = await this.ExtractUserIntentAsync(chatContext);
         if (chatContext.ErrorOccurred)
         {
-            return chatContext;
+            return RemoveExceptionFromContext(chatContext);
         }
 
         chatContext.Variables.Set("userIntent", userIntent);
@@ -354,7 +369,7 @@ public class ChatSkill
         // If the completion function failed, return the context containing the error.
         if (chatContext.ErrorOccurred)
         {
-            return chatContext;
+            return RemoveExceptionFromContext(chatContext);
         }
 
         // Save this response to memory such that subsequent chat responses can use it
@@ -365,7 +380,7 @@ public class ChatSkill
         catch (Exception ex) when (!ex.IsCriticalException())
         {
             context.Log.LogError("Unable to save new response: {0}", ex.Message);
-            context.Fail($"Unable to save new response: {ex.Message}", ex);
+            context.Fail($"Unable to save new response: {ex.Message}");
             return context;
         }
 
@@ -375,6 +390,8 @@ public class ChatSkill
         context.Variables.Update(chatContext.Result);
         context.Variables.Set("userId", "Bot");
         return context;
+
+        
     }
 
     #region Private

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -36,8 +36,10 @@
   //
   "Completion": {
     "Label": "Completion",
-    "AIService": "AzureOpenAI",
-    "DeploymentOrModelId": "gpt-35-turbo",
+    //"AIService": "AzureOpenAI",
+    "AIService": "OpenAI",
+    //"DeploymentOrModelId": "gpt-35-turbo",
+    "DeploymentOrModelId": "gpt-4",
     "Endpoint": "" // ignored when AIService is "OpenAI"
     // "Key": ""
   },

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -36,10 +36,8 @@
   //
   "Completion": {
     "Label": "Completion",
-    //"AIService": "AzureOpenAI",
-    "AIService": "OpenAI",
-    //"DeploymentOrModelId": "gpt-35-turbo",
-    "DeploymentOrModelId": "gpt-4",
+    "AIService": "AzureOpenAI",
+    "DeploymentOrModelId": "gpt-35-turbo",
     "Endpoint": "" // ignored when AIService is "OpenAI"
     // "Key": ""
   },


### PR DESCRIPTION
### Motivation and Context
Don't display full error messages in the frontend.

### Description
- Strip the full exception from the context returned to the WebApp, keeping the error description.
