### PR TITLE
Java: MemoryStore updates

### DIFF
--- a/java/connectors/semantickernel-connectors-memory-sqlite/src/main/java/com/microsoft/semantickernel/connectors/memory/sqlite/SqliteMemoryStore.java
+++ b/java/connectors/semantickernel-connectors-memory-sqlite/src/main/java/com/microsoft/semantickernel/connectors/memory/sqlite/SqliteMemoryStore.java
@@ -165,7 +165,7 @@ public class SqliteMemoryStore implements MemoryStore {
     }
 
     @Override
-    public Mono<Collection<Tuple2<MemoryRecord, Number>>> getNearestMatchesAsync(
+    public Mono<Collection<Tuple2<MemoryRecord, Float>>> getNearestMatchesAsync(
             @Nonnull String collectionName,
             @Nonnull Embedding embedding,
             int limit,
@@ -175,7 +175,7 @@ public class SqliteMemoryStore implements MemoryStore {
     }
 
     @Override
-    public Mono<Tuple2<MemoryRecord, ? extends Number>> getNearestMatchAsync(
+    public Mono<Tuple2<MemoryRecord, Float>> getNearestMatchAsync(
             @Nonnull String collectionName,
             @Nonnull Embedding embedding,
             double minRelevanceScore,

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryStore.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/memory/MemoryStore.java
@@ -124,7 +124,7 @@ public interface MemoryStore {
      * @return A collection of tuples where item1 is a {@link MemoryRecord} and item2 is its
      *     similarity score as a {@code double}.
      */
-    Mono<Collection<Tuple2<MemoryRecord, Number>>> getNearestMatchesAsync(
+    Mono<Collection<Tuple2<MemoryRecord, Float>>> getNearestMatchesAsync(
             @Nonnull String collectionName,
             @Nonnull Embedding embedding,
             int limit,
@@ -140,9 +140,9 @@ public interface MemoryStore {
      * @param minRelevanceScore The minimum relevance threshold for returned results.
      * @param withEmbedding If true, the embedding will be returned in the memory record.
      * @return A tuple consisting of the {@link MemoryRecord} and item2 is its similarity score as a
-     *     {@code double}. Null if no nearest match found.
+     *     {@code float}. Null if no nearest match found.
      */
-    Mono<Tuple2<MemoryRecord, ? extends Number>> getNearestMatchAsync(
+    Mono<Tuple2<MemoryRecord, Float>> getNearestMatchAsync(
             @Nonnull String collectionName,
             @Nonnull Embedding embedding,
             double minRelevanceScore,

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/memory/DefaultSemanticTextMemory.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/memory/DefaultSemanticTextMemory.java
@@ -83,7 +83,7 @@ public class DefaultSemanticTextMemory implements SemanticTextMemory {
     }
 
     private static final Function<
-                    Collection<Tuple2<MemoryRecord, Number>>, Mono<List<MemoryQueryResult>>>
+                    Collection<Tuple2<MemoryRecord, Float>>, Mono<List<MemoryQueryResult>>>
             transformMatchesToResults =
                     records -> {
                         if (records.isEmpty()) {

--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/memory/VolatileMemoryStore.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/memory/VolatileMemoryStore.java
@@ -15,9 +15,9 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -32,94 +32,104 @@ public class VolatileMemoryStore implements MemoryStore {
 
     @Override
     public Mono<Void> createCollectionAsync(@Nonnull String collectionName) {
-        if (this._store.containsKey(collectionName)) {
-            throw new MemoryException(
-                    MemoryException.ErrorCodes.FAILED_TO_CREATE_COLLECTION, collectionName);
-        }
-        this._store.putIfAbsent(collectionName, new ConcurrentHashMap<>());
-        return Mono.empty();
+        Objects.requireNonNull(collectionName);
+        return Mono.fromRunnable(() -> this._store.putIfAbsent(collectionName, new ConcurrentHashMap<>()));
     }
 
     @Override
     public Mono<Boolean> doesCollectionExistAsync(@Nonnull String collectionName) {
+        Objects.requireNonNull(collectionName);
         return Mono.just(this._store.containsKey(collectionName));
     }
 
     @Override
     public Mono<List<String>> getCollectionsAsync() {
-        List<String> keys = new ArrayList<>(this._store.keySet());
-        return Mono.just(Collections.unmodifiableList(keys));
+        return Mono.just(Collections.unmodifiableList(new ArrayList<>(this._store.keySet())));
     }
 
     @Override
     public Mono<Void> deleteCollectionAsync(@Nonnull String collectionName) {
-        if (!this._store.containsKey(collectionName)) {
-            throw new MemoryException(
-                    MemoryException.ErrorCodes.FAILED_TO_DELETE_COLLECTION, collectionName);
-        }
-        this._store.remove(collectionName);
-        return Mono.empty();
+        Objects.requireNonNull(collectionName);
+        return Mono.fromRunnable(() -> {
+            if (this._store.containsKey(collectionName)) {
+                this._store.remove(collectionName);
+            } else {
+                throw new MemoryException(MemoryException.ErrorCodes.ATTEMPTED_TO_ACCESS_NONEXISTENT_COLLECTION, collectionName);
+            }
+        });
     }
 
     @Override
     public Mono<String> upsertAsync(@Nonnull String collectionName, @Nonnull MemoryRecord record) {
-        // Contract:
-        //    Does not guarantee that the collection exists.
-        Map<String, MemoryRecord> collection = null;
-        try {
-            // getCollection throws MemoryException if the collection does not exist.
-            collection = getCollection(collectionName);
-        } catch (MemoryException e) {
-            return Mono.error(e);
-        }
+        Objects.requireNonNull(collectionName);
+        Objects.requireNonNull(record);
 
-        String key = record.getMetadata().getId();
-        // Assumption is that MemoryRecord will always have a non-null id.
-        assert key != null;
-        // Contract:
-        //     If the record already exists, it will be updated.
-        //     If the record does not exist, it will be created.
-        collection.put(key, record);
-        return Mono.just(key);
+        return Mono.fromCallable(() -> {
+            // Contract:
+            //    Does not guarantee that the collection exists.
+
+            // getCollection throws MemoryException if the collection does not exist.
+            Map<String, MemoryRecord> collection = getCollection(collectionName);
+
+            String key = record.getMetadata().getId();
+            // Assumption is that MemoryRecord will always have a non-null id.
+            assert key != null;
+
+            // Contract:
+            //     If the record already exists, it will be updated.
+            //     If the record does not exist, it will be created.
+            collection.put(key, record);
+            return key;
+        });
     }
 
     @Override
     public Mono<Collection<String>> upsertBatchAsync(
             @Nonnull String collectionName, @Nonnull Collection<MemoryRecord> records) {
-        Map<String, MemoryRecord> collection = getCollection(collectionName);
-        Set<String> keys = new HashSet<>();
-        records.forEach(
-                record -> {
-                    String key = record.getMetadata().getId();
-                    // Assumption is that MemoryRecord will always have a non-null id.
-                    assert key != null;
-                    // Contract:
-                    //     If the record already exists, it will be updated.
-                    //     If the record does not exist, it will be created.
-                    collection.put(key, record);
-                    keys.add(key);
-                });
-        return Mono.just(keys);
+        Objects.requireNonNull(collectionName);
+        Objects.requireNonNull(records);
+
+        return Mono.fromCallable(() -> {
+            Map<String, MemoryRecord> collection = getCollection(collectionName);
+            Set<String> keys = new HashSet<>();
+            records.forEach(
+                    record -> {
+                        String key = record.getMetadata().getId();
+                        // Assumption is that MemoryRecord will always have a non-null id.
+                        assert key != null;
+                        // Contract:
+                        //     If the record already exists, it will be updated.
+                        //     If the record does not exist, it will be created.
+                        collection.put(key, record);
+                        keys.add(key);
+                    });
+            return keys;
+        });
     }
 
     @Override
     public Mono<MemoryRecord> getAsync(
             @Nonnull String collectionName, @Nonnull String key, boolean withEmbedding) {
-        Map<String, MemoryRecord> collection = this._store.get(collectionName);
-        MemoryRecord record = collection != null ? collection.get(key) : null;
-        if (record != null) {
-            if (withEmbedding) {
-                return Mono.just(record);
-            } else {
-                return Mono.just(
-                        MemoryRecord.fromMetadata(
-                                record.getMetadata(),
-                                null,
-                                record.getMetadata().getId(),
-                                record.getTimestamp()));
+        Objects.requireNonNull(collectionName);
+        Objects.requireNonNull(key);
+
+        return Mono.fromCallable(() -> {
+            Map<String, MemoryRecord> collection = this._store.get(collectionName);
+            MemoryRecord record = collection != null ? collection.get(key) : null;
+            if (record != null) {
+                if (withEmbedding) {
+                    return record;
+                } else {
+                    return
+                            MemoryRecord.fromMetadata(
+                                    record.getMetadata(),
+                                    null,
+                                    record.getMetadata().getId(),
+                                    record.getTimestamp());
+                }
             }
-        }
-        return Mono.empty();
+            return null;
+        });
     }
 
     @Override
@@ -127,73 +137,80 @@ public class VolatileMemoryStore implements MemoryStore {
             @Nonnull String collectionName,
             @Nonnull Collection<String> keys,
             boolean withEmbeddings) {
-        Map<String, MemoryRecord> collection = getCollection(collectionName);
-        Set<MemoryRecord> records = new HashSet<>();
-        keys.forEach(
-                key -> {
-                    MemoryRecord record = collection.get(key);
-                    if (record != null) {
-                        if (withEmbeddings) {
-                            records.add(record);
-                        } else {
-                            records.add(
-                                    MemoryRecord.fromMetadata(
-                                            record.getMetadata(),
-                                            null,
-                                            record.getMetadata().getId(),
-                                            record.getTimestamp()));
+        Objects.requireNonNull(collectionName);
+        Objects.requireNonNull(keys);
+
+        return Mono.fromCallable(() -> {
+            Map<String, MemoryRecord> collection = getCollection(collectionName);
+            Set<MemoryRecord> records = new HashSet<>();
+            keys.forEach(
+                    key -> {
+                        MemoryRecord record = collection.get(key);
+                        if (record != null) {
+                            if (withEmbeddings) {
+                                records.add(record);
+                            } else {
+                                records.add(
+                                        MemoryRecord.fromMetadata(
+                                                record.getMetadata(),
+                                                null,
+                                                record.getMetadata().getId(),
+                                                record.getTimestamp()));
+                            }
                         }
-                    }
-                });
-        return Mono.just(records);
+                    });
+            return records;
+        });
     }
 
     @Override
     public Mono<Void> removeAsync(@Nonnull String collectionName, @Nonnull String key) {
-        Map<String, MemoryRecord> collection = this._store.get(collectionName);
-        if (collection != null) collection.remove(key);
-        return Mono.empty();
+        return Mono.fromRunnable(() -> {
+            Map<String, MemoryRecord> collection = this._store.get(collectionName);
+            if (collection != null) collection.remove(key);
+        });
     }
 
     @Override
     public Mono<Void> removeBatchAsync(
             @Nonnull String collectionName, @Nonnull Collection<String> keys) {
-        Map<String, MemoryRecord> collection = this._store.get(collectionName);
-        keys.forEach(collection::remove);
-        return Mono.empty();
+        return Mono.fromRunnable(() -> {
+            Map<String, MemoryRecord> collection = this._store.get(collectionName);
+            keys.forEach(collection::remove);
+        });
     }
 
-    @SuppressWarnings("UnnecessaryLambda")
-    private static final ToDoubleFunction<Tuple2<MemoryRecord, ? extends Number>>
-            extractSimilarity = tuple -> tuple.getT2().doubleValue();
-
     @Override
-    public Mono<Collection<Tuple2<MemoryRecord, Number>>> getNearestMatchesAsync(
+    public Mono<Collection<Tuple2<MemoryRecord, Float>>> getNearestMatchesAsync(
             @Nonnull String collectionName,
             @Nonnull Embedding embedding,
             int limit,
             double minRelevanceScore,
             boolean withEmbeddings) {
+        Objects.requireNonNull(collectionName);
+        Objects.requireNonNull(embedding);
 
         if (limit <= 0) {
             return Mono.just(Collections.emptyList());
         }
 
+        return Mono.fromCallable(() -> {
+
         Map<String, MemoryRecord> collection = getCollection(collectionName);
         if (collection == null || collection.isEmpty()) {
-            return Mono.just(Collections.emptyList());
+            return Collections.emptyList();
         }
 
         final EmbeddingVector embeddingVector = new EmbeddingVector(embedding.getVector());
 
-        Collection<Tuple2<MemoryRecord, Number>> nearestMatches = new ArrayList<>();
+        Collection<Tuple2<MemoryRecord, Float>> nearestMatches = new ArrayList<>();
         collection.values().forEach(
                 record -> {
                     if (record != null) {
                         EmbeddingVector recordVector =
                                 new EmbeddingVector(record.getEmbedding().getVector());
-                        double similarity = embeddingVector.cosineSimilarity(recordVector);
-                        if (similarity >= minRelevanceScore) {
+                        float similarity = embeddingVector.cosineSimilarity(recordVector);
+                        if (Float.compare(similarity,(float)minRelevanceScore) >= 0) {
                             if (withEmbeddings) {
                                 nearestMatches.add(Tuples.of(record, similarity));
                             } else {
@@ -210,21 +227,25 @@ public class VolatileMemoryStore implements MemoryStore {
                     }
                 });
 
-        List<Tuple2<MemoryRecord, Number>> result =
+        List<Tuple2<MemoryRecord, Float>> result =
                 nearestMatches.stream()
-                        .sorted(Comparator.comparingDouble(extractSimilarity).reversed())
+                        // sort by similarity score, descending
+                        .sorted(Comparator.comparing(it -> it.getT2().doubleValue(), (a,b) -> Double.compare(b, a)))
                         .limit(limit)
                         .collect(Collectors.toList());
+        return result;
+        });
 
-        return Mono.just(result);
     }
 
     @Override
-    public Mono<Tuple2<MemoryRecord, ? extends Number>> getNearestMatchAsync(
+    public Mono<Tuple2<MemoryRecord, Float>> getNearestMatchAsync(
             @Nonnull String collectionName,
             @Nonnull Embedding embedding,
             double minRelevanceScore,
             boolean withEmbedding) {
+        Objects.requireNonNull(collectionName);
+        Objects.requireNonNull(embedding);
 
         return getNearestMatchesAsync(
                         collectionName, embedding, 1, minRelevanceScore, withEmbedding)
@@ -238,6 +259,7 @@ public class VolatileMemoryStore implements MemoryStore {
     }
 
     protected Map<String, MemoryRecord> getCollection(@Nonnull String collectionName) {
+        Objects.requireNonNull(collectionName);
         Map<String, MemoryRecord> collection = this._store.get(collectionName);
         if (collection == null) {
             throw new MemoryException(

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/memory/VolatileMemoryStoreTests.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/memory/VolatileMemoryStoreTests.java
@@ -93,17 +93,13 @@ class VolatileMemoryStoreTests {
     }
 
     @Test
-    void itCannotCreateDuplicateCollectionAsync() {
+    void  itHandlesExceptionsWhenCreatingCollectionAsync() {
         // Arrange
-        String collection = "test_collection" + this._collectionNum;
-        this._collectionNum++;
-
-        // Act
-        this._db.createCollectionAsync(collection).block();
+        String collection = null;
 
         // Assert
         assertThrows(
-                MemoryException.class,
+                NullPointerException.class,
                 () -> this._db.createCollectionAsync(collection).block(),
                 "Should not be able to create duplicate collection");
     }
@@ -389,7 +385,7 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = -1;
-        Collection<Tuple2<MemoryRecord, Number>> topNResults =
+        Collection<Tuple2<MemoryRecord, Float>> topNResults =
                 this._db
                         .getNearestMatchesAsync(
                                 collection, compareEmbedding, topN, threshold, false)
@@ -398,12 +394,12 @@ class VolatileMemoryStoreTests {
         // Assert
         assertNotNull(topNResults);
         assertEquals(topN, topNResults.size());
-        Tuple2<MemoryRecord, Number>[] topNResultsArray = topNResults.toArray(new Tuple2[0]);
+        Tuple2<MemoryRecord, Float>[] topNResultsArray = topNResults.toArray(new Tuple2[0]);
         for (int j = 0; j < topN - 1; j++) {
             int compare =
                     Double.compare(
-                            topNResultsArray[j].getT2().doubleValue(),
-                            topNResultsArray[j + 1].getT2().doubleValue());
+                            topNResultsArray[j].getT2(),
+                            topNResultsArray[j + 1].getT2());
             assertTrue(compare >= 0);
         }
     }
@@ -477,7 +473,7 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = -1;
-        Collection<Tuple2<MemoryRecord, Number>> topNResults =
+        Collection<Tuple2<MemoryRecord, Float>> topNResults =
                 this._db
                         .getNearestMatchesAsync(
                                 collection, compareEmbedding, i / 2, threshold, false)
@@ -557,7 +553,7 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = -1;
-        Collection<Tuple2<MemoryRecord, Number>> topNResults =
+        Collection<Tuple2<MemoryRecord, Float>> topNResults =
                 this._db
                         .getNearestMatchesAsync(collection, compareEmbedding, 0, threshold, false)
                         .block();
@@ -577,7 +573,7 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = -1;
-        Collection<Tuple2<MemoryRecord, Number>> topNResults =
+        Collection<Tuple2<MemoryRecord, Float>> topNResults =
                 this._db
                         .getNearestMatchesAsync(
                                 collection, compareEmbedding, Integer.MAX_VALUE, threshold, false)
@@ -658,11 +654,11 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = 0.75;
-        Tuple2<MemoryRecord, ? extends Number> topNResultDefault =
+        Tuple2<MemoryRecord, Float> topNResultDefault =
                 this._db
                         .getNearestMatchAsync(collection, compareEmbedding, threshold, false)
                         .block();
-        Tuple2<MemoryRecord, ? extends Number> topNResultWithEmbedding =
+        Tuple2<MemoryRecord, Float> topNResultWithEmbedding =
                 this._db
                         .getNearestMatchAsync(collection, compareEmbedding, threshold, true)
                         .block();
@@ -748,7 +744,7 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = 0.75;
-        Tuple2<MemoryRecord, ? extends Number> topNResult =
+        Tuple2<MemoryRecord, Float> topNResult =
                 this._db
                         .getNearestMatchAsync(collection, compareEmbedding, threshold, false)
                         .block();
@@ -756,7 +752,7 @@ class VolatileMemoryStoreTests {
         // Assert
         assertNotNull(topNResult);
         assertEquals("test0", topNResult.getT1().getMetadata().getId());
-        assertTrue(topNResult.getT2().doubleValue() >= threshold);
+        assertTrue(topNResult.getT2() >= threshold);
     }
 
     @Test
@@ -770,7 +766,7 @@ class VolatileMemoryStoreTests {
 
         // Act
         double threshold = -1;
-        Tuple2<MemoryRecord, ? extends Number> topNResults =
+        Tuple2<MemoryRecord, Float> topNResults =
                 this._db
                         .getNearestMatchAsync(collection, compareEmbedding, threshold, false)
                         .block();
@@ -802,7 +798,7 @@ class VolatileMemoryStoreTests {
         }
 
         // Act
-        Collection<Tuple2<MemoryRecord, Number>> topNResults =
+        Collection<Tuple2<MemoryRecord, Float>> topNResults =
                 this._db
                         .getNearestMatchesAsync(collection, compareEmbedding, topN, 0.75, true)
                         .block();
@@ -815,10 +811,10 @@ class VolatileMemoryStoreTests {
         // Assert
         assertEquals(topN, topNResults.size());
         assertEquals(topN, topNKeys.size());
-        for (Iterator<Tuple2<MemoryRecord, Number>> iterator = topNResults.iterator();
+        for (Iterator<Tuple2<MemoryRecord, Float>> iterator = topNResults.iterator();
                 iterator.hasNext(); ) {
-            Tuple2<MemoryRecord, Number> tuple = iterator.next();
-            int compare = Double.compare(tuple.getT2().doubleValue(), 0.75);
+            Tuple2<MemoryRecord, Float> tuple = iterator.next();
+            int compare = Double.compare(tuple.getT2(), 0.75);
             assertTrue(topNKeys.contains(tuple.getT1().getKey()));
             assertTrue(compare >= 0);
         }
@@ -878,7 +874,7 @@ class VolatileMemoryStoreTests {
         }
 
         // Act
-        this._db.removeBatchAsync(collection, keys);
+        this._db.removeBatchAsync(collection, keys).block();
 
         // Assert
         for (MemoryRecord result : this._db.getBatchAsync(collection, keys, true).block()) {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Embedding changed to be just Float. Some of the MemoryStore API had `? extends Number` for similarity which can now be a Float. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Changed getNearestMatch and getNearestMatches API in MemoryStore which had `Tuple2<MemoryRecord, ? extends Number>` to use Float instead of `? extends Number`. This second value of the tuple is the similarity value for the match. The value is computed on the embedding which is now a vector of Float. 

Also, updated VolatileMemoryStore to make it properly async.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
