### PR TITLE
Having chatlist timestamp reflect time of last change

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -72,7 +72,7 @@ export const ChatList: FC = () => {
                             <ChatListItem
                                 id={id}
                                 header={convo.title}
-                                timestamp={messages[lastMessage].timestamp}
+                                timestamp={convo.lastUpdatedTimestamp ?? messages[lastMessage].timestamp}
                                 preview={
                                     messages.length > 0
                                         ? isPlan(messages[lastMessage].content)

--- a/samples/apps/copilot-chat-app/webapp/src/libs/useChat.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/useChat.ts
@@ -228,6 +228,7 @@ export const useChat = () => {
                     users: [loggedInUser],
                     messages: chatMessages,
                     botProfilePicture: getBotProfilePicture(Object.keys(conversations).length),
+                    lastUpdatedTimestamp: new Date().getTime(),
                 };
 
                 dispatch(addConversation(newChat));

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/ChatState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/ChatState.ts
@@ -9,4 +9,5 @@ export interface ChatState {
     users: IChatUser[];
     messages: IChatMessage[];
     botProfilePicture: string;
+    lastUpdatedTimestamp?: number;
 }

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { ChatMessageState, IChatMessage } from '../../../libs/models/ChatMessage';
 import { ChatState } from './ChatState';
 import { Conversations, ConversationsState, ConversationTitleChange, initialState } from './ConversationsState';
 
-export const conversationsSlice = createSlice({
+export const conversationsSlice: Slice<ConversationsState> = createSlice({
     name: 'conversations',
     initialState,
     reducers: {
@@ -16,6 +16,7 @@ export const conversationsSlice = createSlice({
             const id = action.payload.id;
             const newTitle = action.payload.newTitle;
             state.conversations[id].title = newTitle;
+            state.conversations[id].lastUpdatedTimestamp = new Date().getTime();
             frontLoadChat(state, id);
         },
         setSelectedConversation: (state: ConversationsState, action: PayloadAction<string>) => {
@@ -33,6 +34,7 @@ export const conversationsSlice = createSlice({
             const { message, chatId } = action.payload;
             const id = chatId ?? state.selectedId;
             state.conversations[id].messages.push(message);
+            state.conversations[id].lastUpdatedTimestamp = new Date().getTime();
             frontLoadChat(state, id);
         },
         updateMessageState: (


### PR DESCRIPTION
…tname, upload bot, etc.)

### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Having chatlist timestamp reflect time of last change affecting chat (i.e., time bot was uploaded, chat name change, etc.).

This value is computed in session only. If session is refreshed, chat list will be ordered timestamp of last message in each chat, with most recent message on top. 

![image](https://github.com/microsoft/semantic-kernel/assets/125500434/63477ce5-d77f-4c6f-af6c-9d5ad7c2fb8b)
Notice difference in timestamp of last message vs timestamp in chatlist (reflects time bot was uploaded)