### PR TITLE
Replacing deprecated functions and shortening plan object in chat his…

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/ChatController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/ChatController.cs
@@ -142,13 +142,13 @@ public class ChatController : ControllerBase, IDisposable
         {
             this._logger.LogInformation("Registering Jira Skill");
             var authenticationProvider = new BasicAuthenticationProvider(() => { return Task.FromResult(openApiSkillsAuthHeaders.JiraAuthentication); });
-            var hasServerUrlOverride = variables.Get("jira-server-url", out string serverUrlOverride);
+            var hasServerUrlOverride = variables.TryGetValue("jira-server-url", out string? serverUrlOverride);
 
             await planner.Kernel.ImportOpenApiSkillFromFileAsync(
                 skillName: "JiraSkill",
                 filePath: Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "CopilotChat", "Skills", "OpenApiSkills/JiraSkill/openapi.json"),
                 authCallback: authenticationProvider.AuthenticateRequestAsync,
-                serverUrlOverride: hasServerUrlOverride ? new Uri(serverUrlOverride) : null);
+                serverUrlOverride: hasServerUrlOverride ? new Uri(serverUrlOverride!) : null);
         }
 
         // Microsoft Graph

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ChatSkill.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -158,9 +159,26 @@ public class ChatSkill
             var formattedMessage = chatMessage.ToFormattedString();
             var tokenCount = Utilities.TokenCount(formattedMessage);
 
-            // Plan object is not meaningful content in generating chat response, exclude it
-            if (remainingToken - tokenCount > 0 && !formattedMessage.Contains("proposedPlan\\\":", StringComparison.InvariantCultureIgnoreCase))
+            if (remainingToken - tokenCount > 0)
             {
+                // Plan object is not meaningful content in generating chat response, reduce to intent to save on tokens
+                if (formattedMessage.Contains("proposedPlan\":", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    string pattern = @"(\[.*?\]).*User Intent:User intent: (.*)(?=""}})";
+                    Match match = Regex.Match(formattedMessage, pattern);
+                    if (match.Success)
+                    {
+                        string timestamp = match.Groups[1].Value.Trim();
+                        string userIntent = match.Groups[2].Value.Trim();
+
+                        formattedMessage = $"{timestamp} Bot proposed plan to fulfill user intent: {userIntent}";
+                    }
+                    else
+                    {
+                        formattedMessage = "Bot proposed plan";
+                    }
+                }
+
                 historyText = $"{formattedMessage}\n{historyText}";
                 remainingToken -= tokenCount;
             }
@@ -352,7 +370,7 @@ public class ChatSkill
     /// </summary>
     private async Task<string> GetUserIntentAsync(SKContext context)
     {
-        if (!context.Variables.Get("planUserIntent", out string? userIntent))
+        if (!context.Variables.TryGetValue("planUserIntent", out string? userIntent))
         {
             var contextVariables = new ContextVariables();
             contextVariables.Set("chatId", context["chatId"]);
@@ -471,7 +489,7 @@ public class ChatSkill
     {
         var contextVariables = context.Variables.Clone();
         contextVariables.Set("tokenLimit", tokenLimit.ToString(new NumberFormatInfo()));
-        if (context.Variables.Get("proposedPlan", out string? proposedPlan))
+        if (context.Variables.TryGetValue("proposedPlan", out string? proposedPlan))
         {
             contextVariables.Set("proposedPlan", proposedPlan);
         }

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ExternalInformationSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ExternalInformationSkill.cs
@@ -78,7 +78,7 @@ public class ExternalInformationSkill
 
         // Check if plan exists in ask's context variables.
         // If plan was returned at this point, that means it was approved and should be run
-        var planApproved = context.Variables.Get("proposedPlan", out var planJson);
+        var planApproved = context.Variables.TryGetValue("proposedPlan", out string? planJson);
 
         if (planApproved && !string.IsNullOrWhiteSpace(planJson))
         {
@@ -133,7 +133,7 @@ public class ExternalInformationSkill
                         continue;
                     }
 
-                    if (variables.Get(param.Key, out var value))
+                    if (variables.TryGetValue(param.Key, out string? value))
                     {
                         plan.State.Set(param.Key, value);
                     }

--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -106,7 +106,7 @@ internal static class SemanticKernelExtensions
                 services.AddSingleton<IMemoryStore, VolatileMemoryStore>();
                 services.AddScoped<ISemanticTextMemory>(sp => new SemanticTextMemory(
                     sp.GetRequiredService<IMemoryStore>(),
-                    sp.GetRequiredService<IOptions<AIServiceOptions>>().Value
+                    (ITextEmbeddingGeneration)sp.GetRequiredService<IOptions<AIServiceOptions>>().Value
                         .ToTextEmbeddingsService(logger: sp.GetRequiredService<ILogger<AIServiceOptions>>())));
                 break;
 
@@ -129,7 +129,7 @@ internal static class SemanticKernelExtensions
                 });
                 services.AddScoped<ISemanticTextMemory>(sp => new SemanticTextMemory(
                     sp.GetRequiredService<IMemoryStore>(),
-                    sp.GetRequiredService<IOptions<AIServiceOptions>>().Value
+                    (ITextEmbeddingGeneration)sp.GetRequiredService<IOptions<AIServiceOptions>>().Value
                         .ToTextEmbeddingsService(logger: sp.GetRequiredService<ILogger<AIServiceOptions>>())));
                 break;
 


### PR DESCRIPTION
…tory

### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Replacing deprecated `ContextVariables.Get(string, out string)` with TryGetValue method.
+ truncating plan object to intent only in chat history to save on token limits. 
![image](https://github.com/microsoft/semantic-kernel/assets/125500434/e8690c10-ac9e-4ae4-8506-6fd1426f1818)

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [ X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
