### PR TITLE
Fix code style and xmldocs, add Roslynator analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -90,14 +90,57 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 # Code quality rules
 dotnet_code_quality_unused_parameters = all:suggestion
 
+[*.cs]
+
+# TODO: enable this but stop "dotnet format" from applying incorrect fixes and introducing a lot of unwanted changes.
+dotnet_analyzer_diagnostic.severity = none
+
+# Note: these settings cause "dotnet format" to fix the code. You should review each change if you uses "dotnet format".
+dotnet_diagnostic.RCS1036.severity = warning # Remove unnecessary blank line.
+dotnet_diagnostic.RCS1037.severity = warning # Remove trailing white-space.
+dotnet_diagnostic.RCS1097.severity = warning # Remove redundant 'ToString' call.
+dotnet_diagnostic.RCS1138.severity = warning # Add summary to documentation comment.
+dotnet_diagnostic.RCS1139.severity = warning # Add summary element to documentation comment.
+dotnet_diagnostic.RCS1168.severity = warning # Parameter name 'foo' differs from base name 'bar'.
+dotnet_diagnostic.RCS1175.severity = warning # Unused 'this' parameter 'operation'.
+dotnet_diagnostic.RCS1192.severity = warning # Unnecessary usage of verbatim string literal.
+dotnet_diagnostic.RCS1194.severity = warning # Implement exception constructors.
+dotnet_diagnostic.RCS1211.severity = warning # Remove unnecessary else clause.
+dotnet_diagnostic.RCS1214.severity = warning # Unnecessary interpolated string.
+dotnet_diagnostic.RCS1225.severity = warning # Make class sealed.
+dotnet_diagnostic.RCS1232.severity = warning # Order elements in documentation comment.
+
+# Commented out because `dotnet format` change can be disruptive.
+# dotnet_diagnostic.RCS1085.severity = warning # Use auto-implemented property.
+
+# Commented out because `dotnet format` removes the xmldoc element, while we should add the missing documentation instead.
+# dotnet_diagnostic.RCS1228.severity = warning # Unused element in documentation comment.
+
+# Diagnostics elevated as warnings
+dotnet_diagnostic.CA1000.severity = warning # Do not declare static members on generic types
+dotnet_diagnostic.CA1031.severity = warning # Do not catch general exception types
+dotnet_diagnostic.CA1050.severity = warning # Declare types in namespaces
+dotnet_diagnostic.CA1063.severity = warning # Implement IDisposable correctly
+dotnet_diagnostic.CA1064.severity = warning # Exceptions should be public
+dotnet_diagnostic.CA1416.severity = warning # Validate platform compatibility
+dotnet_diagnostic.CA1508.severity = warning # Avoid dead conditional code
+dotnet_diagnostic.CA1852.severity = warning # Sealed classes
+dotnet_diagnostic.CA1859.severity = warning # Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1860.severity = warning # Prefer comparing 'Count' to 0 rather than using 'Any()', both for clarity and for performance
+dotnet_diagnostic.CA2000.severity = warning # Call System.IDisposable.Dispose on object before all references to it are out of scope
+dotnet_diagnostic.CA2201.severity = warning # Exception type System.Exception is not sufficiently specific
+
+dotnet_diagnostic.IDE0005.severity = warning # Remove unnecessary usings
+dotnet_diagnostic.IDE0130.severity = warning # Namespace does not match folder structure
+
 # Suppressed diagnostics
 dotnet_diagnostic.CA1002.severity = none # Change 'List<string>' in '...' to use 'Collection<T>' ...
+dotnet_diagnostic.CA1032.severity = none # We're using RCS1194 which seems to cover more ctors
 dotnet_diagnostic.CA1034.severity = none # Do not nest type. Alternatively, change its accessibility so that it is not externally visible
 dotnet_diagnostic.CA1062.severity = none # Disable null check, C# already does it for us
 dotnet_diagnostic.CA1303.severity = none # Do not pass literals as localized parameters
@@ -109,21 +152,59 @@ dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
 dotnet_diagnostic.CA2225.severity = none # Operator overloads have named alternates
 dotnet_diagnostic.CA2227.severity = none # Change to be read-only by removing the property setter
 dotnet_diagnostic.CA2253.severity = none # Named placeholders in the logging message template should not be comprised of only numeric characters
+
 dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+dotnet_diagnostic.xUnit1004.severity = none # Test methods should not be skipped. Remove the Skip property to start running the test again.
 
-# Diagnostics elevated as warnings
-dotnet_diagnostic.CA1000.severity = warning # Do not declare static members on generic types
-dotnet_diagnostic.CA1031.severity = warning # Do not catch general exception types
-dotnet_diagnostic.CA1032.severity = warning # Add the following constructor to ...Exception: public ...
-dotnet_diagnostic.CA1063.severity = warning # Implement IDisposable correctly
-dotnet_diagnostic.CA1064.severity = warning # Exceptions should be public
-dotnet_diagnostic.CA1416.severity = warning # Validate platform compatibility
-dotnet_diagnostic.CA1508.severity = warning # Avoid dead conditional code
-dotnet_diagnostic.CA1859.severity = warning # Use concrete types when possible for improved performance
-dotnet_diagnostic.CA1860.severity = warning # Prefer comparing 'Count' to 0 rather than using 'Any()', both for clarity and for performance
-dotnet_diagnostic.CA2000.severity = warning # Call System.IDisposable.Dispose on object before all references to it are out of scope
-dotnet_diagnostic.CA2201.severity = warning # Exception type System.Exception is not sufficiently specific
+dotnet_diagnostic.RCS1021.severity = none # Use expression-bodied lambda.
+dotnet_diagnostic.RCS1032.severity = none # Remove redundant parentheses.
+dotnet_diagnostic.RCS1061.severity = none # Merge 'if' with nested 'if'.
+dotnet_diagnostic.RCS1069.severity = none # Remove unnecessary case label.
+dotnet_diagnostic.RCS1074.severity = none # Remove redundant constructor.
+dotnet_diagnostic.RCS1077.severity = none # Optimize LINQ method call.
+dotnet_diagnostic.RCS1118.severity = none # Mark local variable as const.
+dotnet_diagnostic.RCS1124.severity = none # Inline local variable.
+dotnet_diagnostic.RCS1129.severity = none # Remove redundant field initialization.
+dotnet_diagnostic.RCS1140.severity = none # Add exception to documentation comment.
+dotnet_diagnostic.RCS1141.severity = none # Add 'param' element to documentation comment.
+dotnet_diagnostic.RCS1142.severity = none # Add 'typeparam' element to documentation comment.
+dotnet_diagnostic.RCS1146.severity = none # Use conditional access.
+dotnet_diagnostic.RCS1151.severity = none # Remove redundant cast.
+dotnet_diagnostic.RCS1158.severity = none # Static member in generic type should use a type parameter.
+dotnet_diagnostic.RCS1161.severity = none # Enum should declare explicit value
+dotnet_diagnostic.RCS1163.severity = none # Unused parameter 'foo'.
+dotnet_diagnostic.RCS1170.severity = none # Use read-only auto-implemented property.
+dotnet_diagnostic.RCS1173.severity = none # Use coalesce expression instead of 'if'.
+dotnet_diagnostic.RCS1181.severity = none # Convert comment to documentation comment.
+dotnet_diagnostic.RCS1186.severity = none # Use Regex instance instead of static method.
+dotnet_diagnostic.RCS1188.severity = none # Remove redundant auto-property initialization.
+dotnet_diagnostic.RCS1189.severity = none # Add region name to #endregion.
+dotnet_diagnostic.RCS1197.severity = none # Optimize StringBuilder.AppendLine call.
+dotnet_diagnostic.RCS1201.severity = none # Use method chaining.
+dotnet_diagnostic.RCS1205.severity = none # Order named arguments according to the order of parameters.
+dotnet_diagnostic.RCS1212.severity = none # Remove redundant assignment.
+dotnet_diagnostic.RCS1217.severity = none # Convert interpolated string to concatenation.
+dotnet_diagnostic.RCS1222.severity = none # Merge preprocessor directives.
+dotnet_diagnostic.RCS1226.severity = none # Add paragraph to documentation comment.
+dotnet_diagnostic.RCS1229.severity = none # Use async/await when necessary.
+dotnet_diagnostic.RCS1234.severity = none # Enum duplicate value
+dotnet_diagnostic.RCS1238.severity = none # Avoid nested ?: operators.
+dotnet_diagnostic.RCS1241.severity = none # Implement IComparable when implementing IComparable<T><T>.
 
+dotnet_diagnostic.IDE0001.severity = none # Simplify name
+dotnet_diagnostic.IDE0002.severity = none # Simplify member access
+dotnet_diagnostic.IDE0004.severity = none # Remove unnecessary cast
+dotnet_diagnostic.IDE0035.severity = none # Remove unreachable code
+dotnet_diagnostic.IDE0051.severity = none # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = none # Remove unread private member
+dotnet_diagnostic.IDE0058.severity = none # Remove unused expression value
+dotnet_diagnostic.IDE0059.severity = none # Unnecessary assignment of a value
+dotnet_diagnostic.IDE0060.severity = none # Remove unused parameter
+dotnet_diagnostic.IDE0080.severity = none # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0100.severity = none # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = none # Remove unnecessary discards
+dotnet_diagnostic.IDE0032.severity = none # Use auto property
+dotnet_diagnostic.IDE0160.severity = none # Use block-scoped namespace
 
 ###############################
 # Naming Conventions          #
@@ -266,30 +347,6 @@ csharp_style_expression_bodied_local_functions = false:silent
 ##################
 # C# Style       #
 ##################
-
-# Disable unneccesary style rules by default
-[*.cs]
-dotnet_diagnostic.IDE0001.severity = none # Simplify name
-dotnet_diagnostic.IDE0002.severity = none # Simplify member access
-dotnet_diagnostic.IDE0004.severity = none # Remove unnecessary cast
-# dotnet_diagnostic.IDE0005.severity = none # Remove unnecessary usings
-dotnet_diagnostic.IDE0035.severity = none # Remove unreachable code
-dotnet_diagnostic.IDE0051.severity = none # Remove unused private member
-dotnet_diagnostic.IDE0052.severity = none # Remove unread private member
-dotnet_diagnostic.IDE0058.severity = none # Remove unused expression value
-dotnet_diagnostic.IDE0059.severity = none # Unnecessary assignment of a value
-dotnet_diagnostic.IDE0060.severity = none # Remove unused parameter
-dotnet_diagnostic.IDE0080.severity = none # Remove unnecessary suppression operator
-dotnet_diagnostic.IDE0100.severity = none # Remove unnecessary equality operator
-dotnet_diagnostic.IDE0110.severity = none # Remove unnecessary discards
-
-# Disable select expression-level style rules
-[*.cs]
-dotnet_diagnostic.IDE0032.severity = none # Use auto property
-
-# Disable select language style rules
-[*.cs]
-dotnet_diagnostic.IDE0160.severity = none # Use block-scoped namespace
 
 ###############################
 # VB Coding Conventions       #

