### PR TITLE
.Net: [fix] ImportPlan extension properly import plan object.

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -231,8 +231,8 @@ public class SequentialPlanParserTests
             Assert.Equal("Echo", plan.Steps[0].Name);
             Assert.Null(plan.Steps[0].Description);
 
-            Assert.Equal(plan.GetType().FullName, plan.Steps[1].SkillName);
-            Assert.Equal(string.Empty, plan.Steps[1].Name);
+            Assert.Equal(plan.GetType().Name, plan.Steps[1].SkillName);
+            Assert.NotEmpty(plan.Steps[1].Name);
             Assert.Equal("MockSkill.DoesNotExist", plan.Steps[1].Description);
         }
         else

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -91,7 +91,7 @@ public sealed class Plan : IPlan
     /// <param name="goal">The goal of the plan used as description.</param>
     public Plan(string goal)
     {
-        this.Name = RandomPlanName();
+        this.Name = GetRandomPlanName();
         this.Description = goal;
         this.SkillName = nameof(Plan);
     }
@@ -589,7 +589,7 @@ public sealed class Plan : IPlan
         this.RequestSettings = function.RequestSettings;
     }
 
-    private static string RandomPlanName() => "plan" + Guid.NewGuid().ToString("N");
+    private static string GetRandomPlanName() => "plan" + Guid.NewGuid().ToString("N");
 
     private ISKFunction? Function { get; set; } = null;
 

--- a/dotnet/src/SemanticKernel/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel/Planning/Plan.cs
@@ -91,8 +91,9 @@ public sealed class Plan : IPlan
     /// <param name="goal">The goal of the plan used as description.</param>
     public Plan(string goal)
     {
+        this.Name = RandomPlanName();
         this.Description = goal;
-        this.SkillName = this.GetType().FullName;
+        this.SkillName = nameof(Plan);
     }
 
     /// <summary>
@@ -209,7 +210,7 @@ public sealed class Plan : IPlan
     /// </remarks>
     public void AddSteps(params ISKFunction[] steps)
     {
-        this._steps.AddRange(steps.Select(step => new Plan(step)));
+        this._steps.AddRange(steps.Select(step => step is Plan plan ? plan : new Plan(step)));
     }
 
     /// <summary>
@@ -301,7 +302,32 @@ public sealed class Plan : IPlan
     /// <inheritdoc/>
     public FunctionView Describe()
     {
-        return this.Function?.Describe() ?? new();
+        if (this.Function is not null)
+        {
+            return this.Function.Describe() ?? new();
+        }
+
+        // The parameter mapping definitions from Plan -> Function
+        var stepParameters = this.Steps.SelectMany(s => s.Parameters);
+
+        // The parameter descriptions from the Function
+        var stepDescriptions = this.Steps.SelectMany(s => s.Describe().Parameters);
+
+        // The parameters for the Plan
+        var parameters = this.Parameters.Select(p =>
+        {
+            var matchingParameter = stepParameters.FirstOrDefault(sp => sp.Value.Equals($"${p.Key}", StringComparison.OrdinalIgnoreCase));
+            var stepDescription = stepDescriptions.FirstOrDefault(sd => sd.Name.Equals(matchingParameter.Key, StringComparison.OrdinalIgnoreCase));
+
+            return new ParameterView(p.Key, stepDescription?.Description, stepDescription?.DefaultValue, stepDescription?.Type);
+        }
+        ).ToList();
+
+        return new(name: this.Name,
+                   skillName: this.SkillName,
+                   description: this.Description,
+                   parameters: parameters,
+                   isSemantic: false);
     }
 
     /// <inheritdoc/>
@@ -337,25 +363,19 @@ public sealed class Plan : IPlan
     /// <inheritdoc/>
     public ISKFunction SetDefaultSkillCollection(IReadOnlySkillCollection skills)
     {
-        return this.Function is null
-            ? throw new NotImplementedException()
-            : this.Function.SetDefaultSkillCollection(skills);
+        return this.Function is not null ? this.Function.SetDefaultSkillCollection(skills) : this;
     }
 
     /// <inheritdoc/>
     public ISKFunction SetAIService(Func<ITextCompletion> serviceFactory)
     {
-        return this.Function is null
-            ? throw new NotImplementedException()
-            : this.Function.SetAIService(serviceFactory);
+        return this.Function is not null ? this.Function.SetAIService(serviceFactory) : this;
     }
 
     /// <inheritdoc/>
     public ISKFunction SetAIConfiguration(CompleteRequestSettings settings)
     {
-        return this.Function is null
-            ? throw new NotImplementedException()
-            : this.Function.SetAIConfiguration(settings);
+        return this.Function is not null ? this.Function.SetAIConfiguration(settings) : this;
     }
 
     #endregion ISKFunction implementation
@@ -568,6 +588,8 @@ public sealed class Plan : IPlan
         this.IsSemantic = function.IsSemantic;
         this.RequestSettings = function.RequestSettings;
     }
+
+    private static string RandomPlanName() => "plan" + Guid.NewGuid().ToString("N");
 
     private ISKFunction? Function { get; set; } = null;
 


### PR DESCRIPTION
Update the `Plan` class to handle cases where the function is null and improve the code readability by using the `is not` pattern.

Add a new test case `CanImportAndRunPlanAsync` to verify the ability to import and run a plan involving the email skill. 

Fixes #2758 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
