### PR TITLE
Adding UnitTest tags for dotnet 6,7,8 version support

### DIFF
--- a/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
@@ -4,6 +4,8 @@
     <AssemblyName>SemanticKernel.Connectors.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.UnitTests</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/dotnet/src/Extensions/Extensions.UnitTests/Extensions.UnitTests.csproj
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Extensions.UnitTests.csproj
@@ -4,6 +4,8 @@
     <AssemblyName>SemanticKernel.Extensions.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Extensions.UnitTests</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -4,6 +4,8 @@
     <AssemblyName>IntegrationTests</AssemblyName>
     <RootNamespace>SemanticKernel.IntegrationTests</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,VSTHRD111</NoWarn>
     <UserSecretsId>b7762d10-e29b-4bb1-8b74-b6d69a667dd4</UserSecretsId>

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -4,6 +4,8 @@
     <RootNamespace>SemanticKernel.UnitTests</RootNamespace>
     <AssemblyName>SemanticKernel.UnitTests</AssemblyName>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,VSTHRD111</NoWarn>
   </PropertyGroup>

--- a/dotnet/src/SemanticKernel/Orchestration/ContextVariablesConverter.cs
+++ b/dotnet/src/SemanticKernel/Orchestration/ContextVariablesConverter.cs
@@ -26,6 +26,13 @@ public class ContextVariablesConverter : JsonConverter<ContextVariables>
 
         foreach (var kvp in keyValuePairs!)
         {
+            if (string.IsNullOrWhiteSpace(kvp.Key))
+            {
+                // Json deserialization behaves differently in different versions of .NET. In some cases, the above "Deserialize" call
+                // throws on a null key, and in others it does not. This check is to ensure that we throw in all cases.
+                throw new JsonException("'Key' property cannot be null or empty.");
+            }
+
             context.Set(kvp.Key, kvp.Value);
         }
 

--- a/dotnet/src/Skills/Skills.UnitTests/Skills.UnitTests.csproj
+++ b/dotnet/src/Skills/Skills.UnitTests/Skills.UnitTests.csproj
@@ -4,6 +4,8 @@
     <AssemblyName>SemanticKernel.Skills.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Skills.UnitTests</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
### Motivation and Context
Unit tests are currently targeting net6.0 and the UTs will only run on machines with net6.0 SDK installed. That is, if a machine has only net7.0 or net8.0, installed, the UT projects will build, but the tests will not run.

### Description
With this change, the UT projects self-identify as test projects with the tag:
`<IsTestProject>true</IsTestProject>`

...and we add the RollForward tag which ensures the UTs build for the highest installed version of the SDK:
`<RollForward>LatestMajor</RollForward>`

This ensures that the tests are runnable on any installation net6.0 or greater, including the new docker-based CI builds, each of which targets only a single SDK version.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
