### PR TITLE
SequentialPlanner - Allow custom manual discovery and loading.

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
@@ -179,10 +179,10 @@ internal static class Example12_SequentialPlanner
 
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .WithAzureTextCompletionService(
-                Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
-                Env.Var("AZURE_OPENAI_ENDPOINT"),
-                Env.Var("AZURE_OPENAI_KEY"))
+            .WithAzureChatCompletionService(
+                Env.Var("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"),
+                Env.Var("AZURE_OPENAI_CHAT_ENDPOINT"),
+                Env.Var("AZURE_OPENAI_CHAT_KEY"))
             .WithAzureTextEmbeddingGenerationService(
                 Env.Var("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME"),
                 Env.Var("AZURE_OPENAI_EMBEDDINGS_ENDPOINT"),
@@ -210,7 +210,7 @@ internal static class Example12_SequentialPlanner
 
         var goal = "Create a book with 3 chapters about a group of kids in a club called 'The Thinking Caps.'";
 
-        var planner = new SequentialPlanner(kernel, new SequentialPlannerConfig { RelevancyThreshold = 0.78 });
+        var planner = new SequentialPlanner(kernel, new SequentialPlannerConfig { RelevancyThreshold = 0.5 });
 
         var plan = await planner.CreatePlanAsync(goal);
 
@@ -222,10 +222,10 @@ internal static class Example12_SequentialPlanner
     {
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Log)
-            .WithAzureTextCompletionService(
-                Env.Var("AZURE_OPENAI_DEPLOYMENT_NAME"),
-                Env.Var("AZURE_OPENAI_ENDPOINT"),
-                Env.Var("AZURE_OPENAI_KEY"))
+            .WithAzureChatCompletionService(
+                Env.Var("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"),
+                Env.Var("AZURE_OPENAI_CHAT_ENDPOINT"),
+                Env.Var("AZURE_OPENAI_CHAT_KEY"))
             .Build();
 
         planner = new SequentialPlanner(kernel, new SequentialPlannerConfig { MaxTokens = maxTokens });

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -126,7 +126,7 @@ public class SequentialPlanParserTests
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";
 
         // Act
-        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
+        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -173,7 +173,7 @@ public class SequentialPlanParserTests
         var planString = "<someTag>";
 
         // Act
-        Assert.Throws<PlanningException>(() => planString.ToPlanFromXml(GoalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext())));
+        Assert.Throws<PlanningException>(() => planString.ToPlanFromXml(GoalText, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext())));
     }
 
     // Test that contains a #text node in the plan
@@ -193,7 +193,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -228,7 +228,7 @@ public class SequentialPlanParserTests
         if (allowMissingFunctions)
         {
             // it should not throw
-            var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunction(kernel.CreateNewContext()), allowMissingFunctions);
+            var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()), allowMissingFunctions);
 
             // Assert
             Assert.NotNull(plan);
@@ -244,7 +244,7 @@ public class SequentialPlanParserTests
         }
         else
         {
-            Assert.Throws<PlanningException>(() => planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunction(kernel.CreateNewContext()), allowMissingFunctions));
+            Assert.Throws<PlanningException>(() => planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()), allowMissingFunctions));
         }
     }
 
@@ -278,7 +278,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -302,7 +302,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
+        var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -328,7 +328,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -126,7 +126,7 @@ public class SequentialPlanParserTests
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";
 
         // Act
-        var plan = planString.ToPlanFromXml(goal, kernel.CreateNewContext());
+        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -173,7 +173,7 @@ public class SequentialPlanParserTests
         var planString = "<someTag>";
 
         // Act
-        Assert.Throws<PlanningException>(() => planString.ToPlanFromXml(GoalText, kernel.CreateNewContext()));
+        Assert.Throws<PlanningException>(() => planString.ToPlanFromXml(GoalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext())));
     }
 
     // Test that contains a #text node in the plan
@@ -193,7 +193,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, kernel.CreateNewContext());
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -230,7 +230,7 @@ public class SequentialPlanParserTests
         if (allowMissingFunctions)
         {
             // it should not throw
-            var plan = planText.ToPlanFromXml(string.Empty, kernel.CreateNewContext(), allowMissingFunctions);
+            var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunction(kernel.CreateNewContext()), allowMissingFunctions);
 
             // Assert
             Assert.NotNull(plan);
