### PR TITLE
.Net: Openapi space delimited query string parameters

### DIFF
--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Query/QueryStringBuilder.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Query/QueryStringBuilder.cs
@@ -19,7 +19,8 @@ internal class QueryStringBuilder : IQueryStringBuilder
     /// </summary>
     private static Dictionary<RestApiOperationParameterStyle, Func<RestApiOperationParameter, string, string>> s_queryStringParameterSerializers = new()
     {
-        { RestApiOperationParameterStyle.Form, FormStyleParameterSerializer.Serialize }
+        { RestApiOperationParameterStyle.Form, FormStyleParameterSerializer.Serialize },
+        { RestApiOperationParameterStyle.SpaceDelimited, SpaceDelimitedStyleParameterSerializer.Serialize }
     };
 
     ///<inheritdoc/>

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/FormStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/FormStyleParameterSerializer.cs
@@ -57,7 +57,7 @@ internal static class FormStyleParameterSerializer
             throw new SKException($"Can't deserialize parameter name `{parameter.Name}` argument `{argument}` to JSON array");
         }
 
-        if (parameter.Explode)
+        if (parameter.Expand)
         {
             return SerializeArrayItemsAsSeparateParameters(parameter.Name, array);              //id=1&id=2&id=3
         }

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
@@ -9,6 +9,9 @@ using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 
 namespace Microsoft.SemanticKernel.Functions.OpenAPI.Builders.Serialization;
 
+/// <summary>
+/// Serializes REST API operation parameter of the 'SpaceDelimited' style.
+/// </summary>
 internal static class SpaceDelimitedStyleParameterSerializer
 {
     /// <summary>
@@ -57,7 +60,7 @@ internal static class SpaceDelimitedStyleParameterSerializer
             return SerializeArrayItemsAsSeparateParameters(parameter.Name, array);              //id=1&id=2&id=3
         }
 
-        return SerializeArrayItemsAsParameterWithSpaceSeparatedValues(parameter.Name, array);   //id=1 2 3
+        return SerializeArrayItemsAsParameterWithSpaceSeparatedValues(parameter.Name, array);   //id=1%202%203
     }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Web;
+
+namespace Microsoft.SemanticKernel.Functions.OpenAPI.Builders.Serialization;
+
+internal static class SpaceDelimitedStyleParameterSerializer
+{
+    /// <summary>
+    /// Serializes a REST API operation `SpaceDelimited` style parameter.
+    /// </summary>
+    /// <param name="parameter">The REST API operation parameter to serialize.</param>
+    /// <param name="argument">The parameter argument.</param>
+    /// <returns>The serialized parameter.</returns>
+    public static string Serialize(RestApiOperationParameter parameter, string argument)
+    {
+        const string ArrayType = "array";
+
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        if (parameter.Style != RestApiOperationParameterStyle.SpaceDelimited)
+        {
+            throw new SKException($"Unexpected Rest Api operation parameter style `{parameter.Style}`. Parameter name `{parameter.Name}`.");
+        }
+
+        if (parameter.Type != ArrayType)
+        {
+            throw new SKException($"Serialization of Rest API operation parameters of type `{parameter.Type}` is not supported for the `{RestApiOperationParameterStyle.SpaceDelimited}` style parameters. Parameter name `{parameter.Name}`.");
+        }
+
+        return SerializeArrayParameter(parameter, argument);
+    }
+
+    /// <summary>
+    /// Serializes an array-type parameter.
+    /// </summary>
+    /// <param name="parameter">The REST API operation parameter to serialize.</param>
+    /// <param name="argument">The argument value.</param>
+    /// <returns>The serialized parameter string.</returns>
+    private static string SerializeArrayParameter(RestApiOperationParameter parameter, string argument)
+    {
+        if (JsonNode.Parse(argument) is not JsonArray array)
+        {
+            throw new SKException($"Can't deserialize parameter name `{parameter.Name}` argument `{argument}` to JSON array.");
+        }
+
+        if (parameter.Expand)
+        {
+            return SerializeArrayItemsAsSeparateParameters(parameter.Name, array);              //id=1&id=2&id=3
+        }
+
+        return SerializeArrayItemsAsParameterWithSpaceSeparatedValues(parameter.Name, array);   //id=1 2 3
+    }
+
+    /// <summary>
+    /// Serializes the items of an array as separate parameters with the same name.
+    /// </summary>
+    /// <param name="name">The name of the parameter.</param>
+    /// <param name="array">The array containing the items to be serialized.</param>
+    /// <returns>A string containing the serialized parameters.</returns>
+    private static string SerializeArrayItemsAsSeparateParameters(string name, JsonArray array)
+    {
+        const string SegmentsSeparator = "&";
+
+        var segments = new List<string>();
+
+        foreach (var item in array)
+        {
+            segments.Add($"{name}={HttpUtility.UrlEncode(item?.ToString())}");
+        }
+
+        return string.Join(SegmentsSeparator, segments); //id=1&id=2&id=3
+    }
+
+    /// <summary>
+    /// Serializes the items of an array as a single parameter with space-separated values.
+    /// </summary>
+    /// <param name="name">The name of the parameter.</param>
+    /// <param name="array">The array containing the items to be serialized.</param>
+    /// <returns>A string containing the serialized parameter in the format "name=item1 item2 ...".</returns>
+    private static string SerializeArrayItemsAsParameterWithSpaceSeparatedValues(string name, JsonArray array)
+    {
+        const string ValuesSeparator = "%20";
+
+        var values = new List<string>();
+
+        foreach (var item in array)
+        {
+            values.Add(HttpUtility.UrlEncode(item?.ToString()));
+        }
+
+        return $"{name}={string.Join(ValuesSeparator, values)}"; //id=1%202%203
+    }
+}

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.Diagnostics;
-using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Web;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 
 namespace Microsoft.SemanticKernel.Functions.OpenAPI.Builders.Serialization;
 

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/RestApiOperationExtensions.cs
@@ -55,7 +55,7 @@ internal static class RestApiOperationExtensions
                 name: RestApiOperation.ServerUrlArgumentName,
                 type: "string",
                 isRequired: false,
