### PR TITLE
Copilot Chat: Multi user broadcast user join

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Hubs/MessageRelayHub.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Hubs/MessageRelayHub.cs
@@ -11,9 +11,9 @@ namespace SemanticKernel.Service.CopilotChat.Hubs;
 /// </summary>
 public class MessageRelayHub : Hub
 {
-    private readonly string _receiveMessageClientCall = "ReceiveMessage";
-    private readonly string _receiveTypingStateClientCall = "ReceiveTypingState";
-    private readonly string _receiveFileUploadedEventClientCall = "ReceiveFileUploadedEvent";
+    private const string ReceiveMessageClientCall = "ReceiveMessage";
+    private const string ReceiveTypingStateClientCall = "ReceiveTypingState";
+    private const string ReceiveFileUploadedEventClientCall = "ReceiveFileUploadedEvent";
     private readonly ILogger<MessageRelayHub> _logger;
 
     /// <summary>
@@ -44,7 +44,7 @@ public class MessageRelayHub : Hub
     /// <param name="message">The message to send.</param>
     public async Task SendMessageAsync(string chatId, object message)
     {
-        await this.Clients.OthersInGroup(chatId).SendAsync(this._receiveMessageClientCall, message, chatId);
+        await this.Clients.OthersInGroup(chatId).SendAsync(ReceiveMessageClientCall, message, chatId);
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public class MessageRelayHub : Hub
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async Task SendTypingStateAsync(string chatId, object isTypingState)
     {
-        await this.Clients.OthersInGroup(chatId).SendAsync(this._receiveTypingStateClientCall, isTypingState, chatId);
+        await this.Clients.OthersInGroup(chatId).SendAsync(ReceiveTypingStateClientCall, isTypingState, chatId);
     }
 
     /// <summary>
@@ -66,6 +66,6 @@ public class MessageRelayHub : Hub
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async Task SendFileUploadedEventAsync(string chatId, object fileUploadedAlert)
     {
-        await this.Clients.OthersInGroup(chatId).SendAsync(this._receiveFileUploadedEventClientCall, fileUploadedAlert, chatId);
+        await this.Clients.OthersInGroup(chatId).SendAsync(ReceiveFileUploadedEventClientCall, fileUploadedAlert, chatId);
     }
 }

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Storage/ChatParticipantRepository.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Storage/ChatParticipantRepository.cs
@@ -32,6 +32,22 @@ public class ChatParticipantRepository : Repository<ChatParticipant>
         return base.StorageContext.QueryEntitiesAsync(e => e.UserId == userId);
     }
 
