### PR TITLE
Temporarily add global.json to pin the dotnet version to avoid dotnet-format failures

### DIFF
--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        // TODO: Pinning to 6.0.408 until a dotnet servicing release is deployed: https://github.com/dotnet/format/issues/1546#issuecomment-1572744247
+        "version": "6.0.408",
+        "rollForward": "major"
+    }
+}


### PR DESCRIPTION
### Motivation and Context
PRs are blocked since the dotnet SDK analyzers introduced a back-compat issue.

### Description
Brought in a global.json file to pin the SDK version until the next servicing release of dotnet SDK.