### PR TITLE
.Net: Enhance Debugging with Additional Log Messages for Function/Kernel/Planner/Chain Invocation

### DIFF
--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -176,7 +176,7 @@ public sealed class Kernel : IKernel, IDisposable
             this.Log,
             cancellationToken);
 
-        this.Log.LogDebug("Executing kernel, Executing {0} functions in pipleine", pipeline.Length);
+        this.Log.LogDebug("Executing kernel, Executing {0} functions in pipeline", pipeline.Length);
         int pipelineStepCount = -1;
         foreach (ISKFunction f in pipeline)
         {

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -176,6 +176,7 @@ public sealed class Kernel : IKernel, IDisposable
             this.Log,
             cancellationToken);
 
+        this.Log.LogDebug("Executing kernel, Executing {0} functions in pipleine", pipeline.Length);
         int pipelineStepCount = -1;
         foreach (ISKFunction f in pipeline)
         {
@@ -192,6 +193,11 @@ public sealed class Kernel : IKernel, IDisposable
             try
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
+                this.Log.LogDebug($"Kernel execution, Start execute {0}/{1} function: {2}.{3}",
+                    pipelineStepCount + 1,
+                    pipeline.Length,
+                    f.SkillName,
+                    f.Name);
                 context = await f.InvokeAsync(context).ConfigureAwait(false);
 
                 if (context.ErrorOccurred)
@@ -200,6 +206,11 @@ public sealed class Kernel : IKernel, IDisposable
                         pipelineStepCount, f.SkillName, f.Name, context.LastErrorDescription);
                     return context;
                 }
+                this.Log.LogDebug($"Kernel execution, Finish successfully execute {0}/{1} function: {2}.{3}",
+                    pipelineStepCount + 1,
+                    pipeline.Length,
+                    f.SkillName,
+                    f.Name);
             }
             catch (Exception e) when (!e.IsCriticalException())
             {

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -193,7 +193,7 @@ public sealed class Kernel : IKernel, IDisposable
             try
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
-                this.Log.LogDebug($"Kernel execution, Start execute {0}/{1} function: {2}.{3}",
+                this.Log.LogDebug("Kernel execution, Start execute {0}/{1} function: {2}.{3}",
                     pipelineStepCount + 1,
                     pipeline.Length,
                     f.SkillName,
@@ -206,7 +206,7 @@ public sealed class Kernel : IKernel, IDisposable
                         pipelineStepCount, f.SkillName, f.Name, context.LastErrorDescription);
                     return context;
                 }
-                this.Log.LogDebug($"Kernel execution, Finish successfully execute {0}/{1} function: {2}.{3}",
+                this.Log.LogDebug("Kernel execution, Finish successfully execute {0}/{1} function: {2}.{3}",
                     pipelineStepCount + 1,
                     pipeline.Length,
                     f.SkillName,

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -253,12 +253,22 @@ public sealed class Plan : ISKFunction
             var functionContext = new SKContext(functionVariables, context.Memory, context.Skills, context.Log, context.CancellationToken);
             var result = await step.InvokeAsync(functionContext).ConfigureAwait(false);
             var resultValue = result.Result.Trim();
-
             if (result.ErrorOccurred)
             {
+                result.Log.LogDebug("Executing pipeline, Step {0}/{1}: {2}.{3}, Failed, Error description: {4}",
+                  this.NextStepIndex,
+                  this.Steps.Count,
+                  this.Name,
+                  this.SkillName,
+                  result.LastErrorDescription);
                 throw new KernelException(KernelException.ErrorCodes.FunctionInvokeError,
                     $"Error occurred while running plan step: {result.LastErrorDescription}", result.LastException);
             }
+            result.Log.LogDebug("Executing pipeline, Step {0}/{1}: {2}.{3} Finished successfully",
+                this.NextStepIndex,
+                this.Steps.Count,
+                this.Name,
+                this.SkillName);
 
             #region Update State
 

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -239,18 +239,18 @@ public sealed class SKFunction : ISKFunction, IDisposable
         {
             try
             {
-                this._log.LogDebug($"Executing function {0}.{1}",
+                this._log.LogDebug("Executing function {0}.{1}",
                     this.SkillName,
                     this.Name);
                 context = await this._function(null, settings, context).ConfigureAwait(false);
                 if (context.ErrorOccurred)
                 {
-                    this._log.LogDebug($"Executing function {0}.{1} finished successfully",
+                    this._log.LogDebug("Executing function {0}.{1} finished successfully",
                         this.SkillName,
                         this.Name);
                 } else
                 {
-                    this._log.LogDebug($"Executing function {0}.{1} finished failed, Error Description: {2}",
+                    this._log.LogDebug("Executing function {0}.{1} finished failed, Error Description: {2}",
                         this.SkillName,
                         this.Name,
                         context.LastErrorDescription);

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -240,19 +240,19 @@ public sealed class SKFunction : ISKFunction, IDisposable
             try
             {
                 this._log.LogDebug($"Executing function {0}.{1}",
-                    SkillName,
-                    Name);
+                    this.SkillName,
+                    this.Name);
                 context = await this._function(null, settings, context).ConfigureAwait(false);
                 if (context.ErrorOccurred)
                 {
                     this._log.LogDebug($"Executing function {0}.{1} finished successfully",
-                        SkillName,
-                        Name);
+                        this.SkillName,
+                        this.Name);
                 } else
                 {
                     this._log.LogDebug($"Executing function {0}.{1} finished failed, Error Description: {2}",
-                        SkillName,
-                        Name,
+                        this.SkillName,
+                        this.Name,
                         context.LastErrorDescription);
                 }
             }

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -239,7 +239,22 @@ public sealed class SKFunction : ISKFunction, IDisposable
         {
             try
             {
+                this._log.LogDebug($"Executing function {0}.{1}",
+                    SkillName,
+                    Name);
                 context = await this._function(null, settings, context).ConfigureAwait(false);
+                if (context.ErrorOccurred)
+                {
+                    this._log.LogDebug($"Executing function {0}.{1} finished successfully",
+                        SkillName,
+                        Name);
+                } else
+                {
+                    this._log.LogDebug($"Executing function {0}.{1} finished failed, Error Description: {2}",
+                        SkillName,
+                        Name,
+                        context.LastErrorDescription);
+                }
             }
             catch (Exception e) when (!e.IsCriticalException())
             {


### PR DESCRIPTION
Issue: #1949 

### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
Enhancing our applications' transparency is key to effective debugging and monitoring, especially for applications delivered to customers. With the current lack of LogTrace messages related to specific OpenAI calls, troubleshooting can become cumbersome and inefficient. This change is, therefore, required to solve this problem and contribute to a smoother debugging experience.

This PR adds more LogTrace messages indicating when specific OpenAI calls are made. The added LogTrace messages will cover the following invocations:

* Function Invoke
* Kernel Invoke
* Planner Invoke
* Chain Invoke
* This approach aims to enrich our debugging tools and provide better visibility into the execution of these crucial parts of our software.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
