### PR TITLE
A few minor suggested tweaks to TrustAwareString

### DIFF
--- a/dotnet/src/IntegrationTests/Security/TrustServiceTests.cs
+++ b/dotnet/src/IntegrationTests/Security/TrustServiceTests.cs
@@ -147,7 +147,7 @@ public sealed class TrustServiceTests
         );
 
         // Make this untrusted
-        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.CreateUntrusted(extraVar));
 
         // Act
         var result = await kernel.RunAsync(variables, notSensitiveEchoFunction);
@@ -174,7 +174,7 @@ public sealed class TrustServiceTests
         );
 
         // Make this untrusted
-        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.CreateUntrusted(extraVar));
 
         // Act
         var result = await kernel.RunAsync(variables, sensitiveEchoFunction);
@@ -199,7 +199,7 @@ public sealed class TrustServiceTests
         );
 
         // Make this untrusted
-        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.CreateUntrusted(extraVar));
 
         // Act
         var result = await kernel.RunAsync(variables, notSensitiveEchoFunction);
@@ -225,7 +225,7 @@ public sealed class TrustServiceTests
         );
 
         // Make this untrusted
-        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.Untrusted(extraVar));
+        variables.Set(TrustServiceTests.ExtraVarName, TrustAwareString.CreateUntrusted(extraVar));
 
         // Act
         var result = await kernel.RunAsync(variables, sensitiveEchoFunction);

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ContextVariables.cs
@@ -38,7 +38,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// By default the content will be trusted.
     /// </summary>
     /// <param name="content">Optional value for the main variable of the context.</param>
-    public ContextVariables(string? content) : this(TrustAwareString.Trusted(content)) { }
+    public ContextVariables(string? content) : this(TrustAwareString.CreateTrusted(content)) { }
 
     /// <summary>
     /// Updates the main input text with the new value after a function is complete.
@@ -62,7 +62,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// <returns>The current instance</returns>
     public ContextVariables Update(string? content)
     {
-        return this.Update(TrustAwareString.Trusted(content));
+        return this.Update(TrustAwareString.CreateTrusted(content));
     }
 
     /// <summary>
@@ -132,7 +132,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// TODO: support for more complex data types, and plan for rendering these values into prompt templates.
     public void Set(string name, string value)
     {
-        this.Set(name, TrustAwareString.Trusted(value));
+        this.Set(name, TrustAwareString.CreateTrusted(value));
     }
 
     /// <summary>
@@ -183,7 +183,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
             // TODO: we could plan to replace string usages in the kernel
             // with TrustAwareString, so here "value" could directly be a trust aware string
             // including trust information
-            this._variables[name] = TrustAwareString.Trusted(value);
+            this._variables[name] = TrustAwareString.CreateTrusted(value);
         }
     }
 
@@ -216,7 +216,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
         foreach (var item in this._variables.ToList())
         {
             // Note: we don't use an internal setter for better multi-threading
-            this._variables[item.Key] = TrustAwareString.Untrusted(item.Value.Value);
+            this._variables[item.Key] = TrustAwareString.CreateUntrusted(item.Value.Value);
         }
     }
 
