### PR TITLE
.Net: Move several IKernel methods to a KernelExtensions class

### DIFF
--- a/dotnet/src/Planners/Planners.Core.UnitTests/Sequential/SequentialPlannerTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Sequential/SequentialPlannerTests.cs
@@ -21,10 +21,10 @@ public sealed class SequentialPlannerTests
         // Arrange
         var kernel = new Mock<IKernel>();
         kernel.Setup(x => x.LoggerFactory).Returns(new Mock<ILoggerFactory>().Object);
-        kernel.Setup(x => x.RunAsync(It.IsAny<ISKFunction>(), It.IsAny<ContextVariables>(), It.IsAny<CancellationToken>()))
-            .Returns<ISKFunction, ContextVariables, CancellationToken>(async (function, vars, cancellationToken) =>
+        kernel.Setup(x => x.RunAsync(It.IsAny<ContextVariables>(), It.IsAny<CancellationToken>(), It.IsAny<ISKFunction>()))
+            .Returns<ContextVariables, CancellationToken, ISKFunction[]>(async (vars, cancellationToken, functions) =>
             {
-                var functionResult = await function.InvokeAsync(kernel.Object, vars, cancellationToken: cancellationToken);
+                var functionResult = await functions[0].InvokeAsync(kernel.Object, vars, cancellationToken: cancellationToken);
                 return KernelResult.FromFunctionResults(functionResult.GetValue<string>(), new List<FunctionResult> { functionResult });
             });
 
@@ -168,10 +168,10 @@ public sealed class SequentialPlannerTests
 
         // Mock Plugins
         kernel.Setup(x => x.Functions).Returns(functions.Object);
-        kernel.Setup(x => x.RunAsync(It.IsAny<ISKFunction>(), It.IsAny<ContextVariables>(), It.IsAny<CancellationToken>()))
-            .Returns<ISKFunction, ContextVariables, CancellationToken>(async (function, vars, cancellationToken) =>
+        kernel.Setup(x => x.RunAsync(It.IsAny<ContextVariables>(), It.IsAny<CancellationToken>(), It.IsAny<ISKFunction>()))
+            .Returns<ContextVariables, CancellationToken, ISKFunction[]>(async (vars, cancellationToken, functions) =>
             {
-                var functionResult = await function.InvokeAsync(kernel.Object, vars, cancellationToken: cancellationToken);
+                var functionResult = await functions[0].InvokeAsync(kernel.Object, vars, cancellationToken: cancellationToken);
                 return KernelResult.FromFunctionResults(functionResult.GetValue<string>(), new List<FunctionResult> { functionResult });
             });
 

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Stepwise/ParseResultTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Stepwise/ParseResultTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -25,7 +25,7 @@ public sealed class ParseResultTests
     {
         // Arrange
         var kernel = new Mock<IKernel>();
-        kernel.Setup(x => x.LoggerFactory).Returns(new Mock<ILoggerFactory>().Object);
+        kernel.Setup(x => x.LoggerFactory).Returns(NullLoggerFactory.Instance);
 
         var planner = new StepwisePlanner(kernel.Object);
 
@@ -77,7 +77,7 @@ public sealed class ParseResultTests
 
         // Arrange
         var kernel = new Mock<IKernel>();
-        kernel.Setup(x => x.LoggerFactory).Returns(new Mock<ILoggerFactory>().Object);
+        kernel.Setup(x => x.LoggerFactory).Returns(NullLoggerFactory.Instance);
 
         var planner = new StepwisePlanner(kernel.Object);
 

--- a/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/IKernel.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel;
 public interface IKernel
 {
     /// <summary>
-    /// App logger
+    /// The ILoggerFactory used to create a logger for logging.
     /// </summary>
     ILoggerFactory LoggerFactory { get; }
 
@@ -47,77 +47,6 @@ public interface IKernel
     /// <param name="customFunction">The custom function to register.</param>
     /// <returns>A C# function wrapping the function execution logic.</returns>
     ISKFunction RegisterCustomFunction(ISKFunction customFunction);
-
-    /// <summary>
-    /// Import a set of functions as a plugin from the given object instance. Only the functions that have the `SKFunction` attribute will be included in the plugin.
-    /// Once these functions are imported, the prompt templates can use functions to import content at runtime.
-    /// </summary>
-    /// <param name="functionsInstance">Instance of a class containing functions</param>
-    /// <param name="pluginName">Name of the plugin for function collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
-    /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
-    IDictionary<string, ISKFunction> ImportFunctions(object functionsInstance, string? pluginName = null);
-
-    /// <summary>
-    /// Run a single synchronous or asynchronous <see cref="ISKFunction"/>.
-    /// </summary>
-    /// <param name="skFunction">A Semantic Kernel function to run</param>
-    /// <param name="variables">Input to process</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>Result of the function</returns>
-    Task<KernelResult> RunAsync(
-        ISKFunction skFunction,
-        ContextVariables? variables = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Run a pipeline composed of synchronous and asynchronous functions.
-    /// </summary>
-    /// <param name="pipeline">List of functions</param>
-    /// <returns>Result of the function composition</returns>
-    Task<KernelResult> RunAsync(
-        params ISKFunction[] pipeline);
-
-    /// <summary>
-    /// Run a pipeline composed of synchronous and asynchronous functions.
-    /// </summary>
-    /// <param name="input">Input to process</param>
-    /// <param name="pipeline">List of functions</param>
-    /// <returns>Result of the function composition</returns>
-    Task<KernelResult> RunAsync(
-        string input,
-        params ISKFunction[] pipeline);
-
-    /// <summary>
-    /// Run a pipeline composed of synchronous and asynchronous functions.
-    /// </summary>
-    /// <param name="variables">Input to process</param>
-    /// <param name="pipeline">List of functions</param>
-    /// <returns>Result of the function composition</returns>
-    Task<KernelResult> RunAsync(
-        ContextVariables variables,
-        params ISKFunction[] pipeline);
-
-    /// <summary>
-    /// Run a pipeline composed of synchronous and asynchronous functions.
-    /// </summary>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <param name="pipeline">List of functions</param>
-    /// <returns>Result of the function composition</returns>
-    Task<KernelResult> RunAsync(
-        CancellationToken cancellationToken,
-        params ISKFunction[] pipeline);
-
-    /// <summary>
-    /// Run a pipeline composed of synchronous and asynchronous functions.
-    /// </summary>
-    /// <param name="input">Input to process</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <param name="pipeline">List of functions</param>
-    /// <returns>Result of the function composition</returns>
-    Task<KernelResult> RunAsync(
-        string input,
-        CancellationToken cancellationToken,
-        params ISKFunction[] pipeline);
 
     /// <summary>
     /// Run a pipeline composed of synchronous and asynchronous functions.

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Orchestration;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>Extension methods for interacting with <see cref="IKernel"/>.</summary>
+public static class KernelExtensions
+{
+    /// <summary>
+    /// Import a set of functions as a plugin from the given object instance. Only the functions that have the `SKFunction` attribute will be included in the plugin.
+    /// Once these functions are imported, the prompt templates can use functions to import content at runtime.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="functionsInstance">Instance of a class containing functions</param>
+    /// <param name="pluginName">Name of the plugin for function collection and prompt templates. If the value is empty functions are registered in the global namespace.</param>
+    /// <returns>A list of all the semantic functions found in the directory, indexed by function name.</returns>
+    public static IDictionary<string, ISKFunction> ImportFunctions(
+        this IKernel kernel,
+        object functionsInstance,
+        string? pluginName = null)
+    {
+        Verify.NotNull(kernel);
+        Verify.NotNull(functionsInstance);
+
+        ILogger logger = kernel.LoggerFactory.CreateLogger(kernel.GetType());
+        if (string.IsNullOrWhiteSpace(pluginName))
+        {
+            pluginName = FunctionCollection.GlobalFunctionsPluginName;
+            logger.LogTrace("Importing functions from {0} to the global plugin namespace", functionsInstance.GetType().FullName);
+        }
+        else
+        {
+            logger.LogTrace("Importing functions from {0} to the {1} namespace", functionsInstance.GetType().FullName, pluginName);
+        }
+
+        MethodInfo[] methods = functionsInstance.GetType().GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
+        logger.LogTrace("Importing plugin name: {0}. Potential methods found: {1}", pluginName, methods.Length);
+
+        // Filter out non-SKFunctions and fail if two functions have the same name
+        Dictionary<string, ISKFunction> result = new(StringComparer.OrdinalIgnoreCase);
+        foreach (MethodInfo method in methods)
+        {
+            if (method.GetCustomAttribute<SKFunctionAttribute>() is not null)
+            {
+                ISKFunction function = SKFunction.FromNativeMethod(method, functionsInstance, pluginName, kernel.LoggerFactory);
+                if (result.ContainsKey(function.Name))
+                {
+                    throw new SKException("Function overloads are not supported, please differentiate function names");
+                }
+
+                result.Add(function.Name, function);
+            }
+        }
+
+        logger.LogTrace("Methods imported {0}", result.Count);
+
+        foreach (KeyValuePair<string, ISKFunction> f in result)
+        {
+            kernel.RegisterCustomFunction(f.Value);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Run a single synchronous or asynchronous <see cref="ISKFunction"/>.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="skFunction">A Semantic Kernel function to run</param>
+    /// <param name="variables">Input to process</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of the function</returns>
+    public static Task<KernelResult> RunAsync(
+        this IKernel kernel,
+        ISKFunction skFunction,
+        ContextVariables? variables = null,
+        CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(kernel);
+        return kernel.RunAsync(variables ?? new(), cancellationToken, skFunction);
+    }
+
+    /// <summary>
+    /// Run a pipeline composed of synchronous and asynchronous functions.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="pipeline">List of functions</param>
+    /// <returns>Result of the function composition</returns>
+    public static Task<KernelResult> RunAsync(
+        this IKernel kernel,
+        params ISKFunction[] pipeline)
+    {
+        Verify.NotNull(kernel);
+        return kernel.RunAsync(new ContextVariables(), pipeline);
+    }
+
+    /// <summary>
+    /// Run a pipeline composed of synchronous and asynchronous functions.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="input">Input to process</param>
+    /// <param name="pipeline">List of functions</param>
+    /// <returns>Result of the function composition</returns>
+    public static Task<KernelResult> RunAsync(
+        this IKernel kernel,
+        string input,
+        params ISKFunction[] pipeline)
+    {
+        Verify.NotNull(kernel);
+        return kernel.RunAsync(new ContextVariables(input), pipeline);
+    }
+
+    /// <summary>
+    /// Run a pipeline composed of synchronous and asynchronous functions.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="variables">Input to process</param>
+    /// <param name="pipeline">List of functions</param>
+    /// <returns>Result of the function composition</returns>
+    public static Task<KernelResult> RunAsync(
+        this IKernel kernel,
+        ContextVariables variables,
+        params ISKFunction[] pipeline)
+    {
+        Verify.NotNull(kernel);
+        return kernel.RunAsync(variables, CancellationToken.None, pipeline);
+    }
+
+    /// <summary>
+    /// Run a pipeline composed of synchronous and asynchronous functions.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <param name="pipeline">List of functions</param>
+    /// <returns>Result of the function composition</returns>
+    public static Task<KernelResult> RunAsync(
+        this IKernel kernel,
+        CancellationToken cancellationToken,
+        params ISKFunction[] pipeline)
+    {
+        Verify.NotNull(kernel);
+        return kernel.RunAsync(new ContextVariables(), cancellationToken, pipeline);
+    }
+
+    /// <summary>
+    /// Run a pipeline composed of synchronous and asynchronous functions.
+    /// </summary>
+    /// <param name="kernel">The kernel.</param>
+    /// <param name="input">Input to process</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <param name="pipeline">List of functions</param>
+    /// <returns>Result of the function composition</returns>
+    public static Task<KernelResult> RunAsync(
+        this IKernel kernel,
+        string input,
+        CancellationToken cancellationToken,
+        params ISKFunction[] pipeline)
+    {
+        Verify.NotNull(kernel);
+        return kernel.RunAsync(new ContextVariables(input), cancellationToken, pipeline);
+    }
+}


### PR DESCRIPTION
### Description

`IKernel` declares 7 overloads of `RunAsync`, and `Kernel` dutifully implements all 7, but 6 of them are one-liner convenience methods that just delegate to the 7th.  Rather than having all of these on the interface and making any implementer implement them all, 6 of them can just be extension methods.

`IKernel` also declares an `ImportFunctions` method, which is almost entirely reflection-based logic unrelated to the kernel instance: the only thing it actually needs from the kernel is to be able to add functions to its functions collection, and `RegisterCustomFunction` provides that. So `ImportFunctions` can also be made into an extension method, such that any `IKernel` implementation gets it for free, and the interface is less cluttered.

Also fixed the nullable annotation on Kernel's ctor's ILoggerFactory parameter.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
