### PR TITLE
Add Newtonsoft.Json package reference to Connectors.Memory.CosmosDB

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/Connectors.Memory.CosmosDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/Connectors.Memory.CosmosDB.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-  
+
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <!--<Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />-->
 
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="[13.0.3, )" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit adds a package reference to Newtonsoft.Json version 13.0.3 or higher to the Connectors.Memory.CosmosDB project. This is needed to support serialization and deserialization of Cosmos DB documents using the Newtonsoft.Json library. This also removes some trailing whitespace from the project file.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
