### PR TITLE
Uses WithAzureTextCompletionService replacing deprecated AddAzureTextCompletionService

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -23,14 +23,13 @@ Copy and paste the following code into your project, with your Azure OpenAI key 
 ```csharp
 using Microsoft.SemanticKernel;
 
-var kernel = Kernel.Builder.Build();
-
-// Azure OpenAI
-kernel.Config.AddAzureTextCompletionService(
+var builder = Kernel.Builder.WithAzureTextCompletionService(
     "text-davinci-003",                  // Azure OpenAI Deployment Name
     "https://contoso.openai.azure.com/", // Azure OpenAI Endpoint
     "...your Azure OpenAI Key...",       // Azure OpenAI Key
 );
+
+var kernel = builder.Build();
 
 // Alternative using OpenAI
 // kernel.Config.AddOpenAITextCompletionService(


### PR DESCRIPTION
Readme.md getting started for C# is going to be out-of-date quickly when `WithAzureTextCompletionService` replaces the soon to be depracted `AddAzureTextCompletionService`. 
This change updates the Readme to prep for that event - so people can get started quicker without errors and squiggly lines.