### PR TITLE
.Net: Fixed AppInsights example project

### DIFF
--- a/dotnet/samples/ApplicationInsightsExample/ApplicationInsightsExample.csproj
+++ b/dotnet/samples/ApplicationInsightsExample/ApplicationInsightsExample.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\Extensions\Planning.StepwisePlanner\Planning.StepwisePlanner.csproj" />
     <ProjectReference Include="..\..\src\Connectors\Connectors.AI.OpenAI\Connectors.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel\SemanticKernel.csproj" />
+    <ProjectReference Include="..\..\src\Extensions\TemplateEngine.PromptTemplateEngine\TemplateEngine.PromptTemplateEngine.csproj" />
     <ProjectReference Include="..\..\src\Skills\Skills.Core\Skills.Core.csproj" />
     <ProjectReference Include="..\..\src\Skills\Skills.Web\Skills.Web.csproj" />
     <ProjectReference Include="..\NCalcSkills\NCalcSkills.csproj" />


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

After template engine extraction (https://github.com/microsoft/semantic-kernel/pull/2562), it's required to include template engine project when we reference SK Core package directly. Otherwise `NullPromptTemplateEngine` will be used by default and functionality won't work as expected.

This behavior should not be reproduced in case of using SK Core package from NuGet, because template engine project is included in NuGet MetaPackage by default.

This PR contains changes to include template engine project in AppInsights example project, as it looks like only this project is impacted.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Added `TemplateEngine.PromptTemplateEngine` reference to `ApplicationInsightsExample` project.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
