### PR TITLE
Enable new C# code style checks + fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -135,8 +135,27 @@ dotnet_diagnostic.CA1860.severity = warning # Prefer comparing 'Count' to 0 rath
 dotnet_diagnostic.CA2000.severity = warning # Call System.IDisposable.Dispose on object before all references to it are out of scope
 dotnet_diagnostic.CA2201.severity = warning # Exception type System.Exception is not sufficiently specific
 
-dotnet_diagnostic.IDE0005.severity = warning # Remove unnecessary usings
+dotnet_diagnostic.IDE0001.severity = warning # Simplify name
+dotnet_diagnostic.IDE0005.severity = warning # Remove unnecessary using directives
+dotnet_diagnostic.IDE0009.severity = warning # Add this or Me qualification
+dotnet_diagnostic.IDE0011.severity = warning # Add braces
+dotnet_diagnostic.IDE0018.severity = warning # Inline variable declaration
+dotnet_diagnostic.IDE0032.severity = warning # Use auto-implemented property
+dotnet_diagnostic.IDE0034.severity = warning # Simplify 'default' expression
+dotnet_diagnostic.IDE0035.severity = warning # Remove unreachable code
+dotnet_diagnostic.IDE0040.severity = warning # Add accessibility modifiers
+dotnet_diagnostic.IDE0049.severity = warning # Use language keywords instead of framework type names for type references
+dotnet_diagnostic.IDE0050.severity = warning # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = warning # Remove unused private member
+dotnet_diagnostic.IDE0055.severity = warning # Formatting rule
+dotnet_diagnostic.IDE0060.severity = warning # Remove unused parameter
+dotnet_diagnostic.IDE0070.severity = warning # Use 'System.HashCode.Combine'
+dotnet_diagnostic.IDE0071.severity = warning # Simplify interpolation
+dotnet_diagnostic.IDE0073.severity = warning # Require file header
+dotnet_diagnostic.IDE0082.severity = warning # Convert typeof to nameof
+dotnet_diagnostic.IDE0090.severity = warning # Simplify new expression
 dotnet_diagnostic.IDE0130.severity = warning # Namespace does not match folder structure
+dotnet_diagnostic.IDE0161.severity = warning # Use file-scoped namespace
 
 # Suppressed diagnostics
 dotnet_diagnostic.CA1002.severity = none # Change 'List<string>' in '...' to use 'Collection<T>' ...
@@ -276,7 +295,7 @@ dotnet_naming_rule.async_methods_end_in_async.severity = error
 ###############################
 # C# Coding Conventions       #
 ###############################
-[*.cs]
+
 # var preferences
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = false:none
@@ -306,7 +325,7 @@ csharp_style_inlined_variable_declaration = true:suggestion
 ###############################
 # C# Formatting Rules         #
 ###############################
-[*.cs]
+
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
@@ -344,19 +363,6 @@ csharp_style_prefer_top_level_statements = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 
-##################
-# C# Style       #
-##################
-
-###############################
-# VB Coding Conventions       #
-###############################
-[*.vb]
-trim_trailing_whitespace = true
-tab_width = 4
-indent_size = 4
-# Modifier preferences
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
 
 ###############################
 # Java Coding Conventions     #

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
@@ -193,7 +193,7 @@ public static class GPT3Tokenizer
             return list;
         }
 
