### PR TITLE
Java: Fix invoking Action planner not copying the invocation state

### DIFF
--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/orchestration/AbstractSkFunction.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/orchestration/AbstractSkFunction.java
@@ -116,11 +116,12 @@ public abstract class AbstractSkFunction<RequestConfiguration>
         return functionName;
     }
 
-    public DelegateTypes getDelegateType() {
-        return delegateType;
-    }
-
-    public List<ParameterView> getParameters() {
+    /**
+     * The parameters of the function.
+     *
+     * @return The parameters of the function.
+     */
+    public List<ParameterView> getParametersView() {
         return Collections.unmodifiableList(parameters);
     }
 

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/DefaultCompletionSKFunction.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/DefaultCompletionSKFunction.java
@@ -322,7 +322,7 @@ public class DefaultCompletionSKFunction
                 super.getName(),
                 super.getSkillName(),
                 super.getDescription(),
-                super.getParameters(),
+                super.getParametersView(),
                 true,
                 false);
     }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/NativeSKFunction.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/NativeSKFunction.java
@@ -63,7 +63,7 @@ public class NativeSKFunction extends AbstractSkFunction<Void> {
                 super.getName(),
                 super.getSkillName(),
                 super.getDescription(),
-                super.getParameters(),
+                super.getParametersView(),
                 false,
                 false);
     }

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/planner/actionplanner/ActionPlannerTest.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/planner/actionplanner/ActionPlannerTest.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.planner.actionplanner;
+
+import static com.microsoft.semantickernel.DefaultKernelTest.mockCompletionOpenAIAsyncClient;
+
+import com.azure.ai.openai.OpenAIAsyncClient;
+import com.microsoft.semantickernel.Kernel;
+import com.microsoft.semantickernel.builders.SKBuilders;
+import com.microsoft.semantickernel.skilldefinition.annotations.DefineSKFunction;
+import com.microsoft.semantickernel.skilldefinition.annotations.SKFunctionParameters;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import reactor.util.function.Tuples;
+
+public class ActionPlannerTest {
+
+    public static class SkillWithSomeArgs {
+        @DefineSKFunction(name = "aFunction")
+        public String aFunction(
+                @SKFunctionParameters(
+                                name = "input1",
+                                description = "The first input to the function")
+                        String input1,
+                @SKFunctionParameters(
+                                name = "input2",
+                                description = "The second input to the function")
+                        String input2) {
+            return "A-RESULT";
+        }
+    }
+
+    @Test
+    public void inputsAreCorrectlyPassed() {
+        OpenAIAsyncClient client =
+                mockCompletionOpenAIAsyncClient(
+                        Tuples.of(
+                                "plan",
+                                "{\n"
+                                        + "   \"plan\" : {\n"
+                                        + "      \"function\" : \"SkillWithSomeArgs.aFunction\",\n"
+                                        + "      \"parameters\" : {\n"
+                                        + "         \"input1\" : \"Cleopatra\",\n"
+                                        + "         \"input2\" : \"Anthony\"\n"
+                                        + "      },\n"
+                                        + "      \"rationale\" : \"na\"\n"
+                                        + "   }\n"
+                                        + "}\n"));
+
+        Kernel kernel =
+                SKBuilders.kernel()
+                        .withKernelConfig(
+                                SKBuilders.kernelConfig()
+                                        .addTextCompletionService(
+                                                "text-davinci-002",
+                                                kernel1 ->
+                                                        SKBuilders.textCompletionService()
+                                                                .build(client, "text-davinci-002"))
+                                        .build())
+                        .build();
+
+        SkillWithSomeArgs skill = Mockito.spy(new SkillWithSomeArgs());
+        kernel.importSkill(skill, "SkillWithSomeArgs");
+
+        ActionPlanner planner = new ActionPlanner(kernel, null);
+
+        String goal = "Write a poem about Cleopatra.";
+
+        Plan plan = planner.createPlanAsync(goal).block();
+        String planResult = plan.invokeAsync(goal).block().getResult();
+
+        Assertions.assertEquals("A-RESULT", planResult);
+
+        Mockito.verify(skill, Mockito.atLeastOnce()).aFunction("Cleopatra", "Anthony");
+    }
+}

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/syntaxexamples/Example28ActionPlannerTest.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/syntaxexamples/Example28ActionPlannerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import reactor.util.function.Tuples;
 
