### PR TITLE
Bring ARM templates up to date with their bicep counterparts

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/DeploymentTemplates/sk-existing-azureopenai.json
+++ b/samples/apps/copilot-chat-app/webapi/DeploymentTemplates/sk-existing-azureopenai.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.17.1.54307",
-      "templateHash": "7938609552624669912"
+      "templateHash": "14992924908149939194"
     }
   },
   "parameters": {
@@ -153,7 +153,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.17.1.54307",
-              "templateHash": "14734235123073662514"
+              "templateHash": "4362216299477491752"
             }
           },
           "parameters": {
@@ -365,52 +365,28 @@
                   "use32BitWorkerProcess": false,
                   "appSettings": [
                     {
-                      "name": "Completion:AIService",
+                      "name": "AIService:Type",
                       "value": "[parameters('aiService')]"
                     },
                     {
-                      "name": "Completion:DeploymentOrModelId",
+                      "name": "AIService:Endpoint",
+                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
+                    },
+                    {
+                      "name": "AIService:Key",
+                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
+                    },
+                    {
+                      "name": "AIService:Models:Completion",
                       "value": "[parameters('completionModel')]"
                     },
                     {
-                      "name": "Completion:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Completion:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
-                    },
-                    {
-                      "name": "Embedding:AIService",
-                      "value": "[parameters('aiService')]"
-                    },
-                    {
-                      "name": "Embedding:DeploymentOrModelId",
+                      "name": "AIService:Models:Embedding",
                       "value": "[parameters('embeddingModel')]"
                     },
                     {
-                      "name": "Embedding:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Embedding:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
-                    },
-                    {
-                      "name": "Planner:AIService:AIService",
-                      "value": "[parameters('aiService')]"
-                    },
-                    {
-                      "name": "Planner:AIService:DeploymentOrModelId",
+                      "name": "AIService:Models:Planner",
                       "value": "[parameters('plannerModel')]"
-                    },
-                    {
-                      "name": "Planner:AIService:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Planner:AIService:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
                     },
                     {
                       "name": "Authorization:Type",

--- a/samples/apps/copilot-chat-app/webapi/DeploymentTemplates/sk-existing-openai.json
+++ b/samples/apps/copilot-chat-app/webapi/DeploymentTemplates/sk-existing-openai.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.17.1.54307",
-      "templateHash": "5276912302534852866"
+      "templateHash": "7946454707645002164"
     }
   },
   "parameters": {
@@ -148,7 +148,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.17.1.54307",
-              "templateHash": "14734235123073662514"
+              "templateHash": "4362216299477491752"
             }
           },
           "parameters": {
@@ -360,52 +360,28 @@
                   "use32BitWorkerProcess": false,
                   "appSettings": [
                     {
-                      "name": "Completion:AIService",
+                      "name": "AIService:Type",
                       "value": "[parameters('aiService')]"
                     },
                     {
-                      "name": "Completion:DeploymentOrModelId",
+                      "name": "AIService:Endpoint",
+                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
+                    },
+                    {
+                      "name": "AIService:Key",
+                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
+                    },
+                    {
+                      "name": "AIService:Models:Completion",
                       "value": "[parameters('completionModel')]"
                     },
                     {
-                      "name": "Completion:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Completion:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
-                    },
-                    {
-                      "name": "Embedding:AIService",
-                      "value": "[parameters('aiService')]"
-                    },
-                    {
-                      "name": "Embedding:DeploymentOrModelId",
+                      "name": "AIService:Models:Embedding",
                       "value": "[parameters('embeddingModel')]"
                     },
                     {
-                      "name": "Embedding:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Embedding:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
-                    },
-                    {
-                      "name": "Planner:AIService:AIService",
-                      "value": "[parameters('aiService')]"
-                    },
-                    {
-                      "name": "Planner:AIService:DeploymentOrModelId",
+                      "name": "AIService:Models:Planner",
                       "value": "[parameters('plannerModel')]"
-                    },
-                    {
-                      "name": "Planner:AIService:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Planner:AIService:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
                     },
                     {
                       "name": "Authorization:Type",

--- a/samples/apps/copilot-chat-app/webapi/DeploymentTemplates/sk-new.json
+++ b/samples/apps/copilot-chat-app/webapi/DeploymentTemplates/sk-new.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.17.1.54307",
-      "templateHash": "10267534410369500421"
+      "templateHash": "13483101291283325126"
     }
   },
   "parameters": {
@@ -135,7 +135,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.17.1.54307",
-              "templateHash": "14734235123073662514"
+              "templateHash": "4362216299477491752"
             }
           },
           "parameters": {
@@ -347,52 +347,28 @@
                   "use32BitWorkerProcess": false,
                   "appSettings": [
                     {
-                      "name": "Completion:AIService",
+                      "name": "AIService:Type",
                       "value": "[parameters('aiService')]"
                     },
                     {
-                      "name": "Completion:DeploymentOrModelId",
+                      "name": "AIService:Endpoint",
+                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
+                    },
+                    {
+                      "name": "AIService:Key",
+                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
+                    },
+                    {
+                      "name": "AIService:Models:Completion",
                       "value": "[parameters('completionModel')]"
                     },
                     {
-                      "name": "Completion:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Completion:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
-                    },
-                    {
-                      "name": "Embedding:AIService",
-                      "value": "[parameters('aiService')]"
-                    },
-                    {
-                      "name": "Embedding:DeploymentOrModelId",
+                      "name": "AIService:Models:Embedding",
                       "value": "[parameters('embeddingModel')]"
                     },
                     {
-                      "name": "Embedding:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Embedding:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
-                    },
-                    {
-                      "name": "Planner:AIService:AIService",
-                      "value": "[parameters('aiService')]"
-                    },
-                    {
-                      "name": "Planner:AIService:DeploymentOrModelId",
+                      "name": "AIService:Models:Planner",
                       "value": "[parameters('plannerModel')]"
-                    },
-                    {
-                      "name": "Planner:AIService:Endpoint",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), reference(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').endpoint, parameters('endpoint'))]"
-                    },
-                    {
-                      "name": "Planner:AIService:Key",
-                      "value": "[if(parameters('deployNewAzureOpenAI'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', format('ai-{0}', variables('uniqueName'))), '2022-12-01').key1, parameters('apiKey'))]"
                     },
                     {
                       "name": "Authorization:Type",


### PR DESCRIPTION
### Motivation and Context
Although the source bicep file to deploy SK to Azure was updated to the latest appsettings.json format, the ARM templates it generates were not. The "Deploy to Azure" buttons use the ARM templates and currently deploy broken services.

### Description
Generated ARM json files with the following commands:
az bicep build -f sk-new.bicep
az bicep build -f sk-existing-azureopenai.bicep
az bicep build -f sk-existing-openai.bicep

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
