### PR TITLE
Python: Add missing parameter `logger` on inheriting classes and makes it optional 

### DIFF
--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from logging import Logger
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
@@ -14,7 +14,7 @@ class ChatCompletionClientBase(ABC):
         self,
         messages: List[Tuple[str, str]],
         settings: "ChatRequestSettings",
-        logger: Logger,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         """
         This is the method that is called from the kernel to get a response from a chat-optimized LLM.
@@ -35,7 +35,7 @@ class ChatCompletionClientBase(ABC):
         self,
         messages: List[Tuple[str, str]],
         settings: "ChatRequestSettings",
-        logger: Logger,
+        logger: Optional[Logger] = None,
     ):
         """
         This is the method that is called from the kernel to get a stream response from a chat-optimized LLM.

--- a/python/semantic_kernel/connectors/ai/google_palm/services/gp_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google_palm/services/gp_chat_completion.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from logging import Logger
 from typing import List, Optional, Tuple, Union
 
 import google.generativeai as palm
@@ -80,7 +81,10 @@ class GooglePalmChatCompletion(ChatCompletionClientBase, TextCompletionClientBas
         )
 
     async def complete_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         prompt_to_message = [("user", prompt)]
         chat_settings = ChatRequestSettings(
@@ -108,7 +112,10 @@ class GooglePalmChatCompletion(ChatCompletionClientBase, TextCompletionClientBas
                 return response.last
 
     async def complete_stream_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ):
         raise NotImplementedError(
             "Google Palm API does not currently support streaming"

--- a/python/semantic_kernel/connectors/ai/google_palm/services/gp_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google_palm/services/gp_text_completion.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from typing import List, Union
+from logging import Logger
+from typing import List, Optional, Union
 
 import google.generativeai as palm
 
@@ -34,7 +35,10 @@ class GooglePalmTextCompletion(TextCompletionClientBase):
         self._api_key = api_key
 
     async def complete_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         response = await self._send_completion_request(prompt, request_settings)
 
@@ -44,7 +48,10 @@ class GooglePalmTextCompletion(TextCompletionClientBase):
             return response.result
 
     async def complete_stream_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ):
         raise NotImplementedError(
             "Google Palm API does not currently support streaming"

--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
@@ -65,7 +65,10 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
         )
 
     async def complete_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         try:
             import transformers
@@ -112,7 +115,10 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
             raise AIException("Hugging Face completion failed", e)
 
     async def complete_stream_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ):
         """
         Streams a text completion using a Hugging Face model.

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
@@ -60,7 +60,10 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
         self._messages = []
 
     async def complete_chat_async(
-        self, messages: List[Tuple[str, str]], request_settings: ChatRequestSettings
+        self,
+        messages: List[Tuple[str, str]],
+        request_settings: ChatRequestSettings,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         # TODO: tracking on token counts/etc.
         response = await self._send_chat_request(messages, request_settings, False)
@@ -71,7 +74,10 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
             return [choice.message.content for choice in response.choices]
 
     async def complete_chat_stream_async(
-        self, messages: List[Tuple[str, str]], request_settings: ChatRequestSettings
+        self,
+        messages: List[Tuple[str, str]],
+        request_settings: ChatRequestSettings,
+        logger: Optional[Logger] = None,
     ):
         response = await self._send_chat_request(messages, request_settings, True)
 
@@ -88,7 +94,10 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
                 yield text
 
     async def complete_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         """
         Completes the given prompt.
@@ -120,7 +129,10 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
             return [choice.message.content for choice in response.choices]
 
     async def complete_stream_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ):
         prompt_to_message = [("user", prompt)]
         chat_settings = ChatRequestSettings(

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion.py
@@ -55,7 +55,10 @@ class OpenAITextCompletion(TextCompletionClientBase):
         self._log = log if log is not None else NullLogger()
 
     async def complete_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         # TODO: tracking on token counts/etc.
         response = await self._send_completion_request(prompt, request_settings, False)
@@ -68,7 +71,10 @@ class OpenAITextCompletion(TextCompletionClientBase):
     # TODO: complete w/ multiple...
 
     async def complete_stream_async(
-        self, prompt: str, request_settings: CompleteRequestSettings
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
     ):
         response = await self._send_completion_request(prompt, request_settings, True)
 

--- a/python/semantic_kernel/connectors/ai/text_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/text_completion_client_base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from logging import Logger
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.complete_request_settings import (
@@ -16,7 +16,7 @@ class TextCompletionClientBase(ABC):
         self,
         prompt: str,
         settings: "CompleteRequestSettings",
-        logger: Logger,
+        logger: Optional[Logger] = None,
     ) -> Union[str, List[str]]:
         """
         This is the method that is called from the kernel to get a response from a text-optimized LLM.
@@ -36,7 +36,7 @@ class TextCompletionClientBase(ABC):
         self,
         prompt: str,
         settings: "CompleteRequestSettings",
-        logger: Logger,
+        logger: Optional[Logger] = None,
     ):
         """
         This is the method that is called from the kernel to get a stream response from a text-optimized LLM.


### PR DESCRIPTION
### Motivation and Context
Makes the `logger` parameter optional in `TextCompletionClientBase.complete_async`, `TextCompletionClientBase.complete_stream_async`, `ChatCompletionClientBase.complete_chat_async`, and `ChatCompletionClientBase.complete_chat_stream_async` to match the current usage across the project where it's not passed.
It also adds that `logger` optional parameter to the inheriting classes where needed to match the base class method signatures.

Resolves #2509

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
