### PR TITLE
.Net: Update build.cmd

### DIFF
--- a/dotnet/build.cmd
+++ b/dotnet/build.cmd
@@ -1,7 +1,5 @@
 @echo off
 
-cd dotnet
-
 dotnet build --configuration Release --interactive
 
 dotnet test --configuration Release --no-build --no-restore --interactive


### PR DESCRIPTION
We are already in the dotnet folder, no need to cd again, as there is no dotnet folder inside the dotnet folder! 
Found this while I was building a repo for the first time!

BTW any specific reason we are running tests when building a repo for the first time!? 