### PR TITLE
.Net: Delete duplicative Json.ToJson

### DIFF
--- a/dotnet/src/Functions/Functions.OpenAPI/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/OpenApi/OpenApiDocumentParser.cs
@@ -41,7 +41,7 @@ internal sealed class OpenApiDocumentParser : IOpenApiDocumentParser
     {
         var jsonObject = await this.DowngradeDocumentVersionToSupportedOneAsync(stream, cancellationToken).ConfigureAwait(false);
 
-        using var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(jsonObject.ToJson()));
+        using var memoryStream = new MemoryStream(Json.SerializeToUtf8Bytes(jsonObject));
 
         var result = await this._openApiReader.ReadAsync(memoryStream, cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/Functions/Functions.Semantic/Extensions/KernelSemanticFunctionExtensions.cs
+++ b/dotnet/src/Functions/Functions.Semantic/Extensions/KernelSemanticFunctionExtensions.cs
@@ -250,7 +250,7 @@ public static class KernelSemanticFunctionExtensions
                 logger ??= kernel.LoggerFactory.CreateLogger(typeof(IKernel));
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    logger.LogTrace("Config {0}: {1}", functionName, config.ToJson());
+                    logger.LogTrace("Config {0}: {1}", functionName, Json.Serialize(config));
                 }
 
                 // Load prompt template

--- a/dotnet/src/InternalUtilities/src/Text/Json.cs
+++ b/dotnet/src/InternalUtilities/src/Text/Json.cs
@@ -8,9 +8,9 @@ internal static class Json
 {
     internal static string Serialize(object? o) => JsonSerializer.Serialize(o, s_options);
 
-    internal static T? Deserialize<T>(string json) => JsonSerializer.Deserialize<T>(json, s_options);
+    internal static byte[] SerializeToUtf8Bytes(object? o) => JsonSerializer.SerializeToUtf8Bytes(o, s_options);
 
-    internal static string ToJson(this object o) => JsonSerializer.Serialize(o, s_options);
+    internal static T? Deserialize<T>(string json) => JsonSerializer.Deserialize<T>(json, s_options);
 
     #region private ================================================================================
 

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/ModelResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/ModelResult.cs
@@ -55,6 +55,6 @@ public sealed class ModelResult
     /// <returns>The result object as a JSON element.</returns>
     public JsonElement GetJsonResult()
     {
-        return Json.Deserialize<JsonElement>(this._result.ToJson());
+        return Json.Deserialize<JsonElement>(Json.Serialize(this._result));
     }
 }


### PR DESCRIPTION
### Description

The implementation of this method is identical to that of Serialize.

Also, one of the uses of Serialize immediately converted it to UTF8 bytes. JsonSerializer actually has to do more work to produce a string, as it first generates UTF8 and then transcodes, so we may as well just skip the intermediate string.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
