### PR TITLE
.Net Notebook: Fixing new skills namespace in memory notebook

### DIFF
--- a/samples/notebooks/dotnet/06-memory-and-embeddings.ipynb
+++ b/samples/notebooks/dotnet/06-memory-and-embeddings.ipynb
@@ -213,7 +213,7 @@
    },
    "outputs": [],
    "source": [
-    "using Microsoft.SemanticKernel.CoreSkills;\n",
+    "using Microsoft.SemanticKernel.Skills.Core;\n",
     "\n",
     "// TextMemorySkill provides the \"recall\" function\n",
     "kernel.ImportSkill(new TextMemorySkill());"


### PR DESCRIPTION
### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. Why is this change required?
 It's a simple bug fix to account for namespace updates
  3. What problem does it solve?
 The memory and embedding notebook still uses the previous skills namespace and thus breaks
  5. What scenario does it contribute to?
 Notebooks
  7. If it fixes an open issue, please link to the issue here.



### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
     Just a line change


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
