### PR TITLE
.Net Fix for double retries

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/OpenAIClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/OpenAIClientBase.cs
@@ -40,11 +40,7 @@ public abstract class OpenAIClientBase : ClientBase
 
         this.ModelId = modelId;
 
-        var options = GetClientOptions();
-        if (httpClient != null)
-        {
-            options.Transport = new HttpClientTransport(httpClient);
-        }
+        var options = GetClientOptions(httpClient);
 
         if (!string.IsNullOrWhiteSpace(organization))
         {
@@ -86,10 +82,11 @@ public abstract class OpenAIClientBase : ClientBase
     /// <summary>
     /// Options used by the OpenAI client, e.g. User Agent.
     /// </summary>
-    /// <returns>An instance of <see cref="OpenAIClientOptions"/> with the configured options.</returns>
-    private static OpenAIClientOptions GetClientOptions()
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <returns>An instance of <see cref="OpenAIClientOptions"/>.</returns>
+    private static OpenAIClientOptions GetClientOptions(HttpClient? httpClient)
     {
-        return new OpenAIClientOptions
+        var options = new OpenAIClientOptions
         {
             Diagnostics =
             {
@@ -97,5 +94,13 @@ public abstract class OpenAIClientBase : ClientBase
                 ApplicationId = Telemetry.HttpUserAgent,
             }
         };
+
+        if (httpClient != null)
+        {
+            options.Transport = new HttpClientTransport(httpClient);
+            options.RetryPolicy = new RetryPolicy(maxRetries: 0); //Disabling Azure SDK retry policy to use the one provided by the custom HTTP client.
+        }
+
+        return options;
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIKernelBuilderExtensions.cs
@@ -551,6 +551,7 @@ public static class OpenAIKernelBuilderExtensions
         OpenAIClientOptions options = new();
 #pragma warning disable CA2000 // Dispose objects before losing scope
         options.Transport = new HttpClientTransport(HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory));
+        options.RetryPolicy = new RetryPolicy(maxRetries: 0); //Disabling Azure SDK retry policy to use the one provided by the delegating handler factory or the HTTP client.
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         return options;

--- a/dotnet/src/IntegrationTests/Planners/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/PlanTests.cs
@@ -507,7 +507,9 @@ public sealed class PlanTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        var builder = Kernel.Builder.WithLoggerFactory(this._loggerFactory);
+        var builder = Kernel.Builder
+            .WithLoggerFactory(this._loggerFactory)
+            .WithRetryBasic();
 
         if (useChatModel)
         {

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlanParserTests.cs
@@ -33,6 +33,7 @@ public class SequentialPlanParserTests
         Assert.NotNull(azureOpenAIConfiguration);
 
         IKernel kernel = Kernel.Builder
+            .WithRetryBasic()
             .WithAzureTextCompletionService(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
@@ -118,6 +118,7 @@ public sealed class SequentialPlannerTests : IDisposable
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
         var builder = Kernel.Builder.WithLoggerFactory(this._logger);
+        builder.WithRetryBasic();
 
         if (useChatModel)
         {

--- a/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
@@ -147,7 +147,9 @@ public sealed class StepwisePlannerTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        var builder = Kernel.Builder.WithLoggerFactory(this._loggerFactory);
+        var builder = Kernel.Builder
+            .WithLoggerFactory(this._loggerFactory)
+            .WithRetryBasic();
 
         if (useChatModel)
         {


### PR DESCRIPTION
### Motivation and Context

SK has two mechanisms that should be used to enable/configure a retry policy for accessing REST APIs:
- A custom HTTP client supplied as an argument of all `KernelBuilder.With*Service` extension methods.
- A retry handler supplied through `KernelBuilder.WithHttpHandlerFactory`, `KernelBuilder.WithRetryPolly` or `KernelBuilder.WithRetryBasic' extension methods.

### Description
This PR disables default policy provided Azure SDK library to avoid "double" retries and use the one configured by SK consumer instead.

Related issue - https://github.com/microsoft/semantic-kernel/issues/2486

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
