### PR TITLE
Rewrite how native skill functions are invoked

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
@@ -17,26 +17,25 @@ public sealed class SKFunctionTests2
     private readonly Mock<IReadOnlySkillCollection> _skills;
 
     private static string s_expected = string.Empty;
-    private static string s_canary = string.Empty;
+    private static string s_actual = string.Empty;
 
     public SKFunctionTests2()
     {
         this._log = new Mock<ILogger>();
         this._skills = new Mock<IReadOnlySkillCollection>();
 
-        s_canary = "";
         s_expected = Guid.NewGuid().ToString("D");
     }
 
     [Fact]
-    public async Task ItSupportsType1Async()
+    public async Task ItSupportsStaticVoidVoidAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static void Test()
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
         }
 
         var context = this.MockContext("");
@@ -48,19 +47,18 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(1);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
     }
 
     [Fact]
-    public async Task ItSupportsType2Async()
+    public async Task ItSupportsStaticVoidStringAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static string Test()
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             return s_expected;
         }
 
@@ -73,21 +71,20 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(2);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, result.Result);
         Assert.Equal(s_expected, context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType3Async()
+    public async Task ItSupportsStaticVoidTaskStringAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task<string> Test()
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             return Task.FromResult(s_expected);
         }
 
@@ -100,21 +97,20 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(3);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context.Result);
         Assert.Equal(s_expected, result.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType4Async()
+    public async Task ItSupportsStaticContextVoidAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static void Test(SKContext cx)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             cx["canary"] = s_expected;
         }
 
@@ -128,20 +124,19 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(4);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
     }
 
     [Fact]
-    public async Task ItSupportsType5Async()
+    public async Task ItSupportsStaticContextStringAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static string Test(SKContext cx)
         {
-            s_canary = cx["someVar"];
+            s_actual = cx["someVar"];
             return "abc";
         }
 
