### PR TITLE
Fixing web skill package reference

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.OpenApi" Version="[1.6.3, )" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="[1.6.3, )" />
     <PackageVersion Include="Newtonsoft.Json" Version="[13.0.3, )" />
+    <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="[1.60.0.3001, )" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.52.0" />
     <PackageVersion Include="protobuf-net" Version="3.2.16" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.12" />

--- a/dotnet/src/Skills/Skills.Web/Skills.Web.csproj
+++ b/dotnet/src/Skills/Skills.Web/Skills.Web.csproj
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="[6.0.0, )" />
-    <PackageReference Include="System.Text.Json" VersionOverride="[6.0.0, )" />
-    <PackageReference Include="Google.Apis.CustomSearchAPI.v1" VersionOverride="[1.60.0.3001, )" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Google.Apis.CustomSearchAPI.v1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Setting the PackageVersion in Directory.Packages.props to fix warning called out in https://github.com/microsoft/semantic-kernel/issues/913

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
