### PR TITLE
Make ContextVariables an actual dictionary

### DIFF
--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
@@ -130,7 +130,7 @@ public static class SKContextSequentialPlannerExtensions
     internal static async Task RememberFunctionsAsync(SKContext context, List<FunctionView> availableFunctions)
     {
         // Check if the functions have already been saved to memory.
-        if (context.Variables.Get(PlanSKFunctionsAreRemembered, out string _))
+        if (context.Variables.ContainsKey(PlanSKFunctionsAreRemembered))
         {
             return;
         }

--- a/dotnet/src/IntegrationTests/Fakes/EmailSkillFake.cs
+++ b/dotnet/src/IntegrationTests/Fakes/EmailSkillFake.cs
@@ -14,7 +14,7 @@ internal sealed class EmailSkillFake
     [SKFunctionContextParameter(Name = "email_address", Description = "The email address to send email to.", DefaultValue = "default@email.com")]
     public Task<SKContext> SendEmailAsync(string input, SKContext context)
     {
-        context.Variables.Get("email_address", out string emailAddress);
+        context.Variables.TryGetValue("email_address", out string? emailAddress);
         context.Variables.Update($"Sent email to: {emailAddress}. Body: {input}");
         return Task.FromResult(context);
     }

--- a/dotnet/src/IntegrationTests/Security/TrustServiceTests.cs
+++ b/dotnet/src/IntegrationTests/Security/TrustServiceTests.cs
@@ -381,7 +381,7 @@ public sealed class TrustServiceTests
         [SKFunction("Echoes a given text", isSensitive: false)]
         public string NotSensitiveEcho(SKContext context)
         {
-            context.Variables.Get("extraVar", out string extraVar);
+            context.Variables.TryGetValue("extraVar", out string? extraVar);
 
             return context.Variables.Input + extraVar;
         }
@@ -389,7 +389,7 @@ public sealed class TrustServiceTests
         [SKFunction("Echoes a given text", isSensitive: true)]
         public string SensitiveEcho(SKContext context)
         {
-            context.Variables.Get("extraVar", out string extraVar);
+            context.Variables.TryGetValue("extraVar", out string? extraVar);
 
             return context.Variables.Input + extraVar;
         }

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -4,10 +4,16 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Security;
+
+#pragma warning disable CA1710 // ContextVariables doesn't end in Dictionary or Collection
+#pragma warning disable CA1725, RCS1168 // Uses "name" instead of "key" for some public APIs
+#pragma warning disable CS8767 // Reference type nullability doesn't match because netstandard2.0 surface area isn't nullable reference type annotated
+// TODO: support more complex data types, and plan for rendering these values into prompt templates.
 
 namespace Microsoft.SemanticKernel.Orchestration;
 
@@ -17,13 +23,8 @@ namespace Microsoft.SemanticKernel.Orchestration;
 /// </summary>
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 [DebuggerTypeProxy(typeof(ContextVariables.TypeProxy))]
-public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwareString>>
+public sealed class ContextVariables : IDictionary<string, TrustAwareString>
 {
-    /// <summary>
-    /// In the simplest scenario, the data is an input string, stored here.
-    /// </summary>
-    public TrustAwareString Input => this._variables[MainKey];
-
     /// <summary>
     /// Constructor for context variables.
     /// </summary>
@@ -39,6 +40,25 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// </summary>
     /// <param name="content">Optional value for the main variable of the context.</param>
     public ContextVariables(string? content) : this(TrustAwareString.Trusted(content)) { }
+
+    /// <summary>
+    /// Create a copy of the current instance with a copy of the internal data
+    /// </summary>
+    /// <returns>Copy of the current instance</returns>
+    public ContextVariables Clone()
+    {
+        var clone = new ContextVariables();
+        foreach (KeyValuePair<string, TrustAwareString> x in this._variables)
+        {
+            clone.Set(x.Key, x.Value);
+        }
+
+        return clone;
+    }
+
+    /// <summary>Gets the main input string.</summary>
+    /// <remarks>If the main input string was removed from the collection, an empty string will be returned.</remarks>
+    public TrustAwareString Input => this._variables.TryGetValue(MainKey, out TrustAwareString? value) ? value : TrustAwareString.Empty;
 
     /// <summary>
     /// Updates the main input text with the new value after a function is complete.
@@ -129,7 +149,6 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// </summary>
     /// <param name="name">Variable name</param>
     /// <param name="value">Value to store</param>
-    /// TODO: support for more complex data types, and plan for rendering these values into prompt templates.
     public void Set(string name, string value)
     {
         this.Set(name, TrustAwareString.Trusted(value));
@@ -141,6 +160,8 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// <param name="name">Variable name</param>
     /// <param name="trustAwareValue">Variable value as a string with trust information</param>
     /// <returns>Whether the value exists in the context variables</returns>
+    [Obsolete("This method is deprecated and will be removed in one of the next SK SDK versions. Use the TryGetValue method or indexer instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public bool Get(string name, out TrustAwareString trustAwareValue)
     {
         if (this._variables.TryGetValue(name, out TrustAwareString result))
@@ -150,7 +171,6 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
         }
 
         trustAwareValue = TrustAwareString.Empty;
-
         return false;
     }
 
@@ -160,6 +180,8 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// <param name="name">Variable name</param>
     /// <param name="value">Value</param>
     /// <returns>Whether the value exists in the context variables</returns>
+    [Obsolete("This method is deprecated and will be removed in one of the next SK SDK versions. Use the TryGetValue method or indexer instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public bool Get(string name, out string value)
     {
         var exists = this.Get(name, out TrustAwareString trustAwareValue);
@@ -167,6 +189,39 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
         value = trustAwareValue.Value;
 
         return exists;
+    }
+
+    /// <summary>
+    /// Gets the variable value associated with the specified name.
+    /// </summary>
+    /// <param name="name">The name of the variable to get.</param>
+    /// <param name="value">
+    /// When this method returns, contains the variable value associated with the specified name, if the variable is found;
+    /// otherwise, null.
+    /// </param>
+    /// <returns>true if the <see cref="ContextVariables"/> contains a variable with the specified name; otherwise, false.</returns>
+    public bool TryGetValue(string name, [NotNullWhen(true)] out TrustAwareString? value) =>
+        this._variables.TryGetValue(name, out value);
+
+    /// <summary>
+    /// Gets the variable value associated with the specified name.
+    /// </summary>
+    /// <param name="name">The name of the variable to get.</param>
+    /// <param name="value">
+    /// When this method returns, contains the variable value associated with the specified name, if the variable is found;
+    /// otherwise, null.
+    /// </param>
+    /// <returns>true if the <see cref="ContextVariables"/> contains a variable with the specified name; otherwise, false.</returns>
+    public bool TryGetValue(string name, [NotNullWhen(true)] out string? value)
+    {
+        if (this._variables.TryGetValue(name, out TrustAwareString? trustAwareValue))
+        {
+            value = trustAwareValue.Value;
+            return true;
+        }
+
+        value = null;
+        return false;
     }
 
     /// <summary>
@@ -188,13 +243,13 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     }
 
     /// <summary>
-    /// Returns true if there is a variable with the given name
+    /// Determines whether the <see cref="ContextVariables"/> contains the specified variable.
     /// </summary>
-    /// <param name="key"></param>
-    /// <returns>True if there is a variable with the given name, false otherwise</returns>
-    public bool ContainsKey(string key)
+    /// <param name="name">The name of the variable to locate.</param>
+    /// <returns>true if the <see cref="ContextVariables"/> contains a variable with the specified name; otherwise, false.</returns>
+    public bool ContainsKey(string name)
     {
-        return this._variables.ContainsKey(key);
+        return this._variables.ContainsKey(name);
     }
 
     /// <summary>
@@ -203,7 +258,14 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// <returns></returns>
     public bool IsAllTrusted()
     {
-        return this._variables.Values.All(v => v.IsTrusted);
+        foreach (var pair in this._variables)
+        {
+            if (!pair.Value.IsTrusted)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     /// <summary>
@@ -211,9 +273,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// </summary>
     public void UntrustAll()
     {
-        // Create a copy of the variables map iterator with ToList to avoid
-        // iterating in the map while updating it
-        foreach (var item in this._variables.ToList())
+        foreach (var item in this._variables)
         {
             // Note: we don't use an internal setter for better multi-threading
             this._variables[item.Key] = TrustAwareString.Untrusted(item.Value.Value);
@@ -232,45 +292,37 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// Print the processed input, aka the current data after any processing occurred.
     /// </summary>
     /// <returns>Processed input, aka result</returns>
-    public override string ToString()
-    {
-        return this.Input;
-    }
+    public override string ToString() => this.Input;
 
     /// <summary>
     /// Get an enumerator that iterates through the context variables.
     /// </summary>
     /// <returns>An enumerator that iterates through the context variables</returns>
-    public IEnumerator<KeyValuePair<string, TrustAwareString>> GetEnumerator()
-    {
-        return this._variables.GetEnumerator();
-    }
+    public IEnumerator<KeyValuePair<string, TrustAwareString>> GetEnumerator() => this._variables.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator()
+    IEnumerator IEnumerable.GetEnumerator() => this._variables.GetEnumerator();
+    void IDictionary<string, TrustAwareString>.Add(string key, TrustAwareString value) => ((IDictionary<string, TrustAwareString>)this._variables).Add(key, value);
+    bool IDictionary<string, TrustAwareString>.Remove(string key) => ((IDictionary<string, TrustAwareString>)this._variables).Remove(key);
+    void ICollection<KeyValuePair<string, TrustAwareString>>.Add(KeyValuePair<string, TrustAwareString> item) => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).Add(item);
+    void ICollection<KeyValuePair<string, TrustAwareString>>.Clear() => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).Clear();
+    bool ICollection<KeyValuePair<string, TrustAwareString>>.Contains(KeyValuePair<string, TrustAwareString> item) => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).Contains(item);
+    void ICollection<KeyValuePair<string, TrustAwareString>>.CopyTo(KeyValuePair<string, TrustAwareString>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).CopyTo(array, arrayIndex);
+    bool ICollection<KeyValuePair<string, TrustAwareString>>.Remove(KeyValuePair<string, TrustAwareString> item) => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).Remove(item);
+    ICollection<string> IDictionary<string, TrustAwareString>.Keys => ((IDictionary<string, TrustAwareString>)this._variables).Keys;
+    ICollection<TrustAwareString> IDictionary<string, TrustAwareString>.Values => ((IDictionary<string, TrustAwareString>)this._variables).Values;
+    int ICollection<KeyValuePair<string, TrustAwareString>>.Count => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).Count;
+    bool ICollection<KeyValuePair<string, TrustAwareString>>.IsReadOnly => ((ICollection<KeyValuePair<string, TrustAwareString>>)this._variables).IsReadOnly;
+    TrustAwareString IDictionary<string, TrustAwareString>.this[string key]
     {
-        return this._variables.GetEnumerator();
-    }
-
-    /// <summary>
-    /// Create a copy of the current instance with a copy of the internal data
-    /// </summary>
-    /// <returns>Copy of the current instance</returns>
-    public ContextVariables Clone()
-    {
-        var clone = new ContextVariables();
-        foreach (KeyValuePair<string, TrustAwareString> x in this._variables)
-        {
-            clone.Set(x.Key, x.Value);
-        }
-
-        return clone;
+        get => ((IDictionary<string, TrustAwareString>)this._variables)[key];
+        set => ((IDictionary<string, TrustAwareString>)this._variables)[key] = value;
     }
 
     internal const string MainKey = "INPUT";
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal string DebuggerDisplay =>
-        this._variables.TryGetValue(MainKey, out var input) && !string.IsNullOrEmpty(input.Value)
+        this.TryGetValue(MainKey, out string? input) && !string.IsNullOrEmpty(input)
             ? $"Variables = {this._variables.Count}, Input = {input}"
             : $"Variables = {this._variables.Count}";
 

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Security;
 
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Security;
 /// A string wrapper that carries trust information.
 /// All field are readonly.
 /// </summary>
+[DebuggerDisplay("Value = {Value}, IsTrusted = {IsTrusted}")]
 public class TrustAwareString : IEquatable<TrustAwareString>
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
@@ -105,8 +105,8 @@ public class ContextVariablesTests
         target.Set(anyName, anyContent);
 
         // Assert
-        Assert.True(target.Get(anyName, out string _));
-        Assert.True(target.Get(anyName, out TrustAwareString _));
+        Assert.True(target.TryGetValue(anyName, out string? _));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -122,8 +122,8 @@ public class ContextVariablesTests
         target.Set(anyName, anyContent);
 
         // Assert
-        Assert.True(target.Get(anyName, out string _));
-        Assert.True(target.Get(anyName, out TrustAwareString _));
+        Assert.True(target.TryGetValue(anyName, out string? _));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -139,8 +139,8 @@ public class ContextVariablesTests
         target[anyName] = anyContent;
 
         // Assert
-        Assert.True(target.Get(anyName, out string _));
-        Assert.True(target.Get(anyName, out TrustAwareString _));
+        Assert.True(target.TryGetValue(anyName, out string? _));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -156,8 +156,8 @@ public class ContextVariablesTests
         target.Set(anyName, anyContent);
 
         // Assert
-        Assert.True(target.Get(anyName, out string _));
-        Assert.True(target.Get(anyName, out TrustAwareString _));
+        Assert.True(target.TryGetValue(anyName, out string? _));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -172,8 +172,8 @@ public class ContextVariablesTests
         target.Set(anyName, anyContent);
 
         // Assert
-        Assert.True(target.Get(anyName, out string _));
-        Assert.True(target.Get(anyName, out TrustAwareString _));
+        Assert.True(target.TryGetValue(anyName, out string? _));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -188,8 +188,8 @@ public class ContextVariablesTests
         target.Set(anyName, anyContent);
 
         // Assert
-        Assert.True(target.Get(anyName, out string _));
-        Assert.True(target.Get(anyName, out TrustAwareString _));
+        Assert.True(target.TryGetValue(anyName, out string? _));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -210,8 +210,8 @@ public class ContextVariablesTests
         target.Set(anyName, null);
 
         // Assert - Should have been erased
-        Assert.False(target.Get(anyName, out string _));
-        Assert.False(target.Get(anyName, out TrustAwareString _));
+        Assert.False(target.TryGetValue(anyName, out string? _));
+        Assert.False(target.TryGetValue(anyName, out TrustAwareString? _));
     }
 
     [Fact]
@@ -227,7 +227,8 @@ public class ContextVariablesTests
         target.Set(anyName, TrustAwareString.Untrusted(anyContent));
 
         // Assert
-        Assert.True(target.Get(anyName, out TrustAwareString trustAwareValue));
+        Assert.True(target.TryGetValue(anyName, out TrustAwareString? trustAwareValue));
+        Assert.NotNull(trustAwareValue);
         Assert.Equal(anyContent, trustAwareValue.Value);
         Assert.False(trustAwareValue.IsTrusted);
         Assert.Equal(mainContent, target.Input.Value);
@@ -246,7 +247,7 @@ public class ContextVariablesTests
         target.Set(anyName, TrustAwareString.Untrusted(anyContent));
 
         // Assert
-        Assert.True(target.Get(anyName, out string value));
+        Assert.True(target.TryGetValue(anyName, out string? value));
         Assert.Equal(anyContent, value);
         Assert.Equal(mainContent, target.Input.Value);
     }
@@ -414,19 +415,18 @@ public class ContextVariablesTests
         ContextVariables target = new();
 
         // Act
-        var exists = target.Get(anyName, out TrustAwareString trustAwareValue);
+        var exists = target.TryGetValue(anyName, out TrustAwareString? trustAwareValue);
 
         // Assert
         Assert.False(exists);
-        Assert.Empty(trustAwareValue.Value);
-        Assert.True(trustAwareValue.IsTrusted);
+        Assert.Null(trustAwareValue);
 
         // Act
-        exists = target.Get(anyName, out string value);
+        exists = target.TryGetValue(anyName, out string? value);
 
         // Assert
         Assert.False(exists);
-        Assert.Empty(value);
+        Assert.Null(value);
     }
 
     [Fact]
@@ -551,11 +551,12 @@ public class ContextVariablesTests
 
     private static void AssertContextVariable(ContextVariables variables, string name, string expectedValue, bool expectedIsTrusted)
     {
-        var exists = variables.Get(name, out TrustAwareString trustAwareValue);
+        var exists = variables.TryGetValue(name, out TrustAwareString? trustAwareValue);
 
         // Assert the variable exists
         Assert.True(exists);
         // Assert the value matches
+        Assert.NotNull(trustAwareValue);
         Assert.Equal(expectedValue, trustAwareValue.Value);
         // Assert isTrusted matches
         Assert.Equal(expectedIsTrusted, trustAwareValue.IsTrusted);

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanSerializationTests.cs
@@ -356,7 +356,7 @@ public sealed class PlanSerializationTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("variables", out string v);
+                c.Variables.TryGetValue("variables", out string? v);
                 returnContext.Variables.Update(returnContext.Variables.Input + c.Variables.Input + v);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -428,7 +428,7 @@ public sealed class PlanSerializationTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("variables", out string v);
+                c.Variables.TryGetValue("variables", out string? v);
                 returnContext.Variables.Update(returnContext.Variables.Input + c.Variables.Input + v);
             })
             .Returns(() => Task.FromResult(returnContext));

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -347,7 +347,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), null))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("variables", out string v);
+                c.Variables.TryGetValue("variables", out string? v);
                 returnContext.Variables.Update(returnContext.Variables.Input + c.Variables.Input + v);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -595,7 +595,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), default))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("type", out string t);
