### PR TITLE
.Net: Rename skill -> plugin in examples Update URLs, file paths, and plugin/skill names in Semantic Kernel examples and KernelSyntaxExamples

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
@@ -93,7 +93,7 @@ public static class Example14_SemanticMemory
         Query: Can I build a chat with SK?
 
         Result 1:
-          URL:     : https://github.com/microsoft/semantic-kernel/tree/main/samples/plugins/ChatSkill/ChatGPT
+          URL:     : https://github.com/microsoft/semantic-kernel/tree/main/samples/plugins/ChatPlugin/ChatGPT
           Title    : Sample demonstrating how to create a chat plugin interfacing with ChatGPT
 
         Result 2:
@@ -160,7 +160,7 @@ public static class Example14_SemanticMemory
                 = "Jupyter notebook describing how to pass prompts from a file to a semantic plugin or function",
             ["https://github.com/microsoft/semantic-kernel/blob/main/dotnet/notebooks//00-getting-started.ipynb"]
                 = "Jupyter notebook describing how to get started with the Semantic Kernel",
-            ["https://github.com/microsoft/semantic-kernel/tree/main/samples/plugins/ChatSkill/ChatGPT"]
+            ["https://github.com/microsoft/semantic-kernel/tree/main/samples/plugins/ChatPlugin/ChatGPT"]
                 = "Sample demonstrating how to create a chat plugin interfacing with ChatGPT",
             ["https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel/Memory/VolatileMemoryStore.cs"]
                 = "C# class that defines a volatile embedding store",

--- a/dotnet/samples/KernelSyntaxExamples/Example15_TextMemoryPlugin.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example15_TextMemoryPlugin.cs
@@ -188,8 +188,8 @@ public static class Example15_TextMemoryPlugin
         Console.WriteLine("== PART 2a: Saving Memories through the Kernel with TextMemoryPlugin and the 'Save' function ==");
 
         // Import the TextMemoryPlugin into the Kernel for other functions
-        var memorySkill = new TextMemoryPlugin(textMemory);
-        var memoryFunctions = kernel.ImportFunctions(memorySkill);
+        var memoryPlugin = new TextMemoryPlugin(textMemory);
+        var memoryFunctions = kernel.ImportFunctions(memoryPlugin);
 
         // Save a memory with the Kernel
         Console.WriteLine("Saving memory with key 'info5': \"My family is from New York\"");

--- a/dotnet/samples/KernelSyntaxExamples/Example23_OpenApiPlugin_Github.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example23_OpenApiPlugin_Github.cs
@@ -24,7 +24,7 @@ public static class Example23_OpenApiPlugin_GitHub
     public static async Task RunAsync()
     {
         var authenticationProvider = new BearerAuthenticationProvider(() => { return Task.FromResult(TestConfiguration.Github.PAT); });
-        Console.WriteLine("== Example22_c_OpenApiSkill_GitHub ==");
+        Console.WriteLine("== Example23_OpenApiPlugin_GitHub ==");
         var firstPRNumber = await ListPullRequestsFromGitHubAsync(authenticationProvider);
         await GetPullRequestFromGitHubAsync(authenticationProvider, firstPRNumber);
     }

--- a/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
@@ -29,7 +29,7 @@ public static class Example24_OpenApiPlugin_Jira
         string serverUrl = $"https://{TestConfiguration.Jira.Domain}.atlassian.net/rest/api/latest/";
         contextVariables.Set("server-url", serverUrl);
 
-        IDictionary<string, ISKFunction> jiraSkills;
+        IDictionary<string, ISKFunction> jiraFunctions;
         var tokenProvider = new BasicAuthenticationProvider(() =>
         {
             string s = $"{TestConfiguration.Jira.Email}:{TestConfiguration.Jira.ApiKey}";
@@ -42,40 +42,40 @@ public static class Example24_OpenApiPlugin_Jira
         bool useLocalFile = true;
         if (useLocalFile)
         {
-            var apiSkillFile = "./../../../Skills/JiraSkill/openapi.json";
-            jiraSkills = await kernel.ImportAIPluginAsync("jiraSkills", apiSkillFile, new OpenApiFunctionExecutionParameters(authCallback: tokenProvider.AuthenticateRequestAsync));
+            var apiPluginFile = "./../../../Plugins/JiraPlugin/openapi.json";
+            jiraFunctions = await kernel.ImportAIPluginAsync("jiraPlugin", apiPluginFile, new OpenApiFunctionExecutionParameters(authCallback: tokenProvider.AuthenticateRequestAsync));
         }
         else
         {
-            var apiSkillRawFileURL = new Uri("https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/dev/certified-connectors/JIRA/apiDefinition.swagger.json");
-            jiraSkills = await kernel.ImportAIPluginAsync("jiraSkills", apiSkillRawFileURL, new OpenApiFunctionExecutionParameters(httpClient, tokenProvider.AuthenticateRequestAsync));
+            var apiPluginRawFileURL = new Uri("https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/dev/certified-connectors/JIRA/apiDefinition.swagger.json");
+            jiraFunctions = await kernel.ImportAIPluginAsync("jiraPlugin", apiPluginRawFileURL, new OpenApiFunctionExecutionParameters(httpClient, tokenProvider.AuthenticateRequestAsync));
         }
 
-        // GetIssue Skill
+        // GetIssue Function
         {
             // Set Properties for the Get Issue operation in the openAPI.swagger.json
             contextVariables.Set("issueKey", "SKTES-2");
 
             // Run operation via the semantic kernel
-            var result = await kernel.RunAsync(contextVariables, jiraSkills["GetIssue"]);
+            var result = await kernel.RunAsync(contextVariables, jiraFunctions["GetIssue"]);
 
             Console.WriteLine("\n\n\n");
             var formattedContent = JsonConvert.SerializeObject(JsonConvert.DeserializeObject(result.GetValue<string>()!), Formatting.Indented);
-            Console.WriteLine("GetIssue jiraSkills response: \n{0}", formattedContent);
+            Console.WriteLine("GetIssue jiraPlugin response: \n{0}", formattedContent);
         }
 
-        // AddComment Skill
+        // AddComment Function
         {
             // Set Properties for the AddComment operation in the openAPI.swagger.json
             contextVariables.Set("issueKey", "SKTES-1");
             contextVariables.Set("body", "Here is a rad comment");
 
             // Run operation via the semantic kernel
-            var result = await kernel.RunAsync(contextVariables, jiraSkills["AddComment"]);
+            var result = await kernel.RunAsync(contextVariables, jiraFunctions["AddComment"]);
 
             Console.WriteLine("\n\n\n");
             var formattedContent = JsonConvert.SerializeObject(JsonConvert.DeserializeObject(result.GetValue<string>()!), Formatting.Indented);
-            Console.WriteLine("AddComment jiraSkills response: \n{0}", formattedContent);
+            Console.WriteLine("AddComment jiraPlugin response: \n{0}", formattedContent);
         }
     }
 }

--- a/dotnet/samples/KernelSyntaxExamples/Example31_CustomPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example31_CustomPlanner.cs
@@ -109,9 +109,9 @@ internal static class Example31_CustomPlanner
         }
     }
 
-    // ContextQuery is part of the QASkill
+    // ContextQuery is part of the QAPlugin
     // DependsOn: TimePlugin named "time"
-    // DependsOn: BingSkill named "bing"
+    // DependsOn: BingPlugin named "bing"
     private static IDictionary<string, ISKFunction> LoadQAPlugin(IKernel kernel)
     {
         string folder = RepoFiles.SamplePluginsPath();
@@ -141,7 +141,7 @@ internal static class Example31_CustomPlanner
     }
 }
 
-// Example Skill that can process XML Markup created by ContextQuery
+// Example Plugin that can process XML Markup created by ContextQuery
 public class MarkupPlugin
 {
     [SKFunction, Description("Run Markup")]

--- a/dotnet/samples/KernelSyntaxExamples/Example35_GrpcPlugins.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example35_GrpcPlugins.cs
@@ -31,6 +31,6 @@ public static class Example35_GrpcPlugins
         // Run
         var result = await kernel.RunAsync(contextVariables, plugin["<operation-name>"]);
 
-        Console.WriteLine("Skill response: {0}", result);
+        Console.WriteLine("Plugin response: {0}", result);
     }
 }

