### PR TITLE
Copilot Chat: Fix bot profile pictures end up the same after refresh

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/ConversationsState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/ConversationsState.ts
@@ -10,13 +10,11 @@ export type Conversations = {
 export interface ConversationsState {
     conversations: Conversations;
     selectedId: string;
-    botProfilePictureIndex: number;
 }
 
 export const initialState: ConversationsState = {
     conversations: {},
     selectedId: '',
-    botProfilePictureIndex: 0,
 };
 
 export type UpdateConversationPayload = {

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -9,9 +9,6 @@ export const conversationsSlice = createSlice({
     name: 'conversations',
     initialState,
     reducers: {
-        incrementBotProfilePictureIndex: (state: ConversationsState) => {
-            state.botProfilePictureIndex = ++state.botProfilePictureIndex % 5;
-        },
         setConversations: (state: ConversationsState, action: PayloadAction<Conversations>) => {
             state.conversations = action.payload;
         },
@@ -50,7 +47,6 @@ export const conversationsSlice = createSlice({
 });
 
 export const {
-    incrementBotProfilePictureIndex,
     setConversations,
     editConversationTitle,
     setSelectedConversation,


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The copilot chat webapp has a bug where all bot profile pictures will become identical after a refresh.
![image](https://github.com/microsoft/semantic-kernel/assets/12570346/fece3f56-e4eb-4b36-82b0-6c6a49db6e3d)


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Fix the bug.
2. Remove the botProfilePictureIndex from ConversationState. It's now managed by each chat itself.

The bot profile pictures will still get shuffled around after a refresh because the pictures are not saved in the backend. Will need another PR to get that saved in the backend.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
