### PR TITLE
Python: Correct syntax in core skill examples

### DIFF
--- a/python/semantic_kernel/core_skills/file_io_skill.py
+++ b/python/semantic_kernel/core_skills/file_io_skill.py
@@ -11,7 +11,7 @@ class FileIOSkill:
     Description: Read and write from a file.
 
     Usage:
-        kernel.import_skill(FileIOSkill(), skill_name"file")
+        kernel.import_skill(FileIOSkill(), skill_name="file")
 
     Examples:
 

--- a/python/semantic_kernel/core_skills/file_io_skill.py
+++ b/python/semantic_kernel/core_skills/file_io_skill.py
@@ -11,7 +11,7 @@ class FileIOSkill:
     Description: Read and write from a file.
 
     Usage:
-        kernel.import_skill("file", FileIOSkill());
+        kernel.import_skill(FileIOSkill(), skill_name"file")
 
     Examples:
 

--- a/python/semantic_kernel/core_skills/math_skill.py
+++ b/python/semantic_kernel/core_skills/math_skill.py
@@ -9,7 +9,7 @@ class MathSkill:
     Description: MathSkill provides a set of functions to make Math calculations.
 
     Usage:
-        kernel.import_skill("math", new MathSkill())
+        kernel.import_skill(MathSkill(), skill_name="math")
 
     Examples:
         {{math.Add}}         => Returns the sum of initial_value_text and Amount (provided in the SKContext)

--- a/python/semantic_kernel/core_skills/text_skill.py
+++ b/python/semantic_kernel/core_skills/text_skill.py
@@ -6,7 +6,7 @@ class TextSkill:
     TextSkill provides a set of functions to manipulate strings.
 
     Usage:
-        kernel.import_skill("text", TextSkill());
+        kernel.import_skill(TextSkill(), skill_name="text")
 
     Examples:
         SKContext["input"] = "  hello world  "

--- a/python/semantic_kernel/core_skills/time_skill.py
+++ b/python/semantic_kernel/core_skills/time_skill.py
@@ -9,7 +9,7 @@ class TimeSkill:
                  to get the current time and date.
 
     Usage:
-        kernel.import_skill("time", TimeSkill())
+        kernel.import_skill(TimeSkill(), skill_name="time")
 
     Examples:
         {{time.date}}            => Sunday, 12 January, 2031

--- a/python/semantic_kernel/core_skills/wait_skill.py
+++ b/python/semantic_kernel/core_skills/wait_skill.py
@@ -8,7 +8,7 @@ class WaitSkill:
     WaitSkill provides a set of functions to wait for a certain amount of time.
 
     Usage:
-        kernel.import_skill("wait", WaitSkill());
+        kernel.import_skill(WaitSkill(), skill_name="wait")
 
     Examples:
         {{wait.seconds 5}} => Wait for 5 seconds


### PR DESCRIPTION
Fix for #1730 
Some core skills include example code showing how to import the skill. Some of these examples, used an invalid syntax where arguments were in the reversed order, e.g. kernel.import_skill("wait", WaitSkill()); instead of the valid kernel.import_skill(WaitSkill(), "wait").