### PR TITLE
Python: Integration tests 'needs' path filter job

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install poetry pytest
           cd python
-          poetry install --without azure_cognitive_search --without weaviate --without pinecone --without postgres
+          poetry install
       - name: Run Integration Tests
         id: run_tests
         shell: bash

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -39,6 +39,7 @@ jobs:
         run: echo "NOT python file"
 
   python-merge-gate:
+    needs: paths-filter
     if: github.event_name != 'pull_request' && github.event_name != 'schedule' && needs.paths-filter.outputs.pythonChanges == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -94,6 +95,7 @@ jobs:
           poetry run pytest ./tests/integration -v
 
   python-integration-tests:
+    needs: paths-filter
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.paths-filter.outputs.pythonChanges == 'true'
     runs-on: ${{ matrix.os }}
     strategy:

--- a/python/samples/kernel-syntax-examples/action_planner.py
+++ b/python/samples/kernel-syntax-examples/action_planner.py
@@ -13,7 +13,7 @@ async def main():
     api_key, org_id = sk.openai_settings_from_dot_env()
 
     kernel.add_chat_service(
-        "gpt-3.5", OpenAIChatCompletion("gpt-3.5-turbo", api_key, org_id)
+        "chat-gpt", OpenAIChatCompletion("gpt-3.5-turbo", api_key, org_id)
     )
     kernel.import_skill(MathSkill(), "math")
     kernel.import_skill(FileIOSkill(), "fileIO")


### PR DESCRIPTION
### Motivation and Context

PRs #2533 and #2555 updated the integration tests to trigger off of python changes only, but did not actually have the resulting jobs require the path filtering. This means that the tests never run. 

### Description
Add path-filter job as a requirement for subsequent jobs.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
