### PR TITLE
.Net: remove local variable not used

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Functions/NativeFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/NativeFunction.cs
@@ -286,8 +286,6 @@ internal sealed class NativeFunction : ISKFunction, IDisposable
             }
         }
 
-        SKFunctionAttribute? functionAttribute = method.GetCustomAttribute<SKFunctionAttribute>(inherit: true);
-
         string? description = method.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description;
 
         var result = new MethodDetails


### PR DESCRIPTION
````
**SKFunctionAttribute? functionAttribute = method.GetCustomAttribute<SKFunctionAttribute>(inherit: true);**

string? description = method.GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description;

var result = new MethodDetails
{
    Name = functionName!,
    Description = description ?? string.Empty,
};

(result.Function, result.Parameters) = GetDelegateInfo(functionName!, pluginName, target, method);

logger?.LogTrace("Method '{0}' found", result.Name);

return result;
````