### PR TITLE
make seech service extend base service and use the auth helper

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
@@ -79,7 +79,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         async function initSpeechRecognizer() {
             const speechService = new SpeechService(process.env.REACT_APP_BACKEND_URI as string);
 
-            var response = await speechService.validSpeechKeyAsync(await AuthHelper.getSKaaSAccessToken(instance, inProgress));
+            var response = await speechService.validateSpeechKeyAsync(await AuthHelper.getSKaaSAccessToken(instance, inProgress));
             if (response.isSuccess) {
                 const recognizer = await speechService.getSpeechRecognizerAsyncWithValidKey(response);
                 setRecognizer(recognizer);

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
@@ -78,8 +78,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
     React.useEffect(() => {
         async function initSpeechRecognizer() {
             const speechService = new SpeechService(process.env.REACT_APP_BACKEND_URI as string);
-
-            var response = await speechService.validateSpeechKeyAsync(await AuthHelper.getSKaaSAccessToken(instance, inProgress));
+            var response = await speechService.getSpeechTokenAsync(await AuthHelper.getSKaaSAccessToken(instance, inProgress));
             if (response.isSuccess) {
                 const recognizer = await speechService.getSpeechRecognizerAsyncWithValidKey(response);
                 setRecognizer(recognizer);

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatInput.tsx
@@ -79,7 +79,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         async function initSpeechRecognizer() {
             const speechService = new SpeechService(process.env.REACT_APP_BACKEND_URI as string);
 
-            var response = await speechService.validSpeechKeyAsync();
+            var response = await speechService.validSpeechKeyAsync(await AuthHelper.getSKaaSAccessToken(instance, inProgress));
             if (response.isSuccess) {
                 const recognizer = await speechService.getSpeechRecognizerAsyncWithValidKey(response);
                 setRecognizer(recognizer);
@@ -87,7 +87,7 @@ export const ChatInput: React.FC<ChatInputProps> = (props) => {
         }
 
         initSpeechRecognizer();
-    }, []);
+    }, [instance, inProgress]);
 
     const handleSpeech = () => {
         setIsListening(true);

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/SpeechService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/SpeechService.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import * as speechSdk from 'microsoft-cognitiveservices-speech-sdk';
+import { BaseService } from './BaseService';
 
 interface TokenResponse {
     token: string;
@@ -8,16 +9,9 @@ interface TokenResponse {
     isSuccess: boolean;
 }
 
-interface SpeechServiceRequest {
-    commandPath: string;
-    method?: string;
-}
-
-export class SpeechService {
-    constructor(private readonly serviceUrl: string) {}
-
-    validSpeechKeyAsync = async () => {
-        const response = await this.invokeTokenAsync();
+export class SpeechService extends BaseService {
+    validSpeechKeyAsync = async (accessToken: string) => {
+        const response = await this.invokeTokenAsync(accessToken);
         return response;
     };
 
@@ -32,8 +26,8 @@ export class SpeechService {
         return this.generateSpeechRecognizer(token, region);
     };
 
-    getSpeechRecognizerAsync = async () => {
-        const response = await this.invokeTokenAsync();
+    getSpeechRecognizerAsync = async (accessToken: string) => {
+        const response = await this.invokeTokenAsync(accessToken);
         return await this.getSpeechRecognizerAsyncWithValidKey(response);
     };
 
@@ -44,39 +38,15 @@ export class SpeechService {
         return new speechSdk.SpeechRecognizer(speechConfig, audioConfig);
     }
 
-    private invokeTokenAsync = async (): Promise<TokenResponse> => {
-        const result = await this.getAzureSpeechTokenAsync<TokenResponse>({
-            commandPath: `speechToken`,
-            method: 'GET',
-        });
+    private invokeTokenAsync = async (accessToken: string): Promise<TokenResponse> => {
+        const result = await this.getResponseAsync<TokenResponse>(
+            {
+                commandPath: `speechToken`,
+                method: 'GET',
+            },
+            accessToken,
+        );
+
         return result;
-    };
-
-    private readonly getAzureSpeechTokenAsync = async <TokenResponse>(
-        request: SpeechServiceRequest,
-    ): Promise<TokenResponse> => {
-        const { commandPath, method } = request;
-
-        try {
-            const requestUrl = new URL(commandPath, this.serviceUrl);
-            const response = await fetch(requestUrl, {
-                method: method ?? 'GET',
-                headers: { 'Content-Type': 'application/json' },
-            });
-
-            if (!response.ok) {
-                throw Object.assign(new Error(response.statusText + ' => ' + (await response.text())));
-            }
-
-            return (await response.json()) as TokenResponse;
-        } catch (e) {
-            var additional_error_msg = '';
-            if (e instanceof TypeError) {
-                // fetch() will reject with a TypeError when a network error is encountered.
-                additional_error_msg =
-                    '\n\nPlease check that your backend is running and that it is accessible by the app';
-            }
-            throw Object.assign(new Error(e + additional_error_msg));
-        }
     };
 }

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/SpeechService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/SpeechService.ts
@@ -10,7 +10,7 @@ interface TokenResponse {
 }
 
 export class SpeechService extends BaseService {
-    validSpeechKeyAsync = async (accessToken: string) => {
+    validateSpeechKeyAsync = async (accessToken: string) => {
         const response = await this.invokeTokenAsync(accessToken);
         return response;
     };

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/SpeechService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/SpeechService.ts
@@ -10,35 +10,7 @@ interface TokenResponse {
 }
 
 export class SpeechService extends BaseService {
-    validateSpeechKeyAsync = async (accessToken: string) => {
-        const response = await this.invokeTokenAsync(accessToken);
-        return response;
-    };
-
-    getSpeechRecognizerAsyncWithValidKey = async (response: TokenResponse) => {
-        const { token, region, isSuccess } = response;
-
-        if(!isSuccess)
-        {
-            return;
-        }
-
-        return this.generateSpeechRecognizer(token, region);
-    };
-
-    getSpeechRecognizerAsync = async (accessToken: string) => {
-        const response = await this.invokeTokenAsync(accessToken);
-        return await this.getSpeechRecognizerAsyncWithValidKey(response);
-    };
-
-    private generateSpeechRecognizer ( token: string, region: string) {
-        const speechConfig = speechSdk.SpeechConfig.fromAuthorizationToken(token, region);
-        speechConfig.speechRecognitionLanguage = 'en-US';
-        const audioConfig = speechSdk.AudioConfig.fromDefaultMicrophoneInput();
-        return new speechSdk.SpeechRecognizer(speechConfig, audioConfig);
-    }
-
-    private invokeTokenAsync = async (accessToken: string): Promise<TokenResponse> => {
+    getSpeechTokenAsync = async (accessToken: string): Promise<TokenResponse> => {
         const result = await this.getResponseAsync<TokenResponse>(
             {
                 commandPath: `speechToken`,
@@ -49,4 +21,21 @@ export class SpeechService extends BaseService {
 
         return result;
     };
+
+    getSpeechRecognizerAsyncWithValidKey = async (response: TokenResponse) => {
+        const { token, region, isSuccess } = response;
+        
+        if(isSuccess) {
+            return this.generateSpeechRecognizer(token, region);
+        }
+
+        return;
+    };
+
+    private generateSpeechRecognizer ( token: string, region: string) {
+        const speechConfig = speechSdk.SpeechConfig.fromAuthorizationToken(token, region);
+        speechConfig.speechRecognitionLanguage = 'en-US';
+        const audioConfig = speechSdk.AudioConfig.fromDefaultMicrophoneInput();
+        return new speechSdk.SpeechRecognizer(speechConfig, audioConfig);
+    }
 }


### PR DESCRIPTION
### Motivation and Context
Make SpeechService extend the BaseService class and use the AuthHelper class. This also fixes a bug where the speech service did not support the ApiKey auth.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
