### PR TITLE
.Net: [OpenAPI] Removing duplication in parameters serialization functionality

### DIFF
--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/ArrayParameterValueSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/ArrayParameterValueSerializer.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Web;
+
+namespace Microsoft.SemanticKernel.Functions.OpenAPI.Builders.Serialization;
+
+/// <summary>
+/// This class provides methods for serializing values of array parameters.
+/// </summary>
+internal static class ArrayParameterValueSerializer
+{
+    /// <summary>
+    /// Serializes the items of an array as separate parameters with the same name.
+    /// </summary>
+    /// <param name="name">The name of the parameter.</param>
+    /// <param name="array">The array containing the items to be serialized.</param>
+    /// <param name="delimiter">The delimiter used to separate parameters.</param>
+    /// <returns>A string containing the serialized parameters.</returns>
+    public static string SerializeArrayAsSeparateParameters(string name, JsonArray array, string delimiter)
+    {
+        var segments = new List<string>();
+
+        foreach (var item in array)
+        {
+            segments.Add($"{name}={HttpUtility.UrlEncode(item?.ToString())}");
+        }
+
+        return string.Join(delimiter, segments); //id=1&id=2&id=3
+    }
+
+    /// <summary>
+    /// Serializes the items of an array as one parameter with delimited values.
+    /// </summary>
+    /// <param name="array">The array containing the items to be serialized.</param>
+    /// <param name="delimiter">The delimiter used to separate items.</param>
+    /// <returns>A string containing the serialized parameter.</returns>
+    public static string SerializeArrayAsDelimitedValues(JsonArray array, string delimiter)
+    {
+        var values = new List<string>();
+
+        foreach (var item in array)
+        {
+            values.Add(HttpUtility.UrlEncode(item?.ToString()));
+        }
+
+        return string.Join(delimiter, values);
+    }
+}

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/FormStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/FormStyleParameterSerializer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Web;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -59,49 +58,9 @@ internal static class FormStyleParameterSerializer
 
         if (parameter.Expand)
         {
-            return SerializeArrayItemsAsSeparateParameters(parameter.Name, array);              //id=1&id=2&id=3
+            return ArrayParameterValueSerializer.SerializeArrayAsSeparateParameters(parameter.Name, array, delimiter: "&"); //id=1&id=2&id=3
         }
 
-        return SerializeArrayItemsAsParameterWithCommaSeparatedValues(parameter.Name, array);   //id=1,2,3
-    }
-
-    /// <summary>
-    /// Serializes the items of an array as separate parameters with the same name.
-    /// </summary>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="array">The array containing the items to be serialized.</param>
-    /// <returns>A string containing the serialized parameters.</returns>
-    private static string SerializeArrayItemsAsSeparateParameters(string name, JsonArray array)
-    {
-        const string SegmentsSeparator = "&";
-
-        var segments = new List<string>();
-
-        foreach (var item in array)
-        {
-            segments.Add($"{name}={HttpUtility.UrlEncode(item?.ToString())}");
-        }
-
-        return string.Join(SegmentsSeparator, segments); //id=1&id=2&id=3
-    }
-
-    /// <summary>
-    /// Serializes the items of an array as a single parameter with comma-separated values.
-    /// </summary>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="array">The array containing the items to be serialized.</param>
-    /// <returns>A string containing the serialized parameter in the format "name=item1,item2,...".</returns>
-    private static string SerializeArrayItemsAsParameterWithCommaSeparatedValues(string name, JsonArray array)
-    {
-        const string ValuesSeparator = ",";
-
-        var values = new List<string>();
-
-        foreach (var item in array)
-        {
-            values.Add(HttpUtility.UrlEncode(item?.ToString()));
-        }
-
-        return $"{name}={string.Join(ValuesSeparator, values)}"; //id=1,2,3
+        return $"{parameter.Name}={ArrayParameterValueSerializer.SerializeArrayAsDelimitedValues(array, delimiter: ",")}"; //id=1,2,3
     }
 }

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/Serialization/SpaceDelimitedStyleParameterSerializer.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Nodes;
-using System.Web;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 
@@ -57,49 +55,9 @@ internal static class SpaceDelimitedStyleParameterSerializer
 
         if (parameter.Expand)
         {
-            return SerializeArrayItemsAsSeparateParameters(parameter.Name, array);              //id=1&id=2&id=3
+            return ArrayParameterValueSerializer.SerializeArrayAsSeparateParameters(parameter.Name, array, delimiter: "&"); //id=1&id=2&id=3
         }
 
