### PR TITLE
Python: Allow action planner to exclude skills or functions

### DIFF
--- a/python/semantic_kernel/planning/action_planner/__init__.py
+++ b/python/semantic_kernel/planning/action_planner/__init__.py
@@ -1,0 +1,7 @@
+from semantic_kernel.planning.action_planner.action_planner import (
+    ActionPlanner,
+)
+
+__all__ = [
+    "ActionPlanner",
+]

--- a/python/semantic_kernel/planning/action_planner/action_planner.py
+++ b/python/semantic_kernel/planning/action_planner/action_planner.py
@@ -32,7 +32,7 @@ class ActionPlanner:
     "no function" if nothing relevant is available.
     """
 
-    RESTRICTED_SKILL_NAME = "ActionPlanner"
+    RESTRICTED_SKILL_NAME = "ActionPlanner_Excluded"
     config: ActionPlannerConfig
     _stop_sequence: str = "#END-OF-PLAN"
 

--- a/python/semantic_kernel/planning/action_planner/action_planner_config.py
+++ b/python/semantic_kernel/planning/action_planner/action_planner_config.py
@@ -1,0 +1,13 @@
+from typing import List
+
+
+class ActionPlannerConfig:
+    def __init__(
+        self,
+        excluded_skills: List[str] = None,
+        excluded_functions: List[str] = None,
+        max_tokens: int = 1024,
+    ):
+        self.excluded_skills: List[str] = excluded_skills or []
+        self.excluded_functions: List[str] = excluded_functions or []
+        self.max_tokens: int = max_tokens

--- a/python/semantic_kernel/planning/action_planner/skprompt.txt
+++ b/python/semantic_kernel/planning/action_planner/skprompt.txt
@@ -1,11 +1,11 @@
 A planner takes a list of functions, a goal, and chooses which function to use.
 For each function the list includes details about the input parameters.
 [START OF EXAMPLES]
-{{ActionPlanner.GoodExamples}}
-{{ActionPlanner.EdgeCaseExamples}}
+{{ActionPlanner_Excluded.GoodExamples}}
+{{ActionPlanner_Excluded.EdgeCaseExamples}}
 [END OF EXAMPLES]
 [REAL SCENARIO STARTS HERE]
 - List of functions:
-{{ActionPlanner.ListOfFunctions}}
+{{ActionPlanner_Excluded.ListOfFunctions}}
 - End list of functions.
 Goal: {{ $input }}

--- a/python/semantic_kernel/planning/action_planner/skprompt.txt
+++ b/python/semantic_kernel/planning/action_planner/skprompt.txt
@@ -1,11 +1,11 @@
 A planner takes a list of functions, a goal, and chooses which function to use.
 For each function the list includes details about the input parameters.
 [START OF EXAMPLES]
-{{this.GoodExamples}}
-{{this.EdgeCaseExamples}}
+{{ActionPlanner.GoodExamples}}
+{{ActionPlanner.EdgeCaseExamples}}
 [END OF EXAMPLES]
 [REAL SCENARIO STARTS HERE]
 - List of functions:
-{{this.ListOfFunctions}}
+{{ActionPlanner.ListOfFunctions}}
 - End list of functions.
 Goal: {{ $input }}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Allow ActionPlanner to exclude skills and functions when generating the plan. This is very useful and other planner types all have this functionality.

Solve #3072

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Add `ActionPlannerConfig` class for three settings:
  - `excluded_skills`
  - `excluded_functions`
  - `max_tokens`
- Filter out available skills and functions in `ActionPlanner.list_of_functions` method.
- Rename class attribute "ActionPlanner._skill_name" to "ActionPlanner.RESTRICTED_SKILL_NAME" just like other planners and update its value to "ActionPlanner". The `this.*` skills defined in `skprompt.txt` must also be updated.
- Add the missing `__init__.py`: `semantic_kernel/planning/action_planner/__init__.py`

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
