### PR TITLE
Python: Fix for SemanticTextMemory Embedding issue

### DIFF
--- a/python/semantic_kernel/memory/semantic_text_memory.py
+++ b/python/semantic_kernel/memory/semantic_text_memory.py
@@ -56,7 +56,9 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         ):
             await self._storage.create_collection_async(collection_name=collection)
 
-        embedding = await self._embeddings_generator.generate_embeddings_async([text])
+        embedding = (
+            await self._embeddings_generator.generate_embeddings_async([text])
+        )[0]
         data = MemoryRecord.local_record(
             id=id,
             text=text,
@@ -94,7 +96,9 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         ):
             await self._storage.create_collection_async(collection_name=collection)
 
-        embedding = await self._embeddings_generator.generate_embeddings_async([text])
+        embedding = (
+            await self._embeddings_generator.generate_embeddings_async([text])
+        )[0]
         data = MemoryRecord.reference_record(
             external_id=external_id,
             source_name=external_source_name,
@@ -142,9 +146,9 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         Returns:
             List[MemoryQueryResult] -- The list of MemoryQueryResult found.
         """
-        query_embedding = await self._embeddings_generator.generate_embeddings_async(
-            [query]
-        )
+        query_embedding = (
+            await self._embeddings_generator.generate_embeddings_async([query])
+        )[0]
         results = await self._storage.get_nearest_matches_async(
             collection_name=collection,
             embedding=query_embedding,


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? To fix the SemanticTextMemory functionality
  2. What problem does it solve? #1815 
  3. What scenario does it contribute to?  All  scenarios that intend on using RAG
  4. If it fixes an open issue, please link to the issue here. #1815 
-->
  1. Why is this change required? To fix the SemanticTextMemory functionality
  2. What problem does it solve? #1815 
  3. What scenario does it contribute to?  All  scenarios that intend on using RAG
  4. If it fixes an open issue, please link to the issue here. #1815 


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Simple decomposition of the list of embeddings returned via `generate_embeddings_async`


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
