### PR TITLE
Python: Add support for Azure OpenAI, Palm, Claude-2, Llama2, CodeLlama (100+LLMs)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "semantic_kernel"}]
 python = "^3.8"
 numpy = "^1.24.2"
 openai = "^0.27.0"
+litellm = "^0.1.400"
 aiofiles = "^23.1.0"
 python-dotenv = "1.0.0"
 regex = "^2023.6.3"

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
@@ -4,6 +4,7 @@ from logging import Logger
 from typing import Any, List, Optional, Tuple, Union
 
 import openai
+from litellm import acompletion
 
 from semantic_kernel.connectors.ai.ai_exception import AIException
 from semantic_kernel.connectors.ai.chat_completion_client_base import (
@@ -201,7 +202,7 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
         ]
 
         try:
-            response: Any = await openai.ChatCompletion.acreate(
+            response: Any = await acompletion(
                 **model_args,
                 api_key=self._api_key,
                 api_type=self._api_type,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
Example
```python
# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)
# cohere call
response = completion(model="command-nightly", messages=messages)
# anthropic
response = completion(model="claude-2", messages=messages)
```

In addition LiteLLM client allows you to:
* A/B test LLMs in production 
* Dynamically control each LLMs prompt, temperature, top_k etc in our UI (no need to re-deploy code)
* Logging to view input/outputs for each LLM

Here's a link to a live demo of litellm client: https://admin.litellm.ai/ 

![liteLLM-Ab-testing](https://github.com/ConvLab/ConvLab-3/assets/29436595/4206cb62-4c83-4ea1-9be2-e5a7dd306048)


<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
