### PR TITLE
Add new dotnet analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -119,6 +119,8 @@ dotnet_diagnostic.CA1063.severity = warning # Implement IDisposable correctly
 dotnet_diagnostic.CA1064.severity = warning # Exceptions should be public
 dotnet_diagnostic.CA1416.severity = warning # Validate platform compatibility
 dotnet_diagnostic.CA1508.severity = warning # Avoid dead conditional code
+dotnet_diagnostic.CA1859.severity = warning # Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1860.severity = warning # Prefer comparing 'Count' to 0 rather than using 'Any()', both for clarity and for performance
 dotnet_diagnostic.CA2000.severity = warning # Call System.IDisposable.Dispose on object before all references to it are out of scope
 dotnet_diagnostic.CA2201.severity = warning # Exception type System.Exception is not sufficiently specific
 

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -57,6 +57,12 @@
     </PackageReference>
     -->
 
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview1.23165.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/Skills/ChatSkill.cs
@@ -698,7 +698,7 @@ public class ChatSkill
             .ToListAsync(context.CancellationToken)
             .ConfigureAwait(false);
 
-        if (!memories.Any())
+        if (memories.Count == 0)
         {
             await context.Memory.SaveInformationAsync(
                 collection: memoryCollectionName,


### PR DESCRIPTION
### Motivation and Context
Different versions of dotnet surface different warnings, making it difficult to standardize across environments.

### Description
This change brings in the latest netanalysers package (compatible with net6,7,8) and enables some warnings we'd like to start seeing at development time, regardless of environment.

Also fixes one "Count" warning raised by these rules.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
