### PR TITLE
Copilot Chat: Url DataAnnotation is not compatible with Uri. Should be string

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/ConfigurationExtensions.cs
+++ b/samples/apps/copilot-chat-app/webapi/ConfigurationExtensions.cs
@@ -37,7 +37,7 @@ internal static class ConfigExtensions
                 reloadOnChange: true);
 
             // For settings from Key Vault, see https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-8.0
-            string? keyVaultUri = builderContext.Configuration["KeyVaultUri"];
+            string? keyVaultUri = builderContext.Configuration["Service:KeyVault"];
             if (!string.IsNullOrWhiteSpace(keyVaultUri))
             {
                 configBuilder.AddAzureKeyVault(

--- a/samples/apps/copilot-chat-app/webapi/Options/ServiceOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/ServiceOptions.cs
@@ -16,7 +16,7 @@ public class ServiceOptions
     /// Configuration Key Vault URI
     /// </summary>
     [Url]
-    public Uri? KeyVaultUri { get; set; }
+    public string? KeyVaultUri { get; set; }
 
     /// <summary>
     /// Local directory in which to load semantic skills.

--- a/samples/apps/copilot-chat-app/webapi/Options/ServiceOptions.cs
+++ b/samples/apps/copilot-chat-app/webapi/Options/ServiceOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace SemanticKernel.Service.Options;
@@ -16,7 +15,7 @@ public class ServiceOptions
     /// Configuration Key Vault URI
     /// </summary>
     [Url]
-    public string? KeyVaultUri { get; set; }
+    public string? KeyVault { get; set; }
 
     /// <summary>
     /// Local directory in which to load semantic skills.

--- a/samples/apps/copilot-chat-app/webapi/appsettings.json
+++ b/samples/apps/copilot-chat-app/webapi/appsettings.json
@@ -17,7 +17,7 @@
   //
   "Service": {
     // "SemanticSkillsDirectory": "",
-    // "KeyVaultUri": ""
+    // "KeyVault": ""
   },
 
   //


### PR DESCRIPTION
Having Url annotation check with an Uri type always fails.

The reason is that the UrlAttribute IsValid method always checks if the value is of type string:
```cs
public override bool IsValid(object? value)
{
    if (value == null)
    {
        return true;
    }

    return value is string valueAsString &&
        (valueAsString.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
        || valueAsString.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
        || valueAsString.StartsWith("ftp://", StringComparison.OrdinalIgnoreCase));
}
```

Changing Uri to string here works fine (tested) while keeping the annotation check.

For reference see: https://github.com/dotnet/runtime/issues/71008