### PR TITLE
Basically working VolatileMemoryStore

### DIFF
--- a/java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/e2e/AbstractKernelTest.java
+++ b/java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/e2e/AbstractKernelTest.java
@@ -9,6 +9,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.KernelConfig;
 import com.microsoft.semantickernel.builders.SKBuilders;
 import com.microsoft.semantickernel.connectors.ai.openai.textcompletion.OpenAITextCompletion;
+import com.microsoft.semantickernel.memory.VolatileMemoryStore;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
 
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -33,7 +34,10 @@ public class AbstractKernelTest {
                         .addTextCompletionService(model, kernel -> textCompletion)
                         .build();
 
-        return SKBuilders.kernel().setKernelConfig(kernelConfig).build();
+        return SKBuilders.kernel()
+                .setKernelConfig(kernelConfig)
+                .withMemoryStore(new VolatileMemoryStore())
+                .build();
     }
 
     public static OpenAIAsyncClient getOpenAIClient() throws IOException {

--- a/java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/e2e/TextEmbeddingsTest.java
+++ b/java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/e2e/TextEmbeddingsTest.java
@@ -8,7 +8,9 @@ import com.microsoft.semantickernel.ai.embeddings.EmbeddingGeneration;
 import com.microsoft.semantickernel.builders.SKBuilders;
 import com.microsoft.semantickernel.connectors.ai.openai.textembeddings.OpenAITextEmbeddingGeneration;
 import com.microsoft.semantickernel.coreskills.TextMemorySkill;
-import com.microsoft.semantickernel.skilldefinition.ReadOnlyFunctionCollection;
+import com.microsoft.semantickernel.memory.MemoryQueryResult;
+import com.microsoft.semantickernel.memory.SemanticTextMemory;
+import com.microsoft.semantickernel.memory.VolatileMemoryStore;
 import com.microsoft.semantickernel.textcompletion.CompletionSKContext;
 import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 
@@ -17,8 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -57,13 +57,9 @@ public class TextEmbeddingsTest extends AbstractKernelTest {
     @Test
     @EnabledIf("isAzureTestEnabled")
     public void testMemory() throws IOException {
-        String model = "text-embedding-ada-002";
-        EmbeddingGeneration<String, Float> embeddingGeneration =
-                new OpenAITextEmbeddingGeneration(getAzureOpenAIClient(), model);
 
-        Kernel kernel = buildTextEmbeddingsKernel();
-
-        ReadOnlyFunctionCollection memory = kernel.importSkill(new TextMemorySkill(), null);
+        Kernel kernel = buildTextCompletionKernel();
+        kernel.importSkill(new TextMemorySkill(), "aboutMe");
 
         String skPrompt =
                 "\n"
@@ -83,11 +79,64 @@ public class TextEmbeddingsTest extends AbstractKernelTest {
                     + "User: {{$userInput}}\n"
                     + "ChatBot: ";
 
-        Mono<CompletionSKContext> mono =
-                memory.getFunction("retrieve", CompletionSKFunction.class).invokeAsync("");
-        CompletionSKContext result = mono.block();
+        CompletionSKFunction chat =
+                kernel.getSemanticFunctionBuilder()
+                        .createFunction(
+                                skPrompt, "recall", "aboutMe", "TextEmbeddingTest#testMemory");
 
-        LOGGER.info(result.getResult());
+        VolatileMemoryStore volatileMemoryStore = new VolatileMemoryStore();
+        volatileMemoryStore.createCollectionAsync("aboutMe").block();
+
+        OpenAITextEmbeddingGeneration embeddingGeneration =
+                new OpenAITextEmbeddingGeneration(getAzureOpenAIClient(), "text-embedding-ada-002");
+
+        SemanticTextMemory memory =
+                SKBuilders.semanticTextMemory()
+                        .setEmbeddingGenerator(embeddingGeneration)
+                        .setStorage(volatileMemoryStore)
+                        .build();
+
+        CompletionSKContext context =
+                chat.buildContext(SKBuilders.variables().build(), memory, kernel.getSkills());
+
+        context.getSemanticMemory()
+                .saveInformationAsync("aboutMe", "My name is Andrea", "fact1", null, null)
+                .block();
+
+        context.getSemanticMemory()
+                .saveInformationAsync(
+                        "aboutMe", "I currently work as a tour guide", "fact2", null, null)
+                .block();
+
+        context.getSemanticMemory()
+                .saveInformationAsync(
+                        "aboutMe", "I've been living in Seattle since 2005", "fact3", null, null)
+                .block();
+
+        context.getSemanticMemory()
+                .saveInformationAsync(
+                        "aboutMe",
+                        "I visited France and Italy five times since 2015",
+                        "fact4",
+                        null,
+                        null)
+                .block();
+
+        context.getSemanticMemory()
+                .saveInformationAsync("aboutMe", "My family is from New York", "fact5", null, null)
+                .block();
+
+        String query = "Where are you from originally?";
+        List<MemoryQueryResult> results =
+                memory.searchAsync("aboutMe", query, 10, .5, false).block();
+        results.forEach(
+                result ->
+                        System.out.println(
+                                String.format(
+                                        "%s %s (relevance=%f)",
+                                        query,
+                                        result.getMetadata().getText(),
+                                        result.getRelevance())));
     }
 
     public void testEmbeddingGeneration(OpenAIAsyncClient client, int expectedEmbeddingSize) {

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
@@ -3,6 +3,7 @@ package com.microsoft.semantickernel;
 
 import com.microsoft.semantickernel.builders.BuildersSingleton;
 import com.microsoft.semantickernel.exceptions.SkillsNotFoundException;
+import com.microsoft.semantickernel.memory.MemoryStore;
 import com.microsoft.semantickernel.memory.SemanticTextMemory;
 import com.microsoft.semantickernel.orchestration.ContextVariables;
 import com.microsoft.semantickernel.orchestration.SKContext;
@@ -36,19 +37,19 @@ public interface Kernel {
     PromptTemplateEngine getPromptTemplateEngine();
 
     /**
-     * Set the semantic memory to use.
+     * Return the memory store used by the kernel.
+     *
+     * @return the MemoryStore instance
+     */
+    MemoryStore getMemoryStore();
+
+    /**
+     * Set the SemanticTextMemory to use.
      *
      * @param memory {@link SemanticTextMemory} instance
      */
     void registerMemory(SemanticTextMemory memory);
 
-    /*
-        /// <summary>
-        /// Set the semantic memory to use
-        /// </summary>
-        /// <param name="memory">Semantic memory instance</param>
-        void RegisterMemory(ISemanticTextMemory memory);
-    */
     /**
      * Run a pipeline composed of synchronous and asynchronous functions.
      *
@@ -127,6 +128,7 @@ public interface Kernel {
     class Builder {
         @Nullable private KernelConfig kernelConfig = null;
         @Nullable private PromptTemplateEngine promptTemplateEngine = null;
+        @Nullable private MemoryStore memoryStore = null;
 
         public Builder setKernelConfig(KernelConfig kernelConfig) {
             this.kernelConfig = kernelConfig;
@@ -138,6 +140,11 @@ public interface Kernel {
             return this;
         }
 
+        public Builder withMemoryStore(MemoryStore memoryStore) {
+            this.memoryStore = memoryStore;
+            return this;
+        }
+
         public Kernel build() {
             if (kernelConfig == null) {
                 throw new IllegalStateException("Must provide a kernel configuration");
@@ -145,12 +152,14 @@ public interface Kernel {
 
             return BuildersSingleton.INST
                     .getKernelBuilder()
-                    .build(kernelConfig, promptTemplateEngine);
+                    .build(kernelConfig, promptTemplateEngine, memoryStore);
         }
     }
 
     interface InternalBuilder {
         Kernel build(
-                KernelConfig kernelConfig, @Nullable PromptTemplateEngine promptTemplateEngine);
+                KernelConfig kernelConfig,
+                @Nullable PromptTemplateEngine promptTemplateEngine,
+                @Nullable MemoryStore memoryStore);
     }
 }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/builders/BuildersSingleton.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/builders/BuildersSingleton.java
@@ -3,6 +3,7 @@ package com.microsoft.semantickernel.builders;
 
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.ai.embeddings.EmbeddingGeneration;
+import com.microsoft.semantickernel.memory.SemanticTextMemory;
 import com.microsoft.semantickernel.orchestration.ContextVariables;
 import com.microsoft.semantickernel.orchestration.SKContext;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplate;
@@ -40,6 +41,8 @@ public enum BuildersSingleton {
             "com.microsoft.semantickernel.orchestration.DefaultSemanticSKContext$Builder";
     private static final String FALLBACK_PROMPT_TEMPLATE_ENGINE_BUILDER_CLASS =
             "com.microsoft.semantickernel.templateengine.DefaultPromptTemplateEngine$Builder";
+    private static final String FALLBACK_SEMANTIC_TEXT_MEMORY_CLASS =
+            "com.microsoft.semantickernel.memory.DefaultSemanticTextMemory$Builder";
 
     private final FunctionBuilders functionBuilders;
     private final Kernel.InternalBuilder kernelBuilder;
@@ -50,6 +53,8 @@ public enum BuildersSingleton {
     private final ContextVariables.Builder variables;
     private final SKContext.Builder context;
     private final PromptTemplateEngine.Builder promptTemplateEngine;
+
+    private final SemanticTextMemory.Builder semanticTextMemoryBuilder;
 
     BuildersSingleton() {
         try {
@@ -82,6 +87,9 @@ public enum BuildersSingleton {
             variables =
                     ServiceLoadUtil.findServiceLoader(
                             ContextVariables.Builder.class, FALLBACK_VARIABLE_BUILDER_CLASS);
+            semanticTextMemoryBuilder =
+                    ServiceLoadUtil.findServiceLoader(
+                            SemanticTextMemory.Builder.class, FALLBACK_SEMANTIC_TEXT_MEMORY_CLASS);
 
             context =
                     ServiceLoadUtil.findServiceLoader(
@@ -151,5 +159,9 @@ public enum BuildersSingleton {
 
     public SKContext.Builder context() {
         return context;
+    }
+
+    public SemanticTextMemory.Builder getSemanticTextMemoryBuilder() {
+        return semanticTextMemoryBuilder;
     }
 }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/builders/SKBuilders.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/builders/SKBuilders.java
@@ -4,6 +4,7 @@ package com.microsoft.semantickernel.builders;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.KernelConfig;
 import com.microsoft.semantickernel.ai.embeddings.EmbeddingGeneration;
+import com.microsoft.semantickernel.memory.SemanticTextMemory;
 import com.microsoft.semantickernel.orchestration.ContextVariables;
 import com.microsoft.semantickernel.orchestration.SKContext;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplate;
@@ -34,6 +35,10 @@ public class SKBuilders {
 
     public static KernelConfig.Builder kernelConfig() {
         return new KernelConfig.Builder();
+    }
+
+    public static SemanticTextMemory.Builder semanticTextMemory() {
+        return BuildersSingleton.INST.getSemanticTextMemoryBuilder();
     }
 
     public static ReadOnlySkillCollection.Builder skillCollection() {

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryRecord.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryRecord.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
  * will invalidate existing metadata stored in persistent vector DBs.
  */
 public class MemoryRecord extends DataEntryBase {
-    @Nonnull private final Embedding<Float> embedding;
+    @Nonnull private final Embedding<? extends Number> embedding;
 
     @Nonnull private final MemoryRecordMetadata metadata;
 
@@ -27,7 +27,7 @@ public class MemoryRecord extends DataEntryBase {
      */
     public MemoryRecord(
             @Nonnull MemoryRecordMetadata metadata,
-            @Nonnull Embedding<Float> embedding,
+            @Nonnull Embedding<? extends Number> embedding,
             @Nullable String key,
             @Nullable ZonedDateTime timestamp) {
         super(key, timestamp);
@@ -40,7 +40,7 @@ public class MemoryRecord extends DataEntryBase {
      *
      * @return The source content embeddings.
      */
-    public Embedding<Float> getEmbedding() {
+    public Embedding<? extends Number> getEmbedding() {
         return embedding;
     }
 

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryStore.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryStore.java
@@ -123,9 +123,9 @@ public interface MemoryStore {
      * @return A collection of tuples where item1 is a {@link MemoryRecord} and item2 is its
      *     similarity score as a {@code double}.
      */
-    Mono<Collection<Tuple2<MemoryRecord, Double>>> getNearestMatchesAsync(
+    Mono<Collection<Tuple2<MemoryRecord, Number>>> getNearestMatchesAsync(
             @Nonnull String collectionName,
-            @Nonnull Embedding<Float> embedding,
+            @Nonnull Embedding<? extends Number> embedding,
             int limit,
             double minRelevanceScore,
             boolean withEmbeddings);
@@ -141,9 +141,9 @@ public interface MemoryStore {
      * @return A tuple consisting of the {@link MemoryRecord} and item2 is its similarity score as a
      *     {@code double}. Null if no nearest match found.
      */
-    Mono<Tuple2<MemoryRecord, Double>> getNearestMatchAsync(
+    Mono<Tuple2<MemoryRecord, ? extends Number>> getNearestMatchAsync(
             @Nonnull String collectionName,
-            @Nonnull Embedding<Float> embedding,
+            @Nonnull Embedding<? super Number> embedding,
             double minRelevanceScore,
             boolean withEmbedding);
 }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/SemanticTextMemory.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/SemanticTextMemory.java
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.memory;
 
+import com.microsoft.semantickernel.ai.embeddings.EmbeddingGeneration;
+
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -100,4 +102,13 @@ public interface SemanticTextMemory {
      * @return A group of collection names.
      */
     public Mono<List<String>> getCollectionsAsync();
+
+    interface Builder {
+        Builder setStorage(@Nonnull MemoryStore storage);
+
+        Builder setEmbeddingGenerator(
+                @Nonnull EmbeddingGeneration<String, ? extends Number> embeddingGenerator);
+
+        SemanticTextMemory build();
+    }
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/DefaultKernelBuilder.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/DefaultKernelBuilder.java
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel;
 
+import com.microsoft.semantickernel.memory.MemoryStore;
+import com.microsoft.semantickernel.memory.VolatileMemoryStore;
 import com.microsoft.semantickernel.templateengine.DefaultPromptTemplateEngine;
 import com.microsoft.semantickernel.templateengine.PromptTemplateEngine;
 
@@ -10,7 +12,9 @@ public class DefaultKernelBuilder implements Kernel.InternalBuilder {
 
     @Override
     public Kernel build(
-            KernelConfig kernelConfig, @Nullable PromptTemplateEngine promptTemplateEngine) {
+            KernelConfig kernelConfig,
+            @Nullable PromptTemplateEngine promptTemplateEngine,
+            @Nullable MemoryStore memoryStore) {
         if (promptTemplateEngine == null) {
             promptTemplateEngine = new DefaultPromptTemplateEngine();
         }
@@ -18,7 +22,10 @@ public class DefaultKernelBuilder implements Kernel.InternalBuilder {
         if (kernelConfig == null) {
             throw new IllegalArgumentException();
         }
+        if (memoryStore == null) {
+            memoryStore = new VolatileMemoryStore();
+        }
 
-        return new DefaultKernel(kernelConfig, promptTemplateEngine, null);
+        return new DefaultKernel(kernelConfig, promptTemplateEngine, memoryStore);
     }
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/skilldefinition/DefaultSkillCollection.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/skilldefinition/DefaultSkillCollection.java
@@ -31,7 +31,7 @@ public class DefaultSkillCollection implements ReadOnlySkillCollection {
         }
     }
 
-    protected Map<String, FunctionCollection> getSkillCollection() {
+    public Map<String, FunctionCollection> getSkillCollection() {
         return skillCollection;
     }
 

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/skilldefinition/DefaultSkillCollection.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/skilldefinition/DefaultSkillCollection.java
@@ -31,7 +31,7 @@ public class DefaultSkillCollection implements ReadOnlySkillCollection {
         }
     }
 
-    public Map<String, FunctionCollection> getSkillCollection() {
+    protected Map<String, FunctionCollection> getSkillCollection() {
         return skillCollection;
     }
 

--- a/java/spotbugs-exclude.xml
+++ b/java/spotbugs-exclude.xml
@@ -15,11 +15,41 @@
     <Field name="_storage"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
-
+  
   <Match>
     <Class name="com.microsoft.semantickernel.orchestration.planner.DefaultSequentialPlannerSKFunction"/>
     <Field name="delegate"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.semantickernel.Kernel$Builder"/>
+    <Method name="withMemoryStore"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.semantickernel.DefaultKernel"/>
+    <Field name="memoryStore"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.semantickernel.DefaultKernel"/>
+    <Method name="getMemoryStore"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.semantickernel.memory.DefaultSemanticTextMemory$Builder"/>
+    <Method name="setStorage"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.microsoft.semantickernel.skilldefinition.DefaultSkillCollection"/>
+    <Method name="getSkillCollection"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
 
 </FindBugsFilter>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Initial port of C# memory to Java. Includes VolatileMemoryStore, no others.  


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Introduces semantickernel-api/src/main/java/com/microsoft/semantickernel/memory and 
implementation in semantickernel-core/src/main/java/com/microsoft/semantickernel/memory

e2e integration test provides a sample. See java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/e2e/TextEmbeddingsTest.java 

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] -The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`- Java code uses AOSP style
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
