### PR TITLE
Update typos config for jupyter and msbuild files

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -23,8 +23,12 @@ ACI = "ACI" # Azure Container Instance
 [default.extend-identifiers]
 ags = "ags" # Azure Graph Service
 
-[default]
-extend-ignore-identifiers-re = [
-    # treat any three letters surrounded by numbers as an identifier
-    "[0-9]+[a-zA-Z]{3}[0-9]+"
+[type.jupyter]
+extend-ignore-re = [
+    '"[A-Fa-f0-9]{8}"', # cell id strings
+]
+
+[type.msbuild]
+extend-ignore-re = [
+    'Version=".*"', # ignore package version numbers
 ]


### PR DESCRIPTION
This commit updates the .github/_typos.toml file to add some ignore rules for jupyter and msbuild files. These rules prevent false positives from cell id strings and package version numbers that are not actual typos. The commit also reorganizes the file to use type-specific sections instead of a default section.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
