### PR TITLE
.Net: Bug + Regression Fix + Added UTs

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example57_FunctionEventHandlers.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example57_FunctionEventHandlers.cs
@@ -88,7 +88,7 @@ public static class Example57_FunctionEventHandlers
 
         const string Input = "I missed the F1 final race";
         var result = await kernel.RunAsync(Input, excuseFunction);
-        Console.WriteLine($"Function Result: {result}");
+        Console.WriteLine($"Function Result: {result.GetValue<string>()}");
     }
 
     private static async Task ChangingResultAsync()
@@ -124,7 +124,7 @@ public static class Example57_FunctionEventHandlers
 
         var result = await kernel.RunAsync(writerFunction);
 
-        Console.WriteLine($"Function Result: {result}");
+        Console.WriteLine($"Function Result: {result.GetValue<string>()}");
     }
 
     private static async Task BeforeInvokeCancellationAsync()

--- a/dotnet/src/SemanticKernel.Core/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Core/Kernel.cs
@@ -209,9 +209,16 @@ repeat:
 
                 context = functionResult.Context;
 
+                var functionInvokedArgs = this.OnFunctionInvoked(functionDetails, functionResult);
+
+                if (functionInvokedArgs is not null)
+                {
+                    // All changes to the SKContext by invoked handlers may reflect in the original function result
+                    functionResult = new FunctionResult(functionDetails.Name, functionDetails.PluginName, functionInvokedArgs.SKContext, functionInvokedArgs.SKContext.Result);
+                }
+
                 allFunctionResults.Add(functionResult);
 
-                var functionInvokedArgs = this.OnFunctionInvoked(functionDetails, functionResult);
                 if (functionInvokedArgs?.CancelToken.IsCancellationRequested ?? false)
                 {
                     this._logger.LogInformation("Execution was cancelled on function invoked event of pipeline step {StepCount}: {PluginName}.{FunctionName}.", pipelineStepCount, skFunction.PluginName, skFunction.Name);

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -345,16 +345,275 @@ public class KernelTests
 
         // Act
         var kernelResult = await kernel.RunAsync(function1, function2);
+        var functionResult1 = kernelResult.FunctionResults.First(l => l.FunctionName == "Function1" && l.PluginName == PluginName);
+        var functionResult2 = kernelResult.FunctionResults.First(l => l.FunctionName == "Function2" && l.PluginName == PluginName);
 
         // Assert
         Assert.NotNull(kernelResult);
         Assert.Equal("Result2", kernelResult.GetValue<string>());
-
-        var functionResult1 = kernelResult.FunctionResults.First(l => l.FunctionName == "Function1" && l.PluginName == PluginName);
-        var functionResult2 = kernelResult.FunctionResults.First(l => l.FunctionName == "Function2" && l.PluginName == PluginName);
-
         Assert.Equal("Result1", functionResult1.GetValue<string>());
         Assert.Equal("Result2", functionResult2.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ItReturnsChangedResultsFromFunctionInvokedEventsAsync()
+    {
+        var kernel = Kernel.Builder.Build();
+
+        // Arrange
+        [SKName("Function1")]
+        static string Function1() => "Result1";
+        var function1 = SKFunction.FromNativeMethod(Method(Function1), pluginName: "MyPlugin");
+        const string ExpectedValue = "new result";
+
+        kernel.FunctionInvoked += (object? sender, FunctionInvokedEventArgs args) =>
+        {
+            args.SKContext.Variables.Update(ExpectedValue);
+        };
+
+        // Act
+        var kernelResult = await kernel.RunAsync(function1);
+
+        // Assert
+        Assert.NotNull(kernelResult);
+        Assert.Equal(ExpectedValue, kernelResult.GetValue<string>());
+        Assert.Equal(ExpectedValue, kernelResult.FunctionResults.Single().GetValue<string>());
+        Assert.Equal(ExpectedValue, kernelResult.FunctionResults.Single().Context.Result);
+    }
+
+    [Fact]
+    public async Task ItReturnsChangedResultsFromFunctionInvokingEventsAsync()
+    {
+        // Arrange
+        var kernel = Kernel.Builder.Build();
+
+        [SKName("Function1")]
+        static string Function1(SKContext context) => context.Variables["injected variable"];
+        var function1 = SKFunction.FromNativeMethod(Method(Function1), pluginName: "MyPlugin");
+        const string ExpectedValue = "injected value";
+
+        kernel.FunctionInvoking += (object? sender, FunctionInvokingEventArgs args) =>
+        {
+            args.SKContext.Variables["injected variable"] = ExpectedValue;
+        };
+
+        // Act
+        var kernelResult = await kernel.RunAsync(function1);
+
+        // Assert
+        Assert.NotNull(kernelResult);
+        Assert.Equal(ExpectedValue, kernelResult.GetValue<string>());
+        Assert.Equal(ExpectedValue, kernelResult.FunctionResults.Single().GetValue<string>());
+        Assert.Equal(ExpectedValue, kernelResult.FunctionResults.Single().Context.Result);
+    }
+
+    [Theory]
+    [InlineData("Function1", 5)]
+    [InlineData("Function2", 1)]
+    public async Task ItRepeatsFunctionInvokedEventsAsync(string retryFunction, int numberOfRepeats)
+    {
+        // Arrange
+        var kernel = Kernel.Builder.Build();
+
+        [SKName("Function1")]
+        static string Function1(SKContext context) => "Result1";
+        var function1 = SKFunction.FromNativeMethod(Method(Function1), pluginName: "MyPlugin");
+
+        [SKName("Function2")]
+        static string Function2(SKContext context) => "Result2";
+        var function2 = SKFunction.FromNativeMethod(Method(Function2), pluginName: "MyPlugin");
+
+        int numberOfInvocations = 0;
+        int repeatCount = 0;
+
+        kernel.FunctionInvoked += (object? sender, FunctionInvokedEventArgs args) =>
+        {
+            if (args.FunctionView.Name == retryFunction && repeatCount < numberOfRepeats)
+            {
+                args.Repeat();
+                repeatCount++;
+            }
+
+            numberOfInvocations++;
+        };
+
+        // Act
+        var kernelResult = await kernel.RunAsync(function1, function2);
+
+        // Assert
+        Assert.NotNull(kernelResult);
+        Assert.Equal(2 + numberOfRepeats, kernelResult.FunctionResults.Count);
+        Assert.Equal(2 + numberOfRepeats, numberOfInvocations);
+    }
+
+    [Theory]
+    [InlineData("Function1", "Result2 Result3")]
+    [InlineData("Function2", "Result1 Result3")]
+    [InlineData("Function3", "Result1 Result2")]
+    public async Task ItSkipsFunctionsFromFunctionInvokingEventsAsync(string skipFunction, string expectedResult)
+    {
+        // Arrange
+        [SKName("Function1")]
+        static string Function1(string input) => input + " Result1";
+
+        [SKName("Function2")]
+        static string Function2(string input) => input + " Result2";
+
+        [SKName("Function3")]
+        static string Function3(string input) => input + " Result3";
+
+        const string PluginName = "MyPlugin";
+
+        var kernel = Kernel.Builder.Build();
+
+        var function1 = SKFunction.FromNativeMethod(Method(Function1), pluginName: PluginName);
+        var function2 = SKFunction.FromNativeMethod(Method(Function2), pluginName: PluginName);
+        var function3 = SKFunction.FromNativeMethod(Method(Function3), pluginName: PluginName);
+
+        const int ExpectedInvocations = 2;
+
+        int numberOfInvocations = 0;
+
+        kernel.FunctionInvoking += (object? sender, FunctionInvokingEventArgs args) =>
+        {
+            if (args.FunctionView.Name == skipFunction)
+            {
+                args.Skip();
+            }
+        };
+
+        kernel.FunctionInvoked += (object? sender, FunctionInvokedEventArgs args) =>
+        {
+            numberOfInvocations++;
+        };
+
+        // Act
+        var kernelResult = await kernel.RunAsync(string.Empty, function1, function2, function3);
+
+        // Assert
+        Assert.NotNull(kernelResult);
+        Assert.Equal(expectedResult, kernelResult.GetValue<string>()!.Trim());
+        Assert.Equal(ExpectedInvocations, numberOfInvocations);
+        Assert.Equal(ExpectedInvocations, kernelResult.FunctionResults.Count);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0)]
+    [InlineData(2, 0, 0)]
+    [InlineData(2, 1, 1)]
+    [InlineData(5, 2, 2)]
+    public async Task ItCancelsPipelineFromFunctionInvokingEventsAsync(int numberOfFunctions, int functionCancelIndex, int expectedInvocations)
+    {
+        List<ISKFunction> functions = new();
+        const string PluginName = "MyPlugin";
+
+        // Arrange
+        [SKName("Function1")]
+        static string Function1() => "Result1";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function1), pluginName: PluginName));
+
+        [SKName("Function2")]
+        static string Function2() => "Result2";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function2), pluginName: PluginName));
+
+        [SKName("Function3")]
+        static string Function3() => "Result3";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function3), pluginName: PluginName));
+
+        [SKName("Function4")]
+        static string Function4() => "Result4";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function4), pluginName: PluginName));
+
+        [SKName("Function5")]
+        static string Function5() => "Result5";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function5), pluginName: PluginName));
+
+        var kernel = Kernel.Builder.Build();
+
+        int numberOfInvocations = 0;
+
+        kernel.FunctionInvoking += (object? sender, FunctionInvokingEventArgs args) =>
+        {
+            if (args.FunctionView.Name == functions[functionCancelIndex].Name)
+            {
+                args.Cancel();
+            }
+        };
+
+        kernel.FunctionInvoked += (object? sender, FunctionInvokedEventArgs args) =>
+        {
+            numberOfInvocations++;
+        };
+
+        // Act
+        var kernelResult = await kernel.RunAsync(functions.Take(numberOfFunctions).ToArray());
+
+        // Assert
+        Assert.NotNull(kernelResult);
+
+        // Kernel result is the same as the last invoked function
+        Assert.Equal(expectedInvocations, numberOfInvocations);
+        Assert.Equal(expectedInvocations, kernelResult.FunctionResults.Count);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(2, 0, 1)]
+    [InlineData(2, 1, 2)]
+    [InlineData(5, 2, 3)]
+    public async Task ItCancelsPipelineFromFunctionInvokedEventsAsync(int numberOfFunctions, int functionCancelIndex, int expectedInvocations)
+    {
+        List<ISKFunction> functions = new();
+        const string PluginName = "MyPlugin";
+
+        // Arrange
+        [SKName("Function1")]
+        static string Function1() => "Result1";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function1), pluginName: PluginName));
+
+        [SKName("Function2")]
+        static string Function2() => "Result2";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function2), pluginName: PluginName));
+
+        [SKName("Function3")]
+        static string Function3() => "Result3";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function3), pluginName: PluginName));
+
+        [SKName("Function4")]
+        static string Function4() => "Result4";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function4), pluginName: PluginName));
+
+        [SKName("Function5")]
+        static string Function5() => "Result5";
+        functions.Add(SKFunction.FromNativeMethod(Method(Function5), pluginName: PluginName));
+
+        var kernel = Kernel.Builder.Build();
+
+        int numberOfInvocations = 0;
+
+        kernel.FunctionInvoked += (object? sender, FunctionInvokedEventArgs args) =>
+        {
+            numberOfInvocations++;
+            if (args.FunctionView.Name == functions[functionCancelIndex].Name)
+            {
+                args.Cancel();
+            }
+        };
+
+        // Act
+        var kernelResult = await kernel.RunAsync(functions.Take(numberOfFunctions).ToArray());
+
+        // Assert
+        Assert.NotNull(kernelResult);
+
+        // Kernel result is the same as the last invoked function
+        Assert.Equal($"Result{functionCancelIndex + 1}", kernelResult.GetValue<string>());
+        Assert.Equal(expectedInvocations, numberOfInvocations);
+    }
+
+    private void Kernel_FunctionInvoked(object? sender, FunctionInvokedEventArgs e)
+    {
+        throw new NotImplementedException();
     }
 
     public class MyPlugin

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -611,11 +611,6 @@ public class KernelTests
         Assert.Equal(expectedInvocations, numberOfInvocations);
     }
 
-    private void Kernel_FunctionInvoked(object? sender, FunctionInvokedEventArgs e)
-    {
-        throw new NotImplementedException();
-    }
-
     public class MyPlugin
     {
         [SKFunction, Description("Return any value.")]


### PR DESCRIPTION
### Motivation and Context

1. One Bug was identified in the Pre/Post Handler examples where the result was not showing properly.
2. Regression introduced where changes made during FunctionInvoked event were not reflecting in the result.
3. Added Unit Tests to unsure expected behavior with events.

### Description

- In `Example57_FunctionEventHandlers.cs`, the `Console.WriteLine` statements that print the function results have been updated to use the `GetValue<string>()` method. This change ensures that the function results are correctly converted to strings before being printed.

- In `Kernel.cs`, a mechanism has been introduced to reflect any changes made to the `SKContext` by invoked handlers in the original function result. This is achieved by creating a new `FunctionResult` instance with the updated `SKContext` and its result.

- New test cases have been added to validate the behavior of the kernel when functions invoked including scenarios where Skip, Repead and Cancel can be triggered from `FunctionInvoking` or `FunctionInvoked` events.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
