### PR TITLE
Fix warning in Score.cs

### DIFF
--- a/dotnet/src/SemanticKernel/Memory/Collections/Score.cs
+++ b/dotnet/src/SemanticKernel/Memory/Collections/Score.cs
@@ -46,7 +46,7 @@ public readonly struct Score : IComparable<Score>, IEquatable<Score>
 
     public bool Equals(Score other)
     {
-        return (other != null) && (this.Value == other.Value);
+        return this.Value == other.Value;
     }
 
     public override int GetHashCode()


### PR DESCRIPTION
### Description
Fixing the warning:

/app/dotnet/src/SemanticKernel/Memory/Collections/Score.cs(49,17): warning CS8073: The result of the expression is always 'true' since a value of type 'Score' is never equal to 'null' of type 'Score?' 

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