--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -14,7 +14,8 @@
 
   <Target Name="AddInternalsVisibleTo" BeforeTargets="BeforeCompile">
     <!-- Handle Add InternalsVisibleTo to any targets that don't support it. -->
-    <ItemGroup Condition="'@(InternalsVisibleTo->Count())' &gt; 0 AND $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '5.0.0'))">
+    <ItemGroup
+      Condition="'@(InternalsVisibleTo->Count())' &gt; 0 AND $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '5.0.0'))">
       <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
         <_Parameter1 Condition="'%(InternalsVisibleTo.PublicKey)' != ''">%(InternalsVisibleTo.Identity), PublicKey="%(InternalsVisibleTo.PublicKey)</_Parameter1>
         <_Parameter1 Condition="'%(InternalsVisibleTo.PublicKey)' == ''">%(InternalsVisibleTo.Identity)</_Parameter1>

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -86,5 +86,23 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.3.0" />
+    <PackageReference Include="Roslynator.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.3.0" />
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.3.0" />
+    <PackageReference Include="Roslynator.Formatting.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/dotnet/SK-dotnet.sln.DotSettings
+++ b/dotnet/SK-dotnet.sln.DotSettings
@@ -83,7 +83,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_BLOCK_ON_SAME_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">160</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">512</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Copyright (c) Microsoft. All rights reserved.</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ACS/@EntryIndexedValue">ACS</s:String>

--- a/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextCompletion/HuggingFaceTextCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextCompletion/HuggingFaceTextCompletion.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text.Json;

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/OpenAIClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/OpenAIClientBase.cs
@@ -29,8 +29,7 @@ public abstract class OpenAIClientBase : ClientBase
         string apiKey,
         string? organization = null,
         HttpClient? httpClient = null,
-        ILogger? logger = null
-    )
+        ILogger? logger = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(apiKey);

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/TextCompletion/AzureTextCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/TextCompletion/AzureTextCompletion.cs
@@ -69,4 +69,3 @@ public sealed class AzureTextCompletion : AzureOpenAIClientBase, ITextCompletion
         return this.InternalCompleteTextAsync(text, requestSettings, cancellationToken);
     }
 }
-

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
@@ -58,7 +58,9 @@ public static class GPT3Tokenizer
         (char)0x00F8, (char)0x00F9, (char)0x00FA, (char)0x00FB, (char)0x00FC, (char)0x00FD, (char)0x00FE, (char)0x00FF
     };
 
-    // Regex for English contractions, e.g. "he's", "we'll", "I'm" etc.
+    /// <summary>
+    /// Regex for English contractions, e.g. "he's", "we'll", "I'm" etc.
+    /// </summary>
     private static readonly Regex s_encodingRegex = new(
         @"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+",
         RegexOptions.Compiled,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCognitiveSearch/AzureCognitiveSearchMemoryException.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCognitiveSearch/AzureCognitiveSearchMemoryException.cs
@@ -4,7 +4,8 @@ using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch;
 
-#pragma warning disable CA1032
+#pragma warning disable RCS1194 // Implement exception constructors
+
 /// <summary>
 /// Exception thrown by the Azure Cognitive Search connector
 /// </summary>

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryRecord.cs
@@ -37,4 +37,3 @@ public class CosmosMemoryRecord
     /// </summary>
     public string MetadataString { get; set; } = string.Empty;
 }
-

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/CosmosMemoryStore.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Memory.AzureCosmosDb;
 /// <remarks>The Embedding data is saved to the Azure Cosmos DB database container specified in the constructor.
 /// The embedding data persists between subsequent instances and has similarity search capability, handled by the client as Azure Cosmos DB is not a vector-native DB.
 /// </remarks>
