### PR TITLE
Copilot Chat: Add "Delete" button for users to be able to delete files in copilot-chat-app sample

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/libs/services/DocumentDeleteService.ts
+++ b/samples/apps/copilot-chat-app/webapp/src/libs/services/DocumentDeleteService.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+import { BaseService } from './BaseService';
+
+export class DocumentDeleteService extends BaseService {
+    public deleteDocumentAsync = async (
+        userId: string,
+        chatId: string,
+        documentId: string,
+        accessToken: string,
+    ) => {
+        const formData = new FormData();
+        formData.append('userId', userId);
+        formData.append('chatId', chatId);
+        formData.append('documentId', documentId);
+
+        return await this.getResponseAsync<string>(
+            {
+                commandPath: 'deleteDocument',
+                method: 'POST',
+                body: formData,
+            },
+            accessToken,
+        );
+    };
+}


### PR DESCRIPTION
Hello ! 

I was trying to add a "delete" button in the copilot-chat-app sample to be able to delete files, it seems to work but I don't know if I'm doing it right. I am still a beginner in building webapps, so I was wondering if I could get some help here. (I don't know if a pull request is the best way to do it ? but I thought it might be a nice feature to add to the sample). I made a couple of changes in ChatResourceList and useChat and added DocumentDeleteService and DocumentDeleteController, if someone can help me pinpoint where I might be doing something wrong, I would be really grateful.

Thank you ! 