### PR TITLE
Improve postgres memory store

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/README.md
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/README.md
@@ -19,11 +19,15 @@ docker run -d --name postgres-pgvector -p 5432:5432 -e POSTGRES_PASSWORD=mysecre
 2. To use Postgres as a semantic memory store:
 
 ```csharp
-using PostgresMemoryStore memoryStore = await PostgresMemoryStore.ConnectAsync("Host=localhost;Port=5432;Database=sk_memory;User Id=postgres;Password=mysecretpassword", vectorSize: 1536);
+NpgsqlDataSourceBuilder dataSourceBuilder = new NpgsqlDataSourceBuilder("Host=localhost;Port=5432;Database=sk_memory;User Id=postgres;Password=mysecretpassword");
+dataSourceBuilder.UseVector();// Use pgvector
+using NpgsqlDataSource dataSource = dataSourceBuilder.Build();
+
+PostgresMemoryStore memoryStore = await PostgresMemoryStore.ConnectAsync(dataSource, vectorSize: 1536);
 
 IKernel kernel = Kernel.Builder
     .WithLogger(ConsoleLogger.Log)
-    .Configure(c => c.AddOpenAITextEmbeddingGenerationService("text-embedding-ada-002", Env.Var("OPENAI_API_KEY")))
+    .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", Env.Var("OPENAI_API_KEY"))
     .WithMemoryStorage(memoryStore)
     .Build();
 ```

--- a/samples/dotnet/kernel-syntax-examples/Example39_Postgres.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example39_Postgres.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Memory.Postgres;
 using Microsoft.SemanticKernel.Memory;
+using Npgsql;
+using Pgvector.Npgsql;
 using RepoUtils;
 
 // ReSharper disable once InconsistentNaming
@@ -14,8 +16,11 @@ public static class Example39_Postgres
 
     public static async Task RunAsync()
     {
-        string connectionString = Env.Var("POSTGRES_CONNECTIONSTRING");
-        using PostgresMemoryStore memoryStore = await PostgresMemoryStore.ConnectAsync(connectionString, vectorSize: 1536);
+        NpgsqlDataSourceBuilder dataSourceBuilder = new(Env.Var("POSTGRES_CONNECTIONSTRING"));
+        dataSourceBuilder.UseVector();// Use pgvector
+        using NpgsqlDataSource dataSource = dataSourceBuilder.Build();
+
+        PostgresMemoryStore memoryStore = await PostgresMemoryStore.ConnectAsync(dataSource, vectorSize: 1536);
         IKernel kernel = Kernel.Builder
             .WithLogger(ConsoleLogger.Log)
             .WithOpenAITextCompletionService("text-davinci-003", Env.Var("OPENAI_API_KEY"))

--- a/samples/dotnet/kernel-syntax-examples/Program.cs
+++ b/samples/dotnet/kernel-syntax-examples/Program.cs
@@ -123,6 +123,7 @@ public static class Program
         Console.WriteLine("== DONE ==");
 
         await Example39_Postgres.RunAsync();
+        Console.WriteLine("== DONE ==");
 
         await Example40_DIContainer.RunAsync();
         Console.WriteLine("== DONE ==");


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The metadata uses the jsonb column type to make it easier to filter later. (https://github.com/microsoft/semantic-kernel/issues/1270#issuecomment-1567970396)

For CopilotChat, use PostgresMemoryStore as SemanticTextMemory. It's better to use it as a single instance. Kernel and SemanticTextMemory both implement the Dispose pattern and are registered in the DI container with Scoped lifecycle. This means that whenever the container scoped ends (i.e., when the request is completed), PostgresMemoryStore will be disposed.

Sometimes, the same database may have other tables, and the developer may want to reuse NpgsqlDataSource globally. In such cases, it will be more appropriate for the developer to control when NpgsqlDataSource is disposed.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- Change the `metadata` from text column type to jsonb column type.
- PostgresMemoryStore no longer implements `IDisposable` mode. This is a break change, but its impact is minimal and the developer only needs to modify `ConnectAsync`.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