-                explode: false,
+                expand: false,
                 RestApiOperationParameterLocation.Path,
                 RestApiOperationParameterStyle.Simple,
                 defaultValue: serverUrlString)
@@ -121,7 +121,7 @@ internal static class RestApiOperationExtensions
             RestApiOperation.ContentTypeArgumentName,
             "string",
             isRequired: false,
-            explode: false,
+            expand: false,
             RestApiOperationParameterLocation.Body,
             RestApiOperationParameterStyle.Simple,
             description: "Content type of REST API request body.");
@@ -138,7 +138,7 @@ internal static class RestApiOperationExtensions
             RestApiOperation.PayloadArgumentName,
             operation.Payload?.MediaType == MediaTypeTextPlain ? "string" : "object",
             isRequired: true,
-            explode: false,
+            expand: false,
             RestApiOperationParameterLocation.Body,
             RestApiOperationParameterStyle.Simple,
             description: operation.Payload?.Description ?? "REST API request body.");
@@ -167,7 +167,7 @@ internal static class RestApiOperationExtensions
                     parameterName,
                     property.Type,
                     property.IsRequired,
-                    explode: false,
+                    expand: false,
                     RestApiOperationParameterLocation.Body,
                     RestApiOperationParameterStyle.Simple,
                     description: property.Description));

--- a/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperationParameter.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperationParameter.cs
@@ -55,7 +55,7 @@ public sealed class RestApiOperationParameter
     /// <summary>
     /// Specifies whether arrays and objects should generate separate parameters for each array item or object property.
     /// </summary>
-    public bool Explode { get; }
+    public bool Expand { get; }
 
     /// <summary>
     /// Creates an instance of a <see cref="RestApiOperationParameter"/> class.
@@ -63,7 +63,7 @@ public sealed class RestApiOperationParameter
     /// <param name="name">The parameter name.</param>
     /// <param name="type">The parameter type.</param>
     /// <param name="isRequired">Flag specifying if the parameter is required or not.</param>
-    /// <param name="explode">Specifies whether arrays and objects should generate separate parameters for each array item or object property.</param>
+    /// <param name="expand">Specifies whether arrays and objects should generate separate parameters for each array item or object property.</param>
     /// <param name="location">The parameter location.</param>
     /// <param name="style">The parameter style - defines how multiple values are delimited.</param>
     /// <param name="arrayItemType">Type of array item for parameters of "array" type.</param>
