### PR TITLE
Avoid recursion in TextChunker.BuildParagraph

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Text/TextChunkerTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Microsoft.SemanticKernel.Text;
 using Xunit;
 
@@ -454,4 +455,27 @@ public sealed class TextChunkerTests
     }
 
     // a markdown example that does not have any of the above characters
+
+    [Fact]
+    public void CanSplitVeryLargeDocumentsWithoutStackOverflowing()
+    {
+#pragma warning disable CA5394 // this test relies on repeatable pseudo-random numbers
+        var rand = new Random(42);
+        var sb = new StringBuilder(100_000 * 11);
+        for (int wordNum = 0; wordNum < 100_000; wordNum++)
+        {
+            int wordLength = rand.Next(1, 10);
+            for (int charNum = 0; charNum < wordLength; charNum++)
+            {
+                sb.Append((char)('a' + rand.Next(0, 26)));
+            }
+            sb.Append(' ');
+        }
+
+        string text = sb.ToString();
+        List<string> lines = TextChunker.SplitPlainTextLines(text, 20);
+        List<string> paragraphs = TextChunker.SplitPlainTextParagraphs(lines, 200);
+        Assert.NotEmpty(paragraphs);
+#pragma warning restore CA5394
+    }
 }

--- a/dotnet/src/SemanticKernel/Text/TextChunker.cs
+++ b/dotnet/src/SemanticKernel/Text/TextChunker.cs
@@ -131,31 +131,34 @@ public static class TextChunker
 
     private static List<string> BuildParagraph(List<string> truncatedLines, StringBuilder paragraphBuilder, List<string> paragraphs, int maxTokensPerParagraph, Func<string, int, List<string>> longLinesSplitter)
     {
-        // Base case: no more elements in the list
-        if (truncatedLines.Count == 0)
+        while (true)
         {
-            // Adding any remaining paragraph
-            if (paragraphBuilder.Length > 0)
+            if (truncatedLines.Count == 0)
+            {
+                // Adding any remaining paragraph
+                if (paragraphBuilder.Length > 0)
+                {
+                    paragraphs.Add(paragraphBuilder.ToString().Trim());
+                }
+                return paragraphs;
+            }
+
+            string line = truncatedLines[0];
+
+            if (paragraphBuilder.Length > 0 && TokenCount(paragraphBuilder.Length) + TokenCount(line.Length) + 1 >= maxTokensPerParagraph)
             {
                 paragraphs.Add(paragraphBuilder.ToString().Trim());
+
+                // next paragraph
+                paragraphBuilder.Clear();
             }
-            return paragraphs;
+            else
+            {
+                paragraphBuilder.AppendLine(line);
+
+                truncatedLines.RemoveAt(0);
+            }
         }
-
-        // Recursive case
-        string line = truncatedLines.First();
-
-        if (paragraphBuilder.Length > 0 && TokenCount(paragraphBuilder.Length) + TokenCount(line.Length) + 1 >= maxTokensPerParagraph)
-        {
-            paragraphs.Add(paragraphBuilder.ToString().Trim());
-
-            // next paragraph
-            return BuildParagraph(truncatedLines, new StringBuilder(), paragraphs, maxTokensPerParagraph, longLinesSplitter);
-        }
-
-        paragraphBuilder.AppendLine(line);
-
-        return BuildParagraph(truncatedLines.Skip(1).ToList(), paragraphBuilder, paragraphs, maxTokensPerParagraph, longLinesSplitter);
     }
 
     private static List<string> InternalSplitLines(string text, int maxTokensPerLine, bool trim, string?[] splitOptions)


### PR DESCRIPTION
### Motivation and Context

TextChunker.BuildParagraph is unnecessarily recursive and can lead to stack overflows on large inputs.

### Description

Fixes https://github.com/microsoft/semantic-kernel/issues/1633

Also happens to make it more efficient with a few tweaks.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
