### PR TITLE
.Net: Small typo in example

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example15_MemorySkill.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example15_MemorySkill.cs
@@ -50,8 +50,8 @@ public static class Example15_MemorySkill
         // ========= Test memory remember =========
         Console.WriteLine("========= Example: Recalling a Memory =========");
 
-        var answer = await memorySkill.RetrieveAsync(MemoryCollectionName, "info5", logger: logger);
-        Console.WriteLine("Memory associated with 'info5': {0}", answer);
+        var answer = await memorySkill.RetrieveAsync(MemoryCollectionName, "info1", logger: logger);
+        Console.WriteLine("Memory associated with 'info1': {0}", answer);
         /*
         Output:
         "Memory associated with 'info1': My name is Andrea

--- a/dotnet/samples/KernelSyntaxExamples/Example15_MemorySkill.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example15_MemorySkill.cs
@@ -51,7 +51,7 @@ public static class Example15_MemorySkill
         Console.WriteLine("========= Example: Recalling a Memory =========");
 
         var answer = await memorySkill.RetrieveAsync(MemoryCollectionName, "info5", logger: logger);
-        Console.WriteLine("Memory associated with 'info1': {0}", answer);
+        Console.WriteLine("Memory associated with 'info5': {0}", answer);
         /*
         Output:
         "Memory associated with 'info1': My name is Andrea


### PR DESCRIPTION
### Motivation and Context

This fixes a small type in the Console output the RetrieveAsync method requests "info5" and console says "info1"

### Description

Fix typo:

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
