### PR TITLE
Python wait core skill

### DIFF
--- a/python/semantic_kernel/core_skills/wait_skill.py
+++ b/python/semantic_kernel/core_skills/wait_skill.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from semantic_kernel.skill_definition import sk_function
+
+
+class WaitSkill:
+    """
+    WaitSkill provides a set of functions to wait for a certain amount of time.
+
+    Usage:
+        kernel.import_skill("wait", WaitSkill());
+
+    Examples:
+        {{wait.seconds 5}} => Wait for 5 seconds
+    """
+
+    @sk_function(description="Wait for a certain number of seconds.")
+    async def wait(self, seconds_text: str):
+        try:
+            seconds = float(seconds_text)
+        except ValueError:
+            raise ValueError("seconds text must be a number")
+        await asyncio.sleep(seconds)

--- a/python/semantic_kernel/core_skills/wait_skill.py
+++ b/python/semantic_kernel/core_skills/wait_skill.py
@@ -17,7 +17,7 @@ class WaitSkill:
     @sk_function(description="Wait for a certain number of seconds.")
     async def wait(self, seconds_text: str):
         try:
-            seconds = float(seconds_text)
+            seconds = max(float(seconds_text), 0)
         except ValueError:
             raise ValueError("seconds text must be a number")
         await asyncio.sleep(seconds)

--- a/python/tests/unit/core_skills/test_wait_skill.py
+++ b/python/tests/unit/core_skills/test_wait_skill.py
@@ -1,0 +1,17 @@
+import pytest
+
+from semantic_kernel.core_skills.wait_skill import WaitSkill
+
+
+def test_can_be_instantiated():
+    skill = WaitSkill()
+    assert skill is not None
+
+
+@pytest.mark.asyncio
+async def test_can_wait():
+    skill = WaitSkill()
+
+    await skill.wait("0.1")
+
+    assert True

--- a/python/tests/unit/core_skills/test_wait_skill.py
+++ b/python/tests/unit/core_skills/test_wait_skill.py
@@ -2,6 +2,32 @@ import pytest
 
 from semantic_kernel.core_skills.wait_skill import WaitSkill
 
+test_data_good = [
+    "0",
+    "1",
+    "2.1",
+    "0.1",
+    "0.01",
+    "0.001",
+    "0.0001",
+    "-0.0001",
+    "-10000",
+]
+
+test_data_bad = [
+    "$0",
+    "one hundred",
+    "20..,,2,1",
+    ".2,2.1",
+    "0.1.0",
+    "00-099",
+    "¹²¹",
+    "2²",
+    "zero",
+    "-100 seconds",
+    "1 second",
+]
+
 
 def test_can_be_instantiated():
     skill = WaitSkill()
@@ -9,9 +35,21 @@ def test_can_be_instantiated():
 
 
 @pytest.mark.asyncio
-async def test_can_wait():
+@pytest.mark.parametrize("wait_time", test_data_good)
+async def test_wait_valid_params(wait_time):
     skill = WaitSkill()
 
-    await skill.wait("0.1")
+    await skill.wait(wait_time)
 
     assert True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wait_time", test_data_bad)
+async def test_wait_invalid_params(wait_time):
+    skill = WaitSkill()
+
+    with pytest.raises(ValueError) as exc_info:
+        await skill.wait("wait_time")
+
+    assert exc_info.value.args[0] == "seconds text must be a number"


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? Improved parity between .Net and Python implementations
  2. What problem does it solve? Allow for waiting in Python implementation
  3. What scenario does it contribute to? Parity
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
Pretty simple allows for waiting X seconds in a thread


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
