### PR TITLE
Updating webkit values to relative percentage

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatRoom.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatRoom.tsx
@@ -36,7 +36,7 @@ const useClasses = makeStyles({
                 visibility: 'visible',
             },
         },
-        height: ['-webkit-fill-available', '-moz-available'],
+        height: '100%',
         ...shorthands.margin('4px'),
     },
     history: {

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatRoom.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatRoom.tsx
@@ -36,7 +36,7 @@ const useClasses = makeStyles({
                 visibility: 'visible',
             },
         },
-        height: '-webkit-fill-available',
+        height: ['-webkit-fill-available', '-moz-available'],
         ...shorthands.margin('4px'),
     },
     history: {

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
@@ -31,7 +31,7 @@ const useClasses = makeStyles({
     root: {
         display: 'flex',
         flexDirection: 'column',
-        width: '-webkit-fill-available',
+        width: '100%',
         backgroundColor: '#F5F5F5',
         boxShadow: 'rgb(0 0 0 / 25%) 0 0.2rem 0.4rem -0.075rem',
     },
@@ -73,7 +73,7 @@ const useClasses = makeStyles({
         width: '398px',
     },
     input: {
-        width: '-webkit-fill-available',
+        width: '100%',
     },
     buttons: {
         display: 'flex',

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -10,7 +10,7 @@ const useClasses = makeStyles({
         paddingTop: '0.8rem',
         paddingBottom: '0.8rem',
         paddingRight: '1rem',
-        width: '-webkit-fill-available',
+        width: '93%',
     },
     avatar: {
         flexShrink: '0',


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

-webkit-fill-available is not widely supported across all browsers. It is a non-standard CSS value and doesn't work on Firefox (Mozilla) browsers. Changing this to a relative percentage to be more inclusive of all browsers.

Scrollbars are unaffected and clamps are unaffected as they have a default fallback in moz

Example in Firefox:
![image](https://github.com/microsoft/semantic-kernel/assets/125500434/d865a92e-68c9-4a5c-888d-7d426876096f)
