### PR TITLE
Copilot chat: Document import chat-session scope

### DIFF
--- a/samples/apps/copilot-chat-app/importdocument/Program.cs
+++ b/samples/apps/copilot-chat-app/importdocument/Program.cs
@@ -92,7 +92,7 @@ public static class Program
     /// </summary>
     /// <param name="file">The file to upload for injection.</param>
     /// <param name="config">Configuration.</param>
-    /// <param name="chatCollectionId">Save the extracted context to an isolated user collection.</param>
+    /// <param name="chatCollectionId">Save the extracted context to an isolated chat collection.</param>
     private static async Task UploadFileAsync(FileInfo file, Config config, Guid chatCollectionId)
     {
         if (!file.Exists)

--- a/samples/apps/copilot-chat-app/importdocument/Program.cs
+++ b/samples/apps/copilot-chat-app/importdocument/Program.cs
@@ -31,24 +31,25 @@ public static class Program
             IsRequired = true
         };
 
-        var userCollectionOption = new Option<bool>(
-            name: "--user-collection",
-            description: "Save the extracted context to an isolated user collection.",
-            getDefaultValue: () => false
+        // TODO: UI to retrieve ChatID from the WebApp will be added in the future with multi-user support.
+        var chatCollectionOption = new Option<Guid>(
+            name: "--chat-id",
+            description: "Save the extracted context to an isolated chat collection.",
+            getDefaultValue: () => Guid.Empty
         );
 
         var rootCommand = new RootCommand(
             "This console app imports a file to the CopilotChat WebAPI's document memory store."
         )
         {
-            fileOption, userCollectionOption
+            fileOption, chatCollectionOption
         };
 
-        rootCommand.SetHandler(async (file, userCollection) =>
+        rootCommand.SetHandler(async (file, chatCollectionId) =>
             {
-                await UploadFileAsync(file, config!, userCollection);
+                await UploadFileAsync(file, config!, chatCollectionId);
             },
-            fileOption, userCollectionOption
+            fileOption, chatCollectionOption
         );
 
         rootCommand.Invoke(args);
@@ -91,8 +92,8 @@ public static class Program
     /// </summary>
     /// <param name="file">The file to upload for injection.</param>
     /// <param name="config">Configuration.</param>
-    /// <param name="toUserCollection">Save the extracted context to an isolated user collection.</param>
-    private static async Task UploadFileAsync(FileInfo file, Config config, bool toUserCollection)
+    /// <param name="chatCollectionId">Save the extracted context to an isolated user collection.</param>
+    private static async Task UploadFileAsync(FileInfo file, Config config, Guid chatCollectionId)
     {
         if (!file.Exists)
         {
@@ -105,17 +106,20 @@ public static class Program
         {
             { fileContent, "formFile", file.Name }
         };
-        if (toUserCollection)
+        if (chatCollectionId != Guid.Empty)
         {
-            Console.WriteLine("Uploading and parsing file to user collection...");
+            Console.WriteLine($"Uploading and parsing file to chat {chatCollectionId.ToString()}...");
             var userId = await AcquireUserIdAsync(config);
 
             if (userId != null)
             {
-                using var userScopeContent = new StringContent("User");
+                Console.WriteLine($"Successfully acquired User ID. Continuing...");
+                using var chatScopeContent = new StringContent("Chat");
                 using var userIdContent = new StringContent(userId);
-                formContent.Add(userScopeContent, "documentScope");
+                using var chatCollectionIdContent = new StringContent(chatCollectionId.ToString());
+                formContent.Add(chatScopeContent, "documentScope");
                 formContent.Add(userIdContent, "userId");
+                formContent.Add(chatCollectionIdContent, "chatId");
 
                 // Calling UploadAsync here to make sure disposable objects are still in scope.
                 await UploadAsync(formContent, config);

--- a/samples/apps/copilot-chat-app/importdocument/README.md
+++ b/samples/apps/copilot-chat-app/importdocument/README.md
@@ -31,15 +31,17 @@ Importing documents enables Copilot Chat to have up-to-date knowledge of specifi
 3. Change directory to this folder root.
 4. **Run** the following command to import a document to the app under the global document collection where
    all users will have access to:
+
    `dotnet run -- --file .\sample-docs\ms10k.txt`
    
-   Or **Run** the following command to import a document to the app under a user isolated document collection where
-   only the user who uploaded the document will have access to:
-   `dotnet run -- --file .\sample-docs\ms10k.txt --user-collection`
+   Or **Run** the following command to import a document to the app under a chat isolated document collection where
+   only the chat session will have access to:
 
-   > Note that this will open a browser window for you to sign in to retrieve your user id. 
+   `dotnet run -- --file .\sample-docs\ms10k.txt --chat-id [chatId]`
 
-   > Currently only supports txt files. A sample file is provided under ./sample-docs.
+   > Note that this will open a browser window for you to sign in to retrieve your user id to make sure you have access to the chat session.
+
+   > Currently only supports txt and pdf files. A sample file is provided under ./sample-docs.
 
    Importing may take some time to generate embeddings for each piece/chunk of a document.
 5. Chat with the bot.
@@ -47,7 +49,9 @@ Importing documents enables Copilot Chat to have up-to-date knowledge of specifi
    Examples:
 
    With [ms10k.txt](./sample-docs/ms10k.txt):
+
    ![](../images/Document-Memory-Sample-1.png)
 
    With [Microsoft Responsible AI Standard v2 General Requirements.pdf](./sample-docs/Microsoft-Responsible-AI-Standard-v2-General-Requirements.pdf):
+
    ![](../images/Document-Memory-Sample-2.png)

--- a/samples/apps/copilot-chat-app/webapi/Config/DocumentMemoryOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Config/DocumentMemoryOptions.cs
@@ -18,10 +18,10 @@ public class DocumentMemoryOptions
     public string GlobalDocumentCollectionName { get; set; } = "global-documents";
 
     /// <summary>
-    /// Gets or sets the prefix for the user document collection name.
+    /// Gets or sets the prefix for the chat document collection name.
     /// </summary>
     [Required, NotEmptyOrWhitespace]
-    public string UserDocumentCollectionNamePrefix { get; set; } = "user-documents-";
+    public string ChatDocumentCollectionNamePrefix { get; set; } = "chat-documents-";
 
     /// <summary>
     /// Gets or sets the maximum number of tokens to use when splitting a document into lines.

--- a/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Text;
 using SemanticKernel.Service.Config;
 using SemanticKernel.Service.Model;
-using SemanticKernel.Service.Skills;
+using SemanticKernel.Service.Storage;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
 
@@ -35,24 +35,21 @@ public class DocumentImportController : ControllerBase
         Pdf,
     };
 
-    private readonly IServiceProvider _serviceProvider; // TODO: unused
     private readonly ILogger<DocumentImportController> _logger;
-    private readonly PromptSettings _promptSettings; // TODO: unused
     private readonly DocumentMemoryOptions _options;
+    private readonly ChatSessionRepository _chatSessionRepository;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentImportController"/> class.
     /// </summary>
     public DocumentImportController(
-        IServiceProvider serviceProvider,
-        PromptSettings promptSettings,
         IOptions<DocumentMemoryOptions> documentMemoryOptions,
-        ILogger<DocumentImportController> logger)
+        ILogger<DocumentImportController> logger,
+        ChatSessionRepository chatSessionRepository)
     {
-        this._serviceProvider = serviceProvider;
         this._options = documentMemoryOptions.Value;
-        this._promptSettings = promptSettings;
         this._logger = logger;
+        this._chatSessionRepository = chatSessionRepository;
     }
 
     /// <summary>
@@ -81,6 +78,12 @@ public class DocumentImportController : ControllerBase
         if (formFile.Length > this._options.FileSizeLimit)
         {
             return this.BadRequest("File size exceeds the limit.");
+        }
+
+        if (documentImportForm.DocumentScope == DocumentImportForm.DocumentScopes.Chat &&
+                !(await this.UserHasAccessToChatAsync(documentImportForm.UserId, documentImportForm.ChatId)))
+        {
+            return this.BadRequest("User does not have access to the chat session.");
         }
 
         this._logger.LogInformation("Importing document {0}", formFile.FileName);
@@ -170,9 +173,7 @@ public class DocumentImportController : ControllerBase
         var documentName = Path.GetFileName(documentImportForm.FormFile?.FileName);
         var targetCollectionName = documentImportForm.DocumentScope == DocumentImportForm.DocumentScopes.Global
             ? this._options.GlobalDocumentCollectionName
-            : string.IsNullOrEmpty(documentImportForm.ChatId)
-                ? this._options.GlobalDocumentCollectionName
-                : this._options.ChatDocumentCollectionNamePrefix + documentImportForm.ChatId;
+            : this._options.ChatDocumentCollectionNamePrefix + documentImportForm.ChatId;
 
         // Split the document into lines of text and then combine them into paragraphs.
         // Note that this is only one of many strategies to chunk documents. Feel free to experiment with other strategies.
@@ -193,5 +194,17 @@ public class DocumentImportController : ControllerBase
             paragraphs.Count,
             Path.GetFileName(documentImportForm.FormFile?.FileName)
         );
+    }
+
+    /// <summary>
+    /// Check if the user has access to the chat session.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="chatId">The chat session ID.</param>
+    /// <returns>A boolean indicating whether the user has access to the chat session.</returns>
+    private async Task<bool> UserHasAccessToChatAsync(string userId, Guid chatId)
+    {
+        var chatSessions = await this._chatSessionRepository.FindByUserIdAsync(userId);
+        return chatSessions.Any(c => c.Id == chatId.ToString());
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/DocumentImportController.cs
@@ -170,9 +170,9 @@ public class DocumentImportController : ControllerBase
         var documentName = Path.GetFileName(documentImportForm.FormFile?.FileName);
         var targetCollectionName = documentImportForm.DocumentScope == DocumentImportForm.DocumentScopes.Global
             ? this._options.GlobalDocumentCollectionName
-            : string.IsNullOrEmpty(documentImportForm.UserId)
+            : string.IsNullOrEmpty(documentImportForm.ChatId)
                 ? this._options.GlobalDocumentCollectionName
-                : this._options.UserDocumentCollectionNamePrefix + documentImportForm.UserId;
+                : this._options.ChatDocumentCollectionNamePrefix + documentImportForm.ChatId;
 
         // Split the document into lines of text and then combine them into paragraphs.
         // Note that this is only one of many strategies to chunk documents. Feel free to experiment with other strategies.

--- a/samples/apps/copilot-chat-app/webapi/Model/DocumentImportForm.cs
+++ b/samples/apps/copilot-chat-app/webapi/Model/DocumentImportForm.cs
@@ -13,7 +13,7 @@ public class DocumentImportForm
     public enum DocumentScopes
     {
         Global,
-        User,
+        Chat,
     }
 
     /// <summary>
@@ -27,9 +27,10 @@ public class DocumentImportForm
     public DocumentScopes DocumentScope { get; set; } = DocumentScopes.Global;
 
     /// <summary>
-    /// The ID of the user who owns the document. This is used to create a unique collection name for the user.
-    /// If the user ID is not specified or empty, the documents will be stored in a global collection.
+    /// The ID of the chat who owns the document.
+    /// This is used to create a unique collection name for the chat.
+    /// If the chat ID is not specified or empty, the documents will be stored in a global collection.
     /// If the document scope is set to global, this value is ignored.
     /// </summary>
-    public string UserId { get; set; } = string.Empty;
+    public string ChatId { get; set; } = string.Empty;
 }

--- a/samples/apps/copilot-chat-app/webapi/Model/DocumentImportForm.cs
+++ b/samples/apps/copilot-chat-app/webapi/Model/DocumentImportForm.cs
@@ -24,13 +24,19 @@ public class DocumentImportForm
     /// <summary>
     /// Scope of the document. This determines the collection name in the document memory.
     /// </summary>
-    public DocumentScopes DocumentScope { get; set; } = DocumentScopes.Global;
+    public DocumentScopes DocumentScope { get; set; } = DocumentScopes.Chat;
 
     /// <summary>
-    /// The ID of the chat who owns the document.
+    /// The ID of the chat that owns the document.
     /// This is used to create a unique collection name for the chat.
     /// If the chat ID is not specified or empty, the documents will be stored in a global collection.
     /// If the document scope is set to global, this value is ignored.
     /// </summary>
-    public string ChatId { get; set; } = string.Empty;
+    public Guid ChatId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// The ID of the user who is importing the document to a chat session.
+    /// Will be use to validate if the user has access to the chat session.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
 }

--- a/samples/apps/copilot-chat-app/webapi/Skills/DocumentMemorySkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/DocumentMemorySkill.cs
@@ -40,12 +40,12 @@ public class DocumentMemorySkill
     [SKFunction("Query documents in the memory given a user message")]
     [SKFunctionName("QueryDocuments")]
     [SKFunctionInput(Description = "Query to match.")]
-    [SKFunctionContextParameter(Name = "userId", Description = "ID of the user who owns the documents")]
+    [SKFunctionContextParameter(Name = "chatId", Description = "ID of the chat that owns the documents")]
     [SKFunctionContextParameter(Name = "tokenLimit", Description = "Maximum number of tokens")]
     [SKFunctionContextParameter(Name = "contextTokenLimit", Description = "Maximum number of context tokens")]
     public async Task<string> QueryDocumentsAsync(string query, SKContext context)
     {
-        string userId = context.Variables["userId"];
+        string chatId = context.Variables["chatId"];
         int tokenLimit = int.Parse(context.Variables["tokenLimit"], new NumberFormatInfo());
         int contextTokenLimit = int.Parse(context.Variables["contextTokenLimit"], new NumberFormatInfo());
         var remainingToken = Math.Min(
@@ -56,7 +56,7 @@ public class DocumentMemorySkill
         // Search for relevant document snippets.
         string[] documentCollections = new string[]
         {
-            this._documentImportConfig.UserDocumentCollectionNamePrefix + userId,
+            this._documentImportConfig.ChatDocumentCollectionNamePrefix + chatId,
             this._documentImportConfig.GlobalDocumentCollectionName
         };
 

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -139,7 +139,7 @@
   //
   "DocumentMemory": {
     "GlobalDocumentCollectionName": "global-documents",
-    "UserDocumentCollectionNamePrefix": "user-documents-",
+    "ChatDocumentCollectionNamePrefix": "chat-documents-",
     "DocumentLineSplitMaxTokens": 30,
     "DocumentParagraphSplitMaxLines": 100,
     "FileSizeLimit": 1000000

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
@@ -10,7 +10,8 @@ import { Constants } from '../../Constants';
 import { AuthHelper } from '../../libs/auth/AuthHelper';
 import { AlertType } from '../../libs/models/AlertType';
 import { useDocumentImportService } from '../../libs/semantic-kernel/useDocumentImport';
-import { useAppDispatch } from '../../redux/app/hooks';
+import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
+import { RootState } from '../../redux/app/store';
 import { addAlert } from '../../redux/features/app/appSlice';
 import { useSKSpeechService } from './../../libs/semantic-kernel/useSKSpeech';
 import { TypingIndicatorRenderer } from './typing-indicator/TypingIndicatorRenderer';
@@ -73,6 +74,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
     const [documentImporting, SetDocumentImporting] = React.useState(false);
     const documentImportService = useDocumentImportService(process.env.REACT_APP_BACKEND_URI as string);
     const documentFileRef = useRef<HTMLInputElement | null>(null);
+    const { selectedId } = useAppSelector((state: RootState) => state.conversations);
 
     React.useEffect(() => {
         if (recognizer) return;
@@ -109,6 +111,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
             try {
                 SetDocumentImporting(true);
                 await documentImportService.importDocumentAsync(
+                    selectedId,
                     documentFile,
                     await AuthHelper.getSKaaSAccessToken(instance)
                 );

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { useMsal } from '@azure/msal-react';
+import { useAccount, useMsal } from '@azure/msal-react';
 import { Button, Spinner, Textarea, makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { AttachRegular, MicRegular, SendRegular } from '@fluentui/react-icons';
 import debug from 'debug';
@@ -64,7 +64,8 @@ interface ChatInputProps {
 export const ChatInput: React.FC<ChatInputProps> = (props) => {
     const { isTyping, onSubmit } = props;
     const classes = useClasses();
-    const { instance } = useMsal();
+    const { instance, accounts } = useMsal();
+    const account = useAccount(accounts[0] || {});
     const dispatch = useAppDispatch();
     const [value, setValue] = React.useState('');
     const [previousValue, setPreviousValue] = React.useState('');
@@ -111,6 +112,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
             try {
                 SetDocumentImporting(true);
                 await documentImportService.importDocumentAsync(
+                    account!.homeAccountId!,
                     selectedId,
                     documentFile,
                     await AuthHelper.getSKaaSAccessToken(instance)

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
@@ -119,6 +119,10 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
             }
             SetDocumentImporting(false);
         }
+
+        // Reset the file input so that the onChange event will
+        // be triggered even if the same file is selected again.
+        documentFileRef.current!.value = '';
     };
 
     const handleSubmit = (data: string) => {

--- a/samples/apps/copilot-chat-app/webapp/src/libs/semantic-kernel/DocumentImport.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/semantic-kernel/DocumentImport.ts
@@ -1,15 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+
 export class DocumentImportService {
     constructor(private readonly serviceUrl: string) { }
 
     importDocumentAsync = async (
+        userId: string,
         chatId: string,
         document: File,
         accessToken: string,
     ) => {
         const formData = new FormData();
+        formData.append('userId', userId);
         formData.append('chatId', chatId);
+        formData.append('documentScope', 'Chat');
         formData.append('formFile', document);
         
         const commandPath = `importDocument`;

--- a/samples/apps/copilot-chat-app/webapp/src/libs/semantic-kernel/DocumentImport.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/semantic-kernel/DocumentImport.ts
@@ -4,10 +4,12 @@ export class DocumentImportService {
     constructor(private readonly serviceUrl: string) { }
 
     importDocumentAsync = async (
+        chatId: string,
         document: File,
         accessToken: string,
     ) => {
         const formData = new FormData();
+        formData.append('chatId', chatId);
         formData.append('formFile', document);
         
         const commandPath = `importDocument`;


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
1. There is a bug where the UI doesn't respond to the same document uploaded twice.
2. User-scoped document memories are not particularly useful for our scenarios. Replace it with chat-scoped document memories.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Fix a bug where the UI doesn't respond to the same document uploaded twice.
3. Replace the user scope with chat-session scope for document import.
4. Update the bot import/export to work with chat-scoped document memories.
5. Update the importdocument console app to work with chat-scpped document memories.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
