### PR TITLE
.Net: Removing `FromSemanticConfig` from NativeFunction.cs

### DIFF
--- a/dotnet/src/SemanticKernel/SkillDefinition/NativeFunction.cs
+++ b/dotnet/src/SemanticKernel/SkillDefinition/NativeFunction.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SemanticFunctions;
 
 namespace Microsoft.SemanticKernel.SkillDefinition;
 
@@ -127,23 +126,6 @@ internal sealed class NativeFunction : ISKFunction, IDisposable
             functionName: functionName,
             logger: logger);
     }
-
-    /// <summary>
-    /// Create a native function instance, given a semantic function configuration.
-    /// </summary>
-    /// <param name="skillName">Name of the skill to which the function to create belongs.</param>
-    /// <param name="functionName">Name of the function to create.</param>
-    /// <param name="functionConfig">Semantic function configuration.</param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>SK function instance.</returns>
-    public static ISKFunction FromSemanticConfig(
-        string skillName,
-        string functionName,
-        SemanticFunctionConfig functionConfig,
-        ILoggerFactory? loggerFactory = null,
-        CancellationToken cancellationToken = default) =>
-            SemanticFunction.FromSemanticConfig(skillName, functionName, functionConfig, loggerFactory, cancellationToken);
 
     /// <inheritdoc/>
     public FunctionView Describe()


### PR DESCRIPTION
### Description
Removing `FromSemanticConfig` from NativeFunction.cs has no business being there. That code now exists in SemanticFunction.cs. This is dead code.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
