### PR TITLE
.Net: Obsolete SKContext[...] indexer

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example07_BingAndGoogleSkills.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example07_BingAndGoogleSkills.cs
@@ -140,7 +140,7 @@ Answer: ";
         var oracle = kernel.CreateSemanticFunction(SemanticFunction, maxTokens: 200, temperature: 0, topP: 1);
 
         var context = kernel.CreateNewContext();
-        context["externalInformation"] = "";
+        context.Variables["externalInformation"] = "";
         var answer = await oracle.InvokeAsync(questions, context);
 
         // If the answer contains commands, execute them using the prompt renderer.
@@ -155,7 +155,7 @@ Answer: ";
             Console.WriteLine(information);
 
             // The rendered prompt contains the information retrieved from search engines
-            context["externalInformation"] = information;
+            context.Variables["externalInformation"] = information;
 
             // Run the semantic function again, now including information from Bing
             answer = await oracle.InvokeAsync(questions, context);

--- a/dotnet/samples/KernelSyntaxExamples/Example15_MemorySkill.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example15_MemorySkill.cs
@@ -40,9 +40,9 @@ public static class Example15_MemorySkill
         var memorySaver = kernel.CreateSemanticFunction(SaveFunctionDefinition);
 
         var context = kernel.CreateNewContext();
-        context[TextMemorySkill.CollectionParam] = MemoryCollectionName;
-        context[TextMemorySkill.KeyParam] = "info5";
-        context["info"] = "My family is from New York";
+        context.Variables[TextMemorySkill.CollectionParam] = MemoryCollectionName;
+        context.Variables[TextMemorySkill.KeyParam] = "info5";
+        context.Variables["info"] = "My family is from New York";
         await memorySaver.InvokeAsync(context);
 
         // ========= Test memory remember =========
@@ -96,8 +96,8 @@ Answer:
         var aboutMeOracle = kernel.CreateSemanticFunction(RecallFunctionDefinition, maxTokens: 100);
 
         context = kernel.CreateNewContext();
-        context[TextMemorySkill.CollectionParam] = MemoryCollectionName;
-        context[TextMemorySkill.RelevanceParam] = "0.8";
+        context.Variables[TextMemorySkill.CollectionParam] = MemoryCollectionName;
+        context.Variables[TextMemorySkill.RelevanceParam] = "0.8";
         var result = await aboutMeOracle.InvokeAsync("Do I live in the same town where I grew up?", context);
 
         Console.WriteLine("Do I live in the same town where I grew up?\n");
@@ -114,9 +114,9 @@ Answer:
         // ========= Remove a memory =========
         Console.WriteLine("========= Example: Forgetting a Memory =========");
 
-        context["fact1"] = "What is my name?";
-        context["fact2"] = "What do I do for a living?";
-        context[TextMemorySkill.RelevanceParam] = ".75";
+        context.Variables["fact1"] = "What is my name?";
+        context.Variables["fact2"] = "What do I do for a living?";
+        context.Variables[TextMemorySkill.RelevanceParam] = ".75";
 
         result = await aboutMeOracle.InvokeAsync("Tell me a bit about myself", context);
 
@@ -130,7 +130,7 @@ Answer:
             My name is Andrea and my family is from New York. I work as a tourist operator.
         */
 
-        context[TextMemorySkill.KeyParam] = "info1";
+        context.Variables[TextMemorySkill.KeyParam] = "info1";
         await memorySkill.RemoveAsync(MemoryCollectionName, "info1", logger: context.Log);
 
         result = await aboutMeOracle.InvokeAsync("Tell me a bit about myself", context);

--- a/dotnet/samples/KernelSyntaxExamples/Example30_ChatWithPrompts.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example30_ChatWithPrompts.cs
@@ -77,13 +77,13 @@ public static class Example30_ChatWithPrompts
         var context = kernel.CreateNewContext();
 
         // Put the selected document into the variable used by the system prompt (see 28-system-prompt.txt).
-        context["selectedText"] = selectedText;
+        context.Variables["selectedText"] = selectedText;
 
         // Demo another variable, e.g. when the chat started, used by the system prompt (see 28-system-prompt.txt).
-        context["startTime"] = DateTimeOffset.Now.ToString("hh:mm:ss tt zz", CultureInfo.CurrentCulture);
+        context.Variables["startTime"] = DateTimeOffset.Now.ToString("hh:mm:ss tt zz", CultureInfo.CurrentCulture);
 
         // This is the user message, store it in the variable used by 28-user-prompt.txt
-        context["userMessage"] = "extract locations as a bullet point list";
+        context.Variables["userMessage"] = "extract locations as a bullet point list";
 
         // Instantiate the prompt renderer, which we will use to turn prompt templates
         // into strings, that we will store into a Chat history object, which is then sent

--- a/dotnet/src/IntegrationTests/TemplateLanguage/PromptTemplateEngineTests.cs
+++ b/dotnet/src/IntegrationTests/TemplateLanguage/PromptTemplateEngineTests.cs
@@ -34,8 +34,8 @@ public sealed class PromptTemplateEngineTests : IDisposable
 
         var kernel = Kernel.Builder.Build();
         var context = kernel.CreateNewContext();
-        context["input"] = Input;
-        context["winner"] = Winner;
+        context.Variables["input"] = Input;
+        context.Variables["winner"] = Winner;
 
         // Act
         var result = await this._target.RenderAsync(Template, context);
@@ -72,7 +72,7 @@ public sealed class PromptTemplateEngineTests : IDisposable
         var kernel = Kernel.Builder.Build();
         kernel.ImportSkill(new MySkill(), "my");
         var context = kernel.CreateNewContext();
-        context["call"] = "123";
+        context.Variables["call"] = "123";
 
         // Act
         var result = await this._target.RenderAsync(Template, context);

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
@@ -30,31 +30,10 @@ public sealed class SKContext
     public string Result => this.Variables.ToString();
 
     /// <summary>
