### PR TITLE
.Net: Avoid a few unnecessary Dictionary allocations in Abstractions

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/AIRequestSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/AIRequestSettings.cs
@@ -15,6 +15,8 @@ namespace Microsoft.SemanticKernel.AI;
 /// </summary>
 public class AIRequestSettings
 {
+    private Dictionary<string, object>? _extensionData;
+
     /// <summary>
     /// Service identifier.
     /// This identifies a service and is set when the AI service is registered.
@@ -33,5 +35,9 @@ public class AIRequestSettings
     /// Extra properties
     /// </summary>
     [JsonExtensionData]
-    public Dictionary<string, object> ExtensionData { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> ExtensionData
+    {
+        get => this._extensionData ??= new();
+        set => this._extensionData = value;
+    }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Events/FunctionInvokedEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/FunctionInvokedEventArgs.cs
@@ -10,6 +10,8 @@ namespace Microsoft.SemanticKernel.Events;
 /// </summary>
 public class FunctionInvokedEventArgs : SKCancelEventArgs
 {
+    private Dictionary<string, object>? _metadata;
+
     /// <summary>
     /// Indicates if the function execution should repeat.
     /// </summary>
@@ -18,7 +20,7 @@ public class FunctionInvokedEventArgs : SKCancelEventArgs
     /// <summary>
     /// Metadata for storing additional information about function execution result.
     /// </summary>
-    public Dictionary<string, object> Metadata { get; private set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> Metadata => this._metadata ??= new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionInvokedEventArgs"/> class.
@@ -27,7 +29,7 @@ public class FunctionInvokedEventArgs : SKCancelEventArgs
     /// <param name="result">Function result</param>
     public FunctionInvokedEventArgs(FunctionView functionView, FunctionResult result) : base(functionView, result.Context)
     {
-        this.Metadata = result.Metadata;
+        this._metadata = result._metadata;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/FunctionResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/FunctionResult.cs
@@ -10,6 +10,8 @@ namespace Microsoft.SemanticKernel.Orchestration;
 /// </summary>
 public sealed class FunctionResult
 {
+    internal Dictionary<string, object>? _metadata;
+
     /// <summary>
     /// Name of executed function.
     /// </summary>
@@ -23,7 +25,11 @@ public sealed class FunctionResult
     /// <summary>
     /// Metadata for storing additional information about function execution result.
     /// </summary>
-    public Dictionary<string, object> Metadata { get; internal set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> Metadata
+    {
+        get => this._metadata ??= new();
+        internal set => this._metadata = value;
+    }
 
     /// <summary>
     /// Function result object.
@@ -86,7 +92,8 @@ public sealed class FunctionResult
     /// </summary>
     public bool TryGetMetadataValue<T>(string key, out T value)
     {
-        if (this.Metadata.TryGetValue(key, out object? valueObject) &&
+        if (this._metadata is { } metadata &&
+            metadata.TryGetValue(key, out object? valueObject) &&
             valueObject is T typedValue)
         {
             value = typedValue;


### PR DESCRIPTION
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
