### PR TITLE
Make bug report more inclusive of programming languages other than dotnet

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,10 +23,11 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Windows]
+**Platform**
+ - OS: [e.g. Windows, Mac]
  - IDE: [e.g. Visual Studio, VS Code]
- - NuGet Package Version [e.g. 0.1.0]
+ - Language: [e.g. C#, Python]
+ - Source: [e.g. NuGet package version 0.1.0, pip package version 0.1.0, main branch of repository]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
### Motivation and Context
Small PR that makes it more explicit which programming language the bug is associated with


### Description
Renames the desktop section to platform and replaces the explicit NuGet package suggestion with "Source":

<img width="490" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/146438/a760fcf6-8c2b-4bcb-a2a1-8ab7d3bf98e2">


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