-public class CosmosMemoryStore : IMemoryStore
+public sealed class CosmosMemoryStore : IMemoryStore
 {
     private Database _database;
     private string _databaseName;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Diagnostics/QdrantMemoryException.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Diagnostics/QdrantMemoryException.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Diagnostics;
 
-#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable RCS1194 // Implement exception constructors
 
 /// <summary>
 /// Exception thrown for errors related to the Qdrant connector.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
@@ -13,6 +13,6 @@ internal sealed class ListCollectionsRequest
 
     public HttpRequestMessage Build()
     {
-        return HttpRequest.CreateGetRequest($"collections");
+        return HttpRequest.CreateGetRequest("collections");
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
@@ -28,7 +28,6 @@ internal sealed class UpsertVectorResponse : QdrantResponse
         /// <summary>
         /// Sequential Number of the Operation
         /// </summary>
-
         [JsonPropertyName("operation_id")]
         public int OperationId { get; set; }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -138,17 +138,12 @@ public class QdrantMemoryStore : IMemoryStore
         try
         {
             var vectorData = await this._qdrantClient.GetVectorByPayloadIdAsync(collectionName, key, withEmbedding, cancellationToken).ConfigureAwait(false);
-            if (vectorData != null)
-            {
-                return MemoryRecord.FromJsonMetadata(
-                    json: vectorData.GetSerializedPayload(),
-                    embedding: new Embedding<float>(vectorData.Embedding),
-                    key: vectorData.PointId);
-            }
-            else
-            {
-                return null;
-            }
+            if (vectorData == null) { return null; }
+
+            return MemoryRecord.FromJsonMetadata(
+                json: vectorData.GetSerializedPayload(),
+                embedding: new Embedding<float>(vectorData.Embedding),
+                key: vectorData.PointId);
         }
         catch (HttpRequestException ex)
         {
@@ -185,9 +180,10 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="pointId">The unique indexed ID associated with the Qdrant vector record to get.</param>
     /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns></returns>
+    /// <returns>Memory record</returns>
     /// <exception cref="QdrantMemoryException"></exception>
-    public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, bool withEmbedding = false, CancellationToken cancellationToken = default)
+    public async Task<MemoryRecord?> GetWithPointIdAsync(string collectionName, string pointId, bool withEmbedding = false,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -196,16 +192,11 @@ public class QdrantMemoryStore : IMemoryStore
 
             var vectorData = await vectorDataList.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
-            if (vectorData != null)
-            {
-                return MemoryRecord.FromJsonMetadata(
-                    json: vectorData.GetSerializedPayload(),
-                    embedding: new Embedding<float>(vectorData.Embedding));
-            }
-            else
-            {
-                return null;
-            }
+            if (vectorData == null) { return null; }
+
+            return MemoryRecord.FromJsonMetadata(
+                json: vectorData.GetSerializedPayload(),
+                embedding: new Embedding<float>(vectorData.Embedding));
         }
         catch (HttpRequestException ex)
         {
@@ -222,14 +213,17 @@ public class QdrantMemoryStore : IMemoryStore
     }
 
     /// <summary>
-    /// Get a MemoryRecord from the Qdrant Vector database by a group of pointIds.
+    /// Get memory records from the Qdrant Vector database using a group of pointIds.
     /// </summary>
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="pointIds">The unique indexed IDs associated with Qdrant vector records to get.</param>
     /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns></returns>
-    public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, bool withEmbeddings = false,
+    /// <returns>Memory records</returns>
+    public async IAsyncEnumerable<MemoryRecord> GetWithPointIdBatchAsync(
+        string collectionName,
+        IEnumerable<string> pointIds,
+        bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var vectorDataList = this._qdrantClient
@@ -271,7 +265,6 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="pointId">The unique indexed ID associated with the Qdrant vector record to remove.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
     public async Task RemoveWithPointIdAsync(string collectionName, string pointId, CancellationToken cancellationToken = default)
     {
@@ -293,7 +286,6 @@ public class QdrantMemoryStore : IMemoryStore
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="pointIds">The unique indexed IDs associated with the Qdrant vector records to remove.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns></returns>
     /// <exception cref="QdrantMemoryException"></exception>
     public async Task RemoveWithPointIdBatchAsync(string collectionName, IEnumerable<string> pointIds, CancellationToken cancellationToken = default)
     {
@@ -388,7 +380,10 @@ public class QdrantMemoryStore : IMemoryStore
 
     private readonly IQdrantVectorDbClient _qdrantClient;
 
-    private async Task<QdrantVectorRecord> ConvertFromMemoryRecordAsync(string collectionName, MemoryRecord record, CancellationToken cancellationToken = default)
+    private async Task<QdrantVectorRecord> ConvertFromMemoryRecordAsync(
+        string collectionName,
+        MemoryRecord record,
+        CancellationToken cancellationToken = default)
     {
         string pointId;
 
@@ -400,7 +395,11 @@ public class QdrantMemoryStore : IMemoryStore
         // Check if the data store contains a record with the provided metadata ID
         else
         {
-            var existingRecord = await this._qdrantClient.GetVectorByPayloadIdAsync(collectionName, record.Metadata.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var existingRecord = await this._qdrantClient.GetVectorByPayloadIdAsync(
+                    collectionName,
+                    record.Metadata.Id,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
             if (existingRecord != null)
             {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecord.cs
@@ -54,7 +54,7 @@ public class QdrantVectorRecord
     /// <summary>
     /// Serializes the metadata to JSON.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>Serialized payload</returns>
     public string GetSerializedPayload()
     {
         return JsonSerializer.Serialize(this.Payload);
@@ -67,8 +67,8 @@ public class QdrantVectorRecord
     /// <param name="embedding"></param>
     /// <param name="json"></param>
     /// <param name="tags"></param>
-    /// <returns></returns>
-    /// <exception cref="QdrantMemoryException"></exception>
+    /// <returns>Vector record</returns>
+    /// <exception cref="QdrantMemoryException">Qdrant exception</exception>
     public static QdrantVectorRecord FromJsonMetadata(string pointId, IEnumerable<float> embedding, string json, List<string>? tags = null)
     {
         var payload = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -76,9 +76,7 @@ public class QdrantVectorRecord
         {
             return new QdrantVectorRecord(pointId, embedding, payload, tags);
         }
-        else
-        {
-            throw new QdrantMemoryException(QdrantMemoryException.ErrorCodes.UnableToDeserializeRecordPayload);
-        }
+
+        throw new QdrantMemoryException(QdrantMemoryException.ErrorCodes.UnableToDeserializeRecordPayload);
     }
 }

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -159,8 +159,7 @@ public sealed class SequentialPlannerTests
         var functionsView = new FunctionsView();
         skills.Setup(x => x.GetFunctionsView(It.IsAny<bool>(), It.IsAny<bool>())).Returns(functionsView);
 
-        var planString =
-            @"<plan>notvalid<</plan>";
+        var planString = "<plan>notvalid<</plan>";
         var returnContext = new SKContext(
             new ContextVariables(planString),
             memory.Object,

--- a/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
@@ -245,7 +245,7 @@ Goal: tell me a joke.
                 }
                 else
                 {
-                    this._logger.LogWarning("{0}.{1} is missing a description.", func.SkillName, func.Name);
+                    this._logger.LogWarning("{0}.{1} is missing a description", func.SkillName, func.Name);
                     list.AppendLine($"// Function {func.SkillName}.{func.Name}.");
                 }
 

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -184,7 +184,7 @@ public sealed class OpenAICompletionTests : IDisposable
         Assert.IsType<AIException>(context.LastException);
         Assert.Equal(AIException.ErrorCodes.InvalidRequest, ((AIException)context.LastException).ErrorCode);
         Assert.Contains("The request is not valid, HTTP status: 400", ((AIException)context.LastException).Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("maximum context length is", ((AIException)context.LastException).Detail, StringComparison.OrdinalIgnoreCase); // This messasge could change in the future, comes from Azure OpenAI
+        Assert.Contains("maximum context length is", ((AIException)context.LastException).Detail, StringComparison.OrdinalIgnoreCase); // This message could change in the future, comes from Azure OpenAI
     }
 
     [Theory(Skip = "This test is for manual verification.")]
@@ -196,7 +196,7 @@ public sealed class OpenAICompletionTests : IDisposable
     {
         // Arrange
         var prompt =
-            $"Given a json input and a request. Apply the request on the json input and return the result. " +
+            "Given a json input and a request. Apply the request on the json input and return the result. " +
             $"Put the result in between <result></result> tags{lineEnding}" +
             $"Input:{lineEnding}{{\"name\": \"John\", \"age\": 30}}{lineEnding}{lineEnding}Request:{lineEnding}name";
 

--- a/dotnet/src/IntegrationTests/Planning/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/PlanTests.cs
@@ -119,7 +119,7 @@ public sealed class PlanTests : IDisposable
         // Assert
         Assert.NotNull(result);
         Assert.Equal(
-            $"Sent email to: something@email.com. Body: Roses are red, violets are blue, Roses are red, violets are blue, Roses are red, violets are blue, PlanInput is hard, so is this test. is hard, so is this test. is hard, so is this test.",
+            "Sent email to: something@email.com. Body: Roses are red, violets are blue, Roses are red, violets are blue, Roses are red, violets are blue, PlanInput is hard, so is this test. is hard, so is this test. is hard, so is this test.",
             result.Result);
     }
 

--- a/dotnet/src/IntegrationTests/TestHelpers.cs
+++ b/dotnet/src/IntegrationTests/TestHelpers.cs
@@ -37,7 +37,6 @@ internal static class TestHelpers
 
         string skillParentDirectory = Path.GetFullPath(Path.Combine(currentAssemblyDirectory, "../../../../../../samples/skills"));
 
-        IDictionary<string, ISKFunction> skill = target.ImportSemanticSkillFromDirectory(skillParentDirectory, skillNames);
-        return skill;
+        return target.ImportSemanticSkillFromDirectory(skillParentDirectory, skillNames);
     }
 }

--- a/dotnet/src/InternalUtilities/Diagnostics/Verify.cs
+++ b/dotnet/src/InternalUtilities/Diagnostics/Verify.cs
@@ -15,7 +15,9 @@ internal static class Verify
 {
     private static readonly Regex s_asciiLettersDigitsUnderscoresRegex = new("^[0-9A-Za-z_]*$");
 
-    // Equivalent of ArgumentNullException.ThrowIfNull
+    /// <summary>
+    /// Equivalent of ArgumentNullException.ThrowIfNull
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void NotNull([NotNull] object? obj, [CallerArgumentExpression("obj")] string? paramName = null)
     {

--- a/dotnet/src/InternalUtilities/InternalUtilities.props
+++ b/dotnet/src/InternalUtilities/InternalUtilities.props
@@ -1,5 +1,5 @@
-<Project>  
+<Project>
   <ItemGroup>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/**/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)"/>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/**/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/AIException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/AIException.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.AI;
 
-#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable RCS1194 // Implement exception constructors
 
 /// <summary>
 /// Exception thrown for errors related to AI logic.
@@ -78,7 +78,9 @@ public class AIException : SKException
     public string? Detail { get; }
 
     /// <summary>Translate the error code into a default message.</summary>
-    private static string GetDefaultMessage(ErrorCodes errorCode, string? message)
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="defaultMessage">Default error message if nothing available.</param>
+    private static string GetDefaultMessage(ErrorCodes errorCode, string? defaultMessage)
     {
         string description = errorCode switch
         {
@@ -95,7 +97,7 @@ public class AIException : SKException
             _ => $"Unknown error ({errorCode:G})",
         };
 
-        return message is not null ? $"{description}: {message}" : description;
+        return defaultMessage is not null ? $"{description}: {defaultMessage}" : description;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextCompletion/CompleteRequestSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextCompletion/CompleteRequestSettings.cs
@@ -50,7 +50,7 @@ public class CompleteRequestSettings
     /// <summary>
     /// How many completions to generate for each prompt. Default is 1.
     /// Note: Because this parameter generates many completions, it can quickly consume your token quota.
-    /// Use carefully and ensure that you have reasonable settings for max_tokens and stop. 
+    /// Use carefully and ensure that you have reasonable settings for max_tokens and stop.
     /// </summary>
     public int ResultsPerPrompt { get; set; } = 1;
 

--- a/dotnet/src/SemanticKernel.Abstractions/KernelException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/KernelException.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel;
 
-#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable RCS1194 // Implement exception constructors
 
 /// <summary>
 /// Exception thrown for errors related to kernel logic.
@@ -49,7 +49,9 @@ public class KernelException : SKException
     public ErrorCodes ErrorCode { get; }
 
     /// <summary>Translate the error code into a default message.</summary>
-    private static string GetDefaultMessage(ErrorCodes errorCode, string? message)
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="defaultMessage">Default error message if nothing available.</param>
+    private static string GetDefaultMessage(ErrorCodes errorCode, string? defaultMessage)
     {
         string description = errorCode switch
         {
@@ -65,7 +67,7 @@ public class KernelException : SKException
             _ => $"Unknown error ({errorCode:G})",
         };
 
-        return message is not null ? $"{description}: {message}" : description;
+        return defaultMessage is not null ? $"{description}: {defaultMessage}" : description;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/DataEntryBase.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/DataEntryBase.cs
@@ -32,7 +32,7 @@ public class DataEntryBase
     /// Gets the timestamp of the data.
     /// </summary>
     [JsonPropertyName("timestamp")]
-    public DateTimeOffset? Timestamp { get; set; } = null;
+    public DateTimeOffset? Timestamp { get; set; }
 
     /// <summary>
     /// <c>true</c> if the data has a timestamp.

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/ISemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/ISemanticTextMemory.cs
@@ -15,8 +15,8 @@ public interface ISemanticTextMemory
     /// Save some information into the semantic memory, keeping a copy of the source information.
     /// </summary>
     /// <param name="collection">Collection where to save the information.</param>
-    /// <param name="id">Unique identifier.</param>
     /// <param name="text">Information to save.</param>
+    /// <param name="id">Unique identifier.</param>
     /// <param name="description">Optional description.</param>
     /// <param name="additionalMetadata">Optional string for saving custom metadata.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/MemoryException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/MemoryException.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Memory;
 
-#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable RCS1194 // Implement exception constructors
 
 /// <summary>
 /// Exception thrown for errors related to memory logic.

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/MemoryRecord.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/MemoryRecord.cs
@@ -119,7 +119,7 @@ public class MemoryRecord : DataEntryBase
     /// <param name="embedding">Optional embedding associated with a memory record.</param>
     /// <param name="key">Optional existing database key.</param>
     /// <param name="timestamp">optional timestamp.</param>
-    /// <returns></returns>
+    /// <returns>Memory record</returns>
     /// <exception cref="MemoryException"></exception>
     public static MemoryRecord FromJsonMetadata(
         string json,
@@ -128,14 +128,11 @@ public class MemoryRecord : DataEntryBase
         DateTimeOffset? timestamp = null)
     {
         var metadata = JsonSerializer.Deserialize<MemoryRecordMetadata>(json);
-        if (metadata != null)
-        {
-            return new MemoryRecord(metadata, embedding ?? Embedding<float>.Empty, key, timestamp);
-        }
-
-        throw new MemoryException(
-            MemoryException.ErrorCodes.UnableToDeserializeMetadata,
-            "Unable to create memory record from serialized metadata");
+        return metadata != null
+            ? new MemoryRecord(metadata, embedding ?? Embedding<float>.Empty, key, timestamp)
+            : throw new MemoryException(
+                MemoryException.ErrorCodes.UnableToDeserializeMetadata,
+                "Unable to create memory record from serialized metadata");
     }
 
     /// <summary>
@@ -145,7 +142,7 @@ public class MemoryRecord : DataEntryBase
     /// <param name="embedding">Optional embedding associated with a memory record.</param>
     /// <param name="key">Optional existing database key.</param>
     /// <param name="timestamp">optional timestamp.</param>
-    /// <returns></returns>
+    /// <returns>Memory record</returns>
     public static MemoryRecord FromMetadata(
         MemoryRecordMetadata metadata,
         Embedding<float>? embedding,

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -162,7 +162,9 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
 
     #region private ================================================================================
 
-    // Important: names are case insensitive
+    /// <summary>
+    /// Important: names are case insensitive
+    /// </summary>
     private readonly ConcurrentDictionary<string, string> _variables = new(StringComparer.OrdinalIgnoreCase);
 
     #endregion

--- a/dotnet/src/SemanticKernel.Abstractions/Planning/PlanningException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Planning/PlanningException.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Planning;
 
-#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable RCS1194 // Implement exception constructors
 
 /// <summary>
 /// Exception thrown for errors related to planning.

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticFunctions/PromptTemplateConfig.cs
@@ -179,11 +179,6 @@ public class PromptTemplateConfig
     public static PromptTemplateConfig FromJson(string json)
     {
         var result = Json.Deserialize<PromptTemplateConfig>(json);
-        if (result is null)
-        {
-            throw new ArgumentException("Unable to deserialize prompt template config from argument. The deserialization returned null.", nameof(json));
-        }
-
-        return result;
+        return result ?? throw new ArgumentException("Unable to deserialize prompt template config from argument. The deserialization returned null.", nameof(json));
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Services/IServiceConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Services/IServiceConfig.cs
@@ -7,7 +7,9 @@ namespace Microsoft.SemanticKernel.Services;
 /// </summary>
 public interface IServiceConfig
 {
+    /// <summary>
     /// An identifier used to map semantic functions to AI connectors,
     /// decoupling prompts configurations from the actual model and AI provider used.
+    /// </summary>
     public string ServiceId { get; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/IReadOnlySkillCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/IReadOnlySkillCollection.cs
@@ -31,9 +31,9 @@ public interface IReadOnlySkillCollection
     /// Check if a function is available in the current context, and return it.
     /// </summary>
     /// <param name="functionName">The name of the function to retrieve.</param>
-    /// <param name="functionInstance">When this method returns, the function that was retrieved if one with the specified name was found; otherwise, <see langword="null"/>.</param>
+    /// <param name="availableFunction">When this method returns, the function that was retrieved if one with the specified name was found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if the function was found; otherwise, <see langword="false"/>.</returns>
-    bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? functionInstance);
+    bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction);
 
     /// <summary>
     /// Check if a function is available in the current context, and return it.

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/NullReadOnlySkillCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/NullReadOnlySkillCollection.cs
@@ -4,30 +4,36 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.SkillDefinition;
 
-internal class NullReadOnlySkillCollection : IReadOnlySkillCollection
+internal sealed class NullReadOnlySkillCollection : IReadOnlySkillCollection
 {
     public static NullReadOnlySkillCollection Instance = new();
 
     public ISKFunction GetFunction(string functionName)
-        => ThrowFunctionNotAvailable(functionName);
+    {
+        return ThrowFunctionNotAvailable(functionName);
+    }
 
     public ISKFunction GetFunction(string skillName, string functionName)
-        => ThrowFunctionNotAvailable(skillName, functionName);
-
-    public bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? functionInstance)
     {
-        functionInstance = null;
+        return ThrowFunctionNotAvailable(skillName, functionName);
+    }
+
+    public bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction)
+    {
+        availableFunction = null;
         return false;
     }
 
-    public bool TryGetFunction(string skillName, string functionName, [NotNullWhen(true)] out ISKFunction? functionInstance)
+    public bool TryGetFunction(string skillName, string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction)
     {
-        functionInstance = null;
+        availableFunction = null;
         return false;
     }
 
     public FunctionsView GetFunctionsView(bool includeSemantic = true, bool includeNative = true)
-        => new FunctionsView();
+    {
+        return new();
+    }
 
     private NullReadOnlySkillCollection()
     {
@@ -35,13 +41,17 @@ internal class NullReadOnlySkillCollection : IReadOnlySkillCollection
 
     [DoesNotReturn]
     private static ISKFunction ThrowFunctionNotAvailable(string skillName, string functionName)
-        => throw new KernelException(
-                KernelException.ErrorCodes.FunctionNotAvailable,
-                $"Function not available: {skillName}.{functionName}");
+    {
+        throw new KernelException(
+            KernelException.ErrorCodes.FunctionNotAvailable,
+            $"Function not available: {skillName}.{functionName}");
+    }
 
     [DoesNotReturn]
     private static ISKFunction ThrowFunctionNotAvailable(string functionName)
-        => throw new KernelException(
-                KernelException.ErrorCodes.FunctionNotAvailable,
-                $"Function not available: {functionName}");
+    {
+        throw new KernelException(
+            KernelException.ErrorCodes.FunctionNotAvailable,
+            $"Function not available: {functionName}");
+    }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/ParameterView.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/ParameterView.cs
@@ -19,10 +19,7 @@ public sealed class ParameterView
     /// </summary>
     public string Name
     {
-        get
-        {
-            return this._name;
-        }
+        get => this._name;
         set
         {
             Verify.ValidFunctionParamName(value);

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/SKFunctionContextParameterAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/SKFunctionContextParameterAttribute.cs
@@ -23,7 +23,7 @@ public sealed class SKFunctionContextParameterAttribute : Attribute
     /// </summary>
     public string Name
     {
-        get { return this._name; }
+        get => this._name;
         set
         {
             Verify.ValidFunctionParamName(value);

--- a/dotnet/src/SemanticKernel.UnitTests/CoreSkills/HttpSkillTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/CoreSkills/HttpSkillTests.cs
@@ -16,7 +16,7 @@ namespace SemanticKernel.UnitTests.CoreSkills;
 
 public class HttpSkillTests : IDisposable
 {
-    private readonly SKContext _context = new SKContext();
+    private readonly SKContext _context = new();
     private readonly string _content = "hello world";
     private readonly string _uriString = "http://www.example.com";
 

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -77,7 +77,7 @@ public class KernelTests
         var nativeSkill = new MySkill();
         var skill = kernel.ImportSkill(nativeSkill, "mySk");
 
-        using CancellationTokenSource cts = new CancellationTokenSource();
+        using CancellationTokenSource cts = new();
         cts.Cancel();
 
         // Act
@@ -97,7 +97,7 @@ public class KernelTests
         var nativeSkill = new MySkill();
         kernel.ImportSkill(nativeSkill, "mySk");
 
-        using CancellationTokenSource cts = new CancellationTokenSource();
+        using CancellationTokenSource cts = new();
 
         // Act
         SKContext result = await kernel.RunAsync(cts.Token, kernel.Func("mySk", "GetAnyValue"));

--- a/dotnet/src/SemanticKernel.UnitTests/Memory/VolatileMemoryStoreTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/VolatileMemoryStoreTests.cs
@@ -543,7 +543,7 @@ public class VolatileMemoryStoreTests
         await this._db.CreateCollectionAsync(collection);
         IEnumerable<MemoryRecord> records = this.CreateBatchRecords(numRecords);
 
-        List<string> keys = new List<string>();
+        List<string> keys = new();
         await foreach (var key in this._db.UpsertBatchAsync(collection, records))
         {
             keys.Add(key);

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesConverterTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesConverterTests.cs
@@ -133,7 +133,7 @@ public class ContextVariablesConverterTests
     public void ReadFromJsonReturnsNullWithNull()
     {
         // Arrange
-        string json = /*lang=json,strict*/ @"null";
+        string json = /*lang=json,strict*/ "null";
         var options = new JsonSerializerOptions();
         options.Converters.Add(new ContextVariablesConverter());
 
@@ -148,7 +148,7 @@ public class ContextVariablesConverterTests
     public void ReadFromJsonReturnsDefaultWithEmpty()
     {
         // Arrange
-        string json = /*lang=json,strict*/ @"[]";
+        string json = /*lang=json,strict*/ "[]";
         var options = new JsonSerializerOptions();
         options.Converters.Add(new ContextVariablesConverter());
 

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
@@ -23,7 +23,7 @@ public class ContextVariablesTests
         string secondValue = Guid.NewGuid().ToString();
 
         // Act            
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
         target.Set(firstName, firstValue);
         target.Set(secondName, secondValue);
 
@@ -40,7 +40,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyValue = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target[anyName] = anyValue;
@@ -54,7 +54,7 @@ public class ContextVariablesTests
     {
         // Arrange
         string anyName = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act,Assert
         Assert.Throws<KeyNotFoundException>(() => target[anyName]);
@@ -66,7 +66,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyValue = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target[anyName] = anyValue;
@@ -82,7 +82,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyValue = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target[anyName] = anyValue;
@@ -97,7 +97,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target[anyName] = anyContent;
@@ -113,7 +113,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target.Set(anyName, anyContent);
@@ -129,7 +129,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target.Set(anyName, anyContent);
@@ -145,7 +145,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target.Set(anyName, anyContent);
@@ -161,7 +161,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target.Set(anyName, anyContent);
@@ -176,7 +176,7 @@ public class ContextVariablesTests
         // Arrange
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new ContextVariables();
+        ContextVariables target = new();
 
         // Act
         target.Set(anyName, anyContent);

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
@@ -69,8 +69,8 @@ public sealed class PlanSerializationTests
         Assert.NotNull(serializedPlan);
         Assert.NotEmpty(serializedPlan);
         Assert.Contains($"\"description\":\"{goal}\"", serializedPlan, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains($"\"description\":\"Write a poem or joke\"", serializedPlan, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains($"\"description\":\"Send it in an e-mail to Kai\"", serializedPlan, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"description\":\"Write a poem or joke\"", serializedPlan, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"description\":\"Send it in an e-mail to Kai\"", serializedPlan, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(expectedSteps, serializedPlan, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -508,7 +508,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(plan);
-        Assert.Equal($"Child 3 heard Child 2 is happy about Child 1 output!Write a poem or joke - this just happened.", plan.State.ToString());
+        Assert.Equal("Child 3 heard Child 2 is happy about Child 1 output!Write a poem or joke - this just happened.", plan.State.ToString());
         nodeFunction1.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null), Times.Once);
         childFunction1.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null), Times.Once);
         childFunction2.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null), Times.Once);
@@ -571,7 +571,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a poem about Cleopatra", result.Result);
+        Assert.Equal("Here is a poem about Cleopatra", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), null), Times.Once);
     }
 
@@ -612,7 +612,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a poem about Cleopatra", result.Result);
+        Assert.Equal("Here is a poem about Cleopatra", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), default), Times.Once);
     }
 
@@ -650,7 +650,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a poem about Cleopatra", result.Result);
+        Assert.Equal("Here is a poem about Cleopatra", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), default), Times.Once);
 
         plan = new Plan(mockFunction.Object);
@@ -671,7 +671,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a joke about Medusa", result.Result);
+        Assert.Equal("Here is a joke about Medusa", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), default), Times.Exactly(2));
     }
 
@@ -712,7 +712,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a joke about Medusa", result.Result);
+        Assert.Equal("Here is a joke about Medusa", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), default), Times.Once);
 
         planStep = new Plan(mockFunction.Object);
@@ -728,7 +728,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a poem about Medusa", result.Result);
+        Assert.Equal("Here is a poem about Medusa", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), default), Times.Exactly(2));
 
         planStep = new Plan(mockFunction.Object);
@@ -750,7 +750,7 @@ public sealed class PlanTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal($"Here is a joke about Cleopatra", result.Result);
+        Assert.Equal("Here is a joke about Cleopatra", result.Result);
         mockFunction.Verify(x => x.InvokeAsync(It.IsAny<SKContext>(), default), Times.Exactly(3));
     }
 

--- a/dotnet/src/SemanticKernel/Memory/Collections/TopNCollection.cs
+++ b/dotnet/src/SemanticKernel/Memory/Collections/TopNCollection.cs
@@ -12,17 +12,17 @@ namespace Microsoft.SemanticKernel.Memory.Collections;
 /// </summary>
 public class TopNCollection<T> : IEnumerable<ScoredValue<T>>
 {
-    private readonly int _maxItems;
     private readonly MinHeap<ScoredValue<T>> _heap;
     private bool _sorted = false;
 
     public TopNCollection(int maxItems)
     {
-        this._maxItems = maxItems;
+        this.MaxItems = maxItems;
         this._heap = new MinHeap<ScoredValue<T>>(ScoredValue<T>.Min(), maxItems);
     }
 
-    public int MaxItems => this._maxItems;
+    public int MaxItems { get; }
+
     public int Count => this._heap.Count;
 
     internal ScoredValue<T> this[int i] => this._heap[i];
@@ -47,7 +47,7 @@ public class TopNCollection<T> : IEnumerable<ScoredValue<T>>
             this._sorted = false;
         }
 
-        if (this._heap.Count == this._maxItems)
+        if (this._heap.Count == this.MaxItems)
         {
             // Queue is full. We will need to dequeue the item with lowest weight
             if (value.Score <= this.Top.Score)

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -330,7 +330,7 @@ public sealed class Plan : ISKFunction
                 return result;
             }
 
-            context.Variables.Update(result.Result.ToString());
+            context.Variables.Update(result.Result);
         }
         else
         {

--- a/dotnet/src/SemanticKernel/SemanticFunctions/PromptTemplate.cs
+++ b/dotnet/src/SemanticKernel/SemanticFunctions/PromptTemplate.cs
@@ -14,7 +14,7 @@ using Microsoft.SemanticKernel.TemplateEngine.Blocks;
 namespace Microsoft.SemanticKernel.SemanticFunctions;
 
 /// <summary>
-/// Prompt template. 
+/// Prompt template.
 /// </summary>
 public sealed class PromptTemplate : IPromptTemplate
 {

--- a/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
@@ -75,11 +75,11 @@ public static class InlineFunctionsDefinitionExtension
     /// Allow to define a semantic function passing in the definition in natural language, i.e. the prompt template.
     /// </summary>
     /// <param name="kernel">Semantic Kernel instance</param>
-    /// <param name="functionName">A name for the given function. The name can be referenced in templates and used by the pipeline planner.</param>
     /// <param name="promptTemplate">Plain language definition of the semantic function, using SK template language</param>
+    /// <param name="config">Optional function settings</param>
+    /// <param name="functionName">A name for the given function. The name can be referenced in templates and used by the pipeline planner.</param>
     /// <param name="skillName">An optional skill name, e.g. to namespace functions with the same name. When empty,
     /// the function is added to the global namespace, overwriting functions with the same name</param>
-    /// <param name="config">Optional function settings</param>
     /// <returns>A function ready to use</returns>
     public static ISKFunction CreateSemanticFunction(
         this IKernel kernel,

--- a/dotnet/src/SemanticKernel/SkillDefinition/ReadOnlySkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/ReadOnlySkillCollection.cs
@@ -23,8 +23,8 @@ internal sealed class ReadOnlySkillCollection : IReadOnlySkillCollection
         this._skillCollection.GetFunction(skillName, functionName);
 
     /// <inheritdoc/>
-    public bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? functionInstance) =>
-        this._skillCollection.TryGetFunction(functionName, out functionInstance);
+    public bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction) =>
+        this._skillCollection.TryGetFunction(functionName, out availableFunction);
 
     /// <inheritdoc/>
     public bool TryGetFunction(string skillName, string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction) =>

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -51,8 +51,8 @@ public sealed class SKFunction : ISKFunction, IDisposable
     /// <summary>
     /// Create a native function instance, wrapping a native object method
     /// </summary>
-    /// <param name="methodContainerInstance">Object containing the method to invoke</param>
     /// <param name="methodSignature">Signature of the method to invoke</param>
+    /// <param name="methodContainerInstance">Object containing the method to invoke</param>
     /// <param name="skillName">SK skill name</param>
     /// <param name="log">Application logger</param>
     /// <returns>SK function instance</returns>
@@ -249,7 +249,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
     /// <summary>
     /// JSON serialized string representation of the function.
     /// </summary>
-    /// <returns></returns>
     public override string ToString()
         => this.ToString(false);
 
@@ -257,7 +256,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     /// JSON serialized string representation of the function.
     /// </summary>
     public string ToString(bool writeIndented)
-       => JsonSerializer.Serialize(this, options: new JsonSerializerOptions() { WriteIndented = writeIndented });
+        => JsonSerializer.Serialize(this, options: writeIndented ? s_toStringIndentedSerialization : s_toStringStandardSerialization);
 
     /// <summary>
     /// Finalizer.
@@ -269,6 +268,8 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
     #region private
 
+    private static readonly JsonSerializerOptions s_toStringStandardSerialization = new();
+    private static readonly JsonSerializerOptions s_toStringIndentedSerialization = new() { WriteIndented = true };
     private readonly DelegateTypes _delegateType;
     private readonly Delegate _function;
     private readonly ILogger _log;

--- a/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SkillCollection.cs
@@ -21,7 +21,7 @@ public class SkillCollection : ISkillCollection
     internal const string GlobalSkill = "_GLOBAL_FUNCTIONS_";
 
     /// <inheritdoc/>
-    public IReadOnlySkillCollection ReadOnlySkillCollection { get; private set; }
+    public IReadOnlySkillCollection ReadOnlySkillCollection { get; }
 
     public SkillCollection(ILogger? log = null)
     {
@@ -59,8 +59,8 @@ public class SkillCollection : ISkillCollection
     }
 
     /// <inheritdoc/>
-    public bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? functionInstance) =>
-        this.TryGetFunction(GlobalSkill, functionName, out functionInstance);
+    public bool TryGetFunction(string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction) =>
+        this.TryGetFunction(GlobalSkill, functionName, out availableFunction);
 
     /// <inheritdoc/>
     public bool TryGetFunction(string skillName, string functionName, [NotNullWhen(true)] out ISKFunction? availableFunction)

--- a/dotnet/src/SemanticKernel/TemplateEngine/Blocks/CodeBlock.cs
+++ b/dotnet/src/SemanticKernel/TemplateEngine/Blocks/CodeBlock.cs
@@ -151,11 +151,9 @@ internal sealed class CodeBlock : Block, ICodeRendering
             // Function in the global skill
             return skills.TryGetFunction(fBlock.FunctionName, out function);
         }
-        else
-        {
-            // Function within a specific skill
-            return skills.TryGetFunction(fBlock.SkillName, fBlock.FunctionName, out function);
-        }
+
+        // Function within a specific skill
+        return skills.TryGetFunction(fBlock.SkillName, fBlock.FunctionName, out function);
     }
 
     #endregion

--- a/dotnet/src/SemanticKernel/TemplateEngine/TemplateException.cs
+++ b/dotnet/src/SemanticKernel/TemplateEngine/TemplateException.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.TemplateEngine;
 
-#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable RCS1194 // Implement exception constructors
 
 /// <summary>
 /// Exception thrown for errors related to templating.

--- a/dotnet/src/Skills/Skills.Document/OpenXml/Extensions/WordprocessingDocumentEx.cs
+++ b/dotnet/src/Skills/Skills.Document/OpenXml/Extensions/WordprocessingDocumentEx.cs
@@ -7,8 +7,10 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace Microsoft.SemanticKernel.Skills.Document.OpenXml.Extensions;
 
-// Extension methods for DocumentFormat.OpenXml.Packaging.WordprocessingDocument
-// Note: the "Wordprocessing" vs "WordProcessing" typo is in the 3P class, we follow the original naming.
+/// <summary>
+/// Extension methods for DocumentFormat.OpenXml.Packaging.WordprocessingDocument
+/// Note: the "Wordprocessing" vs "WordProcessing" typo is in the 3P class, we follow the original naming.
+/// </summary>
 internal static class WordprocessingDocumentEx
 {
     internal static void Initialize(this WordprocessingDocument wordprocessingDocument)

--- a/dotnet/src/Skills/Skills.Grpc/Extensions/GrpcOperationExtensions.cs
+++ b/dotnet/src/Skills/Skills.Grpc/Extensions/GrpcOperationExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.SemanticKernel.Skills.Grpc.Model;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.SemanticKernel.Skills.Grpc.Extensions;
 
+#pragma warning disable RCS1175 // Unused 'this' parameter 'operation'.
+
 /// <summary>
 /// Class for extensions methods for the <see cref="GrpcOperation"/> class.
 /// </summary>
@@ -14,16 +16,17 @@ internal static class GrpcOperationExtensions
 {
     /// <summary>
     /// Returns list of gRPC operation parameters.
+    /// TODO: not an extension method, `operation` is never used.
     /// </summary>
     /// <returns>The list of parameters.</returns>
     public static IReadOnlyList<ParameterView> GetParameters(this GrpcOperation operation)
     {
         var parameters = new List<ParameterView>();
 
-        //Register the "address" parameter so that it's possible to override it if needed.
+        // Register the "address" parameter so that it's possible to override it if needed.
         parameters.Add(new ParameterView(GrpcOperation.AddressArgumentName, "Address for gRPC channel to use.", string.Empty));
 
-        //Register the "payload" parameter to be used as gRPC operation request message.
+        // Register the "payload" parameter to be used as gRPC operation request message.
         parameters.Add(new ParameterView(GrpcOperation.PayloadArgumentName, "gRPC request message.", string.Empty));
 
         return parameters;

--- a/dotnet/src/Skills/Skills.Grpc/Model/GrpcOperationDataContractType.cs
+++ b/dotnet/src/Skills/Skills.Grpc/Model/GrpcOperationDataContractType.cs
@@ -19,12 +19,12 @@ internal class GrpcOperationDataContractType
     }
 
     /// <summary>
-    /// Data contract name;
+    /// Data contract name
     /// </summary>
     public string Name { get; set; }
 
     /// <summary>
-    /// 
+    /// List of fields
     /// </summary>
     public IList<GrpcOperationDataContractTypeFiled> Fields { get; } = new List<GrpcOperationDataContractTypeFiled>();
 }

--- a/dotnet/src/Skills/Skills.MsGraph/CalendarSkill.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/CalendarSkill.cs
@@ -93,7 +93,7 @@ public class CalendarSkill
 
         if (string.IsNullOrWhiteSpace(subject))
         {
-            context.Fail($"Missing variables input to use as event subject.");
+            context.Fail("Missing variables input to use as event subject.");
             return;
         }
 

--- a/dotnet/src/Skills/Skills.MsGraph/Connectors/Client/MsGraphClientLoggingHandler.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/Connectors/Client/MsGraphClientLoggingHandler.cs
@@ -19,7 +19,9 @@ namespace Microsoft.SemanticKernel.Skills.MsGraph.Connectors.Client;
 /// </remarks>
 public class MsGraphClientLoggingHandler : DelegatingHandler
 {
-    // From https://learn.microsoft.com/graph/best-practices-concept#reliability-and-support
+    /// <summary>
+    /// From https://learn.microsoft.com/graph/best-practices-concept#reliability-and-support
+    /// </summary>
     private const string ClientRequestIdHeaderName = "client-request-id";
 
     private readonly List<string> _headerNamesToLog = new()

--- a/dotnet/src/Skills/Skills.MsGraph/Connectors/CredentialManagers/LocalUserMSALCredentialManager.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/Connectors/CredentialManagers/LocalUserMSALCredentialManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SemanticKernel.Skills.MsGraph.Connectors.CredentialManagers;
 /// <remarks>
 /// https://learn.microsoft.com/azure/active-directory/develop/msal-net-token-cache-serialization?tabs=desktop
 /// </remarks>
-public class LocalUserMSALCredentialManager
+public sealed class LocalUserMSALCredentialManager
 {
     /// <summary>
     /// An in-memory cache of IPublicClientApplications by clientId and tenantId.

--- a/dotnet/src/Skills/Skills.MsGraph/Connectors/OutlookMailConnector.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/Connectors/OutlookMailConnector.cs
@@ -81,4 +81,3 @@ public class OutlookMailConnector : IEmailConnector
         return messages;
     }
 }
-

--- a/dotnet/src/Skills/Skills.MsGraph/ICloudDriveConnector.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/ICloudDriveConnector.cs
@@ -34,6 +34,5 @@ public interface ICloudDriveConnector
     /// <param name="filePath">Path of the local file to upload.</param>
     /// <param name="destinationPath">Remote path to store the file, which is relative to the root of the OneDrive folder and should begin with the '/' character.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns></returns>
     Task UploadSmallFileAsync(string filePath, string destinationPath, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Skills/Skills.MsGraph/Models/EmailAddress.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/Models/EmailAddress.cs
@@ -13,7 +13,7 @@ public class EmailAddress
     public string? Name { get; set; }
 
     /// <summary>
-    /// Email address 
+    /// Email address
     /// </summary>
     public string? Address { get; set; }
 }

--- a/dotnet/src/Skills/Skills.OpenAPI/Authentication/BasicAuthenticationProvider.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Authentication/BasicAuthenticationProvider.cs
@@ -29,7 +29,6 @@ public class BasicAuthenticationProvider
     /// Applies the authentication content to the provided HTTP request message.
     /// </summary>
     /// <param name="request">The HTTP request message.</param>
-    /// <returns></returns>
     public async Task AuthenticateRequestAsync(HttpRequestMessage request)
     {
         // Base64 encode

--- a/dotnet/src/Skills/Skills.OpenAPI/Authentication/BearerAuthenticationProvider.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Authentication/BearerAuthenticationProvider.cs
@@ -28,7 +28,6 @@ public class BearerAuthenticationProvider
     /// Applies the token to the provided HTTP request message.
     /// </summary>
     /// <param name="request">The HTTP request message.</param>
-    /// <returns></returns>
     public async Task AuthenticateRequestAsync(HttpRequestMessage request)
     {
         var token = await this._bearerToken().ConfigureAwait(false);

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelChatGptPluginExtensions.cs
@@ -180,13 +180,13 @@ public static class KernelChatGptPluginExtensions
         string? apiType = gptPlugin?["api"]?["type"]?.ToString();
         if (string.IsNullOrWhiteSpace(apiType) || apiType != "openapi")
         {
-            throw new InvalidOperationException($"Invalid ChatGPT plugin document. Supported api types are: openapi");
+            throw new InvalidOperationException("Invalid ChatGPT plugin document. Supported api types are: openapi");
         }
 
         string? openApiUrl = gptPlugin?["api"]?["url"]?.ToString();
         if (string.IsNullOrWhiteSpace(openApiUrl))
         {
-            throw new InvalidOperationException($"Invalid ChatGPT plugin document, OpenAPI URL is missing");
+            throw new InvalidOperationException("Invalid ChatGPT plugin document, OpenAPI URL is missing");
         }
 
         return openApiUrl!;

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -109,8 +109,8 @@ public static class KernelOpenApiExtensions
     /// <param name="parentDirectory">Directory containing the skill directory.</param>
     /// <param name="skillDirectoryName">Name of the directory containing the selected skill.</param>
     /// <param name="authCallback">Optional callback for adding auth data to the API requests.</param>
-    /// <param name="retryConfiguration">Optional retry configuration.</param>
     /// <param name="userAgent">Optional user agent header value.</param>
+    /// <param name="retryConfiguration">Optional retry configuration.</param>
     /// <param name="serverUrlOverride">Optional override for REST API server URL if user input required</param>
     /// <param name="cancellationToken"></param>
     /// <returns>A list of all the semantic functions representing the skill.</returns>

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/RestApiOperationExtensions.cs
@@ -67,5 +67,5 @@ internal static class RestApiOperationExtensions
     }
 
     private const string MediaTypeTextPlain = "text/plain";
-    private static readonly Regex s_invalidSymbolsRegex = new(@"[^0-9A-Za-z_]+");
+    private static readonly Regex s_invalidSymbolsRegex = new("[^0-9A-Za-z_]+");
 }

--- a/dotnet/src/Skills/Skills.OpenAPI/JsonPathSkill.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/JsonPathSkill.cs
@@ -31,7 +31,7 @@ public class JsonPathSkill
     {
         if (string.IsNullOrWhiteSpace(json))
         {
-            context.Fail($"Missing input JSON.");
+            context.Fail("Missing input JSON.");
             return string.Empty;
         }
 
@@ -58,7 +58,7 @@ public class JsonPathSkill
     {
         if (string.IsNullOrWhiteSpace(json))
         {
-            context.Fail($"Missing input JSON.");
+            context.Fail("Missing input JSON.");
             return string.Empty;
         }
 

--- a/dotnet/src/Skills/Skills.OpenAPI/Model/RestApiOperationPayload.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Model/RestApiOperationPayload.cs
@@ -20,7 +20,7 @@ public record RestApiOperationPayload
     public string? Description { get; }
 
     /// <summary>
-    /// The payload properties. 
+    /// The payload properties.
     /// </summary>
     public IList<RestApiOperationPayloadProperty> Properties { get; }
 

--- a/dotnet/src/Skills/Skills.OpenAPI/Model/RestApiOperationPayloadProperty.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Model/RestApiOperationPayloadProperty.cs
@@ -40,9 +40,13 @@ public sealed class RestApiOperationPayloadProperty
     /// <param name="name">Property name.</param>
     /// <param name="type">Property type.</param>
     /// <param name="isRequired">Flag specifying if the property is required or not.</param>
-    /// <param name="description">Property description.</param>
     /// <param name="properties">Properties.</param>
-    public RestApiOperationPayloadProperty(string name, string type, bool isRequired, IList<RestApiOperationPayloadProperty> properties,
+    /// <param name="description">Property description.</param>
+    public RestApiOperationPayloadProperty(
+        string name,
+        string type,
+        bool isRequired,
+        IList<RestApiOperationPayloadProperty> properties,
         string? description = null)
     {
         this.Name = name;

--- a/dotnet/src/Skills/Skills.OpenAPI/RestApiOperationRunner.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/RestApiOperationRunner.cs
@@ -49,7 +49,7 @@ internal sealed class RestApiOperationRunner
         // If no auth callback provided, use empty function
         if (authCallback == null)
         {
-            this._authCallback = (request) => { return Task.CompletedTask; };
+            this._authCallback = _ => Task.CompletedTask;
         }
         else
         {
@@ -57,7 +57,6 @@ internal sealed class RestApiOperationRunner
         }
     }
 
-    /// <inheritdoc/>
     public Task<JsonNode?> RunAsync(RestApiOperation operation, IDictionary<string, string> arguments, CancellationToken cancellationToken = default)
     {
         var url = operation.BuildOperationUrl(arguments);
@@ -79,8 +78,12 @@ internal sealed class RestApiOperationRunner
     /// <param name="headers">Headers to include into the HTTP request.</param>
     /// <param name="payload">HTTP request payload.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    private async Task<JsonNode?> SendAsync(Uri url, HttpMethod method, IDictionary<string, string>? headers = null, HttpContent? payload = null,
+    /// <returns>Response content and content type</returns>
+    private async Task<JsonNode?> SendAsync(
+        Uri url,
+        HttpMethod method,
+        IDictionary<string, string>? headers = null,
+        HttpContent? payload = null,
         CancellationToken cancellationToken = default)
     {
         using var requestMessage = new HttpRequestMessage(method, url);
@@ -111,10 +114,12 @@ internal sealed class RestApiOperationRunner
 
         var content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-        //First iteration allowing to associate additional metadata with the returned content.
-        var result = new JsonObject();
-        result.Add("content", content);
-        result.Add("contentType", responseMessage.Content.Headers.ContentType.ToString());
+        // First iteration allowing to associate additional metadata with the returned content.
+        var result = new JsonObject
+        {
+            { "content", content },
+            { "contentType", responseMessage.Content.Headers.ContentType.ToString() }
+        };
 
         return result;
     }
@@ -134,7 +139,7 @@ internal sealed class RestApiOperationRunner
 
         var mediaType = operation.Payload?.MediaType;
 
-        //A try to resolve payload content type from the operation arguments if it's missing in the payload metadata.
+        // A try to resolve payload content type from the operation arguments if it's missing in the payload metadata.
         if (string.IsNullOrEmpty(mediaType))
         {
             if (!arguments.TryGetValue(RestApiOperation.ContentTypeArgumentName, out mediaType))

--- a/dotnet/src/Skills/Skills.UnitTests/Connectors/WebApi/Rest/RestApiOperationTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/Connectors/WebApi/Rest/RestApiOperationTests.cs
@@ -31,7 +31,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host/", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host/", url.OriginalString);
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host-override/", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host-override/", url.OriginalString);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host/fake-path-value/other_fake_path_section", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host/fake-path-value/other_fake_path_section", url.OriginalString);
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host/fake-default-path/other_fake_path_section", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host/fake-default-path/other_fake_path_section", url.OriginalString);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host/?p1=v1&p2=v2", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host/?p1=v1&p2=v2", url.OriginalString);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host/?p1=dv1&p2=dv2", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host/?p1=dv1&p2=dv2", url.OriginalString);
     }
 
     [Fact]
