### PR TITLE
Run markdown link check and spell check on PR's to the java-development branch

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -3,8 +3,8 @@ name: Check .md links
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
-    
+    branches: ["main", "java-development"]
+
 permissions:
   contents: read
 
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     # check out the latest version of the code
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    # Checks the status of hyperlinks in .md files in verbose mode
-    - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-verbose-mode: 'yes'
-        config-file: ".github/workflows/markdown-link-check-config.json"
+      # Checks the status of hyperlinks in .md files in verbose mode
+      - name: Check links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-verbose-mode: "yes"
+          config-file: ".github/workflows/markdown-link-check-config.json"

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -12,18 +12,18 @@ name: Spell Check
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main", "feature*" ]
+    branches: ["main", "java-development", "feature*"]
 
 jobs:
   run:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-    - name: Use custom config file
-      uses: crate-ci/typos@master
-      with:
-        config: .github/_typos.toml
-        write_changes: false
+      - name: Use custom config file
+        uses: crate-ci/typos@master
+        with:
+          config: .github/_typos.toml
+          write_changes: false


### PR DESCRIPTION
### Motivation and Context

Currently these checks only run on PR's to main which means that when we try to merge `java-development` to main we have to fix these issues. We need to catch these issues when code is merged to `java-development` so they can be fixed by the person who introduces the issue.

### Description

Enable markdown link and spell checks for PR's to the `java-development` branch.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
