### PR TITLE
Java: refactor Embedding to be float

### DIFF
--- a/java/connectors/semantickernel-connectors-ai-openai/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/java/connectors/semantickernel-connectors-ai-openai/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletion.java
@@ -102,7 +102,7 @@ public class OpenAIChatCompletion extends ClientBase implements ChatCompletion<O
                         .map(
                                 it ->
                                         new ChatMessage(
-                                                toChatRole(it.getAuthorRoles()), it.getContent()))
+                                                toChatRole(it.getAuthorRoles())).setContent(it.getContent()))
                         .collect(Collectors.toList());
 
         ChatCompletionsOptions options = new ChatCompletionsOptions(messages);

--- a/java/connectors/semantickernel-connectors-ai-openai/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/textembeddings/OpenAITextEmbeddingGeneration.java
+++ b/java/connectors/semantickernel-connectors-ai-openai/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/textembeddings/OpenAITextEmbeddingGeneration.java
@@ -22,11 +22,11 @@ public class OpenAITextEmbeddingGeneration extends ClientBase
     }
 
     @Override
-    public Mono<List<Embedding<Float>>> generateEmbeddingsAsync(List<String> data) {
+    public Mono<List<Embedding>> generateEmbeddingsAsync(List<String> data) {
         return this.internalGenerateTextEmbeddingsAsync(data);
     }
 
-    protected Mono<List<Embedding<Float>>> internalGenerateTextEmbeddingsAsync(List<String> data) {
+    protected Mono<List<Embedding>> internalGenerateTextEmbeddingsAsync(List<String> data) {
         EmbeddingsOptions options =
                 new EmbeddingsOptions(data).setModel(getModelId()).setUser("default");
 

--- a/java/connectors/semantickernel-connectors-memory-sqlite/src/main/java/com/microsoft/semantickernel/connectors/memory/sqlite/SqliteMemoryStore.java
+++ b/java/connectors/semantickernel-connectors-memory-sqlite/src/main/java/com/microsoft/semantickernel/connectors/memory/sqlite/SqliteMemoryStore.java
@@ -167,7 +167,7 @@ public class SqliteMemoryStore implements MemoryStore {
     @Override
     public Mono<Collection<Tuple2<MemoryRecord, Number>>> getNearestMatchesAsync(
             @Nonnull String collectionName,
-            @Nonnull Embedding<? extends Number> embedding,
+            @Nonnull Embedding embedding,
             int limit,
             double minRelevanceScore,
             boolean withEmbeddings) {
@@ -177,7 +177,7 @@ public class SqliteMemoryStore implements MemoryStore {
     @Override
     public Mono<Tuple2<MemoryRecord, ? extends Number>> getNearestMatchAsync(
             @Nonnull String collectionName,
-            @Nonnull Embedding<? extends Number> embedding,
+            @Nonnull Embedding embedding,
             double minRelevanceScore,
             boolean withEmbedding) {
         return null;

--- a/java/connectors/semantickernel-connectors-memory-sqlite/src/test/java/com/microsoft/semantickernel/connectors/memory/sqlite/SqliteMemoryStoreTest.java
+++ b/java/connectors/semantickernel-connectors-memory-sqlite/src/test/java/com/microsoft/semantickernel/connectors/memory/sqlite/SqliteMemoryStoreTest.java
@@ -124,7 +124,7 @@ public class SqliteMemoryStoreTest {
                         "test",
                         "test",
                         "test",
-                        new Embedding<>(new ArrayList<>(Arrays.asList(1.23f, 4.56f, 7.89f))),
+                        new Embedding(new ArrayList<>(Arrays.asList(1.23f, 4.56f, 7.89f))),
                         null,
                         "test",
                         ZonedDateTime.now());

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,7 +14,7 @@
     <description>Parent pom for the Semantic Kernel Project</description>
 
     <properties>
-        <azure-ai-openai.version>1.0.0-beta.3</azure-ai-openai.version>
+        <azure-ai-openai.version>1.0.0-beta.2</azure-ai-openai.version>
         <checkstyle.version>10.12.2</checkstyle.version>
         <com.uber.nullaway.version>0.10.10</com.uber.nullaway.version>
         <google.errorprone.core.version>2.19.1</google.errorprone.core.version>

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/ai/embeddings/Embedding.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/ai/embeddings/Embedding.java
@@ -7,20 +7,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** Represents a strongly typed vector of numeric data. */
-public class Embedding<EmbeddingType extends Number> {
+public class Embedding {
 
-    public List<EmbeddingType> getVector() {
+    public List<Float> getVector() {
         return Collections.unmodifiableList(vector);
     }
 
-    private final List<EmbeddingType> vector;
+    private final List<Float> vector;
 
-    private static final Embedding<Number> EMPTY =
+    private static final Embedding EMPTY =
             new Embedding(Collections.unmodifiableList(new ArrayList<>()));
 
-    @SuppressWarnings("unchecked")
-    public static <EmbeddingType extends Number> Embedding<EmbeddingType> empty() {
-        return (Embedding<EmbeddingType>) EMPTY;
+    public static Embedding empty() {
+        return EMPTY;
     }
 
     /** Initializes a new instance of the Embedding class. */
@@ -34,7 +33,7 @@ public class Embedding<EmbeddingType extends Number> {
      *
      * @param vector The collection whose elements are copied to the new Embedding
      */
-    public Embedding(List<EmbeddingType> vector) {
+    public Embedding(List<Float> vector) {
         //        Verify.NotNull(vector, nameof(vector));
         this.vector =
                 vector != null ? Collections.unmodifiableList(vector) : Collections.emptyList();
@@ -45,7 +44,7 @@ public class Embedding<EmbeddingType extends Number> {
         if (this == o) return true;
         if (!(o instanceof Embedding)) return false;
 
-        Embedding<?> embedding = (Embedding<?>) o;
+        Embedding embedding = (Embedding) o;
 
         return vector.equals(embedding.vector);
     }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/ai/embeddings/EmbeddingGeneration.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/ai/embeddings/EmbeddingGeneration.java
@@ -16,7 +16,7 @@ public interface EmbeddingGeneration<TValue, TEmbedding extends Number> extends 
      * @param data List of texts to generate embeddings for
      * @return List of embeddings of each data point
      */
-    Mono<List<Embedding<TEmbedding>>> generateEmbeddingsAsync(List<TValue> data);
+    Mono<List<Embedding>> generateEmbeddingsAsync(List<TValue> data);
 
     interface Builder<TValue, TEmbedding extends Number> {
         EmbeddingGeneration<TValue, TEmbedding> build(OpenAIAsyncClient client, String modelId);

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryRecord.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryRecord.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
  * will invalidate existing metadata stored in persistent vector DBs.
  */
 public class MemoryRecord extends DataEntryBase {
-    @Nonnull private final Embedding<? extends Number> embedding;
+    @Nonnull private final Embedding embedding;
 
     @Nonnull private final MemoryRecordMetadata metadata;
 
@@ -29,7 +29,7 @@ public class MemoryRecord extends DataEntryBase {
      */
     public MemoryRecord(
             @Nonnull MemoryRecordMetadata metadata,
-            @Nonnull Embedding<? extends Number> embedding,
+            @Nonnull Embedding embedding,
             @Nullable String key,
             @Nullable ZonedDateTime timestamp) {
         super(key, timestamp);
@@ -42,7 +42,7 @@ public class MemoryRecord extends DataEntryBase {
      *
      * @return The source content embeddings.
      */
-    public Embedding<? extends Number> getEmbedding() {
+    public Embedding getEmbedding() {
         return embedding;
     }
 
@@ -73,7 +73,7 @@ public class MemoryRecord extends DataEntryBase {
             @Nonnull String externalId,
             @Nonnull String sourceName,
             @Nullable String description,
-            @Nonnull Embedding<Float> embedding,
+            @Nonnull Embedding embedding,
             @Nullable String additionalMetadata,
             @Nullable String key,
             @Nullable ZonedDateTime timestamp) {
@@ -106,7 +106,7 @@ public class MemoryRecord extends DataEntryBase {
             @Nonnull String id,
             @Nonnull String text,
             @Nullable String description,
-            @Nonnull Embedding<Float> embedding,
+            @Nonnull Embedding embedding,
             @Nullable String additionalMetadata,
             @Nullable String key,
             @Nullable ZonedDateTime timestamp) {
@@ -135,7 +135,7 @@ public class MemoryRecord extends DataEntryBase {
      */
     public static MemoryRecord fromMetadata(
             @Nonnull MemoryRecordMetadata metadata,
-            @Nullable Embedding<Float> embedding,
+            @Nullable Embedding embedding,
             @Nullable String key,
             @Nullable ZonedDateTime timestamp) {
         return new MemoryRecord(
@@ -175,7 +175,7 @@ public class MemoryRecord extends DataEntryBase {
 
     public static MemoryRecord fromJsonMetadata(
             String json,
-            @Nullable Embedding<Float> embedding,
+            @Nullable Embedding embedding,
             @Nullable String key,
             @Nullable ZonedDateTime timestamp)
             throws JsonProcessingException {

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryStore.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryStore.java
@@ -126,7 +126,7 @@ public interface MemoryStore {
      */
     Mono<Collection<Tuple2<MemoryRecord, Number>>> getNearestMatchesAsync(
             @Nonnull String collectionName,
-            @Nonnull Embedding<? extends Number> embedding,
+            @Nonnull Embedding embedding,
             int limit,
             double minRelevanceScore,
             boolean withEmbeddings);
@@ -144,7 +144,7 @@ public interface MemoryStore {
      */
     Mono<Tuple2<MemoryRecord, ? extends Number>> getNearestMatchAsync(
             @Nonnull String collectionName,
-            @Nonnull Embedding<? extends Number> embedding,
+            @Nonnull Embedding embedding,
             double minRelevanceScore,
             boolean withEmbedding);
 

--- a/java/semantickernel-bom/pom.xml
+++ b/java/semantickernel-bom/pom.xml
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-ai-openai</artifactId>
-                <version>1.0.0-beta.3</version>
+                <version>1.0.0-beta.2</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/EmbeddingVector.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/EmbeddingVector.java
@@ -11,24 +11,22 @@ import java.util.stream.Collectors;
 
 /**
  * Represents a strongly typed vector of numeric data
- *
- * @param <TEmbedding>
- */
-public class EmbeddingVector<TEmbedding extends Number>
-        implements DotProduct<TEmbedding>,
+ **/
+public class EmbeddingVector
+        implements DotProduct,
                 EuclideanLength,
-                CosineSimilarity<TEmbedding>,
-                Multiply<TEmbedding>,
-                Divide<TEmbedding>,
-                Normalize<TEmbedding> {
+                CosineSimilarity,
+                Multiply,
+                Divide,
+                Normalize {
 
-    private final List<TEmbedding> vector;
+    private final List<Float> vector;
 
-    public EmbeddingVector(List<TEmbedding> vector) {
+    public EmbeddingVector(List<Float> vector) {
         this.vector = Collections.unmodifiableList(vector);
     }
 
-    public EmbeddingVector(TEmbedding[] vector) {
+    public EmbeddingVector(Float vector) {
         this.vector = Collections.unmodifiableList(Arrays.asList(vector));
     }
 
@@ -45,7 +43,7 @@ public class EmbeddingVector<TEmbedding extends Number>
         return this.vector.size();
     }
 
-    public List<TEmbedding> getVector() {
+    public List<Float> getVector() {
         return Collections.unmodifiableList(this.vector);
     }
 
@@ -56,14 +54,14 @@ public class EmbeddingVector<TEmbedding extends Number>
      * @return Dot product between vectors
      */
     @Override
-    public double dot(EmbeddingVector<TEmbedding> other) {
+    public float dot(EmbeddingVector other) {
         if (this.size() != other.size()) {
             throw new IllegalArgumentException("Vectors lengths must be equal");
         }
 
-        double result = 0;
+        float result = 0;
         for (int i = 0; i < this.size(); ++i) {
-            result += this.vector.get(i).doubleValue() * other.getVector().get(i).doubleValue();
+            result += this.vector.get(i) * other.getVector().get(i);
         }
 
         return result;
@@ -75,8 +73,8 @@ public class EmbeddingVector<TEmbedding extends Number>
      * @return Euclidean length
      */
     @Override
-    public double euclideanLength() {
-        return Math.sqrt(this.dot(this));
+    public float euclideanLength() {
+        return (float) Math.sqrt(this.dot(this));
     }
 
     /**
@@ -86,44 +84,44 @@ public class EmbeddingVector<TEmbedding extends Number>
      * @return Cosine similarity between vectors
      */
     @Override
-    public double cosineSimilarity(EmbeddingVector<TEmbedding> other) {
+    public float cosineSimilarity(EmbeddingVector other) {
         if (this.size() != other.size()) {
             throw new IllegalArgumentException("Vectors lengths must be equal");
         }
 
-        double dotProduct = this.dot(other);
-        double normX = this.dot(this);
-        double normY = other.dot(other);
+        float dotProduct = this.dot(other);
+        float normX = this.dot(this);
+        float normY = other.dot(other);
 
         if (normX == 0 || normY == 0) {
             throw new IllegalArgumentException("Vectors cannot have zero norm");
         }
 
-        return dotProduct / (Math.sqrt(normX) * Math.sqrt(normY));
+        return dotProduct / (float)(Math.sqrt(normX) * Math.sqrt(normY));
     }
 
     @Override
-    public EmbeddingVector<TEmbedding> multiply(double multiplier) {
-        List<Double> result =
+    public EmbeddingVector multiply(float multiplier) {
+        List<Float> result =
                 this.getVector().stream()
-                        .map(x -> x.doubleValue() * multiplier)
+                        .map(x -> x * multiplier)
                         .collect(Collectors.toList());
 
-        return (EmbeddingVector<TEmbedding>) new EmbeddingVector<>(result);
+        return (EmbeddingVector) new EmbeddingVector(result);
     }
 
     @Override
-    public EmbeddingVector<TEmbedding> divide(double divisor) {
-        if (Double.isNaN(divisor) || divisor == 0) {
+    public EmbeddingVector divide(float divisor) {
+        if (Float.isNaN(divisor) || divisor == 0) {
             throw new IllegalArgumentException("Divisor cannot be zero");
         }
 
-        List<Double> result =
+        List<Float> result =
                 this.getVector().stream()
-                        .map(x -> x.doubleValue() / divisor)
+                        .map(x -> x / divisor)
                         .collect(Collectors.toList());
 
-        return (EmbeddingVector<TEmbedding>) new EmbeddingVector<>(result);
+        return new EmbeddingVector(result);
     }
 
     /**
@@ -132,7 +130,7 @@ public class EmbeddingVector<TEmbedding extends Number>
      * @return Normalized embedding
      */
     @Override
-    public EmbeddingVector<TEmbedding> normalize() {
+    public EmbeddingVector normalize() {
         return this.divide(this.euclideanLength());
     }
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/CosineSimilarity.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/CosineSimilarity.java
@@ -3,6 +3,6 @@ package com.microsoft.semantickernel.ai.vectoroperations;
 
 import com.microsoft.semantickernel.ai.EmbeddingVector;
 
-public interface CosineSimilarity<T extends Number> {
-    double cosineSimilarity(EmbeddingVector<T> other);
+public interface CosineSimilarity {
+    float cosineSimilarity(EmbeddingVector other);
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/Divide.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/Divide.java
@@ -3,6 +3,6 @@ package com.microsoft.semantickernel.ai.vectoroperations;
 
 import com.microsoft.semantickernel.ai.EmbeddingVector;
 
-public interface Divide<T extends Number> {
-    EmbeddingVector<T> divide(double divisor);
+public interface Divide {
+    EmbeddingVector divide(float divisor);
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/DotProduct.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/DotProduct.java
@@ -3,6 +3,6 @@ package com.microsoft.semantickernel.ai.vectoroperations;
 
 import com.microsoft.semantickernel.ai.EmbeddingVector;
 
-public interface DotProduct<T extends Number> {
-    double dot(EmbeddingVector<T> other);
+public interface DotProduct {
+    float dot(EmbeddingVector other);
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/EuclideanLength.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/EuclideanLength.java
@@ -2,5 +2,5 @@
 package com.microsoft.semantickernel.ai.vectoroperations;
 
 public interface EuclideanLength {
-    double euclideanLength();
+    float euclideanLength();
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/Multiply.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/Multiply.java
@@ -3,6 +3,6 @@ package com.microsoft.semantickernel.ai.vectoroperations;
 
 import com.microsoft.semantickernel.ai.EmbeddingVector;
 
-public interface Multiply<T extends Number> {
-    EmbeddingVector<T> multiply(double multiplier);
+public interface Multiply {
+    EmbeddingVector multiply(float multiplier);
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/Normalize.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/ai/vectoroperations/Normalize.java
@@ -3,6 +3,6 @@ package com.microsoft.semantickernel.ai.vectoroperations;
 
 import com.microsoft.semantickernel.ai.EmbeddingVector;
 
-public interface Normalize<T extends Number> {
-    EmbeddingVector<T> normalize();
+public interface Normalize {
+    EmbeddingVector normalize();
 }

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/memory/DefaultSemanticTextMemory.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/memory/DefaultSemanticTextMemory.java
@@ -162,7 +162,7 @@ public class DefaultSemanticTextMemory implements SemanticTextMemory {
                                         externalId,
                                         externalSourceName,
                                         description,
-                                        (Embedding<Float>) embeddings.iterator().next(),
+                                        (Embedding) embeddings.iterator().next(),
                                         additionalMetadata,
                                         null,
                                         null))

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletionTest.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletionTest.java
@@ -16,6 +16,7 @@ import com.microsoft.semantickernel.textcompletion.CompletionRequestSettings;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/memory/MemoryRecordTests.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/memory/MemoryRecordTests.java
@@ -21,7 +21,7 @@ class MemoryRecordTests {
     private static final String _description = "description";
     private static final String _externalSourceName = "externalSourceName";
     private static final String _additionalMetadata = "value";
-    private static final Embedding<Float> _embedding = new Embedding<>(Arrays.asList(1f, 2f, 3f));
+    private static final Embedding _embedding =  new Embedding(Arrays.asList(1f, 2f, 3f));
 
     @Test
     void itCanBeConstructedFromMetadataAndVector() {

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/memory/VolatileMemoryStoreTests.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/memory/VolatileMemoryStoreTests.java
@@ -48,7 +48,7 @@ class VolatileMemoryStoreTests {
                             "test" + i,
                             "text" + i,
                             "description" + i,
-                            new Embedding<Float>(Arrays.asList(1f, 1f, 1f)),
+                            new Embedding(Arrays.asList(1f, 1f, 1f)),
                             NULL_ADDITIONAL_METADATA,
                             NULL_KEY,
                             NULL_TIMESTAMP);
@@ -61,7 +61,7 @@ class VolatileMemoryStoreTests {
                             "test" + i,
                             "sourceName" + i,
                             "description" + i,
-                            new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                            new Embedding(Arrays.asList(1f, 2f, 3f)),
                             NULL_ADDITIONAL_METADATA,
                             NULL_KEY,
                             NULL_TIMESTAMP);
@@ -117,7 +117,7 @@ class VolatileMemoryStoreTests {
                         "test",
                         "text",
                         "description",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -139,7 +139,7 @@ class VolatileMemoryStoreTests {
                         "test",
                         "text",
                         "description",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -173,7 +173,7 @@ class VolatileMemoryStoreTests {
                         "test",
                         "text",
                         "description",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -198,7 +198,7 @@ class VolatileMemoryStoreTests {
                         "test",
                         "text",
                         "description",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         ZonedDateTime.now(ZoneId.of("UTC")));
@@ -224,7 +224,7 @@ class VolatileMemoryStoreTests {
                         commonId,
                         "text",
                         "description",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -233,7 +233,7 @@ class VolatileMemoryStoreTests {
                         commonId,
                         "text2",
                         "description2",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 4f)),
+                        new Embedding(Arrays.asList(1f, 2f, 4f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -261,7 +261,7 @@ class VolatileMemoryStoreTests {
                         "test",
                         "text",
                         "description",
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -322,7 +322,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchesReturnsAllResultsWithNoMinScoreAsync() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         int topN = 4;
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -333,7 +333,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 1f, 1f)),
+                        new Embedding(Arrays.asList(1f, 1f, 1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -345,7 +345,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -1f, -1f)),
+                        new Embedding(Arrays.asList(-1f, -1f, -1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -357,7 +357,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -369,7 +369,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -2f, -3f)),
+                        new Embedding(Arrays.asList(-1f, -2f, -3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -381,7 +381,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, -1f, -2f)),
+                        new Embedding(Arrays.asList(1f, -1f, -2f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -411,7 +411,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchesReturnsLimit() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
         this._db.createCollectionAsync(collection).block();
@@ -421,7 +421,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 1f, 1f)),
+                        new Embedding(Arrays.asList(1f, 1f, 1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -433,7 +433,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -1f, -1f)),
+                        new Embedding(Arrays.asList(-1f, -1f, -1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -445,7 +445,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -457,7 +457,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -2f, -3f)),
+                        new Embedding(Arrays.asList(-1f, -2f, -3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -469,7 +469,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, -1f, -2f)),
+                        new Embedding(Arrays.asList(1f, -1f, -2f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -491,7 +491,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchesReturnsEmptyIfLimitZero() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
         this._db.createCollectionAsync(collection).block();
@@ -501,7 +501,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 1f, 1f)),
+                        new Embedding(Arrays.asList(1f, 1f, 1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -513,7 +513,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -1f, -1f)),
+                        new Embedding(Arrays.asList(-1f, -1f, -1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -525,7 +525,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -537,7 +537,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -2f, -3f)),
+                        new Embedding(Arrays.asList(-1f, -2f, -3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -549,7 +549,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, -1f, -2f)),
+                        new Embedding(Arrays.asList(1f, -1f, -2f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -570,7 +570,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchesReturnsEmptyIfCollectionEmpty() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
         this._db.createCollectionAsync(collection).block();
@@ -591,7 +591,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchAsyncReturnsEmptyEmbeddingUnlessSpecifiedAsync() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         int topN = 4;
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -602,7 +602,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 1f, 1f)),
+                        new Embedding(Arrays.asList(1f, 1f, 1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -614,7 +614,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -1f, -1f)),
+                        new Embedding(Arrays.asList(-1f, -1f, -1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -626,7 +626,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -638,7 +638,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -2f, -3f)),
+                        new Embedding(Arrays.asList(-1f, -2f, -3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -650,7 +650,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, -1f, -2f)),
+                        new Embedding(Arrays.asList(1f, -1f, -2f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -681,7 +681,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchAsyncReturnsExpectedAsync() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         int topN = 4;
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -692,7 +692,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 1f, 1f)),
+                        new Embedding(Arrays.asList(1f, 1f, 1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -704,7 +704,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -1f, -1f)),
+                        new Embedding(Arrays.asList(-1f, -1f, -1f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -716,7 +716,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, 2f, 3f)),
+                        new Embedding(Arrays.asList(1f, 2f, 3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -728,7 +728,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(-1f, -2f, -3f)),
+                        new Embedding(Arrays.asList(-1f, -2f, -3f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -740,7 +740,7 @@ class VolatileMemoryStoreTests {
                         "test" + i,
                         "text" + i,
                         "description" + i,
-                        new Embedding<Float>(Arrays.asList(1f, -1f, -2f)),
+                        new Embedding(Arrays.asList(1f, -1f, -2f)),
                         NULL_ADDITIONAL_METADATA,
                         NULL_KEY,
                         NULL_TIMESTAMP);
@@ -762,7 +762,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatcheReturnsEmptyIfCollectionEmpty() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         int topN = 4;
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -782,7 +782,7 @@ class VolatileMemoryStoreTests {
     @Test
     void getNearestMatchesDifferentiatesIdenticalVectorsByKeyAsync() {
         // Arrange
-        Embedding<Float> compareEmbedding = new Embedding<>(Arrays.asList(1f, 1f, 1f));
+        Embedding compareEmbedding =  new Embedding(Arrays.asList(1f, 1f, 1f));
         int topN = 4;
         String collection = "test_collection" + this._collectionNum;
         this._collectionNum++;
@@ -794,7 +794,7 @@ class VolatileMemoryStoreTests {
                             "test" + i,
                             "text" + i,
                             "description" + i,
-                            new Embedding<>(Arrays.asList(1f, 1f, 1f)),
+                             new Embedding(Arrays.asList(1f, 1f, 1f)),
                             NULL_ADDITIONAL_METADATA,
                             NULL_KEY,
                             NULL_TIMESTAMP);


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Embedding was declared `Embedding<? extends Number>` which leads to some unfortunate hacks to cast or convert the vector from List<? extends Number> to a List<Float> (typicall). An embedding vector does not need the precision of a double, so changing `List<? extends Number> vector` to `List<Float> vector` and getting rid of the generic type will make use of Embedding much easier. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Basically, changed `Embedding<? extends Number>` to `Embedding` and `List<? extends Number> getVector()` to `List<Float> getVector()`. The most obvious impact of this is on EmbeddingVector and the vectoroperations API where double becomes float. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
