### PR TITLE
.Net: Rename 'Skills' -> 'Plugins' - Part 8 Update plugin names, descriptions, and parameters

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/Connectors.Memory.Chroma.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/Connectors.Memory.Chroma.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - Chroma Connector</Title>
-    <Description>Chroma connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>Chroma connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.DuckDB/Connectors.Memory.DuckDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.DuckDB/Connectors.Memory.DuckDB.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - DuckDB Connector</Title>
-    <Description>DuckDB connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>DuckDB connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Milvus/Connectors.Memory.Milvus.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Milvus/Connectors.Memory.Milvus.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - Milvus Connector</Title>
-    <Description>Milvus connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>Milvus connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Connectors.Memory.Pinecone.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Connectors.Memory.Pinecone.csproj
@@ -14,7 +14,7 @@
     <PropertyGroup>
         <!-- NuGet Package Settings -->
         <Title>Semantic Kernel - Pinecone Connector</Title>
-        <Description>Pinecone connector for Semantic Kernel skills and semantic memory</Description>
+        <Description>Pinecone connector for Semantic Kernel plugins and semantic memory</Description>
     </PropertyGroup>
 
     <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - Postgres Connector</Title>
-    <Description>Postgres(with pgvector extension) connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>Postgres(with pgvector extension) connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - Qdrant Connector</Title>
-    <Description>Qdrant connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>Qdrant connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/Connectors.Memory.Redis.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/Connectors.Memory.Redis.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - Redis Connector</Title>
-    <Description>Redis connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>Redis connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Connectors.Memory.Sqlite.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - SQLite Connector</Title>
-    <Description>SQLite connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>SQLite connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Connectors.Memory.Weaviate.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Connectors.Memory.Weaviate.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - Weaviate Connector</Title>
-    <Description>Weaviate connector for Semantic Kernel skills and semantic memory</Description>
+    <Description>Weaviate connector for Semantic Kernel plugins and semantic memory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
+++ b/dotnet/src/Extensions/Planning.ActionPlanner/ActionPlanner.cs
@@ -61,7 +61,7 @@ public sealed class ActionPlanner : IActionPlanner
         Verify.NotNull(kernel);
         this._kernel = kernel;
 
-        // Set up Config with default values and excluded skills
+        // Set up Config with default values and excluded plugins
         this.Config = config ?? new();
         this.Config.ExcludedPlugins.Add(PluginName);
 

--- a/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
+++ b/dotnet/src/Extensions/Planning.SequentialPlanner/SequentialPlanner.cs
@@ -32,7 +32,7 @@ public sealed class SequentialPlanner : ISequentialPlanner
     {
         Verify.NotNull(kernel);
 
-        // Set up config with default value and excluded skills
+        // Set up config with default value and excluded plugins
         this.Config = config ?? new();
         this.Config.ExcludedPlugins.Add(RestrictedPluginName);
 

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelAIPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelAIPluginExtensions.cs
@@ -305,7 +305,7 @@ public static class KernelAIPluginExtensions
     /// <param name="pluginName">Plugin name.</param>
     /// <param name="runner">The REST API operation runner.</param>
     /// <param name="operation">The REST API operation.</param>
-    /// <param name="executionParameters">Skill execution parameters.</param>
+    /// <param name="executionParameters">Function execution parameters.</param>
     /// <param name="documentUri">The URI of OpenApi document.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An instance of <see cref="SKFunction"/> class.</returns>

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/TestPlugins/documentV2_0.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/TestPlugins/documentV2_0.json
@@ -198,7 +198,7 @@
         "summary": "Create or update secret value"
       }
     },
-    "/FunSkill/Excuses": {
+    "/FunPlugin/Excuses": {
       "post": {
         "summary": "Turn a scenario into a creative or humorous excuse to send your boss",
         "operationId": "Excuses",

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/TestPlugins/documentV3_0.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/TestPlugins/documentV3_0.json
@@ -173,7 +173,7 @@
         }
       }
     },
-    "/FunSkill/Excuses": {
+    "/FunPlugin/Excuses": {
       "post": {
         "summary": "Turn a scenario into a creative or humorous excuse to send your boss",
         "operationId": "Excuses",

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/TestPlugins/documentV3_1.yaml
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/TestPlugins/documentV3_1.yaml
@@ -115,7 +115,7 @@ paths:
       responses:
         '200':
           description: default
-  /FunSkill/Excuses:
+  /FunPlugin/Excuses:
     post:
       summary: Turn a scenario into a creative or humorous excuse to send your boss
       operationId: Excuses


### PR DESCRIPTION
### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

## Summary
This pull request updates plugin names, descriptions, and parameters in the Semantic Kernel project. Specifically, it updates the descriptions for several connectors and planners to refer to Semantic Kernel plugins instead of skills, and renames the 'FunSkill' plugin to 'FunPlugin'. Additionally, it updates the 'executionParameters' parameter to 'functionExecutionParameters'.

## Changes
- Updated descriptions for Chroma, DuckDB, Milvus, Pinecone, Postgres, Qdrant, Redis, SQLite, and Weaviate connectors to refer to Semantic Kernel plugins instead of skills
- Updated SequentialPlanner and ActionPlanner to exclude plugins instead of skills
- Renamed 'FunSkill' plugin to 'FunPlugin' in OpenAPI documents
- Renamed 'executionParameters' parameter to 'functionExecutionParameters' in OpenAPI documents

---
*Powered by [Microsoft Semantic Kernel](https://github.com/microsoft/semantic-kernel)*