### PR TITLE
.Net: Add control variables and extension methods to Orchestration.Flow

### DIFF
--- a/dotnet/src/Extensions/Experimental/Orchestration.Flow/Execution/Constants.cs
+++ b/dotnet/src/Extensions/Experimental/Orchestration.Flow/Execution/Constants.cs
@@ -30,13 +30,23 @@ internal static class Constants
         public const string PromptInputName = "PromptInput";
 
         /// <summary>
-        /// Variable value to prompt input
-        /// </summary>
-        public const string PromptInputValue = "True";
-
-        /// <summary>
         /// Variable name to exit out the of AtLeastOnce or ZeroOrMore loop
         /// </summary>
         public const string ExitLoopName = "ExitLoop";
+
+        /// <summary>
+        /// Variable name to force the next iteration of the of AtLeastOnce or ZeroOrMore loop
+        /// </summary>
+        public const string ContinueLoopName = "ContinueLoop";
+
+        /// <summary>
+        /// Default variable value
+        /// </summary>
+        public const string DefaultValue = "True";
+
+        /// <summary>
+        /// The variables that change the default flow
+        /// </summary>
+        public static readonly string[] ControlVariables = new[] { PromptInputName, ExitLoopName, ContinueLoopName };
     }
 }

--- a/dotnet/src/Extensions/Experimental/Orchestration.Flow/Extensions/ContextVariablesExtensions.cs
+++ b/dotnet/src/Extensions/Experimental/Orchestration.Flow/Extensions/ContextVariablesExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Microsoft.SemanticKernel.Experimental.Orchestration.Execution;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+// ReSharper disable once CheckNamespace
+namespace Microsoft.SemanticKernel.Orchestration;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// Extension methods for <see cref="SKContext"/>
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public static class ContextVariablesExtensions
+{
+    /// <summary>
+    /// Check if we should prompt user for input based on current context.
+    /// </summary>
+    /// <param name="context">context</param>
+    internal static bool IsPromptInput(this ContextVariables context)
+    {
+        return context.TryGetValue(Constants.ChatSkillVariables.PromptInputName, out string? promptInput)
+               && promptInput == Constants.ChatSkillVariables.DefaultValue;
+    }
+
+    /// <summary>
+    /// Check if we should force the next iteration loop based on current context.
+    /// </summary>
+    /// <param name="context">context</param>
+    internal static bool IsContinueLoop(this ContextVariables context)
+    {
+        return context.TryGetValue(Constants.ChatSkillVariables.ContinueLoopName, out string? continueLoop)
+               && continueLoop == Constants.ChatSkillVariables.DefaultValue;
+    }
+}

--- a/dotnet/src/Extensions/Experimental/Orchestration.Flow/Extensions/SKContextExtensions.cs
+++ b/dotnet/src/Extensions/Experimental/Orchestration.Flow/Extensions/SKContextExtensions.cs
@@ -2,11 +2,10 @@
 
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.Experimental.Orchestration.Execution;
-using Microsoft.SemanticKernel.Orchestration;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 // ReSharper disable once CheckNamespace
-namespace Microsoft.SemanticKernel.Experimental.Orchestration;
+namespace Microsoft.SemanticKernel.Orchestration;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 /// <summary>
@@ -54,7 +53,7 @@ public static class SKContextExtensions
         // Cant prompt the user for input and exit the execution at the same time
         if (!context.Variables.ContainsKey(Constants.ChatSkillVariables.ExitLoopName))
         {
-            context.Variables.Set(Constants.ChatSkillVariables.PromptInputName, Constants.ChatSkillVariables.PromptInputValue);
+            context.Variables.Set(Constants.ChatSkillVariables.PromptInputName, Constants.ChatSkillVariables.DefaultValue);
         }
     }
 
@@ -73,12 +72,11 @@ public static class SKContextExtensions
     }
 
     /// <summary>
-    /// Check if should prompt user for input based on current context.
+    /// Signal the orchestrator to go to the next iteration of the loop in the AtLeastOnce or ZeroOrMore step.
     /// </summary>
     /// <param name="context">context</param>
-    internal static bool IsPromptInput(this ContextVariables context)
+    public static void ContinueLoop(this SKContext context)
     {
-        return context.TryGetValue(Constants.ChatSkillVariables.PromptInputName, out string? promptInput)
-               && promptInput == Constants.ChatSkillVariables.PromptInputValue;
+        context.Variables.Set(Constants.ChatSkillVariables.ContinueLoopName, Constants.ChatSkillVariables.DefaultValue);
     }
 }

--- a/dotnet/src/Extensions/Experimental/Orchestration.Flow/FlowValidator.cs
+++ b/dotnet/src/Extensions/Experimental/Orchestration.Flow/FlowValidator.cs
@@ -23,6 +23,7 @@ public class FlowValidator : IFlowValidator
         this.ValidatePartialOrder(flow);
         this.ValidateReferenceStep(flow);
         this.ValidateStartingMessage(flow);
+        this.ValidatePassthroughVariables(flow);
     }
 
     private void ValidateStartingMessage(Flow flow)
@@ -34,6 +35,20 @@ public class FlowValidator : IFlowValidator
             {
                 throw new ArgumentException(
                     $"Missing starting message for step={step.Goal} with completion type={step.CompletionType}");
+            }
+        }
+    }
+
+    private void ValidatePassthroughVariables(Flow flow)
+    {
+        foreach (var step in flow.Steps)
+        {
+            if (step.CompletionType != CompletionType.AtLeastOnce
+                && step.CompletionType != CompletionType.ZeroOrMore
+                && step.Passthrough.Any())
+            {
+                throw new ArgumentException(
+                    $"step={step.Goal} with completion type={step.CompletionType} cannot have passthrough variables as that is only applicable for the AtLeastOnce or ZeroOrMore completion types");
             }
         }
     }


### PR DESCRIPTION
## Summary
This pull request adds control variables and extension methods to the Orchestration.Flow execution, improving its flexibility and functionality. The control variables allow for more fine-grained control over the flow of execution, including the ability to exit or continue a loop and a default variable value. The extension methods provide additional functionality for the ContextVariables class, including the ability to check if the user should be prompted for input and if the next iteration of a loop should be forced. Additionally, the FlowValidator class has been updated to include a new method for validating passthrough variables.

## Changes
- Added control variables to Orchestration.Flow execution
- Added ExitLoopName and ContinueLoopName variables to Constants.cs
- Added DefaultValue variable to Constants.cs
- Added ControlVariables array to Constants.cs
- Modified FlowExecutor.cs to handle ExitLoopName and ContinueLoopName variables
- Added ContextVariablesExtensions.cs with IsPromptInput and IsContinueLoop extension methods
- Updated SKContextExtensions.cs with changes to PromptInput and ContinueLoop methods
- Updated FlowValidator.cs with new ValidatePassthroughVariables method

---
*Powered by [Microsoft Semantic Kernel](https://github.com/microsoft/semantic-kernel)*

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