-        List<string> word = new List<string>(token.Length);
+        List<string> word = new(token.Length);
         foreach (char c in token)
         {
             word.Add(c.ToString());

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
 using System.Linq;
@@ -223,7 +223,7 @@ public class PineconeMemoryStoreTests
         // Arrange
         Embedding<float> embedding = new(new float[] { 0.1f, 0.2f });
 
-        List<(PineconeDocument, double)> queryResults = new List<(PineconeDocument, double)>
+        List<(PineconeDocument, double)> queryResults = new()
         {
             new(new()
             {

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
@@ -29,9 +29,9 @@ public class QdrantMemoryStoreTests
     private readonly string _description = "description";
     private readonly string _description2 = "description2";
     private readonly string _description3 = "description3";
-    private readonly Embedding<float> _embedding = new Embedding<float>(new float[] { 1, 1, 1 });
-    private readonly Embedding<float> _embedding2 = new Embedding<float>(new float[] { 2, 2, 2 });
-    private readonly Embedding<float> _embedding3 = new Embedding<float>(new float[] { 3, 3, 3 });
+    private readonly Embedding<float> _embedding = new(new float[] { 1, 1, 1 });
+    private readonly Embedding<float> _embedding2 = new(new float[] { 2, 2, 2 });
+    private readonly Embedding<float> _embedding3 = new(new float[] { 3, 3, 3 });
 
     [Fact]
     public void ConnectionCanBeInitialized()

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests2.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests2.cs
@@ -27,9 +27,9 @@ public class QdrantMemoryStoreTests2
     private readonly string _description = "description";
     private readonly string _description2 = "description2";
     private readonly string _description3 = "description3";
-    private readonly Embedding<float> _embedding = new Embedding<float>(new float[] { 1, 1, 1 });
-    private readonly Embedding<float> _embedding2 = new Embedding<float>(new float[] { 2, 2, 2 });
-    private readonly Embedding<float> _embedding3 = new Embedding<float>(new float[] { 3, 3, 3 });
+    private readonly Embedding<float> _embedding = new(new float[] { 1, 1, 1 });
+    private readonly Embedding<float> _embedding2 = new(new float[] { 2, 2, 2 });
+    private readonly Embedding<float> _embedding3 = new(new float[] { 3, 3, 3 });
 
     [Fact]
     public async Task GetAsyncCallsDoNotRequestVectorsUnlessSpecifiedAsync()

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests3.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests3.cs
@@ -21,7 +21,7 @@ public class QdrantMemoryStoreTests3
     private readonly string _id = "Id";
     private readonly string _text = "text";
     private readonly string _description = "description";
-    private readonly Embedding<float> _embedding = new Embedding<float>(new float[] { 1, 1, 1 });
+    private readonly Embedding<float> _embedding = new(new float[] { 1, 1, 1 });
 
     [Fact]
     public async Task GetNearestMatchesAsyncCallsDoNotReturnVectorsUnlessSpecifiedAsync()

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresMemoryStoreTests.cs
@@ -47,10 +47,10 @@ public class PostgresMemoryStoreTests : IDisposable
         {
             if (disposing)
             {
-                using NpgsqlConnection conn = new NpgsqlConnection(string.Format(CultureInfo.CurrentCulture, ConnectionString, "postgres"));
+                using NpgsqlConnection conn = new(string.Format(CultureInfo.CurrentCulture, ConnectionString, "postgres"));
                 conn.Open();
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-                using NpgsqlCommand command = new NpgsqlCommand($"DROP DATABASE IF EXISTS \"{this._databaseName}\"", conn);
+                using NpgsqlCommand command = new($"DROP DATABASE IF EXISTS \"{this._databaseName}\"", conn);
 #pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
                 command.ExecuteNonQuery();
             }
@@ -63,9 +63,9 @@ public class PostgresMemoryStoreTests : IDisposable
 
     private async Task TryCreateDatabaseAsync()
     {
-        using NpgsqlConnection conn = new NpgsqlConnection(string.Format(CultureInfo.CurrentCulture, ConnectionString, "postgres"));
+        using NpgsqlConnection conn = new(string.Format(CultureInfo.CurrentCulture, ConnectionString, "postgres"));
         await conn.OpenAsync();
-        using NpgsqlCommand checkCmd = new NpgsqlCommand("SELECT COUNT(*) FROM pg_database WHERE datname = @databaseName", conn);
+        using NpgsqlCommand checkCmd = new("SELECT COUNT(*) FROM pg_database WHERE datname = @databaseName", conn);
         checkCmd.Parameters.AddWithValue("@databaseName", this._databaseName);
 
         var count = (long?)await checkCmd.ExecuteScalarAsync();

--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/Embedding.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/Embedding.cs
@@ -66,8 +66,7 @@ public readonly struct Embedding<TEmbedding> : IEquatable<Embedding<TEmbedding>>
         // Create a local, protected copy if transferOwnership is false or if the vector is not an array.
         // If the vector is an array and transferOwnership is true, then we can use the array directly.
         this._vector =
-            transferOwnership && vector is TEmbedding[] array ? array :
-            vector.ToArray();
+            transferOwnership && vector is TEmbedding[] array ? array : vector.ToArray();
     }
 
     private static void ThrowNotSupportedEmbedding() =>
@@ -205,7 +204,7 @@ public static class Embedding
     /// <typeparam name="TEmbedding">The type to be checked.</typeparam>
     /// <returns>
     /// <see langword="true"/> if the type is supported; otherwise, <see langword="true"/>.
-    /// Currently only <see cref="Single"/> and <see cref="Double"/> are supported.
+    /// Currently only <see cref="float"/> and <see cref="double"/> are supported.
     /// </returns>
     public static bool IsSupported<TEmbedding>() => typeof(TEmbedding) == typeof(float) || typeof(TEmbedding) == typeof(double);
 
@@ -215,7 +214,7 @@ public static class Embedding
     /// <param name="type">The type to be checked.</param>
     /// <returns>
     /// <see langword="true"/> if the type is supported; otherwise, <see langword="true"/>.
-    /// Currently only <see cref="Single"/> and <see cref="Double"/> are supported.
+    /// Currently only <see cref="float"/> and <see cref="double"/> are supported.
     /// </returns>
     public static bool IsSupported(Type type) => type == typeof(float) || type == typeof(double);
 

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -165,9 +165,9 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal string DebuggerDisplay =>
-        this._variables.TryGetValue(MainKey, out string input) && !string.IsNullOrEmpty(input) ?
-            $"Variables = {this._variables.Count}, Input = {input}" :
-            $"Variables = {this._variables.Count}";
+        this._variables.TryGetValue(MainKey, out string input) && !string.IsNullOrEmpty(input)
+            ? $"Variables = {this._variables.Count}, Input = {input}"
+            : $"Variables = {this._variables.Count}";
 
     #region private ================================================================================
 
@@ -180,10 +180,10 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, string>>
     {
         private readonly ContextVariables _variables;
 
-        public TypeProxy(ContextVariables variables) => _variables = variables;
+        public TypeProxy(ContextVariables variables) => this._variables = variables;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _variables._variables.ToArray();
+        public KeyValuePair<string, string>[] Items => this._variables._variables.ToArray();
     }
 
     #endregion

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/FunctionView.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/FunctionView.cs
@@ -75,5 +75,5 @@ public sealed class FunctionView
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => $"{Name} ({Description})";
+    private string DebuggerDisplay => $"{this.Name} ({this.Description})";
 }

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/FunctionsView.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/FunctionsView.cs
@@ -111,5 +111,5 @@ public sealed class FunctionsView
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => $"Native = {NativeFunctions.Count}, Semantic = {SemanticFunctions.Count}";
+    private string DebuggerDisplay => $"Native = {this.NativeFunctions.Count}, Semantic = {this.SemanticFunctions.Count}";
 }

--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/ParameterView.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/ParameterView.cs
@@ -65,7 +65,7 @@ public sealed class ParameterView
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => string.IsNullOrEmpty(this.Description) ?
-        this.Name :
-        $"{this.Name} ({this.Description})";
+    private string DebuggerDisplay => string.IsNullOrEmpty(this.Description)
+        ? this.Name
+        : $"{this.Name} ({this.Description})";
 }

--- a/dotnet/src/SemanticKernel.UnitTests/AI/Embeddings/EmbeddingTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/Embeddings/EmbeddingTests.cs
@@ -126,8 +126,8 @@ public class EmbeddingTests
     public void ItTransfersOwnershipWhenRequested()
     {
         // Assert
-        Assert.False(ReferenceEquals(_vector, new Embedding<float>(_vector).Vector));
-        Assert.False(ReferenceEquals(_vector, new Embedding<float>(_vector, transferOwnership: false).Vector));
-        Assert.True(ReferenceEquals(_vector, new Embedding<float>(_vector, transferOwnership: true).Vector));
+        Assert.False(ReferenceEquals(this._vector, new Embedding<float>(this._vector).Vector));
+        Assert.False(ReferenceEquals(this._vector, new Embedding<float>(this._vector, transferOwnership: false).Vector));
+        Assert.True(ReferenceEquals(this._vector, new Embedding<float>(this._vector, transferOwnership: true).Vector));
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Memory/MemoryRecordTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Memory/MemoryRecordTests.cs
@@ -16,7 +16,7 @@ public class MemoryRecordTests
     private readonly string _description = "description";
     private readonly string _externalSourceName = "externalSourceName";
     private readonly string _additionalMetadata = "value";
-    private readonly Embedding<float> _embedding = new Embedding<float>(new float[] { 1, 2, 3 });
+    private readonly Embedding<float> _embedding = new(new float[] { 1, 2, 3 });
 
     [Fact]
     public void ItCanBeConstructedFromMetadataAndVector()

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
@@ -498,7 +498,7 @@ public sealed class SKFunctionTests2
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
-        static Task Test(string input)
+        static Task TestAsync(string input)
         {
             s_canary = s_expected;
             return Task.CompletedTask;
@@ -507,7 +507,7 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
@@ -523,7 +523,7 @@ public sealed class SKFunctionTests2
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
-        static Task Test(SKContext cx)
+        static Task TestAsync(SKContext cx)
         {
             s_canary = s_expected;
             cx["canary"] = s_expected;
@@ -534,7 +534,7 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
@@ -552,7 +552,7 @@ public sealed class SKFunctionTests2
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
-        static Task Test(string input, SKContext cx)
+        static Task TestAsync(string input, SKContext cx)
         {
             s_canary = s_expected;
             cx["canary"] = s_expected;
@@ -563,7 +563,7 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("input:");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 
@@ -581,7 +581,7 @@ public sealed class SKFunctionTests2
         // Arrange
         [SKFunction("Test")]
         [SKFunctionName("Test")]
-        static Task Test()
+        static Task TestAsync()
         {
             s_canary = s_expected;
             return Task.CompletedTask;
@@ -590,7 +590,7 @@ public sealed class SKFunctionTests2
         var context = this.MockContext("");
 
         // Act
-        var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
+        var function = SKFunction.FromNativeMethod(Method(TestAsync), log: this._log.Object);
         Assert.NotNull(function);
         SKContext result = await function.InvokeAsync(context);
 

--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/DivideOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/DivideOperation.cs
@@ -60,7 +60,7 @@ public static class DivideOperation
             if (Vector.IsHardwareAccelerated &&
                 x.Length >= Vector<float>.Count)
             {
-                Vector<float> divisorVec = new Vector<float>(divisor);
+                Vector<float> divisorVec = new(divisor);
                 float* pxOneVectorFromEnd = pxEnd - Vector<float>.Count;
                 do
                 {
@@ -87,7 +87,7 @@ public static class DivideOperation
             if (Vector.IsHardwareAccelerated &&
                 x.Length >= Vector<double>.Count)
             {
-                Vector<double> divisorVec = new Vector<double>(divisor);
+                Vector<double> divisorVec = new(divisor);
                 double* pxOneVectorFromEnd = pxEnd - Vector<double>.Count;
                 do
                 {

--- a/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/MultiplyOperation.cs
+++ b/dotnet/src/SemanticKernel/AI/Embeddings/VectorOperations/MultiplyOperation.cs
@@ -62,7 +62,7 @@ public static class MultiplyOperation
             if (Vector.IsHardwareAccelerated &&
                 x.Length >= Vector<float>.Count)
             {
-                Vector<float> multiplierVec = new Vector<float>(multiplier);
+                Vector<float> multiplierVec = new(multiplier);
                 float* pxOneVectorFromEnd = pxEnd - Vector<float>.Count;
                 do
                 {
@@ -89,7 +89,7 @@ public static class MultiplyOperation
             if (Vector.IsHardwareAccelerated &&
                 x.Length >= Vector<double>.Count)
             {
-                Vector<double> multiplierVec = new Vector<double>(multiplier);
+                Vector<double> multiplierVec = new(multiplier);
                 double* pxOneVectorFromEnd = pxEnd - Vector<double>.Count;
                 do
                 {

--- a/dotnet/src/SemanticKernel/CoreSkills/HttpSkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/HttpSkill.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SemanticKernel.CoreSkills;
     Justification = "Semantic Kernel operates on strings")]
 public class HttpSkill : IDisposable
 {
-    private static readonly HttpClientHandler s_httpClientHandler = new HttpClientHandler() { CheckCertificateRevocationList = true };
+    private static readonly HttpClientHandler s_httpClientHandler = new() { CheckCertificateRevocationList = true };
     private readonly HttpClient _client;
 
     /// <summary>

--- a/dotnet/src/SemanticKernel/SkillDefinition/IReadOnlySkillCollectionTypeProxy.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/IReadOnlySkillCollectionTypeProxy.cs
@@ -9,23 +9,24 @@ namespace Microsoft.SemanticKernel.SkillDefinition;
 /// <summary>
 /// Debugger type proxy for <see cref="SkillCollection"/> and <see cref="ReadOnlySkillCollection"/>.
 /// </summary>
+// ReSharper disable once InconsistentNaming
 internal sealed class IReadOnlySkillCollectionTypeProxy
 {
     private readonly IReadOnlySkillCollection _collection;
 
-    public IReadOnlySkillCollectionTypeProxy(IReadOnlySkillCollection collection) => _collection = collection;
+    public IReadOnlySkillCollectionTypeProxy(IReadOnlySkillCollection collection) => this._collection = collection;
 
     [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
     public SkillProxy[] Items
     {
         get
         {
-            var view = _collection.GetFunctionsView();
+            var view = this._collection.GetFunctionsView();
             return view.NativeFunctions
-                       .Concat(view.SemanticFunctions)
-                       .GroupBy(f => f.Key)
-                       .Select(g => new SkillProxy(g.SelectMany(f => f.Value)) { Name = g.Key })
-                       .ToArray();
+                .Concat(view.SemanticFunctions)
+                .GroupBy(f => f.Key)
+                .Select(g => new SkillProxy(g.SelectMany(f => f.Value)) { Name = g.Key })
+                .ToArray();
         }
     }
 

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -553,7 +553,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
         if (!result.HasSkFunctionAttribute || skFunctionAttribute == null)
         {
-            log?.LogTrace("Method '{0}' doesn't have '{1}' attribute", result.Name, typeof(SKFunctionAttribute).Name);
+            log?.LogTrace("Method '{0}' doesn't have '{1}' attribute", result.Name, nameof(SKFunctionAttribute));
             if (skAttributesRequired) { return result; }
         }
         else
@@ -596,7 +596,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
         else if (skMainParam != null)
         {
             // The developer used [SKFunctionInput] on a function that doesn't support a string input
-            var message = $"The method '{result.Name}' doesn't have a string parameter, do not use '{typeof(SKFunctionInputAttribute).Name}' attribute.";
+            var message = $"The method '{result.Name}' doesn't have a string parameter, do not use '{nameof(SKFunctionInputAttribute)}' attribute.";
             throw new KernelException(KernelException.ErrorCodes.InvalidFunctionDescription, message);
         }
 
@@ -766,7 +766,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => $"{Name} ({Description})";
+    private string DebuggerDisplay => $"{this.Name} ({this.Description})";
 
     #endregion
 }

--- a/dotnet/src/Skills/Skills.Document/OpenXml/Extensions/WordprocessingDocumentEx.cs
+++ b/dotnet/src/Skills/Skills.Document/OpenXml/Extensions/WordprocessingDocumentEx.cs
@@ -25,7 +25,7 @@ internal static class WordprocessingDocumentEx
 
     internal static string ReadText(this WordprocessingDocument wordprocessingDocument)
     {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new();
 
         var mainPart = wordprocessingDocument.MainDocumentPart;
         if (mainPart is null)

--- a/dotnet/src/Skills/Skills.Grpc/GrpcOperationRunner.cs
+++ b/dotnet/src/Skills/Skills.Grpc/GrpcOperationRunner.cs
@@ -104,9 +104,7 @@ internal class GrpcOperationRunner
     /// <returns>The channel address.</returns>
     private string GetAddress(GrpcOperation operation, IDictionary<string, string> arguments)
     {
-        string? address = null;
-
-        if (!arguments.TryGetValue(GrpcOperation.AddressArgumentName, out address))
+        if (!arguments.TryGetValue(GrpcOperation.AddressArgumentName, out string? address))
         {
             address = operation.Address;
         }

--- a/dotnet/src/Skills/Skills.MsGraph/CloudDriveSkill.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/CloudDriveSkill.cs
@@ -47,7 +47,7 @@ public class CloudDriveSkill
         this._logger.LogDebug("Getting file content for '{0}'", filePath);
         Stream fileContentStream = await this._connector.GetFileContentStreamAsync(filePath, context.CancellationToken).ConfigureAwait(false);
 
-        using StreamReader sr = new StreamReader(fileContentStream);
+        using StreamReader sr = new(fileContentStream);
         string content = await sr.ReadToEndAsync().ConfigureAwait(false);
         this._logger.LogDebug("File content: {0}", content);
         return content;

--- a/dotnet/src/Skills/Skills.OpenAPI/RestApiOperationRunner.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/RestApiOperationRunner.cs
@@ -190,7 +190,7 @@ internal sealed class RestApiOperationRunner
     /// List of payload builders/factories.
     /// </summary>
     private static readonly Dictionary<string, Func<IDictionary<string, string>, HttpContent>> s_payloadFactoryByMediaType =
-        new Dictionary<string, Func<IDictionary<string, string>, HttpContent>>()
+        new()
         {
             { MediaTypeApplicationJson, BuildAppJsonPayload },
             { MediaTypeTextPlain, BuildPlainTextPayload }

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/CloudDriveSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/CloudDriveSkillTests.cs
@@ -34,12 +34,12 @@ public class CloudDriveSkillTests : IDisposable
         // Arrange
         string anyFilePath = Guid.NewGuid().ToString();
 
-        Mock<ICloudDriveConnector> connectorMock = new Mock<ICloudDriveConnector>();
+        Mock<ICloudDriveConnector> connectorMock = new();
         connectorMock.Setup(c => c.UploadSmallFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         this._context.Variables.Set(Parameters.DestinationPath, Guid.NewGuid().ToString());
-        CloudDriveSkill target = new CloudDriveSkill(connectorMock.Object);
+        CloudDriveSkill target = new(connectorMock.Object);
 
         // Act
         await target.UploadFileAsync(anyFilePath, this._context);
@@ -55,11 +55,11 @@ public class CloudDriveSkillTests : IDisposable
         string anyFilePath = Guid.NewGuid().ToString();
         string anyLink = Guid.NewGuid().ToString();
 
-        Mock<ICloudDriveConnector> connectorMock = new Mock<ICloudDriveConnector>();
+        Mock<ICloudDriveConnector> connectorMock = new();
         connectorMock.Setup(c => c.CreateShareLinkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(anyLink);
 
-        CloudDriveSkill target = new CloudDriveSkill(connectorMock.Object);
+        CloudDriveSkill target = new(connectorMock.Object);
 
         // Act
         string actual = await target.CreateLinkAsync(anyFilePath, this._context);
@@ -74,14 +74,14 @@ public class CloudDriveSkillTests : IDisposable
     {
         string anyFilePath = Guid.NewGuid().ToString();
         string expectedContent = Guid.NewGuid().ToString();
-        using MemoryStream expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(expectedContent));
+        using MemoryStream expectedStream = new(Encoding.UTF8.GetBytes(expectedContent));
 
         // Arrange
-        Mock<ICloudDriveConnector> connectorMock = new Mock<ICloudDriveConnector>();
+        Mock<ICloudDriveConnector> connectorMock = new();
         connectorMock.Setup(c => c.GetFileContentStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStream);
 
-        CloudDriveSkill target = new CloudDriveSkill(connectorMock.Object);
+        CloudDriveSkill target = new(connectorMock.Object);
 
         // Act
         string actual = await target.GetFileContentAsync(anyFilePath, this._context);

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/EmailSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/EmailSkillTests.cs
@@ -13,7 +13,7 @@ namespace SemanticKernel.Skills.UnitTests.MsGraph;
 
 public class EmailSkillTests
 {
-    private readonly SKContext _context = new SKContext();
+    private readonly SKContext _context = new();
 
     [Fact]
     public async Task SendEmailAsyncSucceedsAsync()

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/OrganizationHierarchySkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/OrganizationHierarchySkillTests.cs
@@ -30,9 +30,9 @@ public class OrganizationHierarchySkillTests : IDisposable
     {
         // Arrange
         string[] anyDirectReportsEmail = { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() };
-        Mock<IOrganizationHierarchyConnector> connectorMock = new Mock<IOrganizationHierarchyConnector>();
+        Mock<IOrganizationHierarchyConnector> connectorMock = new();
         connectorMock.Setup(c => c.GetDirectReportsEmailAsync(It.IsAny<CancellationToken>())).ReturnsAsync(anyDirectReportsEmail);
-        OrganizationHierarchySkill target = new OrganizationHierarchySkill(connectorMock.Object);
+        OrganizationHierarchySkill target = new(connectorMock.Object);
 
         // Act
         IEnumerable<string> actual = await target.GetMyDirectReportsEmailAsync(this._context);
@@ -52,9 +52,9 @@ public class OrganizationHierarchySkillTests : IDisposable
     {
         // Arrange
         string anyManagerEmail = Guid.NewGuid().ToString();
-        Mock<IOrganizationHierarchyConnector> connectorMock = new Mock<IOrganizationHierarchyConnector>();
+        Mock<IOrganizationHierarchyConnector> connectorMock = new();
         connectorMock.Setup(c => c.GetManagerEmailAsync(It.IsAny<CancellationToken>())).ReturnsAsync(anyManagerEmail);
-        OrganizationHierarchySkill target = new OrganizationHierarchySkill(connectorMock.Object);
+        OrganizationHierarchySkill target = new(connectorMock.Object);
 
         // Act
         string actual = await target.GetMyManagerEmailAsync(this._context);
@@ -69,9 +69,9 @@ public class OrganizationHierarchySkillTests : IDisposable
     {
         // Arrange
         string anyManagerName = Guid.NewGuid().ToString();
-        Mock<IOrganizationHierarchyConnector> connectorMock = new Mock<IOrganizationHierarchyConnector>();
+        Mock<IOrganizationHierarchyConnector> connectorMock = new();
         connectorMock.Setup(c => c.GetManagerNameAsync(It.IsAny<CancellationToken>())).ReturnsAsync(anyManagerName);
-        OrganizationHierarchySkill target = new OrganizationHierarchySkill(connectorMock.Object);
+        OrganizationHierarchySkill target = new(connectorMock.Object);
 
         // Act
         string actual = await target.GetMyManagerNameAsync(this._context);

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/TaskListSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/TaskListSkillTests.cs
@@ -14,13 +14,13 @@ namespace SemanticKernel.Skills.UnitTests.MsGraph;
 
 public class TaskListSkillTests
 {
-    private readonly SKContext _context = new SKContext();
+    private readonly SKContext _context = new();
 
-    private readonly TaskManagementTaskList _anyTaskList = new TaskManagementTaskList(
+    private readonly TaskManagementTaskList _anyTaskList = new(
         id: Guid.NewGuid().ToString(),
         name: Guid.NewGuid().ToString());
 
-    private readonly TaskManagementTask _anyTask = new TaskManagementTask(
+    private readonly TaskManagementTask _anyTask = new(
         id: Guid.NewGuid().ToString(),
         title: Guid.NewGuid().ToString(),
         reminder: (DateTimeOffset.Now + TimeSpan.FromDays(1)).ToString("o"),
@@ -33,14 +33,14 @@ public class TaskListSkillTests
         // Arrange
         string anyTitle = Guid.NewGuid().ToString();
 
-        Mock<ITaskManagementConnector> connectorMock = new Mock<ITaskManagementConnector>();
+        Mock<ITaskManagementConnector> connectorMock = new();
         connectorMock.Setup(c => c.GetDefaultTaskListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(this._anyTaskList);
 
         connectorMock.Setup(c => c.AddTaskAsync(It.IsAny<string>(), It.IsAny<TaskManagementTask>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(this._anyTask);
 
-        TaskListSkill target = new TaskListSkill(connectorMock.Object);
+        TaskListSkill target = new(connectorMock.Object);
 
         // Verify no reminder is set
         Assert.False(this._context.Variables.Get(Parameters.Reminder, out _));
@@ -59,7 +59,7 @@ public class TaskListSkillTests
         // Arrange
         string anyTitle = Guid.NewGuid().ToString();
 
-        Mock<ITaskManagementConnector> connectorMock = new Mock<ITaskManagementConnector>();
+        Mock<ITaskManagementConnector> connectorMock = new();
         connectorMock.Setup(c => c.GetDefaultTaskListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(this._anyTaskList);
 
@@ -68,7 +68,7 @@ public class TaskListSkillTests
 
         string anyReminder = (DateTimeOffset.Now + TimeSpan.FromHours(1)).ToString("o");
 
-        TaskListSkill target = new TaskListSkill(connectorMock.Object);
+        TaskListSkill target = new(connectorMock.Object);
         this._context.Variables.Set(Parameters.Reminder, anyReminder);
 
         // Act
@@ -85,7 +85,7 @@ public class TaskListSkillTests
         // Arrange
         string anyTitle = Guid.NewGuid().ToString();
 
-        Mock<ITaskManagementConnector> connectorMock = new Mock<ITaskManagementConnector>();
+        Mock<ITaskManagementConnector> connectorMock = new();
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
         connectorMock.Setup(c => c.GetDefaultTaskListAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync((TaskManagementTaskList)null);
@@ -93,7 +93,7 @@ public class TaskListSkillTests
 
         string anyReminder = (DateTimeOffset.Now + TimeSpan.FromHours(1)).ToString("o");
 
-        TaskListSkill target = new TaskListSkill(connectorMock.Object);
+        TaskListSkill target = new(connectorMock.Object);
         this._context.Variables.Set(Parameters.Reminder, anyReminder);
 
         // Act
@@ -115,7 +115,7 @@ public class TaskListSkillTests
     public void GetNextDayOfWeekIsCorrect(DayOfWeek dayOfWeek)
     {
         // Arrange
-        DateTimeOffset today = new DateTimeOffset(DateTime.Today);
+        DateTimeOffset today = new(DateTime.Today);
         TimeSpan timeOfDay = TimeSpan.FromHours(13);
 
         // Act

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/JsonPathSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/JsonPathSkillTests.cs
@@ -47,9 +47,9 @@ public class JsonPathSkillTests
     {
         var target = new JsonPathSkill();
 
-        ContextVariables variables = new ContextVariables(Json);
+        ContextVariables variables = new(Json);
         variables[JsonPathSkill.Parameters.JsonPath] = jsonPath;
-        SKContext context = new SKContext(variables);
+        SKContext context = new(variables);
 
         string actual = target.GetJsonElementValue(Json, context);
 
@@ -64,9 +64,9 @@ public class JsonPathSkillTests
     {
         var target = new JsonPathSkill();
 
-        ContextVariables variables = new ContextVariables(Json);
+        ContextVariables variables = new(Json);
         variables[JsonPathSkill.Parameters.JsonPath] = jsonPath;
-        SKContext context = new SKContext(variables);
+        SKContext context = new(variables);
 
         string actual = target.GetJsonElements(Json, context);
 

--- a/samples/apps/copilot-chat-app/importdocument/Program.cs
+++ b/samples/apps/copilot-chat-app/importdocument/Program.cs
@@ -108,7 +108,7 @@ public static class Program
         };
         if (chatCollectionId != Guid.Empty)
         {
-            Console.WriteLine($"Uploading and parsing file to chat {chatCollectionId.ToString()}...");
+            Console.WriteLine($"Uploading and parsing file to chat {chatCollectionId}...");
             var userId = await AcquireUserIdAsync(config);
 
             if (userId != null)

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -57,7 +57,7 @@ internal static class SemanticKernelExtensions
             .AddEmbeddingBackend(serviceProvider.GetRequiredService<IOptions<AIServiceOptions>>().Value));
 
         // Register skills
-        services.AddScoped<RegisterSkillsWithKernel>(sp => RegisterSkills);
+        services.AddScoped<RegisterSkillsWithKernel>(sp => RegisterSkillsAsync);
 
         return services;
     }
@@ -65,7 +65,7 @@ internal static class SemanticKernelExtensions
     /// <summary>
     /// Register the skills with the kernel.
     /// </summary>
-    private static Task RegisterSkills(IServiceProvider sp, IKernel kernel)
+    private static Task RegisterSkillsAsync(IServiceProvider sp, IKernel kernel)
     {
         // Copilot chat skills
         kernel.RegisterCopilotChatSkills(sp);
@@ -122,6 +122,7 @@ internal static class SemanticKernelExtensions
                     {
                         httpClient.DefaultRequestHeaders.Add("api-key", config.Qdrant.Key);
                     }
+
                     return new QdrantMemoryStore(new QdrantVectorDbClient(
                         config.Qdrant.Host, config.Qdrant.VectorSize, port: config.Qdrant.Port, httpClient: httpClient, log: sp.GetRequiredService<ILogger<IQdrantVectorDbClient>>()));
                 });

--- a/samples/dotnet/kernel-syntax-examples/Example19_Qdrant.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example19_Qdrant.cs
@@ -16,7 +16,7 @@ public static class Example19_Qdrant
     public static async Task RunAsync()
     {
         int qdrantPort = int.Parse(Env.Var("QDRANT_PORT"), CultureInfo.InvariantCulture);
-        QdrantMemoryStore memoryStore = new QdrantMemoryStore(Env.Var("QDRANT_ENDPOINT"), qdrantPort, vectorSize: 1536, ConsoleLogger.Log);
+        QdrantMemoryStore memoryStore = new(Env.Var("QDRANT_ENDPOINT"), qdrantPort, vectorSize: 1536, ConsoleLogger.Log);
         IKernel kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
             .Configure(c =>

--- a/samples/dotnet/kernel-syntax-examples/Example21_ChatGPTPlugins.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example21_ChatGPTPlugins.cs
@@ -18,7 +18,7 @@ public static class Example21_ChatGptPlugins
     private static async Task RunChatGptPluginAsync()
     {
         var kernel = new KernelBuilder().WithLogger(ConsoleLogger.Log).Build();
-        using HttpClient importHttpClient = new HttpClient();
+        using HttpClient importHttpClient = new();
         importHttpClient.DefaultRequestHeaders.Add("User-Agent", "Microsoft-Semantic-Kernel");
 
         //Import a ChatGPT plugin using one of the following Kernel extension methods

--- a/samples/dotnet/kernel-syntax-examples/Example24_OpenApiSkill_Jira.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example24_OpenApiSkill_Jira.cs
@@ -35,7 +35,7 @@ public static class Example24_OpenApiSkill_Jira
             return Task.FromResult(s);
         });
 
-        using HttpClient httpClient = new HttpClient();
+        using HttpClient httpClient = new();
 
         // The bool useLocalFile can be used to toggle the ingestion method for the openapi schema between a file path and a URL
         bool useLocalFile = true;

--- a/samples/dotnet/kernel-syntax-examples/Example38_Pinecone.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example38_Pinecone.cs
@@ -48,7 +48,7 @@ public static class Example38_Pinecone
 
         Console.WriteLine("== Adding Memories ==");
 
-        Dictionary<string, object> metadata = new Dictionary<string, object>()
+        Dictionary<string, object> metadata = new()
         {
             { "type", "text" },
             { "tags", new List<string>() { "memory", "cats" } }


### PR DESCRIPTION
1. Fix missing `this.` and `Async` suffix
2. Fix some indentation, spacing, etc.
3. Enable these rules and format accordingly:

IDE0001: Simplify name
IDE0005: Remove unnecessary using directives
IDE0009: Add this or Me qualification
IDE0011: Add braces
IDE0018: Inline variable declaration
IDE0032: Use auto-implemented property
IDE0034: Simplify 'default' expression
IDE0035: Remove unreachable code
IDE0040: Add accessibility modifiers
IDE0049: Use language keywords instead of framework type names for type references
IDE0050: Convert anonymous type to tuple
IDE0051: Remove unused private member
IDE0055: Formatting rule
IDE0060: Remove unused parameter
IDE0070: Use 'System.HashCode.Combine'
IDE0071: Simplify interpolation
IDE0073: Require file header
IDE0082: Convert typeof to nameof
IDE0090: Simplify new expression
IDE0161: Use file-scoped namespace