### PR TITLE
Python: Fix parameter propagation bug in Plan Object Model

### DIFF
--- a/python/semantic_kernel/planning/plan.py
+++ b/python/semantic_kernel/planning/plan.py
@@ -410,7 +410,7 @@ class Plan(SKFunctionBase):
 
             expanded_value = self.expand_from_variables(variables, param_var)
             if expanded_value.lower() == param_var.lower():
-                step_variables.set(param_var, expanded_value)
+                step_variables.set(param_var, step.parameters._variables[param_var])
             elif variables.contains_key(param_var):
                 step_variables.set(param_var, variables[param_var])
             elif self._state.contains_key(param_var):

--- a/python/tests/unit/planning/test_plan_execution.py
+++ b/python/tests/unit/planning/test_plan_execution.py
@@ -3,6 +3,7 @@
 import pytest
 
 import semantic_kernel as sk
+from semantic_kernel.core_skills.math_skill import MathSkill
 from semantic_kernel.core_skills.text_skill import TextSkill
 from semantic_kernel.planning import Plan
 
@@ -180,3 +181,33 @@ async def test_invoke_multi_step_plan_async():
     plan.add_steps([new_step, new_step2])
     result = await plan.invoke_async(context=context)
     assert result.result == "HELLO WORLD"
+
+
+@pytest.mark.asyncio
+async def test_invoke_multi_step_plan_async_with_variables():
+    # create a kernel
+    kernel = sk.Kernel()
+
+    # import test (text) skill
+    skill = MathSkill()
+    skill_config_dict = kernel.import_skill(skill, "math")
+    test_function = skill_config_dict["Add"]
+    test_function2 = skill_config_dict["Subtract"]
+
+    plan = Plan(name="test")
+
+    # setup context for step 1
+    context1 = kernel.create_new_context()
+    context1["amount"] = "10"
+    new_step = Plan(name="test", function=test_function, parameters=context1._variables)
+
+    # setup context for step 2
+    context2 = kernel.create_new_context()
+    context2["amount"] = "5"
+    new_step2 = Plan(
+        name="test", function=test_function2, parameters=context2._variables
+    )
+
+    plan.add_steps([new_step, new_step2])
+    result = await plan.invoke_async(input="2")
+    assert result.result == "7"


### PR DESCRIPTION
### Motivation and Context

Initially called out and fixed by @joowon-dm-snu in https://github.com/microsoft/semantic-kernel/pull/2223

This PR closes [#2094](https://github.com/microsoft/semantic-kernel/issues/2094)

There was a bug in the Plan Object Model that propagates the name of the step parameter to the next step. It should be propagating the parameter's value


### Description
In addition to making the code change to fix the bug, also added a unit test that covers the changed code. 

Below image shows the before and after of the test with the fix. 

![image](https://github.com/microsoft/semantic-kernel/assets/54643756/7217f42a-a2ac-4491-a709-bea9be7328e3)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
