### PR TITLE
Change the description of the comment due to no "Deployment ID" on Az…

### DIFF
--- a/samples/apps/auth-api-webapp-react/src/components/ServiceConfig.tsx
+++ b/samples/apps/auth-api-webapp-react/src/components/ServiceConfig.tsx
@@ -139,7 +139,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                                 },
                             });
                         }}
-                        placeholder="Enter your deployment id here, ie: my-deployment"
+                        placeholder="Enter your deployment name here, ie: my-deployment"
                     />
                     <Label htmlFor="oaiendpoint">Endpoint</Label>
                     <Input

--- a/samples/apps/book-creator-webapp-react/src/components/ServiceConfig.tsx
+++ b/samples/apps/book-creator-webapp-react/src/components/ServiceConfig.tsx
@@ -139,7 +139,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                                 },
                             });
                         }}
-                        placeholder="Enter your deployment id here, ie: my-deployment"
+                        placeholder="Enter your deployment name here, ie: my-deployment"
                     />
                     <Label htmlFor="oaiendpoint">Endpoint</Label>
                     <Input

--- a/samples/apps/chat-summary-webapp-react/src/components/ServiceConfig.tsx
+++ b/samples/apps/chat-summary-webapp-react/src/components/ServiceConfig.tsx
@@ -139,7 +139,7 @@ const ServiceConfig: FC<IData> = ({ uri, onConfigComplete }) => {
                                 },
                             });
                         }}
-                        placeholder="Enter your deployment id here, ie: my-deployment"
+                        placeholder="Enter your deployment name here, ie: my-deployment"
                     />
                     <Label htmlFor="oaiendpoint">Endpoint</Label>
                     <Input

--- a/samples/notebooks/dotnet/01-basic-loading-the-kernel.ipynb
+++ b/samples/notebooks/dotnet/01-basic-loading-the-kernel.ipynb
@@ -146,7 +146,7 @@
     "IKernel kernel = KernelBuilder.Create();\n",
     "\n",
     "kernel.Config.AddAzureTextCompletionService(\n",
-    "    \"my-finetuned-Curie\",                   // Azure OpenAI *Deployment ID*\n",
+    "    \"my-finetuned-Curie\",                   // Azure OpenAI *Deployment Name*\n",
     "    \"https://contoso.openai.azure.com/\",    // Azure OpenAI *Endpoint*\n",
     "    \"...your Azure OpenAI Key...\",          // Azure OpenAI *Key*\n",
     "    \"Azure_curie\"                           // alias used in the prompt templates' config.json\n",

--- a/samples/notebooks/python/01-basic-loading-the-kernel.ipynb
+++ b/samples/notebooks/python/01-basic-loading-the-kernel.ipynb
@@ -86,7 +86,7 @@
     "kernel.add_text_completion_service(               # We are adding a text service\n",
     "    \"Azure_curie\",                            # The alias we can use in prompt templates' config.json\n",
     "    AzureTextCompletion(\n",
-    "        \"my-finetuned-Curie\",                 # Azure OpenAI *Deployment ID*\n",
+    "        \"my-finetuned-Curie\",                 # Azure OpenAI *Deployment name*\n",
     "        \"https://contoso.openai.azure.com/\",  # Azure OpenAI *Endpoint*\n",
     "        \"...your Azure OpenAI Key...\"         # Azure OpenAI *Key*\n",
     "    )\n",


### PR DESCRIPTION
…ure OpenAI, should be "Deployment Name"
<img width="968" alt="Screenshot 2023-06-01 at 00 39 02" src="https://github.com/microsoft/semantic-kernel/assets/68472667/844fddbf-77fe-463d-af90-3fee94044b02">


### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
