### PR TITLE
Add settings retrieval through properties file and env vars

### DIFF
--- a/java/samples/example.conf.azure.properties
+++ b/java/samples/example.conf.azure.properties
@@ -1,2 +1,0 @@
-token: "Your Azure OpenAI Key"
-endpoint: "Azure OpenAI endpoint"

--- a/java/samples/example.conf.openai.properties
+++ b/java/samples/example.conf.openai.properties
@@ -1,1 +1,0 @@
-token: "Your OpenAI Key"

--- a/java/samples/example.conf.properties
+++ b/java/samples/example.conf.properties
@@ -1,0 +1,5 @@
+openai.key: "OPEN_AI_KEY"
+openai.organizationid: "OPEN_AI_ORGANIZATION_ID"
+azureopenai.key: "AZURE_OPEN_AI_KEY"
+azureopenai.endpoint: "AZURE_OPEN_AI_ENDPOINT"
+azureopenai.deploymentname: "AZURE_OPEN_AI_DEPLOYMENT_NAME"

--- a/java/samples/example.conf.properties
+++ b/java/samples/example.conf.properties
@@ -1,5 +1,6 @@
-openai.key: "OPEN_AI_KEY"
-openai.organizationid: "OPEN_AI_ORGANIZATION_ID"
-azureopenai.key: "AZURE_OPEN_AI_KEY"
-azureopenai.endpoint: "AZURE_OPEN_AI_ENDPOINT"
-azureopenai.deploymentname: "AZURE_OPEN_AI_DEPLOYMENT_NAME"
+client.openai.key: "OPEN_AI_KEY"
+client.openai.organizationid: "OPEN_AI_ORGANIZATION_ID"
+
+client.azureopenai.key: "AZURE_OPEN_AI_KEY"
+client.azureopenai.endpoint: "AZURE_OPEN_AI_ENDPOINT"
+client.azureopenai.deploymentname: "AZURE_OPEN_AI_DEPLOYMENT_NAME"

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
@@ -4,7 +4,9 @@ import com.azure.core.credential.AzureKeyCredential;
 import com.microsoft.openai.AzureOpenAIClient;
 import com.microsoft.openai.OpenAIAsyncClient;
 import com.microsoft.openai.OpenAIClientBuilder;
+import com.microsoft.semantickernel.util.AzureOpenAISettings;
 import com.microsoft.semantickernel.util.ClientSettings;
+import com.microsoft.semantickernel.util.OpenAISettings;
 
 import java.io.IOException;
 
