### PR TITLE
.Net: Unseal FunctionView for extension in external plugin scenarios.

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/FunctionView.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/SkillDefinition/FunctionView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.SkillDefinition;
 /// The data is mutable, but changes do not affect the skill collection.
 /// </summary>
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
-public sealed class FunctionView
+public class FunctionView
 {
     /// <summary>
     /// Name of the function. The name is used by the skill collection and in prompt templates e.g. {{skillName.functionName}}


### PR DESCRIPTION
### Motivation and Context
There is work outside of the SK OSS repo to enable more complicated function views. This change allows `FunctionView` to be extended with additional metadata.

### Description
- Removed `sealed` keyword from `FunctionView` class definition.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
