### PR TITLE
Update sequential planner syntax and documentation

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -198,11 +198,9 @@ public class SequentialPlanParserTests
         // Assert
         Assert.NotNull(plan);
         Assert.Equal(goalText, plan.Description);
-        Assert.Equal(2, plan.Steps.Count);
+        Assert.Equal(1, plan.Steps.Count);
         Assert.Equal("MockSkill", plan.Steps[0].SkillName);
         Assert.Equal("Echo", plan.Steps[0].Name);
-        Assert.Equal("This is some text", plan.Steps[1].Description);
-        Assert.Equal(0, plan.Steps[1].Steps.Count);
     }
 
     // test that a <tag> that is not <function> will just get skipped
@@ -227,12 +225,11 @@ public class SequentialPlanParserTests
         // Assert
         Assert.NotNull(plan);
         Assert.Equal(goalText, plan.Description);
-        Assert.Equal(3, plan.Steps.Count);
+        Assert.Equal(2, plan.Steps.Count);
         Assert.Equal("MockSkill", plan.Steps[0].SkillName);
         Assert.Equal("Echo", plan.Steps[0].Name);
-        Assert.Equal("Some other tag", plan.Steps[1].Description);
         Assert.Equal(0, plan.Steps[1].Steps.Count);
-        Assert.Equal("MockSkill", plan.Steps[2].SkillName);
-        Assert.Equal("Echo", plan.Steps[2].Name);
+        Assert.Equal("MockSkill", plan.Steps[1].SkillName);
+        Assert.Equal("Echo", plan.Steps[1].Name);
     }
 }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -73,13 +73,10 @@ internal static class SequentialPlanParser
 
                 foreach (XmlNode childNode in solutionNode.ChildNodes)
                 {
-                    if (childNode.Name == "#text")
+                    if (childNode.Name == "#text" || childNode.Name == "#comment")
                     {
-                        if (childNode.Value != null)
-                        {
-                            plan.AddSteps(new Plan(childNode.Value.Trim()));
-                        }
-
+                        // Do not add text or comments as steps.
+                        // TODO - this could be a way to get Reasoning for a plan step.
                         continue;
                     }
 
@@ -142,7 +139,8 @@ internal static class SequentialPlanParser
                         continue;
                     }
 
-                    plan.AddSteps(new Plan(childNode.InnerText));
+                    // Similar to comments or text, do not add empty nodes as steps.
+                    // TODO - This could be a way to advertise desired functions for a plan.
                 }
             }
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SemanticKernel.Planning;
 /// </summary>
 public sealed class SequentialPlanner
 {
-    private const string StopSequence = "<!--";
+    private const string StopSequence = "<!-- END -->";
 
     /// <summary>
     /// Initialize a new instance of the <see cref="SequentialPlanner"/> class.

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
@@ -2,22 +2,35 @@ Create an XML plan step by step, to satisfy the goal given.
 To create a plan, follow these steps:
 0. The plan should be as short as possible.
 1. From a <goal> create a <plan> as a series of <functions>.
-2. Before using any function in a plan, check that it is present in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
-3. Only use functions that are required for the given goal.
-4. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list.
-5. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
-6. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
-7. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
+2. Only use functions that are defined in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
+3. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list. Strings should be xml escaped.
+4. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
+5. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
+6. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
+7. Always output valid XML that can be parsed by an XML parser.
 
-Here is an example of how to call a function "_Function_.Name" with a single input and save its output:
+All plans take the form of:
+<plan>
+    <!-- ... reason for taking step ... -->
+    <function.{FullyQualifiedFunctionName} ... />
+    <!-- ... reason for taking step ... -->
+    <function.{FullyQualifiedFunctionName} ... />
+    <!-- ... reason for taking step ... -->
+    <function.{FullyQualifiedFunctionName} ... />
+</plan>
+<!-- END -->
+
+Here is a valid example of how to call a function "_Function_.Name" with a single input and save its output:
 <function._Function_.Name input="this is my input" setContextVariable="SOME_KEY"/>
 
-Here is an example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
+Here is a valid example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
 <function.FunctionName2 input="$SOME_KEY" appendToResult="RESULT__FINAL_ANSWER"/>
 
-Here is an example of how to call a function "Name3" with multiple inputs:
+Here is a valid example of how to call a function "Name3" with multiple inputs:
 <function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a &lt;!-- comment in it--&gt;"/>
 
+Here is an INVALID example of how to call a function "Name4" as the parameter is not xml escaped:
+<function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a <!-- comment in it-->"/>
 
 [AVAILABLE FUNCTIONS]
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
@@ -2,112 +2,22 @@ Create an XML plan step by step, to satisfy the goal given.
 To create a plan, follow these steps:
 0. The plan should be as short as possible.
 1. From a <goal> create a <plan> as a series of <functions>.
-2. Before using any function in a plan, check that it is present in the most recent [AVAILABLE FUNCTIONS] list. If it is not, do not use it. Do not assume that any function that was previously defined or used in another plan or in [EXAMPLES] is automatically available or compatible with the current plan.
+2. Before using any function in a plan, check that it is present in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
 3. Only use functions that are required for the given goal.
-4. A function has a single 'input' and a single 'output' which are both strings and not objects.
-5. The 'output' from each function is automatically passed as 'input' to the subsequent <function>.
-6. 'input' does not need to be specified if it consumes the 'output' of the previous function.
-7. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FunctionName} ... setContextVariable: "<UNIQUE_VARIABLE_KEY>"/>
-8. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FunctionName} ... appendToResult: "RESULT__<UNIQUE_RESULT_KEY>"/>
-9. Append an "END" XML comment at the end of the plan.
+4. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list.
+5. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
+6. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
+7. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
 
