### PR TITLE
Qdrant: fix skipping upserts

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
@@ -30,6 +30,13 @@ internal sealed class DeleteVectorsRequest : IValidatable
         return this;
     }
 
+    public DeleteVectorsRequest DeleteRange(IEnumerable<string> qdrantPointIds)
+    {
+        Verify.NotNull(qdrantPointIds, "The point ID collection is NULL");
+        this.Ids.AddRange(qdrantPointIds);
+        return this;
+    }
+
     public HttpRequestMessage Build()
     {
         this.Validate();

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
@@ -21,6 +21,16 @@ internal sealed class UpsertVectorRequest
         return this;
     }
 
+    public UpsertVectorRequest UpsertRange(IEnumerable<QdrantVectorRecord> vectorRecords)
+    {
+        foreach (var vectorRecord in vectorRecords)
+        {
+            this.UpsertVector(vectorRecord);
+        }
+
+        return this;
+    }
+
     public HttpRequestMessage Build()
     {
         return HttpRequest.CreatePutRequest(

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
@@ -163,15 +163,9 @@ public class QdrantVectorDbClient : IQdrantVectorDbClient
         Verify.NotNullOrEmpty(collectionName, "Collection name is empty");
         Verify.NotNull(pointIds, "Qdrant point IDs are NULL");
 
-        DeleteVectorsRequest requestBuilder = DeleteVectorsRequest.DeleteFrom(collectionName);
-
-        foreach (var pointId in pointIds)
-        {
-            requestBuilder.DeleteVector(pointId);
-        }
-
-        using var request = requestBuilder.Build();
-
+        using var request = DeleteVectorsRequest.DeleteFrom(collectionName)
+            .DeleteRange(pointIds)
+            .Build();
         (HttpResponseMessage response, string responseContent) = await this.ExecuteHttpRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
         try
@@ -239,21 +233,9 @@ public class QdrantVectorDbClient : IQdrantVectorDbClient
         Verify.NotNull(vectorData, "The vector data entries are NULL");
         Verify.NotNullOrEmpty(collectionName, "Collection name is empty");
 
-        var requestBuilder = UpsertVectorRequest.Create(collectionName);
-
-        foreach (var record in vectorData)
-        {
-            QdrantVectorRecord? existingRecord = await this.GetVectorsByIdAsync(collectionName, new[] { record.PointId }, false, cancellationToken).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-
-            if (existingRecord != null)
-            {
-                continue;
-            }
-
-            requestBuilder.UpsertVector(record);
-        }
-
-        using var request = requestBuilder.Build();
+        using var request = UpsertVectorRequest.Create(collectionName)
+            .UpsertRange(vectorData)
+            .Build();
         (HttpResponseMessage response, string responseContent) = await this.ExecuteHttpRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
         try


### PR DESCRIPTION
### Description
In the Qdrant connector, during Upsert(), it checks whether the vector already exists in the db; if so, it calls `continue` and skips upserting. The expected behavior of Upsert() is Insert+Update, but currently only the insert is working updates are explicitly skipped.

Resolves https://github.com/microsoft/semantic-kernel/issues/1035

Also includes some minor cleanup on the internal request builder classes:
- DeleteRange
- UpsertRange
...allow you to create the Builder, add all operations, and Build() in a single statement, so you never have to hold an instance of the Builder as a var just to operate a loop.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
