### PR TITLE
Copilot chat: mitigate JS warning

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/components/FileUploader.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/FileUploader.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import { makeStyles } from '@fluentui/react-components';
-import { Input } from '@fluentui/react-northstar';
 import React, { forwardRef } from 'react';
 
 const useClasses = makeStyles({
@@ -39,8 +38,8 @@ export const FileUploader: React.FC<FileUploaderProps> = forwardRef<HTMLInputEle
         );
 
         return (
-            <Input
-                inputRef={ref}
+            <input
+                ref={ref}
                 type="file"
                 id="fileInput"
                 className={classes.root}

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/prompt-details/PromptDetails.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/prompt-details/PromptDetails.tsx
@@ -34,7 +34,9 @@ export const PromptDetails: React.FC<IPromptDetailsProps> = ({ message }) => {
                     <DialogContent>
                         {(message.prompt === undefined || message.prompt === '')
                             ? 'Empty'
-                            : message.prompt.split('\n').map((paragraph) => <p>{paragraph}</p>)
+                            : message.prompt.split('\n').map(
+                                (paragraph, idx) => <p key={'prompt-details-'+idx}>{paragraph}</p>
+                            )
                         }
                     </DialogContent>
                     <DialogActions>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
There is a warning about list items not having unique keys in PromptDetails.
![image](https://github.com/microsoft/semantic-kernel/assets/12570346/5be0659b-a76e-464e-b1a1-cb8794dfeb85)

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Fix the warning.
2. Replace the React-northstar Input element with the built-in HTML input element in FileUploader since the inputRef prop is deprecated.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
