### PR TITLE
Java: Run Java builds on main, only if java has changed

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main", "experimental*", "feature*"]
+    branches: ["main", "experimental*", "feature*", "*-development"]
   schedule:
     - cron: "17 11 * * 2"
 
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["csharp", "python"]
+        language: ["csharp", "python", "java"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both

--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -3,11 +3,11 @@ name: Build Java Semantic Kernel
 on:
   workflow_dispatch:
   push:
-    branches: [ "java-development" ]
+    branches: [ "main", "java-development" ]
     paths:
       - 'java/**'
   pull_request:
-    branches: [ "java-development" ]
+    branches: [ "main", "java-development" ]
     paths:
       - 'java/**'
 
@@ -15,8 +15,31 @@ permissions:
   contents: read
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      javaChanges: ${{ steps.filter.outputs.java }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            java:
+              - 'java/**'
+              - '**/java/**'
+      # run only if 'java' files were changed
+      - name: java tests
+        if: steps.filter.outputs.java == 'true'
+        run: echo "Java file"
+      # run only if not 'java' files were changed
+      - name: not java tests
+        if: steps.filter.outputs.java != 'true'
+        run: echo "NOT java file"
   java-build:
     runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.javaChanges == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/java-integration-tests.yml
+++ b/.github/workflows/java-integration-tests.yml
@@ -3,11 +3,11 @@ name: Run Java Integration Tests and Samples
 on:
   workflow_dispatch:
   push:
-    branches: [ "java-development" ]
+    branches: [ "main", "java-development" ]
     paths:
       - 'java/**'
   pull_request:
-    branches: [ "java-development" ]
+    branches: [ "main", "java-development" ]
     paths:
       - 'java/**'
 
@@ -15,8 +15,31 @@ permissions:
   contents: read
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      javaChanges: ${{ steps.filter.outputs.java }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            java:
+              - 'java/**'
+              - '**/java/**'
+      # run only if 'java' files were changed
+      - name: java tests
+        if: steps.filter.outputs.java == 'true'
+        run: echo "Java file"
+      # run only if not 'java' files were changed
+      - name: not java tests
+        if: steps.filter.outputs.java != 'true'
+        run: echo "NOT java file"
   java-integration-tests:
     runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.javaChanges == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
