### PR TITLE
Python: [BugFix] ReadOnlySkillCollection is not a Generic

### DIFF
--- a/python/semantic_kernel/skill_definition/constants.py
+++ b/python/semantic_kernel/skill_definition/constants.py
@@ -1,0 +1,3 @@
+import typing as t
+
+GLOBAL_SKILL: t.Final[str] = "_GLOBAL_FUNCTIONS_"

--- a/python/tests/unit/test_serialization.py
+++ b/python/tests/unit/test_serialization.py
@@ -115,6 +115,7 @@ def sk_factory() -> t.Callable[[t.Type[_Serializable]], _Serializable]:
             False,
         ),
         FunctionsView: create_functions_view(),
+        ReadOnlySkillCollection: create_skill_collection().read_only_skill_collection,
         SkillCollection: create_skill_collection(),
     }
 
@@ -171,6 +172,7 @@ PYDANTIC_MODELS = [
     ParameterView,
     FunctionView,
     FunctionsView,
+    ReadOnlySkillCollection,
     SkillCollection,
 ]
 


### PR DESCRIPTION
All (unit) tests are passing.

### Motivation and Context

This change reduces the number of user facing changes and aligns the type of 
ReadOnlySkillCollection with the usage in SK. There is only one type of
`SkillCollection` in SK, so it doesn't make sense to make `ReadOnlySkillCollection`
a generic. If, in the future, another SkillCollection type is added, then we might
want to change this to a generic type.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
