### PR TITLE
Python: skip milvus tests if the platform is windows

### DIFF
--- a/python/tests/integration/connectors/memory/test_milvus.py
+++ b/python/tests/integration/connectors/memory/test_milvus.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import platform
 
 from semantic_kernel.connectors.memory.milvus import MilvusMemoryStore
 from semantic_kernel.memory.memory_record import MemoryRecord
@@ -17,6 +18,10 @@ pytestmark = pytest.mark.skipif(
     not milvus_installed, reason="local milvus is not installed"
 )
 
+pytestmark = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="local milvus is not officially supported on Windows"
+)
 
 @pytest.fixture(scope="module")
 def setup_milvus():

--- a/python/tests/integration/connectors/memory/test_milvus.py
+++ b/python/tests/integration/connectors/memory/test_milvus.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import platform
+
 import numpy as np
 import pytest
-import platform
 
 from semantic_kernel.connectors.memory.milvus import MilvusMemoryStore
 from semantic_kernel.memory.memory_record import MemoryRecord
@@ -20,8 +21,9 @@ pytestmark = pytest.mark.skipif(
 
 pytestmark = pytest.mark.skipif(
     platform.system() == "Windows",
-    reason="local milvus is not officially supported on Windows"
+    reason="local milvus is not officially supported on Windows",
 )
+
 
 @pytest.fixture(scope="module")
 def setup_milvus():


### PR DESCRIPTION
### Motivation and Context
The milvus integration tests are failing on windows systems only - get calls seem to be timing out. The integration tests rely on milvus-lite, a local, lightweight milvus application for python. Milvus is not officially supported for windows, so this PR disables the tests for any windows platform.

See milvus requirements documentation at: https://github.com/milvus-io/milvus-lite/blob/main/README.md#requirements

### Description

- mark the milvus tests as _skip_ if the local platform is windows. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#dev-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
