### PR TITLE
Removing usernames from webapi stores

### DIFF
--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/BotController.cs
@@ -128,7 +128,6 @@ public class BotController : ControllerBase
         {
             var chatMessage = new ChatMessage(
                 message.UserId,
-                message.UserName,
                 chatId,
                 message.Content,
                 message.Prompt,

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/DocumentImportController.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Controllers/DocumentImportController.cs
@@ -159,7 +159,7 @@ public class DocumentImportController : ControllerBase
         }
 
         await messageRelayHubContext.Clients.All
-            .SendAsync(GlobalDocumentUploadedClientCall, formFile.FileName, documentImportForm.UserName);
+            .SendAsync(GlobalDocumentUploadedClientCall, formFile.FileName);
 
         return this.Ok();
     }
@@ -212,7 +212,6 @@ public class DocumentImportController : ControllerBase
 
         var chatMessage = new ChatMessage(
             memorySource.SharedBy,
-            documentImportForm.UserName,
             memorySource.ChatId,
             content.ToString(),
             "",

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/ChatMessage.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/ChatMessage.cs
@@ -68,12 +68,6 @@ public class ChatMessage : IStorageEntity
     public string UserId { get; set; }
 
     /// <summary>
-    /// Name of the user who sent this message.
-    /// </summary>
-    [JsonPropertyName("userName")]
-    public string UserName { get; set; }
-
-    /// <summary>
     /// Id of the chat this message belongs to.
     /// </summary>
     [JsonPropertyName("chatId")]
@@ -114,17 +108,15 @@ public class ChatMessage : IStorageEntity
     /// Create a new chat message. Timestamp is automatically generated.
     /// </summary>
     /// <param name="userId">Id of the user who sent this message</param>
-    /// <param name="userName">Name of the user who sent this message</param>
     /// <param name="chatId">The chat ID that this message belongs to</param>
     /// <param name="content">The message</param>
     /// <param name="prompt">The prompt used to generate the message</param>
     /// <param name="authorRole">Role of the author</param>
     /// <param name="type">Type of the message</param>
-    public ChatMessage(string userId, string userName, string chatId, string content, string prompt = "", AuthorRoles authorRole = AuthorRoles.User, ChatMessageType type = ChatMessageType.Message)
+    public ChatMessage(string userId, string chatId, string content, string prompt = "", AuthorRoles authorRole = AuthorRoles.User, ChatMessageType type = ChatMessageType.Message)
     {
         this.Timestamp = DateTimeOffset.Now;
         this.UserId = userId;
-        this.UserName = userName;
         this.ChatId = chatId;
         this.Content = content;
         this.Id = Guid.NewGuid().ToString();
@@ -141,7 +133,7 @@ public class ChatMessage : IStorageEntity
     /// <param name="prompt">The prompt used to generate the message</param>
     public static ChatMessage CreateBotResponseMessage(string chatId, string content, string prompt)
     {
-        return new ChatMessage("bot", "bot", chatId, content, prompt, AuthorRoles.Bot, IsPlan(content) ? ChatMessageType.Plan : ChatMessageType.Message);
+        return new ChatMessage("bot", chatId, content, prompt, AuthorRoles.Bot, IsPlan(content) ? ChatMessageType.Plan : ChatMessageType.Message);
     }
 
     /// <summary>
@@ -157,7 +149,7 @@ public class ChatMessage : IStorageEntity
             content = $"Sent a file named \"{documentDetails?.Name}\" with a size of {documentDetails?.Size}.";
         }
 
-        return $"[{this.Timestamp.ToString("G", CultureInfo.CurrentCulture)}] {this.UserName}: {content}";
+        return $"[{this.Timestamp.ToString("G", CultureInfo.CurrentCulture)}]: {content}";
     }
 
     /// <summary>

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/DocumentImportForm.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Models/DocumentImportForm.cs
@@ -42,10 +42,4 @@ public class DocumentImportForm
     /// Will be use to validate if the user has access to the chat session.
     /// </summary>
     public string UserId { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Name of the user who sent this message.
-    /// Will be used to create the chat message representing the document upload.
-    /// </summary>
-    public string UserName { get; set; } = string.Empty;
 }

--- a/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ChatSkill.cs
+++ b/samples/apps/copilot-chat-app/webapi/CopilotChat/Skills/ChatSkills/ChatSkill.cs
@@ -241,7 +241,6 @@ public class ChatSkill
     public async Task<SKContext> ChatAsync(
         [Description("The new message")] string message,
         [Description("Unique and persistent identifier for the user")] string userId,
-        [Description("Name of the user")] string userName,
         [Description("Unique and persistent identifier for the chat")] string chatId,
         [Description("Type of the message")] string messageType,
         [Description("Previously proposed plan that is approved"), DefaultValue(null), SKName("proposedPlan")] string? planJson,
@@ -249,7 +248,7 @@ public class ChatSkill
         SKContext context)
     {
         // Save this new message to memory such that subsequent chat responses can use it
-        await this.SaveNewMessageAsync(message, userId, userName, chatId, messageType);
+        await this.SaveNewMessageAsync(message, userId, chatId, messageType);
 
         // Clone the context to avoid modifying the original context variables.
         var chatContext = Utilities.CopyContextWithVariablesClone(context);
@@ -436,7 +435,6 @@ public class ChatSkill
         {
             var contextVariables = new ContextVariables();
             contextVariables.Set("chatId", context["chatId"]);
-            contextVariables.Set("audience", context["userName"]);
 
             var intentContext = new SKContext(
                 contextVariables,
@@ -507,10 +505,9 @@ public class ChatSkill
     /// </summary>
     /// <param name="message">The message</param>
     /// <param name="userId">The user ID</param>
-    /// <param name="userName"></param>
     /// <param name="chatId">The chat ID</param>
     /// <param name="type">Type of the message</param>
-    private async Task<ChatMessage> SaveNewMessageAsync(string message, string userId, string userName, string chatId, string type)
+    private async Task<ChatMessage> SaveNewMessageAsync(string message, string userId, string chatId, string type)
     {
         // Make sure the chat exists.
         if (!await this._chatSessionRepository.TryFindByIdAsync(chatId, v => _ = v))
@@ -520,7 +517,6 @@ public class ChatSkill
 
         var chatMessage = new ChatMessage(
             userId,
-            userName,
             chatId,
             message,
             "",

--- a/samples/apps/copilot-chat-app/webapp/src/App.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/App.tsx
@@ -16,6 +16,7 @@ import { useChat } from './libs/useChat';
 import { useAppDispatch, useAppSelector } from './redux/app/hooks';
 import { RootState } from './redux/app/store';
 import { addAlert, setActiveUserInfo } from './redux/features/app/appSlice';
+import { addUser } from './redux/features/users/usersSlice';
 
 export const useClasses = makeStyles({
     container: {
@@ -77,8 +78,15 @@ const App: FC = () => {
                     dispatch(
                         setActiveUserInfo({
                             id: account.homeAccountId,
-                            email: account.username, // username in an AccountInfo object is the email address
-                            username: account.name ?? account.username,
+                            userPrincipalName: account.username, // username in an AccountInfo object is the email address
+                            displayName: account.name ?? account.username,
+                        }),
+                    );
+                    dispatch(
+                        addUser({
+                            id: account.localAccountId,
+                            displayName: account.name ?? account.username,
+                            userPrincipalName: account.username,
                         }),
                     );
                 }

--- a/samples/apps/copilot-chat-app/webapp/src/Constants.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/Constants.ts
@@ -16,6 +16,8 @@ export const Constants = {
             storeAuthStateInCookie: false,
         },
         semanticKernelScopes: ['openid', 'offline_access', 'profile'],
+        // MS Graph scopes required for loading user information
+        msGraphAppScopes: ['User.Read'],
     },
     bot: {
         profile: {
@@ -39,6 +41,7 @@ export const Constants = {
     },
     // For a list of Microsoft Graph permissions, see https://learn.microsoft.com/en-us/graph/permissions-reference.
     // Your application registration will need to be granted these permissions in Azure Active Directory.
-    msGraphScopes: ['Calendars.Read', 'Mail.Read', 'Mail.Send', 'Tasks.ReadWrite', 'User.Read'],
+    msGraphPluginScopes: ['Calendars.Read', 'Mail.Read', 'Mail.Send', 'Tasks.ReadWrite', 'User.Read'],
     adoScopes: ['vso.work'],
+    BATCH_REQUEST_LIMIT: 20,
 };

--- a/samples/apps/copilot-chat-app/webapp/src/Constants.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/Constants.ts
@@ -17,13 +17,13 @@ export const Constants = {
         },
         semanticKernelScopes: ['openid', 'offline_access', 'profile'],
         // MS Graph scopes required for loading user information
-        msGraphAppScopes: ['User.Read'],
+        msGraphAppScopes: ['User.ReadBasic.All'],
     },
     bot: {
         profile: {
             id: 'bot',
-            fullName: 'Copilot',
-            emailAddress: '',
+            displayName: 'Copilot',
+            userPrincipalName: '',
             photo: botIcon1,
         },
         fileExtension: 'skcb',

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatRoom.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatRoom.tsx
@@ -92,7 +92,6 @@ export const ChatRoom: React.FC = () => {
         const chatInput: IChatMessage = {
             timestamp: new Date().getTime(),
             userId: activeUserInfo?.id as string,
-            userName: activeUserInfo?.username as string,
             content: options.value,
             type: options.messageType,
             authorRole: AuthorRoles.User,

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
@@ -25,13 +25,11 @@ import { Dismiss16Regular, Edit24Filled, EditRegular } from '@fluentui/react-ico
 import React, { useEffect, useState } from 'react';
 import { AuthHelper } from '../../libs/auth/AuthHelper';
 import { AlertType } from '../../libs/models/AlertType';
-import { IChatUser } from '../../libs/models/ChatUser';
 import { ChatService } from '../../libs/services/ChatService';
-import { useGraph } from '../../libs/useGraph';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
 import { addAlert, removeAlert } from '../../redux/features/app/appSlice';
-import { editConversationTitle, setUsersLoaded } from '../../redux/features/conversations/conversationsSlice';
+import { editConversationTitle } from '../../redux/features/conversations/conversationsSlice';
 import { ChatResourceList } from './ChatResourceList';
 import { ChatRoom } from './ChatRoom';
 import { ParticipantsList } from './controls/ParticipantsList';
@@ -101,27 +99,14 @@ export const ChatWindow: React.FC = () => {
     const classes = useClasses();
     const dispatch = useAppDispatch();
     const { instance, inProgress } = useMsal();
-    const msGraph = useGraph();
     const chatService = new ChatService(process.env.REACT_APP_BACKEND_URI as string);
     const { alerts } = useAppSelector((state: RootState) => state.app);
 
     const { conversations, selectedId } = useAppSelector((state: RootState) => state.conversations);
     const chatName = conversations[selectedId].title;
-    const chatUsers = conversations[selectedId].users;
 
     const [title = '', setTitle] = useState<string | undefined>(selectedId);
     const [isEditing, setIsEditing] = useState<boolean>(false);
-
-    useEffect(() => {
-        if (!conversations[selectedId].userDataLoaded) {
-            void msGraph.loadUsers(chatUsers.map((user: IChatUser) => user.id)).then(() => {
-                dispatch(setUsersLoaded(selectedId));
-            });
-        }
-
-        // Limiting dependencies or else this effect is triggered on all user typing events or new chat messages
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedId, chatUsers.length]);
 
     const onSave = async () => {
         if (chatName !== title) {

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-history/ChatHistoryItem.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-history/ChatHistoryItem.tsx
@@ -10,9 +10,9 @@ import { Breakpoints } from '../../../styles';
 import { timestampToDateString } from '../../utils/TextUtils';
 import { PlanViewer } from '../plan-viewer/PlanViewer';
 import { PromptDetails } from '../prompt-details/PromptDetails';
+import * as utils from './../../utils/TextUtils';
 import { ChatHistoryDocumentContent } from './ChatHistoryDocumentContent';
 import { ChatHistoryTextContent } from './ChatHistoryTextContent';
-import * as utils from './../../utils/TextUtils';
 
 const useClasses = makeStyles({
     root: {
@@ -41,7 +41,7 @@ const useClasses = makeStyles({
         ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalL),
     },
     me: {
-        backgroundColor: "#e8ebf9",
+        backgroundColor: '#e8ebf9',
     },
     time: {
         color: tokens.colorNeutralForeground3,
@@ -75,8 +75,8 @@ export const ChatHistoryItem: React.FC<ChatHistoryItemProps> = ({ message, getRe
 
     const isMe = message.authorRole === AuthorRoles.User && message.userId === activeUserInfo?.id;
     const isBot = message.authorRole === AuthorRoles.Bot;
-    const user = chat.getChatUserById(message.userName, selectedId, conversations[selectedId].users);
-    const fullName = user?.fullName ?? message.userName;
+    const user = chat.getChatUserById(message.userId, selectedId);
+    const fullName = user?.displayName ?? 'External User';
 
     const avatar = isBot
         ? { image: { src: conversations[selectedId].botProfilePicture } }

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -68,7 +68,7 @@ const useClasses = makeStyles({
         whiteSpace: 'nowrap',
         lineHeight: tokens.lineHeightBase100,
         color: tokens.colorNeutralForeground2,
-        ...shorthands.overflow('hidden')
+        ...shorthands.overflow('hidden'),
     },
     popoverSurface: {
         display: 'none',
@@ -79,7 +79,7 @@ const useClasses = makeStyles({
     },
     selected: {
         backgroundColor: tokens.colorNeutralBackground1,
-    }
+    },
 });
 
 interface IChatListItemProps {
@@ -121,9 +121,7 @@ export const ChatListItem: FC<IChatListItemProps> = ({
                     <Persona avatar={{ image: { src: botProfilePicture } }} presence={{ status: 'available' }} />
                     <div className={classes.body}>
                         <div className={classes.header}>
-                            <Text className={classes.title}>
-                                {header}
-                            </Text>
+                            <Text className={classes.title}>{header}</Text>
                             <Text className={classes.timestamp} size={300}>
                                 {time}
                             </Text>
@@ -141,7 +139,7 @@ export const ChatListItem: FC<IChatListItemProps> = ({
                 </div>
             </PopoverTrigger>
             <PopoverSurface className={classes.popoverSurface}>
-                <Text weight="bold">{Constants.bot.profile.fullName}</Text>
+                <Text weight="bold">{Constants.bot.profile.displayName}</Text>
                 <Text>{time}</Text>
             </PopoverSurface>
         </Popover>

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/controls/ParticipantsList.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/controls/ParticipantsList.tsx
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+import { FC, useEffect } from 'react';
+
+import {
+    Avatar,
+    Persona,
+    Popover,
+    PopoverSurface,
+    PopoverTrigger,
+    Tooltip,
+    makeStyles,
+    shorthands,
+    tokens,
+} from '@fluentui/react-components';
+import { IChatUser } from '../../../libs/models/ChatUser';
+import { useGraph } from '../../../libs/useGraph';
+import { useAppDispatch, useAppSelector } from '../../../redux/app/hooks';
+import { RootState } from '../../../redux/app/store';
+import { setUsersLoaded } from '../../../redux/features/conversations/conversationsSlice';
+import { ScrollBarStyles } from '../../../styles';
+
+interface ShareBotMenuProps {
+    participants: IChatUser[];
+}
+const useClasses = makeStyles({
+    root: {
+        display: 'flex',
+        ...ScrollBarStyles,
+        ...shorthands.padding(tokens.spacingVerticalNone, tokens.spacingVerticalXS),
+        ...shorthands.border(tokens.spacingVerticalM),
+        ...shorthands.borderRight(tokens.spacingHorizontalXS),
+    },
+    list: {
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'min-content',
+        maxHeight: '220px',
+        width: '200px',
+        overflowWrap: 'anywhere',
+        ...shorthands.gap(tokens.spacingVerticalS),
+    },
+});
+
+export const ParticipantsList: FC<ShareBotMenuProps> = ({ participants }) => {
+    const classes = useClasses();
+    const dispatch = useAppDispatch();
+    const { users } = useAppSelector((state: RootState) => state.users);
+    const { conversations, selectedId } = useAppSelector((state: RootState) => state.conversations);
+    const msGraph = useGraph();
+
+    const chatUsers = conversations[selectedId].users;
+
+    useEffect(() => {
+        if (!conversations[selectedId].userDataLoaded) {
+            void msGraph.loadUsers(chatUsers.map((user: IChatUser) => user.id)).then(() => {
+                dispatch(setUsersLoaded(selectedId));
+            });
+        }
+
+        // Limiting dependencies or else this effect is triggered on all user typing events or new chat messages
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedId, chatUsers.length]);
+
+    return (
+        <Popover positioning={'below-end'} size="small">
+            <PopoverTrigger>
+                <Tooltip content="Chat participants" relationship="label">
+                    <Avatar initials={`+${Math.min(participants.length, 100)}`} />
+                </Tooltip>
+            </PopoverTrigger>
+            <PopoverSurface className={classes.root}>
+                <div className={classes.list}>
+                    {participants.map((participant) => (
+                        <Persona
+                            textAlignment="center"
+                            name={
+                                // falsy lint check, users[userId] can be null if user data hasn't been loaded
+                                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                users[participant.id.split('.')[0]]?.displayName ?? participant.id
+                            }
+                            key={participant.id}
+                            avatar={{ color: 'colorful' }}
+                        />
+                    ))}
+                </div>
+            </PopoverSurface>
+        </Popover>
+    );
+};

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/controls/ShareBotMenu.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/controls/ShareBotMenu.tsx
@@ -4,9 +4,9 @@ import React, { FC, useCallback } from 'react';
 
 import { Button, Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Tooltip } from '@fluentui/react-components';
 import { ArrowDownloadRegular, PeopleTeamAddRegular, ShareRegular } from '@fluentui/react-icons';
-import { useChat } from '../../libs/useChat';
-import { useFile } from '../../libs/useFile';
-import { InvitationCreateDialog } from './invitation-dialog/InvitationCreateDialog';
+import { useChat } from '../../../libs/useChat';
+import { useFile } from '../../../libs/useFile';
+import { InvitationCreateDialog } from '../invitation-dialog/InvitationCreateDialog';
 
 interface ShareBotMenuProps {
     chatId: string;
@@ -39,10 +39,18 @@ export const ShareBotMenu: FC<ShareBotMenuProps> = ({ chatId, chatTitle }) => {
                 </MenuTrigger>
                 <MenuPopover>
                     <MenuList>
-                        <MenuItem data-testid="downloadBotMenuItem" icon={<ArrowDownloadRegular />} onClick={onDownloadBotClick}>
+                        <MenuItem
+                            data-testid="downloadBotMenuItem"
+                            icon={<ArrowDownloadRegular />}
+                            onClick={onDownloadBotClick}
+                        >
                             Download your Bot
                         </MenuItem>
-                        <MenuItem data-testid="inviteOthersMenuItem" icon={<PeopleTeamAddRegular />} onClick={() => setIsGettingInvitationId(true)}>
+                        <MenuItem
+                            data-testid="inviteOthersMenuItem"
+                            icon={<PeopleTeamAddRegular />}
+                            onClick={() => setIsGettingInvitationId(true)}
+                        >
                             Invite others to your Bot
                         </MenuItem>
                     </MenuList>

--- a/samples/apps/copilot-chat-app/webapp/src/components/header/UserSettings.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/header/UserSettings.tsx
@@ -52,8 +52,8 @@ export const UserSettings: FC<IUserSettingsProps> = ({ setLoadingState }) => {
                 {
                     <Avatar
                         className={classes.root}
-                        key={activeUserInfo?.username}
-                        name={activeUserInfo?.username}
+                        key={activeUserInfo?.displayName as string}
+                        name={activeUserInfo?.displayName as string}
                         size={28}
                         badge={{ status: 'available' }}
                     />
@@ -63,14 +63,16 @@ export const UserSettings: FC<IUserSettingsProps> = ({ setLoadingState }) => {
                 <MenuList>
                     <MenuItem className={classes.persona}>
                         <Persona
-                            name={activeUserInfo?.username}
-                            secondaryText={activeUserInfo?.email}
+                            name={activeUserInfo?.displayName as string}
+                            secondaryText={activeUserInfo?.userPrincipalName as string}
                             presence={{ status: 'available' }}
                             avatar={{ color: 'colorful' }}
                         />
                     </MenuItem>
                     <MenuDivider />
-                    <MenuItem data-testid="logOutMenuButton" onClick={onLogout}>Sign out</MenuItem>
+                    <MenuItem data-testid="logOutMenuButton" onClick={onLogout}>
+                        Sign out
+                    </MenuItem>
                 </MenuList>
             </MenuPopover>
         </Menu>

--- a/samples/apps/copilot-chat-app/webapp/src/libs/auth/AuthHelper.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/auth/AuthHelper.ts
@@ -62,9 +62,15 @@ const ssoSilentRequest = async (msalInstance: IPublicClientApplication) => {
 
 const loginAsync = async (instance: IPublicClientApplication) => {
     if (Constants.msal.method === 'redirect') {
-        await instance.loginRedirect({ scopes: Constants.msal.semanticKernelScopes });
+        await instance.loginRedirect({
+            scopes: Constants.msal.semanticKernelScopes,
+            extraScopesToConsent: Constants.msal.msGraphAppScopes,
+        });
     } else {
-        await instance.loginPopup({ scopes: Constants.msal.semanticKernelScopes });
+        await instance.loginPopup({
+            scopes: Constants.msal.semanticKernelScopes,
+            extraScopesToConsent: Constants.msal.msGraphAppScopes,
+        });
     }
 };
 

--- a/samples/apps/copilot-chat-app/webapp/src/libs/models/ChatMessage.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/models/ChatMessage.ts
@@ -33,8 +33,7 @@ export enum ChatMessageType {
 export interface IChatMessage {
     type: ChatMessageType;
     timestamp: number;
-    userName: 'bot' | string;
-    userId: string;
+    userId: 'bot' | string;
     content: string;
     id?: string;
     prompt?: string;

--- a/samples/apps/copilot-chat-app/webapp/src/libs/models/ChatUser.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/models/ChatUser.ts
@@ -3,8 +3,5 @@
 export interface IChatUser {
     id: string;
     online: boolean;
-    fullName: string;
-    emailAddress: string;
-    photo: string | undefined; // TODO: change this to required when we enable token / Graph support
     isTyping: boolean;
 }

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/DocumentImportService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/DocumentImportService.ts
@@ -4,16 +4,9 @@ import { IChatMessage } from '../models/ChatMessage';
 import { BaseService } from './BaseService';
 
 export class DocumentImportService extends BaseService {
-    public importDocumentAsync = async (
-        userId: string,
-        userName: string,
-        chatId: string,
-        document: File,
-        accessToken: string,
-    ) => {
+    public importDocumentAsync = async (userId: string, chatId: string, document: File, accessToken: string) => {
         const formData = new FormData();
         formData.append('userId', userId);
-        formData.append('userName', userName);
         formData.append('chatId', chatId);
         formData.append('documentScope', 'Chat');
         formData.append('formFile', document);

--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/GraphService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/GraphService.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+import { BaseService } from './BaseService';
+
+export interface BatchRequest {
+    id: string;
+    method: 'GET' | 'POST' | 'PUT' | 'UPDATE' | 'DELETE';
+    url: string;
+    headers: any;
+}
+
+export interface BatchResponseBody {
+    responses: BatchResponse[];
+}
+
+export interface BatchResponse {
+    id: number;
+    status: number;
+    body?: any;
+    headers?: any;
+}
+
+export class GraphService extends BaseService {
+    constructor() {
+        super('https://graph.microsoft.com');
+    }
+
+    private version = 'v1.0';
+
+    private getCommandPath = (resourcePath: string) => {
+        return `/${this.version}/${resourcePath}`;
+    };
+
+    public makeBatchRequest = async (batchRequests: BatchRequest[], accessToken: string) => {
+        const result = await this.getResponseAsync<BatchResponseBody>(
+            {
+                commandPath: this.getCommandPath('$batch'),
+                method: 'POST',
+                body: { requests: batchRequests },
+            },
+            accessToken,
+        );
+
+        return result.responses;
+    };
+}

--- a/samples/apps/copilot-chat-app/webapp/src/libs/useChat.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/useChat.ts
@@ -83,6 +83,7 @@ export const useChat = () => {
                     botProfilePicture: getBotProfilePicture(Object.keys(conversations).length),
                     input: '',
                     isBotTyping: false,
+                    userDataLoaded: false,
                 };
 
                 dispatch(addConversation(newChat));
@@ -153,6 +154,7 @@ export const useChat = () => {
                         botProfilePicture: getBotProfilePicture(Object.keys(loadedConversations).length),
                         input: '',
                         isBotTyping: false,
+                        userDataLoaded: false,
                     };
                 }
 
@@ -207,7 +209,7 @@ export const useChat = () => {
             });
     };
 
-    const getBotProfilePicture = (index: number) => {
+    const getBotProfilePicture = (index: number): string => {
         return botProfilePictures[index % botProfilePictures.length];
     };
 
@@ -267,6 +269,7 @@ export const useChat = () => {
                     botProfilePicture: getBotProfilePicture(Object.keys(conversations).length),
                     input: '',
                     isBotTyping: false,
+                    userDataLoaded: false,
                 };
 
                 dispatch(addConversation(newChat));

--- a/samples/apps/copilot-chat-app/webapp/src/libs/useGraph.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/useGraph.ts
@@ -1,0 +1,156 @@
+import { useMsal } from '@azure/msal-react';
+import { Constants } from '../Constants';
+import { useAppDispatch, useAppSelector } from '../redux/app/hooks';
+import { RootState } from '../redux/app/store';
+import { addAlert } from '../redux/features/app/appSlice';
+import { UserData } from '../redux/features/users/UsersState';
+import { setUsers } from '../redux/features/users/usersSlice';
+import { TokenHelper } from './auth/TokenHelper';
+import { AlertType } from './models/AlertType';
+import { BatchRequest, BatchResponse, GraphService } from './services/GraphService';
+
+export const useGraph = () => {
+    const { instance, inProgress } = useMsal();
+    const { users } = useAppSelector((state: RootState) => state.users);
+    const { activeUserInfo } = useAppSelector((state: RootState) => state.app);
+    const dispatch = useAppDispatch();
+    const graphService = new GraphService();
+
+    const loadUsers = async (userIds: string[]) => {
+        const MAX_RETRIES = 3;
+        let retries = 1;
+
+        // Initialize empty arrays to store results
+        const usersToLoad: string[] = [];
+        const loadedUsers: UserData[] = [];
+        const usersToRetry: string[] = [];
+
+        try {
+            // Copy current state of user data
+            const userData = { ...users };
+
+            // Filter user Ids list to optimize fetch
+            userIds.forEach((userId) => {
+                const ids = userId.split('.');
+                const objectId = ids[0]; // Unique GUID assigned to each user in their home tenant
+                const tenantId = ids[1]; // Home tenant id
+
+                // Active user can only access user data within their own tenant
+                // Mark chat users outside of tenant as External
+                if (activeUserInfo && tenantId !== activeUserInfo.id.split('.')[1]) {
+                    userData[objectId] = {
+                        id: objectId,
+                        displayName: 'External User',
+                    };
+                } else {
+                    // Only fetch users that haven't already been loaded
+                    if (!(objectId in users)) {
+                        usersToLoad.push(objectId);
+                    }
+                }
+            });
+
+            if (usersToLoad.length > 0) {
+                await makeBatchGetUsersRequest(usersToLoad, loadedUsers, usersToRetry);
+
+                // Retry any users that failed with transient (5xx) errors up to 3 times
+                while (usersToRetry.length > 0 && retries <= MAX_RETRIES) {
+                    console.log(`Retrying batch request  ${retries}/${MAX_RETRIES}`);
+                    await makeBatchGetUsersRequest(usersToRetry, loadedUsers, usersToRetry);
+                    retries++;
+                }
+
+                // Populate user data record to update state
+                loadedUsers.forEach((user) => {
+                    userData[user.id] = user;
+                });
+
+                usersToRetry.forEach((userId) => {
+                    userData[userId] = {
+                        id: userId,
+                        displayName: 'Unknown',
+                    };
+                });
+            }
+
+            dispatch(setUsers(userData));
+        } catch (e: unknown) {
+            dispatch(
+                addAlert({
+                    type: AlertType.Error,
+                    message: e as string,
+                }),
+            );
+        }
+    };
+
+    // Helper function to fetch user data in batches of up to 20
+    const makeBatchGetUsersRequest = async (userIds: string[], loadedUsers: UserData[], usersToRetry: string[]) => {
+        const getUserScope = 'User.Read';
+
+        const token = await TokenHelper.getAccessTokenUsingMsal(inProgress, instance, [getUserScope]);
+
+        // Loop through the user ids in chunks of the maximum batch size
+        for (let i = 0; i < userIds.length; i += Constants.BATCH_REQUEST_LIMIT) {
+            // Slice the current chunk of user ids
+            const chunk = userIds.slice(i, i + Constants.BATCH_REQUEST_LIMIT);
+
+            // Create an array of batch requests for the chunk
+            const requests = chunk.map((id, index) => createGetUserRequest(id, i + index));
+
+            // Send the batch request using Graph Service
+            const responses: BatchResponse[] = await graphService.makeBatchRequest(requests, token);
+
+            // Loop through the batch responses and parse the user data
+            for (const response of responses) {
+                const userData = parseGetUserResponse(response, userIds, usersToRetry);
+                if (userData) {
+                    // Push the user data to the results array
+                    loadedUsers.push(userData);
+                }
+            }
+        }
+    };
+
+    // Helper function to create a GetUser request given a user id
+    const createGetUserRequest = (id: string, index: number): BatchRequest => {
+        return {
+            id: index.toString(),
+            method: 'GET',
+            url: `/users/${id}?$select=id,displayName,userPrincipalName`,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        };
+    };
+
+    // Helper function to extract the user data from a batch response
+    const parseGetUserResponse = (
+        response: BatchResponse,
+        userIds: string[],
+        usersToRetry: string[],
+    ): UserData | null => {
+        if (response.status === 200 && response.body) {
+            const user = response.body as UserData;
+            return {
+                id: user.id,
+                displayName: user.displayName,
+                userPrincipalName: user.userPrincipalName,
+            };
+        } else if (response.status >= 500) {
+            // Transient error, try again
+            usersToRetry.push(userIds[response.id]);
+        } else {
+            // Failed to fetch, user data unavailable
+            return {
+                id: userIds[response.id],
+                displayName: 'Unknown',
+            };
+        }
+        return null;
+    };
+
+    return {
+        loadUsers,
+    };
+};

--- a/samples/apps/copilot-chat-app/webapp/src/libs/useGraph.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/useGraph.ts
@@ -86,9 +86,9 @@ export const useGraph = () => {
 
     // Helper function to fetch user data in batches of up to 20
     const makeBatchGetUsersRequest = async (userIds: string[], loadedUsers: UserData[], usersToRetry: string[]) => {
-        const getUserScope = 'User.Read';
+        const listUsersScope = 'User.ReadBasic.All';
 
-        const token = await TokenHelper.getAccessTokenUsingMsal(inProgress, instance, [getUserScope]);
+        const token = await TokenHelper.getAccessTokenUsingMsal(inProgress, instance, [listUsersScope]);
 
         // Loop through the user ids in chunks of the maximum batch size
         for (let i = 0; i < userIds.length; i += Constants.BATCH_REQUEST_LIMIT) {

--- a/samples/apps/copilot-chat-app/webapp/src/redux/app/rootReducer.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/app/rootReducer.ts
@@ -4,6 +4,7 @@ import { AnyAction, combineReducers, createAction, Reducer } from '@reduxjs/tool
 import appReducer from '../features/app/appSlice';
 import conversationsReducer from '../features/conversations/conversationsSlice';
 import pluginsReducer from '../features/plugins/pluginsSlice';
+import usersReducer from '../features/users/usersSlice';
 import { RootState } from './store';
 
 // Define a top-level root state reset action
@@ -14,6 +15,7 @@ const rootReducer: Reducer<RootState> = combineReducers({
     app: appReducer,
     conversations: conversationsReducer,
     plugins: pluginsReducer,
+    users: usersReducer,
 });
 
 // Define a special resetApp reducer that handles resetting the entire state
@@ -25,6 +27,7 @@ export const resetAppReducer = (state: RootState | undefined, action: AnyAction)
             app: appReducer(undefined, action),
             conversations: conversationsReducer(undefined, action),
             plugins: pluginsReducer(undefined, action),
+            users: usersReducer(undefined, action),
         };
     }
 

--- a/samples/apps/copilot-chat-app/webapp/src/redux/app/store.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/app/store.ts
@@ -9,6 +9,7 @@ import {
     startSignalRConnection,
 } from '../features/message-relay/signalRMiddleware';
 import { PluginsState } from '../features/plugins/PluginsState';
+import { UsersState } from '../features/users/UsersState';
 import resetStateReducer, { resetApp } from './rootReducer';
 
 export type StoreMiddlewareAPI = MiddlewareAPI<Dispatch, RootState>;
@@ -28,6 +29,7 @@ export interface RootState {
     app: AppState;
     conversations: ConversationsState;
     plugins: PluginsState;
+    users: UsersState;
 }
 
 export const getSelectedChatID = (): string => {

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/app/AppState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/app/AppState.ts
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import { AlertType } from '../../../libs/models/AlertType';
+import { UserData } from '../users/UsersState';
 
 export interface AppState {
     alerts: Alert[];
-    activeUserInfo?: ActiveUserInfo;
-}
-
-export interface ActiveUserInfo {
-    id: string;
-    email: string;
-    username: string;
+    activeUserInfo?: UserData;
 }
 
 export interface Alert {

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/app/appSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/app/appSlice.ts
@@ -2,7 +2,8 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AlertType } from '../../../libs/models/AlertType';
-import { ActiveUserInfo, Alert, AppState } from './AppState';
+import { UserData } from '../users/UsersState';
+import { Alert, AppState } from './AppState';
 
 const initialState: AppState = {
     alerts: [
@@ -30,7 +31,7 @@ export const appSlice = createSlice({
         removeAlert: (state: AppState, action: PayloadAction<number>) => {
             state.alerts.splice(action.payload, 1);
         },
-        setActiveUserInfo: (state: AppState, action: PayloadAction<ActiveUserInfo>) => {
+        setActiveUserInfo: (state: AppState, action: PayloadAction<UserData>) => {
             state.activeUserInfo = action.payload;
         },
     },

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/ChatState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/ChatState.ts
@@ -12,4 +12,5 @@ export interface ChatState {
     lastUpdatedTimestamp?: number;
     input: string;
     isBotTyping: boolean;
+    userDataLoaded: boolean;
 }

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -10,7 +10,7 @@ import {
     Conversations,
     ConversationsState,
     ConversationTitleChange,
-    initialState
+    initialState,
 } from './ConversationsState';
 
 export const conversationsSlice: Slice<ConversationsState> = createSlice({
@@ -45,6 +45,10 @@ export const conversationsSlice: Slice<ConversationsState> = createSlice({
         ) => {
             const { user, chatId } = action.payload;
             state.conversations[chatId].users.push(user);
+            state.conversations[chatId].userDataLoaded = false;
+        },
+        setUsersLoaded: (state: ConversationsState, action: PayloadAction<string>) => {
+            state.conversations[action.payload].userDataLoaded = true;
         },
         /*
          * updateConversationFromUser() and updateConversationFromServer() both update the conversations state.
@@ -122,6 +126,7 @@ export const {
     updateMessageState,
     updateUserIsTyping,
     updateUserIsTypingFromServer,
+    setUsersLoaded,
 } = conversationsSlice.actions;
 
 export default conversationsSlice.reducer;

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/message-relay/signalRMiddleware.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/message-relay/signalRMiddleware.ts
@@ -159,7 +159,6 @@ export const registerSignalREvents = (store: Store) => {
         const message = {
             type: messageType,
             timestamp: new Date().getTime(),
-            userName: 'bot',
             userId: 'bot',
             content: askResult.value,
             prompt: askResult.variables.find((v) => v.key === 'prompt')?.value,
@@ -178,10 +177,7 @@ export const registerSignalREvents = (store: Store) => {
         const user: IChatUser = {
             id: userId,
             online: false,
-            fullName: '',
-            emailAddress: '',
             isTyping: false,
-            photo: '',
         };
         store.dispatch({ type: 'conversations/addUserToConversation', payload: { user, chatId } });
     });
@@ -200,8 +196,8 @@ export const registerSignalREvents = (store: Store) => {
         store.dispatch({ type: 'conversations/updateBotIsTypingFromServer', payload: { chatId, isTyping } });
     });
 
-    hubConnection.on(SignalRCallbackMethods.GlobalDocumentUploaded, (fileName: string, userName: string) => {
-        store.dispatch(addAlert({ message: `${userName} uploaded ${fileName} to all chats`, type: AlertType.Info }));
+    hubConnection.on(SignalRCallbackMethods.GlobalDocumentUploaded, (fileName: string) => {
+        store.dispatch(addAlert({ message: `${fileName} uploaded to all chats`, type: AlertType.Info }));
     });
 
     hubConnection.on(SignalRCallbackMethods.ChatDocumentUploaded, (message: IChatMessage, chatId: string) => {

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/plugins/PluginsState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/plugins/PluginsState.ts
@@ -68,7 +68,7 @@ export const initialState: PluginsState = {
         enabled: false,
         authRequirements: {
             Msal: true,
-            scopes: Constants.msGraphScopes,
+            scopes: Constants.msGraphPluginScopes,
         },
         headerTag: AuthHeaderTags.MsGraph,
         icon: GraphIcon,

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/users/UsersState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/users/UsersState.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+export interface UsersState {
+    users: Users;
+}
+
+export const initialState: UsersState = {
+    users: {},
+};
+
+export type Users = Record<string, UserData>;
+
+export interface UserData {
+    id: string;
+    displayName?: string;
+    userPrincipalName?: string;
+}

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/users/UsersState.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/users/UsersState.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+import { Constants } from '../../../Constants';
+
 export interface UsersState {
     users: Users;
 }
 
 export const initialState: UsersState = {
-    users: {},
+    users: {
+        bot: Constants.bot.profile,
+    },
 };
 
 export type Users = Record<string, UserData>;
@@ -13,5 +17,6 @@ export type Users = Record<string, UserData>;
 export interface UserData {
     id: string;
     displayName?: string;
-    userPrincipalName?: string;
+    userPrincipalName?: string; // email
+    photo?: string | undefined; // TODO: change this to required when we enable token / Graph support
 }

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/users/usersSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/users/usersSlice.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { initialState, Users, UsersState } from './UsersState';
+
+export const usersSlice = createSlice({
+    name: 'users',
+    initialState,
+    reducers: {
+        setUsers: (state: UsersState, action: PayloadAction<Users>) => {
+            state.users = action.payload;
+        },
+    },
+});
+
+export const { setUsers } = usersSlice.actions;
+
+export default usersSlice.reducer;

--- a/samples/apps/copilot-chat-app/webapp/src/redux/features/users/usersSlice.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/redux/features/users/usersSlice.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { initialState, Users, UsersState } from './UsersState';
+import { initialState, UserData, Users, UsersState } from './UsersState';
 
 export const usersSlice = createSlice({
     name: 'users',
@@ -10,9 +10,16 @@ export const usersSlice = createSlice({
         setUsers: (state: UsersState, action: PayloadAction<Users>) => {
             state.users = action.payload;
         },
+        addUser: (state: UsersState, action: PayloadAction<UserData>) => {
+            const newUser = action.payload;
+            state.users = {
+                ...state.users,
+                [newUser.id]: action.payload,
+            };
+        },
     },
 });
 
-export const { setUsers } = usersSlice.actions;
+export const { setUsers, addUser } = usersSlice.actions;
 
 export default usersSlice.reducer;

--- a/samples/apps/copilot-chat-app/webapp/src/styles.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/styles.tsx
@@ -1,22 +1,22 @@
 import { BrandVariants, GriffelStyle, createLightTheme, tokens } from '@fluentui/react-components';
 
 const semanticKernelBrandRamp: BrandVariants = {
-    10: "#060103",
-    20: "#261018",
-    30: "#431426",
-    40: "#591732",
-    50: "#701A3E",
-    60: "#861F4B",
-    70: "#982C57",
-    80: "#A53E63",
-    90: "#B15070",
-    100: "#BC627E",
-    110: "#C6748B",
-    120: "#CF869A",
-    130: "#D898A8",
-    140: "#E0AAB7",
-    150: "#E8BCC6",
-    160: "#EFCFD6"
+    10: '#060103',
+    20: '#261018',
+    30: '#431426',
+    40: '#591732',
+    50: '#701A3E',
+    60: '#861F4B',
+    70: '#982C57',
+    80: '#A53E63',
+    90: '#B15070',
+    100: '#BC627E',
+    110: '#C6748B',
+    120: '#CF869A',
+    130: '#D898A8',
+    140: '#E0AAB7',
+    150: '#E8BCC6',
+    160: '#EFCFD6',
 };
 
 export const semanticKernelLightTheme = createLightTheme(semanticKernelBrandRamp);
@@ -27,20 +27,24 @@ export const Breakpoints = {
     },
 };
 
+export const ScrollBarStyles: GriffelStyle = {
+    overflowY: 'scroll',
+    '&:hover': {
+        '&::-webkit-scrollbar-thumb': {
+            backgroundColor: tokens.colorScrollbarOverlay,
+            visibility: 'visible',
+        },
+        '&::-webkit-scrollbar-track': {
+            backgroundColor: tokens.colorNeutralBackground1,
+            WebkitBoxShadow: 'inset 0 0 5px rgba(0, 0, 0, 0.1)',
+            visibility: 'visible',
+        },
+    },
+};
+
 export const SharedStyles: Record<string, GriffelStyle> = {
     scroll: {
-        overflowY: 'scroll',
-        '&:hover': {
-            '&::-webkit-scrollbar-thumb': {
-                backgroundColor: tokens.colorScrollbarOverlay,
-                visibility: 'visible',
-            },
-            '&::-webkit-scrollbar-track': {
-                backgroundColor: tokens.colorNeutralBackground1,
-                WebkitBoxShadow: 'inset 0 0 5px rgba(0, 0, 0, 0.1)',
-                visibility: 'visible',
-            },
-        },
         height: '100%',
+        ...ScrollBarStyles,
     },
 };


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This PR removes all instances of saved usernames from backend memory stores to alleviate any PII concerns. We now only store user Id, which is used in the UI to query user data and display usernames.

Displaying usernames follow the same convention set in this PR: https://github.com/microsoft/semantic-kernel/pull/1899, where the active user only has access to user info within their own tenant, so any user outside of the tenant will be displayed as "External User".
![image](https://github.com/microsoft/semantic-kernel/assets/125500434/b9ecf687-14fc-4d96-8030-e2b1aef5c555)


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