@@ -246,7 +246,7 @@ public class SequentialPlanParserTests
         }
         else
         {
-            Assert.Throws<PlanningException>(() => planText.ToPlanFromXml(string.Empty, kernel.CreateNewContext(), allowMissingFunctions));
+            Assert.Throws<PlanningException>(() => planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunction(kernel.CreateNewContext()), allowMissingFunctions));
         }
     }
 
@@ -280,7 +280,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, kernel.CreateNewContext());
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -306,7 +306,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(string.Empty, kernel.CreateNewContext());
+        var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);
@@ -332,7 +332,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, kernel.CreateNewContext());
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -198,11 +198,9 @@ public class SequentialPlanParserTests
         // Assert
         Assert.NotNull(plan);
         Assert.Equal(goalText, plan.Description);
-        Assert.Equal(2, plan.Steps.Count);
+        Assert.Equal(1, plan.Steps.Count);
         Assert.Equal("MockSkill", plan.Steps[0].SkillName);
         Assert.Equal("Echo", plan.Steps[0].Name);
-        Assert.Equal("This is some text", plan.Steps[1].Description);
-        Assert.Equal(0, plan.Steps[1].Steps.Count);
     }
 
     // Test that contains a #text node in the plan
@@ -285,11 +283,9 @@ public class SequentialPlanParserTests
         // Assert
         Assert.NotNull(plan);
         Assert.Equal(goalText, plan.Description);
-        Assert.Equal(2, plan.Steps.Count);
+        Assert.Equal(1, plan.Steps.Count);
         Assert.Equal("MockSkill", plan.Steps[0].SkillName);
         Assert.Equal("Echo", plan.Steps[0].Name);
-        Assert.Equal("This is some text", plan.Steps[1].Description);
-        Assert.Equal(0, plan.Steps[1].Steps.Count);
     }
 
     [Theory]
@@ -337,12 +333,11 @@ public class SequentialPlanParserTests
         // Assert
         Assert.NotNull(plan);
         Assert.Equal(goalText, plan.Description);
-        Assert.Equal(3, plan.Steps.Count);
+        Assert.Equal(2, plan.Steps.Count);
         Assert.Equal("MockSkill", plan.Steps[0].SkillName);
         Assert.Equal("Echo", plan.Steps[0].Name);
-        Assert.Equal("Some other tag", plan.Steps[1].Description);
         Assert.Equal(0, plan.Steps[1].Steps.Count);
-        Assert.Equal("MockSkill", plan.Steps[2].SkillName);
-        Assert.Equal("Echo", plan.Steps[2].Name);
+        Assert.Equal("MockSkill", plan.Steps[1].SkillName);
+        Assert.Equal("Echo", plan.Steps[1].Name);
     }
 }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
@@ -33,7 +33,16 @@ public static class SKContextSequentialPlannerExtensions
         SequentialPlannerConfig? config = null)
     {
         config ??= new SequentialPlannerConfig();
-        var functions = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);
+
+        IOrderedEnumerable<FunctionView> functions;
+        if (config.GetAvailableFunctionsAsync is null)
+        {
+            functions = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);
+        }
+        else
+        {
+            functions = await config.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);
+        }
 
         return string.Join("\n\n", functions.Select(x => x.ToManualString()));
     }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
@@ -34,15 +34,9 @@ public static class SKContextSequentialPlannerExtensions
     {
         config ??= new SequentialPlannerConfig();
 
-        IOrderedEnumerable<FunctionView> functions;
-        if (config.GetAvailableFunctionsAsync is null)
-        {
-            functions = await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);
-        }
-        else
-        {
-            functions = await config.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);
-        }
+        IOrderedEnumerable<FunctionView> functions = config.GetAvailableFunctionsAsync is null ?
+            await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false) :
+            await config.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);
 
         return string.Join("\n\n", functions.Select(x => x.ToManualString()));
     }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
