### PR TITLE
.Net: Rename ImportXXXPlugins methods to ImportXXXFunctions for GRPC

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example21_ChatGPTPlugins.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example21_ChatGPTPlugins.cs
@@ -22,7 +22,7 @@ public static class Example21_ChatGptPlugins
         using HttpClient httpClient = new();
 
         //Import a ChatGPT plugin via URI
-        var plugin = await kernel.ImportAIPluginAsync("<plugin name>", new Uri("<chatGPT-plugin>"), new OpenApiPluginExecutionParameters(httpClient) { EnableDynamicPayload = true });
+        var plugin = await kernel.ImportAIPluginAsync("<plugin name>", new Uri("<chatGPT-plugin>"), new OpenApiFunctionExecutionParameters(httpClient) { EnableDynamicPayload = true });
 
         //Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();
@@ -38,7 +38,7 @@ public static class Example21_ChatGptPlugins
 
         //var kernel = new KernelBuilder().WithLogger(ConsoleLogger.LoggerFactory).Build();
 
-        //var plugin = await kernel.ImportAIPluginAsync("Klarna", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"), new OpenApiPluginExecutionParameters(httpClient));
+        //var plugin = await kernel.ImportAIPluginAsync("Klarna", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"), new OpenApiFunctionExecutionParameters(httpClient));
 
         //var contextVariables = new ContextVariables();
         //contextVariables.Set("q", "Laptop");      // A precise query that matches one very small category or product that needs to be searched for to find the products the user is looking for. If the user explicitly stated what they want, use that as a query. The query is as specific as possible to the product name or category mentioned by the user in its singular form, and don't contain any clarifiers like latest, newest, cheapest, budget, premium, expensive or similar. The query is always taken from the latest topic, if there is a new topic a new query is started.

