### PR TITLE
.Net: Refactor PlannerConfig classes for better organization

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SKContextExtensionsTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SKContextExtensionsTests.cs
@@ -108,7 +108,7 @@ public class SKContextExtensionsTests
         Assert.Equal(functionView, result[0]);
 
         // Arrange update IncludedFunctions
-        config.IncludedFunctions.UnionWith(new List<string> { "nativeFunctionName" });
+        config.IncludedFunctions.UnionWith(new List<(string, string)> { ("pluginName", "nativeFunctionName") });
 
         // Act
         result = (await context.GetAvailableFunctionsAsync(config, semanticQuery)).ToList();
@@ -173,7 +173,7 @@ public class SKContextExtensionsTests
         Assert.Equal(functionView, result[0]);
 
         // Arrange update IncludedFunctions
-        config.IncludedFunctions.UnionWith(new List<string> { "nativeFunctionName" });
+        config.IncludedFunctions.UnionWith(new List<(string, string)> { ("pluginName", "nativeFunctionName") });
 
         // Act
         result = (await context.GetAvailableFunctionsAsync(config, semanticQuery)).ToList();

--- a/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -122,7 +122,7 @@ public class SequentialPlanParserTests
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";
 
         // Act
-        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);
@@ -169,7 +169,7 @@ public class SequentialPlanParserTests
         var planString = "<someTag>";
 
         // Act
-        Assert.Throws<SKException>(() => planString.ToPlanFromXml(GoalText, SequentialPlanParser.GetPluginFunction(kernel.Functions)));
+        Assert.Throws<SKException>(() => planString.ToPlanFromXml(GoalText, SequentialPlanParser.GetFunctionCallback(kernel.Functions)));
     }
 
     // Test that contains a #text node in the plan
@@ -189,7 +189,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);
@@ -213,7 +213,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);
@@ -238,7 +238,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);
@@ -273,7 +273,7 @@ public class SequentialPlanParserTests
         if (allowMissingFunctions)
         {
             // it should not throw
-            var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetPluginFunction(kernel.Functions), allowMissingFunctions);
+            var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunctionCallback(kernel.Functions), allowMissingFunctions);
 
             // Assert
             Assert.NotNull(plan);
@@ -289,7 +289,7 @@ public class SequentialPlanParserTests
         }
         else
         {
-            Assert.Throws<SKException>(() => planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetPluginFunction(kernel.Functions), allowMissingFunctions));
+            Assert.Throws<SKException>(() => planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunctionCallback(kernel.Functions), allowMissingFunctions));
         }
     }
 
@@ -323,7 +323,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);
@@ -347,7 +347,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planText.ToPlanFromXml(string.Empty, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);
@@ -373,7 +373,7 @@ public class SequentialPlanParserTests
         this.CreateKernelAndFunctionCreateMocks(functions, out var kernel);
 
         // Act
-        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planText.ToPlanFromXml(goalText, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SKContextSequentialPlannerExtensions.cs
@@ -96,8 +96,8 @@ public static class SKContextSequentialPlannerExtensions
 
             // Add any missing functions that were included but not found in the search results.
             var missingFunctions = config.IncludedFunctions
-                .Except(result.Select(x => x.Name))
-                .Join(availableFunctions, f => f, af => af.Name, (_, af) => af);
+                .Except(result.Select(x => (x.PluginName, x.Name)))
+                .Join(availableFunctions, f => f, af => (af.PluginName, af.Name), (_, af) => af);
 
             result.AddRange(missingFunctions);
         }

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanParser.cs
@@ -40,7 +40,7 @@ internal static class SequentialPlanParser
     /// </summary>
     internal const string AppendToResultTag = "appendToResult";
 
