### PR TITLE
Bump python release number - 0.2.8.dev

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-kernel"
-version = "0.2.7.dev"
+version = "0.2.8.dev"
 description = ""
 authors = ["Microsoft <SK-Support@microsoft.com>"]
 readme = "pip/README.md"

--- a/python/tests/integration/completions/e2e_text_completion.py
+++ b/python/tests/integration/completions/e2e_text_completion.py
@@ -12,7 +12,9 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
 
-async def retry(func, retries=15, delay=1):
+async def retry(func, retries=20):
+    min_delay = 2
+    max_delay = 7
     for i in range(retries):
         try:
             result = str(await func())
@@ -23,7 +25,7 @@ async def retry(func, retries=15, delay=1):
             logger.error(f"Retry {i + 1}: {e}")
             if i == retries - 1:  # Last retry
                 raise
-            time.sleep(delay)
+            time.sleep(max(min(i, max_delay), min_delay))
 
 
 async def summarize_function_test(kernel: sk.Kernel):


### PR DESCRIPTION
* New version number for next SK Python release
* Change integration tests retry logic to progressively back off from 2 to 7 secs