### PR TITLE
Add CLSCompliantAttribute(false) to Copilot Chat Web API

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/CopilotChatWebApi.csproj
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChatWebApi.csproj
@@ -66,4 +66,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.CLSCompliantAttribute">
+      <_Parameter1>false</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description
Adding CLSCompliantAttribute(false) to Copilot Chat Web API to squash the following build warning that only shows up on net6.0 builds:

`CSC : error CA1014: Mark assemblies with CLSCompliant [/app/samples/apps/copilot-chat-app/webapi/CopilotChatWebApi.csproj]`