@@ -223,7 +223,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host/?p2=v2", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host/?p2=v2", url.OriginalString);
     }
 
     [Fact]
@@ -326,7 +326,7 @@ public class RestApiOperationTests
         var url = sut.BuildOperationUrl(arguments);
 
         // Assert
-        Assert.Equal(@"https://fake-random-test-host-override/fake-path-value/?p1=dv1&p2=v2", url.OriginalString);
+        Assert.Equal("https://fake-random-test-host-override/fake-path-value/?p1=dv1&p2=v2", url.OriginalString);
     }
 
     [Fact]

--- a/dotnet/src/Skills/Skills.UnitTests/Grpc/Protobuf/ProtoDocumentParserV30Tests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/Grpc/Protobuf/ProtoDocumentParserV30Tests.cs
@@ -105,4 +105,3 @@ public sealed class ProtoDocumentParserV30Tests
         Assert.Equal("TYPE_STRING", messageField.TypeName);
     }
 }
-

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/Authentication/BasicAuthenticationProviderTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/Authentication/BasicAuthenticationProviderTests.cs
@@ -18,7 +18,7 @@ public class BasicAuthenticationProviderTests
         var credentials = Guid.NewGuid().ToString();
         using var request = new HttpRequestMessage();
 
-        var target = new BasicAuthenticationProvider(() => { return Task.FromResult(credentials); });
+        var target = new BasicAuthenticationProvider(() => Task.FromResult(credentials));
 
         // Act
         await target.AuthenticateRequestAsync(request);

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/Authentication/BearerAuthenticationProviderTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/Authentication/BearerAuthenticationProviderTests.cs
@@ -17,7 +17,7 @@ public class BearerAuthenticationProviderTests
         var token = Guid.NewGuid().ToString();
         using var request = new HttpRequestMessage();
 
-        var target = new BearerAuthenticationProvider(() => { return Task.FromResult(token); });
+        var target = new BearerAuthenticationProvider(() => Task.FromResult(token));
 
         // Act
         await target.AuthenticateRequestAsync(request);

--- a/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
+++ b/samples/apps/copilot-chat-app/webapi/Controllers/SemanticKernelController.cs
@@ -11,7 +11,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
-using SemanticKernel.Service.Model;
+using SemanticKernel.Service.Models;
 
 namespace SemanticKernel.Service.Controllers;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
@@ -12,10 +12,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
-using SemanticKernel.Service.Config;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
+using SemanticKernel.Service.CopilotChat.Options;
 using SemanticKernel.Service.CopilotChat.Storage;
+using SemanticKernel.Service.Options;
 
 namespace SemanticKernel.Service.CopilotChat.Controllers;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/ChatController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/ChatController.cs
@@ -22,10 +22,10 @@ using Microsoft.SemanticKernel.Skills.MsGraph;
 using Microsoft.SemanticKernel.Skills.MsGraph.Connectors;
 using Microsoft.SemanticKernel.Skills.MsGraph.Connectors.Client;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
-using SemanticKernel.Service.CopilotChat.Skills;
-using SemanticKernel.Service.Model;
+using SemanticKernel.Service.CopilotChat.Options;
+using SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
+using SemanticKernel.Service.Models;
 
 namespace SemanticKernel.Service.CopilotChat.Controllers;
 
