### PR TITLE
Fix Yarn link and add QnA in CopilotChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Follow the links for more information and instructions about running these apps.
   are required to run the kernel as a local web service, used by the sample web apps.
 - [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0). If you have .NET 7 installed, Azure Function
   Tools will still require .NET 6, so we suggest installing both.
-- [Yarn](https://yarnpkg.com/getting-started/install) is used for installing web apps' dependencies.
+- [Yarn](https://classic.yarnpkg.com/lang/en/docs/install) is used for installing web apps' dependencies.
 
 
 ## Jupyter Notebooks ⚡

--- a/samples/apps/copilot-chat-app/README.md
+++ b/samples/apps/copilot-chat-app/README.md
@@ -137,6 +137,13 @@ to the back end while waiting for your permission to connect. To resolve this, t
    - Acknowledge, continue, and navigate until you see the message Semantic Kernel service is up and running
 1. Navigate to `http://localhost:3000` or refresh the page to use the Copilot Chat application.
 
+## 4. Have Yarn version 2.x or 3.x
+The webapp uses packages that are only supported by classic Yarn (v1.x). If you have Yarn v2.x+, run the following commands in your preferred shell to flip Yarn to the classic version.
+```shell
+npm install -g yarn
+yarn set version classic
+```
+You can confirm the active Yarn version by running `yarn --version`.
 
 # Additional resources
 


### PR DESCRIPTION
### Motivation and Context
Copilot Chat uses packages that can only be supported by Yarn v1.x. However, we have multiple reported cases where customers follow the instructions to install the wrong version of Yarn that causes errors in the Copilot Chat app. 


### Description
1. Update the Semantic Kernel top README to use classic Yarn installation link.
2. Add Troubleshooting guidance for Yarn 2.x+ in Copilot Chat README.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
~- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`~
~- [ ] All unit tests pass, and I have added new tests where possible~
- [x] I didn't break anyone :smile:
