### PR TITLE
Update python-integration-tests.yml

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -22,21 +22,21 @@ jobs:
     outputs:
       pythonChanges: ${{ steps.filter.outputs.python}}
     steps:
-    - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        filters: |
-          python:
-            - 'python/**'
-    # run only if 'python' files were changed
-    - name: python tests
-      if: steps.filter.outputs.python == 'true'
-      run: echo "Python file"
-    # run only if not 'python' files were changed
-    - name: not python tests
-      if: steps.filter.outputs.python != 'true'
-      run: echo "NOT python file"
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'python/**'
+      # run only if 'python' files were changed
+      - name: python tests
+        if: steps.filter.outputs.python == 'true'
+        run: echo "Python file"
+      # run only if not 'python' files were changed
+      - name: not python tests
+        if: steps.filter.outputs.python != 'true'
+        run: echo "NOT python file"
 
   python-merge-gate:
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' && needs.paths-filter.outputs.pythonChanges == 'true' }}
@@ -91,13 +91,7 @@ jobs:
           AZURE_COGNITIVE_SEARCH_ENDPOINT: ${{secrets.AZURE_COGNITIVE_SEARCH_ENDPOINT}}
         run: |
           cd python
-          poetry run pytest ./tests/integration/completions/test_azure_oai_chat_service.py -v
-          poetry run pytest ./tests/integration/completions/test_oai_chat_service.py -v
-          poetry run pytest ./tests/integration/completions/test_hf_local_text_completions.py -v
-          poetry run pytest ./tests/integration/connectors/memory/test_chroma.py -v
-          poetry run pytest ./tests/integration/connectors/memory/test_qdrant_memory_store.py -v
-          poetry run pytest ./tests/integration/planning -v
-          poetry run pytest ./tests/integration/embeddings -v
+          poetry run pytest ./tests/integration -v
 
   python-integration-tests:
     if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.paths-filter.outputs.pythonChanges == 'true' }}
@@ -204,7 +198,7 @@ jobs:
 
       - name: Microsoft Teams Notification
         uses: skitionek/notify-microsoft-teams@master
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' 
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         with:
           webhook_url: ${{ secrets.MSTEAMS_WEBHOOK }}
           dry_run: ${{ env.run_type != 'Daily' && env.run_type != 'Manual'}}

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -17,8 +17,29 @@ permissions:
   contents: read
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      pythonChanges: ${{ steps.filter.outputs.python}}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          python:
+            - 'python/**'
+    # run only if 'python' files were changed
+    - name: python tests
+      if: steps.filter.outputs.python == 'true'
+      run: echo "Python file"
+    # run only if not 'python' files were changed
+    - name: not python tests
+      if: steps.filter.outputs.python != 'true'
+      run: echo "NOT python file"
+
   python-merge-gate:
-    if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule'}}
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' && needs.paths-filter.outputs.pythonChanges == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
@@ -79,7 +100,7 @@ jobs:
           poetry run pytest ./tests/integration/embeddings -v
 
   python-integration-tests:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.paths-filter.outputs.pythonChanges == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1


### PR DESCRIPTION
Adding back the paths filter on the Python integration tests GitHub actions.

This ensures that the tests only run when changes under the python/ folder are included. Otherwise, it skips to the final validation step.