@@ -225,7 +225,7 @@ public sealed class ContextVariables : IEnumerable<KeyValuePair<string, TrustAwa
     /// </summary>
     public void UntrustInput()
     {
-        this.Update(TrustAwareString.Untrusted(this.Input.Value));
+        this.Update(TrustAwareString.CreateUntrusted(this.Input.Value));
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
@@ -5,29 +5,28 @@ using System;
 namespace Microsoft.SemanticKernel.Security;
 
 /// <summary>
-/// A string wrapper that carries trust information.
-/// All field are readonly.
+/// Provides an immutable string that carries trust information.
 /// </summary>
-public class TrustAwareString : IEquatable<TrustAwareString>
+public sealed class TrustAwareString : IEquatable<TrustAwareString>
 {
     /// <summary>
-    /// Create a new empty trust aware string (default trusted).
+    /// Gets a trusted empty string.
     /// </summary>
-    public static TrustAwareString Empty => new(string.Empty, true);
+    public static TrustAwareString Empty { get; } = new(string.Empty, isTrusted: true);
 
     /// <summary>
     /// Create a new trusted string.
     /// </summary>
     /// <param name="value">The raw string value</param>
     /// <returns>TrustAwareString</returns>
-    public static TrustAwareString Trusted(string? value) => new(value, true);
+    public static TrustAwareString CreateTrusted(string? value) => new(value, isTrusted: true);
 
     /// <summary>
     /// Create a new untrusted string.
     /// </summary>
     /// <param name="value">The raw string value</param>
     /// <returns>TrustAwareString</returns>
-    public static TrustAwareString Untrusted(string? value) => new(value, false);
+    public static TrustAwareString CreateUntrusted(string? value) => new(value, isTrusted: false);
 
     /// <summary>
     /// The raw string value.

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
@@ -224,7 +224,7 @@ public class ContextVariablesTests
         ContextVariables target = new(mainContent);
 
         // Act
-        target.Set(anyName, TrustAwareString.Untrusted(anyContent));
+        target.Set(anyName, TrustAwareString.CreateUntrusted(anyContent));
 
         // Assert
         Assert.True(target.Get(anyName, out TrustAwareString trustAwareValue));
@@ -243,7 +243,7 @@ public class ContextVariablesTests
         ContextVariables target = new(mainContent);
 
         // Act
-        target.Set(anyName, TrustAwareString.Untrusted(anyContent));
+        target.Set(anyName, TrustAwareString.CreateUntrusted(anyContent));
 
         // Assert
         Assert.True(target.Get(anyName, out string value));
@@ -326,8 +326,8 @@ public class ContextVariablesTests
         // Arrange
         string content0 = Guid.NewGuid().ToString();
         string content1 = Guid.NewGuid().ToString();
-        ContextVariables trustedVar = new(TrustAwareString.Trusted(Guid.NewGuid().ToString()));
-        ContextVariables untrustedVar = new(TrustAwareString.Untrusted(Guid.NewGuid().ToString()));
+        ContextVariables trustedVar = new(TrustAwareString.CreateTrusted(Guid.NewGuid().ToString()));
+        ContextVariables untrustedVar = new(TrustAwareString.CreateUntrusted(Guid.NewGuid().ToString()));
 
         // Act
         trustedVar.Update(content0);
@@ -342,7 +342,7 @@ public class ContextVariablesTests
     public void UpdateWithNullDefaultsToEmptyTrustedSucceeds()
     {
         // Arrange
-        ContextVariables untrustedVar = new(TrustAwareString.Untrusted(Guid.NewGuid().ToString()));
+        ContextVariables untrustedVar = new(TrustAwareString.CreateUntrusted(Guid.NewGuid().ToString()));
 
         // Act
         untrustedVar.Update(null);
@@ -357,12 +357,12 @@ public class ContextVariablesTests
         // Arrange
         string trustedContent = Guid.NewGuid().ToString();
         string untrustedContent = Guid.NewGuid().ToString();
-        ContextVariables trustedVar = new(TrustAwareString.Trusted(Guid.NewGuid().ToString()));
-        ContextVariables untrustedVar = new(TrustAwareString.Untrusted(Guid.NewGuid().ToString()));
+        ContextVariables trustedVar = new(TrustAwareString.CreateTrusted(Guid.NewGuid().ToString()));
+        ContextVariables untrustedVar = new(TrustAwareString.CreateUntrusted(Guid.NewGuid().ToString()));
 
         // Act
-        trustedVar.Update(TrustAwareString.Untrusted(trustedContent));
-        untrustedVar.Update(TrustAwareString.Untrusted(untrustedContent));
+        trustedVar.Update(TrustAwareString.CreateUntrusted(trustedContent));
+        untrustedVar.Update(TrustAwareString.CreateUntrusted(untrustedContent));
 
         // Assert
         AssertContextVariable(trustedVar, ContextVariables.MainKey, trustedContent, false);
@@ -439,16 +439,16 @@ public class ContextVariablesTests
         string someOtherMainContent = Guid.NewGuid().ToString();
         string someOtherContent = Guid.NewGuid().ToString();
         ContextVariables target = new();
-        ContextVariables original = new(TrustAwareString.Untrusted(mainContent));
+        ContextVariables original = new(TrustAwareString.CreateUntrusted(mainContent));
 
-        original.Set(anyName, TrustAwareString.Untrusted(anyContent));
+        original.Set(anyName, TrustAwareString.CreateUntrusted(anyContent));
 
         // Act
         // Clone original into target
         target.Update(original);
         // Update original
-        original.Update(TrustAwareString.Trusted(someOtherMainContent));
-        original.Set(anyName, TrustAwareString.Trusted(someOtherContent));
+        original.Update(TrustAwareString.CreateTrusted(someOtherMainContent));
+        original.Set(anyName, TrustAwareString.CreateTrusted(someOtherContent));
 
         // Assert
         // Target should be the same as the original before the update
@@ -466,16 +466,16 @@ public class ContextVariablesTests
         string mainContent = Guid.NewGuid().ToString();
         string anyName = Guid.NewGuid().ToString();
         string anyContent = Guid.NewGuid().ToString();
-        ContextVariables target = new(TrustAwareString.Trusted(mainContent));
+        ContextVariables target = new(TrustAwareString.CreateTrusted(mainContent));
 
         // Act
-        target.Set(anyName, TrustAwareString.Trusted(anyContent));
+        target.Set(anyName, TrustAwareString.CreateTrusted(anyContent));
 
         // Assert
         Assert.True(target.IsAllTrusted());
 
         // Act
-        target.Set(anyName, TrustAwareString.Untrusted(anyContent));
+        target.Set(anyName, TrustAwareString.CreateUntrusted(anyContent));
 
         // Assert
         Assert.False(target.IsAllTrusted());
@@ -490,7 +490,7 @@ public class ContextVariablesTests
         string anyContent0 = Guid.NewGuid().ToString();
         string anyName1 = Guid.NewGuid().ToString();
         string anyContent1 = Guid.NewGuid().ToString();
-        ContextVariables target = new(TrustAwareString.Trusted(mainContent));
+        ContextVariables target = new(TrustAwareString.CreateTrusted(mainContent));
 
         // Act - Default set with string should be trusted
         target.Set(anyName0, anyContent0);
@@ -523,7 +523,7 @@ public class ContextVariablesTests
         string anyContent0 = Guid.NewGuid().ToString();
         string anyName1 = Guid.NewGuid().ToString();
         string anyContent1 = Guid.NewGuid().ToString();
-        ContextVariables target = new(TrustAwareString.Trusted(mainContent));
+        ContextVariables target = new(TrustAwareString.CreateTrusted(mainContent));
 
         // Act - Default set with string should be trusted
         target.Set(anyName0, anyContent0);

--- a/dotnet/src/SemanticKernel.UnitTests/Security/TrustAwareStringTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Security/TrustAwareStringTests.cs
@@ -59,12 +59,12 @@ public sealed class TrustAwareStringTest
     public void EqualsAndGetHashCodeSucceeds()
     {
         // Arrange
-        var trustedValue0 = TrustAwareString.Trusted("some value 0");
-        var trustedValue0Copy = TrustAwareString.Trusted("some value 0");
-        var untrustedValue0 = TrustAwareString.Untrusted("some value 0");
-        var untrustedValue0Copy = TrustAwareString.Untrusted("some value 0");
-        var trustedValue1 = TrustAwareString.Trusted("some value 1");
-        var untrustedValue1 = TrustAwareString.Trusted("some value 1");
+        var trustedValue0 = TrustAwareString.CreateTrusted("some value 0");
+        var trustedValue0Copy = TrustAwareString.CreateTrusted("some value 0");
+        var untrustedValue0 = TrustAwareString.CreateUntrusted("some value 0");
+        var untrustedValue0Copy = TrustAwareString.CreateUntrusted("some value 0");
+        var trustedValue1 = TrustAwareString.CreateTrusted("some value 1");
+        var untrustedValue1 = TrustAwareString.CreateTrusted("some value 1");
         var stringValue0 = "some value 0";
         int someObj = 10;
 

--- a/dotnet/src/SemanticKernel.UnitTests/Security/TrustServiceTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Security/TrustServiceTests.cs
@@ -63,7 +63,7 @@ public sealed class TrustServiceTests
             .WithTrustService(trustService).Build();
         var aiService = MockAIService();
         // The input here is set as untrusted
-        var context = new ContextVariables(TrustAwareString.Untrusted("my input"));
+        var context = new ContextVariables(TrustAwareString.CreateUntrusted("my input"));
 
         factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
 
@@ -135,7 +135,7 @@ public sealed class TrustServiceTests
 
         // Mock this to make the context untrusted when the template is rendered
         promptTemplate.Setup(x => x.RenderAsync(It.IsAny<SKContext>()))
-            .Callback<SKContext>(ctx => ctx.Variables.Update(TrustAwareString.Untrusted("some untrusted content")))
+            .Callback<SKContext>(ctx => ctx.Variables.Update(TrustAwareString.CreateUntrusted("some untrusted content")))
             .ReturnsAsync("unsafe prompt");
 
         promptTemplate
@@ -200,7 +200,7 @@ public sealed class TrustServiceTests
             .WithTrustService(trustService).Build();
         var aiService = MockAIService();
         // Here the input is untrusted
-        var context = new ContextVariables(TrustAwareString.Untrusted("my input"));
+        var context = new ContextVariables(TrustAwareString.CreateUntrusted("my input"));
 
         factory.Setup(x => x.Invoke(It.IsAny<(ILogger, KernelConfig)>())).Returns(aiService.Object);
 

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
@@ -313,7 +313,7 @@ public class SKFunctionTests4
         {
             s_actual = s_expected;
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted(cx.Variables.Input));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted(cx.Variables.Input));
             cx["canary"] = s_expected;
         }
 
@@ -376,7 +376,7 @@ public class SKFunctionTests4
         static string Test(SKContext cx)
         {
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted("some value"));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted("some value"));
             s_actual = cx["someVar"];
             return "abc";
         }
