### PR TITLE
.Net: Handle exceptions when creating plan from XML 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -361,7 +361,6 @@
         "run",
         "--project",
         "${workspaceFolder}/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj",
-        "--args",
         "${input:filter}"
       ],
       "problemMatcher": "$msCompile",

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -67,7 +67,16 @@ public sealed class SequentialPlanner : ISequentialPlanner
         string planResultString = planResult.Result.Trim();
 
         var getSkillFunction = this.Config.GetSkillFunction ?? SequentialPlanParser.GetSkillFunction(this._context);
-        var plan = planResultString.ToPlanFromXml(goal, getSkillFunction, this.Config.AllowMissingFunctions);
+
+        Plan plan;
+        try
+        {
+            plan = planResultString.ToPlanFromXml(goal, getSkillFunction, this.Config.AllowMissingFunctions);
+        }
+        catch (SKException e)
+        {
+            throw new SKException($"Unable to create plan for goal with available functions.\nGoal:{goal}\nFunctions:\n{relevantFunctionsManual}", e);
+        }
 
         if (plan.Steps.Count == 0)
         {


### PR DESCRIPTION
Fixes #2831

This commit adds a try-catch block to handle SKException when
converting planResultString to a Plan object using the
ToPlanFromXml method. It provides a more informative error message
including the goal and relevant functions in case of failure.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
