### PR TITLE
.Net: Add missing ModelResult abstraction in IChatResult interface

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example34_CustomChatModel.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example34_CustomChatModel.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Microsoft.SemanticKernel.Orchestration;
 
 /**
  * The following example shows how to plug use a custom chat model.
@@ -51,11 +52,13 @@ public class MyChatStreamingResult : IChatStreamingResult
 {
     private readonly ChatMessageBase _message;
     private readonly MyRoles _role;
+    public ModelResult ModelResult { get; private set; }
 
     public MyChatStreamingResult(MyRoles role, string content)
     {
         this._role = role;
         this._message = new MyChatMessage(role, content);
+        this.ModelResult = new ModelResult(content);
     }
 
     public Task<ChatMessageBase> GetChatMessageAsync(CancellationToken cancellationToken = default)

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatResult.cs
@@ -2,6 +2,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Orchestration;
 
 namespace Microsoft.SemanticKernel.AI.ChatCompletion;
 
@@ -10,6 +11,11 @@ namespace Microsoft.SemanticKernel.AI.ChatCompletion;
 /// </summary>
 public interface IChatResult
 {
+    /// <summary>
+    /// Gets the model result data.
+    /// </summary>
+    ModelResult ModelResult { get; }
+
     /// <summary>
     /// Get the chat message from the result.
     /// </summary>


### PR DESCRIPTION
### Motivation and Context

`IChatResult` interface misses the ModelResult abstraction

Resolves #1565
Closes #1565

### Description

Added missing abstraction.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