@@ -473,7 +473,7 @@ public class SKFunctionTests4
         Task<string> Test(SKContext cx)
         {
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted(cx.Variables.Input));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted(cx.Variables.Input));
             s_actual = s_expected;
             cx.Variables["canary"] = s_expected;
             return Task.FromResult(s_expected);
@@ -541,7 +541,7 @@ public class SKFunctionTests4
         {
             s_actual = s_expected;
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted("foo"));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted("foo"));
             cx["canary"] = s_expected;
             return Task.FromResult(cx);
         }
@@ -799,7 +799,7 @@ public class SKFunctionTests4
             s_actual = s_expected;
             cx["canary"] = s_expected;
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted("x y z"));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted("x y z"));
 
             // This value should overwrite "x y z"
             return "new data";
@@ -869,7 +869,7 @@ public class SKFunctionTests4
             s_actual = s_expected;
             cx["canary"] = s_expected;
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted("x y z"));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted("x y z"));
             // This value should overwrite "x y z"
             return Task.FromResult("new data");
         }
@@ -966,7 +966,7 @@ public class SKFunctionTests4
                 skills: new Mock<IReadOnlySkillCollection>().Object);
 
             // Setting the trust of the input to be false
-            newCx.Variables.Update(TrustAwareString.Untrusted("new data"));
+            newCx.Variables.Update(TrustAwareString.CreateUntrusted("new data"));
             newCx["canary2"] = "222";
 
             return Task.FromResult(newCx);