@@ -34,6 +34,7 @@ public static class SKContextSequentialPlannerExtensions
     {
         config ??= new SequentialPlannerConfig();
 
+        // Use configured function provider if available, otherwise use the default SKContext function provider.
         IOrderedEnumerable<FunctionView> functions = config.GetAvailableFunctionsAsync is null ?
             await context.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false) :
             await config.GetAvailableFunctionsAsync(config, semanticQuery).ConfigureAwait(false);

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -112,13 +112,10 @@ internal static class SequentialPlanParser
 
             foreach (XmlNode childNode in solutionNode.ChildNodes)
             {
-                if (childNode.Name == "#text")
+                if (childNode.Name == "#text" || childNode.Name == "#comment")
                 {
-                    if (childNode.Value != null)
-                    {
-                        plan.AddSteps(new Plan(childNode.Value.Trim()));
-                    }
-
+                    // Do not add text or comments as steps.
+                    // TODO - this could be a way to get Reasoning for a plan step.
                     continue;
                 }
 
@@ -186,15 +183,11 @@ internal static class SequentialPlanParser
                                 throw new PlanningException(PlanningException.ErrorCodes.InvalidPlan, $"Failed to find function '{skillFunctionName}' in skill '{skillName}'.");
                             }
                         }
-
-                        continue;
                     }
-
-                    // This step is a step in name only. It is not a function call.
-                    plan.AddSteps(new Plan(childNode.InnerText));
                 }
 
