### PR TITLE
.Net Gpt3tokenizer Unbounded Cache Growth Bugfix

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
@@ -214,7 +214,7 @@ public static class GPT3Tokenizer
         }
 
         long smallestRank = long.MaxValue;
-        (string First, string Second) smallestPair = ("", "");
+        (string First, string Second) smallestPair = (string.Empty, string.Empty);
         List<string>? newWord = null;
 
         while (word.Count >= 2)

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Tokenizers/GPT3Tokenizer.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -204,7 +203,7 @@ public static class GPT3Tokenizer
         if (token.Length <= 1)
         {
             var list = new List<string>(1) { token };
-            bpeCache.TryAdd(token, list);
+            bpeCache.Add(token, list);
             return list;
         }
 
@@ -215,7 +214,7 @@ public static class GPT3Tokenizer
         }
 
         long smallestRank = long.MaxValue;
-        (string, string) smallestPair = ("", "");
+        (string First, string Second) smallestPair = ("", "");
         List<string>? newWord = null;
 
         while (word.Count >= 2)
@@ -238,8 +237,8 @@ public static class GPT3Tokenizer
                 break;
             }
 
-            string first = smallestPair.Item1;
-            string second = smallestPair.Item2;
+            string first = smallestPair.First;
+            string second = smallestPair.Second;
 
             newWord ??= new List<string>(word.Count);
             for (int i = 0; i < word.Count; i++)


### PR DESCRIPTION
### Motivation and Context

Cached dictionary could grow unbounded over the lifetime of a process using GPT3Tokenizer.

Resolves #580 

### Description

Changed static Global caching to a per Encode call caching, preventing unbounded growth of memory consumption.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
