### PR TITLE
Support of IEmbeddingGeneration<TValue, TEmbedding> interface by Kernel.GetService method

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/IEmbeddingGeneration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/Embeddings/IEmbeddingGeneration.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Services;
 
 namespace Microsoft.SemanticKernel.AI.Embeddings;
 
@@ -11,7 +12,7 @@ namespace Microsoft.SemanticKernel.AI.Embeddings;
 /// </summary>
 /// <typeparam name="TValue">The type from which embeddings will be generated.</typeparam>
 /// <typeparam name="TEmbedding">The numeric type of the embedding data.</typeparam>
-public interface IEmbeddingGeneration<TValue, TEmbedding>
+public interface IEmbeddingGeneration<TValue, TEmbedding> : IAIService
     where TEmbedding : unmanaged
 {
     /// <summary>


### PR DESCRIPTION
### Motivation and Context
This change is required for backward compatibility of the `Kernel.GetService` method, allowing it to return services registered as instances of classes that implement the `IEmbeddingGeneration<TValue, TEmbedding>` interface.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
