### PR TITLE
Python: Add web file download skill to align with C#

### DIFF
--- a/python/semantic_kernel/__init__.py
+++ b/python/semantic_kernel/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from semantic_kernel import core_skills, memory
+from semantic_kernel import core_skills, memory, skills
 from semantic_kernel.kernel import Kernel
 from semantic_kernel.orchestration.context_variables import ContextVariables
 from semantic_kernel.orchestration.sk_context import SKContext
@@ -33,4 +33,5 @@ __all__ = [
     "SKContext",
     "memory",
     "core_skills",
+    "skills",
 ]

--- a/python/semantic_kernel/skills/web/__init__.py
+++ b/python/semantic_kernel/skills/web/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.skills.web.web_file_download_skill import WebFileDownloadSkill
+
+__all__ = [
+    "WebFileDownloadSkill",
+]

--- a/python/semantic_kernel/skills/web/web_file_download_skill.py
+++ b/python/semantic_kernel/skills/web/web_file_download_skill.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import os
+import aiohttp
+import aiofiles
+
+from semantic_kernel.orchestration.sk_context import SKContext
+from semantic_kernel.skill_definition import sk_function, sk_function_context_parameter
+
+
+class WebFileDownloadSkill:
+
+    @sk_function(description="Downloads a file to local storage", name="downloadToFile")
+    @sk_function_context_parameter(name="filePath", description="Path where to save file locally")
+    async def download_to_file(self, url: str, context: SKContext):
+        _, file_path = context.variables.get("filePath")
+
+        if not file_path:
+            raise ValueError("File path cannot be `None` or empty")
+
+        async with aiohttp.ClientSession() as session, \
+                session.get(url, raise_for_status=True) as response:
+
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+            async with aiofiles.open(file_path, "wb") as f:
+                await f.write(await response.read())

--- a/python/tests/unit/skills/web/test_web_file_download_skill.py
+++ b/python/tests/unit/skills/web/test_web_file_download_skill.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from unittest.mock import patch
+
+import pytest
+import tempfile
+import aiofiles
+import os
+
+from semantic_kernel import Kernel
+from semantic_kernel.skills.web import WebFileDownloadSkill
+from semantic_kernel.orchestration.context_variables import ContextVariables
+from semantic_kernel.orchestration.sk_context import SKContext
+
+
+@pytest.mark.asyncio
+async def test_it_can_be_instantiated():
+    skill = WebFileDownloadSkill()
+    assert skill is not None
+
+
+@pytest.mark.asyncio
+async def test_it_can_be_imported():
+    kernel = Kernel()
+    skill = WebFileDownloadSkill()
+    assert kernel.import_skill(skill, "web")
+    assert kernel.skills.has_native_function(
+        "web", "downloadToFile")
+
+
+@patch("aiohttp.ClientSession.get")
+@pytest.mark.asyncio
+async def test_download_to_file(mock_get):
+    mock_get.return_value.__aenter__.return_value.read.return_value = b"Hello"
+    mock_get.return_value.__aenter__.return_value.status = 200
+    fp = None
+    try:
+        with tempfile.NamedTemporaryFile("rb", delete=False) as fp:
+            skill = WebFileDownloadSkill()
+            context_variables = ContextVariables()
+            context_variables.set("filePath", fp.name)
+            context = SKContext(context_variables, None, None, None) # type: ignore
+
+            await skill.download_to_file("https://example.org/post", context)
+
+            assert fp.read() == b"Hello"
+    finally:
+        if fp is not None:
+            os.remove(fp.name)
+
+
+@patch("aiohttp.ClientSession.get")
+@pytest.mark.asyncio
+async def test_invalid_path(mock_get):
+    mock_get.return_value.__aenter__.return_value.read.return_value = b"Hello"
+    mock_get.return_value.__aenter__.return_value.status = 200
+
+    skill = WebFileDownloadSkill()
+    context_variables = ContextVariables()
+    context_variables.set("filePath", "")
+    context = SKContext(context_variables, None, None, None) # type: ignore
+
+    with pytest.raises(ValueError):
+        await skill.download_to_file("https://example.org/post", context)


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Some skills are missing on Python and are needed to make a Python version of KernelHttpServer for sample apps.

#851 

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

This PR added web file download skill and related tests.

The implementation in this PR is based on the C# [version](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Skills/Skills.Web/WebFileDownloadSkill.cs).

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: