### PR TITLE
Python: Add hybrid search on text memory skill and memory store

### DIFF
--- a/python/semantic_kernel/connectors/memory/weaviate/weaviate_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/weaviate/weaviate_memory_store.py
@@ -341,19 +341,13 @@ class WeaviateMemoryStore(MemoryStoreBase):
         alpha: float,
         with_embeddings: bool,
     ) -> List[Tuple[MemoryRecord, float]]:
-        hybrid = {
-            "query": ask,
-            "vector": embedding,
-            "alpha": alpha,
-        }
-
         additional = ["certainty"]
         if with_embeddings:
             additional.append("vector")
 
         query = (
             self.client.query.get(collection_name, ALL_PROPERTIES)
-            .with_hybrid(hybrid)
+            .with_hybrid(query=ask, vector=embedding, alpha=alpha)
             .with_additional(additional)
             .with_limit(limit)
         )

--- a/python/semantic_kernel/core_skills/text_memory_skill.py
+++ b/python/semantic_kernel/core_skills/text_memory_skill.py
@@ -18,7 +18,7 @@ class TextMemorySkill(PydanticField):
     DEFAULT_COLLECTION = "generic"
     DEFAULT_RELEVANCE = 0.75
     DEFAULT_LIMIT = 1
-    DEFAULT_SEARCH_TYPE = "near_vector"
+    DEFAULT_SEARCH_TYPE = "vector"
 
     # @staticmethod
     @sk_function(
@@ -43,7 +43,7 @@ class TextMemorySkill(PydanticField):
     )
     @sk_function_context_parameter(
         name="search_type",
-        description="The type of search to perform: 'nearVector' or 'hybrid'",
+        description="The type of search to perform: 'vector' or 'hybrid'",
         default_value=DEFAULT_SEARCH_TYPE,
     )
     async def recall_async(self, ask: str, context: "SKContext") -> str:

--- a/python/semantic_kernel/memory/memory_store_base.py
+++ b/python/semantic_kernel/memory/memory_store_base.py
@@ -201,3 +201,54 @@ class MemoryStoreBase(ABC):
             Tuple[MemoryRecord, float] -- A tuple consisting of the MemoryRecord and the similarity score as a float.
         """
         pass
+
+    async def get_hybrid_matches_async(
+        self,
+        collection_name: str,
+        ask: str,
+        embedding: ndarray,
+        limit: int,
+        alpha: float,
+        with_embeddings: bool,
+    ) -> List[Tuple[MemoryRecord, float]]:
+        """Gets the hybrid searched result to a query string. Does not guarantee that the collection exists.
+
+        Arguments:
+            collection_name {str} -- The name associated with a collection of embeddings.
+            ask {str} -- The query string which will be used to search the collection.
+            embedding {ndarray} -- The embedding to compare the collection's embeddings with.
+            limit {int} -- The maximum number of similarity results to return.
+            alpha {float} -- Factor determining how BM25 and vector search are weighted. If 'None' the weaviate default of 0.75 is used.
+                            By default, None, alpha = 0 -> bm25, alpha=1 -> vector search
+            with_embedding {bool} -- If true, the embeddings will be returned in the memory record.
+
+
+        Returns:
+            List[Tuple[MemoryRecord, float]] -- A list of tuples where item1 is a MemoryRecord and item2
+                is its similarity score as a float.
+        """
+        pass
+
+    async def get_hybrid_match_async(
+        self,
+        collection_name: str,
+        ask: str,
+        embedding: ndarray,
+        alpha: float,
+        with_embeddings: bool,
+    ) -> Tuple[MemoryRecord, float]:
+        """Gets the hybrid searched result to a query string. Does not guarantee that the collection exists.
+
+        Arguments:
+            collection_name {str} -- The name associated with a collection of embeddings.
+            ask {str} -- The query string which will be used to search the collection.
+            embedding {ndarray} -- The embedding to compare the collection's embeddings with.
+            alpha {float} -- Factor determining how BM25 and vector search are weighted. If 'None' the weaviate default of 0.75 is used.
+                            By default, None, alpha = 0 -> bm25, alpha=1 -> vector search
+            with_embedding {bool} -- If true, the embeddings will be returned in the memory record.
+
+
+        Returns:
+            Tuple[MemoryRecord, float] -- A tuple consisting of the MemoryRecord and the similarity score as a float.
+        """
+        pass

--- a/python/semantic_kernel/memory/semantic_text_memory.py
+++ b/python/semantic_kernel/memory/semantic_text_memory.py
@@ -133,7 +133,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         limit: int = 1,
         min_relevance_score: float = 0.0,
         with_embeddings: bool = False,
-        search_type: str = "near_vector",
+        search_type: str = "vector",
         alpha: float = 0.75,
     ) -> List[MemoryQueryResult]:
         """Search the memory (calls the memory store's get_nearest_matches method).
@@ -151,7 +151,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         query_embedding = (
             await self._embeddings_generator.generate_embeddings_async([query])
         )[0]
-        if search_type == "near_vector":
+        if search_type == "vector":
             results = await self._storage.get_hybrid_matches_async(
                 collection_name=collection,
                 ask=query,
@@ -160,7 +160,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
                 alpha=alpha,
                 with_embeddings=with_embeddings,
             )
-        else:  # default: nearVector
+        else:  # default: vector
             results = await self._storage.get_nearest_matches_async(
                 collection_name=collection,
                 embedding=query_embedding,

--- a/python/semantic_kernel/memory/semantic_text_memory_base.py
+++ b/python/semantic_kernel/memory/semantic_text_memory_base.py
@@ -82,6 +82,7 @@ class SemanticTextMemoryBase(PydanticField):
         query: str,
         limit: int = 1,
         min_relevance_score: float = 0.7,
+        search_type: str = "near_vector",
         # TODO: ctoken?
     ) -> List[MemoryQueryResult]:
         """Search the memory (calls the memory store's get_nearest_matches method).
@@ -92,6 +93,7 @@ class SemanticTextMemoryBase(PydanticField):
             limit {int} -- The maximum number of results to return. (default: {1})
             min_relevance_score {float} -- The minimum relevance score to return. (default: {0.0})
             with_embeddings {bool} -- Whether to return the embeddings of the results. (default: {False})
+            search_type {str} -- The type of search to perform. (default: {"near_vector"})
 
         Returns:
             List[MemoryQueryResult] -- The list of MemoryQueryResult found.

--- a/python/semantic_kernel/memory/semantic_text_memory_base.py
+++ b/python/semantic_kernel/memory/semantic_text_memory_base.py
@@ -82,7 +82,7 @@ class SemanticTextMemoryBase(PydanticField):
         query: str,
         limit: int = 1,
         min_relevance_score: float = 0.7,
-        search_type: str = "near_vector",
+        search_type: str = "vector",
         # TODO: ctoken?
     ) -> List[MemoryQueryResult]:
         """Search the memory (calls the memory store's get_nearest_matches method).
@@ -93,7 +93,7 @@ class SemanticTextMemoryBase(PydanticField):
             limit {int} -- The maximum number of results to return. (default: {1})
             min_relevance_score {float} -- The minimum relevance score to return. (default: {0.0})
             with_embeddings {bool} -- Whether to return the embeddings of the results. (default: {False})
-            search_type {str} -- The type of search to perform. (default: {"near_vector"})
+            search_type {str} -- The type of search to perform. (default: {"vector"})
 
         Returns:
             List[MemoryQueryResult] -- The list of MemoryQueryResult found.

--- a/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
+++ b/python/tests/integration/connectors/memory/test_weaviate_memory_store.py
@@ -319,3 +319,23 @@ async def test_get_nearest_match(memory_store_with_collection, documents):
 
     expected_result.__dict__["_embedding"] = None
     npt.assert_equal(expected_result.__dict__, actual_result[0].__dict__)
+
+
+@pytest.mark.asyncio
+async def test_get_hybrid_match(memory_store_with_collection, documents):
+    collection_name, memory_store = memory_store_with_collection
+
+    search_query = "The quick brown fox jumps over the lazy dog."
+
+    expected_result = documents[0]
+    actual_result = await memory_store.get_hybrid_match_async(
+        collection_name, search_query, with_embeddings=True
+    )
+
+    npt.assert_equal(expected_result.__dict__, actual_result[0].__dict__)
+
+    actual_result = await memory_store.get_hybrid_match_async(
+        collection_name, search_query, with_embeddings=False
+    )
+    expected_result.__dict__["_embedding"] = None
+    npt.assert_equal(expected_result.__dict__, actual_result[0].__dict__)


### PR DESCRIPTION
### Motivation and Context

  1. Why is this change required? It would be opening the various search types of memory.
  2. What problem does it solve? Currently, sk supports the nearest vector search.
  3. What scenario does it contribute to? This PR supports hybrid search.
  4. If it fixes an open issue, please link to the issue here. #3290 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

I added the "search_type" signature so that we're able to select the search type such as "near_vector" or "hybrid" which is weaviate's a feature
.
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
