### PR TITLE
fix: correct some of the typos reported by SpellChecker action

### DIFF
--- a/dotnet/src/Skills/Skills.MsGraph/Connectors/Client/MsGraphClientLoggingHandler.cs
+++ b/dotnet/src/Skills/Skills.MsGraph/Connectors/Client/MsGraphClientLoggingHandler.cs
@@ -28,7 +28,7 @@ public class MsGraphClientLoggingHandler : DelegatingHandler
     {
         ClientRequestIdHeaderName,
         "request-id",
-        "x-ms-ags-diagnostic",
+        "x-ms-args-diagnostic",
         "Date"
     };
 

--- a/samples/apps/auth-api-webapp-react/src/components/InteractionButton.tsx
+++ b/samples/apps/auth-api-webapp-react/src/components/InteractionButton.tsx
@@ -9,7 +9,7 @@ interface IData {
     runTask: () => Promise<void>;
 }
 
-const IteractionButton: FC<IData> = ({ taskDescription, runTask }) => {
+const InteractionButton: FC<IData> = ({ taskDescription, runTask }) => {
     const [isBusy, setIsBusy] = useState<boolean>(false);
     const [canRunTask, setCanRunTask] = useState<boolean>(true);
 
@@ -37,4 +37,4 @@ const IteractionButton: FC<IData> = ({ taskDescription, runTask }) => {
     );
 };
 
-export default IteractionButton;
+export default InteractionButton;

--- a/samples/apps/hugging-face-http-server/README.md
+++ b/samples/apps/hugging-face-http-server/README.md
@@ -1,4 +1,4 @@
-# Local Hugging Face Model Inteference Server
+# Local Hugging Face Model Interference Server
 
 > [!IMPORTANT]
 > This learning sample is for educational purposes only and should not be used in any production

--- a/samples/dotnet/kernel-syntax-examples/Example16_CustomLLM.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example16_CustomLLM.cs
@@ -106,7 +106,7 @@ public static class Example16_CustomLLM
 
         var textValidationFunction = kernel.CreateSemanticFunction(FunctionDefinition);
 
-        var result = await textValidationFunction.InvokeAsync("I mised the training sesion this morning");
+        var result = await textValidationFunction.InvokeAsync("I mised the training session this morning");
         Console.WriteLine(result);
 
         // Details of the my custom model response
@@ -121,7 +121,7 @@ public static class Example16_CustomLLM
         Console.WriteLine("======== Custom LLM  - Text Completion - Raw ========");
         var completionService = new MyTextCompletionService();
 
-        var result = await completionService.CompleteAsync("I missed the training sesion this morning", new CompleteRequestSettings());
+        var result = await completionService.CompleteAsync("I missed the training session this morning", new CompleteRequestSettings());
 
         Console.WriteLine(result);
     }


### PR DESCRIPTION
## Motivation and Context

Was trying to merge #1368 but it was complaining about typos.

I thought we could address typos in a separate PR, but it seems the issue is actually with the spell checker action misdiagnosing certain cases and then reporting an error instead of a warning.

### Examples misdiagnosed cases:

```
error: `FUNCTIO` should be `FUNCTION`
  --> ./docs/GLOSSARY.md:18:30
   |
18 | - "The Office SKILL has many FUNCTIONs"
   |                              ^^^^^^^

...

    |
error: `caf` should be `calf`
  --> ./samples/notebooks/python/07-hugging-face-for-skills.ipynb:119:12
    |
119 |    "id": "2caf8[57](https://github.com/microsoft/semantic-kernel/actions/runs/5213362324/jobs/9408491014?pr=1368#step:3:59)5",
    |            ^^^
    |
error: `caf` should be `calf`
  --> ./samples/notebooks/python/06-memory-and-embeddings.ipynb:121:12
    |
121 |    "id": "2caf85[75](https://github.com/microsoft/semantic-kernel/actions/runs/5213362324/jobs/9408491014?pr=1368#step:3:77)",
    |            ^^^
```

> are pre-empted by federal law

```
   |
error: `empted` should be `emptied`
  --> ./samples/apps/copilot-chat-app/importdocument/sample-docs/ms10k.txt:2547:935
```

### Description

- Fix SOME of the typos found by SpellChecker

Typo | Fix
--- | ---
`ags`  | `args`
`sesion` | `session`
`Iteraction` | `Interaction`


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

