### PR TITLE
GitHub Repo Q&A: Fixed issue that prevents choosing and saving an OpenAI completions model.

### DIFF
--- a/samples/apps/github-qna-webapp-react/src/components/setup/ModelConfig.tsx
+++ b/samples/apps/github-qna-webapp-react/src/components/setup/ModelConfig.tsx
@@ -359,9 +359,12 @@ const getOpenAiModels = async (apiKey: string, onFailureCallback: (errorMessage?
 };
 
 const isValidOpenAIConfig = async (resourceInput: IResourceInput, model: string, modelType: ModelType) => {
-    const modelObject = modelType === ModelType.Completion ? 'completions' : 'embeddings';
+    const modelObject = modelType === ModelType.Completion ? 'chat/completions' : 'embeddings';
     const inputText = 'Tell me a short joke.';
-    const bodyInput = modelType === ModelType.Completion ? { prompt: inputText } : { input: inputText };
+    const bodyInput =
+        modelType === ModelType.Completion
+            ? { messages: [{ role: 'user', content: inputText }] }
+            : { input: inputText };
 
     return fetch('https://api.openai.com/v1/' + modelObject, {
         method: 'POST',


### PR DESCRIPTION
### Motivation and Context
When using OpenAI in the GitHub Repo Q&A sample, an error occurs when a valid chat completions model is chosen from the dropdown list. Furthermore, selecting a text completions model passes validation but causes a bad request error when saving.


### Description
Fixed issue by updating the model validation function to test model selection against the chat completions endpoint rather than the text completions endpoint.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
