### PR TITLE
Python: Fix incorrect variable name in Plan's __str__ method

### DIFF
--- a/python/semantic_kernel/planning/basic_planner.py
+++ b/python/semantic_kernel/planning/basic_planner.py
@@ -18,7 +18,7 @@ class Plan:
         self.generated_plan = plan
 
     def __str__(self):
-        return f"Prompt: {self.prompt}\nGoal: {self.goal}\nPlan: {self.plan}"
+        return f"Prompt: {self.prompt}\nGoal: {self.goal}\nPlan: {self.generated_plan}"
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
Fix the variable name in the __str__ method of the Plan class to properly display the generated plan instead of the uninitialized attribute. This change improves the string representation of the Plan object.

Fixes #2660 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
