### PR TITLE
.Net: Fix GitHub Repo Q&A Bot Sample

### DIFF
--- a/dotnet/src/SemanticKernel/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel/Memory/SemanticTextMemory.cs
@@ -17,7 +17,6 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
 {
     private readonly ITextEmbeddingGeneration _embeddingGenerator;
     private readonly IMemoryStore _storage;
-    private HashSet<string>? _collections;
 
     public SemanticTextMemory(
         IMemoryStore storage,
@@ -40,7 +39,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         MemoryRecord data = MemoryRecord.LocalRecord(
             id: id, text: text, description: description, additionalMetadata: additionalMetadata, embedding: embedding);
 
-        if (!(await this.DoesCollectionExistAsync(collection, cancellationToken).ConfigureAwait(false)))
+        if (!(await this._storage.DoesCollectionExistAsync(collection, cancellationToken).ConfigureAwait(false)))
         {
             await this._storage.CreateCollectionAsync(collection, cancellationToken).ConfigureAwait(false);
         }
@@ -62,7 +61,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         var data = MemoryRecord.ReferenceRecord(externalId: externalId, sourceName: externalSourceName, description: description,
             additionalMetadata: additionalMetadata, embedding: embedding);
 
-        if (!(await this.DoesCollectionExistAsync(collection, cancellationToken).ConfigureAwait(false)))
+        if (!(await this._storage.DoesCollectionExistAsync(collection, cancellationToken).ConfigureAwait(false)))
         {
             await this._storage.CreateCollectionAsync(collection, cancellationToken).ConfigureAwait(false);
         }
@@ -90,7 +89,6 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         string key,
         CancellationToken cancellationToken = default)
     {
-        // $$$ 
         await this._storage.RemoveAsync(collection, key, cancellationToken).ConfigureAwait(false);
     }
 
@@ -103,12 +101,6 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
         bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Do not proceed with embedding or query if index isn't present
-        if (!(await this.DoesCollectionExistAsync(collection, cancellationToken).ConfigureAwait(false)))
-        {
-            yield break;
-        }
-
         ReadOnlyMemory<float> queryEmbedding = await this._embeddingGenerator.GenerateEmbeddingAsync(query, cancellationToken).ConfigureAwait(false);
 
         IAsyncEnumerable<(MemoryRecord, double)> results = this._storage.GetNearestMatchesAsync(
@@ -128,11 +120,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
     /// <inheritdoc/>
     public async Task<IList<string>> GetCollectionsAsync(CancellationToken cancellationToken = default)
     {
-        IList<string> collections = await this._storage.GetCollectionsAsync(cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        this._collections = new HashSet<string>(collections); // Capture collections
-
-        return collections;
+        return await this._storage.GetCollectionsAsync(cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public void Dispose()
@@ -142,17 +130,5 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
 
         // ReSharper disable once SuspiciousTypeConversion.Global
         if (this._storage is IDisposable storage) { storage.Dispose(); }
-    }
-
-    private async Task<bool> DoesCollectionExistAsync(string collection, CancellationToken cancellationToken = default)
-    {
-        // Search cached list of collections to avoid a round trip to storage.
-        if (this._collections == null || !this._collections.Contains(collection))
-        {
-            // Retrieve current list of collections
-            await this.GetCollectionsAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return this._collections?.Contains(collection) ?? false;
     }
 }

--- a/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
+++ b/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
@@ -212,6 +212,8 @@ BEGIN SUMMARY:
     {
         string[] filePaths = Directory.GetFiles(directoryPath, searchPattern, SearchOption.AllDirectories);
 
+        this._logger.LogDebug("Found {0} files to summarize", filePaths.Length);
+
         if (filePaths != null && filePaths.Length > 0)
         {
             foreach (string filePath in filePaths)

--- a/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
+++ b/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
@@ -89,13 +89,14 @@ BEGIN SUMMARY:
         string tempPath = Path.GetTempPath();
         string directoryPath = Path.Combine(tempPath, $"SK-{Guid.NewGuid()}");
         string filePath = Path.Combine(tempPath, $"SK-{Guid.NewGuid()}.zip");
-        Console.WriteLine("Path: " + directoryPath);
 
         try
         {
             var originalUri = input.Trim(s_trimChars);
             var repositoryUri = Regex.Replace(originalUri, "github.com", "api.github.com/repos", RegexOptions.IgnoreCase);
             var repoBundle = $"{repositoryUri}/zipball/{repositoryBranch}";
+
+            this._logger.LogDebug("Downloading {RepoBundle}", repoBundle);
 
             var headers = new Dictionary<string, string>();
             headers.Add("X-GitHub-Api-Version", "2022-11-28");

--- a/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
+++ b/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
@@ -212,10 +212,10 @@ BEGIN SUMMARY:
     {
         string[] filePaths = Directory.GetFiles(directoryPath, searchPattern, SearchOption.AllDirectories);
 
-        this._logger.LogDebug("Found {0} files to summarize", filePaths.Length);
-
         if (filePaths != null && filePaths.Length > 0)
         {
+            this._logger.LogDebug("Found {0} files to summarize", filePaths.Length);
+
             foreach (string filePath in filePaths)
             {
                 var fileUri = this.BuildFileUri(directoryPath, filePath, repositoryUri, repositoryBranch);

--- a/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
+++ b/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
@@ -89,13 +89,13 @@ BEGIN SUMMARY:
         string tempPath = Path.GetTempPath();
         string directoryPath = Path.Combine(tempPath, $"SK-{Guid.NewGuid()}");
         string filePath = Path.Combine(tempPath, $"SK-{Guid.NewGuid()}.zip");
+        Console.WriteLine("Path: " + directoryPath);
 
         try
         {
-            var repositoryUri = Regex.Replace(input.Trim(s_trimChars), "github.com", "api.github.com/repos", RegexOptions.IgnoreCase);
+            var originalUri = input.Trim(s_trimChars);
+            var repositoryUri = Regex.Replace(originalUri, "github.com", "api.github.com/repos", RegexOptions.IgnoreCase);
             var repoBundle = $"{repositoryUri}/zipball/{repositoryBranch}";
-
-            this._logger.LogDebug("Downloading {RepoBundle}", repoBundle);
 
             var headers = new Dictionary<string, string>();
             headers.Add("X-GitHub-Api-Version", "2022-11-28");
@@ -111,9 +111,9 @@ BEGIN SUMMARY:
 
             ZipFile.ExtractToDirectory(filePath, directoryPath);
 
-            await this.SummarizeCodeDirectoryAsync(directoryPath, searchPattern, repositoryUri, repositoryBranch, cancellationToken);
+            await this.SummarizeCodeDirectoryAsync(directoryPath, searchPattern, originalUri, repositoryBranch, cancellationToken);
 
-            return $"{repositoryUri}-{repositoryBranch}";
+            return $"{originalUri}-{repositoryBranch}";
         }
         finally
         {
@@ -196,10 +196,10 @@ BEGIN SUMMARY:
             else
             {
                 await this._kernel.Memory.SaveInformationAsync(
-                    $"{repositoryUri}-{repositoryBranch}",
-                    text: $"{code} File:{repositoryUri}/blob/{repositoryBranch}/{fileUri}",
-                    id: fileUri,
-                    cancellationToken: cancellationToken);
+                     $"{repositoryUri}-{repositoryBranch}",
+                     text: $"{code} File:{repositoryUri}/blob/{repositoryBranch}/{fileUri}",
+                     id: fileUri,
+                     cancellationToken: cancellationToken);
             }
         }
     }
@@ -213,8 +213,6 @@ BEGIN SUMMARY:
 
         if (filePaths != null && filePaths.Length > 0)
         {
-            this._logger.LogDebug("Found {0} files to summarize", filePaths.Length);
-
             foreach (string filePath in filePaths)
             {
                 var fileUri = this.BuildFileUri(directoryPath, filePath, repositoryUri, repositoryBranch);

--- a/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
+++ b/samples/dotnet/KernelHttpServer/Plugins/GitHubPlugin.cs
@@ -197,10 +197,10 @@ BEGIN SUMMARY:
             else
             {
                 await this._kernel.Memory.SaveInformationAsync(
-                     $"{repositoryUri}-{repositoryBranch}",
-                     text: $"{code} File:{repositoryUri}/blob/{repositoryBranch}/{fileUri}",
-                     id: fileUri,
-                     cancellationToken: cancellationToken);
+                    $"{repositoryUri}-{repositoryBranch}",
+                    text: $"{code} File:{repositoryUri}/blob/{repositoryBranch}/{fileUri}",
+                    id: fileUri,
+                    cancellationToken: cancellationToken);
             }
         }
     }


### PR DESCRIPTION
### Motivation and Context
Not returning relevant results: [GitHub Repo Q&A Bot Sample](https://github.com/microsoft/semantic-kernel/tree/main/samples/apps/github-qna-webapp-react)

Customer reported: https://github.com/microsoft/semantic-kernel/issues/2506

### Description
RCA: Mistmatch between container name being written to and being queried.

`https://api.github.com/repos/microsoft/semantic-kernel-main`

vs

`https://github.com/microsoft/semantic-kernel-main`

![image](https://github.com/microsoft/semantic-kernel/assets/66376200/2902821d-4c6a-4468-ab9e-ddd177d88138)
![image](https://github.com/microsoft/semantic-kernel/assets/66376200/aab4cf46-a9ce-443e-8027-b99beaf5388f)

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
