### PR TITLE
Python: Fix weaviate integration tests

### DIFF
--- a/python/semantic_kernel/connectors/memory/weaviate/weaviate_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/weaviate/weaviate_memory_store.py
@@ -52,6 +52,11 @@ SCHEMA = {
             "description": "The text of the record.",
             "dataType": ["text"],
         },
+        {
+            "name": "additionalMetadata",
+            "description": "Optional custom metadata of the record.",
+            "dataType": ["string"],
+        },
     ],
 }
 
@@ -81,6 +86,7 @@ class WeaviateMemoryStore(MemoryStoreBase):
             "_id": "skId",
             "_description": "description",
             "_text": "text",
+            "_additional_metadata": "additionalMetadata",
             "_embedding": "vector",
         }
 

--- a/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
+++ b/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
@@ -35,7 +35,7 @@ def documents():
             "2",
             "The five boxing wizards jump quickly.",
             "Another popular pangram.",
-            "addtitional info",
+            "additional info",
             np.array([0.1, 0.11]),
         )
     )
@@ -44,7 +44,7 @@ def documents():
             "3",
             "Pack my box with five dozen liquor jugs.",
             "A useful pangram.",
-            "addtitional info",
+            "additional info",
             np.array([0.11, 0.1]),
         )
     )
@@ -54,7 +54,7 @@ def documents():
             "4",
             "Lorem ipsum dolor sit amet.",
             "A common placeholder text.",
-            "addtitional info",
+            "additional info",
             np.array([-10, -10]),
         )
     )
@@ -63,7 +63,7 @@ def documents():
             "5",
             "Etiam faucibus orci vitae lacus pellentesque.",
             "A Latin text.",
-            "addtitional info",
+            "additional info",
             np.array([-10.1, -10.2]),
         )
     )

--- a/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
+++ b/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
@@ -26,6 +26,7 @@ def documents():
             "1",
             "The quick brown fox jumps over the lazy dog.",
             "A classic pangram.",
+            "addtitional info",
             np.array([0.1, 0.1]),
         )
     )
@@ -34,6 +35,7 @@ def documents():
             "2",
             "The five boxing wizards jump quickly.",
             "Another popular pangram.",
+            "addtitional info",
             np.array([0.1, 0.11]),
         )
     )
@@ -42,6 +44,7 @@ def documents():
             "3",
             "Pack my box with five dozen liquor jugs.",
             "A useful pangram.",
+            "addtitional info",
             np.array([0.11, 0.1]),
         )
     )
@@ -51,6 +54,7 @@ def documents():
             "4",
             "Lorem ipsum dolor sit amet.",
             "A common placeholder text.",
+            "addtitional info",
             np.array([-10, -10]),
         )
     )
@@ -59,6 +63,7 @@ def documents():
             "5",
             "Etiam faucibus orci vitae lacus pellentesque.",
             "A Latin text.",
+            "addtitional info",
             np.array([-10.1, -10.2]),
         )
     )

--- a/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
+++ b/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
@@ -26,7 +26,7 @@ def documents():
             "1",
             "The quick brown fox jumps over the lazy dog.",
             "A classic pangram.",
-            "addtitional info",
+            "additional info",
             np.array([0.1, 0.1]),
         )
     )

--- a/python/tests/unit/skill_definition/test_functions_view.py
+++ b/python/tests/unit/skill_definition/test_functions_view.py
@@ -3,7 +3,7 @@
 import pytest
 from semantic_kernel.kernel_exception import KernelException
 from semantic_kernel.skill_definition.function_view import FunctionView
-from semantic_kernel.skill_definition.functions_view import FunctionsView, FunctionView
+from semantic_kernel.skill_definition.functions_view import FunctionsView
 
 
 def test_add_semantic_function():


### PR DESCRIPTION
### Motivation and Context
The addition of the field `additional metadata` to `MemoryRecord` was not propagated to the weaviate integration tests. This PR ensures that the fields are properly filled and aligned. 


### Description
- Added an entry for `"additional info"` to the memory record test fixtures for weaviate. 


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
