### PR TITLE
Python: Fix chromadb connector

### DIFF
--- a/python/semantic_kernel/connectors/memory/chroma/chroma_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/chroma/chroma_memory_store.py
@@ -46,7 +46,7 @@ class ChromaMemoryStore(MemoryStoreBase):
             # Create a ChromaMemoryStore with a custom Settings instance
             chroma_remote_data_store = ChromaMemoryStore(
                 client_settings=Settings(
-                    chroma_api_impl="chromadb.api.fastapi.FastAPI"",
+                    chroma_api_impl="chromadb.api.fastapi.FastAPI",
                     chroma_server_host="xxx.xxx.xxx.xxx",
                     chroma_server_http_port="8000"
                 )

--- a/python/semantic_kernel/connectors/memory/chroma/chroma_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/chroma/chroma_memory_store.py
@@ -46,7 +46,7 @@ class ChromaMemoryStore(MemoryStoreBase):
             # Create a ChromaMemoryStore with a custom Settings instance
             chroma_remote_data_store = ChromaMemoryStore(
                 client_settings=Settings(
-                    chroma_api_impl="rest",
+                    chroma_api_impl="chromadb.api.fastapi.FastAPI"",
                     chroma_server_host="xxx.xxx.xxx.xxx",
                     chroma_server_http_port="8000"
                 )

--- a/python/semantic_kernel/connectors/memory/chroma/chroma_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/chroma/chroma_memory_store.py
@@ -100,11 +100,14 @@ class ChromaMemoryStore(MemoryStoreBase):
         self, collection_name: str
     ) -> Optional["Collection"]:
         try:
-            # Current version of ChromeDB rejects camel case collection names.
-            return self._client.get_collection(
-                name=camel_to_snake(collection_name),
-                embedding_function=self._default_embedding_function,
-            )
+            if camel_to_snake(collection_name) in await self.get_collections_async():
+                # Current version of ChromeDB rejects camel case collection names.
+                return self._client.get_collection(
+                    name=camel_to_snake(collection_name),
+                    embedding_function=self._default_embedding_function,
+                )
+            else:
+                return None
         except ValueError:
             return None
 


### PR DESCRIPTION
### Motivation and Context

The ChromaDB connector works out of the box only for local data storage. This change is required to inform the user of the correct Setting to use as well as fix the `does_collection_exist_async` function that breaks only when its used on a remote data store.

This solves #3046, and also completes work that was started in #2050.

### Description

The change at line 49 updates the Settings for using a remote instance of ChromaDB to work with the changes for v0.4.0 (also mentioned in #2050).

The change starting at line 103 fixes an issue that only occurs when using a remote instance of ChromaDB, where the `does_collection_exist_async` function will always return True, because the `get_collection_async` function expects a ValueError if the collection does not exist. When using a remote instance, it will return an HTTPError instead of a ValueError.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
