### PR TITLE
Make optional strings default to null instead of empty

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
@@ -203,7 +203,7 @@ public abstract class ClientBase
     /// </summary>
     /// <param name="instructions">Optional chat instructions for the AI service</param>
     /// <returns>Chat object</returns>
-    private protected static ChatHistory InternalCreateNewChat(string instructions = "")
+    private protected static ChatHistory InternalCreateNewChat(string? instructions = null)
     {
         return new OpenAIChatHistory(instructions);
     }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/AzureChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/AzureChatCompletion.cs
@@ -72,7 +72,7 @@ public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion
     }
 
     /// <inheritdoc/>
-    public ChatHistory CreateNewChat(string instructions = "")
+    public ChatHistory CreateNewChat(string? instructions = null)
     {
         return InternalCreateNewChat(instructions);
     }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/OpenAIChatCompletion.cs
@@ -55,7 +55,7 @@ public sealed class OpenAIChatCompletion : OpenAIClientBase, IChatCompletion, IT
     }
 
     /// <inheritdoc/>
-    public ChatHistory CreateNewChat(string instructions = "")
+    public ChatHistory CreateNewChat(string? instructions = null)
     {
         return InternalCreateNewChat(instructions);
     }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatCompletion.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatCompletion.cs
@@ -14,7 +14,7 @@ public interface IChatCompletion : IAIService
     /// </summary>
     /// <param name="instructions">Optional chat instructions for the AI service</param>
     /// <returns>Chat object</returns>
-    public ChatHistory CreateNewChat(string instructions = "");
+    public ChatHistory CreateNewChat(string? instructions = null);
 
     /// <summary>
     /// Generate a new chat message

--- a/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
@@ -93,7 +93,7 @@ public interface IKernel
     /// <param name="skillName">Name of the skill for skill collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
     /// <param name="trustService">Service used for trust checks (if null will use the default registered in the kernel).</param>
     /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
-    IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName = "", ITrustService? trustService = null);
+    IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string? skillName = null, ITrustService? trustService = null);
 
     /// <summary>
     /// Set the semantic memory to use

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -108,7 +108,7 @@ public sealed class Kernel : IKernel, IDisposable
     }
 
     /// <inheritdoc/>
-    public IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string skillName = "", ITrustService? trustService = null)
+    public IDictionary<string, ISKFunction> ImportSkill(object skillInstance, string? skillName = null, ITrustService? trustService = null)
     {
         if (string.IsNullOrWhiteSpace(skillName))
         {
@@ -122,7 +122,7 @@ public sealed class Kernel : IKernel, IDisposable
 
         Dictionary<string, ISKFunction> skill = ImportSkill(
             skillInstance,
-            skillName,
+            skillName!,
             // Use the default trust service registered if none is provided
             trustService ?? this.TrustServiceInstance,
             this.Log

--- a/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/InlineFunctionsDefinitionExtension.cs
@@ -41,7 +41,7 @@ public static class InlineFunctionsDefinitionExtension
         this IKernel kernel,
         string promptTemplate,
         string? functionName = null,
-        string skillName = "",
+        string? skillName = null,
         string? description = null,
         int maxTokens = 256,
         double temperature = 0,
@@ -94,7 +94,7 @@ public static class InlineFunctionsDefinitionExtension
         string promptTemplate,
         PromptTemplateConfig config,
         string? functionName = null,
-        string skillName = "",
+        string? skillName = null,
         ITrustService? trustService = null)
     {
         functionName ??= RandomFunctionName();
@@ -109,7 +109,7 @@ public static class InlineFunctionsDefinitionExtension
         // TODO: manage overwrites, potentially error out
         return string.IsNullOrEmpty(skillName)
             ? kernel.RegisterSemanticFunction(functionName, functionConfig, trustService)
-            : kernel.RegisterSemanticFunction(skillName, functionName, functionConfig, trustService);
+            : kernel.RegisterSemanticFunction(skillName!, functionName, functionConfig, trustService);
     }
 
     private static string RandomFunctionName() => "func" + Guid.NewGuid().ToString("N");

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -66,7 +66,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
     public static ISKFunction? FromNativeMethod(
         MethodInfo methodSignature,
         object? methodContainerInstance = null,
-        string skillName = "",
+        string? skillName = null,
         ITrustService? trustService = null,
         ILogger? log = null)
     {
@@ -91,7 +91,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
         return new SKFunction(
             delegateFunction: methodDetails.Function,
             parameters: methodDetails.Parameters,
-            skillName: skillName,
+            skillName: skillName!,
             functionName: methodDetails.Name,
             isSemantic: false,
             description: methodDetails.Description,

--- a/samples/dotnet/kernel-syntax-examples/Example34_CustomChatModel.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example34_CustomChatModel.cs
@@ -23,7 +23,7 @@ public sealed class MyChatCompletionService : IChatCompletion
 {
     private const string OutputAssistantResult = "Hi I'm your SK Custom Assistant and I'm here to help you to create custom chats like this. :)";
 
-    public ChatHistory CreateNewChat(string instructions = "")
+    public ChatHistory CreateNewChat(string? instructions = null)
     {
         var chatHistory = new ChatHistory();
 


### PR DESCRIPTION
### Motivation and Context

Null is the typical / expected default value for optional strings in cases like this.

### Description

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
