### PR TITLE
Remove System.Linq.Async dependency from SK

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="[1.1.0, )" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0, )" />
     <PackageVersion Include="Pgvector" Version="0.1.3" />
-    <PackageVersion Include="System.Linq.Async" Version="[6.0.1, )" />
     <PackageVersion Include="System.Text.Json" Version="[7.0.2, )" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="[1.0.0-beta.5, )" />
     <!-- Microsoft.Extensions.Logging -->

--- a/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextCompletion/TextCompletionResult.cs
+++ b/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextCompletion/TextCompletionResult.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.AI.TextCompletion;
@@ -22,8 +22,8 @@ internal sealed class TextCompletionStreamingResult : ITextCompletionStreamingRe
         return Task.FromResult(this._result);
     }
 
-    public IAsyncEnumerable<string> GetCompletionStreamingAsync(CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> GetCompletionStreamingAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        return this.GetCompletionAsync(cancellationToken).ToAsyncEnumerable();
+        yield return await this.GetCompletionAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.CosmosDB/Connectors.Memory.CosmosDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.CosmosDB/Connectors.Memory.CosmosDB.csproj
@@ -9,6 +9,7 @@
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <!--<Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />-->
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/InternalUtilities.props" />
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Connectors/Connectors.Memory.DuckDB/Connectors.Memory.DuckDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.DuckDB/Connectors.Memory.DuckDB.csproj
@@ -9,7 +9,8 @@
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-  
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/InternalUtilities.props" />
+
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - DuckDB Connector</Title>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Connectors.Memory.Pinecone.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Connectors.Memory.Pinecone.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <!-- THIS PROPERTY GROUP MUST COME FIRST -->
@@ -9,6 +9,7 @@
 
     <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
     <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+    <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/InternalUtilities.props" />
 
     <PropertyGroup>
         <!-- NuGet Package Settings -->

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
@@ -75,9 +75,12 @@ public class PineconeMemoryStore : IPineconeMemoryStore
 
     /// <inheritdoc />
     /// <returns> a list of index names </returns>
-    public IAsyncEnumerable<string> GetCollectionsAsync(CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<string> GetCollectionsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        return this._pineconeClient.ListIndexesAsync(cancellationToken).Select(index => index ?? "");
+        await foreach (var index in this._pineconeClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return index ?? "";
+        }
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- THIS PROPERTY GROUP MUST COME FIRST -->
@@ -9,6 +9,7 @@
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/InternalUtilities.props" />
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/Linq/AsyncEnumerable.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
@@ -9,7 +9,8 @@
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-  
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/InternalUtilities.props" />
+
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - SQLite Connector</Title>

--- a/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.UnitTests</AssemblyName>
@@ -21,6 +21,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/InternalUtilities.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\SemanticKernel\SemanticKernel.csproj" />

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryStoreTests.cs
@@ -101,11 +101,11 @@ public class PineconeMemoryStoreTests
             .Returns(new string[] { "test1", "test2" }.ToAsyncEnumerable());
 
         // Act
-        string[] collections = await this._pineconeMemoryStore.GetCollectionsAsync().ToArrayAsync();
+        var collections = await this._pineconeMemoryStore.GetCollectionsAsync().ToListAsync();
 
         // Assert
         this._mockPineconeClient.Verify<IAsyncEnumerable<string?>>(x => x.ListIndexesAsync(It.IsAny<CancellationToken>()), Times.Once());
-        Assert.Equal(2, collections.Length);
+        Assert.Equal(2, collections.Count);
         Assert.Equal("test1", collections[0]);
         Assert.Equal("test2", collections[1]);
     }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests.cs
@@ -100,11 +100,11 @@ public class QdrantMemoryStoreTests
         var vectorStore = new QdrantMemoryStore(mockQdrantClient.Object);
 
         // Act
-        var collections = await vectorStore.GetCollectionsAsync().ToArrayAsync();
+        var collections = await vectorStore.GetCollectionsAsync().ToListAsync();
 
         // Assert
         mockQdrantClient.Verify<IAsyncEnumerable<string>>(x => x.ListCollectionsAsync(It.IsAny<CancellationToken>()), Times.Once());
-        Assert.Equal(2, collections.Length);
+        Assert.Equal(2, collections.Count);
         Assert.Equal("test1", collections[0]);
         Assert.Equal("test2", collections[1]);
     }

