### PR TITLE
Copilot Chat: Adding missing appsettings chatparticipant config to bicep template

### DIFF
--- a/samples/apps/copilot-chat-app/deploy/main.bicep
+++ b/samples/apps/copilot-chat-app/deploy/main.bicep
@@ -209,6 +209,10 @@ resource appServiceWebConfig 'Microsoft.Web/sites/config@2022-09-01' = {
         value: 'chatmemorysources'
       }
       {
+        name: 'ChatStore:Cosmos:ChatParticipantsContainer'
+        value: 'chatparticipants'
+      }
+      {
         name: 'ChatStore:Cosmos:ConnectionString'
         value: deployCosmosDB ? cosmosAccount.listConnectionStrings().connectionStrings[0].connectionString : ''
       }

--- a/samples/apps/copilot-chat-app/deploy/main.json
+++ b/samples/apps/copilot-chat-app/deploy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.17.1.54307",
-      "templateHash": "14923066769528474387"
+      "version": "0.16.2.56959",
+      "templateHash": "18037485528098010448"
     }
   },
   "parameters": {
@@ -311,6 +311,10 @@
           {
             "name": "ChatStore:Cosmos:ChatMemorySourcesContainer",
             "value": "chatmemorysources"
+          },
+          {
+            "name": "ChatStore:Cosmos:ChatParticipantsContainer",
+            "value": "chatparticipants"
           },
           {
             "name": "ChatStore:Cosmos:ConnectionString",


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Adding `ChatStore:Cosmos:ChatParticipantsContainer` config setting to the bicep template for the web app.
In response to: https://github.com/orgs/microsoft/projects/852/views/5?pane=issue&itemId=32088282

Did a test deployment and verified that new setting is in the config! 
 {

    "name": "ChatStore:Cosmos:ChatParticipantsContainer",
    "value": "chatparticipants",
    "slotSetting": false

  },
  
![image](https://github.com/microsoft/semantic-kernel/assets/125500434/4dba7793-2847-4435-98f9-5f7750f8b87f)

Then tested deployed webapi with local webapp instance and chatbot is running as expected
  
### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