--- a/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
@@ -50,11 +50,11 @@ after this event Caroline became his wife.""";
 
     public static async Task RunAsync()
     {
-        await GroundednessCheckingSkillAsync();
+        await GroundednessCheckingAsync();
         await PlanningWithGroundednessAsync();
     }
 
-    public static async Task GroundednessCheckingSkillAsync()
+    public static async Task GroundednessCheckingAsync()
     {
         Console.WriteLine("======== Groundedness Checks ========");
         var kernel = new KernelBuilder()
@@ -180,9 +180,9 @@ which are not grounded in the original.
 Steps:
   - _GLOBAL_FUNCTIONS_.Echo INPUT='' => ORIGINAL_TEXT
   - SummarizePlugin.Summarize INPUT='' => RESULT__SUMMARY
-  - GroundingSkill.ExtractEntities example_entities='John;Jane;mother;brother;Paris;Rome' topic='people and places' INPUT='$RESULT__SUMMARY' => ENTITIES
-  - GroundingSkill.ReferenceCheckEntities reference_context='$ORIGINAL_TEXT' INPUT='$ENTITIES' => RESULT__UNGROUND_ENTITIES
-  - GroundingSkill.ExciseEntities ungrounded_entities='$RESULT__UNGROUND_ENTITIES' INPUT='$RESULT__SUMMARY' => RESULT__FINAL_SUMMARY
+  - GroundingPlugin.ExtractEntities example_entities='John;Jane;mother;brother;Paris;Rome' topic='people and places' INPUT='$RESULT__SUMMARY' => ENTITIES
+  - GroundingPlugin.ReferenceCheckEntities reference_context='$ORIGINAL_TEXT' INPUT='$ENTITIES' => RESULT__UNGROUND_ENTITIES
+  - GroundingPlugin.ExciseEntities ungrounded_entities='$RESULT__UNGROUND_ENTITIES' INPUT='$RESULT__SUMMARY' => RESULT__FINAL_SUMMARY
 A possible summary is:
 
 

--- a/dotnet/samples/KernelSyntaxExamples/Example51_StepwisePlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example51_StepwisePlanner.cs
@@ -105,9 +105,9 @@ public static class Example51_StepwisePlanner
     {
         currentExecutionResult.question = question;
         var bingConnector = new BingConnector(TestConfiguration.Bing.ApiKey);
-        var webSearchEngineSkill = new WebSearchEnginePlugin(bingConnector);
+        var webSearchEnginePlugin = new WebSearchEnginePlugin(bingConnector);
 
-        kernel.ImportFunctions(webSearchEngineSkill, "WebSearch");
+        kernel.ImportFunctions(webSearchEnginePlugin, "WebSearch");
         kernel.ImportFunctions(new LanguageCalculatorPlugin(kernel), "semanticCalculator");
         kernel.ImportFunctions(new TimePlugin(), "time");
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

## Summary
This pull request updates URLs, file paths, and plugin/skill names in several examples in the Semantic Kernel repository and the KernelSyntaxExamples code samples. Specifically, it updates the URL for the ChatPlugin in Example14_SemanticMemory.cs, updates the file path for the TextMemoryPlugin in Example15_TextMemoryPlugin.cs, updates the name of an example in Example23_OpenApiPlugin_Github.cs, updates the file path for the JiraPlugin in Example24_OpenApiPlugin_Jira.cs, and updates the file path for the JiraPlugin in Example31_CustomPlanner.cs. Additionally, the ContextQuery and BingSkill have been renamed to QAPlugin and BingPlugin, respectively, in the KernelSyntaxExamples code samples. The WebSearchEngineSkill has been renamed to WebSearchEnginePlugin, and the GroundingSkill has been renamed to GroundingPlugin. Finally, the Example48_GroundednessChecks code sample has been updated to reflect these changes.

## Changes
- Update URL for ChatPlugin in Example14_SemanticMemory.cs
- Update file path for TextMemoryPlugin in Example15_TextMemoryPlugin.cs
- Update name of example in Example23_OpenApiPlugin_Github.cs
- Update file path for JiraPlugin in Example24_OpenApiPlugin_Jira.cs
- Update file path for JiraPlugin in Example31_CustomPlanner.cs
- Renamed ContextQuery to QAPlugin in KernelSyntaxExamples
- Renamed BingSkill to BingPlugin in KernelSyntaxExamples
- Renamed WebSearchEngineSkill to WebSearchEnginePlugin in KernelSyntaxExamples
- Renamed GroundingSkill to GroundingPlugin in KernelSyntaxExamples
- Updated Example48_GroundednessChecks code sample to reflect changes in KernelSyntaxExamples

---
*Powered by [Microsoft Semantic Kernel](https://github.com/microsoft/semantic-kernel)*