@@ -73,7 +73,7 @@ public sealed class RestApiOperationParameter
         string name,
         string type,
         bool isRequired,
-        bool explode,
+        bool expand,
         RestApiOperationParameterLocation location,
         RestApiOperationParameterStyle? style = null,
         string? arrayItemType = null,
@@ -83,7 +83,7 @@ public sealed class RestApiOperationParameter
         this.Name = name;
         this.Type = type;
         this.IsRequired = isRequired;
-        this.Explode = explode;
+        this.Expand = expand;
         this.Location = location;
         this.Style = style;
         this.ArrayItemType = arrayItemType;

--- a/dotnet/src/Functions/Functions.UnitTests/Connectors/WebApi/Rest/RestApiOperationTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Connectors/WebApi/Rest/RestApiOperationTests.cs
@@ -94,7 +94,7 @@ public class RestApiOperationTests
             name: "fake-path-parameter",
             type: "fake_type",
             isRequired: true,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Path,
             defaultValue: "fake-default-path");
 
@@ -124,7 +124,7 @@ public class RestApiOperationTests
             name: "p1",
             type: "fake_type",
             isRequired: false,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             defaultValue: "dv1");
 
@@ -132,7 +132,7 @@ public class RestApiOperationTests
             name: "p2",
             type: "fake_type",
             isRequired: false,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query);
 
         var sut = new RestApiOperation(
@@ -247,8 +247,8 @@ public class RestApiOperationTests
 
         var metadata = new List<RestApiOperationParameter>
         {
-            new(name: "fake_header_one", type: "string", isRequired: true, explode: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
-            new(name: "fake_header_two", type : "string", isRequired : false, explode : false, location : RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple)
+            new(name: "fake_header_one", type: "string", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
+            new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple)
         };
 
         var sut = new RestApiOperation("fake_id", new Uri("http://fake_url"), "fake_path", HttpMethod.Get, "fake_description", metadata, rawHeaders);
@@ -272,8 +272,8 @@ public class RestApiOperationTests
 
         var metadata = new List<RestApiOperationParameter>
         {
-            new RestApiOperationParameter(name: "fake_header_one", type : "string", isRequired : true, explode : false, location : RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
-            new RestApiOperationParameter(name : "fake_header_two", type : "string", isRequired : false, explode : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple)
+            new RestApiOperationParameter(name: "fake_header_one", type : "string", isRequired : true, expand : false, location : RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
+            new RestApiOperationParameter(name : "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple)
         };
 
         var arguments = new Dictionary<string, string>
@@ -305,8 +305,8 @@ public class RestApiOperationTests
 
         var metadata = new List<RestApiOperationParameter>
         {
-            new(name : "fake_header_one", type : "string", isRequired : true, explode : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple),
-            new(name: "fake_header_two", type : "string", isRequired : false, explode : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple, defaultValue: "fake_header_two_default_value")
+            new(name : "fake_header_one", type : "string", isRequired : true, expand : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple),
+            new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple, defaultValue: "fake_header_two_default_value")
         };
 
         var arguments = new Dictionary<string, string>

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
@@ -303,20 +303,20 @@ public class QueryStringBuilderTests
         var metadata = new List<RestApiOperationParameter>
         {
             new RestApiOperationParameter(
-                "p1",
-                "array",
-                false,
-                true,
-                RestApiOperationParameterLocation.Query,
-                RestApiOperationParameterStyle.SpaceDelimited,
+                name: "p1",
+                type: "array",
+                isRequired: false,
+                expand: true,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.SpaceDelimited,
                 arrayItemType: "string"),
             new RestApiOperationParameter(
-                "p2",
-                "array",
-                false,
-                true,
-                RestApiOperationParameterLocation.Query,
-                RestApiOperationParameterStyle.SpaceDelimited,
+                name: "p2",
+                type: "array",
+                isRequired: false,
+                expand: true,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.SpaceDelimited,
                 arrayItemType: "integer")
         };
 
@@ -344,20 +344,20 @@ public class QueryStringBuilderTests
         var metadata = new List<RestApiOperationParameter>
         {
             new RestApiOperationParameter(
-                "p1",
-                "array",
-                false,
-                false,
-                RestApiOperationParameterLocation.Query,
-                RestApiOperationParameterStyle.SpaceDelimited,
+                name: "p1",
+                type: "array",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.SpaceDelimited,
                 arrayItemType: "string"),
             new RestApiOperationParameter(
-                "p2",
-                "array",
-                false,
-                false,
-                RestApiOperationParameterLocation.Query,
-                RestApiOperationParameterStyle.SpaceDelimited,
+                name: "p2",
+                type: "array",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.SpaceDelimited,
                 arrayItemType: "integer")
         };
 
@@ -386,7 +386,6 @@ public class QueryStringBuilderTests
         {
             //'Form' style array parameter with comma separated values
             new RestApiOperationParameter(name: "p1", type: "array", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form, arrayItemType: "string"),
-
 
             //'Form' style primitive boolean parameter
             new RestApiOperationParameter(name: "p2", type: "boolean", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form),

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
@@ -26,7 +26,7 @@ public class QueryStringBuilderTests
             name: "p1",
             type: "fake_type",
             isRequired: true,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             style: RestApiOperationParameterStyle.Form);
 
@@ -34,7 +34,7 @@ public class QueryStringBuilderTests
             name: "p2",
             type: "fake_type",
             isRequired: true,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             style: RestApiOperationParameterStyle.Form);
 
@@ -68,7 +68,7 @@ public class QueryStringBuilderTests
             name: "p1",
             type: "fake_type",
             isRequired: false,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             style: RestApiOperationParameterStyle.Form);
 
@@ -76,7 +76,7 @@ public class QueryStringBuilderTests
             name: "p2",
             type: "fake_type",
             isRequired: false,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             style: RestApiOperationParameterStyle.Form);
 
@@ -109,7 +109,7 @@ public class QueryStringBuilderTests
             name: "p1",
             type: "fake_type",
             isRequired: true,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             style: RestApiOperationParameterStyle.Form);
 
