### PR TITLE
Fix SKFunction.InvokeAsync to respect `input` when passed in explicitly.

### DIFF
--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunctionExtensions.cs
@@ -125,19 +125,14 @@ public static class SKFunctionExtensions
                 function.SkillName, function.Name);
         }
 
-        if (mutableContext)
+        if (!mutableContext)
         {
-            // Mutate context to utilize the passed in input
-            context.Variables.Update(input);
-            return function.InvokeAsync(context, settings);
+            // Create a copy of the context, to avoid editing the original set of variables
+            context = context.Clone();
         }
 
-        // Create a copy of the context, to avoid editing the original set of variables
-        SKContext contextClone = context.Clone();
-
-        // Store the input in the context clone
-        contextClone.Variables.Update(input);
-
-        return function.InvokeAsync(contextClone, settings);
+        // Store the input in the context
+        context.Variables.Update(input);
+        return function.InvokeAsync(context, settings);
     }
 }

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunctionExtensions.cs
@@ -127,6 +127,8 @@ public static class SKFunctionExtensions
 
         if (mutableContext)
         {
+            // Mutate context to utilize the passed in input
+            context.Variables.Update(input);
             return function.InvokeAsync(context, settings);
         }
 


### PR DESCRIPTION
- The defaults for `mutableContext` are `true` which make it super easy to fall into this trap. I slammed my head against the wall for a while until realizing that the SK InvokeAsync method wasn't properly utilizing the `input` parameter.