### PR TITLE
CopilotChat: Low-level memory optimizations when uploading bot

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
@@ -24,6 +24,7 @@ namespace SemanticKernel.Service.CopilotChat.Controllers;
 public class BotController : ControllerBase
 {
     private readonly ILogger<BotController> _logger;
+    private readonly IMemoryStore? _memoryStore;
     private readonly ISemanticTextMemory _semanticMemory;
     private readonly ChatSessionRepository _chatRepository;
     private readonly ChatMessageRepository _chatMessageRepository;
@@ -34,7 +35,7 @@ public class BotController : ControllerBase
     /// <summary>
     /// The constructor of BotController.
     /// </summary>
-    /// <param name="memoryStore">The memory store (optional).</param>
+    /// <param name="optionalIMemoryStore">Optional memory store.</param>
     /// <param name="chatRepository">The chat session repository.</param>
     /// <param name="chatMessageRepository">The chat message repository.</param>
     /// <param name="aiServiceOptions">The AI service options where we need the embedding settings from.</param>
@@ -42,6 +43,7 @@ public class BotController : ControllerBase
     /// <param name="documentMemoryOptions">The document memory options.</param>
     /// <param name="logger">The logger.</param>
     public BotController(
+        OptionalIMemoryStore optionalIMemoryStore,
         ISemanticTextMemory semanticMemory,
         ChatSessionRepository chatRepository,
         ChatMessageRepository chatMessageRepository,
@@ -50,6 +52,7 @@ public class BotController : ControllerBase
         IOptions<DocumentMemoryOptions> documentMemoryOptions,
         ILogger<BotController> logger)
     {
+        this._memoryStore = optionalIMemoryStore.MemoryStore;
         this._logger = logger;
         this._semanticMemory = semanticMemory;
         this._chatRepository = chatRepository;
@@ -290,11 +293,30 @@ public class BotController : ControllerBase
                 {
                     var newCollectionName = collection.Key.Replace(oldChatId, chatId, StringComparison.OrdinalIgnoreCase);
 
-                    await this._semanticMemory.SaveInformationAsync(
-                        collection: newCollectionName,
-                        text: record.Metadata.Text,
-                        id: record.Metadata.Id,
-                        cancellationToken: cancellationToken);
+                    if (this._memoryStore == null)
+                    {
+                        await this._semanticMemory.SaveInformationAsync(
+                            collection: newCollectionName,
+                            text: record.Metadata.Text,
+                            id: record.Metadata.Id,
+                            cancellationToken: cancellationToken);
+                    }
+                    else
+                    {
+                        MemoryRecord data = MemoryRecord.LocalRecord(
+                            id: record.Metadata.Id,
+                            text: record.Metadata.Text,
+                            embedding: record.Embedding.Value,
+                            description: null,
+                            additionalMetadata: null);
+
+                        if (!(await this._memoryStore.DoesCollectionExistAsync(newCollectionName, default)))
+                        {
+                            await this._memoryStore.CreateCollectionAsync(newCollectionName, default);
+                        }
+
+                        await this._memoryStore.UpsertAsync(newCollectionName, data, default);
+                    }
                 }
             }
         }

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
@@ -35,7 +35,12 @@ public class BotController : ControllerBase
     /// <summary>
     /// The constructor of BotController.
     /// </summary>
-    /// <param name="optionalIMemoryStore">Optional memory store.</param>
+    /// <param name="optionalIMemoryStore">Optional memory store.
+    ///     High level semantic memory implementations, such as Azure Cognitive Search, do not allow for providing embeddings when storing memories.
+    ///     We wrap the memory store in an optional memory store to allow controllers to pass dependency injection validation and potentially optimize
+    ///     for a lower-level memory implementation (e.g. Qdrant). Lower level memory implementations (i.e., IMemoryStore) allow for reusing embeddings,
+    ///     whereas high level memory implementation (i.e., ISemanticTextMemory) assume embeddings get recalculated on every write.
+    /// </param>
     /// <param name="chatRepository">The chat session repository.</param>
     /// <param name="chatMessageRepository">The chat message repository.</param>
     /// <param name="aiServiceOptions">The AI service options where we need the embedding settings from.</param>

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Storage/OptionalIMemoryStore.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Storage/OptionalIMemoryStore.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Memory;
+
+namespace SemanticKernel.Service.CopilotChat.Storage;
+
+/// <summary>
+/// Wrapper around IMemoryStore to allow for null values.
+/// </summary>
+public sealed class OptionalIMemoryStore
+{
+    /// <summary>
+    /// Optional memory store.
+    /// </summary>
+    public IMemoryStore? MemoryStore { get; set; }
+}


### PR DESCRIPTION
### Motivation and Context
High level semantic memory implementations, such as Azure Cognitive Search, do not allow for providing embeddings when storing memories. We wrap the memory store in an optional memory store to allow controllers to pass dependency injection validation and potentially optimize for a lower-level memory implementation (e.g. Qdrant). Lower level memory implementations (i.e., IMemoryStore) allow for reusing embeddings, whereas high level memory implementation (i.e., ISemanticTextMemory) assume embeddings get recalculated on every write.

### Description
- Implemented OptionalIMemoryStore to allow for BotController to pass DI validation and decide on using IMemoryStore or ISemanticTextMemory when uploading a bot.