### PR TITLE
Fix input handling and context passing in planners

### DIFF
--- a/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
@@ -213,6 +213,7 @@ internal static class Example12_SequentialPlanner
                 else
                 {
                     plan = await kernel.StepAsync(input, plan);
+                    input = "";
                 }
 
                 if (!plan.HasNextStep)

--- a/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example12_SequentialPlanner.cs
@@ -213,7 +213,7 @@ internal static class Example12_SequentialPlanner
                 else
                 {
                     plan = await kernel.StepAsync(input, plan);
-                    input = "";
+                    input = string.Empty;
                 }
 
                 if (!plan.HasNextStep)

--- a/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
+++ b/samples/dotnet/kernel-syntax-examples/Example31_CustomPlanner.cs
@@ -40,7 +40,8 @@ internal static class Example31_CustomPlanner
         plan.AddSteps(skills["ContextQuery"], markup["RunMarkup"]);
 
         // Execute plan
-        var result = await plan.InvokeAsync("Who is my president? Who was president 3 years ago? What should I eat for dinner", context);
+        context.Variables.Update("Who is my president? Who was president 3 years ago? What should I eat for dinner");
+        var result = await plan.InvokeAsync(context);
 
         Console.WriteLine("Result:");
         Console.WriteLine(result.Result);


### PR DESCRIPTION
### Motivation and Context
This pull request fixes a bug in the sequential planner example and improves the custom planner example by adding input reset and context update steps. These changes ensure that the input and context are consistent and up-to-date for each step of the plan execution.

### Description
- In the sequential planner example, add an input reset step after each plan step execution. This prevents the input from accumulating and interfering with the subsequent steps.
- In the custom planner example, update the context variables with the input before invoking the plan. This ensures that the context query skill can access the input as a variable and perform the appropriate queries.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