-public class Example28ActionPlanner {
+public class Example28ActionPlannerTest {
 
     @Test
     public void functionsArePassedToRequest() {
@@ -120,7 +120,7 @@ public class Example28ActionPlanner {
                 });
     }
 
-    private static ActionPlanner createPlanner(OpenAIAsyncClient client) {
+    public static ActionPlanner createPlanner(OpenAIAsyncClient client) {
         Kernel kernel =
                 SKBuilders.kernel()
                         .withKernelConfig(

--- a/java/semantickernel-extensions-parent/actionplanner-extension/src/main/java/com/microsoft/semantickernel/planner/actionplanner/ActionPlanner.java
+++ b/java/semantickernel-extensions-parent/actionplanner-extension/src/main/java/com/microsoft/semantickernel/planner/actionplanner/ActionPlanner.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.builders.SKBuilders;
 import com.microsoft.semantickernel.orchestration.SKContext;
+import com.microsoft.semantickernel.orchestration.SKFunction;
+import com.microsoft.semantickernel.orchestration.WritableContextVariables;
 import com.microsoft.semantickernel.planner.PlanningException;
 import com.microsoft.semantickernel.semanticfunctions.PromptTemplateConfig;
 import com.microsoft.semantickernel.skilldefinition.ReadOnlySkillCollection;
@@ -21,6 +23,8 @@ import reactor.core.publisher.Mono;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
@@ -36,6 +40,8 @@ import javax.annotation.Nullable;
 public class ActionPlanner {
     private static final Logger LOGGER = LoggerFactory.getLogger(ActionPlanner.class);
 
+    private static final Pattern CLEAN_PLAN =
+            Pattern.compile("[^{]*(\\{.*})[^}]*", Pattern.MULTILINE | Pattern.DOTALL);
     private static final String StopSequence = "#END-OF-PLAN";
     private static final String SkillName = "this";
 
@@ -111,9 +117,16 @@ public class ActionPlanner {
 
     private Plan parsePlan(String goal, SKContext result) {
         ActionPlanResponse planData;
+        // Clean up the plan, removing any prompt and the stop sequence
+        Matcher matcher = CLEAN_PLAN.matcher(result.getResult());
+
+        String plan = result.getResult();
+        if (matcher.matches()) {
+            plan = matcher.group(1);
+        }
 
         try {
-            planData = new ObjectMapper().readValue(result.getResult(), ActionPlanResponse.class);
+            planData = new ObjectMapper().readValue(plan, ActionPlanResponse.class);
         } catch (Exception e) {
             throw new PlanningException(
                     PlanningException.ErrorCodes.InvalidPlan,
@@ -127,29 +140,39 @@ public class ActionPlanner {
                     "The plan deserialized to a null object");
         }
 
-        CompletionSKFunction function = getPlanFunction(planData);
+        SKFunction function = getPlanFunction(planData);
+
+        WritableContextVariables variables = SKBuilders.variables().build().writableClone();
+
+        planData.plan
+                .parameters
+                .entrySet()
+                .forEach(
+                        entry -> {
+                            variables.setVariable(entry.getKey(), entry.getValue());
+                        });
 
         if (function == null) {
             // No function was found - return a plan with no steps.
-            return new Plan(goal, () -> kernel.getSkills());
+            return new Plan(goal, variables, () -> kernel.getSkills());
         } else {
-            return new Plan(goal, () -> kernel.getSkills(), function);
+            return new Plan(goal, variables, () -> kernel.getSkills(), function);
         }
     }
 
-    public CompletionSKFunction getPlanFunction(ActionPlanResponse planData) {
+    public SKFunction getPlanFunction(ActionPlanResponse planData) {
 
         if (planData.plan.function.contains(".")) {
             String[] parts = planData.plan.function.split("\\.", -1);
-            CompletionSKFunction skill =
-                    context.getSkills().getFunction(parts[0], parts[1], CompletionSKFunction.class);
+            SKFunction function =
+                    context.getSkills().getFunction(parts[0], parts[1], SKFunction.class);
 
-            if (skill == null) {
+            if (function == null) {
                 throw new PlanningException(
                         PlanningException.ErrorCodes.InvalidPlan,
-                        "Unknown skill " + planData.plan.function);
+                        "Unknown function " + planData.plan.function);
             }
-            return skill;
+            return function;
 
         } else if (!planData.plan.function.isEmpty()) {
             CompletionSKFunction function =

--- a/java/semantickernel-extensions-parent/actionplanner-extension/src/main/java/com/microsoft/semantickernel/planner/actionplanner/Plan.java
+++ b/java/semantickernel-extensions-parent/actionplanner-extension/src/main/java/com/microsoft/semantickernel/planner/actionplanner/Plan.java
@@ -11,7 +11,6 @@ import com.microsoft.semantickernel.skilldefinition.FunctionView;
 import com.microsoft.semantickernel.skilldefinition.KernelSkillsSupplier;
 import com.microsoft.semantickernel.skilldefinition.ParameterView;
 import com.microsoft.semantickernel.textcompletion.CompletionRequestSettings;
-import com.microsoft.semantickernel.textcompletion.CompletionSKFunction;
 
 import reactor.core.publisher.Mono;
 
@@ -68,7 +67,7 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
     }
 
     public Plan(
-            CompletionSKFunction function,
+            SKFunction<?> function,
             ContextVariables state,
             List<String> functionOutputs,
             KernelSkillsSupplier kernelSkillsSupplier) {
@@ -106,18 +105,26 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
     }
 
     public Plan(
-            CompletionSKFunction function,
+            SKFunction<?> function,
             List<String> functionOutputs,
             KernelSkillsSupplier kernelSkillsSupplier) {
         this(function, SKBuilders.variables().build(), functionOutputs, kernelSkillsSupplier);
     }
 
-    public Plan(CompletionSKFunction function, KernelSkillsSupplier kernelSkillsSupplier) {
+    public Plan(SKFunction<?> function, KernelSkillsSupplier kernelSkillsSupplier) {
         this(function, SKBuilders.variables().build(), new ArrayList<>(), kernelSkillsSupplier);
     }
 
     public Plan(
-            String goal, KernelSkillsSupplier kernelSkillsSupplier, CompletionSKFunction... steps) {
+            String goal,
+            ContextVariables parameters,
+            KernelSkillsSupplier kernelSkillsSupplier,
+            SKFunction... steps) {
+        this(goal, parameters, kernelSkillsSupplier);
+        this.addSteps(steps);
+    }
+
+    public Plan(String goal, KernelSkillsSupplier kernelSkillsSupplier, SKFunction... steps) {
         this(goal, kernelSkillsSupplier);
         this.addSteps(steps);
     }
@@ -168,7 +175,7 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
      *
      * @param steps The steps to add to the current plan.
      */
-    public void addSteps(CompletionSKFunction... steps) {
+    public void addSteps(SKFunction<?>... steps) {
         List<Plan> plans =
                 Arrays.stream(steps)
                         .map(step -> new Plan(step, getSkillsSupplier()))
@@ -328,6 +335,18 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
         if (input != null) {
             this.state = state.writableClone().update(input);
         }
+
+        if (context == null) {
+            context =
+                    SKBuilders.context()
+                            .with(state)
+                            .with(getSkillsSupplier() == null ? null : getSkillsSupplier().get())
+                            .build();
+        } else {
+            ContextVariables variables = context.getVariables().writableClone().update(state, true);
+            context = context.update(variables);
+        }
+
         return super.invokeAsync(input, context, settings);
     }
 
@@ -523,7 +542,7 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
     }
 
     private String toPlanString(String indent) {
-        String goalHeader = indent + "Goal: " + getDescription() + "\n\n" + indent + "}Steps:\n";
+        String goalHeader = indent + "Goal: " + getDescription() + "\n\n" + indent + "Steps:\n";
 
         String stepItems =
                 String.join(
@@ -543,8 +562,23 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
             String parameters =
                     String.join(
                             " ",
-                            step.getParameters().stream()
-                                    .map(param -> param.getName() + " " + param.getDefaultValue())
+                            step.getParametersView().stream()
+                                    .map(
+                                            param -> {
+                                                String value = param.getDefaultValue();
+                                                if (step.getParameters() != null
+                                                        && step.getParameters().get(param.getName())
+                                                                != null) {
+                                                    value =
+                                                            step.getParameters()
+                                                                    .get(param.getName());
+                                                }
+                                                return "\t"
+                                                        + param.getName()
+                                                        + ": \""
+                                                        + value
+                                                        + "\"";
+                                            })
                                     .collect(Collectors.toList()));
 
             if (!Verify.isNullOrEmpty(parameters)) {
@@ -560,10 +594,16 @@ public class Plan extends AbstractSkFunction<CompletionRequestSettings> {
                     + indent
                     + "- "
                     + String.join(".", skillName, stepName)
+                    + "\t\t\t"
                     + parameters
                     + outputs;
         }
 
         return step.toPlanString(indent + indent);
+    }
+
+    @Nullable
+    private ContextVariables getParameters() {
+        return parameters;
     }
 }

--- a/java/semantickernel-extensions-parent/sequentialplanner-extensions/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlanner.java
+++ b/java/semantickernel-extensions-parent/sequentialplanner-extensions/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlanner.java
@@ -108,4 +108,8 @@ public class SequentialPlanner {
                     PlanningException.ErrorCodes.InvalidPlan, "Plan parsing error, invalid XML", e);
         }
     }
+
+    public SKContext getContext() {
+        return context;
+    }
 }


### PR DESCRIPTION
- Fix bug with ActionPlanner not copying the invocation state when the plan is invoked
- Improve the pretty printing of plans
- Cleanup ActionPlan returned by completion before parsing it
- Allow ActionPlanner to invoke native functions