@@ -16,7 +18,7 @@ public class Config {
         OPEN_AI {
             @Override
             public OpenAIAsyncClient getClient() throws IOException {
-                ClientSettings.OpenAISettings settings = ClientSettings.getOpenAISettingsFromFile(CONF_PROPERTIES);
+                OpenAISettings settings = ClientSettings.getOpenAISettingsFromFile(CONF_PROPERTIES);
 
                 return new OpenAIClientBuilder()
                         .setApiKey(settings.getKey())
@@ -27,7 +29,7 @@ public class Config {
             @Override
             public OpenAIAsyncClient getClient()
                  throws IOException {
-                    ClientSettings.AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+                    AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
 
                     return new AzureOpenAIClient(
                             new com.azure.ai.openai.OpenAIClientBuilder()

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
@@ -4,41 +4,13 @@ import com.azure.core.credential.AzureKeyCredential;
 import com.microsoft.openai.AzureOpenAIClient;
 import com.microsoft.openai.OpenAIAsyncClient;
 import com.microsoft.openai.OpenAIClientBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.microsoft.semantickernel.util.Settings;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Properties;
 
 public class Config {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Config.class);
-
-    public static final String OPEN_AI_CONF_PROPERTIES = "samples/java/semantickernel-samples/conf.openai.properties";
-    public static final String AZURE_CONF_PROPERTIES = "samples/java/semantickernel-samples/conf.azure.properties";
-
-
-    public static String getOpenAIKey(String conf) {
-        return getConfigValue(conf, "token");
-    }
-
-    public static String getAzureOpenAIEndpoint(String conf) {
-        return getConfigValue(conf, "endpoint");
-    }
-
-    private static String getConfigValue(String configFile, String propertyName) {
-        File config = new File(configFile);
-        try (FileInputStream fis = new FileInputStream(config.getAbsolutePath())) {
-            Properties props = new Properties();
-            props.load(fis);
-            return props.getProperty(propertyName);
-        } catch (IOException e) {
-            LOGGER.error("Unable to load config value " + propertyName + " from file" + configFile, e);
-            throw new RuntimeException(configFile + " not configured properly");
-        }
-    }
+    public static final String CONF_PROPERTIES = "samples/java/semantickernel-samples/conf.properties";
 
     /**
      * Returns the client that will handle AzureOpenAI or OpenAI requests.
@@ -46,17 +18,20 @@ public class Config {
      * @param useAzureOpenAI whether to use AzureOpenAI or OpenAI.
      * @return client to be used by the kernel.
      */
-    public static OpenAIAsyncClient getClient(boolean useAzureOpenAI) {
+    public static OpenAIAsyncClient getClient(boolean useAzureOpenAI) throws IOException {
         if (useAzureOpenAI) {
+            Settings.AzureOpenAISettings settings = Settings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+
             return new AzureOpenAIClient(
                     new com.azure.ai.openai.OpenAIClientBuilder()
-                            .endpoint(Config.getAzureOpenAIEndpoint(AZURE_CONF_PROPERTIES))
-                            .credential(new AzureKeyCredential(Config.getOpenAIKey(AZURE_CONF_PROPERTIES)))
+                            .endpoint(settings.getEndpoint())
+                            .credential(new AzureKeyCredential(settings.getKey()))
                             .buildAsyncClient());
         }
 
+        Settings.OpenAISettings settings = Settings.getOpenAISettingsFromFile(CONF_PROPERTIES);
         return new OpenAIClientBuilder()
-                .setApiKey(Config.getOpenAIKey(OPEN_AI_CONF_PROPERTIES))
+                .setApiKey(settings.getKey())
                 .build();
     }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
@@ -1,11 +1,10 @@
 package com.microsoft.semantickernel;
 
 import com.azure.core.credential.AzureKeyCredential;
-import com.azure.core.credential.TokenCredential;
 import com.microsoft.openai.AzureOpenAIClient;
 import com.microsoft.openai.OpenAIAsyncClient;
 import com.microsoft.openai.OpenAIClientBuilder;
-import com.microsoft.semantickernel.util.Settings;
+import com.microsoft.semantickernel.util.ClientSettings;
 
 import java.io.IOException;
 
@@ -17,7 +16,7 @@ public class Config {
         OPEN_AI {
             @Override
             public OpenAIAsyncClient getClient() throws IOException {
-                Settings.OpenAISettings settings = Settings.getOpenAISettingsFromFile(CONF_PROPERTIES);
+                ClientSettings.OpenAISettings settings = ClientSettings.getOpenAISettingsFromFile(CONF_PROPERTIES);
 
                 return new OpenAIClientBuilder()
                         .setApiKey(settings.getKey())
@@ -28,7 +27,7 @@ public class Config {
             @Override
             public OpenAIAsyncClient getClient()
                  throws IOException {
-                    Settings.AzureOpenAISettings settings = Settings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+                    ClientSettings.AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
 
                     return new AzureOpenAIClient(
                             new com.azure.ai.openai.OpenAIClientBuilder()

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 public class Config {
 
-    public static final String CONF_PROPERTIES = "samples/java/semantickernel-samples/conf.properties";
+    public static final String CONF_PROPERTIES = "java/samples/conf.properties";
 
     /**
      * Returns the client that will handle AzureOpenAI or OpenAI requests.

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Config.java
@@ -5,7 +5,7 @@ import com.microsoft.openai.AzureOpenAIClient;
 import com.microsoft.openai.OpenAIAsyncClient;
 import com.microsoft.openai.OpenAIClientBuilder;
 import com.microsoft.semantickernel.util.AzureOpenAISettings;
-import com.microsoft.semantickernel.util.ClientSettings;
+import com.microsoft.semantickernel.util.AIProviderSettings;
 import com.microsoft.semantickernel.util.OpenAISettings;
 
 import java.io.IOException;
@@ -18,7 +18,7 @@ public class Config {
         OPEN_AI {
             @Override
             public OpenAIAsyncClient getClient() throws IOException {
-                OpenAISettings settings = ClientSettings.getOpenAISettingsFromFile(CONF_PROPERTIES);
+                OpenAISettings settings = AIProviderSettings.getOpenAISettingsFromFile(CONF_PROPERTIES);
 
                 return new OpenAIClientBuilder()
                         .setApiKey(settings.getKey())
@@ -29,7 +29,7 @@ public class Config {
             @Override
             public OpenAIAsyncClient getClient()
                  throws IOException {
-                    AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+                    AzureOpenAISettings settings = AIProviderSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
 
                     return new AzureOpenAIClient(
                             new com.azure.ai.openai.OpenAIClientBuilder()

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example00_GettingStarted.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example00_GettingStarted.java
@@ -1,7 +1,6 @@
 package com.microsoft.semantickernel;
 
 import com.microsoft.openai.OpenAIAsyncClient;
-import com.microsoft.openai.OpenAIClientBuilder;
 import com.microsoft.semantickernel.builders.SKBuilders;
 import com.microsoft.semantickernel.extensions.KernelExtensions;
 import com.microsoft.semantickernel.skilldefinition.ReadOnlyFunctionCollection;
@@ -9,17 +8,17 @@ import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
+
 /**
  * Getting started
  *
- * First create a configuration file based on the examples files at the root of this module:
- *    conf.azure.properties if using Azure OpenAI
- *    conf.openai.properties if using OpenAI
+ * Create a conf.properties file based on the examples files at the root of this module.
  *
  * <a href="https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart">Get started with Azure OpenAI</a>
  * <a href="https://openai.com/product">Get started with OpenAI</a>
  */
-public class Example00GettingStarted {
+public class Example00_GettingStarted {
 
   /**
    * Returns a Semantic Kernel with Text Completion.
@@ -60,13 +59,13 @@ public class Example00GettingStarted {
     }
   }
 
-  public static void run (boolean useAzureOpenAI) {
+  public static void run (boolean useAzureOpenAI) throws IOException {
     OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
     Kernel kernel = getKernel(client);
     joke(kernel);
   }
 
-  public static void main (String args[]) {
+  public static void main (String args[]) throws IOException {
     // Send whether AzureOpenAI will be used. If false, OpenAI will be used.
     run(false);
   }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example00_GettingStarted.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example00_GettingStarted.java
@@ -59,14 +59,13 @@ public class Example00_GettingStarted {
     }
   }
 
-  public static void run (boolean useAzureOpenAI) throws IOException {
-    OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-    Kernel kernel = getKernel(client);
+  public static void run (Config.ClientType clientType) throws IOException {
+    Kernel kernel = getKernel(clientType.getClient());
     joke(kernel);
   }
 
   public static void main (String args[]) throws IOException {
-    // Send whether AzureOpenAI will be used. If false, OpenAI will be used.
-    run(false);
+    // Send one of Config.ClientType.OPEN_AI or Config.ClientType.AZURE_OPEN_AI
+    run(Config.ClientType.OPEN_AI);
   }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example02_RunnningPromptsFromFile.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example02_RunnningPromptsFromFile.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  *
  * The repository includes some examples under the <a href="https://github.com/microsoft/semantic-kernel/tree/main/samples">samples</a> folder.
  */
-public class Example02RunnningPromptsFromFile {
+public class Example02_RunnningPromptsFromFile {
 
   /**
    * Imports skill 'FunSkill' stored in the samples folder and then returns the semantic function 'Joke' within it.
@@ -30,9 +30,9 @@ public class Example02RunnningPromptsFromFile {
     return skill.getFunction("Joke", CompletionSKFunction.class);
   }
 
-  public static void run (boolean useAzureOpenAI) {
+  public static void run (boolean useAzureOpenAI) throws IOException {
     OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-    Kernel kernel = Example00GettingStarted.getKernel(client);
+    Kernel kernel = Example00_GettingStarted.getKernel(client);
     CompletionSKFunction jokeFunction = getJokeFunction(kernel);
 
     System.out.println(jokeFunction.invokeAsync("time travel to dinosaur age").block().getResult());

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example02_RunnningPromptsFromFile.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example02_RunnningPromptsFromFile.java
@@ -30,15 +30,15 @@ public class Example02_RunnningPromptsFromFile {
     return skill.getFunction("Joke", CompletionSKFunction.class);
   }
 
-  public static void run (boolean useAzureOpenAI) throws IOException {
-    OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-    Kernel kernel = Example00_GettingStarted.getKernel(client);
+  public static void run (Config.ClientType clientType) throws IOException {
+    Kernel kernel = Example00_GettingStarted.getKernel(clientType.getClient());
     CompletionSKFunction jokeFunction = getJokeFunction(kernel);
 
     System.out.println(jokeFunction.invokeAsync("time travel to dinosaur age").block().getResult());
   }
 
   public static void main (String args[]) throws IOException {
-    run(false);
+    // Send one of Config.ClientType.OPEN_AI or Config.ClientType.AZURE_OPEN_AI
+    run(Config.ClientType.OPEN_AI);
   }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example03_SemanticFunctionInline.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example03_SemanticFunctionInline.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 /**
  * Define a Semantic Function inline with Java code.
  */
-public class Example03SemanticFunctionInline {
+public class Example03_SemanticFunctionInline {
 
     /**
      * Defines and runs an inline Semantic Function
@@ -115,9 +115,9 @@ public class Example03SemanticFunctionInline {
         inlineFunction(kernel, propmt, "tldr", text);
     }
 
-    public static void run(boolean useAzureOpenAI) {
+    public static void run(boolean useAzureOpenAI) throws IOException {
         OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-        Kernel kernel = Example00GettingStarted.getKernel(client);
+        Kernel kernel = Example00_GettingStarted.getKernel(client);
 
         summarize(kernel);
         TLDR(kernel);

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example03_SemanticFunctionInline.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example03_SemanticFunctionInline.java
@@ -115,15 +115,15 @@ public class Example03_SemanticFunctionInline {
         inlineFunction(kernel, propmt, "tldr", text);
     }
 
-    public static void run(boolean useAzureOpenAI) throws IOException {
-        OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-        Kernel kernel = Example00_GettingStarted.getKernel(client);
+    public static void run (Config.ClientType clientType) throws IOException {
+        Kernel kernel = Example00_GettingStarted.getKernel(clientType.getClient());
 
         summarize(kernel);
         TLDR(kernel);
     }
 
     public static void main(String args[]) throws IOException {
-        run(false);
+        // Send one of Config.ClientType.OPEN_AI or Config.ClientType.AZURE_OPEN_AI
+        run(Config.ClientType.OPEN_AI);
     }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example04_ContextVariablesChat.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example04_ContextVariablesChat.java
@@ -99,16 +99,15 @@ public class Example04_ContextVariablesChat {
     };
   }
 
-  public static void run (boolean useAzureOpenAI)
-          throws ExecutionException, InterruptedException, TimeoutException, IOException {
-    OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-    Kernel kernel = Example00_GettingStarted.getKernel(client);
+    public static void run (Config.ClientType clientType) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        Kernel kernel = Example00_GettingStarted.getKernel(clientType.getClient());
 
     startChat(kernel);
   }
 
   public static void main (String[] args)
           throws ExecutionException, InterruptedException, TimeoutException, IOException {
-    run(false);
+      // Send one of Config.ClientType.OPEN_AI or Config.ClientType.AZURE_OPEN_AI
+      run(Config.ClientType.OPEN_AI);
   }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example04_ContextVariablesChat.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example04_ContextVariablesChat.java
@@ -6,6 +6,7 @@ import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -17,7 +18,7 @@ import java.util.function.Function;
  * Context Variables object which in this demo functions similarly as a key-value store that you can use when running the kernel.
  * The context is local (i.e. in your computer's RAM) and not persisted anywhere beyond the life of the JVM execution.
  */
-public class Example04ContextVariablesChat {
+public class Example04_ContextVariablesChat {
   public static void startChat (Kernel kernel)
       throws ExecutionException, InterruptedException, TimeoutException {
     String prompt ="""
@@ -99,15 +100,15 @@ public class Example04ContextVariablesChat {
   }
 
   public static void run (boolean useAzureOpenAI)
-      throws ExecutionException, InterruptedException, TimeoutException {
+          throws ExecutionException, InterruptedException, TimeoutException, IOException {
     OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-    Kernel kernel = Example00GettingStarted.getKernel(client);
+    Kernel kernel = Example00_GettingStarted.getKernel(client);
 
     startChat(kernel);
   }
 
   public static void main (String[] args)
-      throws ExecutionException, InterruptedException, TimeoutException {
+          throws ExecutionException, InterruptedException, TimeoutException, IOException {
     run(false);
   }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example05_UsingThePlanner.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example05_UsingThePlanner.java
@@ -4,7 +4,9 @@ import com.microsoft.openai.OpenAIAsyncClient;
 import com.microsoft.semantickernel.extensions.KernelExtensions;
 import com.microsoft.semantickernel.planner.sequentialplanner.SequentialPlanner;
 
-public class Example05UsingThePlanner {
+import java.io.IOException;
+
+public class Example05_UsingThePlanner {
 
     public static SequentialPlanner getPlanner(Kernel kernel) {
         kernel.importSkill("SummarizeSkill", KernelExtensions.importSemanticSkillFromDirectory(
@@ -15,9 +17,9 @@ public class Example05UsingThePlanner {
         return new SequentialPlanner(kernel, null, null);
     }
 
-    public static void run(boolean useAzureOpenAI) {
+    public static void run(boolean useAzureOpenAI) throws IOException {
         OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-        Kernel kernel = Example00GettingStarted.getKernel(client);
+        Kernel kernel = Example00_GettingStarted.getKernel(client);
 
         SequentialPlanner planner = getPlanner(kernel);
         System.out.println(planner.createPlanAsync(
@@ -27,7 +29,7 @@ public class Example05UsingThePlanner {
         // TODO: execute the plan
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         run(true);
     }
 

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example05_UsingThePlanner.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example05_UsingThePlanner.java
@@ -17,9 +17,8 @@ public class Example05_UsingThePlanner {
         return new SequentialPlanner(kernel, null, null);
     }
 
-    public static void run(boolean useAzureOpenAI) throws IOException {
-        OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-        Kernel kernel = Example00_GettingStarted.getKernel(client);
+    public static void run (Config.ClientType clientType) throws IOException {
+        Kernel kernel = Example00_GettingStarted.getKernel(clientType.getClient());
 
         SequentialPlanner planner = getPlanner(kernel);
         System.out.println(planner.createPlanAsync(
@@ -30,7 +29,8 @@ public class Example05_UsingThePlanner {
     }
 
     public static void main(String[] args) throws IOException {
-        run(true);
+        // Send one of Config.ClientType.OPEN_AI or Config.ClientType.AZURE_OPEN_AI
+        run(Config.ClientType.OPEN_AI);
     }
 
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example06_MemoryAndEmbeddings.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example06_MemoryAndEmbeddings.java
@@ -24,12 +24,12 @@ public class Example06_MemoryAndEmbeddings {
     return kernel;
   }
 
-  public static void run (boolean useAzureOpenAI) throws IOException {
-    OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
-    Kernel kernel = getKernel(client);
+  public static void run (Config.ClientType clientType) throws IOException {
+    Kernel kernel = getKernel(clientType.getClient());
   }
 
   public static void main(String[] args) throws IOException {
-    run(false);
+    // Send one of Config.ClientType.OPEN_AI or Config.ClientType.AZURE_OPEN_AI
+    run(Config.ClientType.OPEN_AI);
   }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example06_MemoryAndEmbeddings.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/Example06_MemoryAndEmbeddings.java
@@ -3,7 +3,9 @@ package com.microsoft.semantickernel;
 import com.microsoft.openai.OpenAIAsyncClient;
 import com.microsoft.semantickernel.builders.SKBuilders;
 
-public class Example06MemoryAndEmbeddings {
+import java.io.IOException;
+
+public class Example06_MemoryAndEmbeddings {
 
   public static Kernel getKernel(OpenAIAsyncClient client) {
     KernelConfig config = SKBuilders.kernelConfig()
@@ -22,12 +24,12 @@ public class Example06MemoryAndEmbeddings {
     return kernel;
   }
 
-  public static void run (boolean useAzureOpenAI) {
+  public static void run (boolean useAzureOpenAI) throws IOException {
     OpenAIAsyncClient client = Config.getClient(useAzureOpenAI);
     Kernel kernel = getKernel(client);
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws IOException {
     run(false);
   }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example06_TemplateLanguage.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example06_TemplateLanguage.java
@@ -24,7 +24,7 @@ public class Example06_TemplateLanguage {
         System.out.println("======== TemplateLanguage ========");
 
 
-        OpenAIAsyncClient client = Config.getClient(true);
+        OpenAIAsyncClient client = Config.ClientType.AZURE_OPEN_AI.getClient();
 
         KernelConfig kernelConfig = SKBuilders.kernelConfig()
                 .addTextCompletionService(

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example06_TemplateLanguage.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example06_TemplateLanguage.java
@@ -6,14 +6,12 @@ import com.microsoft.semantickernel.Config;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.KernelConfig;
 import com.microsoft.semantickernel.builders.SKBuilders;
-import com.microsoft.semantickernel.connectors.ai.openai.textcompletion.OpenAITextCompletion;
-import com.microsoft.semantickernel.connectors.ai.openai.textembeddings.OpenAITextEmbeddingGeneration;
 import com.microsoft.semantickernel.coreskills.TimeSkill;
-import com.microsoft.semantickernel.memory.NullMemory;
 import com.microsoft.semantickernel.orchestration.SKContext;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.templateengine.PromptTemplateEngine;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class Example06_TemplateLanguage {
@@ -22,7 +20,7 @@ public class Example06_TemplateLanguage {
     /// from a Semantic Function written in natural language
     /// </summary>
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         System.out.println("======== TemplateLanguage ========");
 
 

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
@@ -6,7 +6,6 @@ import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.http.policy.ExponentialBackoffOptions;
 import com.azure.core.http.policy.RetryOptions;
 import com.microsoft.openai.AzureOpenAIClient;
-import com.microsoft.semantickernel.Config;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.KernelConfig;
 import com.microsoft.semantickernel.builders.SKBuilders;
@@ -14,26 +13,29 @@ import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
+import com.microsoft.semantickernel.util.Settings;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 
-import static com.microsoft.semantickernel.Config.AZURE_CONF_PROPERTIES;
+import static com.microsoft.semantickernel.Config.CONF_PROPERTIES;
 
 public class Example08_RetryHandler {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         RetryOptions retryOptions = new RetryOptions(new ExponentialBackoffOptions()
                 .setMaxDelay(Duration.ofSeconds(180))
                 .setBaseDelay(Duration.ofSeconds(60))
                 .setMaxRetries(3)
         );
 
+        Settings.AzureOpenAISettings settings = Settings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
         AzureOpenAIClient client = new AzureOpenAIClient(
                 new OpenAIClientBuilder()
                         .retryOptions(retryOptions)
-                        .endpoint(Config.getAzureOpenAIEndpoint(AZURE_CONF_PROPERTIES))
-                        .credential(new AzureKeyCredential(Config.getOpenAIKey(AZURE_CONF_PROPERTIES)))
+                        .endpoint(settings.getEndpoint())
+                        .credential(new AzureKeyCredential(settings.getKey()))
                         .buildAsyncClient());
 
 

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
@@ -14,7 +14,7 @@ import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
 import com.microsoft.semantickernel.util.AzureOpenAISettings;
-import com.microsoft.semantickernel.util.ClientSettings;
+import com.microsoft.semantickernel.util.AIProviderSettings;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -31,7 +31,7 @@ public class Example08_RetryHandler {
                 .setMaxRetries(3)
         );
 
-        AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+        AzureOpenAISettings settings = AIProviderSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
         AzureOpenAIClient client = new AzureOpenAIClient(
                 new OpenAIClientBuilder()
                         .retryOptions(retryOptions)

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
@@ -13,7 +13,7 @@ import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
-import com.microsoft.semantickernel.util.Settings;
+import com.microsoft.semantickernel.util.ClientSettings;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -30,7 +30,7 @@ public class Example08_RetryHandler {
                 .setMaxRetries(3)
         );
 
-        Settings.AzureOpenAISettings settings = Settings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+        ClientSettings.AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
         AzureOpenAIClient client = new AzureOpenAIClient(
                 new OpenAIClientBuilder()
                         .retryOptions(retryOptions)

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/Example08_RetryHandler.java
@@ -13,6 +13,7 @@ import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
+import com.microsoft.semantickernel.util.AzureOpenAISettings;
 import com.microsoft.semantickernel.util.ClientSettings;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ public class Example08_RetryHandler {
                 .setMaxRetries(3)
         );
 
-        ClientSettings.AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
+        AzureOpenAISettings settings = ClientSettings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES);
         AzureOpenAIClient client = new AzureOpenAIClient(
                 new OpenAIClientBuilder()
                         .retryOptions(retryOptions)

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AIProviderSettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AIProviderSettings.java
@@ -1,0 +1,31 @@
+package com.microsoft.semantickernel.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public abstract class AIProviderSettings<T extends AIProviderSettings<T>> {
+    public abstract T fromEnv();
+    public abstract T fromFile(String path) throws IOException;
+    public abstract T fromFile(String path, String clientSettingsId) throws IOException;
+    private static String getPropertyNameForClientId(String clientSettingsId, String propertyName) {
+        return "client." + clientSettingsId + "." + propertyName;
+    }
+    protected String getSettingsValueFromEnv(String property) {
+        return System.getenv(property);
+    }
+    protected String getSettingsValueFromFile(
+            String settingsFile, String property, String clientSettingsId) throws IOException {
+        File Settings = new File(settingsFile);
+
+        try (FileInputStream fis = new FileInputStream(Settings.getAbsolutePath())) {
+            Properties props = new Properties();
+            props.load(fis);
+
+            return props.getProperty(getPropertyNameForClientId(clientSettingsId, property));
+        } catch (IOException e) {
+            throw new IOException(settingsFile + " not configured properly");
+        }
+    }
+}

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AIProviderSettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AIProviderSettings.java
@@ -1,31 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.util;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Properties;
 
-public abstract class AIProviderSettings<T extends AIProviderSettings<T>> {
-    public abstract T fromEnv();
-    public abstract T fromFile(String path) throws IOException;
-    public abstract T fromFile(String path, String clientSettingsId) throws IOException;
-    private static String getPropertyNameForClientId(String clientSettingsId, String propertyName) {
-        return "client." + clientSettingsId + "." + propertyName;
+public class AIProviderSettings {
+    /**
+     * Returns an instance of OpenAISettings with key and organizationId from the environment
+     *
+     * @return OpenAISettings
+     */
+    public static OpenAISettings getOpenAISettingsFromEnv() {
+        return new OpenAISettings().fromEnv();
     }
-    protected String getSettingsValueFromEnv(String property) {
-        return System.getenv(property);
+
+    /**
+     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
+     * environment
+     *
+     * @return AzureOpenAISettings
+     */
+    public static AzureOpenAISettings getAzureOpenAISettingsFromEnv() {
+        return new AzureOpenAISettings().fromEnv();
     }
-    protected String getSettingsValueFromFile(
-            String settingsFile, String property, String clientSettingsId) throws IOException {
-        File Settings = new File(settingsFile);
 
-        try (FileInputStream fis = new FileInputStream(Settings.getAbsolutePath())) {
-            Properties props = new Properties();
-            props.load(fis);
+    /**
+     * Returns an instance of OpenAISettings with key and organizationId from the properties file
+     *
+     * @param path Path to the properties file
+     * @return OpenAISettings
+     */
+    public static OpenAISettings getOpenAISettingsFromFile(String path) throws IOException {
+        return new OpenAISettings().fromFile(path);
+    }
 
-            return props.getProperty(getPropertyNameForClientId(clientSettingsId, property));
-        } catch (IOException e) {
-            throw new IOException(settingsFile + " not configured properly");
-        }
+    /**
+     * Returns an instance of OpenAISettings with key and organizationId from the properties file
+     *
+     * @param path Path to the properties file
+     * @param clientSettingsId ID of the client settings in the properties file schema
+     * @return OpenAISettings
+     */
+    public static OpenAISettings getOpenAISettingsFromFile(String path, String clientSettingsId)
+            throws IOException {
+        return new OpenAISettings().fromFile(path, clientSettingsId);
+    }
+
+    /**
+     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
+     * properties file
+     *
+     * @param path Path to the properties file
+     * @return AzureOpenAISettings
+     */
+    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(String path)
+            throws IOException {
+        return new AzureOpenAISettings().fromFile(path);
+    }
+
+    /**
+     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
+     * properties file
+     *
+     * @param path Path to the properties file
+     * @param clientSettingsId ID of the client settings in the properties file schema
+     * @return AzureOpenAISettings
+     */
+    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(
+            String path, String clientSettingsId) throws IOException {
+        return new AzureOpenAISettings().fromFile(path, clientSettingsId);
     }
 }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AzureOpenAISettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AzureOpenAISettings.java
@@ -2,7 +2,7 @@ package com.microsoft.semantickernel.util;
 
 import java.io.IOException;
 
-public class AzureOpenAISettings extends AIProviderSettings<AzureOpenAISettings> {
+public class AzureOpenAISettings extends ClientSettings<AzureOpenAISettings> {
 
     private static final String DEFAULT_CLIENT_ID = "azureopenai";
     private String key;

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AzureOpenAISettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/AzureOpenAISettings.java
@@ -1,0 +1,56 @@
+package com.microsoft.semantickernel.util;
+
+import java.io.IOException;
+
+public class AzureOpenAISettings extends AIProviderSettings<AzureOpenAISettings> {
+
+    private static final String DEFAULT_CLIENT_ID = "azureopenai";
+    private String key;
+    private String endpoint;
+    private String deploymentName;
+
+    public enum Property {
+        AZURE_OPEN_AI_KEY("key"),
+        AZURE_OPEN_AI_ENDPOINT("endpoint"),
+        AZURE_OPEN_AI_DEPLOYMENT_NAME("deploymentname");
+        private final String label;
+        Property (String label) {
+            this.label = label;
+        }
+        public String label() {
+            return this.label;
+        }
+    }
+
+    public String getKey() {
+        return key;
+    }
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getDeploymentName() {
+        return deploymentName;
+    }
+
+    @Override
+    public AzureOpenAISettings fromEnv() {
+        this.key = getSettingsValueFromEnv(Property.AZURE_OPEN_AI_KEY.name());
+        this.endpoint = getSettingsValueFromEnv(Property.AZURE_OPEN_AI_ENDPOINT.name());
+        this.deploymentName = getSettingsValueFromEnv(Property.AZURE_OPEN_AI_DEPLOYMENT_NAME.name());
+        return this;
+    }
+
+    @Override
+    public AzureOpenAISettings fromFile(String path) throws IOException {
+        return fromFile(path, DEFAULT_CLIENT_ID);
+    }
+
+    @Override
+    public AzureOpenAISettings fromFile(String path, String clientSettingsId) throws IOException {
+        this.key = getSettingsValueFromFile(path, Property.AZURE_OPEN_AI_KEY.label(), clientSettingsId);
+        this.endpoint = getSettingsValueFromFile(path, Property.AZURE_OPEN_AI_ENDPOINT.label(), clientSettingsId);
+        this.deploymentName = getSettingsValueFromFile(path, Property.AZURE_OPEN_AI_DEPLOYMENT_NAME.label(), clientSettingsId);
+        return this;
+    }
+}

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/ClientSettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/ClientSettings.java
@@ -1,89 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Properties;
 
 public class ClientSettings {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClientSettings.class);
-
-    public static class OpenAISettings {
-        private final String key;
-        private final String organizationId;
-
-        OpenAISettings(String key, String organizationId) {
-            this.key = key;
-            this.organizationId = organizationId;
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public String getOrganizationId() {
-            return organizationId;
-        }
-    }
-
-    public static class AzureOpenAISettings {
-        private final String key;
-        private final String endpoint;
-        private final String deploymentName;
-
-        public AzureOpenAISettings(String key, String endpoint, String deploymentName) {
-            this.key = key;
-            this.endpoint = endpoint;
-            this.deploymentName = deploymentName;
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public String getEndpoint() {
-            return endpoint;
-        }
-
-        public String getDeploymentName() {
-            return deploymentName;
-        }
-    }
-
-    private static final String DEFAULT_OPEN_AI_CLIENT_ID = "openai";
-    private static final String DEFAULT_AZURE_OPEN_AI_CLIENT_ID = "azureopenai";
-
-    public enum Property {
-        OPEN_AI_KEY(".key"),
-        OPEN_AI_ORGANIZATION_ID(".organizationid"),
-        AZURE_OPEN_AI_KEY(".key"),
-        AZURE_OPEN_AI_ENDPOINT(".endpoint"),
-        AZURE_OPEN_AI_DEPLOYMENT_NAME(".deploymentname");
-
-        public final String labelSuffix;
-
-        Property(String labelSuffix) {
-            this.labelSuffix = labelSuffix;
-        }
-
-        String getPropertyNameForClientId(String clientSettingsId) {
-            return "client." + clientSettingsId + labelSuffix;
-        }
-    }
-
     /**
      * Returns an instance of OpenAISettings with key and organizationId from the environment
      *
      * @return OpenAISettings
      */
     public static OpenAISettings getOpenAISettingsFromEnv() {
-        return new OpenAISettings(
-                ClientSettings.getSettingsValueFromEnv(Property.OPEN_AI_KEY),
-                ClientSettings.getSettingsValueFromEnv(Property.OPEN_AI_ORGANIZATION_ID));
+        return new OpenAISettings().fromEnv();
     }
 
     /**
@@ -93,10 +20,7 @@ public class ClientSettings {
      * @return AzureOpenAISettings
      */
     public static AzureOpenAISettings getAzureOpenAISettingsFromEnv() {
-        return new AzureOpenAISettings(
-                ClientSettings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_KEY),
-                ClientSettings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_ENDPOINT),
-                ClientSettings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_DEPLOYMENT_NAME));
+        return new AzureOpenAISettings().fromEnv();
     }
 
     /**
@@ -106,7 +30,7 @@ public class ClientSettings {
      * @return OpenAISettings
      */
     public static OpenAISettings getOpenAISettingsFromFile(String path) throws IOException {
-        return getOpenAISettingsFromFile(path, DEFAULT_OPEN_AI_CLIENT_ID);
+        return new OpenAISettings().fromFile(path);
     }
 
     /**
@@ -118,10 +42,7 @@ public class ClientSettings {
      */
     public static OpenAISettings getOpenAISettingsFromFile(String path, String clientSettingsId)
             throws IOException {
-        return new OpenAISettings(
-                ClientSettings.getSettingsValueFromFile(path, Property.OPEN_AI_KEY, clientSettingsId),
-                ClientSettings.getSettingsValueFromFile(
-                        path, Property.OPEN_AI_ORGANIZATION_ID, clientSettingsId));
+        return new OpenAISettings().fromFile(path, clientSettingsId);
     }
 
     /**
@@ -133,7 +54,7 @@ public class ClientSettings {
      */
     public static AzureOpenAISettings getAzureOpenAISettingsFromFile(String path)
             throws IOException {
-        return getAzureOpenAISettingsFromFile(path, DEFAULT_AZURE_OPEN_AI_CLIENT_ID);
+        return new AzureOpenAISettings().fromFile(path);
     }
 
     /**
@@ -146,62 +67,6 @@ public class ClientSettings {
      */
     public static AzureOpenAISettings getAzureOpenAISettingsFromFile(
             String path, String clientSettingsId) throws IOException {
-        return new AzureOpenAISettings(
-                ClientSettings.getSettingsValueFromFile(
-                        path, Property.AZURE_OPEN_AI_KEY, clientSettingsId),
-                ClientSettings.getSettingsValueFromFile(
-                        path, Property.AZURE_OPEN_AI_ENDPOINT, clientSettingsId),
-                ClientSettings.getSettingsValueFromFile(
-                        path, Property.AZURE_OPEN_AI_DEPLOYMENT_NAME, clientSettingsId));
-    }
-
-    /**
-     * Returns the value associated to the env var with the name of the Property
-     *
-     * @param property Property to get the env var value from
-     * @return String
-     */
-    public static String getSettingsValueFromEnv(Property property) {
-        return System.getenv(property.name());
-    }
-
-    /**
-     * Returns the Property value in the settingsFile
-     *
-     * @param settingsFile Properties file
-     * @param property Property to retrieve from file
-     * @return String with the value
-     * @throws IOException
-     */
-    public static String getSettingsValueFromFile(String settingsFile, Property property)
-            throws IOException {
-        return getSettingsValueFromFile(settingsFile, property, null);
-    }
-
-    /**
-     * Returns the Property value in the settingsFile
-     *
-     * @param settingsFile Properties file
-     * @param property Property to retrieve from file
-     * @param clientSettingsId ID of the client settings in the properties file schema
-     * @throws IOException
-     */
-    public static String getSettingsValueFromFile(
-            String settingsFile, Property property, String clientSettingsId) throws IOException {
-        File Settings = new File(settingsFile);
-
-        try (FileInputStream fis = new FileInputStream(Settings.getAbsolutePath())) {
-            Properties props = new Properties();
-            props.load(fis);
-
-            return props.getProperty(property.getPropertyNameForClientId(clientSettingsId));
-        } catch (IOException e) {
-            LOGGER.error(
-                    "Unable to load config value "
-                            + property.getPropertyNameForClientId(clientSettingsId)
-                            + " from properties file",
-                    e);
-            throw new IOException(settingsFile + " not configured properly");
-        }
+        return new AzureOpenAISettings().fromFile(path, clientSettingsId);
     }
 }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/ClientSettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/ClientSettings.java
@@ -1,72 +1,31 @@
-// Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.util;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Properties;
 
-public class ClientSettings {
-    /**
-     * Returns an instance of OpenAISettings with key and organizationId from the environment
-     *
-     * @return OpenAISettings
-     */
-    public static OpenAISettings getOpenAISettingsFromEnv() {
-        return new OpenAISettings().fromEnv();
+public abstract class ClientSettings<T extends ClientSettings<T>> {
+    public abstract T fromEnv();
+    public abstract T fromFile(String path) throws IOException;
+    public abstract T fromFile(String path, String clientSettingsId) throws IOException;
+    private static String getPropertyNameForClientId(String clientSettingsId, String propertyName) {
+        return "client." + clientSettingsId + "." + propertyName;
     }
-
-    /**
-     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
-     * environment
-     *
-     * @return AzureOpenAISettings
-     */
-    public static AzureOpenAISettings getAzureOpenAISettingsFromEnv() {
-        return new AzureOpenAISettings().fromEnv();
+    protected String getSettingsValueFromEnv(String property) {
+        return System.getenv(property);
     }
+    protected String getSettingsValueFromFile(
+            String settingsFile, String property, String clientSettingsId) throws IOException {
+        File Settings = new File(settingsFile);
 
-    /**
-     * Returns an instance of OpenAISettings with key and organizationId from the properties file
-     *
-     * @param path Path to the properties file
-     * @return OpenAISettings
-     */
-    public static OpenAISettings getOpenAISettingsFromFile(String path) throws IOException {
-        return new OpenAISettings().fromFile(path);
-    }
+        try (FileInputStream fis = new FileInputStream(Settings.getAbsolutePath())) {
+            Properties props = new Properties();
+            props.load(fis);
 
-    /**
-     * Returns an instance of OpenAISettings with key and organizationId from the properties file
-     *
-     * @param path Path to the properties file
-     * @param clientSettingsId ID of the client settings in the properties file schema
-     * @return OpenAISettings
-     */
-    public static OpenAISettings getOpenAISettingsFromFile(String path, String clientSettingsId)
-            throws IOException {
-        return new OpenAISettings().fromFile(path, clientSettingsId);
-    }
-
-    /**
-     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
-     * properties file
-     *
-     * @param path Path to the properties file
-     * @return AzureOpenAISettings
-     */
-    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(String path)
-            throws IOException {
-        return new AzureOpenAISettings().fromFile(path);
-    }
-
-    /**
-     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
-     * properties file
-     *
-     * @param path Path to the properties file
-     * @param clientSettingsId ID of the client settings in the properties file schema
-     * @return AzureOpenAISettings
-     */
-    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(
-            String path, String clientSettingsId) throws IOException {
-        return new AzureOpenAISettings().fromFile(path, clientSettingsId);
+            return props.getProperty(getPropertyNameForClientId(clientSettingsId, property));
+        } catch (IOException e) {
+            throw new IOException(settingsFile + " not configured properly");
+        }
     }
 }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/ClientSettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/ClientSettings.java
@@ -9,8 +9,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-public class Settings {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Settings.class);
+public class ClientSettings {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientSettings.class);
 
     public static class OpenAISettings {
         private final String key;
@@ -82,8 +82,8 @@ public class Settings {
      */
     public static OpenAISettings getOpenAISettingsFromEnv() {
         return new OpenAISettings(
-                Settings.getSettingsValueFromEnv(Property.OPEN_AI_KEY),
-                Settings.getSettingsValueFromEnv(Property.OPEN_AI_ORGANIZATION_ID));
+                ClientSettings.getSettingsValueFromEnv(Property.OPEN_AI_KEY),
+                ClientSettings.getSettingsValueFromEnv(Property.OPEN_AI_ORGANIZATION_ID));
     }
 
     /**
@@ -94,9 +94,9 @@ public class Settings {
      */
     public static AzureOpenAISettings getAzureOpenAISettingsFromEnv() {
         return new AzureOpenAISettings(
-                Settings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_KEY),
-                Settings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_ENDPOINT),
-                Settings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_DEPLOYMENT_NAME));
+                ClientSettings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_KEY),
+                ClientSettings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_ENDPOINT),
+                ClientSettings.getSettingsValueFromEnv(Property.AZURE_OPEN_AI_DEPLOYMENT_NAME));
     }
 
     /**
@@ -116,10 +116,12 @@ public class Settings {
      * @param clientSettingsId ID of the client settings in the properties file schema
      * @return OpenAISettings
      */
-    public static OpenAISettings getOpenAISettingsFromFile(String path, String clientSettingsId) throws IOException {
+    public static OpenAISettings getOpenAISettingsFromFile(String path, String clientSettingsId)
+            throws IOException {
         return new OpenAISettings(
-                Settings.getSettingsValueFromFile(path, Property.OPEN_AI_KEY, clientSettingsId),
-                Settings.getSettingsValueFromFile(path, Property.OPEN_AI_ORGANIZATION_ID, clientSettingsId));
+                ClientSettings.getSettingsValueFromFile(path, Property.OPEN_AI_KEY, clientSettingsId),
+                ClientSettings.getSettingsValueFromFile(
+                        path, Property.OPEN_AI_ORGANIZATION_ID, clientSettingsId));
     }
 
     /**
@@ -142,12 +144,14 @@ public class Settings {
      * @param clientSettingsId ID of the client settings in the properties file schema
      * @return AzureOpenAISettings
      */
-    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(String path, String clientSettingsId)
-            throws IOException {
+    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(
+            String path, String clientSettingsId) throws IOException {
         return new AzureOpenAISettings(
-                Settings.getSettingsValueFromFile(path, Property.AZURE_OPEN_AI_KEY, clientSettingsId),
-                Settings.getSettingsValueFromFile(path, Property.AZURE_OPEN_AI_ENDPOINT, clientSettingsId),
-                Settings.getSettingsValueFromFile(
+                ClientSettings.getSettingsValueFromFile(
+                        path, Property.AZURE_OPEN_AI_KEY, clientSettingsId),
+                ClientSettings.getSettingsValueFromFile(
+                        path, Property.AZURE_OPEN_AI_ENDPOINT, clientSettingsId),
+                ClientSettings.getSettingsValueFromFile(
                         path, Property.AZURE_OPEN_AI_DEPLOYMENT_NAME, clientSettingsId));
     }
 
@@ -193,7 +197,9 @@ public class Settings {
             return props.getProperty(property.getPropertyNameForClientId(clientSettingsId));
         } catch (IOException e) {
             LOGGER.error(
-                    "Unable to load config value " + property.getPropertyNameForClientId(clientSettingsId) + " from properties file",
+                    "Unable to load config value "
+                            + property.getPropertyNameForClientId(clientSettingsId)
+                            + " from properties file",
                     e);
             throw new IOException(settingsFile + " not configured properly");
         }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/OpenAISettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/OpenAISettings.java
@@ -2,7 +2,7 @@ package com.microsoft.semantickernel.util;
 
 import java.io.IOException;
 
-public class OpenAISettings extends AIProviderSettings<OpenAISettings> {
+public class OpenAISettings extends ClientSettings<OpenAISettings> {
     private String key;
     private String organizationId;
     private static final String DEFAULT_CLIENT_ID = "openai";

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/OpenAISettings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/OpenAISettings.java
@@ -1,0 +1,46 @@
+package com.microsoft.semantickernel.util;
+
+import java.io.IOException;
+
+public class OpenAISettings extends AIProviderSettings<OpenAISettings> {
+    private String key;
+    private String organizationId;
+    private static final String DEFAULT_CLIENT_ID = "openai";
+    private enum Property {
+        OPEN_AI_KEY("key"),
+        OPEN_AI_ORGANIZATION_ID("organizationid");
+        private final String label;
+        Property (String label) {
+            this.label = label;
+        }
+        public String label() {
+            return this.label;
+        }
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+    @Override
+    public OpenAISettings fromEnv() {
+        this.key = getSettingsValueFromEnv(Property.OPEN_AI_KEY.name());
+        this.organizationId = getSettingsValueFromEnv(Property.OPEN_AI_ORGANIZATION_ID.name());
+        return this;
+    }
+
+    @Override
+    public OpenAISettings fromFile(String path) throws IOException {
+        return fromFile(path, DEFAULT_CLIENT_ID);
+    }
+
+    @Override
+    public OpenAISettings fromFile(String path, String clientSettingsId) throws IOException {
+        this.key = getSettingsValueFromFile(path, Property.OPEN_AI_KEY.label(), clientSettingsId);
+        this.organizationId = getSettingsValueFromFile(path, Property.OPEN_AI_ORGANIZATION_ID.label(), clientSettingsId);
+        return this;
+    }
+}

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/Settings.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/util/Settings.java
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public class Settings {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Settings.class);
+
+    public static class OpenAISettings {
+        private final String key;
+        private final String organizationId;
+
+        OpenAISettings(String key, String organizationId) {
+            this.key = key;
+            this.organizationId = organizationId;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getOrganizationId() {
+            return organizationId;
+        }
+    }
+
+    public static class AzureOpenAISettings {
+        private final String key;
+        private final String endpoint;
+        private final String deploymentName;
+
+        public AzureOpenAISettings(String key, String endpoint, String deploymentName) {
+            this.key = key;
+            this.endpoint = endpoint;
+            this.deploymentName = deploymentName;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getEndpoint() {
+            return endpoint;
+        }
+
+        public String getDeploymentName() {
+            return deploymentName;
+        }
+    }
+
+    private enum Property {
+        OPEN_AI_KEY("openai.key"),
+        OPEN_AI_ORGANIZATION_ID("openai.organizationid"),
+        AZURE_OPEN_AI_KEY("azureopenai.key"),
+        AZURE_OPEN_AI_ENDPOINT("azureopenai.endpoint"),
+        AZURE_OPEN_AI_DEPLOYMENT_NAME("azureopenai.deploymentname");
+
+        public final String label;
+
+        Property(String label) {
+            this.label = label;
+        }
+    }
+
+    /**
+     * Returns an instance of OpenAISettings with key and organizationId from the properties file
+     *
+     * @param path Path to the properties file
+     * @return OpenAISettings
+     */
+    public static OpenAISettings getOpenAISettingsFromFile(String path) throws IOException {
+        return new OpenAISettings(
+                Settings.getSettingsValue(path, Property.OPEN_AI_KEY.label),
+                Settings.getSettingsValue(path, Property.OPEN_AI_ORGANIZATION_ID.label, ""));
+    }
+
+    /**
+     * Returns an instance of AzureOpenAISettings with key, endpoint and deploymentName from the
+     * properties file
+     *
+     * @param path Path to the properties file
+     * @return OpenAISettings
+     */
+    public static AzureOpenAISettings getAzureOpenAISettingsFromFile(String path)
+            throws IOException {
+        return new AzureOpenAISettings(
+                Settings.getSettingsValue(path, Property.AZURE_OPEN_AI_KEY.label),
+                Settings.getSettingsValue(path, Property.AZURE_OPEN_AI_ENDPOINT.label),
+                Settings.getSettingsValue(path, Property.AZURE_OPEN_AI_DEPLOYMENT_NAME.label, ""));
+    }
+
+    private static String getSettingsValue(String settingsFile, String propertyName)
+            throws IOException {
+        return getSettingsValue(settingsFile, propertyName, null);
+    }
+
+    private static String getSettingsValue(
+            String settingsFile, String propertyName, String defaultValue) throws IOException {
+        File Settings = new File(settingsFile);
+        try (FileInputStream fis = new FileInputStream(Settings.getAbsolutePath())) {
+            Properties props = new Properties();
+            props.load(fis);
+            if (defaultValue == null) {
+                return props.getProperty(propertyName);
+            }
+            return props.getProperty(propertyName, defaultValue);
+        } catch (IOException e) {
+            LOGGER.error(
+                    "Unable to load config value " + propertyName + " from properties file", e);
+            throw new IOException(settingsFile + " not configured properly");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Add settings retrieval through properties file and env vars

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Adds util.Settings to load settings values from a properties file or from the environment.

Also, the ability to have different client settings in the properties file and load them by their specific schema Id:
```yaml
client.azureopenai.key: "AZURE_OPEN_AI_KEY"
client.azureopenai.endpoint: "AZURE_OPEN_AI_ENDPOINT"
client.azureopenai.deploymentname: "AZURE_OPEN_AI_DEPLOYMENT_NAME"

client.myazureopenai.key: "AZURE_OPEN_AI_KEY"
client.myazureopenai.endpoint: "AZURE_OPEN_AI_ENDPOINT"
client.myazureopenai.deploymentname: "AZURE_OPEN_AI_DEPLOYMENT_NAME"
```

By calling `Settings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES)` the user would be able to load the Azure settings using the default schema id, as shown in the block at the top.

By calling `Settings.getAzureOpenAISettingsFromFile(CONF_PROPERTIES, "myazureopenai")` the user would be able to load a different Azure configuration by just adding the second block to the properties file.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
