### PR TITLE
Downgrade several 7.0.* packages to 6.0.*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     directory: "dotnet/"
     schedule:
       interval: "weekly"
+    ignore:
+      # For all System.* and Microsoft.Extensions.* packages, ignore all major version updates
+      - dependency-name: "System.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
       
   # Maintain dependencies for nuget
   - package-ecosystem: "nuget"

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -9,23 +9,23 @@
     <PackageVersion Include="Azure.Identity" Version="1.9.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.5.0-beta.2" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="[1.1.0, )" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="[7.0.0, )" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageVersion Include="NRedisStack" Version="0.7.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageVersion Include="NRedisStack" Version="0.6.1" />
     <PackageVersion Include="Pgvector" Version="0.1.3" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="[7.0.2, )" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.8" />
     <!-- Microsoft.Extensions.Logging -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[7.0.0, )" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[7.0.0, )" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <!-- Microsoft.Extensions.Configuration -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.5.23280.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <!-- Test -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Moq" Version="4.18.4" />
@@ -34,7 +34,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <!-- Skills -->
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="[7.0, )" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="6.0.19" />
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="[0.8, )" />
     <PackageVersion Include="DuckDB.NET.Data" Version="[0.8, )" />
     <PackageVersion Include="Microsoft.Graph" Version="[4.51.0, 5)" />

--- a/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
+++ b/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
@@ -44,6 +44,10 @@
     <ProjectReference Include="..\..\src\Skills\Skills.Web\Skills.Web.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel\SemanticKernel.csproj" />
     <ProjectReference Include="..\NCalcSkills\NCalcSkills.csproj" />
+
+    <!-- Because some of the referenced projects have dependencies that themselves have System.Text.Json set with a minimum of 7.0. -->
+    <PackageReference Include="System.Text.Json" />
+    <PackageVersion Update="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\30-user-prompt.txt" />

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexDefinition.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexDefinition.cs
@@ -3,7 +3,6 @@
 using System.Net.Http;
 using System.Text;
 using System.Text.Json.Serialization;
-using Microsoft.SemanticKernel.Connectors.Memory.Pinecone.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Pinecone.Model;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Pgvector" />
+
+    <!-- pgvector pulls in a 7.0 version -->
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
@@ -20,6 +20,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+
+    <!-- Because some of the referenced projects have dependencies that themselves have System.Text.Json set with a minimum of 7.0. -->
+    <PackageReference Include="System.Text.Json" />
+    <PackageVersion Update="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -27,6 +27,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+
+    <!-- Because some of the referenced projects have dependencies that themselves have System.Text.Json set with a minimum of 7.0. -->
+    <PackageReference Include="System.Text.Json" />
+    <PackageVersion Update="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/IntegrationTests/RedirectOutput.cs
+++ b/dotnet/src/IntegrationTests/RedirectOutput.cs
@@ -27,9 +27,9 @@ public class RedirectOutput : TextWriter, ILogger
         this._logs.AppendLine(value);
     }
 
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    public IDisposable BeginScope<TState>(TState state)
     {
-        return null;
+        return null!;
     }
 
     public bool IsEnabled(LogLevel logLevel)

--- a/dotnet/src/IntegrationTests/XunitLogger.cs
+++ b/dotnet/src/IntegrationTests/XunitLogger.cs
@@ -28,7 +28,7 @@ internal sealed class XunitLogger<T> : ILogger<T>, IDisposable
     public bool IsEnabled(LogLevel logLevel) => true;
 
     /// <inheritdoc/>
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+    public IDisposable BeginScope<TState>(TState state)
         => this;
 
     /// <inheritdoc/>

--- a/dotnet/src/Skills/Skills.UnitTests/XunitHelpers/XunitLogger.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/XunitHelpers/XunitLogger.cs
@@ -28,7 +28,7 @@ internal sealed class XunitLogger<T> : ILogger<T>, IDisposable
     public bool IsEnabled(LogLevel logLevel) => true;
 
     /// <inheritdoc/>
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+    public IDisposable BeginScope<TState>(TState state)
         => this;
 
     /// <inheritdoc/>


### PR DESCRIPTION
This pains me, as it's a technical step backwards.  But there are two problems today:
1) The .NET support policy today unfortunately applies not only to the .NET SDK and runtime but also to nuget packages released in the same wave, which means that if someone is relying on eg System.Text.Json and is running on .NET 6, having SK depend on System.Text.Json with a minimum version of 7.0 forces the consumer to also use the 7.0 version of System.Text.Json from the nuget, which then means that one assembly falls under the STS support policy instead of LTS support policy, which means that one assembly will have support end for it a few months earlier than it otherwise would.  I've raised this issue for further evaluation on the .NET side of things, but in the meantime, this lowers the version number to remove the perceived problem and possible barrier to adoption.
2) Azure Functions has two deployment models: in-process and isolated.  Ideally functions use isolated, which gives them the freedom to reference whatever they need.  The in-process model is exactly what it sounds like: the function runs in the same process as the host, and the host pins several dependencies at 6.0 versions.  That means that if a function references a 7.0 version, it'll fail to load in the in-process model.  While we'd like for folks to be using the isolated model, we can't force it, and we don't want a need for the in-process model to block SK usage.

This commit downgrades back to the 6.0 versions, at least where possible.  Some of the connectors reference libraries (e.g. NRedisStack, pgvector, etc.) that themselves have a 7.0 dependency.

Closes https://github.com/microsoft/semantic-kernel/issues/1793