### PR TITLE
Java: Http skill Added

### DIFF
--- a/java/semantickernel-core-skills/pom.xml
+++ b/java/semantickernel-core-skills/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>semantickernel-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-netty</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -36,4 +40,15 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>1.2.13</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/java/semantickernel-core-skills/pom.xml
+++ b/java/semantickernel-core-skills/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>semantickernel-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-core-http-netty</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -39,16 +35,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.13</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/HttpSkill.java
+++ b/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/HttpSkill.java
@@ -46,7 +46,7 @@ public class HttpSkill {
      */
     public Mono<String> getAsync(String url) {
         if (url == null || url.isEmpty()) {
-            throw new IllegalArgumentException("url cannot be `null` or empty");
+            return Mono.error(new IllegalArgumentException("url cannot be `null` or empty"));
         }
         HttpRequest request = new HttpRequest(HttpMethod.GET, url);
         return httpClient.send(request).flatMap(response -> response.getBodyAsString());
@@ -61,7 +61,7 @@ public class HttpSkill {
      */
     public Mono<String> postAsync(String url, String body) {
         if (url == null || url.isEmpty()) {
-            throw new IllegalArgumentException("url cannot be `null` or empty");
+            return Mono.error(new IllegalArgumentException("url cannot be `null` or empty"));
         }
         HttpRequest request = new HttpRequest(HttpMethod.POST, url);
         request.setBody(body);
@@ -77,7 +77,7 @@ public class HttpSkill {
      */
     public Mono<String> putAsync(String url, String body) {
         if (url == null || url.isEmpty()) {
-            throw new IllegalArgumentException("url cannot be `null` or empty");
+            return Mono.error(new IllegalArgumentException("url cannot be `null` or empty"));
         }
         HttpRequest request = new HttpRequest(HttpMethod.PUT, url);
         request.setBody(body);
@@ -92,7 +92,7 @@ public class HttpSkill {
      */
     public Mono<HttpResponse> deleteAsync(String url) {
         if (url == null || url.isEmpty()) {
-            throw new IllegalArgumentException("url cannot be `null` or empty");
+            return Mono.error(new IllegalArgumentException("url cannot be `null` or empty"));
         }
         HttpRequest request = new HttpRequest(HttpMethod.DELETE, url);
         return httpClient.send(request).flatMap(response -> Mono.just(response));

--- a/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/HttpSkill.java
+++ b/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/HttpSkill.java
@@ -5,7 +5,6 @@ import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
-import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
 
 import reactor.core.publisher.Mono;
 
@@ -31,7 +30,7 @@ public class HttpSkill {
     private final HttpClient httpClient;
 
     public HttpSkill() {
-        this.httpClient = new NettyAsyncHttpClientBuilder().build();
+        this.httpClient = HttpClient.createDefault();
     }
 
     public HttpSkill(HttpClient httpClient) {

--- a/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/HttpSkill.java
+++ b/java/semantickernel-core-skills/src/main/java/com/microsoft/semantickernel/coreskills/HttpSkill.java
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.coreskills;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * A skill that provides HTTP functionality.
+ *
+ * <p>Usage:
+ *
+ * <p>Usage: kernel.importSkill(new HttpSkill(), "http");
+ *
+ * <p>Examples:
+ *
+ * <p>{{http.getAsync $url}}
+ *
+ * <p>{{http.postAsync $url}}
+ *
+ * <p>{{http.putAsync $url}}
+ *
+ * <p>{{http.deleteAsync $url}}
+ */
+public class HttpSkill {
+
+    private final HttpClient httpClient;
+
+    public HttpSkill() {
+        this.httpClient = new NettyAsyncHttpClientBuilder().build();
+    }
+
+    public HttpSkill(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Sends an HTTP GET request to the specified URI and returns body as a string.
+     *
+     * @param url The URI to send the request to.
+     * @return The response body as a string.
+     */
+    public Mono<String> getAsync(String url) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("url cannot be `null` or empty");
+        }
+        HttpRequest request = new HttpRequest(HttpMethod.GET, url);
+        return httpClient.send(request).flatMap(response -> response.getBodyAsString());
+    }
+
+    /**
+     * Sends an HTTP POST request to the specified URI and returns body as a string.
+     *
+     * @param url The URI to send the request to.
+     * @param body The response body as a string.
+     * @return
+     */
+    public Mono<String> postAsync(String url, String body) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("url cannot be `null` or empty");
+        }
+        HttpRequest request = new HttpRequest(HttpMethod.POST, url);
+        request.setBody(body);
+        return httpClient.send(request).flatMap(response -> response.getBodyAsString());
+    }
+
+    /**
+     * Sends an HTTP PUT request to the specified URI and returns body as a string.
+     *
+     * @param url The URI to send the request to.
+     * @param body The response body as a string.
+     * @return
+     */
+    public Mono<String> putAsync(String url, String body) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("url cannot be `null` or empty");
+        }
+        HttpRequest request = new HttpRequest(HttpMethod.PUT, url);
+        request.setBody(body);
+        return httpClient.send(request).flatMap(response -> response.getBodyAsString());
+    }
+
+    /**
+     * Sends an HTTP DELETE request to the specified URI and returns body as a string.
+     *
+     * @param url The URI to send the request to.
+     * @return The response body as a string.
+     */
+    public Mono<HttpResponse> deleteAsync(String url) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("url cannot be `null` or empty");
+        }
+        HttpRequest request = new HttpRequest(HttpMethod.DELETE, url);
+        return httpClient.send(request).flatMap(response -> Mono.just(response));
+    }
+}

--- a/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/HttpSkillTest.java
+++ b/java/semantickernel-core-skills/src/test/java/com/microsoft/semantickernel/coreskills/HttpSkillTest.java
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.coreskills;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class HttpSkillTest {
+
+    private HttpSkill httpSkill;
+
+    @Mock private HttpClient httpClient;
+
+    @Mock private HttpResponse httpResponse;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        httpSkill = new HttpSkill(httpClient);
+    }
+
+    @Test
+    public void testGetAsync() {
+        String url = "https://example.com";
+        String responseBody = "Response body";
+        when(httpResponse.getBodyAsString()).thenReturn(Mono.just(responseBody));
+        when(httpClient.send(any(HttpRequest.class))).thenReturn(Mono.just(httpResponse));
+        Mono<String> responseMono = httpSkill.getAsync(url);
+        StepVerifier.create(responseMono).expectNext(responseBody).verifyComplete();
+    }
+
+    @Test
+    public void testPostAsync() {
+        String url = "https://example.com";
+        String body = "{\"key\": \"value\"}";
+        String responseBody = "Response body";
+        when(httpResponse.getBodyAsString()).thenReturn(Mono.just(responseBody));
+        when(httpClient.send(any(HttpRequest.class))).thenReturn(Mono.just(httpResponse));
+        Mono<String> responseMono = httpSkill.postAsync(url, body);
+        StepVerifier.create(responseMono).expectNext(responseBody).verifyComplete();
+    }
+
+    @Test
+    public void testPutAsync() {
+        String url = "https://example.com";
+        String body = "{\"key\": \"value\"}";
+        String responseBody = "Response body";
+        when(httpResponse.getBodyAsString()).thenReturn(Mono.just(responseBody));
+        when(httpClient.send(any(HttpRequest.class))).thenReturn(Mono.just(httpResponse));
+        Mono<String> responseMono = httpSkill.putAsync(url, body);
+        StepVerifier.create(responseMono).expectNext(responseBody).verifyComplete();
+    }
+
+    @Test
+    public void testDeleteAsync() {
+        String url = "https://example.com";
+        when(httpClient.send(any(HttpRequest.class))).thenReturn(Mono.just(httpResponse));
+        Mono<HttpResponse> responseMono = httpSkill.deleteAsync(url);
+        StepVerifier.create(responseMono).expectNext(httpResponse).verifyComplete();
+    }
+}


### PR DESCRIPTION
Added HttpSkill for Java

### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Based on the [http_skill.py](https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/core_skills/http_skill.py)

I implemented the Http Skill by using Mono of Project Reactor.
And I implemented the Test code with Mock.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
