### PR TITLE
Java: Allow functions to be loaded from the classpath

### DIFF
--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/javaspecific/Java_Example01_ResourceLoading.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/syntaxexamples/javaspecific/Java_Example01_ResourceLoading.java
@@ -1,0 +1,39 @@
+package com.microsoft.semantickernel.syntaxexamples.javaspecific;
+
+import com.microsoft.semantickernel.Kernel;
+import com.microsoft.semantickernel.builders.SKBuilders;
+import com.microsoft.semantickernel.orchestration.SKFunction;
+
+import java.io.IOException;
+
+public class Java_Example01_ResourceLoading {
+
+    public static void main(String[] args) throws IOException {
+        Kernel kernel = SKBuilders.kernel()
+                .withKernelConfig(SKBuilders.kernelConfig().build())
+                .build();
+
+        kernel.importSkillFromResources(
+                "Plugins",
+                "ExamplePlugins",
+                "ExampleFunction",
+                Java_Example01_ResourceLoading.class
+        );
+
+        SKFunction<?> function = kernel.getSkills().getFunctions("ExamplePlugins").getFunction("ExampleFunction");
+
+        System.out.println("Loaded function: " + function.getDescription());
+
+
+        kernel.importSkillFromResources(
+                "Plugins",
+                "ExamplePlugins",
+                "ExampleFunctionRoot"
+        );
+        function = kernel.getSkills().getFunctions("ExamplePlugins").getFunction("ExampleFunctionRoot");
+
+        System.out.println("Loaded function from classpath root: " + function.getDescription());
+
+
+    }
+}

--- a/java/samples/sample-code/src/main/resources/Plugins/ExamplePlugins/ExampleFunctionRoot/config.json
+++ b/java/samples/sample-code/src/main/resources/Plugins/ExamplePlugins/ExampleFunctionRoot/config.json
@@ -1,0 +1,12 @@
+{
+  "schema": 1,
+  "description": "Sample plugin loaded from classpath root via resources",
+  "type": "completion",
+  "completion": {
+    "max_tokens": 150,
+    "temperature": 0.9,
+    "top_p": 0.0,
+    "presence_penalty": 0.6,
+    "frequency_penalty": 0.0
+  }
+}

--- a/java/samples/sample-code/src/main/resources/Plugins/ExamplePlugins/ExampleFunctionRoot/skprompt.txt
+++ b/java/samples/sample-code/src/main/resources/Plugins/ExamplePlugins/ExampleFunctionRoot/skprompt.txt
@@ -1,0 +1,1 @@
+This is an example

--- a/java/samples/sample-code/src/main/resources/com/microsoft/semantickernel/syntaxexamples/javaspecific/Plugins/ExamplePlugins/ExampleFunction/config.json
+++ b/java/samples/sample-code/src/main/resources/com/microsoft/semantickernel/syntaxexamples/javaspecific/Plugins/ExamplePlugins/ExampleFunction/config.json
@@ -1,0 +1,12 @@
+{
+  "schema": 1,
+  "description": "Sample plugin loaded via resources",
+  "type": "completion",
+  "completion": {
+    "max_tokens": 150,
+    "temperature": 0.9,
+    "top_p": 0.0,
+    "presence_penalty": 0.6,
+    "frequency_penalty": 0.0
+  }
+}