-    /// Whether an error occurred while executing functions in the pipeline.
-    /// </summary>
-    public bool ErrorOccurred { get; private set; }
-
-    /// <summary>
-    /// Error details.
-    /// </summary>
-    public string LastErrorDescription { get; private set; } = string.Empty;
-
-    /// <summary>
-    /// When an error occurs, this is the most recent exception.
-    /// </summary>
-    public Exception? LastException { get; private set; }
-
-    /// <summary>
     /// When a prompt is processed, aka the current data after any model results processing occurred.
     /// (One prompt can have multiple results).
     /// </summary>
     public IReadOnlyCollection<ModelResult> ModelResults { get; set; } = Array.Empty<ModelResult>();
-
-    /// <summary>
-    /// The token to monitor for cancellation requests.
-    /// </summary>
-    [Obsolete("Add a CancellationToken param to SKFunction method signatures instead of retrieving it from SKContext.")]
-    public CancellationToken CancellationToken { get; } = default;
 
     /// <summary>
     /// The culture currently associated with this context.
@@ -66,44 +45,9 @@ public sealed class SKContext
     }
 
     /// <summary>
-    /// Shortcut into user data, access variables by name
-    /// </summary>
-    /// <param name="name">Variable name</param>
-    public string this[string name]
-    {
-        get => this.Variables[name];
-        set => this.Variables[name] = value;
-    }
-
-    /// <summary>
-    /// Call this method to signal when an error occurs.
-    /// In the usual scenarios this is also how execution is stopped, e.g. to inform the user or take necessary steps.
-    /// </summary>
-    /// <param name="errorDescription">Error description</param>
-    /// <param name="exception">If available, the exception occurred</param>
-    /// <returns>The current instance</returns>
-    public SKContext Fail(string errorDescription, Exception? exception = null)
-    {
-        this.ErrorOccurred = true;
-        this.LastErrorDescription = errorDescription;
-        this.LastException = exception;
-        return this;
-    }
-
-    /// <summary>
     /// User variables
     /// </summary>
     public ContextVariables Variables { get; }
-
-    /// <summary>
-    /// Semantic memory
-    /// </summary>
-    [Obsolete("Memory no longer passed through SKContext. Instead, initialize your skill class with the memory provider it needs.")]
-    public ISemanticTextMemory Memory
-    {
-        get => throw new InvalidOperationException(
-            "Memory no longer passed through SKContext. Instead, initialize your skill class with the memory provider it needs.");
-    }
 
     /// <summary>
     /// Read only skills collection
@@ -196,4 +140,65 @@ public sealed class SKContext
             return display;
         }
     }
+
+    #region Error handling
+    /// <summary>
+    /// Whether an error occurred while executing functions in the pipeline.
+    /// </summary>
+    public bool ErrorOccurred { get; private set; }
+
+    /// <summary>
+    /// Error details.
+    /// </summary>
+    public string LastErrorDescription { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// When an error occurs, this is the most recent exception.
+    /// </summary>
+    public Exception? LastException { get; private set; }
+
+    /// <summary>
+    /// Call this method to signal when an error occurs.
+    /// In the usual scenarios this is also how execution is stopped, e.g. to inform the user or take necessary steps.
+    /// </summary>
+    /// <param name="errorDescription">Error description</param>
+    /// <param name="exception">If available, the exception occurred</param>
+    /// <returns>The current instance</returns>
+    public SKContext Fail(string errorDescription, Exception? exception = null)
+    {
+        this.ErrorOccurred = true;
+        this.LastErrorDescription = errorDescription;
+        this.LastException = exception;
+        return this;
+    }
+    #endregion
+
+    #region Obsolete
+    /// <summary>
+    /// Shortcut into user data, access variables by name
+    /// </summary>
+    /// <param name="name">Variable name</param>
+    [Obsolete("Use SKContext.Variables instead. The SKContext[...] indexer will be removed in a future release.")]
+    public string this[string name]
+    {
+        get => this.Variables[name];
+        set => this.Variables[name] = value;
+    }
+
+    /// <summary>
+    /// The token to monitor for cancellation requests.
+    /// </summary>
+    [Obsolete("Add a CancellationToken param to SKFunction method signatures instead of retrieving it from SKContext.")]
+    public CancellationToken CancellationToken { get; } = default;
+
+    /// <summary>
+    /// Semantic memory
+    /// </summary>
+    [Obsolete("Memory no longer passed through SKContext. Instead, initialize your skill class with the memory provider it needs.")]
+    public ISemanticTextMemory Memory
+    {
+        get => throw new InvalidOperationException(
+            "Memory no longer passed through SKContext. Instead, initialize your skill class with the memory provider it needs.");
+    }
+    #endregion
 }

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -65,12 +65,12 @@ public class KernelTests
         SKContext result = await kernel.RunAsync(skill["ReadSkillCollectionAsync"]);
 
         // Assert - 3 functions, var name is not case sensitive
-        Assert.Equal("Nice fun", result["jk.joker"]);
-        Assert.Equal("Nice fun", result["JK.JOKER"]);
-        Assert.Equal("Just say hello", result["mySk.sayhello"]);
-        Assert.Equal("Just say hello", result["mySk.SayHello"]);
-        Assert.Equal("Export info.", result["mySk.ReadSkillCollectionAsync"]);
-        Assert.Equal("Export info.", result["mysk.readskillcollectionasync"]);
+        Assert.Equal("Nice fun", result.Variables["jk.joker"]);
+        Assert.Equal("Nice fun", result.Variables["JK.JOKER"]);
+        Assert.Equal("Just say hello", result.Variables["mySk.sayhello"]);
+        Assert.Equal("Just say hello", result.Variables["mySk.SayHello"]);
+        Assert.Equal("Export info.", result.Variables["mySk.ReadSkillCollectionAsync"]);
+        Assert.Equal("Export info.", result.Variables["mysk.readskillcollectionasync"]);
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class KernelTests
             {
                 foreach (FunctionView f in list.Value)
                 {
-                    context[$"{list.Key}.{f.Name}"] = f.Description;
+                    context.Variables[$"{list.Key}.{f.Name}"] = f.Description;
                 }
             }
 
@@ -190,7 +190,7 @@ public class KernelTests
             {
                 foreach (FunctionView f in list.Value)
                 {
-                    context[$"{list.Key}.{f.Name}"] = f.Description;
+                    context.Variables[$"{list.Key}.{f.Name}"] = f.Description;
                 }
             }
 

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKContextTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKContextTests.cs
@@ -33,18 +33,18 @@ public class SKContextTests
         variables.Set("foo1", "bar1");
 
         // Act
-        target["foo2"] = "bar2";
-        target["INPUT"] = Guid.NewGuid().ToString("N");
+        target.Variables["foo2"] = "bar2";
+        target.Variables["INPUT"] = Guid.NewGuid().ToString("N");
 
         // Assert
-        Assert.Equal("bar1", target["foo1"]);
         Assert.Equal("bar1", target.Variables["foo1"]);
-        Assert.Equal("bar2", target["foo2"]);
+        Assert.Equal("bar1", target.Variables["foo1"]);
         Assert.Equal("bar2", target.Variables["foo2"]);
-        Assert.Equal(target["INPUT"], target.Result);
-        Assert.Equal(target["INPUT"], target.ToString());
-        Assert.Equal(target["INPUT"], target.Variables.Input);
-        Assert.Equal(target["INPUT"], target.Variables.ToString());
+        Assert.Equal("bar2", target.Variables["foo2"]);
+        Assert.Equal(target.Variables["INPUT"], target.Result);
+        Assert.Equal(target.Variables["INPUT"], target.ToString());
+        Assert.Equal(target.Variables["INPUT"], target.Variables.Input);
+        Assert.Equal(target.Variables["INPUT"], target.Variables.ToString());
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
@@ -500,7 +500,7 @@ public sealed class SKFunctionTests2
         Assert.True(newContext.Variables.ContainsKey("canary2"));
 
         Assert.Equal(s_expected, oldContext.Variables["canary"]);
-        Assert.Equal("222", oldContext.Variables["canary2"]);
+        Assert.Equal("222", newContext.Variables["canary2"]);
 
         Assert.True(oldContext.Variables.ContainsKey("legacy"));
         Assert.False(newContext.Variables.ContainsKey("legacy"));

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests2.cs
@@ -127,14 +127,14 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticContextVoidAsync()
     {
         // Arrange
-        static void Test(SKContext cx)
+        static void Test(SKContext context)
         {
             s_actual = s_expected;
-            cx["canary"] = s_expected;
+            context.Variables["canary"] = s_expected;
         }
 
         var context = this.MockContext("xy");
-        context["someVar"] = "qz";
+        context.Variables["someVar"] = "qz";
 
         // Act
         var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
@@ -144,21 +144,21 @@ public sealed class SKFunctionTests2
         // Assert
         Assert.False(result.ErrorOccurred);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
     }
 
     [Fact]
     public async Task ItSupportsStaticContextStringAsync()
     {
         // Arrange
-        static string Test(SKContext cx)
+        static string Test(SKContext context)
         {
-            s_actual = cx["someVar"];
+            s_actual = context.Variables["someVar"];
             return "abc";
         }
 
         var context = this.MockContext("");
-        context["someVar"] = s_expected;
+        context.Variables["someVar"] = s_expected;
 
         // Act
         var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
@@ -177,15 +177,15 @@ public sealed class SKFunctionTests2
         // Arrange
         int invocationCount = 0;
 
-        string? Test(SKContext cx)
+        string? Test(SKContext context)
         {
             invocationCount++;
-            s_actual = cx["someVar"];
+            s_actual = context.Variables["someVar"];
             return "abc";
         }
 
         var context = this.MockContext("");
-        context["someVar"] = s_expected;
+        context.Variables["someVar"] = s_expected;
 
         // Act
         Func<SKContext, string?> method = Test;
@@ -206,11 +206,11 @@ public sealed class SKFunctionTests2
         // Arrange
         int invocationCount = 0;
 
-        Task<string> Test(SKContext cx)
+        Task<string> Test(SKContext context)
         {
             invocationCount++;
             s_actual = s_expected;
-            cx.Variables["canary"] = s_expected;
+            context.Variables["canary"] = s_expected;
             return Task.FromResult(s_expected);
         }
 
@@ -227,7 +227,7 @@ public sealed class SKFunctionTests2
         Assert.Equal(1, invocationCount);
         Assert.Equal(s_expected, s_actual);
         Assert.Equal(s_actual, context.Result);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
     }
 
     [Fact]
@@ -236,14 +236,14 @@ public sealed class SKFunctionTests2
         // Arrange
         int invocationCount = 0;
 
-        async Task<SKContext> TestAsync(SKContext cx)
+        async Task<SKContext> TestAsync(SKContext context)
         {
             await Task.Delay(0);
             invocationCount++;
             s_actual = s_expected;
-            cx.Variables.Update("foo");
-            cx["canary"] = s_expected;
-            return cx;
+            context.Variables.Update("foo");
+            context.Variables["canary"] = s_expected;
+            return context;
         }
 
         var context = this.MockContext("");
@@ -258,7 +258,7 @@ public sealed class SKFunctionTests2
         Assert.False(result.ErrorOccurred);
         Assert.Equal(1, invocationCount);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("foo", context.Result);
     }
 
@@ -350,12 +350,12 @@ public sealed class SKFunctionTests2
         // Arrange
         int invocationCount = 0;
 
-        void Test(string input, SKContext cx)
+        void Test(string input, SKContext context)
         {
             invocationCount++;
             s_actual = s_expected;
-            cx.Variables.Update("x y z");
-            cx["canary"] = s_expected;
+            context.Variables.Update("x y z");
+            context.Variables["canary"] = s_expected;
         }
 
         var context = this.MockContext("");
@@ -370,7 +370,7 @@ public sealed class SKFunctionTests2
         Assert.False(result.ErrorOccurred);
         Assert.Equal(1, invocationCount);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("x y z", context.Result);
     }
 
@@ -380,12 +380,12 @@ public sealed class SKFunctionTests2
         // Arrange
         int invocationCount = 0;
 
