### PR TITLE
Removing global.json file that overrides dotnet sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-    "sdk": {
-        // TODO: Pinning to 6.0.408 until a dotnet servicing release is deployed: https://github.com/dotnet/format/issues/1546#issuecomment-1572744247
-        "version": "6.0.408",
-        "rollForward": "major"
-    }
-}


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Removing this config file since newest dotnet sdk release 7.0.304 fixes the issues we were seeing with `dotnet-format`. 

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Verifications locally:

Running `dotnet-format` on a .Net6.0 project: 
![image](https://github.com/microsoft/semantic-kernel/assets/125500434/6f42813c-8da0-4ff3-9664-bd9715b7437b)

In greater SK `dotnet` solution:
![image](https://github.com/microsoft/semantic-kernel/assets/125500434/0ceb55c0-4ffb-4602-a129-d662589cdfb4)


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
