### PR TITLE
Update dotnet-format.yml

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -65,11 +65,11 @@ jobs:
               done
             done
           else
-            # if the changed-files step failed, run dotnet format on all projects
-            csproj_files=$(find ./ -type f -name "*.csproj" | tr '\n' ' ');
+            # if the changed-files step failed, run dotnet on the whole sln instead of specific projects
+            csproj_files=$(find ./ -type f -name "*.sln" | tr '\n' ' ');
           fi
           csproj_files=($(printf "%s\n" "${csproj_files[@]}" | sort -u))
-          echo "Found ${#csproj_files[@]} unique csproj files: ${csproj_files[*]}"
+          echo "Found ${#csproj_files[@]} unique csproj/sln files: ${csproj_files[*]}"
           echo "::set-output name=csproj_files::${csproj_files[*]}"
 
       - name: Pull container dotnet/sdk:${{ matrix.dotnet }}

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -17,8 +17,18 @@ on:
 
 jobs:
   check-format:
-    runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { dotnet: '6.0', configuration: Release, os: ubuntu-latest }
+        - { dotnet: '7.0', configuration: Release, os: ubuntu-latest }
+        - { dotnet: '8.0-preview', configuration: Release, os: ubuntu-latest }
+          
+    runs-on: ${{ matrix.os }}
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline
+      
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -27,18 +37,19 @@ jobs:
           
       - name: Get changed files
         id: changed-files
+        if: github.event_name == 'pull_request'
         uses: jitterbit/get-changed-files@v1
         continue-on-error: true
 
       - name: No C# files changed
         id: no-csharp
-        if: steps.changed-files.outputs.added_modified == ''
+        if: github.event_name == 'pull_request' && steps.changed-files.outputs.added_modified == ''
         run: echo "No C# files changed"
 
       # This step will loop over the changed files and find the nearest .csproj file for each one, then store the unique csproj files in a variable
       - name: Find csproj files
         id: find-csproj
-        if: steps.changed-files.outputs.added_modified != '' || steps.changed-files.outcome == 'failure'
+        if: github.event_name != 'pull_request' || steps.changed-files.outputs.added_modified != '' || steps.changed-files.outcome == 'failure'
         run: |
           csproj_files=()
           if [[ ${{ steps.changed-files.outcome }} == 'success' ]]; then
@@ -61,9 +72,9 @@ jobs:
           echo "Found ${#csproj_files[@]} unique csproj files: ${csproj_files[*]}"
           echo "::set-output name=csproj_files::${csproj_files[*]}"
 
-      - name: Install dotnet-format tool
+      - name: Pull container dotnet/sdk:${{ matrix.dotnet }}
         if: steps.find-csproj.outputs.csproj_files != ''
-        run: dotnet tool install -g dotnet-format
+        run: docker pull mcr.microsoft.com/dotnet/sdk:${{ matrix.dotnet }}
 
       # This step will run dotnet format on each of the unique csproj files and fail if any changes are made
       - name: Run dotnet format
@@ -72,4 +83,5 @@ jobs:
           for csproj in ${{ steps.find-csproj.outputs.csproj_files }}; do
             echo "Running dotnet format on $csproj"
             dotnet format $csproj --verify-no-changes --verbosity diagnostic
+            docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:${{ matrix.dotnet }} /bin/sh -c "dotnet format $csproj --verify-no-changes --verbosity diagnostic"
           done

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -82,6 +82,5 @@ jobs:
         run: |
           for csproj in ${{ steps.find-csproj.outputs.csproj_files }}; do
             echo "Running dotnet format on $csproj"
-            dotnet format $csproj --verify-no-changes --verbosity diagnostic
             docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:${{ matrix.dotnet }} /bin/sh -c "dotnet format $csproj --verify-no-changes --verbosity diagnostic"
           done

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -15,6 +15,10 @@ on:
       - '**.csproj'
       - '**.editorconfig'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-format:
     strategy:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { dotnet: '6.0', configuration: Release, os: ubuntu-latest }
+        #- { dotnet: '6.0', configuration: Release, os: ubuntu-latest }
         - { dotnet: '7.0', configuration: Release, os: ubuntu-latest }
-        - { dotnet: '8.0-preview', configuration: Release, os: ubuntu-latest }
+        #- { dotnet: '8.0-preview', configuration: Release, os: ubuntu-latest }
           
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Updating dotnet-format build to use dotnet sdk docker container for better reliability.

Also updated:
- Fixed workflow trigger so that we can trigger a dotnet format pass manually on any branch, without a PR
- When not a PR, or when we fail to get changed files, it calls dotnet format on the sln instead of each individual csproj, which speeds things up substantially.
- Added concurrency rules, so that subsequent pushes to PR branches will cancel and replace currently-running jobs.

Successful pass:
https://github.com/microsoft/semantic-kernel/actions/runs/5293570328/jobs/9581867741

