### PR TITLE
Fix day format in TimeSkill

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/CoreSkills/TimeSkillTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/CoreSkills/TimeSkillTests.cs
@@ -43,6 +43,16 @@ public class TimeSkillTests
     }
 
     [Fact]
+    public void Day()
+    {
+        string expected = DateTime.Now.ToString("dd", CultureInfo.CurrentCulture);
+        var skill = new TimeSkill();
+        string result = skill.Day();
+        Assert.Equal(expected, result);
+        Assert.True(int.TryParse(result, out _));
+    }
+
+    [Fact]
     public void LastMatchingDayBadInput()
     {
         var skill = new TimeSkill();

--- a/dotnet/src/SemanticKernel/CoreSkills/TimeSkill.cs
+++ b/dotnet/src/SemanticKernel/CoreSkills/TimeSkill.cs
@@ -159,7 +159,7 @@ public class TimeSkill
     public string Day()
     {
         // Example: 12
-        return DateTimeOffset.Now.ToString("DD", CultureInfo.CurrentCulture);
+        return DateTimeOffset.Now.ToString("dd", CultureInfo.CurrentCulture);
     }
 
     /// <summary>


### PR DESCRIPTION
The TimeSkill class was using the wrong format specifier for the day of the month, resulting in a two-digit year instead. This commit changes the format from "DD" to "dd", which correctly outputs the day as a number from 01 to 31. This fixes a potential confusion and inconsistency in the output of the TimeSkill methods.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
