### PR TITLE
Fixes for OpenApiSkillsExample

### DIFF
--- a/samples/dotnet/openapi-skills/OpenApiSkillsExample.csproj
+++ b/samples/dotnet/openapi-skills/OpenApiSkillsExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace></RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <UserSecretsId>0c5a3194-f4af-4ecd-b558-8bf0ebd01d92</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dotnet/openapi-skills/Program.cs
+++ b/samples/dotnet/openapi-skills/Program.cs
@@ -113,7 +113,7 @@ internal sealed class Program
             int tokenCount = GPT3Tokenizer.Encode(JsonSerializer.Serialize(chatHistory)).Count;
             while (tokenCount > aiOptions.TokenLimit)
             {
-                chatHistory.Messages.RemoveAt(0);
+                chatHistory.Messages.RemoveAt(1);
                 tokenCount = GPT3Tokenizer.Encode(JsonSerializer.Serialize(chatHistory)).Count;
             }
             Console.WriteLine($"(tokens: {tokenCount})");

--- a/samples/dotnet/openapi-skills/appsettings.json
+++ b/samples/dotnet/openapi-skills/appsettings.json
@@ -14,7 +14,7 @@
   "AIService": {
     "Type": "AzureOpenAI", // 
     "Endpoint": "", // ignored when AIService is "OpenAI"
-    "CompletionTokenLimit": 4096,
+    "TokenLimit": 4096,
     // "Key": ""
     "Models": {
       "Completion": "gpt-35-turbo" // For OpenAI, change to 'gpt-3.5-turbo' (with a period).


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Fix for issue #1336 - When the token limit is exceeded, we unintentionally remove the system prompt from the chat history in order to remain under the token limit. Also addresses a couple other small issues with this sample.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- Remove chat history items beginning with index 1, so that the system prompt (index 0) remains in the chat history.
- Fix a naming mismatch in the configuration - the code looks for `TokenLimit` not `CompletionTokenLimit`
- Add `UserSecretsId` property to the csproj file so users won't need to run `dotnet user-secrets init` themselves.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
