### PR TITLE
Java: Add URL attribute to POM.xml for Java SDK

### DIFF
--- a/java/semantickernel-bom/pom.xml
+++ b/java/semantickernel-bom/pom.xml
@@ -10,7 +10,7 @@
 
     <name>Semantic Kernel Java BOM</name>
     <description>Bill of Materials for all Semantic Kernel (Java) modules</description>
-
+    <url>https://www.github.com/microsoft/semantic-kernel</url>
     <properties>
         <com.fasterxml.jackson.core.version>2.15.1</com.fasterxml.jackson.core.version>
     </properties>


### PR DESCRIPTION
Added missing required attribute to the pom for publishing to Maven central