### PR TITLE
Add CLSCompliant=false to csproj files

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -29,4 +29,11 @@
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Add CLSCompliant=false to all projects by default. Projects can override. -->
+    <AssemblyAttribute Include="System.CLSCompliantAttribute">
+      <_Parameter1>false</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### Motivation and Context
Build environments with only dotnet6.0 SDK installed are raising dozens of warnings:
"Mark assemblies as CLSCompliant"

### Description
This change marks all dotnet projects as CLSCompliant=false by default (at present, they are noncompliant anyway). If, in the future, we aim to make certain projects CLSCompliant, this can be overridden on a project-by-project basis.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
