### PR TITLE
Fix unweildy XML comment leading to poor IntelliSense

### DIFF
--- a/dotnet/src/SemanticKernel/SkillDefinition/ImportSemanticSkillFromDirectory.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/ImportSemanticSkillFromDirectory.cs
@@ -19,13 +19,18 @@ namespace Microsoft.SemanticKernel;
 public static class ImportSemanticSkillFromDirectoryExtension
 {
     /// <summary>
-    /// A kernel extension that allows to load Semantic Functions, defined by prompt templates stored in the filesystem.
+    /// Loads semantic functions, defined by prompt templates stored in the filesystem.
+    /// </summary>
+    /// <remarks>
+    /// <para>
     /// A skill directory contains a set of subdirectories, one for each semantic function.
-    /// This extension requires the path of the parent directory (e.g. "d:\skills") and the name of the skill directory
-    /// (e.g. "OfficeSkill"), which is used also as the "skill name" in the internal skill collection.
-    ///
-    /// Note: skill and function names can contain only alphanumeric chars and underscore.
-    ///
+    /// </para>
+    /// <para>
+    /// This method accepts the path of the parent directory (e.g. "d:\skills") and the name of the skill directory
+    /// (e.g. "OfficeSkill"), which is used also as the "skill name" in the internal skill collection (note that
+    /// skill and function names can contain only alphanumeric chars and underscore).
+    /// </para>
+    /// <code>
     /// Example:
     /// D:\skills\                            # parentDirectory = "D:\skills"
     ///
@@ -51,9 +56,11 @@ public static class ImportSemanticSkillFromDirectoryExtension
     ///         |__ LaunchGame
     ///             |__ skprompt.txt
     ///             |__ config.json
-    ///
-    /// See https://github.com/microsoft/semantic-kernel/tree/main/samples/skills for some skills in our repo.
-    /// </summary>
+    /// </code>
+    /// <para>
+    /// See https://github.com/microsoft/semantic-kernel/tree/main/samples/skills for examples in the Semantic Kernel repository.
+    /// </para>
+    /// </remarks>
     /// <param name="kernel">Semantic Kernel instance</param>
     /// <param name="parentDirectory">Directory containing the skill directory, e.g. "d:\myAppSkills"</param>
     /// <param name="skillDirectoryNames">Name of the directories containing the selected skills, e.g. "StrategySkill"</param>


### PR DESCRIPTION
### Motivation and Context

Clean up an XML comment that was rendering poorly in IntelliSense.

### Description

Summaries should be kept short, typically just one sentence. Other details should be put into remarks. And if there's any kind of complicated formatting involved, the appropriate XML tags should be used so that docs and IntelliSense can render it well.

Note that there is a separate `<example></example>` tag which I've not used here, as Visual Studio only renders summaries/remarks in IntelliSense today and it seemed like the intent of whoever authored this was to include the example prominently.  If that doesn't need to be shown, it'd be better still to separate the example out into such tags.

Before

<img width="1137" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/2642209/edd023c2-096a-4e88-ba16-11c5cc71abd2">

After

<img width="1164" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/2642209/341cffee-7ded-4f0e-87d7-f9490a71a32e">


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