--- a/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanResponse.cs
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanResponse.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Planning.Action;
 /// </summary>
 internal sealed class ActionPlanResponse
 {
-    public class PlanData
+    public sealed class PlanData
     {
         /// <summary>
         /// Rationale given by the LLM for choosing the function

--- a/dotnet/src/Extensions/Planning.ActionPlanner/EmbeddedResource.cs
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/EmbeddedResource.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace Microsoft.SemanticKernel.Planning.Action;
 
-internal sealed class EmbeddedResource
+internal static class EmbeddedResource
 {
     private static readonly string? s_namespace = typeof(EmbeddedResource).Namespace;
 

--- a/dotnet/src/Extensions/Planning.ActionPlanner/Planning.ActionPlanner.csproj
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/Planning.ActionPlanner.csproj
@@ -22,10 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="IntegrationTests" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="skprompt.txt" />
     <EmbeddedResource Include="skprompt.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/dotnet/src/InternalUtilities/Linq/AsyncEnumerable.cs
+++ b/dotnet/src/InternalUtilities/Linq/AsyncEnumerable.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+namespace System.Linq; // for compatibility with System.Linq.Async.nupkg
+
+internal static class AsyncEnumerable
+{
+    public static IAsyncEnumerable<T> Empty<T>() => EmptyAsyncEnumerable<T>.Instance;
+
+    public static IEnumerable<T> ToEnumerable<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+    {
+        var enumerator = source.GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+            {
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+        }
+    }
+
+    public static async ValueTask<T?> FirstOrDefaultAsync<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            return item;
+        }
+
+        return default;
+    }
+
+    public static async ValueTask<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+    {
+        var result = new List<T>();
+
+        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    public static async ValueTask<bool> ContainsAsync<T>(this IAsyncEnumerable<T> source, T value)
+    {
+        await foreach (var item in source.ConfigureAwait(false))
+        {
+            if (EqualityComparer<T>.Default.Equals(item, value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static async ValueTask<int> CountAsync<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+    {
+        int count = 0;
+        await foreach (var _ in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            checked { count++; }
+        }
+        return count;
+    }
+
+    private sealed class EmptyAsyncEnumerable<T> : IAsyncEnumerable<T>, IAsyncEnumerator<T>
+    {
+        public static readonly EmptyAsyncEnumerable<T> Instance = new();
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
+        public ValueTask<bool> MoveNextAsync() => new(false);
+        public T Current => default!;
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/dotnet/src/InternalUtilities/Text/StringExtensions.cs
+++ b/dotnet/src/InternalUtilities/Text/StringExtensions.cs
@@ -8,7 +8,11 @@ internal static class StringExtensions
 {
     internal static string NormalizeLineEndings(this string src)
     {
+#if NET6_0_OR_GREATER
+        return src.ReplaceLineEndings("\n");
+#else
         return src.Replace("\r\n", "\n");
+#endif
     }
 
     public static bool IsNullOrEmpty([NotNullWhen(false)] this string? data)

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -19,14 +19,12 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Core" />
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" />
-    <InternalsVisibleTo Include="IntegrationTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" /> <!-- Moq -->
   </ItemGroup>
 </Project>

--- a/dotnet/src/SemanticKernel/SemanticKernel.csproj
+++ b/dotnet/src/SemanticKernel/SemanticKernel.csproj
@@ -23,8 +23,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="SemanticKernel.UnitTests" />
-    <InternalsVisibleTo Include="SemanticKernel.IntegrationTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" /> <!-- Moq -->
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/dotnet/kernel-syntax-examples/Example16_CustomLLM.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example16_CustomLLM.cs
@@ -2,13 +2,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using RepoUtils;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 /**
  * The following example shows how to plug into SK a custom text completion model.
@@ -28,12 +29,9 @@ public class MyTextCompletionService : ITextCompletion
         });
     }
 
-    public IAsyncEnumerable<ITextCompletionStreamingResult> GetStreamingCompletionsAsync(string text, CompleteRequestSettings requestSettings, CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<ITextCompletionStreamingResult> GetStreamingCompletionsAsync(string text, CompleteRequestSettings requestSettings, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        return new List<ITextCompletionStreamingResult>()
-        {
-            new MyTextCompletionStreamingResult()
-        }.ToAsyncEnumerable();
+        yield return new MyTextCompletionStreamingResult();
     }
 }
 


### PR DESCRIPTION
### Motivation and Context

We're using very little of the library and can easily achieve the same things without it. From the core libraries like abstractions, we shouldn't force all consumers to take the additional 1MB dependency. And from examples, we shouldn't force anyone copying/pasting to take the additional dependency

Also removed unnecessary InternalsVisibleTo that were also interfering with shared source in multiple assemblies.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
