### PR TITLE
Python: Fix integration test check for PRs

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -154,21 +154,21 @@ jobs:
         shell: bash
         run: |
           echo "run_type=Daily" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV
+          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV"
 
       - name: Run Type is Manual
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
           echo "run_type=Manual" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV
+          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV"
 
       - name: Run Type is Other
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'}}
         shell: bash
         run: |
           echo "run_type=${{ github.event_name }}" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=empty" >> "$GITHUB_ENV
+          echo "MSTEAMS_WEBHOOK=NONE" >> "$GITHUB_ENV"
 
       - name: Fail workflow if tests failed
         id: check_tests_failed

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -154,21 +154,18 @@ jobs:
         shell: bash
         run: |
           echo "run_type=Daily" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV"
 
       - name: Run Type is Manual
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
           echo "run_type=Manual" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV"
 
       - name: Run Type is Other
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'}}
         shell: bash
         run: |
           echo "run_type=${{ github.event_name }}" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=NONE" >> "$GITHUB_ENV"
 
       - name: Fail workflow if tests failed
         id: check_tests_failed
@@ -186,9 +183,19 @@ jobs:
 
       - name: Microsoft Teams Notification
         uses: skitionek/notify-microsoft-teams@master
-        if: always()
+        if: github.ref == 'refs/heads/main'
         with:
-          webhook_url: ${{ env.MSTEAMS_WEBHOOK }}
+          webhook_url: ${{ secrets.MSTEAMS_WEBHOOK }}
+          dry_run: ${{ env.run_type != 'Daily' && env.run_type != 'Manual'}}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}
+          overwrite: "{title: ` ${{ env.run_type }}: ${{ env.date }} `, text: ` ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`}"
+
+      - name: Microsoft Teams Notification (Dry Run)
+        uses: skitionek/notify-microsoft-teams@master
+        if: github.ref != 'refs/heads/main'
+        with:
+          webhook_url: NONE
           dry_run: ${{ env.run_type != 'Daily' && env.run_type != 'Manual'}}
           job: ${{ toJson(job) }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -154,18 +154,21 @@ jobs:
         shell: bash
         run: |
           echo "run_type=Daily" >> "$GITHUB_ENV"
+          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV
 
       - name: Run Type is Manual
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
           echo "run_type=Manual" >> "$GITHUB_ENV"
+          echo "MSTEAMS_WEBHOOK=${{ secrets.MSTEAMS_WEBHOOK }}" >> "$GITHUB_ENV
 
       - name: Run Type is Other
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'}}
         shell: bash
         run: |
           echo "run_type=${{ github.event_name }}" >> "$GITHUB_ENV"
+          echo "MSTEAMS_WEBHOOK=None" >> "$GITHUB_ENV
 
       - name: Fail workflow if tests failed
         id: check_tests_failed
@@ -185,7 +188,7 @@ jobs:
         uses: skitionek/notify-microsoft-teams@master
         if: always()
         with:
-          webhook_url: ${{ secrets.MSTEAMS_WEBHOOK }}
+          webhook_url: ${{ env.MSTEAMS_WEBHOOK }}
           dry_run: ${{ env.run_type != 'Daily' && env.run_type != 'Manual'}}
           job: ${{ toJson(job) }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -168,7 +168,7 @@ jobs:
         shell: bash
         run: |
           echo "run_type=${{ github.event_name }}" >> "$GITHUB_ENV"
-          echo "MSTEAMS_WEBHOOK=None" >> "$GITHUB_ENV
+          echo "MSTEAMS_WEBHOOK=empty" >> "$GITHUB_ENV
 
       - name: Fail workflow if tests failed
         id: check_tests_failed


### PR DESCRIPTION
### Motivation and Context

Python integration test check resolves the MSTEAM_WEBHOOK as "" when run for PRs. The secret is not needed in this scenario, but the value should be non ""

### Description

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
