### PR TITLE
Fix variable expansion in plan steps

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanVariableExpansionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanVariableExpansionTests.cs
@@ -34,9 +34,9 @@ public sealed class PlanVariableExpansionTests
     [InlineData("$VAR1 $VAR2", "value1 value2", "VAR1", "value1", "VAR2", "value2")]
     [InlineData("$A-$A-$A", "x-x-x", "A", "x")]
     [InlineData("$A$B$A", "aba", "A", "a", "B", "b")]
-    [InlineData("$ABC", "", "A", "", "B", "", "C", "")]
-    [InlineData("$NO_VAR", "", "A", "a", "B", "b", "C", "c")]
-    [InlineData("$name$invalid_name", "world", "name", "world")]
+    [InlineData("$ABC", "$ABC", "A", "", "B", "", "C", "")]
+    [InlineData("$NO_VAR", "$NO_VAR", "A", "a", "B", "b", "C", "c")]
+    [InlineData("$name$invalid_name", "world$invalid_name", "name", "world")]
     public void ExpandFromVariablesWithVariablesReturnsExpandedString(string input, string expected, params string[] variables)
     {
         // Arrange

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -402,13 +402,14 @@ public sealed class Plan : ISKFunction
     {
         var result = input;
         var matches = s_variablesRegex.Matches(input);
-        var orderedMatches = matches.Cast<Match>().Select(m => m.Groups["var"].Value).OrderByDescending(m => m.Length);
+        var orderedMatches = matches.Cast<Match>().Select(m => m.Groups["var"].Value).Distinct().OrderByDescending(m => m.Length);
 
         foreach (var varName in orderedMatches)
         {
-            result = result.Replace($"${varName}",
-                variables.TryGetValue(varName, out string? value) || this.State.TryGetValue(varName, out value) ? value :
-                string.Empty);
+            if (variables.TryGetValue(varName, out string? value) || this.State.TryGetValue(varName, out value))
+            {
+                result = result.Replace($"${varName}", value);
+            }
         }
 
         return result;


### PR DESCRIPTION
### Motivation and Context
Fixes #1487 

This pull request adds support for expanding variables with a $ in them in plan parameters, such as JSON payloads. Previously, such variables would be replaced with an empty string or left as is, which could cause unexpected behavior or errors. This change allows the plan to use the values of the variables from the context or the plan state, and only leaves the variable as is if it is not found in either. This feature improves the flexibility and robustness of the plan execution and allows for more complex scenarios involving dynamic payloads.

### Description
Details:
- Add a unit test to verify that variables with a $ in them are expanded correctly in plan parameters
- Modify the PlanVariableExpansionTests to reflect the new behavior of leaving unknown variables as is instead of replacing them with an empty string
- Modify the Plan.ExpandFromVariables method to use Distinct() to avoid duplicate replacements, and to only replace variables that are found in the context or the plan state


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