--- a/dotnet/samples/KernelSyntaxExamples/Example22_OpenApiPlugin_AzureKeyVault.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example22_OpenApiPlugin_AzureKeyVault.cs
@@ -49,7 +49,7 @@ public static class Example22_OpenApiPlugin_AzureKeyVault
         var plugin = await kernel.ImportAIPluginAsync(
             PluginResourceNames.AzureKeyVault,
             stream!,
-            new OpenApiPluginExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
+            new OpenApiFunctionExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
 
         // Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();
@@ -76,7 +76,7 @@ public static class Example22_OpenApiPlugin_AzureKeyVault
         var plugin = await kernel.ImportAIPluginAsync(
             PluginResourceNames.AzureKeyVault,
             stream!,
-            new OpenApiPluginExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
+            new OpenApiFunctionExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
 
         // Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();

--- a/dotnet/samples/KernelSyntaxExamples/Example23_OpenApiPlugin_Github.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example23_OpenApiPlugin_Github.cs
@@ -36,7 +36,7 @@ public static class Example23_OpenApiPlugin_GitHub
         var plugin = await kernel.ImportAIPluginAsync(
             "GitHubPlugin",
             "../../../samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/openapi.json",
-            new OpenApiPluginExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
+            new OpenApiFunctionExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
 
         // Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();
@@ -68,7 +68,7 @@ public static class Example23_OpenApiPlugin_GitHub
         var plugin = await kernel.ImportAIPluginAsync(
             "GitHubPlugin",
             "../../../samples/apps/copilot-chat-app/webapi/Skills/OpenApiSkills/GitHubSkill/openapi.json",
-            new OpenApiPluginExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
+            new OpenApiFunctionExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
 
         // Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();

--- a/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
@@ -43,12 +43,12 @@ public static class Example24_OpenApiPlugin_Jira
         if (useLocalFile)
         {
             var apiSkillFile = "./../../../Skills/JiraSkill/openapi.json";
-            jiraSkills = await kernel.ImportAIPluginAsync("jiraSkills", apiSkillFile, new OpenApiPluginExecutionParameters(authCallback: tokenProvider.AuthenticateRequestAsync));
+            jiraSkills = await kernel.ImportAIPluginAsync("jiraSkills", apiSkillFile, new OpenApiFunctionExecutionParameters(authCallback: tokenProvider.AuthenticateRequestAsync));
         }
         else
         {
             var apiSkillRawFileURL = new Uri("https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/dev/certified-connectors/JIRA/apiDefinition.swagger.json");
-            jiraSkills = await kernel.ImportAIPluginAsync("jiraSkills", apiSkillRawFileURL, new OpenApiPluginExecutionParameters(httpClient, tokenProvider.AuthenticateRequestAsync));
+            jiraSkills = await kernel.ImportAIPluginAsync("jiraSkills", apiSkillRawFileURL, new OpenApiFunctionExecutionParameters(httpClient, tokenProvider.AuthenticateRequestAsync));
         }
 
         // GetIssue Skill

--- a/dotnet/samples/KernelSyntaxExamples/Example35_GrpcPlugins.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example35_GrpcPlugins.cs
@@ -19,9 +19,9 @@ public static class Example35_GrpcPlugins
         var kernel = new KernelBuilder().WithLoggerFactory(ConsoleLogger.LoggerFactory).Build();
 
         // Import a gRPC plugin using one of the following Kernel extension methods
-        // kernel.RegisterGrpcPlugin
-        // kernel.ImportGrpcPluginFromDirectory
-        var plugin = kernel.ImportGrpcPluginFromFile("<plugin-name>", "<path-to-.proto-file>");
+        // kernel.RegisterGrpcFunctions
+        // kernel.ImportGrpcFunctionsFromDirectory
+        var plugin = kernel.ImportGrpcFunctionsFromFile("<plugin-name>", "<path-to-.proto-file>");
 
         // Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();

--- a/dotnet/src/Functions/Functions.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/Functions/Functions.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -28,7 +29,7 @@ public static class KernelGrpcExtensions
     /// <param name="pluginDirectoryName">Name of the directory containing the selected plugin.</param>
     /// <param name="httpClient">HttpClient to use for sending requests.</param>
     /// <returns>A list of all the semantic functions representing the plugin.</returns>
-    public static IDictionary<string, ISKFunction> ImportGrpcPluginFromDirectory(
+    public static IDictionary<string, ISKFunction> ImportGrpcFunctionsFromDirectory(
         this IKernel kernel,
         string parentDirectory,
         string pluginDirectoryName,
@@ -51,7 +52,7 @@ public static class KernelGrpcExtensions
 
         using var stream = File.OpenRead(filePath);
 
-        return kernel.RegisterGrpcPlugin(stream, pluginDirectoryName, httpClient);
+        return kernel.RegisterGrpcFunctions(stream, pluginDirectoryName, httpClient);
     }
 
     /// <summary>
@@ -62,7 +63,7 @@ public static class KernelGrpcExtensions
     /// <param name="filePath">File path to .proto document.</param>
     /// <param name="httpClient">HttpClient to use for sending requests.</param>
     /// <returns>A list of all the semantic functions representing the plugin.</returns>
-    public static IDictionary<string, ISKFunction> ImportGrpcPluginFromFile(
+    public static IDictionary<string, ISKFunction> ImportGrpcFunctionsFromFile(
         this IKernel kernel,
         string pluginName,
         string filePath,
@@ -77,7 +78,7 @@ public static class KernelGrpcExtensions
 
         using var stream = File.OpenRead(filePath);
 
-        return kernel.RegisterGrpcPlugin(stream, pluginName, httpClient);
+        return kernel.RegisterGrpcFunctions(stream, pluginName, httpClient);
     }
 
     /// <summary>
@@ -88,7 +89,7 @@ public static class KernelGrpcExtensions
     /// <param name="pluginName">Plugin name.</param>
     /// <param name="httpClient">HttpClient to use for sending requests.</param>
     /// <returns>A list of all the semantic functions representing the plugin.</returns>
-    public static IDictionary<string, ISKFunction> RegisterGrpcPlugin(
+    public static IDictionary<string, ISKFunction> RegisterGrpcFunctions(
         this IKernel kernel,
         Stream documentStream,
         string pluginName,
@@ -193,6 +194,49 @@ public static class KernelGrpcExtensions
 
         return kernel.RegisterCustomFunction(function);
     }
+
+    #endregion
+
+    #region obsolete
+
+    [Obsolete("Methods and classes which includes Skill in the name have been renamed to use Plugin. Use Kernel.ImportGrpcFunctionsFromDirectory instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    public static IDictionary<string, ISKFunction> ImportGrpcSkillFromDirectory(
+        this IKernel kernel,
+        string parentDirectory,
+        string skillDirectoryName,
+        HttpClient? httpClient = null)
+    {
+        return kernel.ImportGrpcFunctionsFromDirectory(parentDirectory, skillDirectoryName, httpClient);
+    }
+#pragma warning restore CS1591
+
+    [Obsolete("Methods and classes which includes Skill in the name have been renamed to use Plugin. Use Kernel.ImportGrpcFunctionsFromFile instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    public static IDictionary<string, ISKFunction> ImportGrpcSkillFromFile(
+        this IKernel kernel,
+        string skillName,
+        string filePath,
+        HttpClient? httpClient = null)
+    {
+        return kernel.ImportGrpcFunctionsFromFile(skillName, filePath, httpClient);
+    }
+#pragma warning restore CS1591
+
+    [Obsolete("Methods and classes which includes Skill in the name have been renamed to use Plugin. Use Kernel.RegisterGrpcFunctions instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    public static IDictionary<string, ISKFunction> RegisterGrpcSkill(
+        this IKernel kernel,
+        Stream documentStream,
+        string skillName,
+        HttpClient? httpClient = null)
+    {
+        return kernel.RegisterGrpcFunctions(documentStream, skillName, httpClient);
+    }
+#pragma warning restore CS1591
 
     #endregion
 }

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelAIPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelAIPluginExtensions.cs
@@ -39,7 +39,7 @@ public static class KernelAIPluginExtensions
         this IKernel kernel,
         string pluginName,
         string filePath,
-        OpenApiPluginExecutionParameters? executionParameters = null,
+        OpenApiFunctionExecutionParameters? executionParameters = null,
         CancellationToken cancellationToken = default)
     {
         Verify.NotNull(kernel);
@@ -78,7 +78,7 @@ public static class KernelAIPluginExtensions
         this IKernel kernel,
         string pluginName,
         Uri uri,
-        OpenApiPluginExecutionParameters? executionParameters = null,
+        OpenApiFunctionExecutionParameters? executionParameters = null,
         CancellationToken cancellationToken = default)
     {
         Verify.NotNull(kernel);
@@ -118,7 +118,7 @@ public static class KernelAIPluginExtensions
         this IKernel kernel,
         string pluginName,
         Stream stream,
-        OpenApiPluginExecutionParameters? executionParameters = null,
+        OpenApiFunctionExecutionParameters? executionParameters = null,
         CancellationToken cancellationToken = default)
     {
         Verify.NotNull(kernel);
@@ -146,7 +146,7 @@ public static class KernelAIPluginExtensions
         string pluginContents,
         string pluginName,
         HttpClient httpClient,
-        OpenApiPluginExecutionParameters? executionParameters,
+        OpenApiFunctionExecutionParameters? executionParameters,
         Uri? documentUri = null,
         CancellationToken cancellationToken = default)
     {
@@ -174,7 +174,7 @@ public static class KernelAIPluginExtensions
     private static async Task<IDictionary<string, ISKFunction>> LoadPluginAsync(
         IKernel kernel,
         string pluginName,
-        OpenApiPluginExecutionParameters? executionParameters,
+        OpenApiFunctionExecutionParameters? executionParameters,
         HttpClient httpClient,
         string pluginJson,
         Uri? documentUri = null,
@@ -220,7 +220,7 @@ public static class KernelAIPluginExtensions
     private static async Task<string> LoadDocumentFromUriAsync(
         IKernel kernel,
         Uri uri,
-        OpenApiPluginExecutionParameters? executionParameters,
+        OpenApiFunctionExecutionParameters? executionParameters,
         HttpClient httpClient,
         CancellationToken cancellationToken)
     {
@@ -239,7 +239,7 @@ public static class KernelAIPluginExtensions
     private static async Task<string> LoadDocumentFromFilePathAsync(
         IKernel kernel,
         string filePath,
-        OpenApiPluginExecutionParameters? executionParameters,
+        OpenApiFunctionExecutionParameters? executionParameters,
         HttpClient httpClient,
         CancellationToken cancellationToken)
     {
@@ -314,7 +314,7 @@ public static class KernelAIPluginExtensions
         string pluginName,
         RestApiOperationRunner runner,
         RestApiOperation operation,
-        OpenApiPluginExecutionParameters? executionParameters,
+        OpenApiFunctionExecutionParameters? executionParameters,
         Uri? documentUri = null,
         CancellationToken cancellationToken = default)
     {

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/OpenApiFunctionExecutionParameters.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/OpenApiFunctionExecutionParameters.cs
@@ -8,9 +8,9 @@ using Microsoft.SemanticKernel.Functions.OpenAPI.Authentication;
 namespace Microsoft.SemanticKernel.Functions.OpenAPI.Extensions;
 
 /// <summary>
-/// OpenAPI plugin execution parameters.
+/// OpenAPI function execution parameters.
 /// </summary>
-public class OpenApiPluginExecutionParameters
+public class OpenApiFunctionExecutionParameters
 {
     /// <summary>
     /// HttpClient to use for sending HTTP requests.
@@ -55,7 +55,7 @@ public class OpenApiPluginExecutionParameters
     public bool EnablePayloadNamespacing { get; set; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OpenApiPluginExecutionParameters"/> class.
+    /// Initializes a new instance of the <see cref="OpenApiFunctionExecutionParameters"/> class.
     /// </summary>
     /// <param name="httpClient">The HttpClient to use for sending HTTP requests.</param>
     /// <param name="authCallback">The callback for adding authentication data to HTTP requests.</param>
@@ -68,7 +68,7 @@ public class OpenApiPluginExecutionParameters
     /// If false, the operation payload must be provided via the 'payload' context variable.</param>
     /// <param name="enablePayloadNamespacing">Determines whether payload parameter names are augmented with namespaces.
     /// Namespaces prevent naming conflicts by adding the parent parameter name as a prefix, separated by dots.</param>
-    public OpenApiPluginExecutionParameters(
+    public OpenApiFunctionExecutionParameters(
         HttpClient? httpClient = null,
         AuthenticateRequestAsyncCallback? authCallback = null,
         Uri? serverUrlOverride = null,

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/KernelAIPluginExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/KernelAIPluginExtensionsTests.cs
@@ -89,7 +89,7 @@ public sealed class KernelAIPluginExtensionsTests : IDisposable
         using var messageHandlerStub = new HttpMessageHandlerStub(openApiDocument);
         using var httpClient = new HttpClient(messageHandlerStub, false);
 
-        var executionParameters = new OpenApiPluginExecutionParameters { HttpClient = httpClient, ServerUrlOverride = new Uri(ServerUrlOverride) };
+        var executionParameters = new OpenApiFunctionExecutionParameters { HttpClient = httpClient, ServerUrlOverride = new Uri(ServerUrlOverride) };
         var variables = this.GetFakeContextVariables();
 
         // Act
@@ -127,7 +127,7 @@ public sealed class KernelAIPluginExtensionsTests : IDisposable
         using var messageHandlerStub = new HttpMessageHandlerStub(openApiDocument);
         using var httpClient = new HttpClient(messageHandlerStub, false);
 
-        var executionParameters = new OpenApiPluginExecutionParameters { HttpClient = httpClient };
+        var executionParameters = new OpenApiFunctionExecutionParameters { HttpClient = httpClient };
         var variables = this.GetFakeContextVariables();
 
         // Act
@@ -172,7 +172,7 @@ public sealed class KernelAIPluginExtensionsTests : IDisposable
         using var messageHandlerStub = new HttpMessageHandlerStub(content);
         using var httpClient = new HttpClient(messageHandlerStub, false);
 
-        var executionParameters = new OpenApiPluginExecutionParameters { HttpClient = httpClient };
+        var executionParameters = new OpenApiFunctionExecutionParameters { HttpClient = httpClient };
         var variables = this.GetFakeContextVariables();
 
         // Act

--- a/dotnet/src/IntegrationTests/Planning/StepwisePlanner/StepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planning/StepwisePlanner/StepwisePlannerTests.cs
@@ -129,7 +129,7 @@ public sealed class StepwisePlannerTests : IDisposable
         // Arrange
         IKernel kernel = this.InitializeKernel();
 
-        _ = await kernel.ImportAIPluginAsync("Klarna", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"), new OpenApiPluginExecutionParameters(enableDynamicOperationPayload: true));
+        _ = await kernel.ImportAIPluginAsync("Klarna", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"), new OpenApiFunctionExecutionParameters(enableDynamicOperationPayload: true));
 
         var planner = new Microsoft.SemanticKernel.Planning.StepwisePlanner(kernel);
 

--- a/dotnet/src/IntegrationTests/Plugins/PluginTests.cs
+++ b/dotnet/src/IntegrationTests/Plugins/PluginTests.cs
@@ -30,7 +30,7 @@ public class PluginTests
         var plugin = await kernel.ImportAIPluginAsync(
             name,
             new Uri(pluginEndpoint),
-            new OpenApiPluginExecutionParameters(httpClient));
+            new OpenApiFunctionExecutionParameters(httpClient));
 
         var contextVariables = new ContextVariables();
         contextVariables["q"] = query;
@@ -62,7 +62,7 @@ public class PluginTests
         var plugin = await kernel.ImportAIPluginAsync(
             name,
             new Uri(pluginEndpoint),
-            new OpenApiPluginExecutionParameters(httpClient) { IgnoreNonCompliantErrors = true });
+            new OpenApiFunctionExecutionParameters(httpClient) { IgnoreNonCompliantErrors = true });
 
         var contextVariables = new ContextVariables();
         contextVariables["payload"] = payload;
@@ -93,7 +93,7 @@ public class PluginTests
             var plugin = await kernel.ImportAIPluginAsync(
                 name,
                 stream,
-                new OpenApiPluginExecutionParameters(httpClient) { IgnoreNonCompliantErrors = true });
+                new OpenApiFunctionExecutionParameters(httpClient) { IgnoreNonCompliantErrors = true });
 
             var contextVariables = new ContextVariables();
             contextVariables["payload"] = payload;
@@ -123,7 +123,7 @@ public class PluginTests
         var plugin = await kernel.ImportAIPluginAsync(
             name,
             pluginFilePath,
-            new OpenApiPluginExecutionParameters(httpClient) { IgnoreNonCompliantErrors = true });
+            new OpenApiFunctionExecutionParameters(httpClient) { IgnoreNonCompliantErrors = true });
 
         var contextVariables = new ContextVariables();
         contextVariables["payload"] = payload;

--- a/dotnet/src/SemanticKernel.Core/Extensions/KernelSemanticFunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Extensions/KernelSemanticFunctionExtensions.cs
@@ -118,7 +118,7 @@ public static class InlineFunctionsDefinitionExtension
         return kernel.RunAsync(skfunction);
     }
 
-    [Obsolete("Methods and classes which isnclud Skill in the name have been renamed to use Plugin. Use Kernel.ImportSemanticFunctionsFromDirectory instead. This will be removed in a future release.")]
+    [Obsolete("Methods and classes which includes Skill in the name have been renamed to use Plugin. Use Kernel.ImportSemanticFunctionsFromDirectory instead. This will be removed in a future release.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable CS1591
     public static IDictionary<string, ISKFunction> ImportSemanticSkillFromDirectory(


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
