### PR TITLE
Add Token/Logit Bias to Completion/Chat settings

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example49_LogitBias.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example49_LogitBias.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
+using RepoUtils;
+
+/**
+ * The following example shows how to use Semantic Kernel with OpenAI ChatGPT API
+ */
+// ReSharper disable once InconsistentNaming
+public static class Example49_LogitBias
+{
+    public static async Task RunAsync()
+    {
+        OpenAIChatCompletion chatCompletion = new("gpt-3.5-turbo", Env.Var("OPENAI_API_KEY"));
+
+        // Using the GPT Tokenizer: https://platform.openai.com/tokenizer
+        // The following text is the tokenized version of the book related tokens
+        // "novel literature reading author library story chapter paperback hardcover ebook publishing fiction nonfiction manuscript textbook bestseller bookstore reading list bookworm"
+
+        // This will make the model try its best to avoid any of the above related words.
+        var keys = new[] { 3919, 626, 17201, 1300, 25782, 9800, 32016, 13571, 43582, 20189, 1891, 10424, 9631, 16497, 12984, 20020, 24046, 13159, 805, 15817, 5239, 2070, 13466, 32932, 8095, 1351, 25323 };
+
+        var settings = new ChatRequestSettings();
+        foreach (var key in keys)
+        {
+            settings.TokenSelectionBiases.Add(key, -100);
+        }
+
+        Console.WriteLine("Chat content:");
+        Console.WriteLine("------------------------");
+
+        var chatHistory = chatCompletion.CreateNewChat("You are a librarian expert");
+
+        // First user message
+        chatHistory.AddUserMessage("Hi, I'm looking some suggestions");
+        await MessageOutputAsync(chatHistory);
+
+        string reply = await chatCompletion.GenerateMessageAsync(chatHistory, settings);
+        chatHistory.AddAssistantMessage(reply);
+        await MessageOutputAsync(chatHistory);
+
+        chatHistory.AddUserMessage("I love history and philosophy, I'd like to learn something new about Greece, any suggestion?");
+        await MessageOutputAsync(chatHistory);
+
+        reply = await chatCompletion.GenerateMessageAsync(chatHistory, settings);
+        chatHistory.AddAssistantMessage(reply);
+        await MessageOutputAsync(chatHistory);
+
+        /* Output:
+        Chat content:
+        ------------------------
+        User: Hi, I'm looking some suggestions
+        ------------------------
+        Assistant: Sure, what kind of suggestions are you looking for?
+        ------------------------
+        User: I love history and philosophy, I'd like to learn something new about Greece, any suggestion?
+        ------------------------
+        Assistant: If you're interested in learning about ancient Greece, I would recommend the book "The Histories" by Herodotus. It's a fascinating account of the Persian Wars and provides a lot of insight into ancient Greek culture and society. For philosophy, you might enjoy reading the works of Plato, particularly "The Republic" and "The Symposium." These texts explore ideas about justice, morality, and the nature of love.
+        ------------------------
+        */
+    }
+
+    /// <summary>
+    /// Outputs the last message of the chat history
+    /// </summary>
+    private static Task MessageOutputAsync(ChatHistory chatHistory)
+    {
+        var message = chatHistory.Messages.Last();
+
+        Console.WriteLine($"{message.Role}: {message.Content}");
+        Console.WriteLine("------------------------");
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet/samples/KernelSyntaxExamples/Program.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Program.cs
@@ -151,5 +151,8 @@ public static class Program
 
         await Example48_GroundednessChecks.RunAsync();
         Console.WriteLine("== DONE ==");
+
+        await Example49_LogitBias.RunAsync();
+        Console.WriteLine("== DONE ==");
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
@@ -278,6 +278,14 @@ public abstract class ClientBase
             User = null,
         };
 
+        if (requestSettings.TokenSelectionBiases.Count > 0)
+        {
+            foreach(var keyValue in requestSettings.TokenSelectionBiases)
+            {
+                options.TokenSelectionBiases.Add(keyValue.Key, keyValue.Value);
+            }
+        }
+
         if (requestSettings.StopSequences is { Count: > 0 })
         {
             foreach (var s in requestSettings.StopSequences)
@@ -305,6 +313,14 @@ public abstract class ClientBase
             PresencePenalty = (float?)requestSettings.PresencePenalty,
             ChoicesPerPrompt = requestSettings.ResultsPerPrompt
         };
+
+        if (requestSettings.TokenSelectionBiases.Count > 0)
+        {
+            foreach (var keyValue in requestSettings.TokenSelectionBiases)
+            {
+                options.TokenSelectionBiases.Add(keyValue.Key, keyValue.Value);
+            }
+        }
 
         if (requestSettings.StopSequences is { Count: > 0 })
         {

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
@@ -280,7 +280,7 @@ public abstract class ClientBase
 
         if (requestSettings.TokenSelectionBiases.Count > 0)
         {
-            foreach(var keyValue in requestSettings.TokenSelectionBiases)
+            foreach (var keyValue in requestSettings.TokenSelectionBiases)
             {
                 options.TokenSelectionBiases.Add(keyValue.Key, keyValue.Value);
             }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatRequestSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatRequestSettings.cs
@@ -53,4 +53,9 @@ public class ChatRequestSettings
     /// The maximum number of tokens to generate in the completion.
     /// </summary>
     public int MaxTokens { get; set; } = 256;
+
+    /// <summary>
+    /// Modify the likelihood of specified tokens appearing in the completion.
+    /// </summary>
+    public IDictionary<int, int> TokenSelectionBiases { get; set; } = new Dictionary<int, int>();
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextCompletion/CompleteRequestSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextCompletion/CompleteRequestSettings.cs
@@ -61,6 +61,11 @@ public class CompleteRequestSettings
     public string ChatSystemPrompt { get; set; } = "Assistant is a large language model.";
 
     /// <summary>
+    /// Modify the likelihood of specified tokens appearing in the completion.
+    /// </summary>
+    public IDictionary<int, int> TokenSelectionBiases { get; set; } = new Dictionary<int, int>();
+
+    /// <summary>
     /// Create a new settings object with the values from another settings object.
     /// </summary>
     /// <param name="config"></param>


### PR DESCRIPTION
### Motivation and Context

Was not possible until now for advanced LLM steering scenarios make usage of Token Bias during prompt configuration/invocation

Resolves #1635 
Closes #1635 

### Description

This change brings the Token Bias configuration as part of both Text and Chat Completion Settings.

Extra example how to use Token Bias added.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
