### PR TITLE
.Net [RestAPI] Fix to skip optional payload parameters

### DIFF
--- a/dotnet/src/Skills/Skills.OpenAPI/RestApiOperationRunner.cs
+++ b/dotnet/src/Skills/Skills.OpenAPI/RestApiOperationRunner.cs
@@ -248,12 +248,16 @@ internal sealed class RestApiOperationRunner
                 continue;
             }
 
-            if (!arguments.TryGetValue(argumentName, out var propertyValue))
+            if (arguments.TryGetValue(argumentName, out var propertyValue))
+            {
+                result.Add(propertyMetadata.Name, ConvertJsonPropertyValueType(propertyValue, propertyMetadata));
+                continue;
+            }
+
+            if (propertyMetadata.IsRequired)
             {
                 throw new SKException($"No argument is found for the '{propertyMetadata.Name}' payload property.");
             }
-
-            result.Add(propertyMetadata.Name, ConvertJsonPropertyValueType(propertyValue, propertyMetadata));
         }
 
         return result;


### PR DESCRIPTION
### Motivation and Context
This change is necessary to enable the RestAPI functionality to skip optional payload parameters when no arguments are provided for them.

### Description
The logic of the `RestApiOperationRunner` class has been updated to ignore optional payload parameters when their arguments are not provided.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x]  I didn't break anyone :smile:
