### PR TITLE
[Bug fix] Copilot Chat: Filtering breaks when conversations state changes

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -81,38 +81,39 @@ export const ChatList: FC = () => {
     const { conversations, selectedId } = useAppSelector((state: RootState) => state.conversations);
 
     const [isFiltering, setIsFiltering] = useState(false);
+    const [filterText, setFilterText] = useState('');
     const [conversationsView, setConversationsView] = useState(conversations);
 
     useEffect(() => {
-        // Ensure local component state is in line with app state
-        setConversationsView(conversations);
-    }, [conversations]);
+        // Ensure local component state is in line with app state.
+        if (filterText !== '') {
+            // Reapply search string to the updated conversations list.
+            const filteredConversations: Conversations = {};
+            for (var key in conversations) {
+                if (conversations[key].title.toLowerCase().includes(filterText.toLowerCase())) {
+                    filteredConversations[key] = conversations[key];
+                }
+            }
+            setConversationsView(filteredConversations);
+        }
+        else {
+            // If no search string, show full conversations list.
+            setConversationsView(conversations);
+        }
+    }, [conversations, filterText]);
 
     const onFilterClick = () => {
         setIsFiltering(true);
     };
 
     const onFilterCancel = () => {
-        setConversationsView(conversations);
+        setFilterText('');
         setIsFiltering(false);
     };
 
     const onSearch = (ev: any, data: InputOnChangeData) => {
         ev.preventDefault();
-
-        if (data.value !== '') {
-            const filteredConversations: Conversations = {};
-            for (var key in conversations) {
-                if (conversations[key].title.toLowerCase().includes(data.value.toLowerCase())) {
-                    filteredConversations[key] = conversations[key];
-                }
-            }
-
-            setConversationsView(filteredConversations);
-        } else {
-            // If no search string, show full conversations list
-            setConversationsView(conversations);
-        }
+        setFilterText(data.value);
     };
 
     return (
@@ -145,7 +146,7 @@ export const ChatList: FC = () => {
             </div>
             <Tree aria-label={'chat list'} className={classes.list}>
                 {Object.keys(conversationsView).map((id) => {
-                    const convo = conversations[id];
+                    const convo = conversationsView[id];
                     const messages = convo.messages;
                     const lastMessage = messages[convo.messages.length - 1];
                     const isSelected = id === selectedId;


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Fix for #1502

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Add `filterText` as a state variable. Whenever either this or the conversations state is updated, reapply filtering and update the conversations view with the appropriately filtered list.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
