### PR TITLE
Suppress CA1852 warning in KernelBuilder.csproj

### DIFF
--- a/samples/dotnet/KernelBuilder/KernelBuilder.csproj
+++ b/samples/dotnet/KernelBuilder/KernelBuilder.csproj
@@ -6,7 +6,7 @@
       <OutputType>Exe</OutputType>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
-      <NoWarn>CA2000</NoWarn>
+      <NoWarn>CA2000,CA1852</NoWarn>
       <IsPackable>false</IsPackable>
     </PropertyGroup>
 


### PR DESCRIPTION
The KernelBuilder.csproj file was generating a CA1852 warning, which
suggests using a const instead of a static readonly field. However, this
warning is not applicable for the KernelBuilder class, which uses
reflection to load the kernel assemblies. Therefore, the warning is
suppressed by adding it to the NoWarn property in the project file. This
makes the code analysis more accurate and avoids false positives.

This warning was impacting dotnet-pr builds against 7.0.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
