### PR TITLE
Embed encoder.json/vocab.bpe in OpenAI connector assembly

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Connectors.AI.OpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Connectors.AI.OpenAI.csproj
@@ -28,16 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Tokenizers\Settings\encoder.json" />
-    <Content Include="Tokenizers\Settings\encoder.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
-    <None Remove="Tokenizers\Settings\vocab.bpe" />
-    <Content Include="Tokenizers\Settings\vocab.bpe">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
+    <EmbeddedResource Include="Tokenizers\Settings\encoder.json" LogicalName="encoder.json" />
+    <EmbeddedResource Include="Tokenizers\Settings\vocab.bpe" LogicalName="vocab.bpe" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/Settings/EmbeddedResource.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/Settings/EmbeddedResource.cs
@@ -1,24 +1,26 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.IO;
-using System.Reflection;
 
 namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.Tokenizers.Settings;
 
 internal static class EmbeddedResource
 {
-    // This is usually the assembly name, if the project follows the naming conventions about namespaces and assembly names
-    private const string PrefixToIgnore = "Microsoft.SemanticKernel.Connectors.AI.OpenAI";
-
-    private static readonly string s_namespace = typeof(EmbeddedResource).Namespace;
-
     /// <summary>
     /// Return content of BPE file.
     /// </summary>
     /// <returns>BPE file content</returns>
     internal static string ReadBytePairEncodingTable()
     {
-        return ReadFile("vocab.bpe");
+        Stream? stream = typeof(EmbeddedResource).Assembly.GetManifestResourceStream("vocab.bpe");
+        if (stream is null)
+        {
+            throw new InvalidOperationException("vocab.bpe not found");
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
 
     /// <summary>
@@ -27,58 +29,13 @@ internal static class EmbeddedResource
     /// <returns>Encoding table string</returns>
     internal static string ReadEncodingTable()
     {
-        return ReadFile("encoder.json");
-    }
-
-    /// <summary>
-    /// Read a content file embedded in the project. Files are read from disk,
-    /// not from the assembly, to avoid inflating the assembly size.
-    /// </summary>
-    /// <param name="fileName">Filename to read</param>
-    /// <returns>File content</returns>
-    /// <exception cref="FileNotFoundException">Error in case the file doesn't exist</exception>
-    private static string ReadFile(string fileName)
-    {
-        // Assume the class namespace matches the directory structure
-        var currentClassDir = s_namespace
-            .Replace(PrefixToIgnore, string.Empty)
-            .Trim('.')
-            .Replace('.', Path.DirectorySeparatorChar);
-
-        // Check the execution assembly directory first
-        var assembly1 = Assembly.GetExecutingAssembly();
-        var assembly1Dir = Path.GetDirectoryName(Path.GetFullPath(assembly1.Location));
-
-        // Concatenate assembly location with class namespace with file name
-        var filePath1 = Path.Combine(assembly1Dir, currentClassDir, fileName);
-        if (File.Exists(filePath1))
+        Stream? stream = typeof(EmbeddedResource).Assembly.GetManifestResourceStream("encoder.json");
+        if (stream is null)
         {
-            return File.ReadAllText(filePath1);
+            throw new InvalidOperationException("encoder.json not found");
         }
 
-        // Check the current assembly, in case that's a different file on a different directory
-        Assembly? assembly2 = Assembly.GetAssembly(typeof(EmbeddedResource));
-        if (assembly2 == null)
-        {
-            throw new FileNotFoundException($"{fileName} not found, path: '{filePath1}'");
-        }
-
-        // Path where the assembly is
-        var assembly2Dir = Path.GetDirectoryName(Path.GetFullPath(assembly2.Location));
-
-        // No need to continue if the path is the same
-        if (assembly2Dir == assembly1Dir)
-        {
-            throw new FileNotFoundException($"{fileName} not found, path: '{filePath1}'");
-        }
-
-        // Concatenate assembly location with class namespace with file name
-        var filePath2 = Path.Combine(assembly2Dir, currentClassDir, fileName);
-        if (File.Exists(filePath2))
-        {
-            return File.ReadAllText(filePath2);
-        }
-
-        throw new FileNotFoundException($"{fileName} not found, paths: '{filePath1}', '{filePath2}'");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
 }


### PR DESCRIPTION
### Motivation and Context

This makes these files part of the .dll rather than anyone using the nuget package deplying the separate .json/.bpe files.

(If it was an explicit design choice to have these be loose files, e.g. if the goal was to avoid paying the size increase if they weren't being used such that someone could explicitly delete them from their deployment, or being able to somehow update them separately after a build, then this can of course be closed.)

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
