### PR TITLE
Fix KernelHttpServer regression due to change in kernel signatures

### DIFF
--- a/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
+++ b/samples/dotnet/KernelHttpServer/SemanticKernelFactory.cs
@@ -46,17 +46,15 @@ internal static class SemanticKernelFactory
         switch (config.CompletionConfig.AIService)
         {
             case AIService.OpenAI:
-                builder.Configure(c => c.AddOpenAITextCompletionService(
+                builder.Configure(c => c.AddOpenAIChatCompletionService(
                     config.CompletionConfig.DeploymentOrModelId,
-                    config.CompletionConfig.Key,
-                    config.CompletionConfig.ServiceId));
+                    config.CompletionConfig.Key));
                 break;
             case AIService.AzureOpenAI:
-                builder.Configure(c => c.AddAzureTextCompletionService(
+                builder.Configure(c => c.AddAzureChatCompletionService(
                     config.CompletionConfig.DeploymentOrModelId,
                     config.CompletionConfig.Endpoint,
-                    config.CompletionConfig.Key,
-                    serviceId: config.CompletionConfig.ServiceId));
+                    config.CompletionConfig.Key));
                 break;
             default:
                 break;
@@ -69,15 +67,13 @@ internal static class SemanticKernelFactory
                 case AIService.OpenAI:
                     builder.Configure(c => c.AddOpenAITextEmbeddingGenerationService(
                         config.EmbeddingConfig.DeploymentOrModelId,
-                        config.EmbeddingConfig.Key,
-                        serviceId: config.EmbeddingConfig.ServiceId));
+                        config.EmbeddingConfig.Key));
                     break;
                 case AIService.AzureOpenAI:
                     builder.Configure(c => c.AddAzureTextEmbeddingGenerationService(
                         config.EmbeddingConfig.DeploymentOrModelId,
                         config.EmbeddingConfig.Endpoint,
-                        config.EmbeddingConfig.Key,
-                        serviceId: config.EmbeddingConfig.ServiceId));
+                        config.EmbeddingConfig.Key));
                     break;
                 default:
                     break;


### PR DESCRIPTION
A change to the method signature of the kernel config extensions broke the KernelHttpServer and all sample projects that are dependent on it. 

This PR remediates and adds support for chat completion endpoints instead of text completion endpoints.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
