### PR TITLE
.Net: Use Cosine Distance for Azure Cognitive Search

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Memory/IMemoryStore.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/IMemoryStore.cs
@@ -106,7 +106,7 @@ public interface IMemoryStore
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="embedding">The <see cref="Embedding{Single}"/> to compare the collection's embeddings with.</param>
     /// <param name="limit">The maximum number of similarity results to return.</param>
-    /// <param name="minRelevanceScore">The minimum relevance threshold for returned results.</param>
+    /// <param name="minRelevanceScore">The minimum cosine similarity threshold for returned results.</param>
     /// <param name="withEmbeddings">If true, the embeddings will be returned in the memory records.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A group of tuples where item1 is a <see cref="MemoryRecord"/> and item2 is its similarity score as a <see cref="double"/>.</returns>
@@ -123,7 +123,7 @@ public interface IMemoryStore
     /// </summary>
     /// <param name="collectionName">The name associated with a collection of embeddings.</param>
     /// <param name="embedding">The <see cref="Embedding{Single}"/> to compare the collection's embeddings with.</param>
-    /// <param name="minRelevanceScore">The minimum relevance threshold for returned results.</param>
+    /// <param name="minRelevanceScore">The minimum cosine similarity threshold for returned results.</param>
     /// <param name="withEmbedding">If true, the embedding will be returned in the memory record.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A tuple consisting of the <see cref="MemoryRecord"/> and the similarity score as a <see cref="double"/>. Null if no nearest match found.</returns>


### PR DESCRIPTION
When using vector search with `VectorMetricType.Cosine`, Azure Cognitive Search search result score is expressed as Cosine Distance. The value `minRelevanceScore` passed to `IMemoryStore` is expressed as Cosine Similarity, so it's important to transform the values during the comparison and when returning results.

Formulas:

```csharp
double ScoreToCosineSimilarity(double score)
{
    return 2 - 1 / score;
}

double CosineSimilarityToScore(double similarity)
{
    return 1 / (2 - similarity);
}
```
