### PR TITLE
Python: Revert "Python: Update Azure Cognitive Search Class Change VectorSearchAlgorithmConfi…"

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -304,14 +304,14 @@ msal-extensions = ">=0.3.0,<2.0.0"
 
 [[package]]
 name = "azure-search-documents"
-version = "11.4.0b8"
+version = "11.4.0b6"
 description = "Microsoft Azure Cognitive Search Client Library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "azure-search-documents-11.4.0b8.zip", hash = "sha256:b178ff52918590191a9cb7f411a9ab3cb517663666a501a3e84b715d19b0d93b"},
-    {file = "azure_search_documents-11.4.0b8-py3-none-any.whl", hash = "sha256:4137daa2db75bff9484d394c16c0604822a51281cad2f50e11d7c48dd8d4b4cf"},
+    {file = "azure-search-documents-11.4.0b6.zip", hash = "sha256:c9ebd7d99d3c7b879f48acad66141e1f50eae4468cfb8389a4b25d4c620e8df1"},
+    {file = "azure_search_documents-11.4.0b6-py3-none-any.whl", hash = "sha256:24ff85bf2680c36b38d8092bcbbe2d90699aac7c4a228b0839c0ce595a41628c"},
 ]
 
 [package.dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -56,7 +56,7 @@ psycopg = "^3.1.9"
 psycopg-binary = "^3.1.9"
 
 [tool.poetry.group.azure_cognitive_search.dependencies]
-azure-search-documents = {version = "11.4.0b8", allow-prereleases = true}
+azure-search-documents = {version = "11.4.0b6", allow-prereleases = true}
 azure-core = "^1.28.0"
 azure-identity = "^1.13.0"
 

--- a/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_cognitive_search_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_cognitive_search_memory_store.py
@@ -8,9 +8,9 @@ from azure.core.credentials import AzureKeyCredential, TokenCredential
 from azure.core.exceptions import ResourceNotFoundError
 from azure.search.documents.indexes.aio import SearchIndexClient
 from azure.search.documents.indexes.models import (
-    HnswVectorSearchAlgorithmConfiguration,
     SearchIndex,
     VectorSearch,
+    VectorSearchAlgorithmConfiguration,
 )
 from numpy import ndarray
 
@@ -58,6 +58,7 @@ class AzureCognitiveSearchMemoryStore(MemoryStoreBase):
         Instantiate using Async Context Manager:
             async with AzureCognitiveSearchMemoryStore(<...>) as memory:
                 await memory.<...>
+
         """
         try:
             pass
@@ -81,14 +82,14 @@ class AzureCognitiveSearchMemoryStore(MemoryStoreBase):
     async def create_collection_async(
         self,
         collection_name: str,
-        vector_config: Optional[HnswVectorSearchAlgorithmConfiguration] = None,
+        vector_config: Optional[VectorSearchAlgorithmConfiguration] = None,
     ) -> None:
         """Creates a new collection if it does not exist.
 
         Arguments:
             collection_name {str}                              -- The name of the collection to create.
-            vector_config {HnswVectorSearchAlgorithmConfiguration} -- Optional search algorithm configuration
-                                                                      (default: {None}).
+            vector_config {VectorSearchAlgorithmConfiguration} -- Optional search algorithm configuration
+                                                                  (default: {None}).
             semantic_config {SemanticConfiguration}            -- Optional search index configuration (default: {None}).
         Returns:
             None
@@ -99,7 +100,7 @@ class AzureCognitiveSearchMemoryStore(MemoryStoreBase):
         else:
             vector_search = VectorSearch(
                 algorithm_configurations=[
-                    HnswVectorSearchAlgorithmConfiguration(
+                    VectorSearchAlgorithmConfiguration(
                         name="az-vector-config",
                         kind="hnsw",
                         hnsw_parameters={


### PR DESCRIPTION
Reverts microsoft/semantic-kernel#2435

This PR caused a breaking change to the ACS memory store's get_nearest_matches method