@@ -153,7 +153,7 @@ public class ChatController : ControllerBase, IDisposable
                 skillName: "JiraSkill",
                 filePath: Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, @"Skills/OpenApiSkills/JiraSkill/openapi.json"),
                 authCallback: authenticationProvider.AuthenticateRequestAsync,
-                serverUrlOverride: hasServerUrlOverride ? new System.Uri(serverUrlOverride) : null);
+                serverUrlOverride: hasServerUrlOverride ? new Uri(serverUrlOverride) : null);
         }
 
         // Microsoft Graph

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/ChatHistoryController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/ChatHistoryController.cs
@@ -9,8 +9,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
+using SemanticKernel.Service.CopilotChat.Options;
 using SemanticKernel.Service.CopilotChat.Storage;
 
 namespace SemanticKernel.Service.CopilotChat.Controllers;

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/DocumentImportController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/DocumentImportController.cs
@@ -11,8 +11,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Text;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
+using SemanticKernel.Service.CopilotChat.Options;
 using SemanticKernel.Service.CopilotChat.Storage;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
@@ -86,8 +86,8 @@ public class DocumentImportController : ControllerBase
             return this.BadRequest("File size exceeds the limit.");
         }
 
-        if (documentImportForm.DocumentScope == DocumentImportForm.DocumentScopes.Chat &&
-                !(await this.UserHasAccessToChatAsync(documentImportForm.UserId, documentImportForm.ChatId)))
+        if (documentImportForm.DocumentScope == DocumentImportForm.DocumentScopes.Chat
+            && !(await this.UserHasAccessToChatAsync(documentImportForm.UserId, documentImportForm.ChatId)))
         {
             return this.BadRequest("User does not have access to the chat session.");
         }

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/SpeechTokenController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/SpeechTokenController.cs
@@ -9,8 +9,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
+using SemanticKernel.Service.CopilotChat.Options;
 
 namespace SemanticKernel.Service.CopilotChat.Controllers;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Extensions/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Extensions/SemanticKernelExtensions.cs