-    internal static Func<string, string, ISKFunction?> GetPluginFunction(IReadOnlyFunctionCollection functions)
+    internal static Func<string, string, ISKFunction?> GetFunctionCallback(IReadOnlyFunctionCollection functions)
     {
         return (pluginName, functionName) =>
         {
@@ -65,11 +65,11 @@ internal static class SequentialPlanParser
     /// </summary>
     /// <param name="xmlString">The plan xml string.</param>
     /// <param name="goal">The goal for the plan.</param>
-    /// <param name="getPluginFunction">The callback to get a plugin function.</param>
+    /// <param name="getFunctionCallback">The callback to get a plugin function.</param>
     /// <param name="allowMissingFunctions">Whether to allow missing functions in the plan on creation.</param>
     /// <returns>The plan.</returns>
     /// <exception cref="SKException">Thrown when the plan xml is invalid.</exception>
-    internal static Plan ToPlanFromXml(this string xmlString, string goal, Func<string, string, ISKFunction?> getPluginFunction, bool allowMissingFunctions = false)
+    internal static Plan ToPlanFromXml(this string xmlString, string goal, Func<string, string, ISKFunction?> getFunctionCallback, bool allowMissingFunctions = false)
     {
         XmlDocument xmlDoc = new();
         try
@@ -135,11 +135,11 @@ internal static class SequentialPlanParser
                 if (childNode.Name.StartsWith(FunctionTag, StringComparison.OrdinalIgnoreCase))
                 {
                     var pluginFunctionName = childNode.Name.Split(s_functionTagArray, StringSplitOptions.None)?[1] ?? string.Empty;
-                    GetPluginFunctionNames(pluginFunctionName, out var pluginName, out var functionName);
+                    GetFunctionCallbackNames(pluginFunctionName, out var pluginName, out var functionName);
 
                     if (!string.IsNullOrEmpty(functionName))
                     {
-                        var pluginFunction = getPluginFunction(pluginName, functionName);
+                        var pluginFunction = getFunctionCallback(pluginName, functionName);
 
                         if (pluginFunction is not null)
                         {
@@ -207,7 +207,7 @@ internal static class SequentialPlanParser
         return plan;
     }
 
-    private static void GetPluginFunctionNames(string pluginFunctionName, out string pluginName, out string functionName)
+    private static void GetFunctionCallbackNames(string pluginFunctionName, out string pluginName, out string functionName)
     {
         var pluginFunctionNameParts = pluginFunctionName.Split('.');
         pluginName = pluginFunctionNameParts?.Length > 1 ? pluginFunctionNameParts[0] : string.Empty;

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -83,12 +83,12 @@ public sealed class SequentialPlanner : ISequentialPlanner
                 $"\nGoal:{goal}\nFunctions:\n{relevantFunctionsManual}");
         }
 
-        var getPluginFunction = this.Config.GetPluginFunction ?? SequentialPlanParser.GetPluginFunction(this._kernel.Functions);
+        var getFunctionCallback = this.Config.GetFunctionCallback ?? SequentialPlanParser.GetFunctionCallback(this._kernel.Functions);
 
         Plan plan;
         try
         {
-            plan = planResultString!.ToPlanFromXml(goal, getPluginFunction, this.Config.AllowMissingFunctions);
+            plan = planResultString!.ToPlanFromXml(goal, getFunctionCallback, this.Config.AllowMissingFunctions);
         }
         catch (SKException e)
         {

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
@@ -7,7 +7,6 @@ namespace Microsoft.SemanticKernel.Planning.Sequential;
 /// </summary>
 public sealed class SequentialPlannerConfig : PlannerConfigBase
 {
-
     /// <summary>
     /// The maximum number of tokens to allow in a plan.
     /// </summary>

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlannerConfig.cs
@@ -1,12 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Memory;
-
 namespace Microsoft.SemanticKernel.Planning.Sequential;
 
 /// <summary>
@@ -14,31 +7,6 @@ namespace Microsoft.SemanticKernel.Planning.Sequential;
 /// </summary>
 public sealed class SequentialPlannerConfig : PlannerConfigBase
 {
-    /// <summary>
-    /// The minimum relevancy score for a function to be considered
-    /// </summary>
-    /// <remarks>
-    /// Depending on the embeddings engine used, the user ask, the step goal
-    /// and the functions available, this value may need to be adjusted.
-    /// For default, this is set to null to exhibit previous behavior.
-    /// </remarks>
-    public double? RelevancyThreshold { get; set; }
-
-    /// <summary>
-    /// The maximum number of relevant functions to include in the plan.
-    /// </summary>
-    /// <remarks>
-    /// Limits the number of relevant functions as result of semantic
-    /// search included in the plan creation request.
-    /// <see cref="IncludedFunctions"/> will be included
-    /// in the plan regardless of this limit.
-    /// </remarks>
-    public int MaxRelevantFunctions { get; set; } = 100;
-
-    /// <summary>
-    /// A list of functions to include in the plan creation request.
-    /// </summary>
-    public HashSet<string> IncludedFunctions { get; } = new();
 
     /// <summary>
     /// The maximum number of tokens to allow in a plan.
@@ -51,19 +19,4 @@ public sealed class SequentialPlannerConfig : PlannerConfigBase
     /// If set to false (default), the plan creation will fail if any functions are missing.
     /// </summary>
     public bool AllowMissingFunctions { get; set; } = false;
-
-    /// <summary>
-    /// Semantic memory to use for function lookup (optional).
-    /// </summary>
-    public ISemanticTextMemory Memory { get; set; } = NullMemory.Instance;
-
-    /// <summary>
-    /// Optional callback to get the available functions for planning.
-    /// </summary>
-    public Func<SequentialPlannerConfig, string?, CancellationToken, Task<IOrderedEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
-
-    /// <summary>
-    /// Optional callback to get a function by name.
-    /// </summary>
-    public Func<string, string, ISKFunction?>? GetPluginFunction { get; set; }
 }

--- a/dotnet/src/Extensions/Planning.StepwisePlanner/StepwisePlanner.cs
+++ b/dotnet/src/Extensions/Planning.StepwisePlanner/StepwisePlanner.cs
@@ -552,8 +552,8 @@ public class StepwisePlanner : IStepwisePlanner
         {
             return this._kernel.Functions.GetFunction(pluginName, functionName);
         };
-        var getPluginFunction = this.Config.GetPluginFunction ?? getFunction;
-        var function = getPluginFunction(targetFunction.PluginName, targetFunction.Name);
+        var getFunctionCallback = this.Config.GetFunctionCallback ?? getFunction;
+        var function = getFunctionCallback(targetFunction.PluginName, targetFunction.Name);
         return function;
     }
 

--- a/dotnet/src/Extensions/Planning.StepwisePlanner/StepwisePlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.StepwisePlanner/StepwisePlannerConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using Microsoft.SemanticKernel.SemanticFunctions;
 
 namespace Microsoft.SemanticKernel.Planning.Stepwise;

--- a/dotnet/src/Extensions/Planning.StepwisePlanner/StepwisePlannerConfig.cs
+++ b/dotnet/src/Extensions/Planning.StepwisePlanner/StepwisePlannerConfig.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.SemanticKernel.SemanticFunctions;
 
 namespace Microsoft.SemanticKernel.Planning.Stepwise;
@@ -14,30 +10,6 @@ namespace Microsoft.SemanticKernel.Planning.Stepwise;
 /// </summary>
 public sealed class StepwisePlannerConfig : PlannerConfigBase
 {
-    #region Use these to configure which functions to include/exclude
-    /// <summary>
-    /// A list of functions to include in the plan creation request.
-    /// </summary>
-    public HashSet<string> IncludedFunctions { get; } = new();
-
-    #endregion Use these to configure which functions to include/exclude
-
-    #region Use these to completely override the functions available for planning
-
-    /// <summary>
-    /// Optional callback to get the available functions for planning.
-    /// </summary>
-    public Func<StepwisePlannerConfig, string?, CancellationToken, Task<IOrderedEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
-
-    /// <summary>
-    /// Optional callback to get a function by name.
-    /// </summary>
-    public Func<string, string, ISKFunction?>? GetPluginFunction { get; set; }
-
-    #endregion Use these to completely override the functions available for planning
-
-    #region Execution configuration
-
     /// <summary>
     /// The maximum total number of tokens to allow in a completion request,
     /// which includes the tokens from the prompt and completion
@@ -77,6 +49,4 @@ public sealed class StepwisePlannerConfig : PlannerConfigBase
     public string Suffix { get; set; } = @"Let's break down the problem step by step and think about the best approach. Label steps as they are taken.
 
 Continue the thought process!";
-
-    #endregion Execution configuration
 }

--- a/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/SequentialPlanner/SequentialPlanParserTests.cs
@@ -52,7 +52,7 @@ public class SequentialPlanParserTests
         var goal = "Summarize an input, translate to french, and e-mail to John Doe";
 
         // Act
-        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetPluginFunction(kernel.Functions));
+        var plan = planString.ToPlanFromXml(goal, SequentialPlanParser.GetFunctionCallback(kernel.Functions));
 
         // Assert
         Assert.NotNull(plan);

--- a/dotnet/src/SemanticKernel.Core/Planning/PlannerConfigBase.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/PlannerConfigBase.cs
@@ -74,5 +74,5 @@ public abstract class PlannerConfigBase
     /// Callback to get a function by name (optional).
     /// Use if you want to override the default function lookup behavior.
     /// </summary>
-    public Func<string, string, ISKFunction?>? GetPluginFunction { get; set; }
+    public Func<string, string, ISKFunction?>? GetFunctionCallback { get; set; }
 }

--- a/dotnet/src/SemanticKernel.Core/Planning/PlannerConfigBase.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/PlannerConfigBase.cs
@@ -2,6 +2,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Planning;
 
@@ -10,6 +14,11 @@ namespace Microsoft.SemanticKernel.Planning;
 /// </summary>
 public abstract class PlannerConfigBase
 {
+    /// <summary>
+    /// Delegate to get the prompt template string.
+    /// </summary>
+    public Func<string>? GetPromptTemplate { get; set; } = null;
+
     /// <summary>
     /// A list of plugins to exclude from the plan creation request.
     /// </summary>
@@ -21,7 +30,49 @@ public abstract class PlannerConfigBase
     public HashSet<string> ExcludedFunctions { get; } = new();
 
     /// <summary>
-    /// Delegate to get the prompt template string.
+    /// When using <see cref="Memory"/> to get relevant functions,
+    /// this list of functions will be included regardless of relevancy.
     /// </summary>
-    public Func<string>? GetPromptTemplate { get; set; } = null;
+    public HashSet<string> IncludedFunctions { get; } = new();
+
+    /// <summary>
+    /// Semantic memory to use for function lookup (optional).
+    /// This property will be ignored if <see cref="GetAvailableFunctionsAsync"/> is set.
+    /// </summary>
+    public ISemanticTextMemory Memory { get; set; } = NullMemory.Instance;
+
+    /// <summary>
+    /// The maximum number of relevant functions to include in the plan.
+    /// </summary>
+    /// <remarks>
+    /// Limits the number of relevant functions as result of semantic
+    /// search included in the plan creation request.
+    /// <see cref="IncludedFunctions"/> will be included
+    /// in the plan regardless of this limit.
+    /// </remarks>
+    public int MaxRelevantFunctions { get; set; } = 100;
+
+    /// <summary>
+    /// The minimum relevancy score for a function to be considered
+    /// </summary>
+    /// <remarks>
+    /// Depending on the embeddings engine used, the user ask, the step goal
+    /// and the functions available, this value may need to be adjusted.
+    /// For default, this is set to null to exhibit previous behavior.
+    /// </remarks>
+    public double? RelevancyThreshold { get; set; }
+
+    /// <summary>
+    /// Callback to get the available functions for planning (optional).
+    /// Use if you want to override the default function lookup behavior.
+    /// If set, this function takes precedence over <see cref="Memory"/>.
+    /// Setting <see cref="ExcludedPlugins"/>, <see cref="ExcludedFunctions"/> will be used to filter the results.
+    /// </summary>
+    public Func<PlannerConfigBase, string?, CancellationToken, Task<IOrderedEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
+
+    /// <summary>
+    /// Callback to get a function by name (optional).
+    /// Use if you want to override the default function lookup behavior.
+    /// </summary>
+    public Func<string, string, ISKFunction?>? GetPluginFunction { get; set; }
 }

--- a/dotnet/src/SemanticKernel.Core/Planning/PlannerConfigBase.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/PlannerConfigBase.cs
@@ -33,7 +33,7 @@ public abstract class PlannerConfigBase
     /// When using <see cref="Memory"/> to get relevant functions,
     /// this list of functions will be included regardless of relevancy.
     /// </summary>
-    public HashSet<string> IncludedFunctions { get; } = new();
+    public HashSet<(string, string)> IncludedFunctions { get; } = new();
 
     /// <summary>
     /// Semantic memory to use for function lookup (optional).


### PR DESCRIPTION
Moved common properties and methods from SequentialPlannerConfig and StepwisePlannerConfig to the base class PlannerConfigBase. This change improves code organization and reduces redundancy. Additionally, added a new GetSkillFunction property to the PlannerConfigBase class, allowing for custom function lookup behavior. This change provides flexibility in how skill functions are retrieved and used within the planning process.

Resolves #2911 

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