@@ -155,20 +150,22 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(5);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal("abc", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType5NullableAsync()
+    public async Task ItSupportsInstanceContextStringNullableAsync()
     {
         // Arrange
+        int invocationCount = 0;
+
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         string? Test(SKContext cx)
         {
-            s_canary = cx["someVar"];
+            invocationCount++;
+            s_actual = cx["someVar"];
             return "abc";
         }
 
@@ -176,26 +173,30 @@ public sealed class SKFunctionTests2
         context["someVar"] = s_expected;
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Func<SKContext, string?> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(5);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal("abc", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType6Async()
+    public async Task ItSupportsInstanceContextTaskStringAsync()
     {
         // Arrange
+        int invocationCount = 0;
+
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         Task<string> Test(SKContext cx)
         {
-            s_canary = s_expected;
+            invocationCount++;
+            s_actual = s_expected;
             cx.Variables["canary"] = s_expected;
             return Task.FromResult(s_expected);
         }
@@ -203,57 +204,32 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Func<SKContext, Task<string>> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(6);
-        Assert.Equal(s_expected, s_canary);
-        Assert.Equal(s_canary, context.Result);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_actual, context.Result);
         Assert.Equal(s_expected, context["canary"]);
     }
 
     [Fact]
-    public async Task ItSupportsType7Async()
+    public async Task ItSupportsInstanceContextTaskContextAsync()
     {
         // Arrange
-        [SKFunction("Test")]
-        [SKFunctionName("Test")]
-        Task<SKContext> Test(SKContext cx)
-        {
-            s_canary = s_expected;
-            cx.Variables.Update("foo");
-            cx["canary"] = s_expected;
-            return Task.FromResult(cx);
-        }
+        int invocationCount = 0;
 
-        var context = this.MockContext("");
-
-        // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
-        Assert.NotNull(function);
-        SKContext result = await function.InvokeAsync(context);
-
-        // Assert
-        Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(7);
-        Assert.Equal(s_expected, s_canary);
-        Assert.Equal(s_expected, context["canary"]);
-        Assert.Equal("foo", context.Result);
-    }
-
-    [Fact]
-    public async Task ItSupportsAsyncType7Async()
-    {
-        // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         async Task<SKContext> TestAsync(SKContext cx)
         {
             await Task.Delay(0);
-            s_canary = s_expected;
+            invocationCount++;
+            s_actual = s_expected;
             cx.Variables.Update("foo");
             cx["canary"] = s_expected;
             return cx;
@@ -262,103 +238,119 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(TestAsync), log: this._log.Object);
+        Func<SKContext, Task<SKContext>> method = TestAsync;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(7);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
         Assert.Equal("foo", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType8Async()
+    public async Task ItSupportsInstanceStringVoidAsync()
     {
         // Arrange
+        int invocationCount = 0;
+
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         void Test(string input)
         {
-            s_canary = s_expected + input;
+            invocationCount++;
+            s_actual = s_expected + input;
         }
 
         var context = this.MockContext(".blah");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Action<string> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(8);
-        Assert.Equal(s_expected + ".blah", s_canary);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected + ".blah", s_actual);
     }
 
     [Fact]
-    public async Task ItSupportsType9Async()
+    public async Task ItSupportsInstanceStringStringAsync()
     {
         // Arrange
+        int invocationCount = 0;
+
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         string Test(string input)
         {
-            s_canary = s_expected;
+            invocationCount++;
+            s_actual = s_expected;
             return "foo-bar";
         }
 
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Func<string, string> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(9);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal("foo-bar", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType10Async()
+    public async Task ItSupportsInstanceStringTaskStringAsync()
     {
         // Arrange
+        int invocationCount = 0;
+
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         Task<string> Test(string input)
         {
-            s_canary = s_expected;
+            invocationCount++;
+            s_actual = s_expected;
             return Task.FromResult("hello there");
         }
 
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Func<string, Task<string>> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(10);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal("hello there", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType11Async()
+    public async Task ItSupportsInstanceStringContextVoidAsync()
     {
         // Arrange
+        int invocationCount = 0;
+
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         void Test(string input, SKContext cx)
         {
-            s_canary = s_expected;
+            invocationCount++;
+            s_actual = s_expected;
             cx.Variables.Update("x y z");
             cx["canary"] = s_expected;
         }
@@ -366,27 +358,60 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        Action<string, SKContext> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(11);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
         Assert.Equal("x y z", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType12Async()
+    public async Task ItSupportsInstanceContextStringVoidAsync()
+    {
+        // Arrange
+        int invocationCount = 0;
+
+        [SKFunction("Test")]
+        [SKFunctionName("Test")]
+        void Test(SKContext cx, string input)
+        {
+            invocationCount++;
+            s_actual = s_expected;
+            cx.Variables.Update("x y z");
+            cx["canary"] = s_expected;
+        }
+
+        var context = this.MockContext("");
+
+        // Act
+        Action<SKContext, string> method = Test;
+        var function = SKFunction.FromNativeMethod(Method(method), method.Target, log: this._log.Object);
+        Assert.NotNull(function);
+        SKContext result = await function.InvokeAsync(context);
+
+        // Assert
+        Assert.False(result.ErrorOccurred);
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(s_expected, s_actual);
+        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal("x y z", context.Result);
+    }
+
+    [Fact]
+    public async Task ItSupportsStaticStringContextStringAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static string Test(string input, SKContext cx)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             cx["canary"] = s_expected;
             cx.Variables.Update("x y z");
             // This value should overwrite "x y z"
@@ -402,21 +427,20 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(12);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
         Assert.Equal("new data", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType13Async()
+    public async Task ItSupportsStaticStringContextTaskStringAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task<string> Test(string input, SKContext cx)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             cx["canary"] = s_expected;
             cx.Variables.Update("x y z");
             // This value should overwrite "x y z"
@@ -432,21 +456,20 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(13);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
         Assert.Equal("new data", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType14Async()
+    public async Task ItSupportsStaticStringContextTaskContextAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task<SKContext> Test(string input, SKContext cx)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             cx["canary"] = s_expected;
             cx.Variables.Update("x y z");
 
@@ -472,9 +495,8 @@ public sealed class SKFunctionTests2
         // Assert
         Assert.False(oldContext.ErrorOccurred);
         Assert.False(newContext.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(14);
 
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
 
         Assert.True(oldContext.Variables.ContainsKey("canary"));
         Assert.False(oldContext.Variables.ContainsKey("canary2"));
@@ -493,14 +515,14 @@ public sealed class SKFunctionTests2
     }
 
     [Fact]
-    public async Task ItSupportsType15Async()
+    public async Task ItSupportsStaticStringTaskAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task TestAsync(string input)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             return Task.CompletedTask;
         }
 
@@ -513,19 +535,18 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(15);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
     }
 
     [Fact]
-    public async Task ItSupportsType16Async()
+    public async Task ItSupportsStaticContextTaskAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task TestAsync(SKContext cx)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             cx["canary"] = s_expected;
             cx.Variables.Update("x y z");
             return Task.CompletedTask;
@@ -540,21 +561,20 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(16);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
         Assert.Equal("x y z", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType17Async()
+    public async Task ItSupportsStaticStringContextTaskAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task TestAsync(string input, SKContext cx)
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             cx["canary"] = s_expected;
             cx.Variables.Update(input + "x y z");
             return Task.CompletedTask;
@@ -569,21 +589,20 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(17);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_expected, context["canary"]);
         Assert.Equal("input:x y z", context.Result);
     }
 
     [Fact]
-    public async Task ItSupportsType18Async()
+    public async Task ItSupportsStaticVoidTaskAsync()
     {
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
         static Task TestAsync()
         {
-            s_canary = s_expected;
+            s_actual = s_expected;
             return Task.CompletedTask;
         }
 
@@ -596,8 +615,7 @@ public sealed class SKFunctionTests2
 
         // Assert
         Assert.False(result.ErrorOccurred);
-        this.VerifyFunctionTypeMatch(18);
-        Assert.Equal(s_expected, s_canary);
+        Assert.Equal(s_expected, s_actual);
     }
 
     private static MethodInfo Method(Delegate method)
@@ -611,30 +629,5 @@ public sealed class SKFunctionTests2
             new ContextVariables(input),
             skills: this._skills.Object,
             logger: this._log.Object);
-    }
-
-    private void VerifyFunctionTypeMatch(int typeNumber)
-    {
-#pragma warning disable CS8620
-        // Verify that the expected function has been called
-        this._log.Verify(logger => logger.Log(
-                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
-                It.Is<EventId>(eventId => eventId.Id == typeNumber),
-                It.Is<It.IsAnyType>((@object, @type) => true),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once);
-
-        // Verify that unexpected functions have not been called (e.g. missing a return statement)
-        // TODO: check for "Executing function type" instead of using "eventId.Id != 0"
-        // Note: eventId.Id != 0 is used to avoid catching other Log.Trace events and failing the tests
-        this._log.Verify(logger => logger.Log(
-                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
-                It.Is<EventId>(eventId => eventId.Id != 0 && eventId.Id != typeNumber),
-                It.Is<It.IsAnyType>((@object, @type) => true),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Never);
-#pragma warning restore CS8620
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests3.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests3.cs
@@ -61,7 +61,7 @@ public sealed class SKFunctionTests3
         }
 
         // Assert
-        Assert.Equal(3, count);
+        Assert.Equal(2, count);
     }
 
     [Fact]
@@ -138,13 +138,8 @@ public sealed class SKFunctionTests3
         {
         }
 
-        [SKFunction("two")]
-        public void Invalid2(SKContext cx, string y)
-        {
-        }
-
         [SKFunction("three")]
-        public void Invalid3(string y, int n)
+        public void Invalid2(string y, int n)
         {
         }
     }

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -255,7 +255,13 @@ public sealed class SKFunction : ISKFunction, IDisposable
     /// <summary>
     /// Dispose of resources.
     /// </summary>
-    public void Dispose() => (this._aiService as IDisposable)?.Dispose();
+    public void Dispose()
+    {
+        if (this._aiService is { IsValueCreated: true } aiService)
+        {
+            (aiService.Value as IDisposable)?.Dispose();
+        }
+    }
 
     /// <summary>
     /// JSON serialized string representation of the function.

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -41,10 +40,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     public bool IsSemantic { get; }
 
     /// <inheritdoc/>
-    public CompleteRequestSettings RequestSettings
-    {
-        get { return this._aiRequestSettings; }
-    }
+    public CompleteRequestSettings RequestSettings => this._aiRequestSettings;
 
     /// <summary>
     /// List of function parameters
@@ -65,7 +61,15 @@ public sealed class SKFunction : ISKFunction, IDisposable
         string skillName = "",
         ILogger? log = null)
     {
-        if (string.IsNullOrWhiteSpace(skillName)) { skillName = SkillCollection.GlobalSkill; }
+        if (!methodSignature.IsStatic && methodContainerInstance is null)
+        {
+            throw new ArgumentNullException(nameof(methodContainerInstance), "Argument cannot be null for non-static methods");
+        }
+
+        if (string.IsNullOrWhiteSpace(skillName))
+        {
+            skillName = SkillCollection.GlobalSkill;
+        }
 
         MethodDetails methodDetails = GetMethodDetails(methodSignature, methodContainerInstance, true, log);
 
@@ -76,7 +80,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
         }
 
         return new SKFunction(
-            delegateType: methodDetails.Type,
             delegateFunction: methodDetails.Function,
             parameters: methodDetails.Parameters,
             skillName: skillName,
@@ -107,9 +110,8 @@ public sealed class SKFunction : ISKFunction, IDisposable
         MethodDetails methodDetails = GetMethodDetails(nativeFunction.Method, nativeFunction.Target, false, log);
 
         return new SKFunction(
-            delegateType: methodDetails.Type,
             delegateFunction: methodDetails.Function,
-            parameters: (parameters ?? Enumerable.Empty<ParameterView>()).ToList(),
+            parameters: parameters is not null ? parameters.ToList() : (IList<ParameterView>)Array.Empty<ParameterView>(),
             description: description,
             skillName: skillName,
             functionName: functionName,
@@ -134,11 +136,12 @@ public sealed class SKFunction : ISKFunction, IDisposable
         Verify.NotNull(functionConfig);
 
         async Task<SKContext> LocalFunc(
-            ITextCompletion client,
-            CompleteRequestSettings requestSettings,
+            ITextCompletion? client,
+            CompleteRequestSettings? requestSettings,
             SKContext context)
         {
             Verify.NotNull(client);
+            Verify.NotNull(requestSettings);
 
             try
             {
@@ -166,7 +169,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
         }
 
         return new SKFunction(
-            delegateType: DelegateTypes.ContextSwitchInSKContextOutTaskSKContext,
             delegateFunction: LocalFunc,
             parameters: functionConfig.PromptTemplate.GetParameters(),
             description: functionConfig.PromptTemplateConfig.Description,
@@ -190,13 +192,21 @@ public sealed class SKFunction : ISKFunction, IDisposable
     }
 
     /// <inheritdoc/>
-    public Task<SKContext> InvokeAsync(
-        SKContext context,
-        CompleteRequestSettings? settings = null)
+    public Task<SKContext> InvokeAsync(SKContext context, CompleteRequestSettings? settings = null)
     {
-        return this.IsSemantic
-            ? this.InvokeSemanticAsync(context, settings)
-            : this.InvokeNativeAsync(context);
+        // If the function is invoked manually, the user might have left out the skill collection
+        context.Skills ??= this._skillCollection;
+
+        return this.IsSemantic ?
+            InvokeSemanticAsync(context, settings) :
+            this._function(null, settings, context);
+
+        async Task<SKContext> InvokeSemanticAsync(SKContext context, CompleteRequestSettings? settings)
+        {
+            var resultContext = await this._function(this._aiService?.Value, settings ?? this._aiRequestSettings, context).ConfigureAwait(false);
+            context.Variables.Update(resultContext.Variables);
+            return context;
+        }
     }
 
     /// <inheritdoc/>
@@ -245,11 +255,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     /// <summary>
     /// Dispose of resources.
     /// </summary>
-    public void Dispose()
-    {
-        this.ReleaseUnmanagedResources();
-        GC.SuppressFinalize(this);
-    }
+    public void Dispose() => (this._aiService as IDisposable)?.Dispose();
 
     /// <summary>
     /// JSON serialized string representation of the function.
@@ -263,20 +269,11 @@ public sealed class SKFunction : ISKFunction, IDisposable
     public string ToString(bool writeIndented)
         => JsonSerializer.Serialize(this, options: writeIndented ? s_toStringIndentedSerialization : s_toStringStandardSerialization);
 
-    /// <summary>
-    /// Finalizer.
-    /// </summary>
-    ~SKFunction()
-    {
-        this.ReleaseUnmanagedResources();
-    }
-
     #region private
 
     private static readonly JsonSerializerOptions s_toStringStandardSerialization = new();
     private static readonly JsonSerializerOptions s_toStringIndentedSerialization = new() { WriteIndented = true };
-    private readonly DelegateTypes _delegateType;
-    private readonly Delegate _function;
+    private readonly Func<ITextCompletion?, CompleteRequestSettings?, SKContext, Task<SKContext>> _function;
     private readonly ILogger _log;
     private IReadOnlySkillCollection? _skillCollection;
     private Lazy<ITextCompletion>? _aiService = null;
@@ -285,46 +282,20 @@ public sealed class SKFunction : ISKFunction, IDisposable
     private struct MethodDetails
     {
         public bool HasSkFunctionAttribute { get; set; }
-        public DelegateTypes Type { get; set; }
-        public Delegate Function { get; set; }
+        public Func<ITextCompletion?, CompleteRequestSettings?, SKContext, Task<SKContext>> Function { get; set; }
         public List<ParameterView> Parameters { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
     }
 
-    internal enum DelegateTypes
-    {
-        Unknown = 0,
-        Void = 1,
-        OutString = 2,
-        OutTaskString = 3,
-        InSKContext = 4,
-        InSKContextOutString = 5,
-        InSKContextOutTaskString = 6,
-        ContextSwitchInSKContextOutTaskSKContext = 7,
-        InString = 8,
-        InStringOutString = 9,
-        InStringOutTaskString = 10,
-        InStringAndContext = 11,
-        InStringAndContextOutString = 12,
-        InStringAndContextOutTaskString = 13,
-        ContextSwitchInStringAndContextOutTaskContext = 14,
-        InStringOutTask = 15,
-        InContextOutTask = 16,
-        InStringAndContextOutTask = 17,
-        OutTask = 18
-    }
-
     internal SKFunction(
-        DelegateTypes delegateType,
-        Delegate delegateFunction,
+        Func<ITextCompletion?, CompleteRequestSettings?, SKContext, Task<SKContext>> delegateFunction,
         IList<ParameterView> parameters,
         string skillName,
         string functionName,
         string description,
         bool isSemantic = false,
-        ILogger? log = null
-    )
+        ILogger? log = null)
     {
         Verify.NotNull(delegateFunction);
         Verify.ValidSkillName(skillName);
@@ -333,7 +304,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         this._log = log ?? NullLogger.Instance;
 
-        this._delegateType = delegateType;
         this._function = delegateFunction;
         this.Parameters = parameters;
 
@@ -341,19 +311,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
         this.Name = functionName;
         this.SkillName = skillName;
         this.Description = description;
-    }
-
-    private void ReleaseUnmanagedResources()
-    {
-        if (this._aiService == null || !this._aiService.IsValueCreated)
-        {
-            return;
-        }
-
-        if (this._aiService.Value is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
     }
 
     /// <summary>
@@ -368,171 +325,6 @@ public sealed class SKFunction : ISKFunction, IDisposable
         throw new KernelException(
             KernelException.ErrorCodes.InvalidFunctionType,
             "Invalid operation, the method requires a semantic function");
-    }
-
-    // Run the semantic function
-    private async Task<SKContext> InvokeSemanticAsync(SKContext context, CompleteRequestSettings? settings)
-    {
-        this.VerifyIsSemantic();
-
-        this.EnsureContextHasSkills(context);
-
-        settings ??= this._aiRequestSettings;
-
-        var callable = (Func<ITextCompletion?, CompleteRequestSettings?, SKContext, Task<SKContext>>)this._function;
-        context.Variables.Update((await callable(this._aiService?.Value, settings, context).ConfigureAwait(false)).Variables);
-        return context;
-    }
-
-    // Run the native function
-    private async Task<SKContext> InvokeNativeAsync(SKContext context)
-    {
-        TraceFunctionTypeCall(this._delegateType, this._log);
-
-        this.EnsureContextHasSkills(context);
-
-        switch (this._delegateType)
-        {
-            case DelegateTypes.Void: // 1
-            {
-                var callable = (Action)this._function;
-                callable();
-                return context;
-            }
-
-            case DelegateTypes.OutString: // 2
-            {
-                var callable = (Func<string>)this._function;
-                context.Variables.Update(callable());
-                return context;
-            }
-
-            case DelegateTypes.OutTaskString: // 3
-            {
-                var callable = (Func<Task<string>>)this._function;
-                context.Variables.Update(await callable().ConfigureAwait(false));
-                return context;
-            }
-
-            case DelegateTypes.InSKContext: // 4
-            {
-                var callable = (Action<SKContext>)this._function;
-                callable(context);
-                return context;
-            }
-
-            case DelegateTypes.InSKContextOutString: // 5
-            {
-                var callable = (Func<SKContext, string>)this._function;
-                context.Variables.Update(callable(context));
-                return context;
-            }
-
-            case DelegateTypes.InSKContextOutTaskString: // 6
-            {
-                var callable = (Func<SKContext, Task<string>>)this._function;
-                context.Variables.Update(await callable(context).ConfigureAwait(false));
-                return context;
-            }
-
-            case DelegateTypes.ContextSwitchInSKContextOutTaskSKContext: // 7
-            {
-                var callable = (Func<SKContext, Task<SKContext>>)this._function;
-                // Note: Context Switching: allows the function to replace with a new context, e.g. to branch execution path
-                context = await callable(context).ConfigureAwait(false);
-                return context;
-            }
-
-            case DelegateTypes.InString:
-            {
-                var callable = (Action<string>)this._function; // 8
-                callable(context.Variables.Input);
-                return context;
-            }
-
-            case DelegateTypes.InStringOutString: // 9
-            {
-                var callable = (Func<string, string>)this._function;
-                context.Variables.Update(callable(context.Variables.Input));
-                return context;
-            }
-
-            case DelegateTypes.InStringOutTaskString: // 10
-            {
-                var callable = (Func<string, Task<string>>)this._function;
-                context.Variables.Update(await callable(context.Variables.Input).ConfigureAwait(false));
-                return context;
-            }
-
-            case DelegateTypes.InStringAndContext: // 11
-            {
-                var callable = (Action<string, SKContext>)this._function;
-                callable(context.Variables.Input, context);
-                return context;
-            }
-
-            case DelegateTypes.InStringAndContextOutString: // 12
-            {
-                var callable = (Func<string, SKContext, string>)this._function;
-                context.Variables.Update(callable(context.Variables.Input, context));
-                return context;
-            }
-
-            case DelegateTypes.InStringAndContextOutTaskString: // 13
-            {
-                var callable = (Func<string, SKContext, Task<string>>)this._function;
-                context.Variables.Update(await callable(context.Variables.Input, context).ConfigureAwait(false));
-                return context;
-            }
-
-            case DelegateTypes.ContextSwitchInStringAndContextOutTaskContext: // 14
-            {
-                var callable = (Func<string, SKContext, Task<SKContext>>)this._function;
-                // Note: Context Switching: allows the function to replace with a new context, e.g. to branch execution path
-                context = await callable(context.Variables.Input, context).ConfigureAwait(false);
-                return context;
-            }
-
-            case DelegateTypes.InStringOutTask: // 15
-            {
-                var callable = (Func<string, Task>)this._function;
-                await callable(context.Variables.Input).ConfigureAwait(false);
-                return context;
-            }
-
-            case DelegateTypes.InContextOutTask: // 16
-            {
-                var callable = (Func<SKContext, Task>)this._function;
-                await callable(context).ConfigureAwait(false);
-                return context;
-            }
-
-            case DelegateTypes.InStringAndContextOutTask: // 17
-            {
-                var callable = (Func<string, SKContext, Task>)this._function;
-                await callable(context.Variables.Input, context).ConfigureAwait(false);
-                return context;
-            }
-
-            case DelegateTypes.OutTask: // 18
-            {
-                var callable = (Func<Task>)this._function;
-                await callable().ConfigureAwait(false);
-                return context;
-            }
-
-            case DelegateTypes.Unknown:
-            default:
-                throw new KernelException(
-                    KernelException.ErrorCodes.FunctionTypeNotSupported,
-                    "Invalid function type detected, unable to execute.");
-        }
-    }
-
-    private void EnsureContextHasSkills(SKContext context)
-    {
-        // If the function is invoked manually, the user might have left out the skill collection
-        context.Skills ??= this._skillCollection;
     }
 
     private static MethodDetails GetMethodDetails(
@@ -567,7 +359,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
             result.HasSkFunctionAttribute = true;
         }
 
-        (result.Type, result.Function, bool hasStringParam) = GetDelegateInfo(methodContainerInstance, methodSignature);
+        (result.Function, bool hasStringParam) = GetDelegateInfo(methodContainerInstance, methodSignature);
 
         // SKFunctionName attribute
         SKFunctionNameAttribute? skFunctionNameAttribute = methodSignature
@@ -617,158 +409,115 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         result.Description = skFunctionAttribute?.Description ?? "";
 
-        log?.LogTrace("Method '{0}' found, type `{1}`", result.Name, result.Type.ToString("G"));
+        log?.LogTrace("Method '{0}' found", result.Name);
 
         return result;
     }
 
     // Inspect a method and returns the corresponding delegate and related info
-    private static (DelegateTypes type, Delegate function, bool hasStringParam) GetDelegateInfo(object? instance, MethodInfo method)
+    private static (Func<ITextCompletion?, CompleteRequestSettings?, SKContext, Task<SKContext>> function, bool hasStringParam) GetDelegateInfo(object? instance, MethodInfo method)
     {
-        if (EqualMethods(instance, method, typeof(Action), out Delegate? funcDelegate))
+        // Get marshaling funcs for parameters
+        var parameters = method.GetParameters();
+        if (parameters.Length > 2)
         {
-            return (DelegateTypes.Void, funcDelegate, false);
+            ThrowForInvalidSignature();
         }
 
-        if (EqualMethods(instance, method, typeof(Func<string>), out funcDelegate))
+        var parameterFuncs = new Func<SKContext, object>[parameters.Length];
+        bool hasStringParam = false;
+        bool hasContextParam = false;
+        for (int i = 0; i < parameters.Length; i++)
         {
-            return (DelegateTypes.OutString, funcDelegate, false);
+            if (!hasStringParam && parameters[i].ParameterType == typeof(string))
+            {
+                hasStringParam = true;
+                parameterFuncs[i] = static (SKContext ctx) => ctx.Variables.Input;
+            }
+            else if (!hasContextParam && parameters[i].ParameterType == typeof(SKContext))
+            {
+                hasContextParam = true;
+                parameterFuncs[i] = static (SKContext ctx) => ctx;
+            }
+            else
+            {
+                ThrowForInvalidSignature();
+            }
         }
 
-        if (EqualMethods(instance, method, typeof(Func<Task<string>>), out funcDelegate!))
+        // Get marshaling func for the return value
+        Func<object?, SKContext, Task<SKContext>> returnFunc;
+        if (method.ReturnType == typeof(void))
         {
-            return (DelegateTypes.OutTaskString, funcDelegate, false);
+            returnFunc = static (result, context) => Task.FromResult(context);
+        }
+        else if (method.ReturnType == typeof(string))
+        {
+            returnFunc = static (result, context) =>
+            {
+                context.Variables.Update((string?)result);
+                return Task.FromResult(context);
+            };
+        }
+        else if (method.ReturnType == typeof(SKContext))
+        {
+            returnFunc = static (result, _) => Task.FromResult((SKContext)ThrowIfNullResult(result));
+        }
+        else if (method.ReturnType == typeof(Task))
+        {
+            returnFunc = async static (result, context) =>
+            {
+                await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
+                return context;
+            };
+        }
+        else if (method.ReturnType == typeof(Task<string>))
+        {
+            returnFunc = async static (result, context) =>
+            {
+                context.Variables.Update(await ((Task<string>)ThrowIfNullResult(result)).ConfigureAwait(false));
+                return context;
+            };
+        }
+        else if (method.ReturnType == typeof(Task<SKContext>))
+        {
+            returnFunc = static (result, _) => (Task<SKContext>)ThrowIfNullResult(result);
+        }
+        else
+        {
+            ThrowForInvalidSignature();
         }
 
-        if (EqualMethods(instance, method, typeof(Action<SKContext>), out funcDelegate!))
+        // Create the func
+        Func<ITextCompletion?, CompleteRequestSettings?, SKContext, Task<SKContext>> function = (_, _, context) =>
         {
-            return (DelegateTypes.InSKContext, funcDelegate, false);
-        }
+            // Create the arguments.
+            object[] args = parameterFuncs.Length != 0 ? new object[parameterFuncs.Length] : Array.Empty<object>();
+            for (int i = 0; i < args.Length; i++)
+            {
+                args[i] = parameterFuncs[i](context);
+            }
 
-        if (EqualMethods(instance, method, typeof(Func<SKContext, string>), out funcDelegate!))
-        {
-            return (DelegateTypes.InSKContextOutString, funcDelegate, false);
-        }
+            // Invoke the method.
+            object? result = method.Invoke(instance, args);
 
-        if (EqualMethods(instance, method, typeof(Func<SKContext, Task<string>>), out funcDelegate!))
-        {
-            return (DelegateTypes.InSKContextOutTaskString, funcDelegate, false);
-        }
+            // Extract and return the result.
+            return returnFunc(result, context);
+        };
 
-        if (EqualMethods(instance, method, typeof(Func<SKContext, Task<SKContext>>), out funcDelegate!))
-        {
-            return (DelegateTypes.ContextSwitchInSKContextOutTaskSKContext, funcDelegate, false);
-        }
+        // Return the func and whether it has a string param
+        return (function, hasStringParam);
 
-        // === string input ==
-
-        if (EqualMethods(instance, method, typeof(Action<string>), out funcDelegate!))
-        {
-            return (DelegateTypes.InString, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<string, string>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringOutString, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<string, Task<string>>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringOutTaskString, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Action<string, SKContext>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringAndContext, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<string, SKContext, string>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringAndContextOutString, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<string, SKContext, Task<string>>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringAndContextOutTaskString, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<string, SKContext, Task<SKContext>>), out funcDelegate!))
-        {
-            return (DelegateTypes.ContextSwitchInStringAndContextOutTaskContext, funcDelegate, true);
-        }
-
-        // == Tasks without output ==
-
-        if (EqualMethods(instance, method, typeof(Func<string, Task>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringOutTask, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<SKContext, Task>), out funcDelegate!))
-        {
-            return (DelegateTypes.InContextOutTask, funcDelegate, false);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<string, SKContext, Task>), out funcDelegate!))
-        {
-            return (DelegateTypes.InStringAndContextOutTask, funcDelegate, true);
-        }
-
-        if (EqualMethods(instance, method, typeof(Func<Task>), out funcDelegate!))
-        {
-            return (DelegateTypes.OutTask, funcDelegate, false);
-        }
-
-        // [SKContext DoSomething(SKContext context)] is not supported, use the async form instead.
-        // If you encounter scenarios that require to interact with the context synchronously, please let us know.
-        if (EqualMethods(instance, method, typeof(Func<SKContext, SKContext>), out _))
-        {
+        void ThrowForInvalidSignature() =>
             throw new KernelException(
                 KernelException.ErrorCodes.FunctionTypeNotSupported,
-                $"Function '{method.Name}' has an invalid signature 'Func<SKContext, SKContext>'. " +
-                "Please use 'Func<SKContext, Task<SKContext>>' instead.");
-        }
+                $"Function '{method.Name}' has an invalid signature not supported by the kernel.");
 
-        throw new KernelException(
-            KernelException.ErrorCodes.FunctionTypeNotSupported,
-            $"Function '{method.Name}' has an invalid signature not supported by the kernel.");
-    }
-
-    /// <summary>
-    /// Compare a method against the given signature type using Delegate.CreateDelegate.
-    /// </summary>
-    /// <param name="instance">Optional object containing the given method</param>
-    /// <param name="userMethod">Method to inspect</param>
-    /// <param name="delegateDefinition">Definition of the delegate, i.e. method signature</param>
-    /// <param name="result">The delegate to use, if the function returns TRUE, otherwise NULL</param>
-    /// <returns>True if the method to inspect matches the delegate type</returns>
-    [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "Delegate.CreateDelegate can return NULL")]
-    private static bool EqualMethods(
-        object? instance,
-        MethodInfo userMethod,
-        Type delegateDefinition,
-        [NotNullWhen(true)] out Delegate? result)
-    {
-        // Instance methods
-        if (instance != null)
-        {
-            result = Delegate.CreateDelegate(delegateDefinition, instance, userMethod, false);
-            if (result != null) { return true; }
-        }
-
-        // Static methods
-        result = Delegate.CreateDelegate(delegateDefinition, userMethod, false);
-
-        return result != null;
-    }
-
-    // Internal event to count (and test) that the correct delegates are invoked
-    private static void TraceFunctionTypeCall(DelegateTypes type, ILogger log)
-    {
-        log.Log(
-            LogLevel.Trace,
-            new EventId((int)type, $"FuncType{type}"),
-            "Executing function type {0}: {1}", (int)type, type.ToString("G"));
+        static object ThrowIfNullResult(object? result) =>
+            result ??
+            throw new KernelException(
+                KernelException.ErrorCodes.FunctionInvokeError,
+                "Function returned null unexpectedly.");
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/samples/dotnet/github-skills/GitHubSkill.cs
+++ b/samples/dotnet/github-skills/GitHubSkill.cs
@@ -59,6 +59,7 @@ public class GitHubSkill
     private readonly IKernel _kernel;
     private readonly WebFileDownloadSkill _downloadSkill;
     private readonly ILogger<GitHubSkill> _logger;
+    private static readonly char[] s_trimChars = new char[] { ' ', '/' };
 
     internal const string SummarizeCodeSnippetDefinition =
         @"BEGIN CONTENT TO SUMMARIZE:
@@ -123,7 +124,7 @@ BEGIN SUMMARY:
 
         try
         {
-            var repositoryUri = source.Trim(new char[] { ' ', '/' });
+            var repositoryUri = source.Trim(s_trimChars);
             var context1 = new SKContext(logger: context.Log);
             context1.Variables.Set(FilePathParamName, filePath);
             await this._downloadSkill.DownloadToFileAsync($"{repositoryUri}/archive/refs/heads/{repositoryBranch}.zip", context1);

--- a/samples/dotnet/kernel-syntax-examples/Example22_OpenApiSkill_AzureKeyVault.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example22_OpenApiSkill_AzureKeyVault.cs
@@ -10,6 +10,7 @@ using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Skills;
 using RepoUtils;
 
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
 // ReSharper disable once InconsistentNaming
 public static class Example22_OpenApiSkill_AzureKeyVault
 {


### PR DESCRIPTION
### Motivation and Context

Simplify native function invocation and prepare for additional functionality.

### Description

The current approach involves exactly matching the target method against a fixed set of known signatures.  I've revised it to instead be a little more dynamic, such that it instead just looks for valid parameters (e.g. currently up to one string and up to one SKContext) and valid return types (e.g. void, string, context, and tasks of each of those), and any combination of those is valid.  This not only allows the implementation to be simplified and supports combinations that someone could reasonably expect to be valid (e.g. Func(context, string) rather than just Func(string, context)), but it also sets it up to easily allow for additional features to be added, e.g. parameters that match by name against context variables such that any number of parameters could be supported, non-string arguments once those are allowed in context variables, etc.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

cc: @dluc, @shawncal 