+    /// <summary>
+    /// Finds chat participants by chat id.
+    /// </summary>
+    /// <param name="chatId">The chat id.</param>
+    /// <returns>A list of chat participants in the same chat sessions.</returns>
+    public Task<IEnumerable<ChatParticipant>> FindByChatIdAsync(string chatId)
+    {
+        return base.StorageContext.QueryEntitiesAsync(e => e.ChatId == chatId);
+    }
+
+    /// <summary>
+    /// Checks if a user is in a chat session.
+    /// </summary>
+    /// <param name="userId">The user id.</param>
+    /// <param name="chatId">The chat id.</param>
+    /// <returns>True if the user is in the chat session, false otherwise.</returns>
     public Task<bool> IsUserInChatAsync(string userId, string chatId)
     {
         return base.StorageContext.QueryEntitiesAsync(e => e.UserId == userId && e.ChatId == chatId).

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
@@ -2,6 +2,8 @@
 
 import { useMsal } from '@azure/msal-react';
 import {
+    AvatarGroupItem,
+    AvatarGroupPopover,
     Button,
     Input,
     InputOnChangeData,
@@ -181,6 +183,11 @@ export const ChatWindow: React.FC = () => {
                     </Popover>
                 </div>
                 <div className={classes.controls}>
+                    <AvatarGroupPopover>
+                        {conversations[selectedId].users.map((user) => (
+                            <AvatarGroupItem name={user.id} key={user.id} />
+                        ))}
+                    </AvatarGroupPopover>
                     <ShareBotMenu chatId={selectedId} chatTitle={title || ''} />
                 </div>
             </div>

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/ChatService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/ChatService.ts
@@ -4,6 +4,7 @@ import { AdditionalApiProperties, AuthHeaderTags } from '../../redux/features/pl
 import { IChatMessage } from '../models/ChatMessage';
 import { IChatParticipant } from '../models/ChatParticipant';
 import { IChatSession } from '../models/ChatSession';
+import { IChatUser } from '../models/ChatUser';
 import { IAsk, IAskVariables } from '../semantic-kernel/model/Ask';
 import { IAskResult } from '../semantic-kernel/model/AskResult';
 import { BaseService } from './BaseService';
@@ -156,5 +157,27 @@ export class ChatService extends BaseService {
         );
 
         return result;
+    };
+
+    public getAllChatParticipantsAsync = async (chatId: string, accessToken: string): Promise<IChatUser[]> => {
+        const result = await this.getResponseAsync<any>(
+            {
+                commandPath: `chatParticipant/getAllParticipants/${chatId}`,
+                method: 'GET',
+            },
+            accessToken,
+        );
+
+        const chatUsers: IChatUser[] = result.map((participant: any) => {
+            return {
+                id: participant.userId,
+                online: false,
+                fullName: '',
+                emailAddress: '',
+                lastTypingTimestamp: 0,
+            } as IChatUser;
+        });
+
+        return chatUsers;
     };
 }

--- a/samples/apps/copilot-chat-app/webapp/src/libs/useChat.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/useChat.ts
@@ -164,6 +164,11 @@ export const useChat = () => {
                         await AuthHelper.getSKaaSAccessToken(instance),
                     );
 
+                    const chatUsers = await chatService.getAllChatParticipantsAsync(
+                        chatSession.id,
+                        await AuthHelper.getSKaaSAccessToken(instance),
+                    );
+
                     // Messages are returned with most recent message at index 0 and oldest message at the last index,
                     // so we need to reverse the order for render
                     const orderedMessages = chatMessages.reverse();
@@ -171,7 +176,7 @@ export const useChat = () => {
                     loadedConversations[chatSession.id] = {
                         id: chatSession.id,
                         title: chatSession.title,
-                        users: [loggedInUser],
+                        users: chatUsers,
                         messages: orderedMessages,
                         botProfilePicture: getBotProfilePicture(Object.keys(loadedConversations).length),
                     };

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -2,6 +2,7 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ChatMessageState, IChatMessage } from '../../../libs/models/ChatMessage';
+import { IChatUser } from '../../../libs/models/ChatUser';
 import { ChatState, ConversationTypingState, FileUploadedAlert } from './ChatState';
 import { Conversations, ConversationsState, ConversationTitleChange, initialState } from './ConversationsState';
 
@@ -24,6 +25,10 @@ export const conversationsSlice = createSlice({
         addConversation: (state: ConversationsState, action: PayloadAction<ChatState>) => {
             const newId = action.payload.id ?? '';
             state.conversations = { [newId]: action.payload, ...state.conversations };
+        },
+        addUserToConversation: (state: ConversationsState, action: PayloadAction<{ user: IChatUser, chatId: string }>) => {
+            const { user, chatId } = action.payload;
+            state.conversations[chatId].users.push(user);
         },
         /*
         * updateConversationFromUser() and updateConversationFromServer() both update the conversations state.

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/message-relay/signalRMiddleware.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/message-relay/signalRMiddleware.ts
@@ -2,6 +2,7 @@
 
 import * as signalR from "@microsoft/signalr";
 import { AlertType } from "../../../libs/models/AlertType";
+import { IChatUser } from "../../../libs/models/ChatUser";
 import { IAskResult } from "../../../libs/semantic-kernel/model/AskResult";
 import { addAlert } from "../app/appSlice";
 import { AuthorRoles, ChatMessageState, IChatMessage } from './../../../libs/models/ChatMessage';
@@ -12,6 +13,7 @@ import { ConversationTypingState, FileUploadedAlert } from './../conversations/C
 // These have to match the callback names used in the backend
 const receiveMessageFromServerCallbackName = "ReceiveMessage" as string;
 const receiveResponseFromServerCallbackName = "ReceiveResponse" as string;
+const userJoinedFromServerCallbackName = "UserJoined" as string;
 const receiveTypingStateFromServerCallbackName = "ReceiveTypingState" as string;
 const receiveFileUploadedAlertFromServerCallbackName = "ReceiveFileUploadedEvent" as string;
 
@@ -135,6 +137,17 @@ export const registerSignalREvents = async (store: any) => {
         } as IChatMessage;
 
         store.dispatch({ type: "conversations/updateConversationFromServer", payload: { message, chatId } });
+    });
+
+    hubConnection.on(userJoinedFromServerCallbackName, (chatId: string, userId: string) => {
+        const user = {
+            id: userId,
+            online: false,
+            fullName: '',
+            emailAddress: '',
+            lastTypingTimestamp: 0,
+        } as IChatUser;
+        store.dispatch({ type: "conversations/addUserToConversation", payload: { user, chatId } });
     });
 
     hubConnection.on(receiveTypingStateFromServerCallbackName, (typingState: ConversationTypingState, chatId: string) => {


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Need to show how many users are in a chat.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Create a widget in the Webapp that can show users that are part of the chat. This only shows user ids for now.
2. Broadcast to all chat members when a user joins.
![image](https://github.com/microsoft/semantic-kernel/assets/12570346/c63fd541-ffb4-4564-b020-20fdd728bbbe)

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
