### PR TITLE
Python: add python repl skill

### DIFF
--- a/python/semantic_kernel/core_skills/__init__.py
+++ b/python/semantic_kernel/core_skills/__init__.py
@@ -6,6 +6,7 @@ from semantic_kernel.core_skills.conversation_summary_skill import (
 from semantic_kernel.core_skills.file_io_skill import FileIOSkill
 from semantic_kernel.core_skills.http_skill import HttpSkill
 from semantic_kernel.core_skills.math_skill import MathSkill
+from semantic_kernel.core_skills.python_repl_skill import PythonREPLSkill
 from semantic_kernel.core_skills.text_memory_skill import TextMemorySkill
 from semantic_kernel.core_skills.text_skill import TextSkill
 from semantic_kernel.core_skills.time_skill import TimeSkill
@@ -20,4 +21,5 @@ __all__ = [
     "ConversationSummarySkill",
     "MathSkill",
     "WebSearchEngineSkill",
+    "PythonREPLSkill",
 ]

--- a/python/semantic_kernel/core_skills/python_repl_skill.py
+++ b/python/semantic_kernel/core_skills/python_repl_skill.py
@@ -1,0 +1,108 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import ast
+import re
+from contextlib import redirect_stdout
+from io import StringIO
+from typing import TYPE_CHECKING
+
+from semantic_kernel.sk_pydantic import PydanticField
+from semantic_kernel.skill_definition import sk_function, sk_function_context_parameter
+
+if TYPE_CHECKING:
+    from semantic_kernel.orchestration.sk_context import SKContext
+
+
+def reindent_code_block(code_block: str) -> str:
+    """Reindents a code block."""
+    lines = code_block.split("\n")
+    # Remove leading and trailing empty lines
+    lines = [line for line in lines if line.strip()]
+    # Get the minimum leading whitespace for non-empty lines
+    min_indent = min(
+        len(re.match(r"^(\s*)", line).group(1)) for line in lines if line.strip()
+    )
+    # Dedent each line
+    dedented = [line[min_indent:] for line in lines]
+    return "\n".join(dedented)
+
+
+def sanitize_input(query: str) -> str:
+    pattern = r"```python\n(.*?)\n\s*```"
+    code_block = re.search(pattern, query, re.DOTALL).group(1)
+    code_block = reindent_code_block(code_block)
+    return code_block
+
+
+class PythonREPLSkill(PydanticField):
+    """
+    A skill that provides Python code execution functionality within a restricted environment.
+
+    Usage:
+        kernel.import_skill(PythonREPLSkill(), "pyrepl")
+    """
+
+    @sk_function(
+        description="Run python code encapsulated in a specific pattern (```python ... ```).",
+        name="runPythonREPL",
+    )
+    @sk_function_context_parameter(
+        name="include_stdout",
+        description="Include the standard output of the Python code execution as final REPL output.",
+        default_value=False,
+    )
+    async def run_python_repl(self, query: str, context: "SKContext" = None) -> str:
+        """
+        Parses and executes the Python code provided within a given string query.
+        The code must be encapsulated within a specific pattern (```python ... ```).
+
+        params:
+            query: A string that encapsulates the Python code to be executed.
+
+        returns:
+            The output of the Python code execution as a string.
+
+        Exceptions:
+            Raises ValueError if no valid Python code block is found or if the provided code has syntax errors.
+        """
+        if context is not None:
+            _, include_stdout = context.variables.get("include_stdout")
+            assert isinstance(include_stdout, bool)
+        else:
+            include_stdout = False
+
+        __globals = {}
+
+        try:
+            query = sanitize_input(query)
+        except AttributeError:
+            raise ValueError("Couldn't find python code block.")
+
+        try:
+            tree = ast.parse(query)
+        except SyntaxError:
+            raise ValueError("Invalid python code.")
+
+        module = ast.Module(tree.body[:-1], type_ignores=[])
+        exec(ast.unparse(module), __globals)
+
+        # execute last line of the code
+        module_end = ast.Module(tree.body[-1:], type_ignores=[])
+        module_end_str = ast.unparse(module_end)
+
+        io_buffer = StringIO()
+        try:
+            with redirect_stdout(io_buffer):
+                ret = eval(module_end_str, __globals)
+                if ret is None:
+                    return io_buffer.getvalue()
+                else:
+                    ret = str(ret)
+                    if include_stdout:
+                        ret = io_buffer.getvalue() + "\n" + ret
+                    return ret
+
+        except Exception:
+            with redirect_stdout(io_buffer):
+                exec(module_end_str, __globals)
+            return io_buffer.getvalue()

--- a/python/semantic_kernel/core_skills/python_repl_skill.py
+++ b/python/semantic_kernel/core_skills/python_repl_skill.py
@@ -91,6 +91,11 @@ class PythonREPLSkill(PydanticField):
         module_end_str = ast.unparse(module_end)
 
         io_buffer = StringIO()
+
+        # TODO(joowon-dm-snu): Execution of the code should be done in a separate thread/process
+        #      1) to avoid blocking the main thread.
+        #      2) to avoid the possibility of malicious code execution. -> separate process is better but complicated.
+        #      3) to avoid the possibility of code execution that takes too long. -> Add timeout.
         try:
             with redirect_stdout(io_buffer):
                 ret = eval(module_end_str, __globals)

--- a/python/tests/unit/core_skills/test_python_repl_skill.py
+++ b/python/tests/unit/core_skills/test_python_repl_skill.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import pytest
+
 from semantic_kernel import Kernel
 from semantic_kernel.core_skills import PythonREPLSkill
 

--- a/python/tests/unit/core_skills/test_python_repl_skill.py
+++ b/python/tests/unit/core_skills/test_python_repl_skill.py
@@ -1,0 +1,109 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import pytest
+from semantic_kernel import Kernel
+from semantic_kernel.core_skills import PythonREPLSkill
+
+
+@pytest.mark.asyncio
+async def test_it_can_be_instantiated():
+    skill = PythonREPLSkill()
+    assert skill is not None
+
+
+@pytest.mark.asyncio
+async def test_it_can_be_imported():
+    kernel = Kernel()
+    skill = PythonREPLSkill()
+    assert kernel.import_skill(skill, "pyrepl")
+    assert kernel.skills.has_native_function("pyrepl", "runPythonREPL")
+
+
+@pytest.mark.asyncio
+async def test_valid_code_execution():
+    skill = PythonREPLSkill()
+    response = await skill.run_python_repl(
+        """
+        ```python
+        def fibonacci(n):
+            if n <= 0:
+                return 0
+            elif n == 1:
+                return 1
+            else:
+                return fibonacci(n-1) + fibonacci(n-2)
+    
+        fibonacci(10)
+        ```
+    """
+    )
+    assert response == "55"
+
+
+@pytest.mark.asyncio
+async def test_invalid_code():
+    skill = PythonREPLSkill()
+    with pytest.raises(ValueError):
+        await skill.run_python_repl("x = 10\ny = 20\nx + y")
+
+
+@pytest.mark.asyncio
+async def test_syntax_error_code():
+    skill = PythonREPLSkill()
+    with pytest.raises(ValueError):
+        await skill.run_python_repl(
+            """
+            ```python
+            x = 10
+            y = 20
+            x + y z
+            ```
+        """
+        )
+
+
+@pytest.mark.asyncio
+async def test_code_without_return():
+    skill = PythonREPLSkill()
+    response = await skill.run_python_repl(
+        """
+        ```python
+        x = 10
+        y = 20
+        z = x + y
+        ```
+    """
+    )
+    assert response == ""
+
+
+@pytest.mark.asyncio
+async def test_code_with_stdout_in_function():
+    kernel = Kernel()
+    skill = PythonREPLSkill()
+    context = kernel.create_new_context()
+    context.variables.set("include_stdout", True)
+    response = await skill.run_python_repl(
+        """
+        ```python
+        def fibonacci(n):
+            if n <= 0:
+                return 0
+            elif n == 1:
+                return 1
+            else:
+                print(f"Run fibonacci({n}) => fibonacci({n-1}) + fibonacci({n-2})")
+                return fibonacci(n-1) + fibonacci(n-2)
+    
+        fibonacci(3)
+        ```
+    """,
+        context=context,
+    )
+
+    expected = "Run fibonacci(3) => fibonacci(2) + fibonacci(1)\nRun fibonacci(2) => fibonacci(1) + fibonacci(0)\n\n2"
+    assert response == expected
+
+
+if __name__ == "__main__":
+    pytest.main(["-vv", "-s", __file__])


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
implement #2592 

As mentioned in #2385, I believe that the `custom_execute_async` in the `CodeSkill` is a necessary feature. 
However, the PR has been stagnant for a long time, and it seems a bit complicated mixed with the Chat feature.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
The python REPL execution part is entirely separated as a Native function, and the stdout generated by the print command is optionally returned. 

For security, considering a separate thread and strict management of global and local variables can be taken into account. However, it's currently left as a TODO since it's complex to manage and time-consuming. 
Also, it seems much better to input the include_stdout variable directly rather than using the context.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