-        return SerializeArrayItemsAsParameterWithSpaceSeparatedValues(parameter.Name, array);   //id=1%202%203
-    }
-
-    /// <summary>
-    /// Serializes the items of an array as separate parameters with the same name.
-    /// </summary>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="array">The array containing the items to be serialized.</param>
-    /// <returns>A string containing the serialized parameters.</returns>
-    private static string SerializeArrayItemsAsSeparateParameters(string name, JsonArray array)
-    {
-        const string SegmentsSeparator = "&";
-
-        var segments = new List<string>();
-
-        foreach (var item in array)
-        {
-            segments.Add($"{name}={HttpUtility.UrlEncode(item?.ToString())}");
-        }
-
-        return string.Join(SegmentsSeparator, segments); //id=1&id=2&id=3
-    }
-
-    /// <summary>
-    /// Serializes the items of an array as a single parameter with space-separated values.
-    /// </summary>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="array">The array containing the items to be serialized.</param>
-    /// <returns>A string containing the serialized parameter in the format "name=item1 item2 ...".</returns>
-    private static string SerializeArrayItemsAsParameterWithSpaceSeparatedValues(string name, JsonArray array)
-    {
-        const string ValuesSeparator = "%20";
-
-        var values = new List<string>();
-
-        foreach (var item in array)
-        {
-            values.Add(HttpUtility.UrlEncode(item?.ToString()));
-        }
-
-        return $"{name}={string.Join(ValuesSeparator, values)}"; //id=1%202%203
+        return $"{parameter.Name}={ArrayParameterValueSerializer.SerializeArrayAsDelimitedValues(array, delimiter: "%20")}"; //id=1%202%203
     }
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/Serialization/ArrayParameterSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/Serialization/ArrayParameterSerializerTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Functions.OpenAPI.Builders.Serialization;
+using Xunit;
+
+namespace SemanticKernel.Functions.UnitTests.OpenAPI.Builders.Serialization;
+public class ArrayParameterSerializerTests
+{
+    [Fact]
+    public void ItShouldCreateParameterPerArrayItem()
+    {
+        // Arrange
+        var array = new JsonArray(1, 2, 3);
+
+        // Act
+        var result = ArrayParameterValueSerializer.SerializeArrayAsSeparateParameters("id", array, delimiter: "&");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal("id=1&id=2&id=3", result);
+    }
+
+    [Theory]
+    [InlineData(":", "%3a")]
+    [InlineData("/", "%2f")]
+    [InlineData("?", "%3f")]
+    [InlineData("#", "%23")]
+    public void ItShouldEncodeSpecialSymbolsInSeparateParameterValues(string specialSymbol, string encodedEquivalent)
+    {
+        // Arrange
+        var array = new JsonArray($"{specialSymbol}");
+
+        // Act
+        var result = ArrayParameterValueSerializer.SerializeArrayAsSeparateParameters("id", array, delimiter: "&");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.EndsWith(encodedEquivalent, result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ItShouldCreateParameterWithDelimitedValuePerArrayItem()
+    {
+        // Arrange
+        var array = new JsonArray(1, 2, 3);
+
+        // Act
+        var result = ArrayParameterValueSerializer.SerializeArrayAsDelimitedValues(array, delimiter: "%20");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal("1%202%203", result);
+    }
+
+    [Theory]
+    [InlineData(":", "%3a")]
+    [InlineData("/", "%2f")]
+    [InlineData("?", "%3f")]
+    [InlineData("#", "%23")]
+    public void ItShouldEncodeSpecialSymbolsInDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
+    {
+        // Arrange
+        var array = new JsonArray($"{specialSymbol}");
+
+        // Act
+        var result = ArrayParameterValueSerializer.SerializeArrayAsDelimitedValues(array, delimiter: "%20");
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.EndsWith(encodedEquivalent, result, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
### Motivation, Context

The `FormStyleParameterSerializer` and `SpaceDelimitedStyleParameterSerializer` classes currently share similar serialization logic for array-type parameters. The upcoming PR introduces the `PipeDelimitedStyleParameterSerializer` class, which adds a similar but slightly different serialization functionality. To prevent code duplication, the common serialization logic is moved to the `ArrayParameterValueSerializer` class.

Related issue - https://github.com/microsoft/semantic-kernel/issues/2745

### Description

- The `ArrayParameterValueSerializer` class has been added to contain common serialization functionality for parameters of an array type.
- The `FormStyleParameterSerializer` and `SpaceDelimitedStyleParameterSerializer` classes have been modified to delegate array parameter serialization to the `ArrayParameterValueSerializer` class. 
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
