### PR TITLE
Using BaseService as parent class for DocumentImportService

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/DocumentImportService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/DocumentImportService.ts
@@ -1,46 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+import { BaseService } from './BaseService';
 
-export class DocumentImportService {
-    constructor(private readonly serviceUrl: string) { }
-
-    importDocumentAsync = async (
-        userId: string,
-        chatId: string,
-        document: File,
-        accessToken: string,
-    ) => {
+export class DocumentImportService extends BaseService {
+    public importDocumentAsync = async (userId: string, chatId: string, document: File, accessToken: string) => {
         const formData = new FormData();
         formData.append('userId', userId);
         formData.append('chatId', chatId);
         formData.append('documentScope', 'Chat');
         formData.append('formFile', document);
-        
-        const commandPath = `importDocument`;
-        const requestUrl = new URL(commandPath, this.serviceUrl);
 
-        const headers = new Headers({
-            Authorization: `Bearer ${accessToken}`,
-        });
-
-        try {
-            const response = await fetch(requestUrl, {
+        return await this.getResponseAsync(
+            {
+                commandPath: 'importDocument',
                 method: 'POST',
                 body: formData,
-                headers: headers,
-            });
-
-            if (!response.ok) {
-                throw Object.assign(new Error(response.statusText + ' => ' + (await response.text())));
-            }
-        } catch (e) {
-            var additional_error_msg = '';
-            if (e instanceof TypeError) {
-                // fetch() will reject with a TypeError when a network error is encountered.
-                additional_error_msg =
-                    '\n\nPlease check that your backend is running and that it is accessible by the app';
-            }
-            throw Object.assign(new Error(e + additional_error_msg));
-        }
+            },
+            accessToken,
+        );
     };
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
DocumentImportService needs to extend BaseService to get all the auth / header handling implemented in the parent.