### PR TITLE
Copilot Chat: align bash deploy-webapi script with powershell

### DIFF
--- a/samples/apps/copilot-chat-app/deploy/deploy-webapi.sh
+++ b/samples/apps/copilot-chat-app/deploy/deploy-webapi.sh
@@ -5,13 +5,13 @@
 set -e
 
 usage() {
-    echo "Usage: $0 -d DEPLOYMENT_NAME -s SUBSCRIPTION --ai AI_SERVICE_TYPE -aikey AI_SERVICE_KEY [OPTIONS]"
+    echo "Usage: $0 -d DEPLOYMENT_NAME -s SUBSCRIPTION -rg RESOURCE_GROUP [OPTIONS]"
     echo ""
     echo "Arguments:"
-    echo "  -s, --subscription SUBSCRIPTION        Subscription to which to make the deployment (mandatory)"
+    echo "  -d, --deployment-name DEPLOYMENT_NAME   Name of the deployment from a 'deploy-azure.sh' deployment (mandatory)"
+    echo "  -s, --subscription SUBSCRIPTION         Subscription to which to make the deployment (mandatory)"
     echo "  -rg, --resource-group RESOURCE_GROUP    Resource group name from a 'deploy-azure.sh' deployment (mandatory)"
-    echo "  -d, --deployment-name DEPLOYMENT_NAME  Name of the deployment from a 'deploy-azure.sh' deployment (mandatory)"
-    echo "  -p, --package PACKAGE_FILE_PATH        Path to the WebAPI package file from a 'package-webapi.sh' run (mandatory)"
+    echo "  -p, --package PACKAGE_FILE_PATH         Path to the WebAPI package file from a 'package-webapi.sh' run"
 }
 
 # Parse arguments
@@ -47,10 +47,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Check mandatory arguments
-if [[ -z "$DEPLOYMENT_NAME" ]] || [[ -z "$SUBSCRIPTION" ]] || [[ -z "$RESOURCE_GROUP" ]] || [[ -z "$PACKAGE_FILE_PATH" ]]; then
+if [[ -z "$DEPLOYMENT_NAME" ]] || [[ -z "$SUBSCRIPTION" ]] || [[ -z "$RESOURCE_GROUP" ]]; then
     usage
     exit 1
 fi
+
+# Set defaults
+: "${PACKAGE_FILE_PATH:="$(dirname "$0")/out/webapi.zip"}"
 
 # Ensure $PACKAGE_FILE_PATH exists
 if [[ ! -f "$PACKAGE_FILE_PATH" ]]; then


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
I noticed the script was slightly misaligned during my deployment of webapi.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
corrects the usage string and sets a default value for the `PACKAGE_FILE_PATH` similar to the Powershell script.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