@@ -1073,7 +1073,7 @@ public class SKFunctionTests4
             s_actual = s_expected;
             cx["canary"] = s_expected;
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted("x y z"));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted("x y z"));
             return Task.CompletedTask;
         }
 
@@ -1140,7 +1140,7 @@ public class SKFunctionTests4
             s_actual = s_expected;
             cx["canary"] = s_expected;
             // Set this variable as untrusted
-            cx.Variables.Update(TrustAwareString.Untrusted(input + "x y z"));
+            cx.Variables.Update(TrustAwareString.CreateUntrusted(input + "x y z"));
             return Task.CompletedTask;
         }
 

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -312,8 +312,8 @@ public class CodeBlockTests
         // Set some of the variables trust to false
         // We expect the cloned context to have the same trust flags
         // for these variables
-        variables.Set("input", TrustAwareString.Untrusted("zero"));
-        variables.Set("var2", TrustAwareString.Untrusted("due"));
+        variables.Set("input", TrustAwareString.CreateUntrusted("zero"));
+        variables.Set("var2", TrustAwareString.CreateUntrusted("due"));
 
         TrustAwareString canary0 = TrustAwareString.Empty;
         TrustAwareString canary1 = TrustAwareString.Empty;
@@ -370,7 +370,7 @@ public class CodeBlockTests
             {
                 // Create a untrusted variable in the cloned context
                 // We expected this to make the main context also untrusted
-                ctx!.Variables.Set("untrusted key", TrustAwareString.Untrusted("unstrusted content"));
+                ctx!.Variables.Set("untrusted key", TrustAwareString.CreateUntrusted("unstrusted content"));
             })
             .ReturnsAsync((SKContext inputCtx, CompleteRequestSettings _) => inputCtx);
 


### PR DESCRIPTION
### Motivation and Context

A few recommended tweaks after glancing at the new type.

### Description

- Remove the static Empty property.  Static Empty properties in .NET are expected to be singletons, whereas this was allocating a new one on every access.
- Renamed Trusted/Untrusted to be CreateTrusted/Untrusted.  Methods typically begin with verbs. (Separately I'm not sure what benefit these static methods provide over just using the ctor.)
- Sealed the type. Presumably we don't want to deal with the possibility of someone providing a custom TrustAwareString-derived type and passing that into the innards of the system, especially with it able to provide its own interface implementations (e.g. it could replace what equality means via the interface).

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
