### PR TITLE
.Net: Set default max tokens for SequentialPlanner

### DIFF
--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -42,7 +42,7 @@ public sealed class SequentialPlanner
             skillName: RestrictedSkillName,
             description: "Given a request or command or goal generate a step by step plan to " +
                          "fulfill the request using functions. This ability is also known as decision making and function flow",
-            maxTokens: this.Config.MaxTokens,
+            maxTokens: this.Config.MaxTokens ?? 512,
             temperature: 0.0,
             stopSequences: new[] { StopSequence });
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -42,7 +42,7 @@ public sealed class SequentialPlanner
             skillName: RestrictedSkillName,
             description: "Given a request or command or goal generate a step by step plan to " +
                          "fulfill the request using functions. This ability is also known as decision making and function flow",
-            maxTokens: this.Config.MaxTokens ?? 512,
+            maxTokens: this.Config.MaxTokens ?? 1024,
             temperature: 0.0,
             stopSequences: new[] { StopSequence });
 


### PR DESCRIPTION
Setting SequentialPlanner's max tokens to 512 in cases where it's left null. Without this, plans are never completed and cannot be parsed.

Required to fix dotnet integration tests.

### Contribution Checklist
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
