### PR TITLE
[.Net CoreSkills]: Added ability to send custom Headers in HttpSkill

### DIFF
--- a/dotnet/src/Skills/Skills.Core/HttpSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/HttpSkill.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.SkillDefinition;
@@ -47,65 +49,95 @@ public sealed class HttpSkill : IDisposable
     /// <summary>
     /// Sends an HTTP GET request to the specified URI and returns the response body as a string.
     /// </summary>
-    /// <param name="uri">URI of the request</param>
+    /// <param name="uri">URI of the request.</param>
+    /// <param name="serializedHeaders">Optional headers for the request of keyVaulePair List type in in serialized form using System.Text.Json</param>
     /// <param name="cancellationToken">The token to use to request cancellation.</param>
     /// <returns>The response body as a string.</returns>
     [SKFunction, Description("Makes a GET request to a uri")]
     public Task<string> GetAsync(
         [Description("The URI of the request")] string uri,
+        [Description("Optional headers for the request of keyVaulePair List type in serialized form")] string? serializedHeaders = null,
         CancellationToken cancellationToken = default) =>
-        this.SendRequestAsync(uri, HttpMethod.Get, requestContent: null, cancellationToken);
+        this.SendRequestAsync(uri, HttpMethod.Get, null, serializedHeaders, cancellationToken);
 
     /// <summary>
     /// Sends an HTTP POST request to the specified URI and returns the response body as a string.
     /// </summary>
-    /// <param name="uri">URI of the request</param>
-    /// <param name="body">The body of the request</param>
+    /// <param name="uri">URI of the request.</param>
+    /// <param name="body">The body of the request.</param>
+    /// <param name="serializedHeaders">Optional headers for the request of keyVaulePair List type in in serialized form using System.Text.Json</param>
     /// <param name="cancellationToken">The token to use to request cancellation.</param>
     /// <returns>The response body as a string.</returns>
     [SKFunction, Description("Makes a POST request to a uri")]
     public Task<string> PostAsync(
         [Description("The URI of the request")] string uri,
         [Description("The body of the request")] string body,
+        [Description("Optional headers for the request of keyVaulePair List type in serialized form")] string? serializedHeaders = null,
         CancellationToken cancellationToken = default) =>
-        this.SendRequestAsync(uri, HttpMethod.Post, new StringContent(body), cancellationToken);
+        this.SendRequestAsync(uri, HttpMethod.Post, new StringContent(body), serializedHeaders, cancellationToken);
 
     /// <summary>
     /// Sends an HTTP PUT request to the specified URI and returns the response body as a string.
     /// </summary>
-    /// <param name="uri">URI of the request</param>
-    /// <param name="body">The body of the request</param>
+    /// <param name="uri">URI of the request.</param>
+    /// <param name="body">The body of the request.</param>
+    /// <param name="serializedHeaders">Optional headers for the request of keyVaulePair List type in in serialized form using System.Text.Json</param>
     /// <param name="cancellationToken">The token to use to request cancellation.</param>
     /// <returns>The response body as a string.</returns>
     [SKFunction, Description("Makes a PUT request to a uri")]
     public Task<string> PutAsync(
         [Description("The URI of the request")] string uri,
         [Description("The body of the request")] string body,
+        [Description("Optional headers for the request of keyVaulePair List type in serialized form")] string? serializedHeaders = null,
         CancellationToken cancellationToken = default) =>
-        this.SendRequestAsync(uri, HttpMethod.Put, new StringContent(body), cancellationToken);
+        this.SendRequestAsync(uri, HttpMethod.Put, new StringContent(body), serializedHeaders, cancellationToken);
 
     /// <summary>
     /// Sends an HTTP DELETE request to the specified URI and returns the response body as a string.
     /// </summary>
     /// <param name="uri">URI of the request</param>
+    /// <param name="serializedHeaders">Optional headers for the request of keyVaulePair List type in in serialized form using System.Text.Json</param>
     /// <param name="cancellationToken">The token to use to request cancellation.</param>
     /// <returns>The response body as a string.</returns>
     [SKFunction, Description("Makes a DELETE request to a uri")]
     public Task<string> DeleteAsync(
         [Description("The URI of the request")] string uri,
+        [Description("Optional headers for the request of keyVaulePair List type in serialized form")] string? serializedHeaders = null,
         CancellationToken cancellationToken = default) =>
-        this.SendRequestAsync(uri, HttpMethod.Delete, requestContent: null, cancellationToken);
+        this.SendRequestAsync(uri, HttpMethod.Delete, null, serializedHeaders, cancellationToken);
 
     /// <summary>Sends an HTTP request and returns the response content as a string.</summary>
     /// <param name="uri">The URI of the request.</param>
     /// <param name="method">The HTTP method for the request.</param>
     /// <param name="requestContent">Optional request content.</param>
+    /// <param name="serializedHeaders">Optional headers for the request of keyVaulePair List type in in serialized form using System.Text.Json</param>
     /// <param name="cancellationToken">The token to use to request cancellation.</param>
-    private async Task<string> SendRequestAsync(string uri, HttpMethod method, HttpContent? requestContent, CancellationToken cancellationToken)
+    private async Task<string> SendRequestAsync(string uri, HttpMethod method, HttpContent? requestContent, string? serializedHeaders, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(method, uri) { Content = requestContent };
+        foreach (KeyValuePair<string, string> header in this.GetHeadersList(serializedHeaders))
+        {
+            request.Headers.Add(header.Key, header.Value);
+        }
         using var response = await this._client.SendAsync(request, cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>Deserializes the Http headers string and returns the header list.</summary>
+    /// <param name="serializedHeaders">Optional headers for the request of keyVaulePair List type in in serialized form using System.Text.Json</param>
+    private List<KeyValuePair<string, string>> GetHeadersList(string? serializedHeaders)
+    {
+        List<KeyValuePair<string, string>> headers = new();
+        if (string.IsNullOrEmpty(serializedHeaders))
+        {
+            return headers;
+        }
+        List<KeyValuePair<string, string>>? deserializedHeaders = JsonSerializer.Deserialize<List<KeyValuePair<string, string>>>(serializedHeaders);
+        if (deserializedHeaders == null)
+        {
+            return headers;
+        }
+        return deserializedHeaders;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Currently, the HttpSkill present as part of the core skills in Semantic Kernel dotnet source does not have an option to add any custom headers to the http request. This makes it hard to make many of the API calls using this Core skill as generally some or the other authentication headers or other keys need to be added to the headers.


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- This change adds the ability to apply custom headers to the Http request by adding a new optional parameter to the various method functions of Http skill. 
- This new parameter is optional headers for the request and is a serialized List of keyVaulePair types. HttpHeaders is also an enumerable of KeyValuePairs (https://learn.microsoft.com/en-us/dotnet/api/system.net.http.headers.httpheaders?view=net-7.0). 
- This List should be serialized using System.Text.Json which is then used to deserialize the headers before adding to the request. Serialization is important as Semantic Kernel operates on strings only.
- The "serializedHeaders" variable is completely optional and not necessary for the request.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
 