+                c.Variables.TryGetValue("type", out string? t);
                 returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -636,7 +636,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), default))
             .Callback<SKContext, CompleteRequestSettings?>((c, s) =>
             {
-                c.Variables.Get("type", out string t);
+                c.Variables.TryGetValue("type", out string? t);
                 returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
             })
             .Returns(() => Task.FromResult(returnContext));
@@ -695,7 +695,7 @@ public sealed class PlanTests
         mockFunction.Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), default))
             .Callback<SKContext, CompleteRequestSettings>((c, s) =>
             {
-                c.Variables.Get("type", out string t);
+                c.Variables.TryGetValue("type", out string? t);
                 returnContext.Variables.Update($"Here is a {t} about " + c.Variables.Input);
             })
             .Returns(() => Task.FromResult(returnContext));

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -388,9 +388,10 @@ public class CodeBlockTests
 
     private static TrustAwareString GetAsTrustAwareString(SKContext context, string name)
     {
-        var exists = context.Variables.Get(name, out TrustAwareString trustAwareValue);
+        var exists = context.Variables.TryGetValue(name, out TrustAwareString? trustAwareValue);
 
         Assert.True(exists);
+        Assert.NotNull(trustAwareValue);
 
         return trustAwareValue;
     }

--- a/dotnet/src/SemanticKernel/TemplateEngine/Blocks/VarBlock.cs
+++ b/dotnet/src/SemanticKernel/TemplateEngine/Blocks/VarBlock.cs
@@ -73,7 +73,7 @@ internal sealed class VarBlock : Block, ITextRendering
             throw new TemplateException(TemplateException.ErrorCodes.SyntaxError, ErrMsg);
         }
 
