### PR TITLE
Add simple nuget.config to avoid lots of package management warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ dotnet/.config
 *.user
 *.userosscache
 *.sln.docstates
-nuget.config
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+  
+</configuration>


### PR DESCRIPTION
### Motivation and Context

Otherwise, someone with multiple package sources defined gets dozens of warnings like the following when building the repo:
```
warning NU1507: There are 4 package sources defined in your configuration. When using central package management, please map your packa
ge sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: ...
```

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
