### PR TITLE
Adding CopilotChat.sln

### DIFF
--- a/samples/apps/copilot-chat-app/CopilotChat.sln
+++ b/samples/apps/copilot-chat-app/CopilotChat.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33706.43
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CopilotChatWebApi", "webapi\CopilotChatWebApi.csproj", "{5252E68F-B653-44CE-9A32-360A75C54E0E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5252E68F-B653-44CE-9A32-360A75C54E0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5252E68F-B653-44CE-9A32-360A75C54E0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5252E68F-B653-44CE-9A32-360A75C54E0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5252E68F-B653-44CE-9A32-360A75C54E0E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {971570D3-60EA-4EE4-980C-0BDA3E66E741}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Copilot Chat's .net project builds, runs, works just fine when opened from the `CopilotChatWebApi.csproj` directly. Every time you open this project, however, VS kindly creates a new .sln for you and offers to save it.

This just creates a convenient .sln that one can open. This can also be used by dotnet format and build scripts. It contains just the one `CopilotChatWebApi` project right now, but it's placed in the copilot-chat folder so that additional projects (tests, extensions, etc.) could be added in the future.