### PR TITLE
Use method to check char is Symbol

### DIFF
--- a/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/Block.cs
+++ b/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/Block.cs
@@ -41,4 +41,24 @@ public abstract class Block
     /// <param name="errorMsg">Error message in case the content is not valid</param>
     /// <returns>True if the block content is valid</returns>
     public abstract bool IsValid(out string errorMsg);
+
+    internal static bool IsVarPrefix(char c)
+    {
+        return (c == Symbols.VarPrefix);
+    }
+
+    internal static bool IsBlankSpace(char c)
+    {
+        return c is Symbols.Space or Symbols.NewLine or Symbols.CarriageReturn or Symbols.Tab;
+    }
+
+    internal static bool IsQuote(char c)
+    {
+        return c is Symbols.DblQuote or Symbols.SglQuote;
+    }
+
+    internal static bool CanBeEscaped(char c)
+    {
+        return c is Symbols.DblQuote or Symbols.SglQuote or Symbols.EscapeChar;
+    }
 }

--- a/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/NamedArgBlock.cs
+++ b/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/NamedArgBlock.cs
@@ -48,7 +48,7 @@ internal sealed class NamedArgBlock : Block, ITextRendering
             throw new SKException($"A function named argument must contain a quoted value or variable after the '{Symbols.NamedArgBlockSeparator}' character.");
         }
 
-        if (argValue[0] == Symbols.VarPrefix)
+        if (IsVarPrefix(argValue[0]))
         {
             this._argValueAsVarBlock = new VarBlock(argValue);
         }

--- a/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/ValBlock.cs
+++ b/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/ValBlock.cs
@@ -70,6 +70,6 @@ internal sealed class ValBlock : Block, ITextRendering
     {
         return !string.IsNullOrEmpty(text)
                && text!.Length > 0
-               && (text[0] is Symbols.DblQuote or Symbols.SglQuote);
+               && (IsQuote(text[0]));
     }
 }

--- a/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/VarBlock.cs
+++ b/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/Blocks/VarBlock.cs
@@ -37,7 +37,7 @@ internal sealed class VarBlock : Block, ITextRendering
             return false;
         }
 
-        if (this.Content[0] != Symbols.VarPrefix)
+        if (!IsVarPrefix(this.Content[0]))
         {
             errorMsg = $"A variable must start with the symbol {Symbols.VarPrefix}";
             this.Logger.LogError(errorMsg);

--- a/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/TemplateTokenizer.cs
+++ b/dotnet/src/Extensions/TemplateEngine.PromptTemplateEngine/TemplateTokenizer.cs
@@ -108,7 +108,7 @@ internal sealed class TemplateTokenizer
                 // While inside a text value, when the end quote is found
                 if (insideTextValue)
                 {
-                    if (currentChar == Symbols.EscapeChar && CanBeEscaped(nextChar))
+                    if (currentChar == Symbols.EscapeChar && Block.CanBeEscaped(nextChar))
                     {
                         skipNextChar = true;
                         continue;
@@ -122,7 +122,7 @@ internal sealed class TemplateTokenizer
                 else
                 {
                     // A value starts here
-                    if (IsQuote(currentChar))
+                    if (Block.IsQuote(currentChar))
                     {
                         insideTextValue = true;
                         textValueDelimiter = currentChar;
@@ -211,16 +211,5 @@ internal sealed class TemplateTokenizer
     {
         return text.Substring(startIndex, stopIndex - startIndex);
     }
-
-    private static bool IsQuote(char c)
-    {
-        return c is Symbols.DblQuote or Symbols.SglQuote;
-    }
-
-    private static bool CanBeEscaped(char c)
-    {
-        return c is Symbols.DblQuote or Symbols.SglQuote or Symbols.EscapeChar;
-    }
-
     #endregion
 }


### PR DESCRIPTION
Use same method to check char is Symbol

for example:
````
switch (nextChar)
{
    case Symbols.VarPrefix:
        blocks.Add(new VarBlock(text, this._loggerFactory));
        break;

    case Symbols.DblQuote:
    case Symbols.SglQuote:
        blocks.Add(new ValBlock(text, this._loggerFactory));
        break;

    default:
        blocks.Add(new FunctionIdBlock(text, this._loggerFactory));
        break;
}
````
use method:
````
if (Block.IsVarPrefix(nextChar))
{
    blocks.Add(new VarBlock(text, this._loggerFactory));
}
else if (Block.IsQuote(nextChar))
{
    blocks.Add(new ValBlock(text, this._loggerFactory));
}
else
{
    blocks.Add(new FunctionIdBlock(text, this._loggerFactory));
}
````