### PR TITLE
.Net: Fix redis memory store index check

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisMemoryStore.cs
@@ -119,7 +119,7 @@ public class RedisMemoryStore : IMemoryStore, IDisposable
             await this._ft.InfoAsync(collectionName).ConfigureAwait(false);
             return true;
         }
-        catch (RedisServerException ex) when (ex.Message.Equals(IndexDoesNotExistErrorMessage, StringComparison.Ordinal))
+        catch (RedisServerException ex) when (ex.Message.Equals(IndexDoesNotExistErrorMessage, StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
@@ -294,7 +294,7 @@ public class RedisMemoryStore : IMemoryStore, IDisposable
     /// Message when index does not exist.
     /// <see href="https://github.com/RediSearch/RediSearch/blob/master/src/info_command.c#L97"/>
     /// </summary>
-    private const string IndexDoesNotExistErrorMessage = "Unknown Index name";
+    private const string IndexDoesNotExistErrorMessage = "Unknown index name";
 
     private readonly IDatabase _database;
     private readonly int _vectorSize;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
fix #2682

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
The case of the error message has changed

https://github.com/RediSearch/RediSearch/commit/e1ad1b099a7da2091bd14485c863e5da646d6e60#diff-4d570566161a8f0ca29c7e12a31bc46b08fa89960ff034b711235bdd897efd6fR114

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
