### PR TITLE
Add methods to import plans into kernel

### DIFF
--- a/dotnet/src/SemanticKernel/Planning/KernelPlanExtensions.cs
+++ b/dotnet/src/SemanticKernel/Planning/KernelPlanExtensions.cs
@@ -16,6 +16,28 @@ namespace Microsoft.SemanticKernel;
 public static class KernelPlanExtensions
 {
     /// <summary>
+    /// Import a plan into the kernel
+    /// </summary>
+    /// <param name="kernel">Kernel instance to use</param>
+    /// <param name="plan">Plan to import</param>
+    /// <returns>Function definition for the plan</returns>
+    public static SkillDefinition.ISKFunction ImportPlan(this IKernel kernel, Plan plan)
+    {
+        return kernel.RegisterCustomFunction(plan);
+    }
+
+    /// <summary>
+    /// Import a plan into the kernel
+    /// </summary>
+    /// <param name="kernel">Kernel instance to use</param>
+    /// <param name="json">Json representation of the plan</param>
+    /// <returns>Function definition for the plan</returns>
+    public static SkillDefinition.ISKFunction ImportPlanFromJson(this IKernel kernel, string json)
+    {
+        return kernel.RegisterCustomFunction(Plan.FromJson(json, kernel.CreateNewContext()));
+    }
+
+    /// <summary>
     /// Run the next step in a plan asynchronously
     /// </summary>
     /// <param name="kernel">Kernel instance to use</param>


### PR DESCRIPTION
This commit adds two extension methods to the KernelPlanExtensions class that allow importing a plan into the kernel from either a Plan object or a JSON string. These methods simplify the process of registering custom functions based on plans and make it easier to integrate with external sources of plans. The methods use the kernel.RegisterCustomFunction method internally and return the corresponding function definition.

Resolves #1653 

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
