### PR TITLE
[C# CoreSkills]: Added ability to send custom Headers in HttpSkill

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/CoreSkills/HttpSkillTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/CoreSkills/HttpSkillTests.cs
@@ -51,6 +51,7 @@ public class HttpSkillTests : IDisposable
         var mockHandler = this.CreateMock();
         using var client = new HttpClient(mockHandler.Object);
         using var skill = new HttpSkill(client);
+        this._context["serializedHeaders"] = "{\"key\":\"value\"}";
 
         // Act
         var result = await skill.GetAsync(this._uriString, this._context);
@@ -67,6 +68,7 @@ public class HttpSkillTests : IDisposable
         var mockHandler = this.CreateMock();
         using var client = new HttpClient(mockHandler.Object);
         using var skill = new HttpSkill(client);
+        this._context["serializedHeaders"] = "{\"key\":\"value\"}";
         this._context["body"] = this._content;
 
         // Act
@@ -84,6 +86,7 @@ public class HttpSkillTests : IDisposable
         var mockHandler = this.CreateMock();
         using var client = new HttpClient(mockHandler.Object);
         using var skill = new HttpSkill(client);
+        this._context["serializedHeaders"] = "{\"key\":\"value\"}";
         this._context["body"] = this._content;
 
         // Act
@@ -101,6 +104,7 @@ public class HttpSkillTests : IDisposable
         var mockHandler = this.CreateMock();
         using var client = new HttpClient(mockHandler.Object);
         using var skill = new HttpSkill(client);
+        this._context["serializedHeaders"] = "{\"key\":\"value\"}";
 
         // Act
         var result = await skill.DeleteAsync(this._uriString, this._context);
@@ -127,6 +131,7 @@ public class HttpSkillTests : IDisposable
             ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == method // we expected a POST request
                     && req.RequestUri == new Uri(this._uriString) // to this uri
+                    && req.Headers.Contains("key")
             ),
             ItExpr.IsAny<CancellationToken>()
         );


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Currently, the HttpSkill present as part of the core skills in Semantic Kernel dotnet source does not have an option to add any custom headers to the http request. This makes it hard to make many of the API calls using this Core skill as generally some or the other authentication headers or other keys need to be added to the headers.


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
This change adds the ability to apply custom headers to the Http request by adding a serialized dictionary of headers to the semantic kernel context variables. This dictionary should be serialized using System.Text.Json which is then used to deserialize the headers before adding to the request. The "serializedHeaders" variable is completely optional and not necessary to be present.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
