### PR TITLE
.Net: Remove ILoggerFactory from FunctionCollection

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Functions/FunctionCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/FunctionCollection.cs
@@ -3,10 +3,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Diagnostics;
 
 #pragma warning disable IDE0130
@@ -32,34 +32,26 @@ public class FunctionCollection : IFunctionCollection
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionCollection"/> class.
     /// </summary>
-    /// <param name="readOnlyFunctionCollection">Optional skill collection to copy from</param>
-    /// <param name="loggerFactory">The logger factory.</param>
-    public FunctionCollection(IReadOnlyFunctionCollection? readOnlyFunctionCollection = null, ILoggerFactory? loggerFactory = null)
+    public FunctionCollection() : this((IReadOnlyFunctionCollection?)null)
     {
-        this._logger = loggerFactory?.CreateLogger(typeof(FunctionCollection)) ?? NullLogger.Instance;
+    }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionCollection"/> class.
+    /// </summary>
+    /// <param name="readOnlyFunctionCollection">Collection of functions with which to populate this instance.</param>
+    public FunctionCollection(IReadOnlyFunctionCollection? readOnlyFunctionCollection)
+    {
         // Important: names are case insensitive
         this._functionCollection = new(StringComparer.OrdinalIgnoreCase);
 
         if (readOnlyFunctionCollection is not null)
         {
-            this.Populate(readOnlyFunctionCollection);
+            foreach (var functionView in readOnlyFunctionCollection.GetFunctionViews())
+            {
+                this.AddFunction(readOnlyFunctionCollection.GetFunction(functionView.PluginName, functionView.Name));
+            }
         }
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="FunctionCollection"/> class.
-    /// </summary>
-    /// <param name="loggerFactory">The logger factory.</param>
-    public FunctionCollection(ILoggerFactory? loggerFactory = null) : this(null, loggerFactory)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="FunctionCollection"/> class.
-    /// </summary>
-    public FunctionCollection() : this(null, null)
-    {
     }
 
     /// <summary>
@@ -86,7 +78,7 @@ public class FunctionCollection : IFunctionCollection
     {
         if (!this.TryGetFunction(pluginName, functionName, out ISKFunction? functionInstance))
         {
-            this.ThrowFunctionNotAvailable(pluginName, functionName);
+            throw new SKException($"Function not available {pluginName}.{functionName}");
         }
 
         return functionInstance;
@@ -130,29 +122,30 @@ public class FunctionCollection : IFunctionCollection
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     internal string DebuggerDisplay => $"Count = {this._functionCollection.Count}";
 
-    #region private ================================================================================
+    #region Obsolete to be removed
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionCollection"/> class.
+    /// </summary>
+    /// <param name="readOnlyFunctionCollection">Optional skill collection to copy from</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    [Obsolete("Use a constructor that doesn't accept an ILoggerFactory. This constructor will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public FunctionCollection(IReadOnlyFunctionCollection? readOnlyFunctionCollection = null, ILoggerFactory? loggerFactory = null) : this(readOnlyFunctionCollection)
+    {
+    }
 
     /// <summary>
-    /// Populates the current functions collection from another.
+    /// Initializes a new instance of the <see cref="FunctionCollection"/> class.
     /// </summary>
-    /// <param name="readOnlyCollection">The target read only functions collection</param>
-    /// <returns>A new editable functions collection copy</returns>
-    private void Populate(IReadOnlyFunctionCollection readOnlyCollection)
+    /// <param name="loggerFactory">The logger factory.</param>
+    [Obsolete("Use a constructor that doesn't accept an ILoggerFactory. This constructor will be removed in a future release.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public FunctionCollection(ILoggerFactory? loggerFactory = null) : this()
     {
-        foreach (var functionView in readOnlyCollection.GetFunctionViews())
-        {
-            this.AddFunction(readOnlyCollection.GetFunction(functionView.PluginName, functionView.Name));
-        }
     }
+    #endregion
 
-    [DoesNotReturn]
-    private void ThrowFunctionNotAvailable(string pluginName, string functionName)
-    {
-        this._logger.LogError("Function not available: plugin:{PluginName} function:{FunctionName}", pluginName, functionName);
-        throw new SKException($"Function not available {pluginName}.{functionName}");
-    }
-
-    private readonly ILogger _logger;
+    #region private ================================================================================
 
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, ISKFunction>> _functionCollection;
 

--- a/dotnet/src/SemanticKernel.Core/KernelBuilder.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelBuilder.cs
@@ -49,7 +49,7 @@ public sealed class KernelBuilder
     public IKernel Build()
     {
         var instance = new Kernel(
-            new FunctionCollection(this._loggerFactory),
+            new FunctionCollection(),
             this._aiServices.Build(),
             this._promptTemplateEngine ?? this.CreateDefaultPromptTemplateEngine(this._loggerFactory),
             this._memoryFactory.Invoke(),


### PR DESCRIPTION
### Description

The only reason FunctionCollection was accepting an ILoggerFactory was to log an error when GetFunction threw, in which case the caller is just as capable as deciding to log, and it's really the logic error of the caller that it tried to access a non-existent method using a method designed to throw in such a case. On top of all of that, it's not a thing in .NET world for a simple collection to do its own logging.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
