### PR TITLE
Fix parameter assignment in ActionPlanner

### DIFF
--- a/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
@@ -143,8 +143,7 @@ public sealed class ActionPlanner
     /// <returns>List of functions, formatted accordingly to the prompt</returns>
     [SKFunction, Description("List all functions available in the kernel")]
     public string ListOfFunctions(
-        [Description("The current goal processed by the planner")]
-        string goal,
+        [Description("The current goal processed by the planner")] string goal,
         SKContext context)
     {
         Verify.NotNull(context.Skills);
@@ -162,8 +161,7 @@ public sealed class ActionPlanner
     // TODO: use goal to find relevant examples
     [SKFunction, Description("List a few good examples of plans to generate")]
     public string GoodExamples(
-        [Description("The current goal processed by the planner")]
-        string goal,
+        [Description("The current goal processed by the planner")] string goal,
         SKContext context)
     {
         return @"
@@ -198,8 +196,7 @@ Goal: create a file called ""something.txt"".
     // TODO: generate string programmatically
     [SKFunction, Description("List a few edge case examples of plans to handle")]
     public string EdgeCaseExamples(
-        [Description("The current goal processed by the planner")]
-        string goal,
+        [Description("The current goal processed by the planner")] string goal,
         SKContext context)
     {
         return @"

--- a/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
@@ -126,7 +126,7 @@ public sealed class ActionPlanner
         {
             if (p.Value != null)
             {
-                plan.State[p.Key] = p.Value.ToString();
+                plan.Parameters[p.Key] = p.Value.ToString();
             }
         }
 
@@ -143,7 +143,8 @@ public sealed class ActionPlanner
     /// <returns>List of functions, formatted accordingly to the prompt</returns>
     [SKFunction, Description("List all functions available in the kernel")]
     public string ListOfFunctions(
-        [Description("The current goal processed by the planner")] string goal,
+        [Description("The current goal processed by the planner")]
+        string goal,
         SKContext context)
     {
         Verify.NotNull(context.Skills);
@@ -161,7 +162,8 @@ public sealed class ActionPlanner
     // TODO: use goal to find relevant examples
     [SKFunction, Description("List a few good examples of plans to generate")]
     public string GoodExamples(
-        [Description("The current goal processed by the planner")] string goal,
+        [Description("The current goal processed by the planner")]
+        string goal,
         SKContext context)
     {
         return @"
@@ -196,7 +198,8 @@ Goal: create a file called ""something.txt"".
     // TODO: generate string programmatically
     [SKFunction, Description("List a few edge case examples of plans to handle")]
     public string EdgeCaseExamples(
-        [Description("The current goal processed by the planner")] string goal,
+        [Description("The current goal processed by the planner")]
+        string goal,
         SKContext context)
     {
         return @"

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
@@ -50,6 +50,7 @@ export const PlanViewer: React.FC<PlanViewerProps> = ({ message, messageIndex, g
     var planState = message.state ?? parsedContent.state;
 
     // If plan came from ActionPlanner, use parameters from top-level plan state
+    // TODO: Can remove this after consuming nugets with #997 fixed
     if (parsedContent.type === PlanType.Action) {
         originalPlan.steps[0].parameters = originalPlan.state;
     }


### PR DESCRIPTION
### Motivation and Context
This pull request fixes a bug in the ActionPlanner class where the plan parameters were not assigned correctly from the input parameters. It also updates some formatting

Fixes #997 

### Description
- Fix parameter assignment in ActionPlanner.CreatePlanFromParameters method
  - Use plan.Parameters instead of plan.State to assign the input parameters to the plan object
  - This fixes a bug where the plan state was overwritten by the input parameters, causing unexpected behavior and errors

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