--- a/java/samples/sample-code/src/main/resources/com/microsoft/semantickernel/syntaxexamples/javaspecific/Plugins/ExamplePlugins/ExampleFunction/skprompt.txt
+++ b/java/samples/sample-code/src/main/resources/com/microsoft/semantickernel/syntaxexamples/javaspecific/Plugins/ExamplePlugins/ExampleFunction/skprompt.txt
@@ -1,0 +1,1 @@
+This is an example

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/SkillExecutor.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/SkillExecutor.java
@@ -56,6 +56,28 @@ public interface SkillExecutor {
     ReadOnlyFunctionCollection importSkillFromDirectory(String skillName, String parentDirectory);
 
     /**
+     * Imports a skill using ClassLoader.getResourceAsStream to load skills from the classpath.
+     *
+     * @param pluginDirectory directory within the classpath that contains the skill
+     * @param skillName name of the skill
+     * @param functionName name of the function
+     * @return the function collection
+     */
+    ReadOnlyFunctionCollection importSkillFromResources(
+            String pluginDirectory, String skillName, String functionName);
+
+    /**
+     * Imports a skill using clazz.getResourceAsStream to load skills from the classpath.
+     *
+     * @param skillName name of the skill
+     * @param functionName name of the function
+     * @param clazz class that contains the skill
+     * @return the function collection
+     */
+    ReadOnlyFunctionCollection importSkillFromResources(
+            String pluginDirectory, String skillName, String functionName, @Nullable Class clazz);
+
+    /**
      * Imports the native functions annotated on the given object as a skill.
      *
      * @param nativeSkill object containing the native functions

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/extensions/KernelExtensions.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/extensions/KernelExtensions.java
@@ -12,15 +12,23 @@ import com.microsoft.semantickernel.templateengine.PromptTemplateEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 public class KernelExtensions {
     private static final Logger LOGGER = LoggerFactory.getLogger(KernelExtensions.class);
+    private static final String CONFIG_FILE = "config.json";
+    private static final String PROMPT_FILE = "skprompt.txt";
 
     private KernelExtensions() {}
 
@@ -28,9 +36,6 @@ public class KernelExtensions {
             String parentDirectory,
             String skillDirectoryName,
             PromptTemplateEngine promptTemplateEngine) {
-
-        String CONFIG_FILE = "config.json";
-        String PROMPT_FILE = "skprompt.txt";
 
         // Verify.ValidSkillName(skillDirectoryName);
         File skillDir = new File(parentDirectory, skillDirectoryName);
@@ -86,5 +91,100 @@ public class KernelExtensions {
         }
 
         return skills;
+    }
+
+    public static Map<String, SemanticFunctionConfig> importSemanticSkillFromResourcesDirectory(
+            String pluginDirectory,
+            String pluginName,
+            String functionName,
+            @Nullable Class clazz,
+            PromptTemplateEngine promptTemplateEngine) {
+
+        PromptTemplateConfig config =
+                getPromptTemplateConfig(pluginDirectory, pluginName, functionName, clazz);
+
+        if (config == null) {
+            config = new PromptTemplateConfig("", "", null);
+        }
+
+        String template = getTemplatePrompt(pluginDirectory, pluginName, functionName, clazz);
+
+        HashMap<String, SemanticFunctionConfig> skills = new HashMap<>();
+
+        PromptTemplate promptTemplate =
+                SKBuilders.promptTemplate()
+                        .withPromptTemplate(template)
+                        .withPromptTemplateConfig(config)
+                        .build(promptTemplateEngine);
+
+        skills.put(functionName, new SemanticFunctionConfig(config, promptTemplate));
+
+        return skills;
+    }
+
+    private static String getTemplatePrompt(
+            String pluginDirectory, String pluginName, String functionName, @Nullable Class clazz) {
+        String promptFileName =
+                pluginDirectory
+                        + File.separator
+                        + pluginName
+                        + File.separator
+                        + functionName
+                        + File.separator
+                        + PROMPT_FILE;
+
+        InputStream promptFileStream;
+        if (clazz == null) {
+            promptFileStream =
+                    KernelExtensions.class.getClassLoader().getResourceAsStream(promptFileName);
+        } else {
+            promptFileStream = clazz.getResourceAsStream(promptFileName);
+        }
+
+        String template;
+
+        try (BufferedReader promptFile =
+                new BufferedReader(
+                        new InputStreamReader(promptFileStream, Charset.defaultCharset()))) {
+            template = promptFile.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            LOGGER.error("Failed to read file " + promptFileName, e);
+
+            throw new KernelException(
+                    KernelException.ErrorCodes.FunctionNotAvailable,
+                    "No Skills found in directory " + promptFileName);
+        }
+        return template;
+    }
+
+    private static PromptTemplateConfig getPromptTemplateConfig(
+            String pluginDirectory, String pluginName, String functionName, @Nullable Class clazz) {
+        String configFileName =
+                pluginDirectory
+                        + File.separator
+                        + pluginName
+                        + File.separator
+                        + functionName
+                        + File.separator
+                        + CONFIG_FILE;
+
+        InputStream configFileStream;
+        if (clazz == null) {
+            configFileStream =
+                    KernelExtensions.class.getClassLoader().getResourceAsStream(configFileName);
+        } else {
+            configFileStream = clazz.getResourceAsStream(configFileName);
+        }
+
+        if (configFileStream == null) {
+            return null;
+        }
+
+        try (InputStream is = configFileStream) {
+            return new ObjectMapper().readValue(is, PromptTemplateConfig.class);
+        } catch (IOException e) {
+            LOGGER.debug("No config for " + functionName + " in " + pluginName);
+            return null;
+        }
     }
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/DefaultKernel.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/DefaultKernel.java
@@ -13,7 +13,11 @@ import com.microsoft.semantickernel.memory.MemoryConfiguration;
 import com.microsoft.semantickernel.memory.MemoryStore;
 import com.microsoft.semantickernel.memory.NullMemory;
 import com.microsoft.semantickernel.memory.SemanticTextMemory;
-import com.microsoft.semantickernel.orchestration.*;
+import com.microsoft.semantickernel.orchestration.ContextVariables;
+import com.microsoft.semantickernel.orchestration.DefaultCompletionSKFunction;
+import com.microsoft.semantickernel.orchestration.RegistrableSkFunction;
+import com.microsoft.semantickernel.orchestration.SKContext;
+import com.microsoft.semantickernel.orchestration.SKFunction;
 import com.microsoft.semantickernel.semanticfunctions.SemanticFunctionConfig;
 import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.services.AIServiceProvider;
@@ -266,6 +270,21 @@ public class DefaultKernel implements Kernel {
     public ReadOnlyFunctionCollection importSkillFromDirectory(
             String skillName, String parentDirectory) {
         return importSkillFromDirectory(skillName, parentDirectory, skillName);
+    }
+
+    @Override
+    public ReadOnlyFunctionCollection importSkillFromResources(
+            String pluginDirectory, String skillName, String functionName) {
+        return importSkillFromResources(pluginDirectory, skillName, functionName, null);
+    }
+
+    @Override
+    public ReadOnlyFunctionCollection importSkillFromResources(
+            String pluginDirectory, String skillName, String functionName, @Nullable Class clazz) {
+        Map<String, SemanticFunctionConfig> skills =
+                KernelExtensions.importSemanticSkillFromResourcesDirectory(
+                        pluginDirectory, skillName, functionName, clazz, promptTemplateEngine);
+        return importSkill(skillName, skills);
     }
 
     @Override


### PR DESCRIPTION
Allow importing skills from the classpath using `getResourceAsStream` so that people can embed skills inside their jar