### PR TITLE
Fixes searchAsync does not limit the number of results

### DIFF
--- a/java/connectors/semantickernel-connectors-memory-azurecognitivesearch/src/main/java/com/microsoft/semantickernel/connectors/memory/azurecognitivesearch/AzureCognitiveSearchMemory.java
+++ b/java/connectors/semantickernel-connectors-memory-azurecognitivesearch/src/main/java/com/microsoft/semantickernel/connectors/memory/azurecognitivesearch/AzureCognitiveSearchMemory.java
@@ -243,7 +243,7 @@ public class AzureCognitiveSearchMemory implements SemanticTextMemory {
                         .setQueryType(QueryType.SEMANTIC)
                         .setSemanticConfigurationName("default")
                         .setQueryLanguage(QueryLanguage.EN_US)
-                        .setAnswersCount(limit);
+                        .setTop(limit);
 
         return client.search(query, options).byPage().collect(toMemoryQueryResultList);
     }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Fixes https://github.com/microsoft/semantic-kernel/issues/2572

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

As per the ACS documentation/sourcode setTop() is the right method to control the return of number of search results.

https://github.com/Azure/azure-sdk-for-java/blob/fa886839e05fa40fbd2b10100434af0e2a809059/sdk/search/azure-search-documents/src/main/java/com/azure/search/documents/models/SearchOptions.java#L206

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