@@ -117,7 +117,7 @@ public class QueryStringBuilderTests
             name: "p2",
             type: "fake_type",
             isRequired: false,
-            explode: false,
+            expand: false,
             location: RestApiOperationParameterLocation.Query,
             style: RestApiOperationParameterStyle.Form);
 
@@ -153,7 +153,7 @@ public class QueryStringBuilderTests
                 name: "p1",
                 type: "string",
                 isRequired: false,
-                explode: false,
+                expand: false,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form)
         };
@@ -184,7 +184,7 @@ public class QueryStringBuilderTests
                 name: "p1",
                 type: "array",
                 isRequired: false,
-                explode: true,
+                expand: true,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "string"),
@@ -192,7 +192,7 @@ public class QueryStringBuilderTests
                 name: "p2",
                 type: "array",
                 isRequired: false,
-                explode: true,
+                expand: true,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "integer")
@@ -225,7 +225,7 @@ public class QueryStringBuilderTests
                 name: "p1",
                 type: "array",
                 isRequired: false,
-                explode: false,
+                expand: false,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "string"),
@@ -233,7 +233,7 @@ public class QueryStringBuilderTests
                 name: "p2",
                 type: "array",
                 isRequired: false,
-                explode: false,
+                expand: false,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "integer")
@@ -266,7 +266,7 @@ public class QueryStringBuilderTests
                 name: "p1",
                 type: "string",
                 isRequired: false,
-                explode: false,
+                expand: false,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "string"),
@@ -274,7 +274,7 @@ public class QueryStringBuilderTests
                 name: "p2",
                 type: "boolean",
                 isRequired: false,
-                explode: false,
+                expand: false,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form)
         };
@@ -303,13 +303,13 @@ public class QueryStringBuilderTests
         var metadata = new List<RestApiOperationParameter>
         {
             //'Form' style array parameter with comma separated values
-            new RestApiOperationParameter(name: "p1", type: "array", isRequired: true, explode: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form, arrayItemType: "string"),
+            new RestApiOperationParameter(name: "p1", type: "array", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form, arrayItemType: "string"),
 
             //Primitive boolean parameter
-            new RestApiOperationParameter(name : "p2", type : "boolean", isRequired : true, explode : false, location : RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form),
+            new RestApiOperationParameter(name : "p2", type : "boolean", isRequired : true, expand : false, location : RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form),
 
             //'Form' style array parameter with parameter per array item
-            new RestApiOperationParameter(name: "p3", type: "array", isRequired: true, explode: true, location: RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.Form, arrayItemType: "number")
+            new RestApiOperationParameter(name: "p3", type: "array", isRequired: true, expand: true, location: RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.Form, arrayItemType: "number")
         };
 
         var arguments = new Dictionary<string, string>

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
@@ -175,7 +175,7 @@ public class QueryStringBuilderTests
     }
 
     [Fact]
