### PR TITLE
Null input variable should be preserved

### DIFF
--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlannerTests.cs
@@ -74,7 +74,7 @@ public sealed class SequentialPlannerTests : IDisposable
             step =>
                 step.Name.Equals(expectedFunction, StringComparison.OrdinalIgnoreCase) &&
                 step.SkillName.Equals(expectedSkill, StringComparison.OrdinalIgnoreCase) &&
-                step.Parameters["endMarker"].Equals(expectedDefault, StringComparison.OrdinalIgnoreCase));
+                step.Parameters["endMarker"]!.Equals(expectedDefault, StringComparison.OrdinalIgnoreCase));
     }
 
     [Theory]

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
@@ -73,7 +73,7 @@ public sealed class SKContext
     /// Shortcut into user data, access variables by name
     /// </summary>
     /// <param name="name">Variable name</param>
-    public string this[string name]
+    public string? this[string name]
     {
         get => this.Variables[name];
         set => this.Variables[name] = value;

--- a/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Security/TrustAwareString.cs
@@ -21,14 +21,14 @@ public sealed class TrustAwareString : IEquatable<TrustAwareString>
     /// </summary>
     /// <param name="value">The raw string value</param>
     /// <returns>TrustAwareString</returns>
-    public static TrustAwareString CreateTrusted(string? value) => new(value, isTrusted: true);
+    public static TrustAwareString? CreateTrusted(string? value) => (value == null) ? null : new(value, isTrusted: true);
 
     /// <summary>
     /// Create a new untrusted string.
     /// </summary>
     /// <param name="value">The raw string value</param>
     /// <returns>TrustAwareString</returns>
-    public static TrustAwareString CreateUntrusted(string? value) => new(value, isTrusted: false);
+    public static TrustAwareString? CreateUntrusted(string? value) => (value == null) ? null : new(value, isTrusted: false);
 
     /// <summary>
     /// The raw string value.
@@ -45,13 +45,13 @@ public sealed class TrustAwareString : IEquatable<TrustAwareString>
     /// </summary>
     /// <param name="value">The raw string value</param>
     /// <param name="isTrusted">Whether the raw string value is trusted or not</param>
-    public TrustAwareString(string? value, bool isTrusted = true)
+    public TrustAwareString(string value, bool isTrusted = true)
     {
-        this.Value = value ?? string.Empty;
+        this.Value = value;
         this.IsTrusted = isTrusted;
     }
 
-    public override string ToString()
+    public override string? ToString()
     {
         return this.Value;
     }

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesConverterTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesConverterTests.cs
@@ -26,7 +26,7 @@ public class ContextVariablesConverterTests
 
         // Assert
         Assert.Equal("b", result!["a"]);
-        Assert.Equal(string.Empty, result!["INPUT"]);
+        Assert.False(result.ContainsKey("INPUT"));
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class ContextVariablesConverterTests
     [Theory]
     [InlineData(null, new[] { "a", "b" }, new[]
     {
-        /*lang=json,strict*/ @"{""Key"":""INPUT"",""Value"":""""}", /*lang=json,strict*/ @"{""Key"":""a"",""Value"":""b""}"
+        /*lang=json,strict*/ @"{""Key"":""a"",""Value"":""b""}"
     })]
     [InlineData("", new[] { "a", "b" }, new[]
     {
@@ -145,7 +145,7 @@ public class ContextVariablesConverterTests
     }
 
     [Fact]
-    public void ReadFromJsonReturnsDefaultWithEmpty()
+    public void ReadFromJsonReturnsDefaultWithNull()
     {
         // Arrange
         string json = /*lang=json,strict*/ "[]";
@@ -157,7 +157,7 @@ public class ContextVariablesConverterTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(string.Empty, result!["INPUT"]);
+        Assert.False(result.ContainsKey("INPUT"));
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Orchestration/ContextVariablesTests.cs
@@ -348,8 +348,9 @@ public class ContextVariablesTests
         // Act
         untrustedVar.Update(null);
 
-        // Assert
-        AssertContextVariable(untrustedVar, ContextVariables.MainKey, string.Empty, true);
+        // Assert the variable does not exist
+        var exists = untrustedVar.TryGetValue(ContextVariables.MainKey, out TrustAwareString? trustAwareValue);
+        Assert.False(exists);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/Security/TrustAwareStringTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Security/TrustAwareStringTests.cs
@@ -33,8 +33,8 @@ public sealed class TrustAwareStringTest
         TrustAwareString value = TrustAwareString.Empty;
 
         // Assert
-        Assert.Empty(value.ToString());
-        Assert.Empty(value.Value);
+        Assert.Empty(value.ToString()!);
+        Assert.Empty(value.Value!);
         Assert.True(value.IsTrusted);
     }
 
@@ -63,14 +63,14 @@ public sealed class TrustAwareStringTest
         var trustedValue0Copy = TrustAwareString.CreateTrusted("some value 0");
         var untrustedValue0 = TrustAwareString.CreateUntrusted("some value 0");
         var untrustedValue0Copy = TrustAwareString.CreateUntrusted("some value 0");
-        var trustedValue1 = TrustAwareString.CreateTrusted("some value 1");
+        var trustedValue1 = TrustAwareString.CreateTrusted("some value 1")!;
         var untrustedValue1 = TrustAwareString.CreateTrusted("some value 1");
         var stringValue0 = "some value 0";
         int someObj = 10;
 
         // Act and assert
-        Assert.True(trustedValue0.Equals(trustedValue0Copy));
-        Assert.True(untrustedValue0.Equals(untrustedValue0Copy));
+        Assert.True(trustedValue0!.Equals(trustedValue0Copy));
+        Assert.True(untrustedValue0!.Equals(untrustedValue0Copy));
         Assert.True(trustedValue0 == trustedValue0Copy);
         Assert.True(untrustedValue0 == untrustedValue0Copy);
 

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKContextTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKContextTests.cs
@@ -69,7 +69,7 @@ public class SKContextTests
     public void ItCanUntrustAll()
     {
         // Arrange
-        var variables = new ContextVariables();
+        var variables = new ContextVariables("");
         var target = new SKContext(variables);
 
         // Assert

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
@@ -154,7 +154,7 @@ public sealed class SKFunctionTests2
         // Arrange
         static string Test(SKContext cx)
         {
-            s_actual = cx["someVar"];
+            s_actual = cx["someVar"]!;
             return "abc";
         }
 
@@ -181,7 +181,7 @@ public sealed class SKFunctionTests2
         string? Test(SKContext cx)
         {
             invocationCount++;
-            s_actual = cx["someVar"];
+            s_actual = cx["someVar"]!;
             return "abc";
         }
 
@@ -822,7 +822,7 @@ public sealed class SKFunctionTests2
         // Arrange
         var context = this.MockContext("1");
 
-        static async Task AssertResult(Delegate d, SKContext context, string expected)
+        static async Task AssertResult(Delegate d, SKContext context, string? expected)
         {
             context = await SKFunction.FromNativeFunction(d, functionName: "Test")!.InvokeAsync(context);
             Assert.False(context.ErrorOccurred, context.LastErrorDescription);
@@ -897,7 +897,7 @@ public sealed class SKFunctionTests2
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
-        AssertExtensions.AssertIsArgumentOutOfRange(result.LastException, "g", context.Variables["g"]);
+        AssertExtensions.AssertIsArgumentOutOfRange(result.LastException, "g", context.Variables["g"]!);
     }
 
     [Obsolete("This test tests obsolete functionality and should be removed when that functionality is removed.")]
@@ -910,7 +910,7 @@ public sealed class SKFunctionTests2
         [SKFunctionContextParameter(Name = "y", Description = "Awesome additional input", DefaultValue = "42")]
         static string Add(string x, SKContext context) =>
            (int.Parse(x, CultureInfo.InvariantCulture) +
-            int.Parse(context["y"], CultureInfo.InvariantCulture)).ToString(CultureInfo.InvariantCulture);
+            int.Parse(context["y"]!, CultureInfo.InvariantCulture)).ToString(CultureInfo.InvariantCulture);
 
         // Arrange
         var context = Kernel.Builder.Build().CreateNewContext();

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests4.cs
@@ -331,7 +331,7 @@ public class SKFunctionTests4
         // Arrange
         static string Test(SKContext cx)
         {
-            s_actual = cx["someVar"];
+            s_actual = cx["someVar"]!;
             return "abc";
         }
 
@@ -360,7 +360,7 @@ public class SKFunctionTests4
         {
             // Set this variable as untrusted
             cx.Variables.Update(TrustAwareString.CreateUntrusted("some value"));
-            s_actual = cx["someVar"];
+            s_actual = cx["someVar"]!;
             return "abc";
         }
 
@@ -391,7 +391,7 @@ public class SKFunctionTests4
         // Arrange
         string? Test(SKContext cx)
         {
-            s_actual = cx["someVar"];
+            s_actual = cx["someVar"]!;
             return "abc";
         }
 

--- a/dotnet/src/Skills/Skills.UnitTests/MsGraph/CalendarSkillTests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/MsGraph/CalendarSkillTests.cs
@@ -257,8 +257,8 @@ public class CalendarSkillTests : IDisposable
 
         // Assert
         Assert.True(context.ErrorOccurred);
-        ArgumentException e = Assert.IsType<ArgumentException>(context.LastException);
-        Assert.Equal("subject", e.ParamName);
+        KernelException e = Assert.IsType<KernelException>(context.LastException);
+        Assert.Equal(KernelException.ErrorCodes.FunctionInvokeError, e.ErrorCode);
     }
 
     protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. Why is this change required? Currently the trust aware version of a null string has a value of "". As side effect of this is if the `input` variable is not provided it is defaulting to "" rather than null. This prevents default values being used.

### Description
If I have the following semantic function

**skprompt.txt**
```
WRITE EXACTLY ONE JOKE or HUMOROUS STORY ABOUT THE TOPIC BELOW

JOKE MUST BE:
- G RATED
- WORKPLACE/FAMILY SAFE
NO SEXISM, RACISM OR OTHER BIAS/BIGOTRY

BE CREATIVE AND FUNNY. I WANT TO LAUGH.

{{FunSkill.Excuses $input}}
+++++
```

**config.json**
```
{
  "schema": 1,
  "description": "Generate a funny joke for an excuse",
  "type": "completion",
  "completion": {
    "max_tokens": 1000,
    "temperature": 0.9,
    "top_p": 0,
    "presence_penalty": 0,
    "frequency_penalty": 0
  },
  "input": {
    "parameters": [
      {
        "name": "input",
        "description": "The event to generate an excuse for",
        "defaultValue": "Late for work"
      }
    ]
  }
}
```

If I run this function and do not provide an input I expect the default value to be provided. But what happens is the `input` is converted to a trust aware string with it's value set to an empty string. The rendered prompt looks like this.
```
WRITE EXACTLY ONE JOKE or HUMOROUS STORY ABOUT THE TOPIC BELOW

JOKE MUST BE:
- G RATED
- WORKPLACE/FAMILY SAFE
NO SEXISM, RACISM OR OTHER BIAS/BIGOTRY

BE CREATIVE AND FUNNY. I WANT TO LAUGH.

I forgot to do my homework.
Excuse:My pet unicorn ate it.
+++++
```
And the response from the AI looks like this:
```
Teacher: "That's not a very believable excuse."
Student: "Well, it's more believable than my pet dragon eating it!"
```

With the proposed changed the rendered prompt looks like this:
```
WRITE EXACTLY ONE JOKE or HUMOROUS STORY ABOUT THE TOPIC BELOW

JOKE MUST BE:
- G RATED
- WORKPLACE/FAMILY SAFE
NO SEXISM, RACISM OR OTHER BIAS/BIGOTRY

BE CREATIVE AND FUNNY. I WANT TO LAUGH.


Excuse:My alarm clock was abducted by aliens.
```
And the response from the AI looks like this:
```
Boss: That's a new one. What did they want with it?
Employee: I'm not sure, but they left a note saying they'd be back in an hour.
```

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
