### PR TITLE
Update input when invoking function with mutable context

### DIFF
--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunctionExtensions.cs
@@ -127,6 +127,7 @@ public static class SKFunctionExtensions
 
         if (mutableContext)
         {
+            context.Variables.Update(input);
             return function.InvokeAsync(context, settings);
         }
 


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This change fixes #1443. There is a code path in `SKFunctionExtensions.InvokeAsync` where we don't update the context with the input from the user.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Update the `input` context variable before invoking the SK function, to ensure the input gets passed through.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
