### PR TITLE
Java: fixed minRelevance filtering in getNearestMatchesAsync. make getSearc…

### DIFF
--- a/java/connectors/semantickernel-connectors-memory-azurecognitivesearch/src/main/java/com/microsoft/semantickernel/connectors/memory/azurecognitivesearch/AzureCognitiveSearchMemoryStore.java
+++ b/java/connectors/semantickernel-connectors-memory-azurecognitivesearch/src/main/java/com/microsoft/semantickernel/connectors/memory/azurecognitivesearch/AzureCognitiveSearchMemoryStore.java
@@ -215,7 +215,7 @@ public class AzureCognitiveSearchMemoryStore implements MemoryStore {
         SearchOptions searchOptions = new SearchOptions().setVectors(searchVector);
 
         return client.search(null, searchOptions)
-                .filter(result -> (double) minRelevanceScore >= result.getScore())
+                .filter(result -> (double) minRelevanceScore <= result.getScore())
                 .map(
                         result -> {
                             MemoryRecord memoryRecord =
@@ -418,7 +418,7 @@ public class AzureCognitiveSearchMemoryStore implements MemoryStore {
      * @param indexName Index name
      * @return Search client ready to read/write
      */
-    private SearchAsyncClient getSearchClient(@Nonnull String indexName) {
+    protected SearchAsyncClient getSearchClient(@Nonnull String indexName) {
         String normalizedIndexName = normalizeIndexName(indexName);
         return _clientsByIndex.computeIfAbsent(
                 normalizedIndexName, _adminClient::getSearchAsyncClient);


### PR DESCRIPTION
### Motivation and Context
While trying to use current AzureCognitiveSearchMemoryStore I think I found a bug in getNearestMatchesAsynch.
I had to create my own implementation extending this class in order to test it. 
Furthermore It was hard to create a custom implementation as getSearchClient is private and I could not reuse the cognitive search client.
For my custom implementation look here: https://github.com/Azure-Samples/azure-search-openai-demo-java/blob/main/app/backend/src/main/java/com/microsoft/openai/samples/rag/ask/approaches/semantickernel/memory/CustomAzureCognitiveSearchMemoryStore.java


### Description

- fixed minRelevance filtering in getNearestMatchesAsync. 
- make getSearchClient protected to improve extensibility

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
 - Maven build worked locally
- All unit tests passed locally. However I noticed the cognitive search tests are skipped. However the same implementation has been tested in my code repo: https://github.com/Azure-Samples/azure-search-openai-demo-java 

