### PR TITLE
.Net Returning actual function result

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
@@ -134,7 +134,7 @@ public class LocalExamplePlugin
         var summarizer = context.Functions.GetFunction("SummarizePlugin", "Summarize");
         var summary = await context.Kernel.RunAsync("blah blah blah", summarizer);
 
-        Console.WriteLine($"Running function type 6 [{summary}]");
+        Console.WriteLine($"Running function type 6 [{summary.GetValue<string>()}]");
         return "";
     }
 


### PR DESCRIPTION
### Description

The Example09_FunctionTypes sample is fixed to return actual function value instead of `functionResult` type name.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
