### PR TITLE
Fix error handling for OpenAI completion tests

### DIFF
--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -17,6 +17,8 @@ using Xunit.Abstractions;
 
 namespace SemanticKernel.IntegrationTests.Connectors.OpenAI;
 
+#pragma warning disable xUnit1004 // Contains test methods used in manual verification. Disable warning for this file only.
+
 public sealed class OpenAICompletionTests : IDisposable
 {
     private readonly IConfigurationRoot _configuration;
@@ -126,7 +128,8 @@ public sealed class OpenAICompletionTests : IDisposable
         // Assert
         Assert.True(context.ErrorOccurred);
         Assert.IsType<AIException>(context.LastException);
-        Assert.Contains("Incorrect API key provided", ((AIException)context.LastException).Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(AIException.ErrorCodes.AccessDenied, ((AIException)context.LastException).ErrorCode);
+        Assert.Contains("The request is not authorized, HTTP status: 401", ((AIException)context.LastException).Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -152,7 +155,8 @@ public sealed class OpenAICompletionTests : IDisposable
         // Assert
         Assert.True(context.ErrorOccurred);
         Assert.IsType<AIException>(context.LastException);
-        Assert.Contains("provide a valid key", ((AIException)context.LastException).Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(AIException.ErrorCodes.AccessDenied, ((AIException)context.LastException).ErrorCode);
+        Assert.Contains("The request is not authorized, HTTP status: 401", ((AIException)context.LastException).Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -178,7 +182,9 @@ public sealed class OpenAICompletionTests : IDisposable
         // Assert
         Assert.True(context.ErrorOccurred);
         Assert.IsType<AIException>(context.LastException);
-        Assert.Contains("maximum context length is", ((AIException)context.LastException).Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(AIException.ErrorCodes.InvalidRequest, ((AIException)context.LastException).ErrorCode);
+        Assert.Contains("The request is not valid, HTTP status: 400", ((AIException)context.LastException).Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("maximum context length is", ((AIException)context.LastException).Detail, StringComparison.OrdinalIgnoreCase); // This messasge could change in the future, comes from Azure OpenAI
     }
 
     [Theory(Skip = "This test is for manual verification.")]


### PR DESCRIPTION
This commit fixes the error handling for the OpenAI completion tests by using the correct error codes and messages from the AIException class. It also adds a pragma warning to disable xUnit1004 for the file, since some of the tests are used for manual verification.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] [I didn't break anyone :smile:](https://github.com/lemillermicrosoft/semantic-kernel/actions/runs/4948672971)
