### PR TITLE
Java: Fix when TimeSkillTest fail when non US local

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -285,6 +285,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire-plugin.version}</version>
+                    <configuration>
+                        <argLine>-Duser.language=en -Duser.region=US</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Motivation and Context

When executing `./mvnw clean install` the `TimeSkillTest` fails with several Local assertions. Tests should pass even if the local is different from US. To fix the tests, one way is to force the local in the Surefire plugin.

Fix #1819

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