-        void Test(SKContext cx, string input)
+        void Test(SKContext context, string input)
         {
             invocationCount++;
             s_actual = s_expected;
-            cx.Variables.Update("x y z");
-            cx["canary"] = s_expected;
+            context.Variables.Update("x y z");
+            context.Variables["canary"] = s_expected;
         }
 
         var context = this.MockContext("");
@@ -400,7 +400,7 @@ public sealed class SKFunctionTests2
         Assert.False(result.ErrorOccurred);
         Assert.Equal(1, invocationCount);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("x y z", context.Result);
     }
 
@@ -408,11 +408,11 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticStringContextStringAsync()
     {
         // Arrange
-        static string Test(string input, SKContext cx)
+        static string Test(string input, SKContext context)
         {
             s_actual = s_expected;
-            cx["canary"] = s_expected;
-            cx.Variables.Update("x y z");
+            context.Variables["canary"] = s_expected;
+            context.Variables.Update("x y z");
             // This value should overwrite "x y z"
             return "new data";
         }
@@ -427,7 +427,7 @@ public sealed class SKFunctionTests2
         // Assert
         Assert.False(result.ErrorOccurred);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("new data", context.Result);
     }
 
@@ -435,11 +435,11 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticStringContextTaskStringAsync()
     {
         // Arrange
-        static Task<string> Test(string input, SKContext cx)
+        static Task<string> Test(string input, SKContext context)
         {
             s_actual = s_expected;
-            cx["canary"] = s_expected;
-            cx.Variables.Update("x y z");
+            context.Variables["canary"] = s_expected;
+            context.Variables.Update("x y z");
             // This value should overwrite "x y z"
             return Task.FromResult("new data");
         }
@@ -454,7 +454,7 @@ public sealed class SKFunctionTests2
         // Assert
         Assert.False(result.ErrorOccurred);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("new data", context.Result);
     }
 
