### PR TITLE
Fix typo in Samples causing error: PlanningException: Create plan err

### DIFF
--- a/samples/notebooks/dotnet/05-using-the-planner.ipynb
+++ b/samples/notebooks/dotnet/05-using-the-planner.ipynb
@@ -169,7 +169,7 @@
     "\n",
     "Rewrite the above in the style of Shakespeare.\n",
     "\"\"\";\n",
-    "var shakespeareFunction = kernel.CreateSemanticFunction(skPrompt, \"shakespeare\", \"ShakespeareSkill\", maxTokens: 2000, temperature: 0.2, topP: 0.5);"
+    "var shakespeareFunction = kernel.CreateSemanticFunction(skPrompt, \"Shakespeare\", \"ShakespeareSkill\", maxTokens: 2000, temperature: 0.2, topP: 0.5);"
    ]
   },
   {


### PR DESCRIPTION


### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

I am testing the Samples. I was getting this error:

```
Error: Microsoft.SemanticKernel.Planning.PlanningException: Create plan error: Unable to create plan
---> Microsoft.SemanticKernel.Planning.PlanningException: Invalid plan: Failed to find function 'WriterSkill.Shakespeare' in skill 'WriterSkill'.
at Microsoft.SemanticKernel.Planning.Sequential.SequentialPlanParser.ToPlanFromXml(String xmlString, String goal, SKContext context, Boolean allowMissingFunctions)
at Microsoft.SemanticKernel.Planning.SequentialPlanner.CreatePlanAsync(String goal)
--- End of inner exception stack trace ---
at Microsoft.SemanticKernel.Planning.SequentialPlanner.CreatePlanAsync(String goal)
at Submission#10.<<Initialize>>d__0.MoveNext()
--- End of stack trace from previous location ---
at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)
```

After fixing the function name, the sample worked as expected.


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Error when trying to run sample `05-using-the-planner.ipynb`


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#dev-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
