### PR TITLE
.Net: Update indentation in FunctionViewExtensions

### DIFF
--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
@@ -61,7 +61,7 @@ public sealed class SequentialPlannerTests : IDisposable
     {
         // Arrange
         IKernel kernel = this.InitializeKernel();
-        TestHelpers.ImportSamplePlugins(kernel, "WriterPlugin");
+        TestHelpers.ImportSamplePlugins(kernel, "WriterPlugin", "MiscPlugin");
 
         var planner = new Microsoft.SemanticKernel.Planners.SequentialPlanner(kernel);
 

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.SemanticKernel.Planners;
 using Microsoft.SemanticKernel.Plugins.Memory;
 using SemanticKernel.IntegrationTests.Fakes;
 using SemanticKernel.IntegrationTests.TestSettings;
+using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -55,7 +56,7 @@ public sealed class SequentialPlannerTests : IDisposable
                 step.PluginName.Equals(expectedPlugin, StringComparison.OrdinalIgnoreCase));
     }
 
-    [Theory]
+    [RetryTheory]
     [InlineData("Write a novel about software development that is 3 chapters long.", "NovelOutline", "WriterPlugin", "<!--===ENDPART===-->")]
     public async Task CreatePlanWithDefaultsAsync(string prompt, string expectedFunction, string expectedPlugin, string expectedDefault)
     {
@@ -77,7 +78,7 @@ public sealed class SequentialPlannerTests : IDisposable
                 step.Parameters["endMarker"].Equals(expectedDefault, StringComparison.OrdinalIgnoreCase));
     }
 
-    [Theory]
+    [RetryTheory]
     [InlineData("Write a poem and a joke and send it in an e-mail to Kai.", "SendEmail", FunctionCollection.GlobalFunctionsPluginName)]
     public async Task CreatePlanGoalRelevantAsync(string prompt, string expectedFunction, string expectedPlugin)
     {

--- a/dotnet/src/Planners/Planners.Core/Extensions/FunctionViewExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Extensions/FunctionViewExtensions.cs
@@ -21,13 +21,15 @@ internal static class FunctionViewExtensions
         var inputs = string.Join("\n", function.Parameters.Select(parameter =>
         {
             var defaultValueString = string.IsNullOrEmpty(parameter.DefaultValue) ? string.Empty : $" (default value: {parameter.DefaultValue})";
-            return $"  - {parameter.Name}: {parameter.Description}{defaultValueString}";
+            return $"    - {parameter.Name}: {parameter.Description}{defaultValueString}";
         }));
 
+        // description and inputs are indented by 2 spaces
+        // While each parameter in inputs is indented by 4 spaces
         return $@"{function.ToFullyQualifiedName()}:
   description: {function.Description}
   inputs:
-  {inputs}";
+{inputs}";
     }
 
     /// <summary>

--- a/samples/plugins/MiscPlugin/ElementAtIndex/config.json
+++ b/samples/plugins/MiscPlugin/ElementAtIndex/config.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "description": "Get an element from an array at a specified index",
+  "description": "Get an element from an array or list at a specified index",
   "models": [
     {
       "max_tokens": 1024,
@@ -14,7 +14,7 @@
     "parameters": [
       {
         "name": "input",
-        "description": "The input array",
+        "description": "The input array or list",
         "defaultValue": ""
       },
       {

--- a/samples/skills/MiscSkill/ElementAtIndex/config.json
+++ b/samples/skills/MiscSkill/ElementAtIndex/config.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "description": "Get an element from an array at a specified index",
+  "description": "Get an element from an array or list at a specified index",
   "type": "completion",
   "completion": {
     "max_tokens": 1024,
@@ -13,7 +13,7 @@
     "parameters": [
       {
         "name": "input",
-        "description": "The input array",
+        "description": "The input array or list.",
         "defaultValue": ""
       },
       {


### PR DESCRIPTION
## Summary
This pull request refactors the FunctionViewExtensions.cs file in the Planners.Core.Extensions namespace. The changes include modifying the formatting of the inputs section of the ToManualString method to improve readability.

## Changes
- Modified the formatting of the inputs section of the ToManualString method in the FunctionViewExtensions.cs file to improve readability.

---
*Powered by [Microsoft Semantic Kernel](https://github.com/microsoft/semantic-kernel)*

Adjust the indentation of input parameters in the `FunctionViewExtensions` class to improve readability and maintain consistency in the codebase.

Before:
```text
MiscPlugin.ElementAtIndex:
  description: Get an element from an array at a specified index
  inputs:
    - input: The input array
  - index: The index of the element to retrieve
  - count: The number of items in the input
```

After:
```text
MiscPlugin.ElementAtIndex:
  description: Get an element from an array at a specified index
  inputs:
    - input: The input array
    - index: The index of the element to retrieve
    - count: The number of items in the input
```

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
