### PR TITLE
Python: Update fake skill and planner test

### DIFF
--- a/python/tests/integration/fakes/writer_skill_fake.py
+++ b/python/tests/integration/fakes/writer_skill_fake.py
@@ -15,12 +15,11 @@ class WriterSkillFake:
     def translate(self, language: str) -> str:
         return f"Translate: {language}"
 
-    @sk_function(
-        description="Write an outline for a novel",
-        name="NovelOutline")
+    @sk_function(description="Write an outline for a novel", name="NovelOutline")
     @sk_function_context_parameter(
         name="endMarker",
-        description="The marker to use to end each chapter.",default_value="<!--===ENDPART===-->"
-        )
+        description="The marker to use to end each chapter.",
+        default_value="<!--===ENDPART===-->",
+    )
     def write_novel_outline(self, input: str) -> str:
         return f"Novel outline: {input}"

--- a/python/tests/integration/fakes/writer_skill_fake.py
+++ b/python/tests/integration/fakes/writer_skill_fake.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from semantic_kernel.skill_definition.sk_function_decorator import sk_function
+from semantic_kernel.skill_definition import sk_function, sk_function_context_parameter
 
 # TODO: this fake skill is temporal usage.
 # C# supports import skill from samples dir by using test helper and python should do the same
@@ -17,8 +17,10 @@ class WriterSkillFake:
 
     @sk_function(
         description="Write an outline for a novel",
-        name="NovelOutline",
-        input_default_value="<!--===ENDPART===-->",
-    )
+        name="NovelOutline")
+    @sk_function_context_parameter(
+        name="endMarker",
+        description="The marker to use to end each chapter.",default_value="<!--===ENDPART===-->"
+        )
     def write_novel_outline(self, input: str) -> str:
         return f"Novel outline: {input}"

--- a/python/tests/integration/planning/sequential_planner/test_sequential_planner.py
+++ b/python/tests/integration/planning/sequential_planner/test_sequential_planner.py
@@ -123,11 +123,7 @@ async def test_create_plan_with_defaults_async(
     assert any(
         step.name == expected_function
         and step.skill_name == expected_skill
-        and step.parameters["input"] == expected_default
-        # TODO: current sk_function decorator only support default values ["input"] key
-        # TODO: current version of fake skills used inline sk_function but actually most of them already in samples dir.
-        #           add test helper for python to import skills from samples dir. C# already has it.
-        # and step.parameters["endMarker"] == expected_default
+        and step.parameters["endMarker"] == expected_default
         for step in plan._steps
     )
 


### PR DESCRIPTION
Fix failing integration tests introduced in #2474 (May be filing follow up issue on that)

- Update WriterSkillFake to include a context parameter for the end marker
- Update test_sequential_planner to use the new end marker parameter in WriterSkillFake

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
