### PR TITLE
Fix dotnet Example14 for WithOpenAITextEmbeddingGenerationService

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
@@ -57,7 +57,7 @@ public static class Example14_SemanticMemory
 
         var kernelWithCustomDb = Kernel.Builder
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithOpenAITextEmbeddingGenerationService("ada", "text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
+            .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
             .WithMemoryStorage(new VolatileMemoryStore())
             .Build();
 


### PR DESCRIPTION
…Service params

### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. Why is this change required?
dotnet / KernelSyntaxExamples Example 14 currently fails

  2. What problem does it solve?
Update Example 14 (dotnet, `KernelSyntaxExamples`) to conform to the proper use of `WithOpenAITextEmbeddingGenerationService`.  The old `serviceId` parameter is no longer required here.

  
  3. What scenario does it contribute to?
dotnet Examples

  
  5. If it fixes an open issue, please link to the issue here.
TBD


### Description
Removed the `serviceId` parameter from the call to `WithOpenAITextEmbeddingGenerationService`


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:


THANK YOU to all the contributors at Microsoft & the community. 