-    public void ItShouldCreateAmpersandSeparatedParameterPerArrayItem()
+    public void ItShouldCreateAmpersandSeparatedParameterPerArrayItemForFormStyleParameters()
     {
         // Arrange
         var metadata = new List<RestApiOperationParameter>
@@ -216,7 +216,7 @@ public class QueryStringBuilderTests
     }
 
     [Fact]
-    public void ItShouldCreateParameterWithCommaSeparatedValuePerArrayItem()
+    public void ItShouldCreateParameterWithCommaSeparatedValuePerArrayItemForFormStyleParameters()
     {
         // Arrange
         var metadata = new List<RestApiOperationParameter>
@@ -257,7 +257,7 @@ public class QueryStringBuilderTests
     }
 
     [Fact]
-    public void ItShouldCreateParameterForPrimitiveValues()
+    public void ItShouldCreateParameterForPrimitiveValuesForFormStyleParameters()
     {
         // Arrange
         var metadata = new List<RestApiOperationParameter>
@@ -297,26 +297,33 @@ public class QueryStringBuilderTests
     }
 
     [Fact]
-    public void ItShouldMixAndMatchParametersOfDifferentTypesAndStyles()
+    public void ItShouldCreateAmpersandSeparatedParameterPerArrayItemForSpaceDelimitedStyleParameters()
     {
         // Arrange
         var metadata = new List<RestApiOperationParameter>
         {
-            //'Form' style array parameter with comma separated values
-            new RestApiOperationParameter(name: "p1", type: "array", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form, arrayItemType: "string"),
-
-            //Primitive boolean parameter
-            new RestApiOperationParameter(name : "p2", type : "boolean", isRequired : true, expand : false, location : RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form),
-
-            //'Form' style array parameter with parameter per array item
-            new RestApiOperationParameter(name: "p3", type: "array", isRequired: true, expand: true, location: RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.Form, arrayItemType: "number")
+            new RestApiOperationParameter(
+                "p1",
+                "array",
+                false,
+                true,
+                RestApiOperationParameterLocation.Query,
+                RestApiOperationParameterStyle.SpaceDelimited,
+                arrayItemType: "string"),
+            new RestApiOperationParameter(
+                "p2",
+                "array",
+                false,
+                true,
+                RestApiOperationParameterLocation.Query,
+                RestApiOperationParameterStyle.SpaceDelimited,
+                arrayItemType: "integer")
         };
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\"]" },
-            { "p2", "false" },
-            { "p3", "[1,2]" }
+            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p2", "[1,2,3]" }
         };
 
         var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
@@ -327,6 +334,90 @@ public class QueryStringBuilderTests
         // Assert
         Assert.NotNull(result);
 
