### PR TITLE
Fix bug in Copilot Chat setup scripts

### DIFF
--- a/samples/apps/copilot-chat-app/scripts/Start-Frontend.sh
+++ b/samples/apps/copilot-chat-app/scripts/Start-Frontend.sh
@@ -6,7 +6,7 @@ set -e
 
 ScriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ScriptDir/../WebApp"
-EnvFilePath="$ScriptDir/../WebApp/.env"
+EnvFilePath='.env'
 
 # Parameters
 ClientId="$1"

--- a/samples/apps/copilot-chat-app/scripts/Start.ps1
+++ b/samples/apps/copilot-chat-app/scripts/Start.ps1
@@ -31,13 +31,11 @@ $FrontendScript = Join-Path '.' 'Start-Frontend.ps1'
 # Start backend (in new PS process)
 if ($AzureOpenAIOrOpenAIKey -eq '')
 {
-    Write-Host '0'
     # no key
     Start-Process pwsh -ArgumentList "-noexit", "-command $BackendScript"
 }
 else
 {
-    Write-Host '1'
     # with key
     Start-Process pwsh -ArgumentList "-noexit", "-command $BackendScript -AzureOpenAIOrOpenAIKey $AzureOpenAIOrOpenAIKey"
 }

--- a/samples/apps/copilot-chat-app/scripts/Start.ps1
+++ b/samples/apps/copilot-chat-app/scripts/Start.ps1
@@ -24,17 +24,23 @@ param (
     [string] $AzureOpenAIOrOpenAIKey
 )
 
+Set-Location "$PSScriptRoot"
+$BackendScript = Join-Path '.' 'Start-Backend.ps1'
+$FrontendScript = Join-Path '.' 'Start-Frontend.ps1'
+
 # Start backend (in new PS process)
 if ($AzureOpenAIOrOpenAIKey -eq '')
 {
+    Write-Host '0'
     # no key
-    Start-Process pwsh -ArgumentList "-noexit", "-command $PSScriptRoot/Start-Backend.ps1"
+    Start-Process pwsh -ArgumentList "-noexit", "-command $BackendScript"
 }
 else
 {
+    Write-Host '1'
     # with key
-    Start-Process pwsh -ArgumentList "-noexit", "-command $PSScriptRoot/Start-Backend.ps1 -AzureOpenAIOrOpenAIKey $AzureOpenAIOrOpenAIKey"
+    Start-Process pwsh -ArgumentList "-noexit", "-command $BackendScript -AzureOpenAIOrOpenAIKey $AzureOpenAIOrOpenAIKey"
 }
 
 # Start frontend (in current PS process)
-& "$PSScriptRoot/Start-Frontend.ps1" -ClientId $ClientId -Tenant $Tenant
+& $FrontendScript -ClientId $ClientId -Tenant $Tenant

--- a/samples/apps/copilot-chat-app/scripts/Start.sh
+++ b/samples/apps/copilot-chat-app/scripts/Start.sh
@@ -9,10 +9,11 @@ ClientId="$1"
 Tenant="${2:-common}"
 AzureOpenAIOrOpenAIKey="${3:-}"
 
-ScriptDir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ScriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ScriptDir"
 
 # Start backend (in background)
-$ScriptDir/Start-Backend.sh $AzureOpenAIOrOpenAIKey &
+./Start-Backend.sh $AzureOpenAIOrOpenAIKey &
 
 # Start frontend
-$ScriptDir/Start-Frontend.sh $ClientId $Tenant
+./Start-Frontend.sh $ClientId $Tenant


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Copilot Chat "Start" scripts are failing if the path has a space in it.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Fix the path issue by changing directory at the beginning of the script. (Already doing this in the Start-Frontend and Start-Backend child scripts, but it was apparently overlooked in the parent script.) Also fix path to .env file in Start-Frontend.sh.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
