### PR TITLE
Python: strings don't have contains method in python

### DIFF
--- a/python/semantic_kernel/planning/stepwise_planner/stepwise_planner.py
+++ b/python/semantic_kernel/planning/stepwise_planner/stepwise_planner.py
@@ -229,7 +229,7 @@ class StepwisePlanner:
 
         if thought_match:
             result.thought = thought_match.group(0).strip()
-        elif not input.contains(ACTION):
+        elif ACTION not in input:
             result.thought = input
         else:
             raise ValueError("Unexpected input format")

--- a/python/tests/unit/planning/stepwise_planner/test_stepwise_planner_parse_result.py
+++ b/python/tests/unit/planning/stepwise_planner/test_stepwise_planner_parse_result.py
@@ -30,5 +30,21 @@ def test_when_input_is_final_answer_returns_final_answer(input: str, expected: s
     assert result.final_answer == expected
 
 
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("My thought", "My thought"),
+        ("My thought\n", "My thought"),
+        ("My thought\n\n", "My thought"),
+        ("My thought\n\n\n", "My thought")
+    ],
+)
+def test_when_input_is_only_thought_does_not_throw_error(input: str, expected: str):
+    kernel = Mock(spec=Kernel)
+    planner = StepwisePlanner(kernel)
+    result = planner.parse_result(input)
+    assert result.thought == expected
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/tests/unit/planning/stepwise_planner/test_stepwise_planner_parse_result.py
+++ b/python/tests/unit/planning/stepwise_planner/test_stepwise_planner_parse_result.py
@@ -36,7 +36,7 @@ def test_when_input_is_final_answer_returns_final_answer(input: str, expected: s
         ("My thought", "My thought"),
         ("My thought\n", "My thought"),
         ("My thought\n\n", "My thought"),
-        ("My thought\n\n\n", "My thought")
+        ("My thought\n\n\n", "My thought"),
     ],
 )
 def test_when_input_is_only_thought_does_not_throw_error(input: str, expected: str):


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  - A substring in string check was being done using a '.contains' method which doesn't exist in python.
  2. What problem does it solve?
  - avoids the error: Error occurred while running plan step: 'str' object has no attribute 'contains'", AttributeError("'str' object has no attribute 'contains'"))
  3. What scenario does it contribute to?
  - stepwise planner execution
  7. If it fixes an open issue, please link to the issue here.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

I changed the substring in string check to the proper method for python. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X ] The code builds clean without any errors or warnings
- [ X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ X] All unit tests pass, and I have added new tests where possible
- [ X] I didn't break anyone :smile:
