### PR TITLE
.Net: [Error handling] [Part8] Replacing AIException by SKException for non-HTTP related cases

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextCompletion/HuggingFaceTextCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextCompletion/HuggingFaceTextCompletion.cs
@@ -112,7 +112,7 @@ public sealed class HuggingFaceTextCompletion : ITextCompletion
 
             if (completionResponse is null)
             {
-                throw new AIException(AIException.ErrorCodes.InvalidResponseContent, "Unexpected response from model")
+                throw new SKException("Unexpected response from model")
                 {
                     Data = { { "ResponseData", body } },
                 };
@@ -120,7 +120,7 @@ public sealed class HuggingFaceTextCompletion : ITextCompletion
 
             return completionResponse.ConvertAll(c => new TextCompletionStreamingResult(c));
         }
-        catch (Exception e) when (e is not AIException && !e.IsCriticalException())
+        catch (Exception e) when (e is not SKException && !e.IsCriticalException())
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,

--- a/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextEmbedding/HuggingFaceTextEmbeddingGeneration.cs
+++ b/dotnet/src/Connectors/Connectors.AI.HuggingFace/TextEmbedding/HuggingFaceTextEmbeddingGeneration.cs
@@ -74,9 +74,7 @@ public sealed class HuggingFaceTextEmbeddingGeneration : ITextEmbeddingGeneratio
 
         if (httpClient.BaseAddress == null && string.IsNullOrEmpty(endpoint))
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidConfiguration,
-                "The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
+            throw new SKException("The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
         }
     }
 
@@ -115,7 +113,7 @@ public sealed class HuggingFaceTextEmbeddingGeneration : ITextEmbeddingGeneratio
 
             return embeddingResponse?.Embeddings?.Select(l => l.Embedding).ToList()!;
         }
-        catch (Exception e) when (e is not AIException && !e.IsCriticalException())
+        catch (Exception e) when (e is not SKException && !e.IsCriticalException())
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,
@@ -143,7 +141,7 @@ public sealed class HuggingFaceTextEmbeddingGeneration : ITextEmbeddingGeneratio
         }
         else
         {
-            throw new AIException(AIException.ErrorCodes.InvalidConfiguration, "No endpoint or HTTP client base address has been provided");
+            throw new SKException("No endpoint or HTTP client base address has been provided");
         }
 
         return new Uri($"{baseUrl!.TrimEnd('/')}/{this._model}");

--- a/dotnet/src/Connectors/Connectors.AI.Oobabooga/TextCompletion/OobaboogaTextCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.Oobabooga/TextCompletion/OobaboogaTextCompletion.cs
@@ -225,7 +225,7 @@ public sealed class OobaboogaTextCompletion : ITextCompletion
 
             return completionResponse.Results.Select(completionText => new TextCompletionResult(completionText)).ToList();
         }
-        catch (Exception e) when (e is not AIException && !e.IsCriticalException())
+        catch (Exception e) when (e is not SKException && !e.IsCriticalException())
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ChatStreamingResult.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ChatStreamingResult.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.OpenAI;
-using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -37,7 +36,7 @@ internal sealed class ChatStreamingResult : IChatStreamingResult, ITextStreaming
 
         if (chatMessage is null)
         {
-            throw new AIException(AIException.ErrorCodes.UnknownError, "Unable to get chat message from stream");
+            throw new SKException("Unable to get chat message from stream");
         }
 
         return new SKChatMessage(chatMessage);

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
@@ -358,9 +358,7 @@ public abstract class ClientBase
     {
         if (maxTokens.HasValue && maxTokens < 1)
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidRequest,
-                $"MaxTokens {maxTokens} is not valid, the value must be greater than zero");
+            throw new SKException($"MaxTokens {maxTokens} is not valid, the value must be greater than zero");
         }
     }
 
@@ -439,7 +437,7 @@ public abstract class ClientBase
                         e.Message, e);
             }
         }
-        catch (Exception e) when (e is not AIException)
+        catch (Exception e) when (e is not SKException)
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureChatCompletionWithData.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureChatCompletionWithData.cs
@@ -139,9 +139,7 @@ public sealed class AzureChatCompletionWithData : IChatCompletion, ITextCompleti
     {
         if (maxTokens.HasValue && maxTokens < 1)
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidRequest,
-                $"MaxTokens {maxTokens} is not valid, the value must be greater than zero");
+            throw new SKException($"MaxTokens {maxTokens} is not valid, the value must be greater than zero");
         }
     }
 
@@ -245,9 +243,7 @@ public sealed class AzureChatCompletionWithData : IChatCompletion, ITextCompleti
 
             this._logger.LogError(errorMessage);
 
-            throw new AIException(
-                AIException.ErrorCodes.InvalidResponseContent,
-                errorMessage);
+            throw new SKException(errorMessage);
         }
 
         return response;

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAIClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAIClientBase.cs
@@ -55,9 +55,7 @@ public abstract class OpenAIClientBase
         var result = await this.ExecutePostRequestAsync<TextEmbeddingResponse>(url, requestBody, cancellationToken).ConfigureAwait(false);
         if (result.Embeddings is not { Count: >= 1 })
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidResponseContent,
-                "Embeddings not found");
+            throw new SKException("Embeddings not found");
         }
 
         return result.Embeddings.Select(e => e.Values).ToList();
@@ -120,7 +118,7 @@ public abstract class OpenAIClientBase
             T result = this.JsonDeserialize<T>(responseJson);
             return result;
         }
-        catch (Exception e) when (e is not AIException)
+        catch (Exception e) when (e is not SKException)
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,
@@ -133,7 +131,7 @@ public abstract class OpenAIClientBase
         var result = Json.Deserialize<T>(responseJson);
         if (result is null)
         {
-            throw new AIException(AIException.ErrorCodes.InvalidResponseContent, "Response JSON parse error");
+            throw new SKException("Response JSON parse error");
         }
 
         return result;
@@ -231,7 +229,7 @@ public abstract class OpenAIClientBase
                         errorDetail);
             }
         }
-        catch (Exception e) when (e is not AIException)
+        catch (Exception e) when (e is not SKException)
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageGeneration.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageGeneration.cs
@@ -87,9 +87,7 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
 
         if (httpClient.BaseAddress == null && string.IsNullOrEmpty(endpoint))
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidConfiguration,
-                "The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
+            throw new SKException("The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
         }
 
         endpoint = !string.IsNullOrEmpty(endpoint) ? endpoint! : httpClient.BaseAddress!.AbsoluteUri;
@@ -148,7 +146,7 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
 
         if (result == null || string.IsNullOrWhiteSpace(result.Id))
         {
-            throw new AIException(AIException.ErrorCodes.InvalidResponseContent, "Response not contains result");
+            throw new SKException("Response not contains result");
         }
 
         return result.Id;
@@ -171,7 +169,7 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
             {
                 if (this._maxRetryCount == retryCount)
                 {
-                    throw new AIException(AIException.ErrorCodes.RequestTimeout, "Reached maximum retry attempts");
+                    throw new SKException("Reached maximum retry attempts");
                 }
 
                 using var response = await this.ExecuteRequestAsync(operationLocation, HttpMethod.Get, null, cancellationToken).ConfigureAwait(false);
@@ -196,7 +194,7 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
                 retryCount++;
             }
         }
-        catch (Exception e) when (e is not AIException)
+        catch (Exception e) when (e is not SKException)
         {
             throw new AIException(
                 AIException.ErrorCodes.UnknownError,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/Settings/GPT3Settings.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/Settings/GPT3Settings.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
-using Microsoft.SemanticKernel.AI;
+using Microsoft.SemanticKernel.Diagnostics;
 
 namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.Tokenizers.Settings;
 
@@ -19,9 +19,7 @@ internal static class GPT3Settings
     /// <summary>Lazy load the cached encoding table (encoder.json).</summary>
     private static readonly Lazy<Dictionary<string, int>> s_encoder = new(() =>
         JsonSerializer.Deserialize<Dictionary<string, int>>(
-            EmbeddedResource.ReadEncodingTable()) ?? throw new AIException(
-            AIException.ErrorCodes.InvalidConfiguration,
-            "Encoding table deserialization returned NULL"));
+            EmbeddedResource.ReadEncodingTable()) ?? throw new SKException("Encoding table deserialization returned NULL"));
 
     /// <summary>Lazy load the cached byte pair encoding table (vocab.bpe).</summary>
     private static readonly Lazy<Dictionary<(string, string), int>> s_bpeRanks = new(() =>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
@@ -11,9 +11,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.AI;
-using Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Diagnostics;
 using Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
+using Microsoft.SemanticKernel.Diagnostics;
+using Verify = Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Diagnostics.Verify;
 
 namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
 
@@ -57,9 +57,7 @@ public sealed class QdrantVectorDbClient : IQdrantVectorDbClient
     {
         if (string.IsNullOrEmpty(httpClient.BaseAddress?.AbsoluteUri) && string.IsNullOrEmpty(endpoint))
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidConfiguration,
-                "The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
+            throw new SKException("The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
         }
 
         this._httpClient = httpClient;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryStore.cs
@@ -15,7 +15,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Connectors.Memory.Weaviate.Http.ApiSchema;
 using Microsoft.SemanticKernel.Connectors.Memory.Weaviate.Model;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -83,9 +82,7 @@ public class WeaviateMemoryStore : IMemoryStore
 
         if (string.IsNullOrEmpty(httpClient.BaseAddress?.AbsoluteUri) && string.IsNullOrEmpty(endpoint))
         {
-            throw new AIException(
-                AIException.ErrorCodes.InvalidConfiguration,
-                "The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
+            throw new SKException("The HttpClient BaseAddress and endpoint are both null or empty. Please ensure at least one is provided.");
         }
 
         this._apiKey = apiKey;

--- a/dotnet/src/SemanticKernel.Abstractions/AI/AIException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/AIException.cs
@@ -75,16 +75,11 @@ public class AIException : SKException
     {
         string description = errorCode switch
         {
-            ErrorCodes.NoResponse => "No response",
             ErrorCodes.AccessDenied => "Access denied",
             ErrorCodes.InvalidRequest => "Invalid request",
-            ErrorCodes.InvalidResponseContent => "Invalid response content",
             ErrorCodes.Throttling => "Throttling",
             ErrorCodes.RequestTimeout => "Request timeout",
             ErrorCodes.ServiceError => "Service error",
-            ErrorCodes.ModelNotAvailable => "Model not available",
-            ErrorCodes.InvalidConfiguration => "Invalid configuration",
-            ErrorCodes.FunctionTypeNotSupported => "Function type not supported",
             _ => $"Unknown error ({errorCode:G})",
         };
 
@@ -102,11 +97,6 @@ public class AIException : SKException
         UnknownError = -1,
 
         /// <summary>
-        /// No response.
-        /// </summary>
-        NoResponse,
-
-        /// <summary>
         /// Access is denied.
         /// </summary>
         AccessDenied,
@@ -115,11 +105,6 @@ public class AIException : SKException
         /// The request was invalid.
         /// </summary>
         InvalidRequest,
-
-        /// <summary>
-        /// The content of the response was invalid.
-        /// </summary>
-        InvalidResponseContent,
 
         /// <summary>
         /// The request was throttled.
@@ -135,20 +120,5 @@ public class AIException : SKException
         /// There was an error in the service.
         /// </summary>
         ServiceError,
-
-        /// <summary>
-        /// The requested model is not available.
-        /// </summary>
-        ModelNotAvailable,
-
-        /// <summary>
-        /// The supplied configuration was invalid.
-        /// </summary>
-        InvalidConfiguration,
-
-        /// <summary>
-        /// The function is not supported.
-        /// </summary>
-        FunctionTypeNotSupported,
     }
 }

--- a/dotnet/src/SemanticKernel/Kernel.cs
+++ b/dotnet/src/SemanticKernel/Kernel.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
@@ -271,9 +270,7 @@ public sealed class Kernel : IKernel, IDisposable
     {
         if (!functionConfig.PromptTemplateConfig.Type.Equals("completion", StringComparison.OrdinalIgnoreCase))
         {
-            throw new AIException(
-                AIException.ErrorCodes.FunctionTypeNotSupported,
-                $"Function type not supported: {functionConfig.PromptTemplateConfig}");
+            throw new SKException($"Function type not supported: {functionConfig.PromptTemplateConfig}");
         }
 
         ISKFunction func = SemanticFunction.FromSemanticConfig(


### PR DESCRIPTION
### Motivation and Context
This PR is one of the follow-up PRs aimed at gradually replacing SK custom exceptions with SKException to provide a simple, consistent, and extensible exception model. You can find more details in the [ADR](https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0004-error-handling.md) discussing error handling.

### Description
This PR replaces AIException with SKException for cases that are not related to HTTP request status, such as invalid configuration, wrong response content, not supported function type, etc.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
