### PR TITLE
Add option to deserialize plan without requiring functions

### DIFF
--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -173,15 +173,16 @@ public sealed class Plan : ISKFunction
     /// </summary>
     /// <param name="json">JSON string representation of a Plan</param>
     /// <param name="context">The context to use for function registrations.</param>
+    /// <param name="requireFunctions">Whether to require functions to be registered. Only used when context is not null.</param>
     /// <returns>An instance of a Plan object.</returns>
     /// <remarks>If Context is not supplied, plan will not be able to execute.</remarks>
-    public static Plan FromJson(string json, SKContext? context = null)
+    public static Plan FromJson(string json, SKContext? context = null, bool requireFunctions = true)
     {
         var plan = JsonSerializer.Deserialize<Plan>(json, new JsonSerializerOptions { IncludeFields = true }) ?? new Plan(string.Empty);
 
         if (context != null)
         {
-            plan = SetAvailableFunctions(plan, context);
+            plan = SetAvailableFunctions(plan, context, requireFunctions);
         }
 
         return plan;
@@ -420,8 +421,9 @@ public sealed class Plan : ISKFunction
     /// </summary>
     /// <param name="plan">Plan to set functions for.</param>
     /// <param name="context">Context to use.</param>
+    /// <param name="requireFunctions">Whether to throw an exception if a function is not found.</param>
     /// <returns>The plan with functions set.</returns>
-    private static Plan SetAvailableFunctions(Plan plan, SKContext context)
+    private static Plan SetAvailableFunctions(Plan plan, SKContext context, bool requireFunctions = true)
     {
         if (plan.Steps.Count == 0)
         {
@@ -436,12 +438,18 @@ public sealed class Plan : ISKFunction
             {
                 plan.SetFunction(skillFunction);
             }
+            else if (requireFunctions)
+            {
+                throw new KernelException(
+                    KernelException.ErrorCodes.FunctionNotAvailable,
+                    $"Function '{plan.SkillName}.{plan.Name}' not found in skill collection");
+            }
         }
         else
         {
             foreach (var step in plan.Steps)
             {
-                SetAvailableFunctions(step, context);
+                SetAvailableFunctions(step, context, requireFunctions);
             }
         }
 


### PR DESCRIPTION
This commit adds a new parameter to the Plan.FromJson method that allows deserializing a plan without requiring the functions to be registered in the skill collection. This is useful for scenarios where the plan is only used for inspection or analysis, and not for execution. The default behavior is still to require the functions, and throw an exception if they are not found. The commit also adds unit tests for both cases, and updates the JSON serialization options to ignore default values.

Resolves #1631

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
