### PR TITLE
.Net: [OpenAPI] Fallback to operation summary if no description provided

### DIFF
--- a/dotnet/src/Skills/Skills.OpenAPI/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/OpenApi/OpenApiDocumentParser.cs
@@ -186,7 +186,7 @@ internal sealed class OpenApiDocumentParser : IOpenApiDocumentParser
                 string.IsNullOrEmpty(serverUrl) ? null : new Uri(serverUrl),
                 path,
                 new HttpMethod(method),
-                operationItem.Description,
+                string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description,
                 CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters),
                 CreateRestApiOperationHeaders(operationItem.Parameters),
                 CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody)

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
@@ -130,6 +130,21 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
     }
 
     [Fact]
+    public async Task ItCanUseOperationSummaryAsync()
+    {
+        // Act
+        var operations = await this._sut.ParseAsync(this._openApiDocument);
+
+        // Assert
+        Assert.NotNull(operations);
+        Assert.True(operations.Any());
+
+        var operation = operations.Single(o => o.Id == "Excuses");
+        Assert.NotNull(operation);
+        Assert.Equal("Turn a scenario into a creative or humorous excuse to send your boss", operation.Description);
+    }
+
+    [Fact]
     public async Task ItCanExtractSimpleTypeHeaderParameterMetadataSuccessfullyAsync()
     {
         // Act

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
@@ -154,6 +154,21 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
     }
 
     [Fact]
+    public async Task ItCanUseOperationSummaryAsync()
+    {
+        // Act
+        var operations = await this._sut.ParseAsync(this._openApiDocument);
+
+        // Assert
+        Assert.NotNull(operations);
+        Assert.True(operations.Any());
+
+        var operation = operations.Single(o => o.Id == "Excuses");
+        Assert.NotNull(operation);
+        Assert.Equal("Turn a scenario into a creative or humorous excuse to send your boss", operation.Description);
+    }
+
+    [Fact]
     public async Task ItCanExtractCsvStyleHeaderParameterMetadataSuccessfullyAsync()
     {
         // Act

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
@@ -129,6 +129,21 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
     }
 
     [Fact]
+    public async Task ItCanUseOperationSummaryAsync()
+    {
+        // Act
+        var operations = await this._sut.ParseAsync(this._openApiDocument);
+
+        // Assert
+        Assert.NotNull(operations);
+        Assert.True(operations.Any());
+
+        var operation = operations.Single(o => o.Id == "Excuses");
+        Assert.NotNull(operation);
+        Assert.Equal("Turn a scenario into a creative or humorous excuse to send your boss", operation.Description);
+    }
+
+    [Fact]
     public async Task ItCanExtractSimpleTypeHeaderParameterMetadataSuccessfullyAsync()
     {
         // Act

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/TestSkills/documentV2_0.json
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/TestSkills/documentV2_0.json
@@ -200,7 +200,7 @@
     },
     "/FunSkill/Excuses": {
       "post": {
-        "description": "Turn a scenario into a creative or humorous excuse to send your boss",
+        "summary": "Turn a scenario into a creative or humorous excuse to send your boss",
         "operationId": "Excuses",
         "consumes": [
           "text/plain"

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/TestSkills/documentV3_0.json
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/TestSkills/documentV3_0.json
@@ -141,7 +141,7 @@
     },
     "/FunSkill/Excuses": {
       "post": {
-        "description": "Turn a scenario into a creative or humorous excuse to send your boss",
+        "summary": "Turn a scenario into a creative or humorous excuse to send your boss",
         "operationId": "Excuses",
         "requestBody": {
           "description": "excuse event",

--- a/dotnet/src/Skills/Skills.UnitTests/OpenAPI/TestSkills/documentV3_1.yaml
+++ b/dotnet/src/Skills/Skills.UnitTests/OpenAPI/TestSkills/documentV3_1.yaml
@@ -95,7 +95,7 @@ paths:
           description: default
   /FunSkill/Excuses:
     post:
-      description: Turn a scenario into a creative or humorous excuse to send your boss
+      summary: Turn a scenario into a creative or humorous excuse to send your boss
       operationId: Excuses
       requestBody:
         description: excuse event


### PR DESCRIPTION
### Motivation and Context

The code provides a fallback mechanism to allow the use of operation summary if no operation description is provided.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
