### PR TITLE
Removed embeddingSpan instance, as it is not used within the GetNeare…

### DIFF
--- a/dotnet/src/SemanticKernel/Memory/VolatileMemoryStore.cs
+++ b/dotnet/src/SemanticKernel/Memory/VolatileMemoryStore.cs
@@ -158,8 +158,6 @@ public class VolatileMemoryStore : IMemoryStore
             return AsyncEnumerable.Empty<(MemoryRecord, double)>();
         }
 
-        EmbeddingReadOnlySpan<float> embeddingSpan = new(embedding.AsReadOnlySpan());
-
         TopNCollection<MemoryRecord> embeddings = new(limit);
 
         foreach (var record in embeddingCollection)


### PR DESCRIPTION
Removed embeddingSpan instance in the GetNearestMatchesAsync method, within the VolatileMemoryStore class, as it's not used in the cosine similarity calculation.