### PR TITLE
Print Chat History at the end of Notebooks

### DIFF
--- a/samples/notebooks/dotnet/04-context-variables-chat.ipynb
+++ b/samples/notebooks/dotnet/04-context-variables-chat.ipynb
@@ -331,6 +331,33 @@
    "source": [
     "await Chat(\"could you list some more books I could read about the topic(s) you mentioned?\");"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After chatting for a while, we have built a growing history, which we are attaching to each prompt and which contains the full conversation. Let's take a look!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Console.WriteLine(context[\"history\"]);"
+   ]
   }
  ],
  "metadata": {

--- a/samples/notebooks/python/04-context-variables-chat.ipynb
+++ b/samples/notebooks/python/04-context-variables-chat.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fde98ddf",
    "metadata": {},
@@ -52,6 +53,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7971783d",
    "metadata": {},
@@ -76,6 +78,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "61716b16",
    "metadata": {},
@@ -94,6 +97,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6e8a676f",
    "metadata": {},
@@ -113,6 +117,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4ce7c497",
    "metadata": {},
@@ -133,6 +138,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a5b03748",
    "metadata": {},
@@ -152,6 +158,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "23a2eb02",
    "metadata": {},
@@ -219,6 +226,25 @@
    "outputs": [],
    "source": [
     "await chat(\"could you list some more books I could read about this topic?\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c30bac97",
+   "metadata": {},
+   "source": [
+    "After chatting for a while, we have built a growing history, which we are attaching to each prompt and which contains the full conversation. Let's take a look!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e34ae55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(context[\"history\"])"
    ]
   }
  ],


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

When working through the notebooks, I had the feeling that printing the chat history at the end, makes it much clearer how it actually looks like after a bunch of chats. I would like to see this added for everyone.


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Printing the chat history in the Notebooks at the end of the _Planner_ section


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