@@ -462,25 +462,25 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticStringContextTaskContextAsync()
     {
         // Arrange
-        static Task<SKContext> Test(string input, SKContext cx)
+        static Task<SKContext> Test(string input, SKContext context)
         {
             s_actual = s_expected;
-            cx["canary"] = s_expected;
-            cx.Variables.Update("x y z");
+            context.Variables["canary"] = s_expected;
+            context.Variables.Update("x y z");
 
             // This value should overwrite "x y z". Contexts are merged.
-            var newCx = new SKContext(
+            var newContext = new SKContext(
                 new ContextVariables(input),
                 skills: new Mock<IReadOnlySkillCollection>().Object);
 
-            newCx.Variables.Update("new data");
-            newCx["canary2"] = "222";
+            newContext.Variables.Update("new data");
+            newContext.Variables["canary2"] = "222";
 
-            return Task.FromResult(newCx);
+            return Task.FromResult(newContext);
         }
 
         var oldContext = this.MockContext("");
-        oldContext["legacy"] = "something";
+        oldContext.Variables["legacy"] = "something";
 
         // Act
         var function = SKFunction.FromNativeMethod(Method(Test), log: this._log.Object);
@@ -499,8 +499,8 @@ public sealed class SKFunctionTests2
         Assert.False(newContext.Variables.ContainsKey("canary"));
         Assert.True(newContext.Variables.ContainsKey("canary2"));
 
-        Assert.Equal(s_expected, oldContext["canary"]);
-        Assert.Equal("222", newContext["canary2"]);
+        Assert.Equal(s_expected, oldContext.Variables["canary"]);
+        Assert.Equal("222", oldContext.Variables["canary2"]);
 
         Assert.True(oldContext.Variables.ContainsKey("legacy"));
         Assert.False(newContext.Variables.ContainsKey("legacy"));
@@ -513,7 +513,7 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticContextValueTaskContextAsync()
     {
         // Arrange
-        static ValueTask<SKContext> Test(string input, SKContext cx)
+        static ValueTask<SKContext> Test(string input, SKContext context)
         {
             // This value should overwrite "x y z". Contexts are merged.
             var newCx = new SKContext(
@@ -582,11 +582,11 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticContextTaskAsync()
     {
         // Arrange
-        static Task TestAsync(SKContext cx)
+        static Task TestAsync(SKContext context)
         {
             s_actual = s_expected;
-            cx["canary"] = s_expected;
-            cx.Variables.Update("x y z");
+            context.Variables["canary"] = s_expected;
+            context.Variables.Update("x y z");
             return Task.CompletedTask;
         }
 
@@ -600,7 +600,7 @@ public sealed class SKFunctionTests2
         // Assert
         Assert.False(result.ErrorOccurred);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("x y z", context.Result);
     }
 
@@ -608,11 +608,11 @@ public sealed class SKFunctionTests2
     public async Task ItSupportsStaticStringContextTaskAsync()
     {
         // Arrange
-        static Task TestAsync(string input, SKContext cx)
+        static Task TestAsync(string input, SKContext context)
         {
             s_actual = s_expected;
-            cx["canary"] = s_expected;
-            cx.Variables.Update(input + "x y z");
+            context.Variables["canary"] = s_expected;
+            context.Variables.Update(input + "x y z");
             return Task.CompletedTask;
         }
 
@@ -626,7 +626,7 @@ public sealed class SKFunctionTests2
         // Assert
         Assert.False(result.ErrorOccurred);
         Assert.Equal(s_expected, s_actual);
-        Assert.Equal(s_expected, context["canary"]);
+        Assert.Equal(s_expected, context.Variables["canary"]);
         Assert.Equal("input:x y z", context.Result);
     }
 

--- a/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests3.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/SkillDefinition/SKFunctionTests3.cs
@@ -82,13 +82,13 @@ public sealed class SKFunctionTests3
     {
         // Arrange
         var context = Kernel.Builder.Build().CreateNewContext();
-        context["done"] = "NO";
+        context.Variables["done"] = "NO";
 
         // Note: the function doesn't have any SK attributes
         async Task<SKContext> ExecuteAsync(SKContext contextIn)
         {
-            Assert.Equal("NO", contextIn["done"]);
-            contextIn["canary"] = "YES";
+            Assert.Equal("NO", contextIn.Variables["done"]);
+            contextIn.Variables["canary"] = "YES";
 
             await Task.Delay(0);
             return contextIn;
@@ -105,8 +105,8 @@ public sealed class SKFunctionTests3
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
-        Assert.Equal("YES", context["canary"]);
-        Assert.Equal("YES", result["canary"]);
+        Assert.Equal("YES", context.Variables["canary"]);
+        Assert.Equal("YES", result.Variables["canary"]);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public sealed class SKFunctionTests3
     {
         // Arrange
         var context = Kernel.Builder.Build().CreateNewContext();
-        context["done"] = "NO";
+        context.Variables["done"] = "NO";
 
         // Note: This is an important edge case that affects the function signature and how delegates
         //       are handled internally: the function references an external variable and cannot be static.
@@ -124,7 +124,7 @@ public sealed class SKFunctionTests3
         async Task<SKContext> ExecuteAsync(SKContext contextIn)
         {
             string referenceToExternalVariable = variableOutsideTheFunction;
-            contextIn["canary"] = "YES";
+            contextIn.Variables["canary"] = "YES";
 
             await Task.Delay(0);
             return contextIn;
@@ -140,7 +140,7 @@ public sealed class SKFunctionTests3
         SKContext result = await function.InvokeAsync(context);
 
         // Assert
-        Assert.Equal("YES", result["canary"]);
+        Assert.Equal("YES", result.Variables["canary"]);
     }
 
     private sealed class InvalidSkill

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -198,17 +198,17 @@ public class CodeBlockTests
         var function = new Mock<ISKFunction>();
         function
             .Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), It.IsAny<CompleteRequestSettings?>(), It.IsAny<CancellationToken>()))
-            .Callback<SKContext, CompleteRequestSettings?, CancellationToken>((ctx, _, _) =>
+            .Callback<SKContext, CompleteRequestSettings?, CancellationToken>((context, _, _) =>
             {
-                canary0 = ctx!["input"];
-                canary1 = ctx["var1"];
-                canary2 = ctx["var2"];
+                canary0 = context!.Variables["input"];
+                canary1 = context.Variables["var1"];
+                canary2 = context.Variables["var2"];
 
-                ctx["input"] = "overridden";
-                ctx["var1"] = "overridden";
-                ctx["var2"] = "overridden";
+                context.Variables["input"] = "overridden";
+                context.Variables["var1"] = "overridden";
+                context.Variables["var2"] = "overridden";
             })
-            .ReturnsAsync((SKContext inputCtx, CompleteRequestSettings _, CancellationToken _) => inputCtx);
+            .ReturnsAsync((SKContext inputcontext, CompleteRequestSettings _, CancellationToken _) => inputcontext);
 
         ISKFunction? outFunc = function.Object;
         this._skills.Setup(x => x.TryGetFunction(Func, out outFunc)).Returns(true);
@@ -246,11 +246,11 @@ public class CodeBlockTests
         var function = new Mock<ISKFunction>();
         function
             .Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), It.IsAny<CompleteRequestSettings?>(), It.IsAny<CancellationToken>()))
-            .Callback<SKContext, CompleteRequestSettings?, CancellationToken>((ctx, _, _) =>
+            .Callback<SKContext, CompleteRequestSettings?, CancellationToken>((context, _, _) =>
             {
-                canary = ctx!["input"];
+                canary = context!.Variables["input"];
             })
-            .ReturnsAsync((SKContext inputCtx, CompleteRequestSettings _, CancellationToken _) => inputCtx);
+            .ReturnsAsync((SKContext inputcontext, CompleteRequestSettings _, CancellationToken _) => inputcontext);
 
         ISKFunction? outFunc = function.Object;
         this._skills.Setup(x => x.TryGetFunction(Func, out outFunc)).Returns(true);
@@ -280,11 +280,11 @@ public class CodeBlockTests
         var function = new Mock<ISKFunction>();
         function
             .Setup(x => x.InvokeAsync(It.IsAny<SKContext>(), It.IsAny<CompleteRequestSettings?>(), It.IsAny<CancellationToken>()))
-            .Callback<SKContext, CompleteRequestSettings?, CancellationToken>((ctx, _, _) =>
+            .Callback<SKContext, CompleteRequestSettings?, CancellationToken>((context, _, _) =>
             {
-                canary = ctx!["input"];
+                canary = context!.Variables["input"];
             })
-            .ReturnsAsync((SKContext inputCtx, CompleteRequestSettings _, CancellationToken _) => inputCtx);
+            .ReturnsAsync((SKContext inputcontext, CompleteRequestSettings _, CancellationToken _) => inputcontext);
 
         ISKFunction? outFunc = function.Object;
         this._skills.Setup(x => x.TryGetFunction(Func, out outFunc)).Returns(true);

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/PromptTemplateEngineTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/PromptTemplateEngineTests.cs
@@ -123,10 +123,10 @@ public sealed class PromptTemplateEngineTests
     public async Task ItRendersCodeUsingInputAsync()
     {
         // Arrange
-        string MyFunctionAsync(SKContext cx)
+        string MyFunctionAsync(SKContext context)
         {
-            this._logger.WriteLine("MyFunction call received, input: {0}", cx.Variables.Input);
-            return $"F({cx.Variables.Input})";
+            this._logger.WriteLine("MyFunction call received, input: {0}", context.Variables.Input);
+            return $"F({context.Variables.Input})";
         }
 
         ISKFunction func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);
@@ -152,10 +152,10 @@ public sealed class PromptTemplateEngineTests
     public async Task ItRendersCodeUsingVariablesAsync()
     {
         // Arrange
-        string MyFunctionAsync(SKContext cx)
+        string MyFunctionAsync(SKContext context)
         {
-            this._logger.WriteLine("MyFunction call received, input: {0}", cx.Variables.Input);
-            return $"F({cx.Variables.Input})";
+            this._logger.WriteLine("MyFunction call received, input: {0}", context.Variables.Input);
+            return $"F({context.Variables.Input})";
         }
 
         ISKFunction func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);
@@ -181,11 +181,11 @@ public sealed class PromptTemplateEngineTests
     public async Task ItRendersAsyncCodeUsingVariablesAsync()
     {
         // Arrange
-        Task<string> MyFunctionAsync(SKContext cx)
+        Task<string> MyFunctionAsync(SKContext context)
         {
             // Input value should be "BAR" because the variable $myVar is passed in
-            this._logger.WriteLine("MyFunction call received, input: {0}", cx.Variables.Input);
-            return Task.FromResult(cx.Variables.Input);
+            this._logger.WriteLine("MyFunction call received, input: {0}", context.Variables.Input);
+            return Task.FromResult(context.Variables.Input);
         }
 
         ISKFunction func = SKFunction.FromNativeMethod(Method(MyFunctionAsync), this);
@@ -216,24 +216,24 @@ public sealed class PromptTemplateEngineTests
         this._variables.Update("BAR");
         this._variables.Set("myVar", "BAZ");
 
-        string MyFunction1Async(SKContext cx)
+        string MyFunction1Async(SKContext context)
         {
-            this._logger.WriteLine("MyFunction1 call received, input: {0}", cx.Variables.Input);
-            cx.Variables.Update("foo");
+            this._logger.WriteLine("MyFunction1 call received, input: {0}", context.Variables.Input);
+            context.Variables.Update("foo");
             return "F(OUTPUT-FOO)";
         }
-        string MyFunction2Async(SKContext cx)
+        string MyFunction2Async(SKContext context)
         {
             // Input value should be "BAR" because the variable $input is immutable in MyFunction1
-            this._logger.WriteLine("MyFunction2 call received, input: {0}", cx.Variables.Input);
-            cx.Variables.Set("myVar", "bar");
-            return cx.Variables.Input;
+            this._logger.WriteLine("MyFunction2 call received, input: {0}", context.Variables.Input);
+            context.Variables.Set("myVar", "bar");
+            return context.Variables.Input;
         }
-        string MyFunction3Async(SKContext cx)
+        string MyFunction3Async(SKContext context)
         {
             // Input value should be "BAZ" because the variable $myVar is immutable in MyFunction2
-            this._logger.WriteLine("MyFunction3 call received, input: {0}", cx.Variables.Input);
-            return cx.Variables.TryGetValue("myVar", out string? value) ? value : "";
+            this._logger.WriteLine("MyFunction3 call received, input: {0}", context.Variables.Input);
+            return context.Variables.TryGetValue("myVar", out string? value) ? value : "";
         }
 
         var functions = new List<ISKFunction>()

--- a/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/SKFunction.cs
@@ -511,19 +511,19 @@ public sealed class SKFunction : ISKFunction, IDisposable
         if (type == typeof(SKContext))
         {
             TrackUniqueParameterType(ref hasSKContextParam, method, $"At most one {nameof(SKContext)} parameter is permitted.");
-            return (static (SKContext ctx, CancellationToken _) => ctx, null);
+            return (static (SKContext context, CancellationToken _) => context, null);
         }
 
         if (type == typeof(ILogger))
         {
             TrackUniqueParameterType(ref hasLoggerParam, method, $"At most one {nameof(ILogger)} parameter is permitted.");
-            return (static (SKContext ctx, CancellationToken _) => ctx.Log, null);
+            return (static (SKContext context, CancellationToken _) => context.Log, null);
         }
 
         if (type == typeof(CultureInfo) || type == typeof(IFormatProvider))
         {
             TrackUniqueParameterType(ref hasCultureParam, method, $"At most one {nameof(CultureInfo)}/{nameof(IFormatProvider)} parameter is permitted.");
-            return (static (SKContext ctx, CancellationToken _) => ctx.Culture, null);
+            return (static (SKContext context, CancellationToken _) => context.Culture, null);
         }
 
         if (type == typeof(CancellationToken))
@@ -580,10 +580,10 @@ public sealed class SKFunction : ISKFunction, IDisposable
             }
 
             bool fallBackToInput = !sawFirstParameter && !nameIsInput;
-            Func<SKContext, CancellationToken, object?> parameterFunc = (SKContext ctx, CancellationToken _) =>
+            Func<SKContext, CancellationToken, object?> parameterFunc = (SKContext context, CancellationToken _) =>
             {
                 // 1. Use the value of the variable if it exists.
-                if (ctx.Variables.TryGetValue(name, out string? value))
+                if (context.Variables.TryGetValue(name, out string? value))
                 {
                     return Process(value);
                 }
@@ -597,7 +597,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
                 // 3. Otherwise, use "input" if this is the first (or only) parameter.
                 if (fallBackToInput)
                 {
-                    return Process(ctx.Variables.Input);
+                    return Process(context.Variables.Input);
                 }
 
                 // 4. Otherwise, fail.
@@ -612,7 +612,7 @@ public sealed class SKFunction : ISKFunction, IDisposable
 
                     try
                     {
-                        return parser(value, ctx.Culture);
+                        return parser(value, context.Culture);
                     }
                     catch (Exception e) when (!e.IsCriticalException())
                     {

--- a/dotnet/src/Skills/Skills.Core/HttpSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/HttpSkill.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel.Skills.Core;
 /// <example>
 /// Usage: kernel.ImportSkill("http", new HttpSkill());
 /// Examples:
-/// SKcontext.Variables["url"] = "https://www.bing.com"
+/// SKContext.Variables["url"] = "https://www.bing.com"
 /// {{http.getAsync $url}}
 /// {{http.postAsync $url}}
 /// {{http.putAsync $url}}

--- a/dotnet/src/Skills/Skills.Core/HttpSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/HttpSkill.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel.Skills.Core;
 /// <example>
 /// Usage: kernel.ImportSkill("http", new HttpSkill());
 /// Examples:
-/// SKContext["url"] = "https://www.bing.com"
+/// SKcontext.Variables["url"] = "https://www.bing.com"
 /// {{http.getAsync $url}}
 /// {{http.postAsync $url}}
 /// {{http.putAsync $url}}

--- a/dotnet/src/Skills/Skills.Core/TextMemorySkill.cs
+++ b/dotnet/src/Skills/Skills.Core/TextMemorySkill.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SemanticKernel.Skills.Core;
 /// <example>
 /// Usage: kernel.ImportSkill("memory", new TextMemorySkill());
 /// Examples:
-/// SKContext["input"] = "what is the capital of France?"
+/// SKcontext.Variables["input"] = "what is the capital of France?"
 /// {{memory.recall $input }} => "Paris"
 /// </example>
 public sealed class TextMemorySkill
@@ -67,7 +67,7 @@ public sealed class TextMemorySkill
     /// <param name="logger">Application logger</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <example>
-    /// SKContext[TextMemorySkill.KeyParam] = "countryInfo1"
+    /// SKcontext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
     /// {{memory.retrieve }}
     /// </example>
     [SKFunction, Description("Key-based lookup for a specific memory")]
@@ -92,7 +92,7 @@ public sealed class TextMemorySkill
     /// Semantic search and return up to N memories related to the input text
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "what is the capital of France?"
+    /// SKcontext.Variables["input"] = "what is the capital of France?"
     /// {{memory.recall $input }} => "Paris"
     /// </example>
     /// <param name="input">The input text to find related memories for.</param>
@@ -137,8 +137,8 @@ public sealed class TextMemorySkill
     /// Save information to semantic memory
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "the capital of France is Paris"
-    /// SKContext[TextMemorySkill.KeyParam] = "countryInfo1"
+    /// SKcontext.Variables["input"] = "the capital of France is Paris"
+    /// SKcontext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
     /// {{memory.save $input }}
     /// </example>
     /// <param name="input">The information to save</param>
@@ -167,7 +167,7 @@ public sealed class TextMemorySkill
     /// Remove specific memory
     /// </summary>
     /// <example>
-    /// SKContext[TextMemorySkill.KeyParam] = "countryInfo1"
+    /// SKcontext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
     /// {{memory.remove }}
     /// </example>
     /// <param name="collection">Memories collection associated with the information to save</param>

--- a/dotnet/src/Skills/Skills.Core/TextMemorySkill.cs
+++ b/dotnet/src/Skills/Skills.Core/TextMemorySkill.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SemanticKernel.Skills.Core;
 /// <example>
 /// Usage: kernel.ImportSkill("memory", new TextMemorySkill());
 /// Examples:
-/// SKcontext.Variables["input"] = "what is the capital of France?"
+/// SKContext.Variables["input"] = "what is the capital of France?"
 /// {{memory.recall $input }} => "Paris"
 /// </example>
 public sealed class TextMemorySkill
@@ -67,7 +67,7 @@ public sealed class TextMemorySkill
     /// <param name="logger">Application logger</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <example>
-    /// SKcontext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
+    /// SKContext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
     /// {{memory.retrieve }}
     /// </example>
     [SKFunction, Description("Key-based lookup for a specific memory")]
@@ -92,7 +92,7 @@ public sealed class TextMemorySkill
     /// Semantic search and return up to N memories related to the input text
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "what is the capital of France?"
+    /// SKContext.Variables["input"] = "what is the capital of France?"
     /// {{memory.recall $input }} => "Paris"
     /// </example>
     /// <param name="input">The input text to find related memories for.</param>
@@ -137,8 +137,8 @@ public sealed class TextMemorySkill
     /// Save information to semantic memory
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "the capital of France is Paris"
-    /// SKcontext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
+    /// SKContext.Variables["input"] = "the capital of France is Paris"
+    /// SKContext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
     /// {{memory.save $input }}
     /// </example>
     /// <param name="input">The information to save</param>
@@ -167,7 +167,7 @@ public sealed class TextMemorySkill
     /// Remove specific memory
     /// </summary>
     /// <example>
-    /// SKcontext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
+    /// SKContext.Variables[TextMemorySkill.KeyParam] = "countryInfo1"
     /// {{memory.remove }}
     /// </example>
     /// <param name="collection">Memories collection associated with the information to save</param>

--- a/dotnet/src/Skills/Skills.Core/TextSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/TextSkill.cs
@@ -13,13 +13,13 @@ namespace Microsoft.SemanticKernel.Skills.Core;
 /// Usage: kernel.ImportSkill("text", new TextSkill());
 ///
 /// Examples:
-/// SKContext["input"] = "  hello world  "
+/// SKcontext.Variables["input"] = "  hello world  "
 /// {{text.trim $input}} => "hello world"
 /// {{text.trimStart $input} => "hello world  "
 /// {{text.trimEnd $input} => "  hello world"
-/// SKContext["input"] = "hello world"
+/// SKcontext.Variables["input"] = "hello world"
 /// {{text.uppercase $input}} => "HELLO WORLD"
-/// SKContext["input"] = "HELLO WORLD"
+/// SKcontext.Variables["input"] = "HELLO WORLD"
 /// {{text.lowercase $input}} => "hello world"
 /// </example>
 public sealed class TextSkill
@@ -28,7 +28,7 @@ public sealed class TextSkill
     /// Trim whitespace from the start and end of a string.
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "  hello world  "
+    /// SKcontext.Variables["input"] = "  hello world  "
     /// {{text.trim $input}} => "hello world"
     /// </example>
     /// <param name="input"> The string to trim. </param>
@@ -40,7 +40,7 @@ public sealed class TextSkill
     /// Trim whitespace from the start of a string.
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "  hello world  "
+    /// SKcontext.Variables["input"] = "  hello world  "
     /// {{text.trimStart $input} => "hello world  "
     /// </example>
     /// <param name="input"> The string to trim. </param>
@@ -52,7 +52,7 @@ public sealed class TextSkill
     /// Trim whitespace from the end of a string.
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "  hello world  "
+    /// SKcontext.Variables["input"] = "  hello world  "
     /// {{text.trimEnd $input} => "  hello world"
     /// </example>
     /// <param name="input"> The string to trim. </param>
@@ -64,7 +64,7 @@ public sealed class TextSkill
     /// Convert a string to uppercase.
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "hello world"
+    /// SKcontext.Variables["input"] = "hello world"
     /// {{text.uppercase $input}} => "HELLO WORLD"
     /// </example>
     /// <param name="input"> The string to convert. </param>
@@ -77,7 +77,7 @@ public sealed class TextSkill
     /// Convert a string to lowercase.
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "HELLO WORLD"
+    /// SKcontext.Variables["input"] = "HELLO WORLD"
     /// {{text.lowercase $input}} => "hello world"
     /// </example>
     /// <param name="input"> The string to convert. </param>
@@ -90,7 +90,7 @@ public sealed class TextSkill
     /// Get the length of a string. Returns 0 if null or empty
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "HELLO WORLD"
+    /// SKcontext.Variables["input"] = "HELLO WORLD"
     /// {{text.length $input}} => "11"
     /// </example>
     /// <param name="input"> The string to get length. </param>
@@ -103,7 +103,7 @@ public sealed class TextSkill
     /// </summary>
     /// <example>
     /// text = "HELLO "
-    /// SKContext["input2"] = "WORLD"
+    /// SKcontext.Variables["input2"] = "WORLD"
     /// Result: "HELLO WORLD"
     /// </example>
     /// <param name="input">First input to concatenate with</param>

--- a/dotnet/src/Skills/Skills.Core/TextSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/TextSkill.cs
@@ -13,13 +13,13 @@ namespace Microsoft.SemanticKernel.Skills.Core;
 /// Usage: kernel.ImportSkill("text", new TextSkill());
 ///
 /// Examples:
-/// SKcontext.Variables["input"] = "  hello world  "
+/// SKContext.Variables["input"] = "  hello world  "
 /// {{text.trim $input}} => "hello world"
 /// {{text.trimStart $input} => "hello world  "
 /// {{text.trimEnd $input} => "  hello world"
-/// SKcontext.Variables["input"] = "hello world"
+/// SKContext.Variables["input"] = "hello world"
 /// {{text.uppercase $input}} => "HELLO WORLD"
-/// SKcontext.Variables["input"] = "HELLO WORLD"
+/// SKContext.Variables["input"] = "HELLO WORLD"
 /// {{text.lowercase $input}} => "hello world"
 /// </example>
 public sealed class TextSkill
@@ -28,7 +28,7 @@ public sealed class TextSkill
     /// Trim whitespace from the start and end of a string.
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "  hello world  "
+    /// SKContext.Variables["input"] = "  hello world  "
     /// {{text.trim $input}} => "hello world"
     /// </example>
     /// <param name="input"> The string to trim. </param>
@@ -40,7 +40,7 @@ public sealed class TextSkill
     /// Trim whitespace from the start of a string.
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "  hello world  "
+    /// SKContext.Variables["input"] = "  hello world  "
     /// {{text.trimStart $input} => "hello world  "
     /// </example>
     /// <param name="input"> The string to trim. </param>
@@ -52,7 +52,7 @@ public sealed class TextSkill
     /// Trim whitespace from the end of a string.
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "  hello world  "
+    /// SKContext.Variables["input"] = "  hello world  "
     /// {{text.trimEnd $input} => "  hello world"
     /// </example>
     /// <param name="input"> The string to trim. </param>
@@ -64,7 +64,7 @@ public sealed class TextSkill
     /// Convert a string to uppercase.
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "hello world"
+    /// SKContext.Variables["input"] = "hello world"
     /// {{text.uppercase $input}} => "HELLO WORLD"
     /// </example>
     /// <param name="input"> The string to convert. </param>
@@ -77,7 +77,7 @@ public sealed class TextSkill
     /// Convert a string to lowercase.
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "HELLO WORLD"
+    /// SKContext.Variables["input"] = "HELLO WORLD"
     /// {{text.lowercase $input}} => "hello world"
     /// </example>
     /// <param name="input"> The string to convert. </param>
@@ -90,7 +90,7 @@ public sealed class TextSkill
     /// Get the length of a string. Returns 0 if null or empty
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "HELLO WORLD"
+    /// SKContext.Variables["input"] = "HELLO WORLD"
     /// {{text.length $input}} => "11"
     /// </example>
     /// <param name="input"> The string to get length. </param>
@@ -103,7 +103,7 @@ public sealed class TextSkill
     /// </summary>
     /// <example>
     /// text = "HELLO "
-    /// SKcontext.Variables["input2"] = "WORLD"
+    /// SKContext.Variables["input2"] = "WORLD"
     /// Result: "HELLO WORLD"
     /// </example>
     /// <param name="input">First input to concatenate with</param>

--- a/dotnet/src/Skills/Skills.Core/TimeSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/TimeSkill.cs
@@ -152,7 +152,7 @@ public sealed class TimeSkill
     /// Get the date a provided number of days in the past
     /// </summary>
     /// <example>
-    /// SKcontext.Variables["input"] = "3"
+    /// SKContext.Variables["input"] = "3"
     /// {{time.daysAgo}} => Sunday, January 12, 2025 9:15 PM
     /// </example>
     /// <returns> The date the provided number of days before today </returns>

--- a/dotnet/src/Skills/Skills.Core/TimeSkill.cs
+++ b/dotnet/src/Skills/Skills.Core/TimeSkill.cs
@@ -152,7 +152,7 @@ public sealed class TimeSkill
     /// Get the date a provided number of days in the past
     /// </summary>
     /// <example>
-    /// SKContext["input"] = "3"
+    /// SKcontext.Variables["input"] = "3"
     /// {{time.daysAgo}} => Sunday, January 12, 2025 9:15 PM
     /// </example>
     /// <returns> The date the provided number of days before today </returns>


### PR DESCRIPTION
### Motivation and Context
The SKContext[...] indexer is simply shorthand for SKContext.Variables[...]. With additional routes to doing the same thing, there's more confusion about which to use when. In this case, there's a great deal of confusion about the mutability of these variables and whether they can/should be changed within functions or between functions.

### Description
This PR starts to address the above issues by simplifying the SDK surface. The first step is to remove the "extra" route to accessing the same data, the indexer on SKContext. 

**This is a breaking change.** The mitigation is simply to update all uses of `context["MY_VALUE"]` to `context.Variables["MY_VALUE"]`

In the PRs that follow, the mutability issue will be addressed by making it clear which variables are input, how and where to set output, and which can/cannot be transformed by an SKFunction.

### Contribution Checklist
- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
   => This is a breaking change.