### PR TITLE
CopilotChat: add missing container

### DIFF
--- a/samples/apps/copilot-chat-app/deploy/main.bicep
+++ b/samples/apps/copilot-chat-app/deploy/main.bicep
@@ -205,6 +205,10 @@ resource appServiceWebConfig 'Microsoft.Web/sites/config@2022-09-01' = {
         value: 'chatmessages'
       }
       {
+        name: 'ChatStore:Cosmos:ChatMemorySourcesContainer'
+        value: 'chatmemorysources'
+      }
+      {
         name: 'ChatStore:Cosmos:ConnectionString'
         value: deployCosmosDB ? cosmosAccount.listConnectionStrings().connectionStrings[0].connectionString : ''
       }
@@ -607,6 +611,37 @@ resource participantContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabase
   properties: {
     resource: {
       id: 'chatparticipants'
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          {
+            path: '/*'
+          }
+        ]
+        excludedPaths: [
+          {
+            path: '/"_etag"/?'
+          }
+        ]
+      }
+      partitionKey: {
+        paths: [
+          '/id'
+        ]
+        kind: 'Hash'
+        version: 2
+      }
+    }
+  }
+}
+
+resource memorySourcesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-04-15' = if (deployCosmosDB) {
+  parent: cosmosDatabase
+  name: 'chatmemorysources'
+  properties: {
+    resource: {
+      id: 'chatmemorysources'
       indexingPolicy: {
         indexingMode: 'consistent'
         automatic: true


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This fixes an [issue](https://github.com/microsoft/semantic-kernel/issues/1402) with uploading documents from the copilot chat sample app when Azure Cosmos DB resources are used.

### Description
The `chatmemorysources` Cosmos DB container referenced in the web API appsettings.json was missing from the bicep template and this caused the "resource not found" error.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