@@ -5,10 +5,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
-using SemanticKernel.Service.Config;
-using SemanticKernel.Service.CopilotChat.Config;
-using SemanticKernel.Service.CopilotChat.Skills;
+using SemanticKernel.Service.CopilotChat.Options;
+using SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 using SemanticKernel.Service.CopilotChat.Storage;
+using SemanticKernel.Service.Options;
 
 namespace SemanticKernel.Service.CopilotChat.Extensions;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Extensions/ServiceExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Extensions/ServiceExtensions.cs
@@ -7,10 +7,10 @@ using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using SemanticKernel.Service.Config;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
+using SemanticKernel.Service.CopilotChat.Options;
 using SemanticKernel.Service.CopilotChat.Storage;
+using SemanticKernel.Service.Options;
 
 namespace SemanticKernel.Service.CopilotChat.Extensions;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/Bot.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/Bot.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 using Microsoft.SemanticKernel.Memory;
-using SemanticKernel.Service.CopilotChat.Config;
+using SemanticKernel.Service.CopilotChat.Options;
 
 namespace SemanticKernel.Service.CopilotChat.Models;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/BotEmbeddingConfig.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/BotEmbeddingConfig.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
 namespace SemanticKernel.Service.CopilotChat.Models;
 

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/ProposedPlan.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/ProposedPlan.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Planning;
 
 namespace SemanticKernel.Service.CopilotChat.Models;
@@ -12,7 +14,7 @@ public class ProposedPlan
     /// Plan object to be approved or invoked.
     /// </summary>
     [JsonPropertyName("proposedPlan")]
-    public Plan plan { get; set; }
+    public Plan Plan { get; set; }
 
     /// <summary>
     /// Create a new proposed plan.
@@ -20,6 +22,6 @@ public class ProposedPlan
     /// <param name="plan">Proposed plan object</param>
     public ProposedPlan(Plan plan)
     {
-        this.plan = plan;
+        this.Plan = plan;
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/AzureSpeechOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/AzureSpeechOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration options for Azure speech recognition.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/BotSchemaOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/BotSchemaOptions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel.DataAnnotations;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration options for the bot file schema that is supported by this application.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/ChatStoreOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/ChatStoreOptions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration settings for the chat store.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/CosmosOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/CosmosOptions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel.DataAnnotations;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration settings for connecting to Azure CosmosDB.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/DocumentMemoryOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/DocumentMemoryOptions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel.DataAnnotations;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration options for handling memorized documents.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/FileSystemOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/FileSystemOptions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel.DataAnnotations;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// File system storage configuration.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/PlannerOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/PlannerOptions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel.DataAnnotations;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration options for the planner.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/PromptsOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Options/PromptsOptions.cs
@@ -2,9 +2,9 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Config;
+namespace SemanticKernel.Service.CopilotChat.Options;
 
 /// <summary>
 /// Configuration options for the chat
@@ -61,6 +61,7 @@ public class PromptsOptions
     [Required, NotEmptyOrWhitespace] public string InitialBotMessage { get; set; } = string.Empty;
     [Required, NotEmptyOrWhitespace] public string SystemDescription { get; set; } = string.Empty;
     [Required, NotEmptyOrWhitespace] public string SystemResponse { get; set; } = string.Empty;
+
     internal string[] SystemIntentPromptComponents => new string[]
     {
         this.SystemDescription,
@@ -68,6 +69,7 @@ public class PromptsOptions
         "{{ChatSkill.ExtractChatHistory}}",
         this.SystemIntentContinuation
     };
+
     internal string SystemIntentExtraction => string.Join("\n", this.SystemIntentPromptComponents);
 
     // Intent extraction
@@ -83,6 +85,7 @@ public class PromptsOptions
     // Long-term memory
     [Required, NotEmptyOrWhitespace] public string LongTermMemoryName { get; set; } = string.Empty;
     [Required, NotEmptyOrWhitespace] public string LongTermMemoryExtraction { get; set; } = string.Empty;
+
     internal string[] LongTermMemoryPromptComponents => new string[]
     {
         this.SystemCognitive,
@@ -92,11 +95,13 @@ public class PromptsOptions
         "{{ChatSkill.ExtractChatHistory}}",
         this.MemoryContinuation
     };
+
     internal string LongTermMemory => string.Join("\n", this.LongTermMemoryPromptComponents);
 
     // Working memory
     [Required, NotEmptyOrWhitespace] public string WorkingMemoryName { get; set; } = string.Empty;
     [Required, NotEmptyOrWhitespace] public string WorkingMemoryExtraction { get; set; } = string.Empty;
+
     internal string[] WorkingMemoryPromptComponents => new string[]
     {
         this.SystemCognitive,
@@ -106,13 +111,14 @@ public class PromptsOptions
         "{{ChatSkill.ExtractChatHistory}}",
         this.MemoryContinuation
     };
+
     internal string WorkingMemory => string.Join("\n", this.WorkingMemoryPromptComponents);
 
     // Memory map
     internal IDictionary<string, string> MemoryMap => new Dictionary<string, string>()
     {
-        { this.LongTermMemoryName, this.LongTermMemory},
-        { this.WorkingMemoryName, this.WorkingMemory}
+        { this.LongTermMemoryName, this.LongTermMemory },
+        { this.WorkingMemoryName, this.WorkingMemory }
     };
 
     // Chat commands
@@ -131,7 +137,6 @@ public class PromptsOptions
     };
 
     internal string SystemChatPrompt => string.Join("\n", this.SystemChatPromptComponents);
