### PR TITLE
Python: Fix OpenAITextCompletion and AzureTextCompletion connectors

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion.py
@@ -56,6 +56,9 @@ class OpenAITextCompletion(TextCompletionClientBase):
         self._endpoint = endpoint.rstrip("/") if endpoint is not None else None
         self._org_id = org_id
         self._log = log if log is not None else NullLogger()
+        self._prompt_tokens = 0
+        self._completion_tokens = 0
+        self._total_tokens = 0
 
     async def complete_async(
         self,

--- a/python/tests/unit/ai/open_ai/services/test_azure_text_completion.py
+++ b/python/tests/unit/ai/open_ai/services/test_azure_text_completion.py
@@ -35,6 +35,9 @@ def test_azure_text_completion_init() -> None:
     assert azure_text_completion._endpoint == endpoint
     assert azure_text_completion._api_version == api_version
     assert azure_text_completion._api_type == "azure"
+    assert azure_text_completion._prompt_tokens == 0
+    assert azure_text_completion._completion_tokens == 0
+    assert azure_text_completion._total_tokens == 0
     assert isinstance(azure_text_completion, OpenAITextCompletion)
 
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
Calling the complete_async() method would raise an exception because some of the instance variables are not initialized.

<img width="717" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/107901166/ec8f94be-7fb3-4552-ab95-46fbe56ed46e">

<img width="712" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/107901166/dd16cb8e-8070-44d6-bc94-57c11f63b227">


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