-        if (variables.Get(this.Name, out string value))
+        if (variables.TryGetValue(this.Name, out string? value))
         {
             return value;
         }

--- a/dotnet/src/Skills/Skills.Document/DocumentSkill.cs
+++ b/dotnet/src/Skills/Skills.Document/DocumentSkill.cs
@@ -85,7 +85,7 @@ public class DocumentSkill
     [SKFunctionContextParameter(Name = Parameters.FilePath, Description = "Destination file path")]
     public async Task AppendTextAsync(string text, SKContext context)
     {
-        if (!context.Variables.Get(Parameters.FilePath, out string filePath))
+        if (!context.Variables.TryGetValue(Parameters.FilePath, out string? filePath))
         {
             context.Fail($"Missing variable {Parameters.FilePath}.");
             return;

--- a/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/Skills/Skills.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -145,7 +145,7 @@ public static class KernelGrpcExtensions
                 foreach (var parameter in operationParameters)
                 {
                     //A try to resolve argument parameter name.
-                    if (context.Variables.Get(parameter.Name, out string value))
+                    if (context.Variables.TryGetValue(parameter.Name, out string? value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;

--- a/dotnet/src/Skills/Skills.MsGraph/CalendarSkill.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/CalendarSkill.cs
@@ -97,13 +97,13 @@ public class CalendarSkill
             return;
         }
 
-        if (!variables.Get(Parameters.Start, out string start))
+        if (!variables.TryGetValue(Parameters.Start, out string? start))
         {
             context.Fail($"Missing variable {Parameters.Start}.");
             return;
         }
 
-        if (!variables.Get(Parameters.End, out string end))
+        if (!variables.TryGetValue(Parameters.End, out string? end))
         {
             context.Fail($"Missing variable {Parameters.End}.");
             return;
@@ -116,17 +116,17 @@ public class CalendarSkill
             End = DateTimeOffset.Parse(end, CultureInfo.InvariantCulture.DateTimeFormat)
         };
 
-        if (variables.Get(Parameters.Location, out string location))
+        if (variables.TryGetValue(Parameters.Location, out string? location))
         {
             calendarEvent.Location = location;
         }
 
-        if (variables.Get(Parameters.Content, out string content))
+        if (variables.TryGetValue(Parameters.Content, out string? content))
         {
             calendarEvent.Content = content;
         }
 
-        if (variables.Get(Parameters.Attendees, out string attendees))
+        if (variables.TryGetValue(Parameters.Attendees, out string? attendees))
         {
             calendarEvent.Attendees = attendees.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
@@ -143,8 +143,8 @@ public class CalendarSkill
     [SKFunctionContextParameter(Name = Parameters.Skip, Description = "Optional number of events to skip before retrieving results.", DefaultValue = "0")]
     public async Task<string> GetCalendarEventsAsync(SKContext context)
     {
-        context.Variables.Get(Parameters.MaxResults, out string maxResultsString);
-        context.Variables.Get(Parameters.Skip, out string skipString);
+        context.Variables.TryGetValue(Parameters.MaxResults, out string? maxResultsString);
+        context.Variables.TryGetValue(Parameters.Skip, out string? skipString);
         this._logger.LogInformation("Getting calendar events with query options top: '{0}', skip:'{1}'.", maxResultsString, skipString);
 
         string selectString = "start,subject,organizer,location";

--- a/dotnet/src/Skills/Skills.MsGraph/CloudDriveSkill.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/CloudDriveSkill.cs
@@ -59,7 +59,7 @@ public class CloudDriveSkill
     [SKFunction("Upload a small file to OneDrive (less than 4MB).")]
     public async Task UploadFileAsync(string filePath, SKContext context)
     {
-        if (!context.Variables.Get(Parameters.DestinationPath, out string destinationPath))
+        if (!context.Variables.TryGetValue(Parameters.DestinationPath, out string? destinationPath))
         {
             context.Fail($"Missing variable {Parameters.DestinationPath}.");
             return;

--- a/dotnet/src/Skills/Skills.MsGraph/EmailSkill.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/EmailSkill.cs
@@ -77,13 +77,13 @@ public class EmailSkill
     [SKFunctionContextParameter(Name = Parameters.Subject, Description = "Subject of the email")]
     public async Task SendEmailAsync(string content, SKContext context)
     {
-        if (!context.Variables.Get(Parameters.Recipients, out string recipients))
+        if (!context.Variables.TryGetValue(Parameters.Recipients, out string? recipients))
         {
             context.Fail($"Missing variable {Parameters.Recipients}.");
             return;
         }
 
-        if (!context.Variables.Get(Parameters.Subject, out string subject))
+        if (!context.Variables.TryGetValue(Parameters.Subject, out string? subject))
         {
             context.Fail($"Missing variable {Parameters.Subject}.");
             return;
@@ -104,8 +104,8 @@ public class EmailSkill
         DefaultValue = "0")]
     public async Task<string> GetEmailMessagesAsync(SKContext context)
     {
-        context.Variables.Get(Parameters.MaxResults, out string maxResultsString);
-        context.Variables.Get(Parameters.Skip, out string skipString);
+        context.Variables.TryGetValue(Parameters.MaxResults, out string? maxResultsString);
+        context.Variables.TryGetValue(Parameters.Skip, out string? skipString);
         this._logger.LogInformation("Getting email messages with query options top: '{0}', skip:'{1}'.", maxResultsString, skipString);
 
         string selectString = "subject,receivedDateTime,bodyPreview";

--- a/dotnet/src/Skills/Skills.MsGraph/TaskListSkill.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/TaskListSkill.cs
@@ -87,7 +87,7 @@ public class TaskListSkill
             id: Guid.NewGuid().ToString(),
             title: title);
 
-        if (context.Variables.Get(Parameters.Reminder, out string reminder))
+        if (context.Variables.TryGetValue(Parameters.Reminder, out string? reminder))
         {
             task.Reminder = reminder;
         }
@@ -113,7 +113,7 @@ public class TaskListSkill
         }
 
         bool includeCompleted = false;
-        if (context.Variables.Get(Parameters.IncludeCompleted, out string includeCompletedString))
+        if (context.Variables.TryGetValue(Parameters.IncludeCompleted, out string? includeCompletedString))
         {
             if (!bool.TryParse(includeCompletedString, out includeCompleted))
             {

--- a/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/Extensions/KernelOpenApiExtensions.cs
@@ -273,14 +273,14 @@ public static class KernelOpenApiExtensions
                 foreach (var parameter in restOperationParameters)
                 {
                     // A try to resolve argument by alternative parameter name
-                    if (!string.IsNullOrEmpty(parameter.AlternativeName) && context.Variables.Get(parameter.AlternativeName!, out string value))
+                    if (!string.IsNullOrEmpty(parameter.AlternativeName) && context.Variables.TryGetValue(parameter.AlternativeName!, out string? value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;
                     }
 
                     // A try to resolve argument by original parameter name
-                    if (context.Variables.Get(parameter.Name, out value))
+                    if (context.Variables.TryGetValue(parameter.Name, out value))
                     {
                         arguments.Add(parameter.Name, value);
                         continue;

--- a/dotnet/src/Skills/Skills.OpenAPI/JsonPathSkill.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/JsonPathSkill.cs
@@ -35,7 +35,7 @@ public class JsonPathSkill
             return string.Empty;
         }
 
-        if (!context.Variables.Get(Parameters.JsonPath, out string jsonPath))
+        if (!context.Variables.TryGetValue(Parameters.JsonPath, out string? jsonPath))
         {
             context.Fail($"Missing variable {Parameters.JsonPath}.");
             return string.Empty;
@@ -62,7 +62,7 @@ public class JsonPathSkill
             return string.Empty;
         }
 
-        if (!context.Variables.Get(Parameters.JsonPath, out string jsonPath))
+        if (!context.Variables.TryGetValue(Parameters.JsonPath, out string? jsonPath))
         {
             context.Fail($"Missing variable {Parameters.JsonPath}.");
             return string.Empty;

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/TaskListSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/TaskListSkillTests.cs
@@ -43,7 +43,7 @@ public class TaskListSkillTests
         TaskListSkill target = new(connectorMock.Object);
 
         // Verify no reminder is set
-        Assert.False(this._context.Variables.Get(Parameters.Reminder, out string _));
+        Assert.False(this._context.Variables.ContainsKey(Parameters.Reminder));
 
         // Act
         await target.AddTaskAsync(anyTitle, this._context);

--- a/dotnet/src/Skills/Skills.Web/WebFileDownloadSkill.cs
+++ b/dotnet/src/Skills/Skills.Web/WebFileDownloadSkill.cs
@@ -52,7 +52,7 @@ public class WebFileDownloadSkill : IDisposable
     {
         this._logger.LogDebug($"{nameof(this.DownloadToFileAsync)} got called");
 
-        if (!context.Variables.Get(FilePathParamName, out string filePath))
+        if (!context.Variables.TryGetValue(FilePathParamName, out string? filePath))
         {
             this._logger.LogError($"Missing context variable in {nameof(this.DownloadToFileAsync)}");
             string errorMessage = $"Missing variable {FilePathParamName}";


### PR DESCRIPTION
### Motivation and Context

Make ContextVariables feel more like the dictionary it is.

### Description

ContextVariables waddles like a dictionary and quacks like a dictionary but for some reason isn't a dictionary.  This makes it one.  For now I added the rest of the IDictionary surface area explicitly such that it won't show up on the public surface area of ContextVariables, but we should revisit some members, like Count.  This also renames Get to TryGetValue, as that's the expected name in .NET for a method with its semantics, and it fixes the nullable behavior of the out param when it returns false.

It was also possible previously for someone to Set("input", null), in which case the Input property would return null even though the rest of the type is obviously trying to avoid that.  I changed Input to handle it.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
