### PR TITLE
Java: Fix reactor flatMap producing out of order results

### DIFF
--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/DefaultCompletionSKFunction.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/DefaultCompletionSKFunction.java
@@ -126,7 +126,7 @@ public class DefaultCompletionSKFunction
         // function
         BiFunction<Flux<SKContext>, String, Flux<SKContext>> executeNextChunk =
                 (contextInput, input) ->
-                        contextInput.flatMap(
+                        contextInput.concatMap(
                                 newContext -> {
                                     SKContext updated = newContext.update(input);
                                     return invokeAsync(updated, null);

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/templateengine/DefaultPromptTemplateEngine.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/templateengine/DefaultPromptTemplateEngine.java
@@ -69,7 +69,7 @@ public class DefaultPromptTemplateEngine implements PromptTemplateEngine {
     /// <inheritdoc/>
     public Mono<String> renderAsync(List<Block> blocks, SKContext context) {
         return Flux.fromIterable(blocks)
-                .flatMap(
+                .concatMap(
                         block -> {
                             if (block instanceof TextRendering) {
                                 return Mono.just(

--- a/java/semantickernel-extensions-parent/sequentialplanner-extensions/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/DefaultSequentialPlannerSKContext.java
+++ b/java/semantickernel-extensions-parent/sequentialplanner-extensions/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/DefaultSequentialPlannerSKContext.java
@@ -202,7 +202,7 @@ public class DefaultSequentialPlannerSKContext {
         }
 
         return Flux.fromIterable(availableFunctions)
-                .flatMap(
+                .concatMap(
                         function -> {
                             String functionName = function.toFullyQualifiedName();
                             String key = functionName;


### PR DESCRIPTION
Fixes a concurrency bug, `Flux.flatMap` will return the first available result rather than keeping the results in order,  changed to concatMap