### PR TITLE
.Net: Memory Plugin extraction - Part 2

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Planners;
@@ -298,7 +299,7 @@ internal static class Example12_SequentialPlanner
     {
         var memoryStorage = new VolatileMemoryStore();
 
-        var textEmbeddingGenerator = new Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding.AzureTextEmbeddingGeneration(
+        var textEmbeddingGenerator = new AzureTextEmbeddingGeneration(
             modelId: TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
             endpoint: TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
             apiKey: TestConfiguration.AzureOpenAIEmbeddings.ApiKey);

--- a/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
@@ -149,7 +149,7 @@ internal static class Example12_SequentialPlanner
         Console.WriteLine("======== Sequential Planner - Find and Execute Saved Plan ========");
 
         // Save the plan for future use
-        var semanticMemory = GetMemory();
+        var semanticMemory = InitializeMemory();
         await semanticMemory.SaveInformationAsync(
             "plans",
             id: Guid.NewGuid().ToString(),
@@ -228,7 +228,8 @@ internal static class Example12_SequentialPlanner
     {
         Console.WriteLine("======== Sequential Planner - Create and Execute Plan using Memory ========");
 
-        var kernel = InitializeKernelWithMemory();
+        var kernel = InitializeKernel();
+        var memory = InitializeMemory();
 
         string folder = RepoFiles.SamplePluginsPath();
         kernel.ImportSemanticFunctionsFromDirectory(folder,
@@ -251,7 +252,7 @@ internal static class Example12_SequentialPlanner
         var goal = "Create a book with 3 chapters about a group of kids in a club called 'The Thinking Caps.'";
 
         // IMPORTANT: To use memory and embeddings to find relevant plugins in the planner, set the 'Memory' property on the planner config.
-        var planner = new SequentialPlanner(kernel, new SequentialPlannerConfig { SemanticMemoryConfig = new() { RelevancyThreshold = 0.5, Memory = kernel.Memory } });
+        var planner = new SequentialPlanner(kernel, new SequentialPlannerConfig { SemanticMemoryConfig = new() { RelevancyThreshold = 0.5, Memory = memory } });
 
         var plan = await planner.CreatePlanAsync(goal);
 
@@ -274,7 +275,7 @@ internal static class Example12_SequentialPlanner
         return kernel;
     }
 
-    private static IKernel InitializeKernelWithMemory()
+    private static IKernel InitializeKernel()
     {
         // IMPORTANT: Register an embedding generation service and a memory store. The Planner will
         // use these to generate and store embeddings for the function descriptions.
@@ -288,24 +289,22 @@ internal static class Example12_SequentialPlanner
                 TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
                 TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
                 TestConfiguration.AzureOpenAIEmbeddings.ApiKey)
-            .WithMemoryStorage(new VolatileMemoryStore())
             .Build();
 
         return kernel;
     }
 
-    private static ISemanticTextMemory GetMemory(IKernel? kernel = null)
+    private static SemanticTextMemory InitializeMemory()
     {
-        if (kernel is not null)
-        {
-            return kernel.Memory;
-        }
         var memoryStorage = new VolatileMemoryStore();
+
         var textEmbeddingGenerator = new Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding.AzureTextEmbeddingGeneration(
             modelId: TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
             endpoint: TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
             apiKey: TestConfiguration.AzureOpenAIEmbeddings.ApiKey);
+
         var memory = new SemanticTextMemory(memoryStorage, textEmbeddingGenerator);
+
         return memory;
     }
 

--- a/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI;
 using Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch;
 using Microsoft.SemanticKernel.Memory;

--- a/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Plugins.Memory;
@@ -35,13 +36,19 @@ public static class Example14_SemanticMemory
          * need to worry about embedding generation.
          */
 
-        var kernelWithACS = Kernel.Builder
-            .WithLoggerFactory(ConsoleLogger.LoggerFactory)
+        var kernel = Kernel.Builder
             .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
-            .WithMemoryStorage(new AzureCognitiveSearchMemoryStore(TestConfiguration.ACS.Endpoint, TestConfiguration.ACS.ApiKey))
             .Build();
 
-        await RunExampleAsync(kernelWithACS);
+        var embeddingGeneration = kernel.GetService<ITextEmbeddingGeneration>();
+
+        var memoryWithACS = new MemoryBuilder()
+            .WithLoggerFactory(ConsoleLogger.LoggerFactory)
+            .WithTextEmbeddingGeneration(embeddingGeneration)
+            .WithMemoryStore(new AzureCognitiveSearchMemoryStore(TestConfiguration.ACS.Endpoint, TestConfiguration.ACS.ApiKey))
+            .Build();
+
+        await RunExampleAsync(memoryWithACS);
 
         Console.WriteLine("====================================================");
         Console.WriteLine("======== Semantic Memory (volatile, in RAM) ========");
@@ -56,20 +63,20 @@ public static class Example14_SemanticMemory
          * or implement your connectors for Pinecone, Vespa, Postgres + pgvector, SQLite VSS, etc.
          */
 
-        var kernelWithCustomDb = Kernel.Builder
+        var memoryWithCustomDb = new MemoryBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithOpenAITextEmbeddingGenerationService("ada", "text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
-            .WithMemoryStorage(new VolatileMemoryStore())
+            .WithTextEmbeddingGeneration(embeddingGeneration)
+            .WithMemoryStore(new VolatileMemoryStore())
             .Build();
 
-        await RunExampleAsync(kernelWithCustomDb);
+        await RunExampleAsync(memoryWithCustomDb);
     }
 
-    public static async Task RunExampleAsync(IKernel kernel)
+    public static async Task RunExampleAsync(ISemanticTextMemory memory)
     {
-        await StoreMemoryAsync(kernel);
+        await StoreMemoryAsync(memory);
 
-        await SearchMemoryAsync(kernel, "How do I get started?");
+        await SearchMemoryAsync(memory, "How do I get started?");
 
         /*
         Output:
@@ -86,7 +93,7 @@ public static class Example14_SemanticMemory
 
         */
 
-        await SearchMemoryAsync(kernel, "Can I build a chat with SK?");
+        await SearchMemoryAsync(memory, "Can I build a chat with SK?");
 
         /*
         Output:
@@ -104,26 +111,26 @@ public static class Example14_SemanticMemory
         */
     }
 
-    private static async Task SearchMemoryAsync(IKernel kernel, string query)
+    private static async Task SearchMemoryAsync(ISemanticTextMemory memory, string query)
     {
         Console.WriteLine("\nQuery: " + query + "\n");
 
-        var memories = kernel.Memory.SearchAsync(MemoryCollectionName, query, limit: 2, minRelevanceScore: 0.5);
+        var memoryResults = memory.SearchAsync(MemoryCollectionName, query, limit: 2, minRelevanceScore: 0.5);
 
         int i = 0;
-        await foreach (MemoryQueryResult memory in memories)
+        await foreach (MemoryQueryResult memoryResult in memoryResults)
         {
             Console.WriteLine($"Result {++i}:");
-            Console.WriteLine("  URL:     : " + memory.Metadata.Id);
-            Console.WriteLine("  Title    : " + memory.Metadata.Description);
-            Console.WriteLine("  Relevance: " + memory.Relevance);
+            Console.WriteLine("  URL:     : " + memoryResult.Metadata.Id);
+            Console.WriteLine("  Title    : " + memoryResult.Metadata.Description);
+            Console.WriteLine("  Relevance: " + memoryResult.Relevance);
             Console.WriteLine();
         }
 
         Console.WriteLine("----------------------");
     }
 
-    private static async Task StoreMemoryAsync(IKernel kernel)
+    private static async Task StoreMemoryAsync(ISemanticTextMemory memory)
     {
         /* Store some data in the semantic memory.
          *
@@ -138,7 +145,7 @@ public static class Example14_SemanticMemory
         var i = 0;
         foreach (var entry in githubFiles)
         {
-            await kernel.Memory.SaveReferenceAsync(
+            await memory.SaveReferenceAsync(
                 collection: MemoryCollectionName,
                 externalSourceName: "GitHub",
                 externalId: entry.Key,

--- a/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI;
 using Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch;
 using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Plugins.Memory;
@@ -36,15 +37,9 @@ public static class Example14_SemanticMemory
          * need to worry about embedding generation.
          */
 
-        var kernel = Kernel.Builder
-            .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
-            .Build();
-
-        var embeddingGeneration = kernel.GetService<ITextEmbeddingGeneration>();
-
         var memoryWithACS = new MemoryBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithTextEmbeddingGeneration(embeddingGeneration)
+            .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
             .WithMemoryStore(new AzureCognitiveSearchMemoryStore(TestConfiguration.ACS.Endpoint, TestConfiguration.ACS.ApiKey))
             .Build();
 
@@ -65,7 +60,7 @@ public static class Example14_SemanticMemory
 
         var memoryWithCustomDb = new MemoryBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithTextEmbeddingGeneration(embeddingGeneration)
+            .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
             .WithMemoryStore(new VolatileMemoryStore())
             .Build();
 

--- a/dotnet/samples/KernelSyntaxExamples/Example15_TextMemoryPlugin.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example15_TextMemoryPlugin.cs
@@ -152,7 +152,7 @@ public static class Example15_TextMemoryPlugin
 
         // The combination of the text embedding generator and the memory store makes up the 'SemanticTextMemory' object used to
         // store and retrieve memories.
-        using SemanticTextMemory textMemory = new(memoryStore, embeddingGenerator);
+        SemanticTextMemory textMemory = new(memoryStore, embeddingGenerator);
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////
         // PART 1: Store and retrieve memories using the ISemanticTextMemory (textMemory) object.

--- a/dotnet/samples/KernelSyntaxExamples/Example31_CustomPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example31_CustomPlanner.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.XPath;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI;
+using Microsoft.SemanticKernel.Memory;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
@@ -24,16 +26,17 @@ internal static class Example31_CustomPlanner
     {
         Console.WriteLine("======== Custom Planner - Create and Execute Markup Plan ========");
         IKernel kernel = InitializeKernel();
+        ISemanticTextMemory memory = InitializeMemory();
 
         // ContextQuery is part of the QAPlugin
         IDictionary<string, ISKFunction> qaPlugin = LoadQAPlugin(kernel);
         SKContext context = CreateContextQueryContext(kernel);
 
         // Create a memory store using the VolatileMemoryStore and the embedding generator registered in the kernel
-        kernel.ImportFunctions(new TextMemoryPlugin(kernel.Memory));
+        kernel.ImportFunctions(new TextMemoryPlugin(memory));
 
         // Setup defined memories for recall
-        await RememberFactsAsync(kernel);
+        await RememberFactsAsync(kernel, memory);
 
         // MarkupPlugin named "markup"
         var markup = kernel.ImportFunctions(new MarkupPlugin(), "markup");
@@ -85,9 +88,9 @@ internal static class Example31_CustomPlanner
         return context;
     }
 
-    private static async Task RememberFactsAsync(IKernel kernel)
+    private static async Task RememberFactsAsync(IKernel kernel, ISemanticTextMemory memory)
     {
-        kernel.ImportFunctions(new TextMemoryPlugin(kernel.Memory));
+        kernel.ImportFunctions(new TextMemoryPlugin(memory));
 
         List<string> memoriesToSave = new()
         {
@@ -105,7 +108,7 @@ internal static class Example31_CustomPlanner
 
         foreach (var memoryToSave in memoriesToSave)
         {
-            await kernel.Memory.SaveInformationAsync("contextQueryMemories", memoryToSave, Guid.NewGuid().ToString());
+            await memory.SaveInformationAsync("contextQueryMemories", memoryToSave, Guid.NewGuid().ToString());
         }
     }
 
@@ -136,7 +139,18 @@ internal static class Example31_CustomPlanner
                 TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
-            .WithMemoryStorage(new VolatileMemoryStore())
+            .Build();
+    }
+
+    private static ISemanticTextMemory InitializeMemory()
+    {
+        return new MemoryBuilder()
+            .WithLoggerFactory(ConsoleLogger.LoggerFactory)
+            .WithAzureTextEmbeddingGenerationService(
+                TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
+                TestConfiguration.AzureOpenAI.Endpoint,
+                TestConfiguration.AzureOpenAI.ApiKey)
+            .WithMemoryStore(new VolatileMemoryStore())
             .Build();
     }
 }

--- a/dotnet/samples/KernelSyntaxExamples/Example42_KernelBuilder.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example42_KernelBuilder.cs
@@ -78,7 +78,8 @@ public static class Example42_KernelBuilder
             endpoint: azureOpenAIEndpoint,
             apiKey: azureOpenAIKey,
             loggerFactory: loggerFactory);
-        using var memory = new SemanticTextMemory(memoryStorage, textEmbeddingGenerator);
+
+        var memory = new SemanticTextMemory(memoryStorage, textEmbeddingGenerator);
         var plugins = new FunctionCollection();
         var templateEngine = new PromptTemplateEngine(loggerFactory);
 
@@ -103,30 +104,6 @@ public static class Example42_KernelBuilder
         // ==========================================================================================================
         // The kernel builder purpose is to simplify this process, automating how dependencies
         // are connected, still allowing to customize parts of the composition.
-
-        // Example: how to use a custom memory and configure Azure OpenAI
-        var kernel4 = Kernel.Builder
-            .WithLoggerFactory(NullLoggerFactory.Instance)
-            .WithMemory(memory)
-            .WithAzureChatCompletionService(
-                deploymentName: azureOpenAIChatCompletionDeployment,
-                endpoint: azureOpenAIEndpoint,
-                apiKey: azureOpenAIKey)
-            .Build();
-
-        // Example: how to use a custom memory storage
-        var kernel6 = Kernel.Builder
-            .WithLoggerFactory(NullLoggerFactory.Instance)
-            .WithMemoryStorage(memoryStorage) // Custom memory storage
-            .WithAzureChatCompletionService(
-                deploymentName: azureOpenAIChatCompletionDeployment,
-                endpoint: azureOpenAIEndpoint,
-                apiKey: azureOpenAIKey) // This will be used when using AI completions
-            .WithAzureTextEmbeddingGenerationService(
-                deploymentName: azureOpenAIEmbeddingDeployment,
-                endpoint: azureOpenAIEndpoint,
-                apiKey: azureOpenAIKey) // This will be used when indexing memory records
-            .Build();
 
         // ==========================================================================================================
         // The AI services are defined with the builder

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/Connectors.AI.OpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/Connectors.AI.OpenAI.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Plugins.Memory\Plugins.Memory.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIMemoryBuilderExtensions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Net.Http;
 using Azure.Core;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
-using System.Net.Http;
 using Microsoft.SemanticKernel.Plugins.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI;

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIMemoryBuilderExtensions.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Azure.Core;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
+using System.Net.Http;
+using Microsoft.SemanticKernel.Plugins.Memory;
+
+namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI;
+
+/// <summary>
+/// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure OpenAI and AzureOpenAI connectors.
+/// </summary>
+public static class OpenAIMemoryBuilderExtensions
+{
+    /// <summary>
+    /// Adds an Azure OpenAI text embeddings service.
+    /// See https://learn.microsoft.com/azure/cognitive-services/openai for service details.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <returns>Self instance</returns>
+    public static MemoryBuilder WithAzureTextEmbeddingGenerationService(
+        this MemoryBuilder builder,
+        string deploymentName,
+        string endpoint,
+        string apiKey,
+        string? serviceId = null,
+        bool setAsDefault = false,
+        HttpClient? httpClient = null)
+    {
+        builder.WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
+            new AzureTextEmbeddingGeneration(
+                deploymentName,
+                endpoint,
+                apiKey,
+                HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),
+                loggerFactory));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an Azure OpenAI text embeddings service.
+    /// See https://learn.microsoft.com/azure/cognitive-services/openai for service details.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="credential">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <returns>Self instance</returns>
+    public static MemoryBuilder WithAzureTextEmbeddingGenerationService(
+        this MemoryBuilder builder,
+        string deploymentName,
+        string endpoint,
+        TokenCredential credential,
+        string? serviceId = null,
+        bool setAsDefault = false,
+        HttpClient? httpClient = null)
+    {
+        builder.WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
+            new AzureTextEmbeddingGeneration(
+                deploymentName,
+                endpoint,
+                credential,
+                HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),
+                loggerFactory));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the OpenAI text embeddings service.
+    /// See https://platform.openai.com/docs for service details.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance</param>
+    /// <param name="modelId">OpenAI model name, see https://platform.openai.com/docs/models</param>
+    /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
+    /// <param name="orgId">OpenAI organization id. This is usually optional unless your account belongs to multiple organizations.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <returns>Self instance</returns>
+    public static MemoryBuilder WithOpenAITextEmbeddingGenerationService(
+        this MemoryBuilder builder,
+        string modelId,
+        string apiKey,
+        string? orgId = null,
+        string? serviceId = null,
+        bool setAsDefault = false,
+        HttpClient? httpClient = null)
+    {
+        builder.WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
+            new OpenAITextEmbeddingGeneration(
+                modelId,
+                apiKey,
+                orgId,
+                HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),
+                loggerFactory));
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaKernelBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Connectors.Memory.Chroma;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaKernelBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Chroma memory connector.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use ChromaMemoryBuilderExtensions instead.")]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class ChromaKernelBuilderExtensions
 {
@@ -22,7 +22,7 @@ public static class ChromaKernelBuilderExtensions
     /// <param name="builder">The <see cref="KernelBuilder"/> instance.</param>
     /// <param name="endpoint">Chroma server endpoint URL.</param>
     /// <returns>Self instance.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use ChromaMemoryBuilderExtensions.WithChromaMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithChromaMemoryStore(this KernelBuilder builder, string endpoint)
     {
@@ -44,7 +44,7 @@ public static class ChromaKernelBuilderExtensions
     /// <param name="httpClient">The <see cref="HttpClient"/> instance used for making HTTP requests.</param>
     /// <param name="endpoint">Chroma server endpoint URL. If not specified, the base address of the HTTP client is used.</param>
     /// <returns>Self instance.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use ChromaMemoryBuilderExtensions.WithChromaMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithChromaMemoryStore(this KernelBuilder builder,
         HttpClient httpClient,

--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaKernelBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ComponentModel;
+using System;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Connectors.Memory.Chroma;
 
@@ -10,6 +12,8 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Chroma memory connector.
 /// </summary>
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class ChromaKernelBuilderExtensions
 {
     /// <summary>
@@ -18,6 +22,8 @@ public static class ChromaKernelBuilderExtensions
     /// <param name="builder">The <see cref="KernelBuilder"/> instance.</param>
     /// <param name="endpoint">Chroma server endpoint URL.</param>
     /// <returns>Self instance.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithChromaMemoryStore(this KernelBuilder builder, string endpoint)
     {
         builder.WithMemoryStorage((loggerFactory, httpHandlerFactory) =>
@@ -38,6 +44,8 @@ public static class ChromaKernelBuilderExtensions
     /// <param name="httpClient">The <see cref="HttpClient"/> instance used for making HTTP requests.</param>
     /// <param name="endpoint">Chroma server endpoint URL. If not specified, the base address of the HTTP client is used.</param>
     /// <returns>Self instance.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithChromaMemoryStore(this KernelBuilder builder,
         HttpClient httpClient,
         string? endpoint = null)

--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/ChromaMemoryBuilderExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Net.Http;
+using Microsoft.SemanticKernel.Plugins.Memory;
+
+namespace Microsoft.SemanticKernel.Connectors.Memory.Chroma;
+
+/// <summary>
+/// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Chroma memory connector.
+/// </summary>
+public static class ChromaMemoryBuilderExtensions
+{
+    /// <summary>
+    /// Registers Chroma memory connector.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
+    /// <param name="endpoint">Chroma server endpoint URL.</param>
+    /// <returns>Updated Memory builder including Chroma memory connector.</returns>
+    public static MemoryBuilder WithChromaMemoryStore(this MemoryBuilder builder, string endpoint)
+    {
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
+        {
+            return new ChromaMemoryStore(
+                HttpClientProvider.GetHttpClient(httpHandlerFactory, null, loggerFactory),
+                endpoint,
+                loggerFactory);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers Chroma memory connector.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
+    /// <param name="httpClient">The <see cref="HttpClient"/> instance used for making HTTP requests.</param>
+    /// <param name="endpoint">Chroma server endpoint URL. If not specified, the base address of the HTTP client is used.</param>
+    /// <returns>Updated Memory builder including Chroma memory connector.</returns>
+    public static MemoryBuilder WithChromaMemoryStore(
+        this MemoryBuilder builder,
+        HttpClient httpClient,
+        string? endpoint = null)
+    {
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
+        {
+            return new ChromaMemoryStore(
+                HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),
+                endpoint,
+                loggerFactory);
+        });
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/Connectors.Memory.Chroma.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/Connectors.Memory.Chroma.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Plugins.Memory\Plugins.Memory.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Connectors.Memory.Pinecone.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Connectors.Memory.Pinecone.csproj
@@ -22,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\Plugins\Plugins.Memory\Plugins.Memory.csproj" />
         <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
     </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ComponentModel;
+using System;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Connectors.Memory.Pinecone;
 
@@ -10,6 +12,8 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Pinecone connectors.
 /// </summary>
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class PineconeKernelBuilderExtensions
 {
     /// <summary>
@@ -20,6 +24,8 @@ public static class PineconeKernelBuilderExtensions
     /// <param name="apiKey">The API key for accessing Pinecone services.</param>
     /// <param name="httpClient">An optional HttpClient instance for making HTTP requests.</param>
     /// <returns>Self instance</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPineconeMemoryStore(this KernelBuilder builder,
         string environment,
         string apiKey,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Pinecone connectors.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use PineconeMemoryBuilderExtensions instead.")]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class PineconeKernelBuilderExtensions
 {
@@ -24,7 +24,7 @@ public static class PineconeKernelBuilderExtensions
     /// <param name="apiKey">The API key for accessing Pinecone services.</param>
     /// <param name="httpClient">An optional HttpClient instance for making HTTP requests.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use PineconeMemoryBuilderExtensions.WithPineconeMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPineconeMemoryStore(this KernelBuilder builder,
         string environment,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Connectors.Memory.Pinecone;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryBuilderExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Net.Http;
+using Microsoft.SemanticKernel.Plugins.Memory;
+
+namespace Microsoft.SemanticKernel.Connectors.Memory.Pinecone;
+
+/// <summary>
+/// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Pinecone connector.
+/// </summary>
+public static class PineconeMemoryBuilderExtensions
+{
+    /// <summary>
+    /// Registers Pinecone memory connector.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
+    /// <param name="environment">The environment for Pinecone.</param>
+    /// <param name="apiKey">The API key for accessing Pinecone services.</param>
+    /// <param name="httpClient">An optional HttpClient instance for making HTTP requests.</param>
+    /// <returns>Updated Memory builder including Pinecone memory connector.</returns>
+    public static MemoryBuilder WithPineconeMemoryStore(
+        this MemoryBuilder builder,
+        string environment,
+        string apiKey,
+        HttpClient? httpClient = null)
+    {
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
+        {
+            var client = new PineconeClient(
+                environment,
+                apiKey,
+                loggerFactory,
+                HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory));
+
+            return new PineconeMemoryStore(client, loggerFactory);
+        });
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Plugins.Memory\Plugins.Memory.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresKernelBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using Microsoft.SemanticKernel.Connectors.Memory.Postgres;
 using Npgsql;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresKernelBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ComponentModel;
+using System;
 using Microsoft.SemanticKernel.Connectors.Memory.Postgres;
 using Npgsql;
 
@@ -10,6 +12,8 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Postgres connectors.
 /// </summary>
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class PostgresKernelBuilderExtensions
 {
     /// <summary>
@@ -20,6 +24,8 @@ public static class PostgresKernelBuilderExtensions
     /// <param name="vectorSize">Embedding vector size.</param>
     /// <param name="schema">Schema of collection tables.</param>
     /// <returns>Self instance</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPostgresMemoryStore(this KernelBuilder builder,
         string connectionString,
         int vectorSize,
@@ -41,6 +47,8 @@ public static class PostgresKernelBuilderExtensions
     /// <param name="vectorSize">Embedding vector size.</param>
     /// <param name="schema">Schema of collection tables.</param>
     /// <returns>Self instance</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPostgresMemoryStore(this KernelBuilder builder,
         NpgsqlDataSource dataSource,
         int vectorSize,
@@ -60,6 +68,8 @@ public static class PostgresKernelBuilderExtensions
     /// <param name="builder">The <see cref="KernelBuilder"/> instance</param>
     /// <param name="postgresDbClient">Postgres database client.</param>
     /// <returns>Self instance</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPostgresMemoryStore(this KernelBuilder builder, IPostgresDbClient postgresDbClient)
     {
         builder.WithMemoryStorage((loggerFactory) =>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresKernelBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Postgres connectors.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use PostgresMemoryBuilderExtensions instead.")]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class PostgresKernelBuilderExtensions
 {
@@ -24,7 +24,7 @@ public static class PostgresKernelBuilderExtensions
     /// <param name="vectorSize">Embedding vector size.</param>
     /// <param name="schema">Schema of collection tables.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use PostgresMemoryBuilderExtensions.WithPostgresMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPostgresMemoryStore(this KernelBuilder builder,
         string connectionString,
@@ -47,7 +47,7 @@ public static class PostgresKernelBuilderExtensions
     /// <param name="vectorSize">Embedding vector size.</param>
     /// <param name="schema">Schema of collection tables.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use PostgresMemoryBuilderExtensions.WithPostgresMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPostgresMemoryStore(this KernelBuilder builder,
         NpgsqlDataSource dataSource,
@@ -68,7 +68,7 @@ public static class PostgresKernelBuilderExtensions
     /// <param name="builder">The <see cref="KernelBuilder"/> instance</param>
     /// <param name="postgresDbClient">Postgres database client.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use PostgresMemoryBuilderExtensions.WithPostgresMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithPostgresMemoryStore(this KernelBuilder builder, IPostgresDbClient postgresDbClient)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Plugins.Memory;
+using Npgsql;
+
+namespace Microsoft.SemanticKernel.Connectors.Memory.Postgres;
+
+/// <summary>
+/// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Postgres connector.
+/// </summary>
+public static class PostgresMemoryBuilderExtensions
+{
+    /// <summary>
+    /// Registers Postgres memory connector.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
+    /// <param name="connectionString">Postgres database connection string.</param>
+    /// <param name="vectorSize">Embedding vector size.</param>
+    /// <param name="schema">Schema of collection tables.</param>
+    /// <returns>Updated Memory builder including Postgres memory connector.</returns>
+    public static MemoryBuilder WithPostgresMemoryStore(
+        this MemoryBuilder builder,
+        string connectionString,
+        int vectorSize,
+        string schema = PostgresMemoryStore.DefaultSchema)
+    {
+        builder.WithMemoryStore((_) =>
+        {
+            return new PostgresMemoryStore(connectionString, vectorSize, schema);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers Postgres memory connector.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
+    /// <param name="dataSource">Postgres data source.</param>
+    /// <param name="vectorSize">Embedding vector size.</param>
+    /// <param name="schema">Schema of collection tables.</param>
+    /// <returns>Updated Memory builder including Postgres memory connector.</returns>
+    public static MemoryBuilder WithPostgresMemoryStore(
+        this MemoryBuilder builder,
+        NpgsqlDataSource dataSource,
+        int vectorSize,
+        string schema = PostgresMemoryStore.DefaultSchema)
+    {
+        builder.WithMemoryStore((_) =>
+        {
+            return new PostgresMemoryStore(dataSource, vectorSize, schema);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers Postgres memory connector.
+    /// </summary>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
+    /// <param name="postgresDbClient">Postgres database client.</param>
+    /// <returns>Updated Memory builder including Postgres memory connector.</returns>
+    public static MemoryBuilder WithPostgresMemoryStore(
+        this MemoryBuilder builder,
+        IPostgresDbClient postgresDbClient)
+    {
+        builder.WithMemoryStore((_) =>
+        {
+            return new PostgresMemoryStore(postgresDbClient);
+        });
+
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Plugins.Memory\Plugins.Memory.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Qdrant memory connector.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use QdrantMemoryBuilderExtensions instead.")]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class QdrantKernelBuilderExtensions
 {
@@ -23,7 +23,7 @@ public static class QdrantKernelBuilderExtensions
     /// <param name="endpoint">The Qdrant Vector Database endpoint.</param>
     /// <param name="vectorSize">The size of the vectors.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use QdrantMemoryBuilderExtensions.WithQdrantMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithQdrantMemoryStore(this KernelBuilder builder,
         string endpoint,
@@ -51,7 +51,7 @@ public static class QdrantKernelBuilderExtensions
     /// <param name="vectorSize">The size of the vectors.</param>
     /// <param name="endpoint">The Qdrant Vector Database endpoint. If not specified, the base address of the HTTP client is used.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use QdrantMemoryBuilderExtensions.WithQdrantMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithQdrantMemoryStore(this KernelBuilder builder,
         HttpClient httpClient,

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryBuilderExtensions.cs
@@ -1,35 +1,28 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
-using System;
 using System.Net.Http;
-using Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
+using Microsoft.SemanticKernel.Plugins.Memory;
 
-#pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel;
-#pragma warning restore IDE0130
+namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
 
 /// <summary>
-/// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Qdrant memory connector.
+/// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Qdrant connector.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class QdrantKernelBuilderExtensions
+public static class QdrantMemoryBuilderExtensions
 {
     /// <summary>
     /// Registers Qdrant memory connector.
     /// </summary>
-    /// <param name="builder">The <see cref="KernelBuilder"/> instance.</param>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
     /// <param name="endpoint">The Qdrant Vector Database endpoint.</param>
     /// <param name="vectorSize">The size of the vectors.</param>
-    /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static KernelBuilder WithQdrantMemoryStore(this KernelBuilder builder,
+    /// <returns>Updated Memory builder including Qdrant memory connector.</returns>
+    public static MemoryBuilder WithQdrantMemoryStore(
+        this MemoryBuilder builder,
         string endpoint,
         int vectorSize)
     {
-        builder.WithMemoryStorage((loggerFactory, httpHandlerFactory) =>
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
         {
             var client = new QdrantVectorDbClient(
                 HttpClientProvider.GetHttpClient(httpHandlerFactory, null, loggerFactory),
@@ -46,19 +39,18 @@ public static class QdrantKernelBuilderExtensions
     /// <summary>
     /// Registers Qdrant memory connector.
     /// </summary>
-    /// <param name="builder">The <see cref="KernelBuilder"/> instance</param>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
     /// <param name="httpClient">The optional <see cref="HttpClient"/> instance used for making HTTP requests.</param>
     /// <param name="vectorSize">The size of the vectors.</param>
     /// <param name="endpoint">The Qdrant Vector Database endpoint. If not specified, the base address of the HTTP client is used.</param>
-    /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static KernelBuilder WithQdrantMemoryStore(this KernelBuilder builder,
+    /// <returns>Updated Memory builder including Qdrant memory connector.</returns>
+    public static MemoryBuilder WithQdrantMemoryStore(
+        this MemoryBuilder builder,
         HttpClient httpClient,
         int vectorSize,
         string? endpoint = null)
     {
-        builder.WithMemoryStorage((loggerFactory, httpHandlerFactory) =>
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
         {
             var client = new QdrantVectorDbClient(
                 HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Connectors.Memory.Weaviate.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Connectors.Memory.Weaviate.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Plugins.Memory\Plugins.Memory.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Connectors.Memory.Weaviate;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Weaviate memory connector.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use WeaviateMemoryBuilderExtensions instead.")]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class WeaviateKernelBuilderExtensions
 {
@@ -24,7 +24,7 @@ public static class WeaviateKernelBuilderExtensions
     /// <param name="apiKey">The API key for accessing Weaviate server.</param>
     /// <param name="apiVersion">The API version to use.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use WeaviateMemoryBuilderExtensions.WithWeaviateMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithWeaviateMemoryStore(
         this KernelBuilder builder,
@@ -54,7 +54,7 @@ public static class WeaviateKernelBuilderExtensions
     /// <param name="apiKey">The API key for accessing Weaviate server.</param>
     /// <param name="apiVersion">The API version to use.</param>
     /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. Use WeaviateMemoryBuilderExtensions.WithWeaviateMemoryStore instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static KernelBuilder WithWeaviateMemoryStore(this KernelBuilder builder,
         HttpClient httpClient,

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
@@ -1,38 +1,30 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
-using System;
 using System.Net.Http;
-using Microsoft.SemanticKernel.Connectors.Memory.Weaviate;
+using Microsoft.SemanticKernel.Plugins.Memory;
 
-#pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel;
-#pragma warning restore IDE0130
+namespace Microsoft.SemanticKernel.Connectors.Memory.Weaviate;
 
 /// <summary>
-/// Provides extension methods for the <see cref="KernelBuilder"/> class to configure Weaviate memory connector.
+/// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Weaviate connector.
 /// </summary>
-[Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class WeaviateKernelBuilderExtensions
+public static class WeaviateMemoryBuilderExtensions
 {
     /// <summary>
     /// Registers Weaviate memory connector.
     /// </summary>
-    /// <param name="builder">The <see cref="KernelBuilder"/> instance.</param>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
     /// <param name="endpoint">The Weaviate server endpoint URL.</param>
     /// <param name="apiKey">The API key for accessing Weaviate server.</param>
     /// <param name="apiVersion">The API version to use.</param>
-    /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static KernelBuilder WithWeaviateMemoryStore(
-        this KernelBuilder builder,
+    /// <returns>Updated Memory builder including Weaviate memory connector.</returns>
+    public static MemoryBuilder WithWeaviateMemoryStore(
+        this MemoryBuilder builder,
         string endpoint,
         string? apiKey,
         string? apiVersion = null)
     {
-        builder.WithMemoryStorage((loggerFactory, httpHandlerFactory) =>
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
         {
             return new WeaviateMemoryStore(
                 HttpClientProvider.GetHttpClient(httpHandlerFactory, null, loggerFactory),
@@ -48,21 +40,20 @@ public static class WeaviateKernelBuilderExtensions
     /// <summary>
     /// Registers Weaviate memory connector.
     /// </summary>
-    /// <param name="builder">The <see cref="KernelBuilder"/> instance</param>
+    /// <param name="builder">The <see cref="MemoryBuilder"/> instance.</param>
     /// <param name="httpClient">The optional <see cref="HttpClient"/> instance used for making HTTP requests.</param>
     /// <param name="endpoint">The Weaviate server endpoint URL. If not specified, the base address of the HTTP client is used.</param>
     /// <param name="apiKey">The API key for accessing Weaviate server.</param>
     /// <param name="apiVersion">The API version to use.</param>
-    /// <returns>Self instance</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static KernelBuilder WithWeaviateMemoryStore(this KernelBuilder builder,
+    /// <returns>Updated Memory builder including Weaviate memory connector.</returns>
+    public static MemoryBuilder WithWeaviateMemoryStore(
+        this MemoryBuilder builder,
         HttpClient httpClient,
         string? endpoint = null,
         string? apiKey = null,
         string? apiVersion = null)
     {
-        builder.WithMemoryStorage((loggerFactory, httpHandlerFactory) =>
+        builder.WithMemoryStore((loggerFactory, httpHandlerFactory) =>
         {
             return new WeaviateMemoryStore(
                 HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel;
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-using System;
-using Xunit;
-using Microsoft.SemanticKernel.Plugins.Memory;
-using Microsoft.SemanticKernel.Connectors.Memory.Pinecone;
-using Moq;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Connectors.Memory.Pinecone;
+using Microsoft.SemanticKernel.Plugins.Memory;
+using Moq;
+using Xunit;
 
 namespace SemanticKernel.Connectors.UnitTests.Memory.Pinecone;
 

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
@@ -1,22 +1,26 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
+using Microsoft.SemanticKernel;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel;
+using System;
 using Xunit;
+using Microsoft.SemanticKernel.Plugins.Memory;
+using Microsoft.SemanticKernel.Connectors.Memory.Pinecone;
+using Moq;
+using Microsoft.SemanticKernel.AI.Embeddings;
 
 namespace SemanticKernel.Connectors.UnitTests.Memory.Pinecone;
 
-public sealed class PineconeKernelBuilderExtensionsTests : IDisposable
+public sealed class PineconeMemoryBuilderExtensionsTests : IDisposable
 {
     private readonly HttpMessageHandlerStub _messageHandlerStub;
     private readonly HttpClient _httpClient;
 
-    public PineconeKernelBuilderExtensionsTests()
+    public PineconeMemoryBuilderExtensionsTests()
     {
         this._messageHandlerStub = new HttpMessageHandlerStub();
 
@@ -26,22 +30,20 @@ public sealed class PineconeKernelBuilderExtensionsTests : IDisposable
     [Fact]
     public async Task PineconeMemoryStoreShouldBeProperlyInitializedAsync()
     {
-        //Arrange
+        // Arrange
+        var embeddingGenerationMock = Mock.Of<ITextEmbeddingGeneration>();
         this._messageHandlerStub.ResponseToReturn.Content = new StringContent("[\"fake-index1\"]", Encoding.UTF8, MediaTypeNames.Application.Json);
 
-        var builder = new KernelBuilder();
-#pragma warning disable CS0618 // This will be removed in a future release.
+        var builder = new MemoryBuilder();
         builder.WithPineconeMemoryStore("fake-environment", "fake-api-key", this._httpClient);
-#pragma warning restore CS0618 // This will be removed in a future release.
-        builder.WithAzureTextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-test-host/fake-path", "fake -api-key");
-        var kernel = builder.Build(); //This call triggers the internal factory registered by WithPineconeMemoryStore method to create an instance of the PineconeMemoryStore class.
+        builder.WithTextEmbeddingGeneration(embeddingGenerationMock);
 
-        //Act
-#pragma warning disable CS0618 // This will be removed in a future release.
-        await kernel.Memory.GetCollectionsAsync(); //This call triggers a subsequent call to Pinecone memory store.
-#pragma warning restore CS0618 // This will be removed in a future release.
+        var memory = builder.Build(); //This call triggers the internal factory registered by WithPineconeMemoryStore method to create an instance of the PineconeMemoryStore class.
 
-        //Assert
+        // Act
+        await memory.GetCollectionsAsync(); //This call triggers a subsequent call to Pinecone memory store.
+
+        // Assert
         Assert.Equal("https://controller.fake-environment.pinecone.io/databases", this._messageHandlerStub?.RequestUri?.AbsoluteUri);
 
         var headerValues = Enumerable.Empty<string>();

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryBuilderExtensionsTests.cs
@@ -6,16 +6,20 @@ using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Connectors.Memory.Qdrant;
+using Microsoft.SemanticKernel.Plugins.Memory;
+using Moq;
 using Xunit;
 
 namespace SemanticKernel.Connectors.UnitTests.Memory.Qdrant;
 
-public sealed class QdrantKernelBuilderExtensionsTests : IDisposable
+public sealed class QdrantMemoryBuilderExtensionsTests : IDisposable
 {
     private readonly HttpMessageHandlerStub _messageHandlerStub;
     private readonly HttpClient _httpClient;
 
-    public QdrantKernelBuilderExtensionsTests()
+    public QdrantMemoryBuilderExtensionsTests()
     {
         this._messageHandlerStub = new HttpMessageHandlerStub();
 
@@ -25,23 +29,21 @@ public sealed class QdrantKernelBuilderExtensionsTests : IDisposable
     [Fact]
     public async Task QdrantMemoryStoreShouldBeProperlyInitializedAsync()
     {
-        //Arrange
+        // Arrange
+        var embeddingGenerationMock = Mock.Of<ITextEmbeddingGeneration>();
+
         this._httpClient.BaseAddress = new Uri("https://fake-random-qdrant-host");
         this._messageHandlerStub.ResponseToReturn.Content = new StringContent("{\"result\":{\"collections\":[]}}", Encoding.UTF8, MediaTypeNames.Application.Json);
 
-        var builder = new KernelBuilder();
-#pragma warning disable CS0618 // This will be removed in a future release.
+        var builder = new MemoryBuilder();
         builder.WithQdrantMemoryStore(this._httpClient, 123);
-#pragma warning restore CS0618 // This will be removed in a future release.
-        builder.WithAzureTextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-text-embedding-generation-host/fake-path", "fake-api-key");
-        var kernel = builder.Build(); //This call triggers the internal factory registered by WithQdrantMemoryStore method to create an instance of the QdrantMemoryStore class.
+        builder.WithTextEmbeddingGeneration(embeddingGenerationMock);
+        var memory = builder.Build(); //This call triggers the internal factory registered by WithQdrantMemoryStore method to create an instance of the QdrantMemoryStore class.
 
-        //Act
-#pragma warning disable CS0618 // This will be removed in a future release.
-        await kernel.Memory.GetCollectionsAsync(); //This call triggers a subsequent call to Qdrant memory store.
-#pragma warning restore CS0618 // This will be removed in a future release.
+        // Act
+        await memory.GetCollectionsAsync(); //This call triggers a subsequent call to Qdrant memory store.
 
-        //Assert
+        // Assert
         Assert.Equal("https://fake-random-qdrant-host/collections", this._messageHandlerStub?.RequestUri?.AbsoluteUri);
     }
 

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryBuilderExtensionsTests.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
-using System.Text.Json;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
-using System;
-using Xunit;
-using Microsoft.SemanticKernel.Plugins.Memory;
-using Microsoft.SemanticKernel.Connectors.Memory.Weaviate;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Connectors.Memory.Weaviate;
+using Microsoft.SemanticKernel.Plugins.Memory;
 using Moq;
+using Xunit;
 
 namespace SemanticKernel.Connectors.UnitTests.Memory.Weaviate;
 

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryBuilderExtensionsTests.cs
@@ -1,24 +1,28 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
+using Microsoft.SemanticKernel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
-using System.Text;
 using System.Text.Json;
+using System.Text;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel;
+using System;
 using Xunit;
+using Microsoft.SemanticKernel.Plugins.Memory;
+using Microsoft.SemanticKernel.Connectors.Memory.Weaviate;
+using Microsoft.SemanticKernel.AI.Embeddings;
+using Moq;
 
 namespace SemanticKernel.Connectors.UnitTests.Memory.Weaviate;
 
-public sealed class WeaviateKernelBuilderExtensionsTests : IDisposable
+public sealed class WeaviateMemoryBuilderExtensionsTests : IDisposable
 {
     private readonly HttpMessageHandlerStub _messageHandlerStub;
     private readonly HttpClient _httpClient;
 
-    public WeaviateKernelBuilderExtensionsTests()
+    public WeaviateMemoryBuilderExtensionsTests()
     {
         this._messageHandlerStub = new HttpMessageHandlerStub();
 
@@ -30,7 +34,9 @@ public sealed class WeaviateKernelBuilderExtensionsTests : IDisposable
     [InlineData("v2", "https://fake-random-test-weaviate-host/v2/objects/fake-key")]
     public async Task WeaviateMemoryStoreShouldBeProperlyInitializedAsync(string? apiVersion, string expectedAddress)
     {
-        //Arrange
+        // Arrange
+        var embeddingGenerationMock = Mock.Of<ITextEmbeddingGeneration>();
+
         var getResponse = new
         {
             Properties = new Dictionary<string, string> {
@@ -43,19 +49,16 @@ public sealed class WeaviateKernelBuilderExtensionsTests : IDisposable
 
         this._messageHandlerStub.ResponseToReturn.Content = new StringContent(JsonSerializer.Serialize(getResponse, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }), Encoding.UTF8, MediaTypeNames.Application.Json);
 
-        var builder = new KernelBuilder();
-#pragma warning disable CS0618 // This will be removed in a future release.
+        var builder = new MemoryBuilder();
         builder.WithWeaviateMemoryStore(this._httpClient, "https://fake-random-test-weaviate-host", "fake-api-key", apiVersion);
-#pragma warning restore CS0618 // This will be removed in a future release.
-        builder.WithAzureTextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-test-host/fake-path", "fake -api-key");
-        var kernel = builder.Build(); //This call triggers the internal factory registered by WithWeaviateMemoryStore method to create an instance of the WeaviateMemoryStore class.
+        builder.WithTextEmbeddingGeneration(embeddingGenerationMock);
 
-        //Act
-#pragma warning disable CS0618 // This will be removed in a future release.
-        await kernel.Memory.GetAsync("fake-collection", "fake-key"); //This call triggers a subsequent call to Weaviate memory store.
-#pragma warning restore CS0618 // This will be removed in a future release.
+        var memory = builder.Build(); //This call triggers the internal factory registered by WithWeaviateMemoryStore method to create an instance of the WeaviateMemoryStore class.
 
-        //Assert
+        // Act
+        await memory.GetAsync("fake-collection", "fake-key"); //This call triggers a subsequent call to Weaviate memory store.
+
+        // Assert
         Assert.Equal(expectedAddress, this._messageHandlerStub?.RequestUri?.AbsoluteUri);
 
         var headerValues = Enumerable.Empty<string>();

--- a/dotnet/src/IntegrationTests/Planners/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/PlanTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
-using Microsoft.SemanticKernel.Plugins.Memory;
 using SemanticKernel.IntegrationTests.Fakes;
 using SemanticKernel.IntegrationTests.TestSettings;
 using Xunit;
@@ -531,8 +530,7 @@ public sealed class PlanTests : IDisposable
                 .WithAzureTextEmbeddingGenerationService(
                     deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                     endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
-                    apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey)
-                .WithMemoryStorage(new VolatileMemoryStore());
+                    apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);
         }
 
         var kernel = builder.Build();

--- a/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
@@ -10,7 +10,6 @@ using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Functions.OpenAPI.Extensions;
 using Microsoft.SemanticKernel.Planners;
 using Microsoft.SemanticKernel.Plugins.Core;
-using Microsoft.SemanticKernel.Plugins.Memory;
 using Microsoft.SemanticKernel.Plugins.Web;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
 using SemanticKernel.IntegrationTests.TestSettings;
@@ -170,8 +169,7 @@ public sealed class StepwisePlannerTests : IDisposable
             builder.WithAzureTextEmbeddingGenerationService(
                     deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                     endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
-                    apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey)
-                .WithMemoryStorage(new VolatileMemoryStore());
+                    apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);
         }
 
         var kernel = builder.Build();

--- a/dotnet/src/Plugins/Plugins.Memory/MemoryBuilder.cs
+++ b/dotnet/src/Plugins/Plugins.Memory/MemoryBuilder.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Http;
+using Microsoft.SemanticKernel.Memory;
+using System;
+
+namespace Microsoft.SemanticKernel.Plugins.Memory;
+
+/// <summary>
+/// A builder for Memory plugin.
+/// </summary>
+public sealed class MemoryBuilder
+{
+    private Func<IMemoryStore>? _memoryStoreFactory = null;
+    private Func<ITextEmbeddingGeneration>? _embeddingGenerationFactory = null;
+    private IDelegatingHandlerFactory _httpHandlerFactory = NullHttpHandlerFactory.Instance;
+    private ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    /// <summary>
+    /// Build a new instance of <see cref="ISemanticTextMemory"/> using the settings passed so far.
+    /// </summary>
+    /// <returns>Instance of <see cref="ISemanticTextMemory"/>.</returns>
+    public ISemanticTextMemory Build()
+    {
+        var memoryStore = this._memoryStoreFactory?.Invoke() ??
+            throw new SKException($"{nameof(IMemoryStore)} dependency was not provided. Use {nameof(WithMemoryStore)} method.");
+
+        var embeddingGeneration = this._embeddingGenerationFactory?.Invoke() ??
+            throw new SKException($"{nameof(ITextEmbeddingGeneration)} dependency was not provided. Use {nameof(WithTextEmbeddingGeneration)} method.");
+
+        return new SemanticTextMemory(memoryStore, embeddingGeneration);
+    }
+
+    /// <summary>
+    /// Add a logger factory.
+    /// </summary>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <returns>Updated Memory builder including the logger factory.</returns>
+    public MemoryBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        Verify.NotNull(loggerFactory);
+        this._loggerFactory = loggerFactory;
+        return this;
+    }
+
+    /// <summary>
+    /// Add a http handler factory.
+    /// </summary>
+    /// <param name="httpHandlerFactory">Http handler factory to add.</param>
+    /// <returns>Updated Memory builder including the http handler factory.</returns>
+    public MemoryBuilder WithHttpHandlerFactory(IDelegatingHandlerFactory httpHandlerFactory)
+    {
+        Verify.NotNull(httpHandlerFactory);
+        this._httpHandlerFactory = httpHandlerFactory;
+        return this;
+    }
+
+    /// <summary>
+    /// Add memory store.
+    /// </summary>
+    /// <param name="store">Store to add.</param>
+    /// <returns>Updated Memory builder including the memory store.</returns>
+    public MemoryBuilder WithMemoryStore(IMemoryStore store)
+    {
+        Verify.NotNull(store);
+        this._memoryStoreFactory = () => store;
+        return this;
+    }
+
+    /// <summary>
+    /// Add memory store factory.
+    /// </summary>
+    /// <param name="factory">The store factory.</param>
+    /// <returns>Updated Memory builder including the memory store.</returns>
+    public MemoryBuilder WithMemoryStore<TStore>(Func<ILoggerFactory, TStore> factory) where TStore : IMemoryStore
+    {
+        Verify.NotNull(factory);
+        this._memoryStoreFactory = () => factory(this._loggerFactory);
+        return this;
+    }
+
+    /// <summary>
+    /// Add memory store factory.
+    /// </summary>
+    /// <param name="factory">The store factory.</param>
+    /// <returns>Updated Memory builder including the memory store.</returns>
+    public MemoryBuilder WithMemoryStore<TStore>(Func<ILoggerFactory, IDelegatingHandlerFactory, TStore> factory) where TStore : IMemoryStore
+    {
+        Verify.NotNull(factory);
+        this._memoryStoreFactory = () => factory(this._loggerFactory, this._httpHandlerFactory);
+        return this;
+    }
+
+    /// <summary>
+    /// Add text embedding generation.
+    /// </summary>
+    /// <param name="textEmbeddingGeneration">The text embedding generation.</param>
+    /// <returns>Updated Memory builder including the text embedding generation.</returns>
+    public MemoryBuilder WithTextEmbeddingGeneration(ITextEmbeddingGeneration textEmbeddingGeneration)
+    {
+        Verify.NotNull(textEmbeddingGeneration);
+        this._embeddingGenerationFactory = () => textEmbeddingGeneration;
+        return this;
+    }
+
+    /// <summary>
+    /// Add text embedding generation.
+    /// </summary>
+    /// <param name="factory">The text embedding generation factory.</param>
+    /// <returns>Updated Memory builder including the text embedding generation.</returns>
+    public MemoryBuilder WithTextEmbeddingGeneration<TEmbeddingGeneration>(
+        Func<ILoggerFactory, IDelegatingHandlerFactory, TEmbeddingGeneration> factory) where TEmbeddingGeneration : ITextEmbeddingGeneration
+    {
+        Verify.NotNull(factory);
+        this._embeddingGenerationFactory = () => factory(this._loggerFactory, this._httpHandlerFactory);
+        return this;
+    }
+}

--- a/dotnet/src/Plugins/Plugins.Memory/MemoryBuilder.cs
+++ b/dotnet/src/Plugins/Plugins.Memory/MemoryBuilder.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
-using System;
 
 namespace Microsoft.SemanticKernel.Plugins.Memory;
 

--- a/dotnet/src/Plugins/Plugins.UnitTests/Memory/MemoryBuilderTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Memory/MemoryBuilderTests.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Http;
+using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Plugins.Memory;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.Plugins.UnitTests.Memory;
+
+/// <summary>
+/// Unit tests for <see cref="MemoryBuilder"/> class.
+/// </summary>
+public sealed class MemoryBuilderTests
+{
+    [Fact]
+    public void ItThrowsExceptionWhenMemoryStoreIsNotProvided()
+    {
+        // Arrange
+        var builder = new MemoryBuilder();
+
+        // Act
+        var exception = Assert.Throws<SKException>(() => builder.Build());
+
+        // Assert
+        Assert.Equal("IMemoryStore dependency was not provided. Use WithMemoryStore method.", exception.Message);
+    }
+
+    [Fact]
+    public void ItThrowsExceptionWhenEmbeddingGenerationIsNotProvided()
+    {
+        // Arrange
+        var builder = new MemoryBuilder()
+            .WithMemoryStore(Mock.Of<IMemoryStore>());
+
+        // Act
+        var exception = Assert.Throws<SKException>(() => builder.Build());
+
+        // Assert
+        Assert.Equal("ITextEmbeddingGeneration dependency was not provided. Use WithTextEmbeddingGeneration method.", exception.Message);
+    }
+
+    [Fact]
+    public void ItInitializesMemoryWhenRequiredDependenciesAreProvided()
+    {
+        // Arrange
+        var builder = new MemoryBuilder()
+            .WithMemoryStore(Mock.Of<IMemoryStore>())
+            .WithTextEmbeddingGeneration(Mock.Of<ITextEmbeddingGeneration>());
+
+        // Act
+        var memory = builder.Build();
+
+        // Assert
+        Assert.NotNull(memory);
+    }
+
+    [Fact]
+    public void ItUsesProvidedLoggerFactory()
+    {
+        // Arrange
+        var loggerFactoryUsed = Mock.Of<ILoggerFactory>();
+        var loggerFactoryUnused = Mock.Of<ILoggerFactory>();
+
+        // Act & Assert
+        var builder = new MemoryBuilder()
+            .WithLoggerFactory(loggerFactoryUsed)
+            .WithMemoryStore((loggerFactory) =>
+            {
+                Assert.Same(loggerFactoryUsed, loggerFactory);
+                Assert.NotSame(loggerFactoryUnused, loggerFactory);
+
+                return Mock.Of<IMemoryStore>();
+            })
+            .WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
+            {
+                Assert.Same(loggerFactoryUsed, loggerFactory);
+                Assert.NotSame(loggerFactoryUnused, loggerFactory);
+
+                return Mock.Of<ITextEmbeddingGeneration>();
+            })
+            .Build();
+    }
+
+    [Fact]
+    public void ItUsesProvidedHttpHandlerFactory()
+    {
+        // Arrange
+        var httpHandlerFactoryUsed = Mock.Of<IDelegatingHandlerFactory>();
+        var httpHandlerFactoryUnused = Mock.Of<IDelegatingHandlerFactory>();
+
+        // Act & Assert
+        var builder = new MemoryBuilder()
+            .WithHttpHandlerFactory(httpHandlerFactoryUsed)
+            .WithMemoryStore((loggerFactory, httpHandlerFactory) =>
+            {
+                Assert.Same(httpHandlerFactoryUsed, httpHandlerFactory);
+                Assert.NotSame(httpHandlerFactoryUnused, httpHandlerFactory);
+
+                return Mock.Of<IMemoryStore>();
+            })
+            .WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
+            {
+                Assert.Same(httpHandlerFactoryUsed, httpHandlerFactory);
+                Assert.NotSame(httpHandlerFactoryUnused, httpHandlerFactory);
+
+                return Mock.Of<ITextEmbeddingGeneration>();
+            })
+            .Build();
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
@@ -27,11 +27,6 @@ public interface IKernel
     ILoggerFactory LoggerFactory { get; }
 
     /// <summary>
-    /// Semantic memory instance
-    /// </summary>
-    ISemanticTextMemory Memory { get; }
-
-    /// <summary>
     /// Reference to the engine rendering prompt templates
     /// </summary>
     IPromptTemplateEngine PromptTemplateEngine { get; }
@@ -40,12 +35,6 @@ public interface IKernel
     /// Reference to the read-only function collection containing all the imported functions
     /// </summary>
     IReadOnlyFunctionCollection Functions { get; }
-
-    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.Functions instead. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591
-    IReadOnlyFunctionCollection Skills { get; }
-#pragma warning restore CS1591
 
     /// <summary>
     /// Reference to Http handler factory
@@ -67,18 +56,6 @@ public interface IKernel
     /// <param name="pluginName">Name of the plugin for function collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
     /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
     IDictionary<string, ISKFunction> ImportFunctions(object functionsInstance, string? pluginName = null);
-
-    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.ImportFunctions instead. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591
-    IDictionary<string, ISKFunction> ImportSkill(object functionsInstance, string? pluginName = null);
-#pragma warning restore CS1591
-
-    /// <summary>
-    /// Set the semantic memory to use
-    /// </summary>
-    /// <param name="memory">Semantic memory instance</param>
-    void RegisterMemory(ISemanticTextMemory memory);
 
     /// <summary>
     /// Run a single synchronous or asynchronous <see cref="ISKFunction"/>.
@@ -191,6 +168,19 @@ public interface IKernel
     #region Obsolete
 
     /// <summary>
+    /// Semantic memory instance
+    /// </summary>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    ISemanticTextMemory Memory { get; }
+
+    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.Functions instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    IReadOnlyFunctionCollection Skills { get; }
+#pragma warning restore CS1591
+
+    /// <summary>
     /// Access registered functions by plugin name and function name. Not case sensitive.
     /// The function might be native or semantic, it's up to the caller handling it.
     /// </summary>
@@ -200,6 +190,21 @@ public interface IKernel
     [Obsolete("Func shorthand no longer no longer supported. Use Kernel.Plugins collection instead. This will be removed in a future release.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     ISKFunction Func(string pluginName, string functionName);
+
+    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.ImportFunctions instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    IDictionary<string, ISKFunction> ImportSkill(object functionsInstance, string? pluginName = null);
+#pragma warning restore CS1591
+
+    /// <summary>
+    /// Set the semantic memory to use
+    /// </summary>
+    /// <param name="memory">Semantic memory instance</param>
+    /// <inheritdoc/>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    void RegisterMemory(ISemanticTextMemory memory);
 
     #endregion
 }

--- a/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
@@ -170,7 +170,7 @@ public interface IKernel
     /// <summary>
     /// Semantic memory instance
     /// </summary>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     ISemanticTextMemory Memory { get; }
 
@@ -202,7 +202,7 @@ public interface IKernel
     /// </summary>
     /// <param name="memory">Semantic memory instance</param>
     /// <inheritdoc/>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     void RegisterMemory(ISemanticTextMemory memory);
 

--- a/dotnet/src/SemanticKernel.Core/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Core/Kernel.cs
@@ -345,7 +345,7 @@ repeat:
     #region Obsolete ===============================================================================
 
     /// <inheritdoc/>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public ISemanticTextMemory Memory => this._memory;
 
@@ -364,7 +364,7 @@ repeat:
     }
 
     /// <inheritdoc/>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void RegisterMemory(ISemanticTextMemory memory)
     {

--- a/dotnet/src/SemanticKernel.Core/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Core/Kernel.cs
@@ -36,16 +36,7 @@ public sealed class Kernel : IKernel, IDisposable
     public ILoggerFactory LoggerFactory { get; }
 
     /// <inheritdoc/>
-    public ISemanticTextMemory Memory => this._memory;
-
-    /// <inheritdoc/>
     public IReadOnlyFunctionCollection Functions => this._functionCollection;
-
-    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.Functions instead. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591
-    public IReadOnlyFunctionCollection Skills => this._functionCollection;
-#pragma warning restore CS1591
 
     /// <inheritdoc/>
     public IPromptTemplateEngine PromptTemplateEngine { get; }
@@ -122,15 +113,6 @@ public sealed class Kernel : IKernel, IDisposable
         return functions;
     }
 
-    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.ImportFunctions instead. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591
-    public IDictionary<string, ISKFunction> ImportSkill(object functionsInstance, string? pluginName = null)
-    {
-        return this.ImportFunctions(functionsInstance, pluginName);
-    }
-#pragma warning restore CS1591
-
     /// <inheritdoc/>
     public ISKFunction RegisterCustomFunction(ISKFunction customFunction)
     {
@@ -140,12 +122,6 @@ public sealed class Kernel : IKernel, IDisposable
         this._functionCollection.AddFunction(customFunction);
 
         return customFunction;
-    }
-
-    /// <inheritdoc/>
-    public void RegisterMemory(ISemanticTextMemory memory)
-    {
-        this._memory = memory;
     }
 
     /// <inheritdoc/>
@@ -369,11 +345,40 @@ repeat:
     #region Obsolete ===============================================================================
 
     /// <inheritdoc/>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ISemanticTextMemory Memory => this._memory;
+
+    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.Functions instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    public IReadOnlyFunctionCollection Skills => this._functionCollection;
+#pragma warning restore CS1591
+
+    /// <inheritdoc/>
     [Obsolete("Func shorthand no longer no longer supported. Use Kernel.Functions collection instead. This will be removed in a future release.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public ISKFunction Func(string pluginName, string functionName)
     {
         return this.Functions.GetFunction(pluginName, functionName);
     }
+
+    /// <inheritdoc/>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void RegisterMemory(ISemanticTextMemory memory)
+    {
+        this._memory = memory;
+    }
+
+    [Obsolete("Methods, properties and classes which include Skill in the name have been renamed. Use Kernel.ImportFunctions instead. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS1591
+    public IDictionary<string, ISKFunction> ImportSkill(object functionsInstance, string? pluginName = null)
+    {
+        return this.ImportFunctions(functionsInstance, pluginName);
+    }
+#pragma warning restore CS1591
+
     #endregion
 }

--- a/dotnet/src/SemanticKernel.Core/KernelBuilder.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelBuilder.cs
@@ -85,7 +85,7 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="memory">Semantic text memory entity to add.</param>
     /// <returns>Updated kernel builder including the semantic text memory entity.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemory(ISemanticTextMemory memory)
     {
@@ -99,7 +99,7 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="factory">The store factory.</param>
     /// <returns>Updated kernel builder including the semantic text memory entity.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemory<TStore>(Func<ILoggerFactory, TStore> factory) where TStore : ISemanticTextMemory
     {
@@ -113,7 +113,7 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="storage">Storage to add.</param>
     /// <returns>Updated kernel builder including the memory storage.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemoryStorage(IMemoryStore storage)
     {
@@ -127,7 +127,7 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="factory">The storage factory.</param>
     /// <returns>Updated kernel builder including the memory storage.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemoryStorage<TStore>(Func<ILoggerFactory, TStore> factory) where TStore : IMemoryStore
     {
@@ -141,7 +141,7 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="factory">The storage factory.</param>
     /// <returns>Updated kernel builder including the memory storage.</returns>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemoryStorage<TStore>(Func<ILoggerFactory, IDelegatingHandlerFactory, TStore> factory) where TStore : IMemoryStore
     {

--- a/dotnet/src/SemanticKernel.Core/KernelBuilder.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -59,7 +60,9 @@ public sealed class KernelBuilder
         // TODO: decouple this from 'UseMemory' kernel extension
         if (this._memoryStorageFactory != null)
         {
+#pragma warning disable CS0618 // This will be removed in a future release.
             instance.UseMemory(this._memoryStorageFactory.Invoke());
+#pragma warning restore CS0618 // This will be removed in a future release.
         }
 
         return instance;
@@ -82,6 +85,8 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="memory">Semantic text memory entity to add.</param>
     /// <returns>Updated kernel builder including the semantic text memory entity.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemory(ISemanticTextMemory memory)
     {
         Verify.NotNull(memory);
@@ -94,6 +99,8 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="factory">The store factory.</param>
     /// <returns>Updated kernel builder including the semantic text memory entity.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemory<TStore>(Func<ILoggerFactory, TStore> factory) where TStore : ISemanticTextMemory
     {
         Verify.NotNull(factory);
@@ -106,6 +113,8 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="storage">Storage to add.</param>
     /// <returns>Updated kernel builder including the memory storage.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemoryStorage(IMemoryStore storage)
     {
         Verify.NotNull(storage);
@@ -118,6 +127,8 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="factory">The storage factory.</param>
     /// <returns>Updated kernel builder including the memory storage.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemoryStorage<TStore>(Func<ILoggerFactory, TStore> factory) where TStore : IMemoryStore
     {
         Verify.NotNull(factory);
@@ -130,6 +141,8 @@ public sealed class KernelBuilder
     /// </summary>
     /// <param name="factory">The storage factory.</param>
     /// <returns>Updated kernel builder including the memory storage.</returns>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public KernelBuilder WithMemoryStorage<TStore>(Func<ILoggerFactory, IDelegatingHandlerFactory, TStore> factory) where TStore : IMemoryStore
     {
         Verify.NotNull(factory);

--- a/dotnet/src/SemanticKernel.Core/Memory/MemoryConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/MemoryConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Diagnostics;

--- a/dotnet/src/SemanticKernel.Core/Memory/MemoryConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/MemoryConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ComponentModel;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -21,6 +23,8 @@ public static class MemoryConfiguration
     /// <param name="kernel">Kernel instance</param>
     /// <param name="storage">Memory storage</param>
     /// <param name="embeddingsServiceId">Kernel service id for embedding generation</param>
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void UseMemory(this IKernel kernel, IMemoryStore storage, string? embeddingsServiceId = null)
     {
         var embeddingGenerator = kernel.GetService<ITextEmbeddingGeneration>(embeddingsServiceId);
@@ -35,6 +39,8 @@ public static class MemoryConfiguration
     /// <param name="embeddingGenerator">Embedding generator</param>
     /// <param name="storage">Memory storage</param>
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The embeddingGenerator object is disposed by the kernel")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void UseMemory(this IKernel kernel, ITextEmbeddingGeneration embeddingGenerator, IMemoryStore storage)
     {
         Verify.NotNull(storage);

--- a/dotnet/src/SemanticKernel.Core/Memory/MemoryConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/MemoryConfiguration.cs
@@ -23,7 +23,7 @@ public static class MemoryConfiguration
     /// <param name="kernel">Kernel instance</param>
     /// <param name="storage">Memory storage</param>
     /// <param name="embeddingsServiceId">Kernel service id for embedding generation</param>
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void UseMemory(this IKernel kernel, IMemoryStore storage, string? embeddingsServiceId = null)
     {
@@ -39,7 +39,7 @@ public static class MemoryConfiguration
     /// <param name="embeddingGenerator">Embedding generator</param>
     /// <param name="storage">Memory storage</param>
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The embeddingGenerator object is disposed by the kernel")]
-    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release.")]
+    [Obsolete("Memory functionality will be placed in separate Microsoft.SemanticKernel.Plugins.Memory package. This will be removed in a future release. See sample dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs in the semantic-kernel repository.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void UseMemory(this IKernel kernel, ITextEmbeddingGeneration embeddingGenerator, IMemoryStore storage)
     {

--- a/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel.Memory;
 /// Implementation of <see cref="ISemanticTextMemory"/>. Provides methods to save, retrieve, and search for text information
 /// in a semantic memory store.
 /// </summary>
-public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
+public sealed class SemanticTextMemory : ISemanticTextMemory
 {
     private readonly ITextEmbeddingGeneration _embeddingGenerator;
     private readonly IMemoryStore _storage;
@@ -127,17 +127,5 @@ public sealed class SemanticTextMemory : ISemanticTextMemory, IDisposable
     public async Task<IList<string>> GetCollectionsAsync(CancellationToken cancellationToken = default)
     {
         return await this._storage.GetCollectionsAsync(cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Disposes the resources used by the <see cref="SemanticTextMemory"/> instance.
-    /// </summary>
-    public void Dispose()
-    {
-        // ReSharper disable once SuspiciousTypeConversion.Global
-        if (this._embeddingGenerator is IDisposable emb) { emb.Dispose(); }
-
-        // ReSharper disable once SuspiciousTypeConversion.Global
-        if (this._storage is IDisposable storage) { storage.Dispose(); }
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR contains changes to mark Memory-related functionality in Kernel as Obsolete and create alternative methods in `Plugins.Memory` and Connectors projects. 

Note: Obsolete methods and properties will be removed in future releases.

ADR: [0011-memory-as-plugin.md](https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0011-memory-as-plugin.md)

**Main change**: helper methods for Memory were moved from `KernelBuilder` to `MemoryBuilder`. Previously, it was possible to configure only one Memory instance per Kernel instance. Now, Memory functionality is decoupled from Kernel and should be configured separately.

Previous Memory usage:
```csharp
var kernel = Kernel.Builder
    .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
    .WithMemoryStorage(new AzureCognitiveSearchMemoryStore(TestConfiguration.ACS.Endpoint, TestConfiguration.ACS.ApiKey))
    .Build();

kernel.Memory.SaveInformationAsync(...);
```

New Memory usage:
```csharp
var memory = new MemoryBuilder()
    .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", TestConfiguration.OpenAI.ApiKey)
    .WithMemoryStore(new AzureCognitiveSearchMemoryStore(TestConfiguration.ACS.Endpoint, TestConfiguration.ACS.ApiKey))
    .Build();

memory.SaveInformationAsync(...);
```


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Added `MemoryBuilder` as equivalent to `KernelBuilder` to initialize the logic related to Memory.
2. Added unit tests for `MemoryBuilder`.
3. Added extension methods for `MemoryBuilder` related to Memory and AI Connectors.
4. Marked Memory-related methods and properties in Kernel/KernelBuilder as obsolete.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
