### PR TITLE
Java: remove default NullMemory from DefaultSKContext builder

### DIFF
--- a/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/DefaultSKContext.java
+++ b/java/semantickernel-core/src/main/java/com/microsoft/semantickernel/orchestration/DefaultSKContext.java
@@ -37,7 +37,7 @@ public class DefaultSKContext extends AbstractSKContext {
 
         private ContextVariables variables;
         private ReadOnlySkillCollection skills;
-        private SemanticTextMemory memory = NullMemory.getInstance();
+        private SemanticTextMemory memory;
 
         @Override
         public SKContext build() {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Bug #2183 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

DefaultSKContext.Builder should not set a default for SemanticTextMemory. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