-
 
     internal double ResponseTemperature { get; } = 0.7;
     internal double ResponseTopP { get; } = 1;

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ChatSkill.cs
@@ -16,13 +16,13 @@ using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.SkillDefinition;
-using SemanticKernel.Service.CopilotChat.Config;
 using SemanticKernel.Service.CopilotChat.Models;
+using SemanticKernel.Service.CopilotChat.Options;
 using SemanticKernel.Service.CopilotChat.Skills.OpenApiSkills.GitHubSkill.Model;
 using SemanticKernel.Service.CopilotChat.Skills.OpenApiSkills.JiraSkill.Model;
 using SemanticKernel.Service.CopilotChat.Storage;
 
-namespace SemanticKernel.Service.CopilotChat.Skills;
+namespace SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 
 /// <summary>
 /// ChatSkill offers a more coherent chat experience by using memories

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/CopilotChatPlanner.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/CopilotChatPlanner.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.SkillDefinition;
 
-namespace SemanticKernel.Service.CopilotChat.Skills;
+namespace SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 
 /// <summary>
 /// A lightweight wrapper around a planner to allow for curating which skills are available to it.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/DocumentMemorySkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/DocumentMemorySkill.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
-using SemanticKernel.Service.CopilotChat.Config;
+using SemanticKernel.Service.CopilotChat.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Skills;
+namespace SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 
 /// <summary>
 /// This skill provides the functions to query the document memory.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/SemanticChatMemory.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/SemanticChatMemory.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace SemanticKernel.Service.CopilotChat.Skills;
+namespace SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 
 /// <summary>
 /// A collection of semantic chat memory.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/SemanticChatMemoryItem.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/SemanticChatMemoryItem.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace SemanticKernel.Service.CopilotChat.Skills;
+namespace SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 
 /// <summary>
 /// A single entry in the chat memory.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/SemanticMemoryExtractor.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/SemanticMemoryExtractor.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Orchestration;
-using SemanticKernel.Service.CopilotChat.Config;
+using SemanticKernel.Service.CopilotChat.Options;
 
-namespace SemanticKernel.Service.CopilotChat.Skills;
+namespace SemanticKernel.Service.CopilotChat.Skills.ChatSkills;
 
 internal static class SemanticMemoryExtractor
 {

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/OpenApiSkills/GitHubSkill/Model/Label.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/OpenApiSkills/GitHubSkill/Model/Label.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace SemanticKernel.Services.CopilotChat.Skills.OpenApiSkills.GitHubSkill.Model;
+namespace SemanticKernel.Service.CopilotChat.Skills.OpenApiSkills.GitHubSkill.Model;
 
 /// <summary>
 /// Represents a pull request label.

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/OpenApiSkills/GitHubSkill/Model/PullRequest.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/OpenApiSkills/GitHubSkill/Model/PullRequest.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using SemanticKernel.Services.CopilotChat.Skills.OpenApiSkills.GitHubSkill.Model;
 
 namespace SemanticKernel.Service.CopilotChat.Skills.OpenApiSkills.GitHubSkill.Model;
 

--- a/samples/apps/copilot-chat-app/webapi/Diagnostics/ExceptionExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Diagnostics/ExceptionExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-#pragma warning disable IDE0130
-// ReSharper disable once CheckNamespace - Using NS of Exception
 using System.Threading;
 
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace - Using NS of Exception
 namespace System;
 #pragma warning restore IDE0130
 

--- a/samples/apps/copilot-chat-app/webapi/Models/Ask.cs
+++ b/samples/apps/copilot-chat-app/webapi/Models/Ask.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SemanticKernel.Service.Model;
+namespace SemanticKernel.Service.Models;
 
 public class Ask
 {

--- a/samples/apps/copilot-chat-app/webapi/Models/AskResult.cs
+++ b/samples/apps/copilot-chat-app/webapi/Models/AskResult.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SemanticKernel.Service.Model;
+namespace SemanticKernel.Service.Models;
 
 public class AskResult
 {

--- a/samples/apps/copilot-chat-app/webapi/Options/AIServiceOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/AIServiceOptions.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel.DataAnnotations;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// Configuration options for AI services, such as Azure OpenAI and OpenAI.

--- a/samples/apps/copilot-chat-app/webapi/Options/AuthorizationOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/AuthorizationOptions.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel.DataAnnotations;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// Configuration options for authorizing to the service.

--- a/samples/apps/copilot-chat-app/webapi/Options/AzureCognitiveSearchOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/AzureCognitiveSearchOptions.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel.DataAnnotations;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// Configuration settings for connecting to Azure Cognitive Search.

--- a/samples/apps/copilot-chat-app/webapi/Options/MemoriesStoreOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/MemoriesStoreOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// Configuration settings for the memories store.

--- a/samples/apps/copilot-chat-app/webapi/Options/NotEmptyOrWhitespaceAttribute.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/NotEmptyOrWhitespaceAttribute.cs
@@ -3,7 +3,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// If the string is set, it must not be empty or whitespace.

--- a/samples/apps/copilot-chat-app/webapi/Options/QdrantOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/QdrantOptions.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel.DataAnnotations;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// Configuration settings for connecting to Qdrant.

--- a/samples/apps/copilot-chat-app/webapi/Options/RequiredOnPropertyValueAttribute.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/RequiredOnPropertyValueAttribute.cs
@@ -4,7 +4,7 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// If the other property is set to the expected value, then this property is required.

--- a/samples/apps/copilot-chat-app/webapi/Options/ServiceOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/ServiceOptions.cs
@@ -3,7 +3,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace SemanticKernel.Service.Config;
+namespace SemanticKernel.Service.Options;
 
 /// <summary>
 /// Configuration options for the CopilotChat service.

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -15,8 +15,8 @@ using Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
 using Microsoft.SemanticKernel.CoreSkills;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.TemplateEngine;
-using SemanticKernel.Service.Config;
 using SemanticKernel.Service.CopilotChat.Extensions;
+using SemanticKernel.Service.Options;
 
 namespace SemanticKernel.Service;
 

--- a/samples/apps/copilot-chat-app/webapi/ServiceExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/ServiceExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web;
 using SemanticKernel.Service.Auth;
-using SemanticKernel.Service.Config;
+using SemanticKernel.Service.Options;
 
 namespace SemanticKernel.Service;
 

--- a/samples/dotnet/KernelBuilder/Program.cs
+++ b/samples/dotnet/KernelBuilder/Program.cs
@@ -4,6 +4,8 @@
 // The easier way to instantiate the Semantic Kernel is to use KernelBuilder.
 // You can access the builder using either Kernel.Builder or KernelBuilder.
 
+#pragma warning disable CA1050
+
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextCompletion;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;

--- a/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelEndpoint.cs
@@ -17,7 +17,7 @@ namespace KernelHttpServer;
 
 public class SemanticKernelEndpoint
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     private readonly IMemoryStore _memoryStore;
 
     public SemanticKernelEndpoint(IMemoryStore memoryStore)

--- a/samples/dotnet/kernel-syntax-examples/Example33_StreamingChat.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example33_StreamingChat.cs
@@ -103,4 +103,3 @@ public static class Example33_StreamingChat
         return Task.CompletedTask;
     }
 }
-


### PR DESCRIPTION
Add [Roslynator](https://github.com/JosefPihrt/Roslynator) and fix some code style issues found.

`dotnet_analyzer_diagnostic.severity` is set to `none` to stop `dotnet format` from editing a lot of files, even unrelated issues, probably detected by other analyzers, and a lot of issues are disabled. Currently only these are enabled:

```
dotnet_diagnostic.RCS1036.severity = warning # Remove unnecessary blank line.
dotnet_diagnostic.RCS1037.severity = warning # Remove trailing white-space.
dotnet_diagnostic.RCS1097.severity = warning # Remove redundant 'ToString' call.
dotnet_diagnostic.RCS1138.severity = warning # Add summary to documentation comment.
dotnet_diagnostic.RCS1168.severity = warning # Parameter name 'foo' differs from base name 'bar'.
dotnet_diagnostic.RCS1175.severity = warning # Unused 'this' parameter 'operation'.
dotnet_diagnostic.RCS1192.severity = warning # Unnecessary usage of verbatim string literal.
dotnet_diagnostic.RCS1139.severity = warning # Add summary element to documentation comment.
dotnet_diagnostic.RCS1211.severity = warning # Remove unnecessary else clause.
dotnet_diagnostic.RCS1214.severity = warning # Unnecessary interpolated string.
dotnet_diagnostic.RCS1225.severity = warning # Make class sealed.
dotnet_diagnostic.RCS1232.severity = warning # Order elements in documentation comment.
```

Note: 
* There are a lot more issues to fix, for now I disabled a lot of checks and fixed only a bunch.
* Future: enable more of `dotnet_diagnostic.RCS` currently disabled, e.g. XMLDoc checks, to get better code docs

Other fixes:
* fix incorrect namespaces in copilot chat
* use static property for regex
* typos, missing copyright
* switch from CA1032 to RCS1194 to cover more exception ctors