-[EXAMPLES]
-[AVAILABLE FUNCTIONS]
+Here is an example of how to call a function "_Function_.Name" with a single input and save its output:
+<function._Function_.Name input="this is my input" setContextVariable="SOME_KEY"/>
 
-  EmailConnector.LookupContactEmail:
-    description: looks up the a contact and retrieves their email address
-    inputs:
-    - input: the name to look up
+Here is an example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
+<function.FunctionName2 input="$SOME_KEY" appendToResult="RESULT__FINAL_ANSWER"/>
 
-  EmailConnector.EmailTo:
-    description: email the input text to a recipient
-    inputs:
-    - input: the text to email
-    - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
+Here is an example of how to call a function "Name3" with multiple inputs:
+<function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a &lt;!-- comment in it--&gt;"/>
 
-  LanguageHelpers.TranslateTo:
-    description: translate the input to another language
-    inputs:
-    - input: the text to translate
-    - translate_to_language: the language to translate to
-
-  WriterSkill.Summarize:
-    description: summarize input text
-    inputs:
-    - input: the text to summarize
-
-[END AVAILABLE FUNCTIONS]
-
-<goal>Summarize the input, then translate to japanese and email it to Martin</goal>
-<plan>
-  <function.WriterSkill.Summarize/>
-  <function.LanguageHelpers.TranslateTo translate_to_language="Japanese" setContextVariable="TRANSLATED_TEXT" />
-  <function.EmailConnector.LookupContactEmail input="Martin" setContextVariable="CONTACT_RESULT" />
-  <function.EmailConnector.EmailTo input="$TRANSLATED_TEXT" recipient="$CONTACT_RESULT"/>
-</plan><!-- END -->
-
-[AVAILABLE FUNCTIONS]
-
-  _GLOBAL_FUNCTIONS_.GetEmailAddress:
-    description: Gets email address for given contact
-    inputs:
-    - input: the name to look up
-
-  _GLOBAL_FUNCTIONS_.SendEmail:
-    description: email the input text to a recipient
-    inputs:
-    - input: the text to email
-    - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
-
-  AuthorAbility.Summarize:
-    description: summarizes the input text
-    inputs:
-    - input: the text to summarize
-
-  Magician.TranslateTo:
-    description: translate the input to another language
-    inputs:
-    - input: the text to translate
-    - translate_to_language: the language to translate to
-
-[END AVAILABLE FUNCTIONS]
-
-<goal>Summarize an input, translate to french, and e-mail to John Doe</goal>
-<plan>
-    <function.AuthorAbility.Summarize/>
-    <function.Magician.TranslateTo translate_to_language="French" setContextVariable="TRANSLATED_SUMMARY"/>
-    <function._GLOBAL_FUNCTIONS_.GetEmailAddress input="John Doe" setContextVariable="EMAIL_ADDRESS"/>
-    <function._GLOBAL_FUNCTIONS_.SendEmail input="$TRANSLATED_SUMMARY" recipient="$EMAIL_ADDRESS"/>
-</plan><!-- END -->
-
-[AVAILABLE FUNCTIONS]
-
-  _GLOBAL_FUNCTIONS_.NovelOutline :
-    description: Outlines the input text as if it were a novel
-    inputs:
-    - input: the title of the novel to outline
-    - chapterCount: the number of chapters to outline
-
-  Emailer.EmailTo:
-    description: email the input text to a recipient
-    inputs:
-    - input: the text to email
-    - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
-
-  Everything.Summarize:
-    description: summarize input text
-    inputs:
-    - input: the text to summarize
-
-[END AVAILABLE FUNCTIONS]
-
-<goal>Create an outline for a children's book with 3 chapters about a group of kids in a club and then summarize it.</goal>
-<plan>
-  <function._GLOBAL_FUNCTIONS_.NovelOutline input="A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic." chapterCount="3" />
-  <function.Everything.Summarize/>
-</plan><!-- END -->
-
-[END EXAMPLES]
 
 [AVAILABLE FUNCTIONS]
 


### PR DESCRIPTION
This pull request adds an END comment to the sequential planner XML format, to mark the end of the plan after the closing </plan> tag. This makes the format more consistent and easier to parse. It also simplifies the instructions for creating a plan, by removing some redundant or outdated information and clarifying some points. The examples and available functions are removed accordingly.

### Description
Details:
- Add an END comment to the sequential planner XML format, to mark the end of the plan after the closing </plan> tag. This is done by changing the StopSequence constant in SequentialPlanner.cs and updating the skprompt.txt file.
- Simplify the instructions for creating a plan, by removing some redundant or outdated information and clarifying some points. Specifically, the following changes are made:
  - Remove the requirement to check that a function is present in the most recent available functions list, as this is implied by the fact that the list is updated for each goal.
  - Remove the statement that a function has a single input and output, as some functions may have additional parameters as defined in the available functions list.
  - Remove the statement that input does not need to be specified if it consumes the output of the previous function, as this is not always the case and may cause confusion.
  - Change the syntax for saving an output to a context variable or a result, by using "=" instead of ":" and removing the "/" at the end of the function tag.
  - Clarify that the END comment should be appended after the final closing </plan> tag, not inside it.
- Update the examples and available functions in skprompt.txt to reflect the changes in the format and the instructions.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
