### PR TITLE
Adding -pre tag to build version to address build warning

### DIFF
--- a/.github/workflows/update-version.sh
+++ b/.github/workflows/update-version.sh
@@ -59,7 +59,7 @@ if [ -z "$buildAndRevisionNumber" ]; then
 fi
 
 propsVersionString=$(cat $propsFile | grep -i "<Version>");
-regex="<Version>([0-9.]*)<\/Version>"
+regex="<Version>([0-9.]*)-pre<\/Version>"
 if [[ $propsVersionString =~ $regex ]]; then
   propsVersion=${BASH_REMATCH[1]}
 else

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -2,8 +2,10 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
-    <!-- Central version prefix - applies to all nuget packages -->
-    <Version>0.14</Version>
+    <!-- Central version prefix - applies to all nuget packages.
+         Only the numeric portion is used; '-pre' is ignored, but required 
+         for packges with prerelease dependencies -->
+    <Version>0.14-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -4,7 +4,7 @@
     <IsPackable>true</IsPackable>
     <!-- Central version prefix - applies to all nuget packages.
          Only the numeric portion is used; '-pre' is ignored, but required 
-         for packges with prerelease dependencies -->
+         for packages with prerelease dependencies -->
     <Version>0.14-pre</Version>
   </PropertyGroup>
 


### PR DESCRIPTION
### Motivation and Context
New SDKs raise warnings about our SDK including prerelease dependencies in a stable package.

_warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Azure.Search.Documents [11.5.0-beta.2, )" or update the version field in the nuspec._

### Description
Marking as "-pre" so that the builds know that we are a prerelease package too. This will not affect the names of the builds we ship, as those are overridden when packaging.

### Contribution Checklist
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
