### PR TITLE
Add deprecation warnings to samples

### DIFF
--- a/samples/apps/auth-api-webapp-react/README.md
+++ b/samples/apps/auth-api-webapp-react/README.md
@@ -1,6 +1,11 @@
 # Authenticated API’s Sample Learning App
 
 > [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
+> [!IMPORTANT]
 > This learning sample is for educational purposes only and should not be used in any production
 > use case. It is intended to highlight concepts of Semantic Kernel and not any
 > architectural / security design practices to be used.
@@ -21,7 +26,7 @@
     - Select **`Single-page application (SPA)`** as platform type, and the Redirect URI will be **`http://localhost:3000`**
     - Select **`Personal Microsoft accounts only`** as supported account types for this sample
 4. Copy **[.env.example](.env.example)** into a new file with name "**.env**".
-   > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
+    > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
 5. Once registered, copy the **Application (client) ID** from the Azure Portal and paste
    the GUID into the **.env** file next to `REACT_APP_GRAPH_CLIENT_ID=` (first line of the .env file).
 6. **Run** the following command `yarn install` (if you have never run the sample before)

--- a/samples/apps/book-creator-webapp-react/README.md
+++ b/samples/apps/book-creator-webapp-react/README.md
@@ -1,5 +1,10 @@
 # Book Creator Sample Learning App
 
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 > **!IMPORTANT**
 > This learning sample is for educational purposes only and should not be used in any
 > production use case. It is intended to highlight concepts of Semantic Kernel and not
@@ -15,7 +20,7 @@
 2. Ensure the KernelHttpServer sample is already running at `http://localhost:7071`. If not, follow the steps
    to start it [here](../../dotnet/KernelHttpServer/README.md).
 3. Copy **[.env.example](.env.example)** into a new file with name "**.env**".
-   > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
+    > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
 4. You will also need to **Run** the following command `yarn install` (if you have never run the sample before)
    and/or `yarn start` from the command line.
 5. A browser will automatically open, otherwise you can navigate to `http://localhost:3000` to use the sample.

--- a/samples/apps/chat-summary-webapp-react/README.md
+++ b/samples/apps/chat-summary-webapp-react/README.md
@@ -1,5 +1,10 @@
 # Simple Chat Summary Sample Learning App
 
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 Watch the [Chat Summary Quick Start Video](https://aka.ms/SK-Samples-SimChat-Video).
 
 > **!IMPORTANT**
@@ -15,7 +20,7 @@ Watch the [Chat Summary Quick Start Video](https://aka.ms/SK-Samples-SimChat-Vid
 2. Ensure the KernelHttpServer sample is already running at `http://localhost:7071`. If not, follow the steps
    to start it [here](../../dotnet/KernelHttpServer/README.md).
 3. Copy **[.env.example](.env.example)** into a new file with name "**.env**".
-   > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
+    > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
 4. You will also need to **Run** the following command `yarn install` (if you have never run the sample before)
    and/or `yarn start` from the command line.
 5. A browser will automatically open, otherwise you can navigate to `http://localhost:3000` to use the sample.

--- a/samples/apps/github-qna-webapp-react/README.md
+++ b/samples/apps/github-qna-webapp-react/README.md
@@ -1,5 +1,10 @@
 # GitHub Repo Q&A Bot Sample
 
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 > **!IMPORTANT**
 > This learning sample is for educational purposes only and should not be used in any
 > production use case. It is intended to highlight concepts of Semantic Kernel and not
@@ -13,7 +18,7 @@
 2. Ensure the service API is already running `http://localhost:7071`. If not, learn
    how to start it [here](../../dotnet/KernelHttpServer/README.md).
 3. You will also need to Copy **[.env.example](.env.example)** into a new file with name "**.env**".
-   > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
+    > **Note**: Samples are configured to use chat completion AI models (e.g., gpt-3.5-turbo, gpt-4, etc.). See https://platform.openai.com/docs/models/model-endpoint-compatibility for chat completion model options.
 4. **Run** the following command `yarn install` (if you have never run the sample before)
    and/or `yarn start` from the command line.
 5. A browser will open or you can navigate to `http://localhost:3000` to use the sample.
@@ -37,9 +42,9 @@ only content extracted from markdown files.
 > Each function will call Open AI which will use tokens that you will be billed for.
 
 ## Working with private repositories
+
 The GitHub Repo Q&A Bot sample allows you to pull in data from a private GitHub repo. To do so, you must create a [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) if you have not already. The token must have access to the repository you are trying to pull data from as well as read access to the Contents of the repository:
 ![Alt text](contents-read-access.png)
-
 
 ## Next Steps
 

--- a/samples/apps/hugging-face-http-server/README.md
+++ b/samples/apps/hugging-face-http-server/README.md
@@ -1,6 +1,11 @@
 # Local Hugging Face Model Inference Server
 
 > [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
+> [!IMPORTANT]
 > This learning sample is for educational purposes only and should not be used in any production
 > use case. It is intended to make Semantic Kernel features more accessible for scenarios that
 > do not require an OpenAI or Azure OpenAI endpoint.

--- a/samples/dotnet/KernelHttpServer/README.md
+++ b/samples/dotnet/KernelHttpServer/README.md
@@ -1,12 +1,16 @@
 # Semantic Kernel Service API (For Learning Samples)
 
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 Watch the [Service API Quick Start Video](https://aka.ms/SK-Local-API-Setup).
 
 This service API is written in C# against Azure Function Runtime v4 and exposes
 some Semantic Kernel APIs that you can call via HTTP POST requests for the learning samples.
 
 ![azure-function-diagram](https://user-images.githubusercontent.com/146438/222305329-0557414d-38ce-4712-a7c1-4f6c63c20320.png)
-
 
 **!IMPORTANT**
 
@@ -25,12 +29,12 @@ installation is required for this service API to run locally.
 
 Two endpoints will be exposed by the service API:
 
--   **InvokeFunction**: [POST] `http://localhost:7071/api/skills/{skillName}/invoke/{functionName}`
--   **Ping**: [GET] `http://localhost:7071/api/ping`
+- **InvokeFunction**: [POST] `http://localhost:7071/api/skills/{skillName}/invoke/{functionName}`
+- **Ping**: [GET] `http://localhost:7071/api/ping`
 
 ### Working with Secrets
 
-We need keys to work with various aspects of the project including accessing openAI models. This opens up the possibility of exposing keys in commits. There are a [couple of options](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-7.0&tabs=windows) to safeguard developers from exposing keys. Outside of using the dotnet's users-secrets and environment variables, we've also added *.development.config to the .gitignore if developers want to use config files for secret storage.
+We need keys to work with various aspects of the project including accessing openAI models. This opens up the possibility of exposing keys in commits. There are a [couple of options](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-7.0&tabs=windows) to safeguard developers from exposing keys. Outside of using the dotnet's users-secrets and environment variables, we've also added \*.development.config to the .gitignore if developers want to use config files for secret storage.
 
 ## Next steps
 
@@ -40,10 +44,10 @@ The service API will need to be run or running for each sample app you want to t
 
 Sample app learning examples:
 
--   [Simple chat summary](../../apps/chat-summary-webapp-react/README.md) (**Recommended**) – learn how basic
-    semantic functions can be added to an app
--   [Book creator](../../apps/book-creator-webapp-react/README.md) – learn how Planner and chaining of
-    semantic functions can be used in your app
--   [Authentication and APIs](../../apps/auth-api-webapp-react/README.md) – learn how to connect to external
-    API's with authentication while using Semantic Kernel
--   [GitHub Repo Q&A](../../apps//github-qna-webapp-react/README.md) – learn how Memories and Embeddings can be used in your app
+- [Simple chat summary](../../apps/chat-summary-webapp-react/README.md) (**Recommended**) – learn how basic
+  semantic functions can be added to an app
+- [Book creator](../../apps/book-creator-webapp-react/README.md) – learn how Planner and chaining of
+  semantic functions can be used in your app
+- [Authentication and APIs](../../apps/auth-api-webapp-react/README.md) – learn how to connect to external
+  API's with authentication while using Semantic Kernel
+- [GitHub Repo Q&A](../../apps//github-qna-webapp-react/README.md) – learn how Memories and Embeddings can be used in your app

--- a/samples/dotnet/MsGraphPluginsExample/README.md
+++ b/samples/dotnet/MsGraphPluginsExample/README.md
@@ -1,5 +1,10 @@
 ﻿# Graph API Plugin Example
 
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 This example program demonstrates how to use the Microsoft Graph API plugins with the Semantic Kernel.
 
 ## Setup

--- a/samples/dotnet/OpenApiPluginsExample/README.md
+++ b/samples/dotnet/OpenApiPluginsExample/README.md
@@ -1,15 +1,24 @@
-﻿# Open API Plugins Example
+# Open API Plugins Example
+
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 The chat example below is meant to demonstrate the use of an OpenAPI-based plugin (e.g., GitHub), a planner (e.g., ActionPlanner)
 and chat completions to create a conversational experience with additional information from a plugin when needed.
 
 The specific GitHub OpenAPI used is a reduced definition supporting viewing of pull requests.
 
 ## Preparing your environment
+
 Before you get started, make sure you have the following requirements in place:
+
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 - [Azure OpenAI](https://aka.ms/oai/access) resource or an account with [OpenAI](https://platform.openai.com).
 
 ## Running the sample
+
 1. Clone the repository
 2. Open the `./appsettings.json` and configure your AI service and GitHub credentials.
 3. Run the sample
@@ -17,6 +26,7 @@ Before you get started, make sure you have the following requirements in place:
    - OR open a terminal window, change directory to the `OpenApiPluginsExample` project, then run `dotnet run`.
 
 ## Using the sample
+
 The sample will provide a simple chat interface the large language model (e.g., gpt-3.5-turbo) and the planner will invoke the GitHub plugin when needed.
 
 When asking for results from GitHub, try using bounded asks such as "List the three most recent open pull requests and include the name, number, and state for each."

--- a/samples/python/kernel_http_server/README.md
+++ b/samples/python/kernel_http_server/README.md
@@ -1,5 +1,10 @@
 # Semantic Kernel Service API (For Learning Samples)
 
+> [!IMPORTANT]
+> This sample will be removed in a future release. If you are looking for samples that demonstrate
+> how to use Semantic Kernel, please refer to the sample folders in the root [python](../../../python/samples/)
+> and [dotnet](../../../dotnet/samples/) folders.
+
 Watch the [Service API Quick Start Video](https://aka.ms/SK-Local-API-Setup).
 
 This service API is written in Python against Azure Function Runtime v4 and exposes
@@ -70,15 +75,13 @@ They accept input in the JSON body of the request:
 ```json
 {
   "value": "", // the "input" of the prompt
-  "inputs": // a list of extra key-value parameters for ContextVariables or Plan State
-  [
-    {"key": "", "value": ""}
-  ],
+  // a list of extra key-value parameters for ContextVariables or Plan State
+  "inputs": [{ "key": "", "value": "" }],
   "skills": [] // list of skills to use (for the planner)
 }
 ```
 
-For planning, first create a plan with your prompt in the "value" parameter.  Take the JSON "state" response,
+For planning, first create a plan with your prompt in the "value" parameter. Take the JSON "state" response,
 rename "state" to "inputs", and use it for the input to ExecutePlan.
 
 ## Next steps
@@ -90,4 +93,4 @@ The service API will need to be run or running for each sample app you want to t
 Sample app learning examples:
 
 - [Book creator](../../apps/book-creator-webapp-react/README.md) – learn how Planner and chaining of
-    semantic functions can be used in your app
+  semantic functions can be used in your app


### PR DESCRIPTION
### Motivation and Context

Per https://github.com/microsoft/semantic-kernel/issues/2810, we will be deprecating the current web-based samples in favor of console apps in the dotnet and python samples folders.

### Description

Added a deprecation warning to the samples

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
