### PR TITLE
Fix linter not running

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,8 +55,8 @@ jobs:
       matrix:
         python-version: ["3.8"]
     runs-on: ubuntu-latest
-    needs: paths-filter
-    if: needs.paths-filter.outputs.output1 == 'true'
+    needs: check-for-python-changes
+    if: needs.check-for-python-changes.outputs.output1 == 'true'
     timeout-minutes: 5
     steps:
       - run: echo "/root/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Black wasn't running because it depended on paths-filter which was renamed in a previous commit.
