### PR TITLE
CopilotChat: deploy webapp typo fix

### DIFF
--- a/samples/apps/copilot-chat-app/deploy/deploy-webapi.ps1
+++ b/samples/apps/copilot-chat-app/deploy/deploy-webapi.ps1
@@ -42,7 +42,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Getting Azure WebApp resource name..."
-$webappName=$(az deployment group show --name $DeploymentName --resource-group $ResourceGroupName --output json | ConvertFrom-Json).properties.outputs.webapiName.value
+$webappName=$(az deployment group show --name $DeploymentName --resource-group $ResourceGroupName --output json | ConvertFrom-Json).properties.outputs.webappName.value
 if ($null -eq $webAppName) {
     Write-Error "Could not get Azure WebApp resource name from deployment output."
     exit 1

--- a/samples/apps/copilot-chat-app/deploy/deploy-webapi.ps1
+++ b/samples/apps/copilot-chat-app/deploy/deploy-webapi.ps1
@@ -42,7 +42,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Getting Azure WebApp resource name..."
-$webappName=$(az deployment group show --name $DeploymentName --resource-group $ResourceGroupName --output json | ConvertFrom-Json).properties.outputs.webappName.value
+$webappName=$(az deployment group show --name $DeploymentName --resource-group $ResourceGroupName --output json | ConvertFrom-Json).properties.outputs.webapiName.value
 if ($null -eq $webAppName) {
     Write-Error "Could not get Azure WebApp resource name from deployment output."
     exit 1

--- a/samples/apps/copilot-chat-app/deploy/deploy-webapp.ps1
+++ b/samples/apps/copilot-chat-app/deploy/deploy-webapp.ps1
@@ -86,7 +86,7 @@ if ($LASTEXITCODE -ne 0) {
 
 $origin = "https://$webappUrl"
 Write-Host "Ensuring CORS origin '$origin' to webapi '$webapiName'..."
-if (-not ((az webapp cors show --name webapiName --resource-group $ResourceGroupName --subscription $Subscription | ConvertFrom-Json).allowedOrigins -contains $origin)) {
+if (-not ((az webapp cors show --name $webapiName --resource-group $ResourceGroupName --subscription $Subscription | ConvertFrom-Json).allowedOrigins -contains $origin)) {
     az webapp cors add --name $webapiName --resource-group $ResourceGroupName --subscription $Subscription --allowed-origins $origin
 }
 


### PR DESCRIPTION
Fixes missing "$" in deploy-webapp.ps1, causing a failure in CORS configuration.