### PR TITLE
Python: Default logit-bias {} instead of None

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
@@ -214,7 +214,7 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
                     request_settings.token_selection_biases
                     if request_settings.token_selection_biases is not None
                     and len(request_settings.token_selection_biases) > 0
-                    else None
+                    else {}
                 ),
             )
         except Exception as ex:

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion.py
@@ -146,7 +146,7 @@ class OpenAITextCompletion(TextCompletionClientBase):
                     request_settings.token_selection_biases
                     if request_settings.token_selection_biases is not None
                     and len(request_settings.token_selection_biases) > 0
-                    else None
+                    else {}
                 ),
             )
         except Exception as ex:

--- a/python/tests/unit/ai/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/ai/open_ai/services/test_azure_chat_completion.py
@@ -154,7 +154,7 @@ async def test_azure_chat_completion_call_with_parameters() -> None:
             frequency_penalty=complete_request_settings.frequency_penalty,
             n=complete_request_settings.number_of_responses,
             stream=False,
-            logit_bias=None,
+            logit_bias={},
         )
 
 

--- a/python/tests/unit/ai/open_ai/services/test_azure_text_completion.py
+++ b/python/tests/unit/ai/open_ai/services/test_azure_text_completion.py
@@ -153,7 +153,7 @@ async def test_azure_text_completion_call_with_parameters() -> None:
             stop=None,
             n=complete_request_settings.number_of_responses,
             stream=False,
-            logit_bias=None,
+            logit_bias={},
         )
 
 


### PR DESCRIPTION
### Motivation and Context
The openai API expects that logit bias is always a set. Passing None will not be successful. 

### Description
- if logit-bias is None, pass {} to the openai request create call

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#dev-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
