### PR TITLE
Java - Waitskill added

### DIFF
--- a/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/WaitSkill.java
+++ b/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/WaitSkill.java
@@ -27,13 +27,12 @@ public class WaitSkill {
      */
     @DefineSKFunction(name = "seconds", description = "Wait a given amount of seconds")
     public Mono<Void> wait(String seconds) {
-        double sec;
         try {
-            sec = Math.max(Double.parseDouble(seconds), 0);
+            double sec = Math.max(Double.parseDouble(seconds), 0);
+            long milliseconds = (long) (sec * 1000);
+            return Mono.delay(Duration.ofMillis(milliseconds)).then();
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("seconds text must be a number", e);
+            return Mono.error(new IllegalArgumentException("seconds text must be a number", e));
         }
-        long milliseconds = (long) (sec * 1000);
-        return Mono.delay(Duration.ofMillis(milliseconds)).then();
     }
 }

--- a/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/WaitSkill.java
+++ b/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/WaitSkill.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+package com.microsoft.semantickernel.coreskills;
+
+import reactor.core.publisher.Mono;
+import java.time.Duration;
+import com.microsoft.semantickernel.skilldefinition.annotations.DefineSKFunction;
+
+/**
+ * WaitSkill provides a set of functions to wait before making the rest of operations.
+ */
+public class WaitSkill {
+
+    /**
+     * Wait for a certain number of seconds.
+     *
+     * <p>Examples:
+     *
+     * <p>SKContext context = SKBuilders.context().build();
+     * <p>context.setVariable("input","10");
+     * <p>   {{wait.seconds $input}}
+     *
+     * @param seconds The number of seconds to wait as a string.
+     * @return A Mono<Void> that completes after the specified delay.
+     * @throws IllegalArgumentException If the input is not a valid number.
+     */
+    @DefineSKFunction(name = "seconds", description = "Wait a given amount of seconds")
+    public Mono<Void> wait(String seconds) {
+        double sec;
+        try {
+            sec = Math.max(Double.parseDouble(seconds), 0);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("seconds text must be a number", e);
+        }
+        long milliseconds = (long) (sec * 1000);
+        return Mono.delay(Duration.ofMillis(milliseconds)).then();
+    }
+}

--- a/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/WaitSkill.java
+++ b/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/WaitSkill.java
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
-
 package com.microsoft.semantickernel.coreskills;
 
-import reactor.core.publisher.Mono;
-import java.time.Duration;
 import com.microsoft.semantickernel.skilldefinition.annotations.DefineSKFunction;
 
-/**
- * WaitSkill provides a set of functions to wait before making the rest of operations.
- */
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+/** WaitSkill provides a set of functions to wait before making the rest of operations. */
 public class WaitSkill {
 
     /**
@@ -17,8 +16,10 @@ public class WaitSkill {
      * <p>Examples:
      *
      * <p>SKContext context = SKBuilders.context().build();
+     *
      * <p>context.setVariable("input","10");
-     * <p>   {{wait.seconds $input}}
+     *
+     * <p>{{wait.seconds $input}}
      *
      * @param seconds The number of seconds to wait as a string.
      * @return A Mono<Void> that completes after the specified delay.

--- a/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
+++ b/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
@@ -1,9 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.semantickernel.coreskills;
 
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.time.Duration;
 
 class WaitSkillTest {
 
@@ -26,19 +29,13 @@ class WaitSkillTest {
     void secondsAsync_givenZeroSeconds_shouldNotDelay() {
         String seconds = "0";
         Mono<Void> result = waitSkill.wait(seconds);
-        StepVerifier.create(result)
-                .expectSubscription()
-                .expectComplete()
-                .verify();
+        StepVerifier.create(result).expectSubscription().expectComplete().verify();
     }
 
     @Test
     void secondsAsync_givenNegativeSeconds_shouldNotDelay() {
         String seconds = "-1.5";
         Mono<Void> result = waitSkill.wait(seconds);
-        StepVerifier.create(result)
-                .expectSubscription()
-                .expectComplete()
-                .verify();
+        StepVerifier.create(result).expectSubscription().expectComplete().verify();
     }
 }

--- a/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
+++ b/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
@@ -3,7 +3,6 @@ package com.microsoft.semantickernel.coreskills;
 
 import org.junit.jupiter.api.Test;
 
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -14,11 +13,10 @@ class WaitSkillTest {
 
     @Test
     void secondsAsync_givenPositiveSeconds_shouldDelay() {
-        Duration expectedDelay = Duration.ofMillis(1490);
+        Duration expectedDelay = Duration.ofMillis(1500);
 
         String seconds = "1.5";
-        Mono<Void> result = waitSkill.wait(seconds);
-        StepVerifier.create(result)
+        StepVerifier.withVirtualTime(() -> waitSkill.wait(seconds))
                 .expectSubscription()
                 .expectNoEvent(expectedDelay)
                 .expectComplete()
@@ -28,14 +26,18 @@ class WaitSkillTest {
     @Test
     void secondsAsync_givenZeroSeconds_shouldNotDelay() {
         String seconds = "0";
-        Mono<Void> result = waitSkill.wait(seconds);
-        StepVerifier.create(result).expectSubscription().expectComplete().verify();
+        StepVerifier.withVirtualTime(() -> waitSkill.wait(seconds))
+                .expectSubscription()
+                .expectComplete()
+                .verify();
     }
 
     @Test
     void secondsAsync_givenNegativeSeconds_shouldNotDelay() {
         String seconds = "-1.5";
-        Mono<Void> result = waitSkill.wait(seconds);
-        StepVerifier.create(result).expectSubscription().expectComplete().verify();
+        StepVerifier.withVirtualTime(() -> waitSkill.wait(seconds))
+                .expectSubscription()
+                .expectComplete()
+                .verify();
     }
 }

--- a/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
+++ b/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
@@ -1,0 +1,44 @@
+package com.microsoft.semantickernel.coreskills;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class WaitSkillTest {
+
+    WaitSkill waitSkill = new WaitSkill();
+
+    @Test
+    void secondsAsync_givenPositiveSeconds_shouldDelay() {
+        Duration expectedDelay = Duration.ofMillis(1500);
+
+        String seconds = "1.5";
+        Mono<Void> result = waitSkill.wait(seconds);
+        StepVerifier.create(result)
+                .expectSubscription()
+                .expectNoEvent(expectedDelay)
+                .expectComplete()
+                .verify();
+    }
+
+    @Test
+    void secondsAsync_givenZeroSeconds_shouldNotDelay() {
+        String seconds = "0";
+        Mono<Void> result = waitSkill.wait(seconds);
+        StepVerifier.create(result)
+                .expectSubscription()
+                .expectComplete()
+                .verify();
+    }
+
+    @Test
+    void secondsAsync_givenNegativeSeconds_shouldNotDelay() {
+        String seconds = "-1.5";
+        Mono<Void> result = waitSkill.wait(seconds);
+        StepVerifier.create(result)
+                .expectSubscription()
+                .expectComplete()
+                .verify();
+    }
+}

--- a/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
+++ b/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/WaitSkillTest.java
@@ -14,7 +14,7 @@ class WaitSkillTest {
 
     @Test
     void secondsAsync_givenPositiveSeconds_shouldDelay() {
-        Duration expectedDelay = Duration.ofMillis(1500);
+        Duration expectedDelay = Duration.ofMillis(1490);
 
         String seconds = "1.5";
         Mono<Void> result = waitSkill.wait(seconds);


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Based on the [wait_skill.py](https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/core_skills/wait_skill.py)

I implemented the WaitSkill by using Mono of Project Reactor.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
