### PR TITLE
Python: Include `token_selection_biases` in `PromptTemplateConfig`

### DIFF
--- a/python/semantic_kernel/connectors/ai/complete_request_settings.py
+++ b/python/semantic_kernel/connectors/ai/complete_request_settings.py
@@ -31,6 +31,7 @@ class CompleteRequestSettings:
         self.max_tokens = completion_config.max_tokens
         self.stop_sequences = completion_config.stop_sequences
         self.number_of_responses = completion_config.number_of_responses
+        self.token_selection_biases = completion_config.token_selection_biases
 
     @staticmethod
     def from_completion_config(

--- a/python/semantic_kernel/semantic_functions/prompt_template_config.py
+++ b/python/semantic_kernel/semantic_functions/prompt_template_config.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import Dict, List
 
 
 @dataclass
@@ -15,6 +15,7 @@ class PromptTemplateConfig:
         max_tokens: int = 256
         number_of_responses: int = 1
         stop_sequences: List[str] = field(default_factory=list)
+        token_selection_biases: Dict[int, int] = field(default_factory=dict)
 
     @dataclass
     class InputParameter:
@@ -56,6 +57,10 @@ class PromptTemplateConfig:
             "number_of_responses"
         )
         config.completion.stop_sequences = completion_dict.get("stop_sequences", [])
+        config.token_selection_biases = completion_dict.get(
+            "token_selection_biases", {}
+        )
+
         config.default_services = data.get("default_services", [])
 
         # Some skills may not have input parameters defined
@@ -108,6 +113,7 @@ class PromptTemplateConfig:
         max_tokens: int = 256,
         number_of_responses: int = 1,
         stop_sequences: List[str] = [],
+        token_selection_biases: Dict[int, int] = {},
     ) -> "PromptTemplateConfig":
         config = PromptTemplateConfig()
         config.completion.temperature = temperature
@@ -117,4 +123,5 @@ class PromptTemplateConfig:
         config.completion.max_tokens = max_tokens
         config.completion.number_of_responses = number_of_responses
         config.completion.stop_sequences = stop_sequences
+        config.token_selection_biases = token_selection_biases
         return config


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

`token_selection_biases` was missing from constructors in `PromptTemplateConfig` and `CompleteRequestSettings`

Closes #2564 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Added `token_selection_biases` into the config template and defaults to an empty dictionary

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
