### PR TITLE
Copilot Chat: Update obsolete qDrant constructor

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/SemanticKernelExtensions.cs
@@ -120,8 +120,15 @@ internal static class SemanticKernelExtensions
                         httpClient.DefaultRequestHeaders.Add("api-key", config.Qdrant.Key);
                     }
 
-                    return new QdrantMemoryStore(new QdrantVectorDbClient(
-                        config.Qdrant.Host, config.Qdrant.VectorSize, port: config.Qdrant.Port, httpClient: httpClient, log: sp.GetRequiredService<ILogger<IQdrantVectorDbClient>>()));
+                    var endPointBuilder = new UriBuilder(config.Qdrant.Host);
+                    endPointBuilder.Port = config.Qdrant.Port;
+
+                    return new QdrantMemoryStore(
+                        httpClient: httpClient,
+                        config.Qdrant.VectorSize,
+                        endPointBuilder.ToString(),
+                        logger: sp.GetRequiredService<ILogger<IQdrantVectorDbClient>>()
+                    );
                 });
                 services.AddScoped<ISemanticTextMemory>(sp => new SemanticTextMemory(
                     sp.GetRequiredService<IMemoryStore>(),


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
There is a warning indicating that CP is using an obsolete qDrant constructor.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Replace the obsolete constructor.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
