### PR TITLE
.Net: Add support for partial XML and global functions in plan parser

### DIFF
--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -89,6 +89,12 @@ internal static class SequentialPlanParser
             // '</plan>': Matches the literal string "</plan>", indicating the closing tag of the <plan> element.
             Regex planRegex = new(@"<plan\b[^>]*>(.*?)</plan>", RegexOptions.Singleline);
             Match match = planRegex.Match(xmlString);
+
+            if (!match.Success)
+            {
+                match = planRegex.Match($"{xmlString}</plan>"); // try again with a closing tag
+            }
+
             if (match.Success)
             {
                 string planXml = match.Value;
@@ -205,7 +211,7 @@ internal static class SequentialPlanParser
     private static void GetSkillFunctionNames(string skillFunctionName, out string skillName, out string functionName)
     {
         var skillFunctionNameParts = skillFunctionName.Split('.');
-        skillName = skillFunctionNameParts?.Length > 0 ? skillFunctionNameParts[0] : string.Empty;
+        skillName = skillFunctionNameParts?.Length > 1 ? skillFunctionNameParts[0] : string.Empty;
         functionName = skillFunctionNameParts?.Length > 1 ? skillFunctionNameParts[1] : skillFunctionName;
     }
 


### PR DESCRIPTION
- Added support for parsing partial XML by appending a closing tag if not present.
- Enabled plan creation with global functions by handling cases where skill name is not provided.
- Updated unit tests to cover these new scenarios.

Fixes #2502

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