-        Assert.Equal("p1=a,b&p2=false&p3=1&p3=2", result);
+        Assert.Equal("p1=a&p1=b&p1=c&p2=1&p2=2&p2=3", result);
+    }
+
+    [Fact]
+    public void ItShouldCreateParameterWithSpaceSeparatedValuePerArrayItemForSpaceDelimitedStyleParameters()
+    {
+        // Arrange
+        var metadata = new List<RestApiOperationParameter>
+        {
+            new RestApiOperationParameter(
+                "p1",
+                "array",
+                false,
+                false,
+                RestApiOperationParameterLocation.Query,
+                RestApiOperationParameterStyle.SpaceDelimited,
+                arrayItemType: "string"),
+            new RestApiOperationParameter(
+                "p2",
+                "array",
+                false,
+                false,
+                RestApiOperationParameterLocation.Query,
+                RestApiOperationParameterStyle.SpaceDelimited,
+                arrayItemType: "integer")
+        };
+
+        var arguments = new Dictionary<string, string>
+        {
+            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p2", "[1,2,3]" }
+        };
+
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+
+        // Act
+        var result = this._sut.Build(operation, arguments);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal("p1=a%20b%20c&p2=1%202%203", result);
+    }
+
+    [Fact]
+    public void ItShouldMixAndMatchParametersOfDifferentTypesAndStyles()
+    {
+        // Arrange
+        var metadata = new List<RestApiOperationParameter>
+        {
+            //'Form' style array parameter with comma separated values
+            new RestApiOperationParameter(name: "p1", type: "array", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form, arrayItemType: "string"),
+
+
+            //'Form' style primitive boolean parameter
+            new RestApiOperationParameter(name: "p2", type: "boolean", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Form),
+
+            //'Form' style array parameter with parameter per array item
+            new RestApiOperationParameter(name : "p3", type : "array", isRequired : true, expand : true, location : RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.Form),
+
+            //'SpaceDelimited' style array parameter with space separated values
+            new RestApiOperationParameter(name : "p4", type : "array", isRequired : true, expand : false, location : RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.SpaceDelimited),
+
+            //'SpaceDelimited' style array parameter with parameter per array item
+            new RestApiOperationParameter(name : "p5", type : "array", isRequired : true, expand : true, location : RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.SpaceDelimited),
+        };
+
+        var arguments = new Dictionary<string, string>
+        {
+            { "p1", "[\"a\",\"b\"]" },
+            { "p2", "false" },
+            { "p3", "[1,2]" },
+            { "p4", "[3,4]" },
+            { "p5", "[\"c\",\"d\"]" }
+        };
+
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+
+        // Act
+        var result = this._sut.Build(operation, arguments);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal("p1=a,b&p2=false&p3=1&p3=2&p4=3%204&p5=c&p5=d", result);
     }
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/Serialization/FormStyleParametersSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/Serialization/FormStyleParametersSerializerTests.cs
@@ -17,7 +17,7 @@ public class FormStyleParametersSerializerTests
                 name: "id",
                 type: "array",
                 isRequired: true,
-                explode: true, //Specify generating a separate parameter for each array item.
+                expand: true, //Specify generating a separate parameter for each array item.
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "integer");
@@ -39,7 +39,7 @@ public class FormStyleParametersSerializerTests
                 name: "id",
                 type: "array",
                 isRequired: true,
-                explode: false, //Specify generating a parameter with comma-separated values for each array item.
+                expand: false, //Specify generating a parameter with comma-separated values for each array item.
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form,
                 arrayItemType: "integer");
@@ -61,7 +61,7 @@ public class FormStyleParametersSerializerTests
                 name: "id",
                 type: "integer",
                 isRequired: true,
