### PR TITLE
Update dependabot.yml to ignore Microsoft.Bcl.* major versions as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,12 @@ updates:
       interval: "weekly"
       day: "monday"
     ignore:
-      # For all System.* and Microsoft.Extensions.* packages, ignore all major version updates
+      # For all System.* and Microsoft.Extensions/Bcl.* packages, ignore all major version updates
       - dependency-name: "System.*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.Bcl.*"
         update-types: ["version-update:semver-major"]      
     labels:
       - ".NET"


### PR DESCRIPTION
### Motivation and Context

Don't force major version upgrades to Microsoft.Bcl.* via dependabot

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
