### PR TITLE
.Net: Added possibility to get Plan results 

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/FunctionResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/FunctionResult.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Orchestration;
 /// <summary>
 /// Function result after execution.
 /// </summary>
-public sealed class FunctionResult
+public class FunctionResult
 {
     internal Dictionary<string, object>? _metadata;
 

--- a/dotnet/src/SemanticKernel.Core/Planning/KernelResultPlanExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/KernelResultPlanExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Orchestration;
+
+namespace Microsoft.SemanticKernel.Planning;
+
+/// <summary>
+/// Extension methods for <see cref="KernelResult"/> with plan execution results.
+/// </summary>
+public static class KernelResultPlanExtensions
+{
+    /// <summary>
+    /// Returns plan execution results from <see cref="KernelResult"/>.
+    /// </summary>
+    /// <param name="kernelResult">Instance of <see cref="KernelResult"/>.</param>
+    public static IReadOnlyCollection<FunctionResult> GetPlanResults(this KernelResult kernelResult)
+    {
+        var functionResult = kernelResult.FunctionResults.FirstOrDefault();
+
+        if (functionResult is not null && functionResult is PlanResult planResult)
+        {
+            return planResult.StepResults;
+        }
+
+        return Array.Empty<FunctionResult>();
+    }
+}

--- a/dotnet/src/SemanticKernel.Core/Planning/PlanResult.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/PlanResult.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Orchestration;
+
+namespace Microsoft.SemanticKernel.Planning;
+
+/// <summary>
+/// Plan result after execution.
+/// </summary>
+public class PlanResult : FunctionResult
+{
+    /// <summary>
+    /// Results from all steps in plan.
+    /// </summary>
+    public IReadOnlyCollection<PlanResult> StepResults { get; internal set; } = Array.Empty<PlanResult>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlanResult"/> class.
+    /// </summary>
+    /// <param name="functionName">Name of executed function.</param>
+    /// <param name="pluginName">Name of the plugin containing the function.</param>
+    /// <param name="context">Instance of <see cref="SKContext"/> to pass in function pipeline.</param>
+    public PlanResult(string functionName, string pluginName, SKContext context)
+        : base(functionName, pluginName, context)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlanResult"/> class.
+    /// </summary>
+    /// <param name="functionName">Name of executed function.</param>
+    /// <param name="pluginName">Name of the plugin containing the function.</param>
+    /// <param name="context">Instance of <see cref="SKContext"/> to pass in function pipeline.</param>
+    /// <param name="value">Function result object.</param>
+    public PlanResult(string functionName, string pluginName, SKContext context, object? value)
+        : base(functionName, pluginName, context, value)
+    {
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Planning/PlanTests.cs
@@ -853,12 +853,14 @@ Previously:Outline section #1 of 3: Here is a 3 chapter outline about NovelOutli
 
         // Act
         var result = await kernel.RunAsync(plan);
-        var functionResults = result.FunctionResults.ToList();
+        var planResults = result.GetPlanResults().ToList();
 
         // Assert
-        Assert.Equal("Result1", functionResults[0].GetValue<string>());
-        Assert.Equal("Result2", functionResults[1].GetValue<string>());
-        Assert.Equal("Result3", functionResults[2].GetValue<string>());
+        Assert.Equal("Result3", result.GetValue<string>());
+
+        this.AssertFunctionResult(planResults[0], PluginName, "Function1", "Result1");
+        this.AssertFunctionResult(planResults[1], PluginName, "Function2", "Result2");
+        this.AssertFunctionResult(planResults[2], PluginName, "Function3", "Result3");
     }
 
     private (Mock<IKernel> kernelMock, Mock<IFunctionRunner> functionRunnerMock) SetupKernelMock(IFunctionCollection? functions = null)
@@ -889,5 +891,12 @@ Previously:Outline section #1 of 3: Here is a 3 chapter outline about NovelOutli
     private static MethodInfo Method(Delegate method)
     {
         return method.Method;
+    }
+
+    private void AssertFunctionResult(FunctionResult actualResult, string pluginName, string functionName, object value)
+    {
+        Assert.Equal(pluginName, actualResult.PluginName);
+        Assert.Equal(functionName, actualResult.FunctionName);
+        Assert.Equal(value, actualResult.Value);
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/3157

After plan execution `var result = await kernel.RunAsync(plan)`, `result` is `KernelResult`, which contains `FunctionResults` collection. At the moment, in this collection there is only one `FunctionResult` which is original `Plan`, but there is no possibility to get function result from each plan step. 

This PR contains changes to add possibility to get Plan results after plan execution. Taking into account `Plan` tree-like structure (`Plan.Steps` are also of type `Plan`), and the fact that `Plan` implements `ISKFunction`, new structure was added - `PlanResult` which inherits `FunctionResult` and contains list of steps, which are also of type `PlanResult`. 

In order to get Plan results from `KernelResult`, additional extension method `GetPlanResults` was added for `KernelResult` which takes first `FunctionResult` in collection (which is original parent `Plan`) and returns step results.

Usage:
```csharp
 var result = await kernel.RunAsync(plan);
 var planResults = result.GetPlanResults().ToList();
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