-                explode: false,
+                expand: false,
                 location: RestApiOperationParameterLocation.Query,
                 style: RestApiOperationParameterStyle.Form);
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/Serialization/SpaceDelimitedStyleParametersSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/Serialization/SpaceDelimitedStyleParametersSerializerTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Functions.OpenAPI.Builders.Serialization;
+using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
+using Xunit;
+
+namespace SemanticKernel.Functions.UnitTests.OpenAPI.Builders.Serialization;
+public class SpaceDelimitedStyleParametersSerializerTests
+{
+    [Fact]
+    public void ItShouldThrowExceptionForUnsupportedParameterStyle()
+    {
+        //Arrange
+        var parameter = new RestApiOperationParameter(name: "p1", type: "string", isRequired: false, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.Label);
+
+        //Act & Assert
+        Assert.Throws<SKException>(() => SpaceDelimitedStyleParameterSerializer.Serialize(parameter, "fake-argument"));
+    }
+
+    [Theory]
+    [InlineData("integer")]
+    [InlineData("number")]
+    [InlineData("string")]
+    [InlineData("boolean")]
+    [InlineData("object")]
+    public void ItShouldThrowExceptionIfParameterTypeIsNotArray(string parameterType)
+    {
+        //Arrange
+        var parameter = new RestApiOperationParameter(name: "p1", type: parameterType, isRequired: false, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.SpaceDelimited);
+
+        //Act & Assert
+        Assert.Throws<SKException>(() => SpaceDelimitedStyleParameterSerializer.Serialize(parameter, "fake-argument"));
+    }
+
+    [Fact]
+    public void ItShouldCreateAmpersandSeparatedParameterPerArrayItem()
+    {
+        // Arrange
+        var parameter = new RestApiOperationParameter(
+                name: "id",
+                type: "array",
+                isRequired: true,
+                expand: true, //Specifies to generate a separate parameter for each array item.
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.SpaceDelimited,
+                arrayItemType: "integer");
+
+        // Act
+        var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, "[1,2,3]");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal("id=1&id=2&id=3", result);
+    }
+
+    [Fact]
+    public void ItShouldCreateParameterWithSpaceSeparatedValuePerArrayItem()
+    {
+        // Arrange
+        var parameter = new RestApiOperationParameter(
+                name: "id",
+                type: "array",
+                isRequired: true,
+                expand: false, //Specify generating a parameter with space-separated values for each array item.
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.SpaceDelimited,
+                arrayItemType: "integer");
+
+        // Act
+        var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, "[1,2,3]");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal("id=1%202%203", result);
+    }
+
+    [Theory]
+    [InlineData(":", "%3a")]
+    [InlineData("/", "%2f")]
+    [InlineData("?", "%3f")]
+    [InlineData("#", "%23")]
+    public void ItShouldEncodeSpecialSymbolsInSpaceDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
+    {
+        // Arrange
+        var parameter = new RestApiOperationParameter(name: "id", type: "array", isRequired: false, expand: false, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.SpaceDelimited);
+
+        // Act
+        var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, $"[\"{specialSymbol}\"]");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.EndsWith(encodedEquivalent, result, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(":", "%3a")]
+    [InlineData("/", "%2f")]
+    [InlineData("?", "%3f")]
+    [InlineData("#", "%23")]
+    public void ItShouldEncodeSpecialSymbolsInAmpersandDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
+    {
+        // Arrange
+        var parameter = new RestApiOperationParameter(name: "id", type: "array", isRequired: false, expand: true, location: RestApiOperationParameterLocation.Query, style: RestApiOperationParameterStyle.SpaceDelimited);
+
+        // Act
+        var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, $"[\"{specialSymbol}\"]");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.EndsWith(encodedEquivalent, result, StringComparison.Ordinal);
+    }
+}

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
@@ -308,7 +308,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
 
         var explodeFormParam = operation.Parameters.Single(p => p.Name == parameterName);
 
-        Assert.True(explodeFormParam.Explode);
+        Assert.True(explodeFormParam.Expand);
     }
 
     [Fact]
@@ -324,7 +324,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
 
         var explodeFormParam = operation.Parameters.Single(p => p.Name == "nonExplodeFormParam");
 
-        Assert.False(explodeFormParam.Explode);
+        Assert.False(explodeFormParam.Expand);
     }
 
     private static MemoryStream ModifyOpenApiDocument(Stream openApiDocument, Action<JsonObject> transformer)

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
@@ -283,7 +283,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
 
         var explodeFormParam = operation.Parameters.Single(p => p.Name == parameterName);
 
-        Assert.True(explodeFormParam.Explode);
+        Assert.True(explodeFormParam.Expand);
     }
 
     [Fact]
@@ -299,7 +299,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
 
         var explodeFormParam = operation.Parameters.Single(p => p.Name == "nonExplodeFormParam");
 
-        Assert.False(explodeFormParam.Explode);
+        Assert.False(explodeFormParam.Expand);
     }
 
     private static MemoryStream ModifyOpenApiDocument(Stream openApiDocument, Action<IDictionary<string, object>> transformer)


### PR DESCRIPTION
### Motivation and Context

This change is required to support two ways of serializing array query string parameters of 'spaceDelimited' style:

A query string parameter per array item - p1=a&p1=b&p1=c.
A space-separated value per array item - p1=a%20b%20c.

![image](https://github.com/microsoft/semantic-kernel/assets/68852919/7cdab782-a9db-41d6-98aa-1b102529e10f)


Related issue - https://github.com/microsoft/semantic-kernel/issues/2745

### Description
- The `SpaceDelimitedStyleParametersSerializer` class has been added to perform `spaceDelimited` style parameter serialization. For more details about parameter styles, please refer to the [link](https://swagger.io/specification/v3/#parameter-object).
- The `QueryStringBuilder` class has been modified to use the `SpaceDelimitedStyleParametersSerializer` for the `spaceDelimited` style parameter serialization.
- The `RestApiOperationParameter.Explode` property was renamed to `Expand` based on feedback on previos PR.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