-                plan.AddSteps(new Plan(childNode.InnerText));
+                // Similar to comments or text, do not add empty nodes as steps.
+                // TODO - This could be a way to advertise desired functions for a plan.
             }
         }
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -44,7 +44,14 @@ internal static class SequentialPlanParser
     {
         return (skillName, functionName) =>
         {
-            if (context.Skills!.TryGetFunction(skillName, functionName, out var skillFunction))
+            if (string.IsNullOrEmpty(skillName))
+            {
+                if (context.Skills!.TryGetFunction(functionName, out var skillFunction))
+                {
+                    return skillFunction;
+                }
+            }
+            else if (context.Skills!.TryGetFunction(skillName, functionName, out var skillFunction))
             {
                 return skillFunction;
             }
@@ -58,7 +65,7 @@ internal static class SequentialPlanParser
     /// </summary>
     /// <param name="xmlString">The plan xml string.</param>
     /// <param name="goal">The goal for the plan.</param>
-    /// <param name="getSkillFunction">The function to get a skill function.</param>
+    /// <param name="getSkillFunction">The callback to get a skill function.</param>
     /// <param name="allowMissingFunctions">Whether to allow missing functions in the plan on creation.</param>
     /// <returns>The plan.</returns>
     /// <exception cref="PlanningException">Thrown when the plan xml is invalid.</exception>

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -58,8 +58,8 @@ internal static class SequentialPlanParser
     /// </summary>
     /// <param name="xmlString">The plan xml string.</param>
     /// <param name="goal">The goal for the plan.</param>
-    /// <param name="allowMissingFunctions">Whether to allow missing functions in the plan on creation.</param>
     /// <param name="GetFunction">The function to get a skill function.</param>
+    /// <param name="allowMissingFunctions">Whether to allow missing functions in the plan on creation.</param>
     /// <returns>The plan.</returns>
     /// <exception cref="PlanningException">Thrown when the plan xml is invalid.</exception>
     internal static Plan ToPlanFromXml(this string xmlString, string goal, Func<string, string, ISKFunction?> GetFunction, bool allowMissingFunctions = false)

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -40,7 +40,7 @@ internal static class SequentialPlanParser
     /// </summary>
     internal const string AppendToResultTag = "appendToResult";
 
-    internal static Func<string, string, ISKFunction?> GetFunction(SKContext context)
+    internal static Func<string, string, ISKFunction?> GetSkillFunction(SKContext context)
     {
         return (skillName, functionName) =>
         {
@@ -58,11 +58,11 @@ internal static class SequentialPlanParser
     /// </summary>
     /// <param name="xmlString">The plan xml string.</param>
     /// <param name="goal">The goal for the plan.</param>
-    /// <param name="GetFunction">The function to get a skill function.</param>
+    /// <param name="getSkillFunction">The function to get a skill function.</param>
     /// <param name="allowMissingFunctions">Whether to allow missing functions in the plan on creation.</param>
     /// <returns>The plan.</returns>
     /// <exception cref="PlanningException">Thrown when the plan xml is invalid.</exception>
-    internal static Plan ToPlanFromXml(this string xmlString, string goal, Func<string, string, ISKFunction?> GetFunction, bool allowMissingFunctions = false)
+    internal static Plan ToPlanFromXml(this string xmlString, string goal, Func<string, string, ISKFunction?> getSkillFunction, bool allowMissingFunctions = false)
     {
         XmlDocument xmlDoc = new();
         try
@@ -126,7 +126,7 @@ internal static class SequentialPlanParser
 
                     if (!string.IsNullOrEmpty(functionName))
                     {
-                        var skillFunction = GetFunction(skillName, functionName);
+                        var skillFunction = getSkillFunction(skillName, functionName);
 
                         if (skillFunction is not null)
                         {

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -78,8 +78,8 @@ public sealed class SequentialPlanner
 
         try
         {
-            var GetFunction = this.Config.GetFunction ?? SequentialPlanParser.GetFunction(this._context);
-            var plan = planResultString.ToPlanFromXml(goal, GetFunction, this.Config.AllowMissingFunctions);
+            var getSkillFunction = this.Config.GetSkillFunction ?? SequentialPlanParser.GetSkillFunction(this._context);
+            var plan = planResultString.ToPlanFromXml(goal, getSkillFunction, this.Config.AllowMissingFunctions);
 
             if (plan.Steps.Count == 0)
             {

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SemanticKernel.Planning;
 /// </summary>
 public sealed class SequentialPlanner
 {
-    private const string StopSequence = "<!--";
+    private const string StopSequence = "<!-- END -->";
 
     /// <summary>
     /// Initialize a new instance of the <see cref="SequentialPlanner"/> class.
@@ -78,7 +78,8 @@ public sealed class SequentialPlanner
 
         try
         {
-            var plan = planResultString.ToPlanFromXml(goal, this._context, this.Config.AllowMissingFunctions);
+            var GetFunction = this.Config.GetFunction ?? SequentialPlanParser.GetFunction(this._context);
+            var plan = planResultString.ToPlanFromXml(goal, GetFunction, this.Config.AllowMissingFunctions);
 
             if (plan.Steps.Count == 0)
             {

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace Microsoft.SemanticKernel.Planning.Sequential;
 
@@ -56,4 +60,14 @@ public sealed class SequentialPlannerConfig
     /// If set to false (default), the plan creation will fail if any functions are missing.
     /// </summary>
     public bool AllowMissingFunctions { get; set; } = false;
+
+    /// <summary>
+    /// Optional function to get the available functions for planning.
+    /// </summary>
+    public Func<SequentialPlannerConfig, string?, Task<IOrderedEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
+
+    /// <summary>
+    /// Optional function to get a function by name.
+    /// </summary>
+    public Func<string, string, ISKFunction?>? GetFunction { get; set; }
 }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
@@ -62,12 +62,12 @@ public sealed class SequentialPlannerConfig
     public bool AllowMissingFunctions { get; set; } = false;
 
     /// <summary>
-    /// Optional function to get the available functions for planning.
+    /// Optional callback to get the available functions for planning.
     /// </summary>
     public Func<SequentialPlannerConfig, string?, Task<IOrderedEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
 
     /// <summary>
-    /// Optional function to get a function by name.
+    /// Optional callback to get a function by name.
     /// </summary>
     public Func<string, string, ISKFunction?>? GetSkillFunction { get; set; }
 }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
@@ -69,5 +69,5 @@ public sealed class SequentialPlannerConfig
     /// <summary>
     /// Optional function to get a function by name.
     /// </summary>
-    public Func<string, string, ISKFunction?>? GetFunction { get; set; }
+    public Func<string, string, ISKFunction?>? GetSkillFunction { get; set; }
 }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
@@ -2,113 +2,23 @@ Create an XML plan step by step, to satisfy the goal given.
 To create a plan, follow these steps:
 0. The plan should be as short as possible.
 1. From a <goal> create a <plan> as a series of <functions>.
-2. Before using any function in a plan, check that it is present in the most recent [AVAILABLE FUNCTIONS] list. If it is not, do not use it. Do not assume that any function that was previously defined or used in another plan or in [EXAMPLES] is automatically available or compatible with the current plan.
+2. Before using any function in a plan, check that it is present in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
 3. Only use functions that are required for the given goal.
-4. A function has a single 'input' and a single 'output' which are both strings and not objects.
-5. The 'output' from each function is automatically passed as 'input' to the subsequent <function>.
-6. 'input' does not need to be specified if it consumes the 'output' of the previous function.
-7. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FunctionName} ... setContextVariable: "<UNIQUE_VARIABLE_KEY>"/>
-8. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FunctionName} ... appendToResult: "RESULT__<UNIQUE_RESULT_KEY>"/>
-9. Append an "END" XML comment at the end of the plan.
-10. If a plan cannot be created with the [AVAILABLE FUNCTIONS], return <noplan />.
+4. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list.
+5. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
+6. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
+7. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
+8. If a plan cannot be created with the [AVAILABLE FUNCTIONS], return <noplan />.
 
-[EXAMPLES]
-[AVAILABLE FUNCTIONS]
+Here is an example of how to call a function "_Function_.Name" with a single input and save its output:
+<function._Function_.Name input="this is my input" setContextVariable="SOME_KEY"/>
 
-  EmailConnector.LookupContactEmail:
-    description: looks up the a contact and retrieves their email address
-    inputs:
-    - input: the name to look up
+Here is an example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
+<function.FunctionName2 input="$SOME_KEY" appendToResult="RESULT__FINAL_ANSWER"/>
 
-  EmailConnector.EmailTo:
-    description: email the input text to a recipient
-    inputs:
-    - input: the text to email
-    - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
+Here is an example of how to call a function "Name3" with multiple inputs:
+<function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a &lt;!-- comment in it--&gt;"/>
 
-  LanguageHelpers.TranslateTo:
-    description: translate the input to another language
-    inputs:
-    - input: the text to translate
-    - translate_to_language: the language to translate to
-
-  WriterSkill.Summarize:
-    description: summarize input text
-    inputs:
-    - input: the text to summarize
-
-[END AVAILABLE FUNCTIONS]
-
-<goal>Summarize the input, then translate to japanese and email it to Martin</goal>
-<plan>
-  <function.WriterSkill.Summarize/>
-  <function.LanguageHelpers.TranslateTo translate_to_language="Japanese" setContextVariable="TRANSLATED_TEXT" />
-  <function.EmailConnector.LookupContactEmail input="Martin" setContextVariable="CONTACT_RESULT" />
-  <function.EmailConnector.EmailTo input="$TRANSLATED_TEXT" recipient="$CONTACT_RESULT"/>
-</plan><!-- END -->
-
-[AVAILABLE FUNCTIONS]
-
-  _GLOBAL_FUNCTIONS_.GetEmailAddress:
-    description: Gets email address for given contact
-    inputs:
-    - input: the name to look up
-
-  _GLOBAL_FUNCTIONS_.SendEmail:
-    description: email the input text to a recipient
-    inputs:
-    - input: the text to email
-    - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
-
-  AuthorAbility.Summarize:
-    description: summarizes the input text
-    inputs:
-    - input: the text to summarize
-
-  Magician.TranslateTo:
-    description: translate the input to another language
-    inputs:
-    - input: the text to translate
-    - translate_to_language: the language to translate to
-
-[END AVAILABLE FUNCTIONS]
-
-<goal>Summarize an input, translate to french, and e-mail to John Doe</goal>
-<plan>
-    <function.AuthorAbility.Summarize/>
-    <function.Magician.TranslateTo translate_to_language="French" setContextVariable="TRANSLATED_SUMMARY"/>
-    <function._GLOBAL_FUNCTIONS_.GetEmailAddress input="John Doe" setContextVariable="EMAIL_ADDRESS"/>
-    <function._GLOBAL_FUNCTIONS_.SendEmail input="$TRANSLATED_SUMMARY" recipient="$EMAIL_ADDRESS"/>
-</plan><!-- END -->
-
-[AVAILABLE FUNCTIONS]
-
-  _GLOBAL_FUNCTIONS_.NovelOutline :
-    description: Outlines the input text as if it were a novel
-    inputs:
-    - input: the title of the novel to outline
-    - chapterCount: the number of chapters to outline
-
-  Emailer.EmailTo:
-    description: email the input text to a recipient
-    inputs:
-    - input: the text to email
-    - recipient: the recipient's email address. Multiple addresses may be included if separated by ';'.
-
-  Everything.Summarize:
-    description: summarize input text
-    inputs:
-    - input: the text to summarize
-
-[END AVAILABLE FUNCTIONS]
-
-<goal>Create an outline for a children's book with 3 chapters about a group of kids in a club and then summarize it.</goal>
-<plan>
-  <function._GLOBAL_FUNCTIONS_.NovelOutline input="A group of kids in a club called 'The Thinking Caps' that solve mysteries and puzzles using their creativity and logic." chapterCount="3" />
-  <function.Everything.Summarize/>
-</plan><!-- END -->
-
-[END EXAMPLES]
 
 [AVAILABLE FUNCTIONS]
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
@@ -1,15 +1,20 @@
-Create an XML plan step by step, to satisfy the goal given.
+Create an XML plan step by step, to satisfy the goal given, with the available functions.
+
+[AVAILABLE FUNCTIONS]
+
+{{$available_functions}}
+
+[END AVAILABLE FUNCTIONS]
+
 To create a plan, follow these steps:
 0. The plan should be as short as possible.
 1. From a <goal> create a <plan> as a series of <functions>.
-2. Before using any function in a plan, check that it is present in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
-3. Only use functions that are required for the given goal.
-4. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list. Strings should be xml escaped.
-5. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
-6. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
-7. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
-8. Always output valid XML that can be parsed by an XML parser.
-9. If a plan cannot be created with the [AVAILABLE FUNCTIONS], return <plan />.
+2. A plan has 'INPUT' available in context variables by default.
+3. Before using any function in a plan, check that it is present in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
+4. Only use functions that are required for the given goal.
+5. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
+6. Always output valid XML that can be parsed by an XML parser.
+7. If a plan cannot be created with the [AVAILABLE FUNCTIONS], return <plan />.
 
 All plans take the form of:
 <plan>
@@ -19,25 +24,32 @@ All plans take the form of:
     <function.{FullyQualifiedFunctionName} ... />
     <!-- ... reason for taking step ... -->
     <function.{FullyQualifiedFunctionName} ... />
+    (... etc ...)
 </plan>
 <!-- END -->
+
+To call a function, follow these steps:
+1. A function has one or more named parameters and a single 'output' which are all strings. Parameter values should be xml escaped.
+2. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
+3. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
+4. Use a '$' to reference a context variable in a parameter, e.g. when `INPUT='world'` the parameter 'Hello $INPUT' will evaluate to `Hello world`.
+5. Functions do not have access to the context variables of other functions. Do not attempt to use context variables as arrays or objects. Instead, use available functions to extract specific elements or properties from context variables.
+
+DO NOT DO THIS, THE PARAMETER VALUE IS NOT XML ESCAPED:
+<function.Name4 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a <!-- comment in it-->"/>
+
+DO NOT DO THIS, THE PARAMETER VALUE IS ATTEMPTING TO USE A CONTEXT VARIABLE AS AN ARRAY/OBJECT:
+<function.CallFunction input="$OTHER_OUTPUT[1]"/>
 
 Here is a valid example of how to call a function "_Function_.Name" with a single input and save its output:
 <function._Function_.Name input="this is my input" setContextVariable="SOME_KEY"/>
 
 Here is a valid example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
-<function.FunctionName2 input="$SOME_KEY" appendToResult="RESULT__FINAL_ANSWER"/>
+<function.FunctionName2 input="Hello $INPUT" appendToResult="RESULT__FINAL_ANSWER"/>
 
 Here is a valid example of how to call a function "Name3" with multiple inputs:
 <function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a &lt;!-- comment in it--&gt;"/>
 
-Here is an INVALID example of how to call a function "Name4" as the parameter is not xml escaped:
-<function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a <!-- comment in it-->"/>
-
-[AVAILABLE FUNCTIONS]
-
-{{$available_functions}}
-
-[END AVAILABLE FUNCTIONS]
+Begin!
 
 <goal>{{$input}}</goal>

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
@@ -4,21 +4,35 @@ To create a plan, follow these steps:
 1. From a <goal> create a <plan> as a series of <functions>.
 2. Before using any function in a plan, check that it is present in the [AVAILABLE FUNCTIONS] list. If it is not, do not use it.
 3. Only use functions that are required for the given goal.
-4. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list.
+4. A function has at least a single 'input' and a single 'output' which are both strings and not objects. Additional parameters may be required for some functions as defined in the [AVAILABLE FUNCTIONS] list. Strings should be xml escaped.
 5. To save an 'output' from a <function>, to pass into a future <function>, use <function.{FullyQualifiedFunctionName} ... setContextVariable="<UNIQUE_VARIABLE_KEY>"/>
 6. To save an 'output' from a <function>, to return as part of a plan result, use <function.{FullyQualifiedFunctionName} ... appendToResult="RESULT__<UNIQUE_RESULT_KEY>"/>
 7. Append an "END" XML comment at the end of the plan after the final closing </plan> tag.
-8. If a plan cannot be created with the [AVAILABLE FUNCTIONS], return <noplan />.
+8. Always output valid XML that can be parsed by an XML parser.
+9. If a plan cannot be created with the [AVAILABLE FUNCTIONS], return <plan />.
 
-Here is an example of how to call a function "_Function_.Name" with a single input and save its output:
+All plans take the form of:
+<plan>
+    <!-- ... reason for taking step ... -->
+    <function.{FullyQualifiedFunctionName} ... />
+    <!-- ... reason for taking step ... -->
+    <function.{FullyQualifiedFunctionName} ... />
+    <!-- ... reason for taking step ... -->
+    <function.{FullyQualifiedFunctionName} ... />
+</plan>
+<!-- END -->
+
+Here is a valid example of how to call a function "_Function_.Name" with a single input and save its output:
 <function._Function_.Name input="this is my input" setContextVariable="SOME_KEY"/>
 
-Here is an example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
+Here is a valid example of how to call a function "FunctionName2" with a single input and return its output as part of the plan result:
 <function.FunctionName2 input="$SOME_KEY" appendToResult="RESULT__FINAL_ANSWER"/>
 
-Here is an example of how to call a function "Name3" with multiple inputs:
+Here is a valid example of how to call a function "Name3" with multiple inputs:
 <function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a &lt;!-- comment in it--&gt;"/>
 
+Here is an INVALID example of how to call a function "Name4" as the parameter is not xml escaped:
+<function.Name3 input="$SOME_PREVIOUS_OUTPUT" parameter_name="some value with a <!-- comment in it-->"/>
 
 [AVAILABLE FUNCTIONS]
 

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -52,7 +52,7 @@ public class SequentialPlanParserTests
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";
 
         // Act
-        var plan = planString.ToPlanFromXml(goal, kernel.CreateNewContext());
+        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -52,7 +52,7 @@ public class SequentialPlanParserTests
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";
 
         // Act
-        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetFunction(kernel.CreateNewContext()));
+        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetSkillFunction(kernel.CreateNewContext()));
 
         // Assert
         Assert.NotNull(plan);

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -39,6 +39,7 @@ public sealed class SequentialPlannerTests : IDisposable
         // Arrange
         bool useEmbeddings = false;
         IKernel kernel = this.InitializeKernel(useEmbeddings, useChatModel);
+        _ = kernel.ImportSkill(new EmailSkillFake());
         TestHelpers.GetSkills(kernel, "FunSkill");
 
         var planner = new Microsoft.SemanticKernel.Planning.SequentialPlanner(kernel);
@@ -83,6 +84,7 @@ public sealed class SequentialPlannerTests : IDisposable
         // Arrange
         bool useEmbeddings = true;
         IKernel kernel = this.InitializeKernel(useEmbeddings);
+        _ = kernel.ImportSkill(new EmailSkillFake());
 
         // Import all sample skills available for demonstration purposes.
         TestHelpers.ImportSampleSkills(kernel);
@@ -137,7 +139,6 @@ public sealed class SequentialPlannerTests : IDisposable
 
         var kernel = builder.Build();
 
-        _ = kernel.ImportSkill(new EmailSkillFake());
         return kernel;
     }
 


### PR DESCRIPTION
### Motivation and Context
This change is part of a need to enable planners that can reference a large list of potential plugins that aren't loaded in a kernel instance. Additionally, consumers of planners need to be able to load plugins on demand when needed by a plan. The change includes some additional improvements to the sequential plan parser and prompt.

Part of #1728 

### Description
This pull request refactors and improves the sequential plan parser and config, simplifying the code, adding new features, and fixing some issues. The main changes are:

- Use the Azure Chat Completion Service instead of the Azure Text Completion Service for the sequential planner, and lower the relevancy threshold for creating a plan. This allows for more flexibility and creativity in generating plans, and improves the performance and accuracy of the planner.        
- Refactor the plan parsing logic to simplify the code and improve readability. Remove unnecessary try-catch blocks, logging statements, and string splitting logic. Reorder the parameters of the ToPlanFromXml method to match the order of the XML attributes. Ignore text and comment nodes in the plan XML, as they are not valid steps and could cause confusion or errors. Remove the logic that adds empty nodes as steps, as they are not valid functions and could cause errors or confusion.
- Add two optional functions to the SequentialPlannerConfig class that allow the planner to use custom logic for getting available functions and finding functions by name. These functions can be useful for scenarios where the planner needs to access functions from different sources or with different criteria, such as filtering by skill category or function type. The default behavior of the planner remains unchanged if these functions are not specified.
- Simplify and standardize the syntax for calling functions in the plan XML, using fully qualified function names and consistent attribute names for inputs, outputs, and parameters. Update the skprompt.txt file to reflect the new syntax and add more instructions and examples for creating a plan. Update the sequential plan parser tests to use the new syntax and function names, and add a helper method to get the function from the kernel context.      
- Fix some minor typos and errors in the code and the skprompt.txt file.

Details:

- dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
  - Changed the KernelSyntaxExamples and SequentialPlannerTests to use the Azure Chat Completion Service instead of the Azure Text Completion Service, by replacing the deployment name, endpoint, and key environment variables.
  - Removed the EmailSkillFake import from the InitializeKernel method, as it is not used in any test case and is already imported in the TestHelpers class.
  - Updated the tests to reflect the changes in the plan parser and remove the redundant or invalid steps. For example, remove the text and empty nodes from the plan XML, and update the expected number and description of the steps.
- dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
  - Simplified the ToPlanFromXml method by removing unnecessary try-catch blocks, logging statements, and string splitting logic.
  - Reordered the parameters of the ToPlanFromXml method to match the order of the XML attributes, as this makes the code more consistent and easier to read.
  - Ignored text and comment nodes in the plan XML, as they are not valid steps and could cause confusion or errors. Added TODO comments for possible future enhancements using text or comments as reasoning or desired functions.
  - Removed the logic that adds empty nodes as steps, as they are not valid functions and could cause errors or confusion. Added TODO comments for possible future enhancements using empty nodes as desired functions.
  - Added a GetFunction parameter to the ToPlanFromXml method that takes a delegate for finding a skill function by skill name and function name. This delegate can be specified in the SequentialPlannerConfig class or default to the existing logic of using the SKContext.
  - Added a new static method GetFunction to the SequentialPlanParser class that returns the default delegate for getting the ISKFunction instance, which calls context.Skills.TryGetFunction.
  - Fixed a minor typo in the GetFunctionName method, changing "functionName" to "functionNameAttribute". This makes the code more accurate and clear. 
- dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
  - Added a new property GetAvailableFunctionsAsync to the SequentialPlannerConfig class that takes a delegate of type Func<SequentialPlannerConfig, string, Task<IOrderedEnumerable<FunctionView>>>. This delegate can be used to provide a custom logic for retrieving available functions from a semantic query, instead of using the default logic that calls context.GetAvailableFunctionsAsync. The default value of this property is null, which means the default logic will be used.
  - Modified the SKContextSequentialPlannerExtensions class to use the GetAvailableFunctionsAsync delegate if it is not null, otherwise fall back to the default logic.
- dotnet/src/Extensions/Planning.SequentialPlanner/skprompt.txt
  - Simplified and standardized the syntax for calling functions from <function.{FunctionName} ... /> to <function.{FullyQualifiedFunctionName} ... />, where {FullyQualifiedFunctionName} is the name of the function with its namespace or skill prefix, such as _GLOBAL_FUNCTIONS_.NovelOutline or AuthorAbility.Summarize.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
