### PR TITLE
Fixed function parameter not being used for LoadFromFile

### DIFF
--- a/samples/notebooks/dotnet/config/Settings.cs
+++ b/samples/notebooks/dotnet/config/Settings.cs
@@ -131,16 +131,16 @@ public static class Settings
     public static (bool useAzureOpenAI, string model, string azureEndpoint, string apiKey, string orgId)
         LoadFromFile(string configFile = DefaultConfigFile)
     {
-        if (!File.Exists(DefaultConfigFile))
+        if (!File.Exists(configFile))
         {
-            Console.WriteLine("Configuration not found: " + DefaultConfigFile);
+            Console.WriteLine("Configuration not found: " + configFile);
             Console.WriteLine("\nPlease run the Setup Notebook (0-AI-settings.ipynb) to configure your AI backend first.\n");
             throw new Exception("Configuration not found, please setup the notebooks first using notebook 0-AI-settings.pynb");
         }
 
         try
         {
-            var config = JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(DefaultConfigFile));
+            var config = JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(configFile));
             bool useAzureOpenAI = config[TypeKey] == "azure";
             string model = config[ModelKey];
             string azureEndpoint = config[EndpointKey];


### PR DESCRIPTION
### Motivation and Context
While trying to reuse the Settings class used in the C# notebooks to load the Kernel configuration, I saw the parameter to specify a file was not properly used.


### Description
Very simple changes as I just updated the code to use the function parameter instead of the Class variable Default 
It is in the notebook part so no build nor tests. Notebooks are still working.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
