### PR TITLE
Fix typo in poem generated by chatbot

### DIFF
--- a/python/tests/integration/completions/e2e_text_completion.py
+++ b/python/tests/integration/completions/e2e_text_completion.py
@@ -347,7 +347,7 @@ async def summarize_conversation_using_skill(kernel: sk.Kernel):
         Jane: What about you?
         John: That's cool. Let me see if mine will write a poem, too.
         John: Here's a poem my chatbot wrote:
-        John: The signularity of the universe is a mystery.
+        John: The singularity of the universe is a mystery.
         Jane: You might want to try using a different model.
         John: I'm using the GPT-2 model. That makes sense.
         John: Here is a new poem after updating the model.


### PR DESCRIPTION
This commit fixes a typo in the e2e_text_completion.py test file, where the word "signularity" was misspelled as "singularity". This could cause confusion or errors in the test output. The typo was corrected to "singularity" to match the intended meaning of the poem. No other changes were made to the test file or the functionality of the chatbot.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
