### PR TITLE
Python: [WIP] Add AzureChatCompletionWithData connector

### DIFF
--- a/python/samples/kernel-syntax-examples/azure_chat_with_your_data.py
+++ b/python/samples/kernel-syntax-examples/azure_chat_with_your_data.py
@@ -73,7 +73,6 @@ async def chat() -> bool:
         print("\n\nExiting chat...")
         return False
 
-    print(context_vars.variables)
     answer = await kernel.run_async(chat_function, input_vars=context_vars)
     citations = answer.objects.get("tool", "{}")
     print(f"ChatWithYourDataBot:> {answer}")

--- a/python/samples/kernel-syntax-examples/azure_chat_with_your_data.py
+++ b/python/samples/kernel-syntax-examples/azure_chat_with_your_data.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import os
-import json
 import asyncio
-from pprint import pprint
+import json
 import logging
+import os
+from pprint import pprint
 
 from dotenv import load_dotenv
 
@@ -76,7 +76,7 @@ async def chat() -> bool:
     answer = await kernel.run_async(chat_function, input_vars=context_vars)
     citations = answer.objects.get("tool", "{}")
     print(f"ChatWithYourDataBot:> {answer}")
-    print(f"Tool message:>")
+    print("Tool message:>")
     pprint(json.loads(citations))
     return True
 

--- a/python/samples/kernel-syntax-examples/azure_chat_with_your_data.py
+++ b/python/samples/kernel-syntax-examples/azure_chat_with_your_data.py
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import os
+import json
+import asyncio
+from pprint import pprint
+import logging
+
+from dotenv import load_dotenv
+
+import semantic_kernel as sk
+import semantic_kernel.connectors.ai.open_ai as sk_oai
+from semantic_kernel.utils.settings import azure_openai_settings_from_dot_env_as_dict
+
+logging.basicConfig(level=logging.DEBUG)
+load_dotenv()
+
+system_message = """
+You are a chat bot. Your name is Mosscap and
+you have one goal: figure out what people need.
+Your full name, should you need to know it, is
+Splendid Speckled Mosscap. You communicate
+effectively, but you tend to answer with long
+flowery prose.
+"""
+
+kernel = sk.Kernel()
+
+data_source_config = sk_oai.AzureChatCompletionDataSourceConfig(
+    endpoint=os.environ["AZURE_COGNITIVE_SEARCH_ENDPOINT"],
+    key=os.environ["AZURE_COGNITIVE_SEARCH_KEY"],
+    index_name=os.environ["AZURE_COGNITIVE_SEARCH_INDEX_NAME"],
+)
+
+kernel.add_chat_service(
+    "chat-with-your-data",
+    sk_oai.AzureChatCompletionWithData(
+        **azure_openai_settings_from_dot_env_as_dict(include_api_version=False),
+        data_source_configs=[data_source_config],
+        api_version="2023-08-01-preview",  # This is the only supported API version
+        logger=logging.getLogger("chat-with-your-data"),
+    ),
+)
+
+prompt_config = sk.PromptTemplateConfig.from_completion_parameters(
+    max_tokens=2000, temperature=0.7, top_p=0.8
+)
+
+prompt_template = sk.ChatPromptTemplate(
+    "{{$user_input}}", kernel.prompt_template_engine, prompt_config
+)
+
+function_config = sk.SemanticFunctionConfig(prompt_config, prompt_template)
+chat_function = kernel.register_semantic_function(
+    "ChatWithYourDataBot", "Chat", function_config
+)
+
+
+async def chat() -> bool:
+    context_vars = sk.ContextVariables()
+
+    try:
+        user_input = input("User:> ")
+        context_vars["user_input"] = user_input
+    except KeyboardInterrupt:
+        print("\n\nExiting chat...")
+        return False
+    except EOFError:
+        print("\n\nExiting chat...")
+        return False
+
+    if user_input == "exit":
+        print("\n\nExiting chat...")
+        return False
+
+    print(context_vars.variables)
+    answer = await kernel.run_async(chat_function, input_vars=context_vars)
+    citations = answer.objects.get("tool", "{}")
+    print(f"ChatWithYourDataBot:> {answer}")
+    print(f"Tool message:>")
+    pprint(json.loads(citations))
+    return True
+
+
+async def main() -> None:
+    chatting = True
+    while chatting:
+        chatting = await chat()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/semantic_kernel/connectors/ai/open_ai/__init__.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/__init__.py
@@ -1,5 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion_with_data import (
+    AzureChatCompletionWithData,
+    AzureChatCompletionDataSourceConfig,
+)
 from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
     AzureChatCompletion,
 )
@@ -26,4 +30,6 @@ __all__ = [
     "AzureTextCompletion",
     "AzureChatCompletion",
     "AzureTextEmbedding",
+    "AzureChatCompletionWithData",
+    "AzureChatCompletionDataSourceConfig",
 ]

--- a/python/semantic_kernel/connectors/ai/open_ai/__init__.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/__init__.py
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion_with_data import (
-    AzureChatCompletionWithData,
-    AzureChatCompletionDataSourceConfig,
-)
 from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
     AzureChatCompletion,
+)
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion_with_data import (
+    AzureChatCompletionDataSourceConfig,
+    AzureChatCompletionWithData,
 )
 from semantic_kernel.connectors.ai.open_ai.services.azure_text_completion import (
     AzureTextCompletion,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion_with_data.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion_with_data.py
@@ -88,14 +88,14 @@ class AzureChatCompletionDataSourceConfig:
 
 
 class AzureChatCompletionWithData(AzureChatCompletion):
-    _data_source_configs: list[AzureChatCompletionDataSourceConfig]
+    _data_source_configs: List[AzureChatCompletionDataSourceConfig]
 
     def __init__(
         self,
         deployment_name: str,
         endpoint: Optional[str] = None,
         api_key: Optional[str] = None,
-        data_source_configs: list[AzureChatCompletionDataSourceConfig] = [],
+        data_source_configs: List[AzureChatCompletionDataSourceConfig] = [],
         api_version: str = "2023-08-01-preview",
         logger: Optional[Logger] = None,
         ad_auth=False,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion_with_data.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion_with_data.py
@@ -1,19 +1,18 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-
 from logging import Logger
-from typing import List, Dict, Tuple, Optional, Any, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import aiohttp
 
-from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
-    AzureChatCompletion,
-)
+from semantic_kernel.connectors.ai.ai_exception import AIException
 from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
 from semantic_kernel.connectors.ai.complete_request_settings import (
     CompleteRequestSettings,
 )
-from semantic_kernel.connectors.ai.ai_exception import AIException
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
+    AzureChatCompletion,
+)
 
 
 class AzureChatCompletionDataSourceConfig:

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion_with_data.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion_with_data.py
@@ -1,0 +1,276 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+
+from logging import Logger
+from typing import List, Dict, Tuple, Optional, Any, Union
+
+import aiohttp
+
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
+    AzureChatCompletion,
+)
+from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
+from semantic_kernel.connectors.ai.complete_request_settings import (
+    CompleteRequestSettings,
+)
+from semantic_kernel.connectors.ai.ai_exception import AIException
+
+
+class AzureChatCompletionDataSourceConfig:
+    def __init__(
+        self,
+        endpoint: str,
+        key: str,
+        index_name: str,
+        type: str = "AzureCognitiveSearch",
+        fields_mapping: Optional[Dict] = None,
+        in_scope: bool = True,
+        top_n_documents: int = 5,
+        query_type: str = "simple",
+        semantic_configuration: Optional[str] = None,
+        role_information: Optional[str] = None,
+        filter: Optional[str] = None,
+        embedding_endpoint: Optional[str] = None,
+        embedding_key: Optional[str] = None,
+        embedding_deployment_name: Optional[str] = None,
+    ):
+        """
+        TODO: Docstring and validators
+        See https://learn.microsoft.com/en-us/azure/ai-services/openai/reference for definitions
+        """
+        if (embedding_endpoint and embedding_key) and embedding_deployment_name:
+            raise ValueError(
+                "Either provide embedding_endpoint and embedding_key or only embedding_deployment_name"
+            )
+
+        self._endpoint = endpoint
+        self._key = key
+        self._index_name = index_name
+        self._type = type
+        self._fields_mapping = fields_mapping
+        self._in_scope = in_scope
+        self._top_n_documents = top_n_documents
+        self._query_type = query_type
+        self._semantic_configuration = semantic_configuration
+        self._role_information = role_information
+        self._filter = filter
+        self._embedding_endpoint = embedding_endpoint
+        self._embedding_key = embedding_key
+        self._embedding_deployment_name = embedding_deployment_name
+
+    def as_datasource_param(self) -> Dict:
+        """Return instance variables as a dictionary with CamelCase keys."""
+        param = {
+            "type": self._type,
+            "parameters": {
+                "endpoint": self._endpoint,
+                "key": self._key,
+                "indexName": self._index_name,
+                "fieldsMapping": self._fields_mapping,
+                "inScope": self._in_scope,
+                "topNDocuments": self._top_n_documents,
+                "queryType": self._query_type,
+                "semanticConfiguration": self._semantic_configuration,
+                "roleInformation": self._role_information,
+                "filter": self._filter,
+            },
+        }
+
+        if self._embedding_deployment_name:
+            param["parameters"][
+                "embeddingDeploymentName"
+            ] = self._embedding_deployment_name
+        elif self._embedding_endpoint and self._embedding_key:
+            param["parameters"]["embeddingEndpoint"] = self._embedding_endpoint
+            param["parameters"]["embeddingKey"] = self._embedding_key
+
+        return param
+
+
+class AzureChatCompletionWithData(AzureChatCompletion):
+    _data_source_configs: list[AzureChatCompletionDataSourceConfig]
+
+    def __init__(
+        self,
+        deployment_name: str,
+        endpoint: Optional[str] = None,
+        api_key: Optional[str] = None,
+        data_source_configs: list[AzureChatCompletionDataSourceConfig] = [],
+        api_version: str = "2023-08-01-preview",
+        logger: Optional[Logger] = None,
+        ad_auth=False,
+    ) -> None:
+        """
+        Initialize an AzureChatCompletion service.
+
+        You must provide:
+        - A deployment_name, endpoint, and api_key (plus, optionally: ad_auth)
+
+        :param deployment_name: The name of the Azure deployment. This value
+            will correspond to the custom name you chose for your deployment
+            when you deployed a model. This value can be found under
+            Resource Management > Deployments in the Azure portal or, alternatively,
+            under Management > Deployments in Azure OpenAI Studio.
+        :param endpoint: The endpoint of the Azure deployment. This value
+            can be found in the Keys & Endpoint section when examining
+            your resource from the Azure portal.
+        :param api_key: The API key for the Azure deployment. This value can be
+            found in the Keys & Endpoint section when examining your resource in
+            the Azure portal. You can use either KEY1 or KEY2.
+        :param api_version: The API version to use. (Optional)
+            The default value is "2022-12-01".
+        :param logger: The logger instance to use. (Optional)
+        :param ad_auth: Whether to use Azure Active Directory authentication.
+            (Optional) The default value is False.
+        """
+        if len(data_source_configs) == 0:
+            raise ValueError("The data source configs cannot be empty")
+
+        if api_version != "2023-08-01-preview":
+            raise ValueError('Only API version "2023-08-01-preview" is supported')
+
+        self._data_source_configs = data_source_configs
+
+        super().__init__(
+            deployment_name,
+            endpoint,
+            api_key,
+            api_version,
+            logger,
+            ad_auth,
+        )
+
+    def _validate_chat_request(
+        self,
+        messages: List[Tuple[str, str]],
+        request_settings: ChatRequestSettings,
+        stream: bool,
+        functions: Optional[List[Dict[str, Any]]] = None,
+    ):
+        super()._validate_chat_request(messages, request_settings, stream, functions)
+        # Chat with your data API does not support function call
+        if functions is not None:
+            raise ValueError("Chat with your data API does not support function call")
+
+    def _gen_api_payload(
+        self,
+        messages: List[Tuple[str, str]],
+        request_settings: ChatRequestSettings,
+        stream: bool,
+    ):
+        return {
+            "model": self._model_id,
+            "messages": messages,
+            "temperature": request_settings.temperature,
+            "top_p": request_settings.top_p,
+            "n": request_settings.number_of_responses,
+            "stream": stream,
+            "stop": (
+                request_settings.stop_sequences
+                if request_settings.stop_sequences is not None
+                and len(request_settings.stop_sequences) > 0
+                else None
+            ),
+            "max_tokens": request_settings.max_tokens,
+            "presence_penalty": request_settings.presence_penalty,
+            "frequency_penalty": request_settings.frequency_penalty,
+            "logit_bias": (
+                request_settings.token_selection_biases
+                if request_settings.token_selection_biases is not None
+                and len(request_settings.token_selection_biases) > 0
+                else {}
+            ),
+            "dataSources": [
+                ds.as_datasource_param() for ds in self._data_source_configs
+            ],
+        }
+
+    def _gen_api_headers(self):
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        if self._api_type == "azure_ad":
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        elif self._api_type == "azure":
+            headers["Api-Key"] = self._api_key
+        else:
+            raise ValueError('The api_type must be either "azure" or "azure_ad"')
+
+        return headers
+
+    def _parse_response(self, response: Dict) -> Tuple[Optional[str], Optional[str]]:
+        if len(response["choices"]) == 1:
+            choice = response["choices"][0]
+            content = choice["message"]["content"]
+            citations = choice["message"]["context"]["messages"][0]["content"]
+            return (content, citations)
+        else:
+            return [
+                (
+                    choice["message"]["content"],
+                    choice["message"]["context"]["messages"][0]["content"],
+                )
+                for choice in response["choices"]
+            ]
+
+    async def complete_chat_with_data_async(
+        self,
+        messages: List[Dict[str, str]],
+        request_settings: ChatRequestSettings,
+        logger: Optional[Logger] = None,
+    ) -> Union[
+        Tuple[Optional[str], Optional[dict]],
+        List[Tuple[Optional[str], Optional[dict]]],
+    ]:
+        self._validate_chat_request(messages, request_settings, False, None)
+        payload = self._gen_api_payload(messages, request_settings, False)
+        headers = self._gen_api_headers()
+        url = (
+            f"{self._endpoint}"
+            f"/openai/deployments/{self._model_id}"
+            f"/extensions/chat/completions?api-version={self._api_version}"
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                ) as response:
+                    resp_dict = await response.json()
+                    return self._parse_response(resp_dict)
+        # TODO: Error handling
+        except Exception as ex:
+            raise AIException(
+                AIException.ErrorCodes.ServiceError,
+                f"{self.__class__.__name__} failed to complete the chat",
+                ex,
+            ) from ex
+
+    async def complete_chat_async(
+        self,
+        messages: List[Dict[str, str]],
+        request_settings: ChatRequestSettings,
+        logger: Optional[Logger] = None,
+    ) -> Union[str, List[str]]:
+        result = await self.complete_chat_with_data_async(
+            messages, request_settings, logger
+        )
+        # First element of the tuple is the response
+        if isinstance(result, list):
+            return [choice[0] for choice in result]
+        return result[0]
+
+    async def complete_async(
+        self,
+        prompt: str,
+        request_settings: CompleteRequestSettings,
+        logger: Optional[Logger] = None,
+    ) -> Union[str, List[str]]:
+        prompt_to_message = [{"role": "user", "content": prompt}]
+        chat_settings = ChatRequestSettings.from_completion_config(request_settings)
+        result = await self.complete_chat_async(
+            prompt_to_message, chat_settings, logger
+        )
+        return result

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion.py
@@ -202,28 +202,7 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
         Returns:
             str -- The completed text.
         """
-        if request_settings is None:
-            raise ValueError("The request settings cannot be `None`")
-
-        if request_settings.max_tokens < 1:
-            raise AIException(
-                AIException.ErrorCodes.InvalidRequest,
-                "The max tokens must be greater than 0, "
-                f"but was {request_settings.max_tokens}",
-            )
-
-        if len(messages) <= 0:
-            raise AIException(
-                AIException.ErrorCodes.InvalidRequest,
-                "To complete a chat you need at least one message",
-            )
-
-        if messages[-1]["role"] in ["assistant", "system"]:
-            raise AIException(
-                AIException.ErrorCodes.InvalidRequest,
-                "The last message must be from the user or a function output",
-            )
-
+        self._validate_chat_request(messages, request_settings, stream, functions)
         model_args = {
             "api_key": self._api_key,
             "api_type": self._api_type,
@@ -283,6 +262,35 @@ class OpenAIChatCompletion(ChatCompletionClientBase, TextCompletionClientBase):
             self._total_tokens += response.usage.total_tokens
 
         return response
+
+    def _validate_chat_request(
+        self,
+        messages: List[Tuple[str, str]],
+        request_settings: ChatRequestSettings,
+        stream: bool,
+        functions: Optional[List[Dict[str, Any]]] = None,
+    ):
+        if request_settings is None:
+            raise ValueError("The request settings cannot be `None`")
+
+        if request_settings.max_tokens < 1:
+            raise AIException(
+                AIException.ErrorCodes.InvalidRequest,
+                "The max tokens must be greater than 0, "
+                f"but was {request_settings.max_tokens}",
+            )
+
+        if len(messages) <= 0:
+            raise AIException(
+                AIException.ErrorCodes.InvalidRequest,
+                "To complete a chat you need at least one message",
+            )
+
+        if messages[-1]["role"] in ["assistant", "system"]:
+            raise AIException(
+                AIException.ErrorCodes.InvalidRequest,
+                "The last message must be from the user or a function output",
+            )
 
     @property
     def prompt_tokens(self) -> int:

--- a/python/semantic_kernel/orchestration/sk_function.py
+++ b/python/semantic_kernel/orchestration/sk_function.py
@@ -164,6 +164,18 @@ class SKFunction(SKFunctionBase):
                         context.variables.update(completion)
                     if function_call is not None:
                         context.objects["function_call"] = function_call
+                elif hasattr(client, "complete_chat_with_data_async"):
+                    (
+                        completion,
+                        citations,
+                    ) = await client.complete_chat_with_data_async(
+                        messages, request_settings
+                    )
+                    if completion is not None:
+                        as_chat_prompt.add_assistant_message(completion)
+                        context.variables.update(completion)
+                    if citations is not None:
+                        context.objects["tool"] = citations
                 else:
                     completion = await client.complete_chat_async(
                         messages, request_settings

--- a/python/semantic_kernel/utils/settings.py
+++ b/python/semantic_kernel/utils/settings.py
@@ -74,12 +74,20 @@ def azure_openai_settings_from_dot_env_as_dict(
         Dict[str, str]: The deployment name (or empty), Azure OpenAI API key,
         endpoint and api version (or empty)
     """
-    (
-        deployment_name,
-        api_key,
-        endpoint,
-        api_version,
-    ) = azure_openai_settings_from_dot_env(include_deployment, include_api_version)
+    if include_api_version:
+        (
+            deployment_name,
+            api_key,
+            endpoint,
+            api_version,
+        ) = azure_openai_settings_from_dot_env(include_deployment, include_api_version)
+    else:
+        (
+            deployment_name,
+            api_key,
+            endpoint,
+        ) = azure_openai_settings_from_dot_env(include_deployment, include_api_version)
+
     ret = {
         "api_key": api_key,
         "endpoint": endpoint,

--- a/python/tests/unit/ai/open_ai/services/test_azure_chat_completion_with_data.py
+++ b/python/tests/unit/ai/open_ai/services/test_azure_chat_completion_with_data.py
@@ -1,14 +1,14 @@
 from logging import Logger
+
 import pytest
 
+from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
+    AzureChatCompletion,
+)
 from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion_with_data import (
     AzureChatCompletionDataSourceConfig,
     AzureChatCompletionWithData,
-)
-from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
-
-from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
-    AzureChatCompletion,
 )
 
 
@@ -24,23 +24,23 @@ class TestAzureChatCompletionDataSourceConfig:
         assert config._index_name == "test_index"
         # Optional, fallback to default
         assert config._type == "AzureCognitiveSearch"
-        assert config._fields_mapping == None
-        assert config._in_scope == True
+        assert config._fields_mapping is None
+        assert config._in_scope is True
         assert config._top_n_documents == 5
         assert config._query_type == "simple"
-        assert config._semantic_configuration == None
-        assert config._role_information == None
-        assert config._filter == None
-        assert config._embedding_endpoint == None
-        assert config._embedding_key == None
-        assert config._embedding_deployment_name == None
+        assert config._semantic_configuration is None
+        assert config._role_information is None
+        assert config._filter is None
+        assert config._embedding_endpoint is None
+        assert config._embedding_key is None
+        assert config._embedding_deployment_name is None
 
     def test_datasource_provide_both_embedding_configs(self):
         with pytest.raises(
             ValueError,
             match="Either provide embedding_endpoint and embedding_key or only embedding_deployment_name",
         ):
-            config = AzureChatCompletionDataSourceConfig(
+            AzureChatCompletionDataSourceConfig(
                 endpoint="test_endpoint",
                 key="test_key",
                 index_name="test_index",

--- a/python/tests/unit/ai/open_ai/services/test_azure_chat_completion_with_data.py
+++ b/python/tests/unit/ai/open_ai/services/test_azure_chat_completion_with_data.py
@@ -1,0 +1,333 @@
+from logging import Logger
+import pytest
+
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion_with_data import (
+    AzureChatCompletionDataSourceConfig,
+    AzureChatCompletionWithData,
+)
+from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
+
+from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import (
+    AzureChatCompletion,
+)
+
+
+class TestAzureChatCompletionDataSourceConfig:
+    def test_initialization_with_required_only(self):
+        config = AzureChatCompletionDataSourceConfig(
+            endpoint="test_endpoint", key="test_key", index_name="test_index"
+        )
+
+        # Required
+        assert config._endpoint == "test_endpoint"
+        assert config._key == "test_key"
+        assert config._index_name == "test_index"
+        # Optional, fallback to default
+        assert config._type == "AzureCognitiveSearch"
+        assert config._fields_mapping == None
+        assert config._in_scope == True
+        assert config._top_n_documents == 5
+        assert config._query_type == "simple"
+        assert config._semantic_configuration == None
+        assert config._role_information == None
+        assert config._filter == None
+        assert config._embedding_endpoint == None
+        assert config._embedding_key == None
+        assert config._embedding_deployment_name == None
+
+    def test_datasource_provide_both_embedding_configs(self):
+        with pytest.raises(
+            ValueError,
+            match="Either provide embedding_endpoint and embedding_key or only embedding_deployment_name",
+        ):
+            config = AzureChatCompletionDataSourceConfig(
+                endpoint="test_endpoint",
+                key="test_key",
+                index_name="test_index",
+                embedding_endpoint="https://fake.embedding.endpoint.com",
+                embedding_key="fakeEmbeddingKEY",
+                embedding_deployment_name="fake-embedding-deployment-name",
+            )
+
+    def test_datasource_param(self):
+        config = AzureChatCompletionDataSourceConfig(
+            endpoint="test_endpoint",
+            key="test_key",
+            index_name="test_index",
+            type="SomeNewType",
+            fields_mapping={"field1": "mapped1", "field2": "mapped2"},
+            in_scope=False,
+            top_n_documents=42,
+            query_type="semantic",
+            semantic_configuration="default",
+            role_information="You are a helpful bot",
+            filter="someFilterPattern",
+            embedding_endpoint="https://fake.embedding.endpoint.com",
+            embedding_key="fakeEmbeddingKEY",
+        )
+
+        expected_output = {
+            "type": "SomeNewType",
+            "parameters": {
+                "endpoint": "test_endpoint",
+                "key": "test_key",
+                "indexName": "test_index",
+                "fieldsMapping": {"field1": "mapped1", "field2": "mapped2"},
+                "inScope": False,
+                "topNDocuments": 42,
+                "queryType": "semantic",
+                "semanticConfiguration": "default",
+                "roleInformation": "You are a helpful bot",
+                "filter": "someFilterPattern",
+                "embeddingEndpoint": "https://fake.embedding.endpoint.com",
+                "embeddingKey": "fakeEmbeddingKEY",
+            },
+        }
+
+        assert config.as_datasource_param() == expected_output
+
+
+class TestAzureChatCompletionWithData:
+    @pytest.fixture
+    def azure_chat_completion_with_data(self) -> AzureChatCompletionWithData:
+        return AzureChatCompletionWithData(
+            deployment_name="test_deployment",
+            endpoint="https://test-endpoint.com",
+            api_key="test_api_key",
+            data_source_configs=[
+                AzureChatCompletionDataSourceConfig(
+                    endpoint="test_endpoint", key="test_key", index_name="test_index"
+                )
+            ],
+        )
+
+    def test_initialization(self):
+        deployment_name = "test_deployment"
+        endpoint = "https://test-endpoint.com"
+        api_key = "test_api_key"
+        api_version = "2023-08-01-preview"
+        logger = Logger("test_logger")
+        data_source_config = AzureChatCompletionDataSourceConfig(
+            endpoint="test_endpoint", key="test_key", index_name="test_index"
+        )
+
+        # Test successful initialization
+        azure_chat_completion_with_data = AzureChatCompletionWithData(
+            deployment_name=deployment_name,
+            endpoint=endpoint,
+            api_key=api_key,
+            api_version=api_version,
+            logger=logger,
+            data_source_configs=[data_source_config],
+        )
+
+        assert azure_chat_completion_with_data._endpoint == endpoint
+        assert azure_chat_completion_with_data._api_version == api_version
+        assert azure_chat_completion_with_data._api_type == "azure"
+        assert azure_chat_completion_with_data._data_source_configs == [
+            data_source_config
+        ]
+        assert isinstance(azure_chat_completion_with_data, AzureChatCompletion)
+
+    def test_initialization_with_empty_data_source_configs(self):
+        deployment_name = "test_deployment"
+        endpoint = "https://test-endpoint.com"
+        api_key = "test_api_key"
+
+        with pytest.raises(ValueError, match="The data source configs cannot be empty"):
+            AzureChatCompletionWithData(
+                deployment_name=deployment_name,
+                endpoint=endpoint,
+                api_key=api_key,
+                data_source_configs=[],
+            )
+
+    def test_initialize_with_unsupported_api_version(self):
+        deployment_name = "test_deployment"
+        endpoint = "https://test-endpoint.com"
+        api_key = "test_api_key"
+        data_source_config = AzureChatCompletionDataSourceConfig(
+            endpoint="test_endpoint", key="test_key", index_name="test_index"
+        )
+
+        with pytest.raises(
+            ValueError, match='Only API version "2023-08-01-preview" is supported'
+        ):
+            AzureChatCompletionWithData(
+                deployment_name=deployment_name,
+                endpoint=endpoint,
+                api_key=api_key,
+                data_source_configs=[data_source_config],
+                api_version="2023-06-01-preview",
+            )
+
+    def test_functions_not_supported(self, azure_chat_completion_with_data):
+        with pytest.raises(
+            ValueError, match="Chat with your data API does not support function call"
+        ):
+            azure_chat_completion_with_data._validate_chat_request(
+                messages=[{"role": "user", "text": "Hello"}],
+                request_settings=ChatRequestSettings(function_call="auto"),
+                stream=False,
+                functions=[
+                    {
+                        "name": "get_current_weather",
+                        "description": "Get the current weather in a given location",
+                    }
+                ],
+            )
+
+    def test_gen_payload(self, azure_chat_completion_with_data):
+        payload = azure_chat_completion_with_data._gen_api_payload(
+            messages=[{"role": "user", "text": "Hello"}],
+            request_settings=ChatRequestSettings(function_call="auto"),
+            stream=False,
+        )
+
+        expected = {
+            "model": "test_deployment",
+            "messages": [{"role": "user", "text": "Hello"}],
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "n": 1,
+            "stream": False,
+            "stop": None,
+            "max_tokens": 256,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "logit_bias": {},
+            "dataSources": [
+                {
+                    "type": "AzureCognitiveSearch",
+                    "parameters": {
+                        "endpoint": "test_endpoint",
+                        "key": "test_key",
+                        "indexName": "test_index",
+                        "fieldsMapping": None,
+                        "inScope": True,
+                        "topNDocuments": 5,
+                        "queryType": "simple",
+                        "semanticConfiguration": None,
+                        "roleInformation": None,
+                        "filter": None,
+                    },
+                },
+            ],
+        }
+
+        assert payload == expected
+
+    def test_gen_headers_azure(self, azure_chat_completion_with_data):
+        headers = azure_chat_completion_with_data._gen_api_headers()
+
+        expected = {"Content-Type": "application/json", "Api-Key": "test_api_key"}
+
+        assert headers == expected
+
+    def test_gen_headers_azure_ad(self):
+        conn = AzureChatCompletionWithData(
+            deployment_name="test_deployment",
+            endpoint="https://test-endpoint.com",
+            api_key="test_api_key",
+            data_source_configs=[
+                AzureChatCompletionDataSourceConfig(
+                    endpoint="test_endpoint", key="test_key", index_name="test_index"
+                )
+            ],
+            ad_auth=True,
+        )
+
+        headers = conn._gen_api_headers()
+
+        expected = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer test_api_key",
+        }
+
+        assert headers == expected
+
+    def test_parse_2023_08_01_preview_response(self, azure_chat_completion_with_data):
+        resp = {
+            # Fields like id, model, created, and object are not parsed
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "Here's the answer.",
+                        "end_turn": True,
+                        "context": {
+                            "messages": [
+                                {
+                                    "role": "tool",
+                                    "content": '{"citations": [{"content": "Citation 1"}, {"content": "Citation 2"}]}',
+                                    "end_turn": False,
+                                }
+                            ]
+                        },
+                    },
+                }
+            ]
+        }
+        result = azure_chat_completion_with_data._parse_response(resp)
+        assert result == (
+            "Here's the answer.",
+            '{"citations": [{"content": "Citation 1"}, {"content": "Citation 2"}]}',
+        )
+
+    def test_parse_2023_08_01_preview_response_multiple_choices(
+        self, azure_chat_completion_with_data
+    ):
+        resp = {
+            # Fields like id, model, created, and object are not parsed
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "Here's the answer.",
+                        "end_turn": True,
+                        "context": {
+                            "messages": [
+                                {
+                                    "role": "tool",
+                                    "content": '{"citations": [{"content": "Citation 1"}, {"content": "Citation 2"}]}',
+                                    "end_turn": False,
+                                }
+                            ]
+                        },
+                    },
+                },
+                {
+                    "index": 1,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "Here's another answer.",
+                        "end_turn": True,
+                        "context": {
+                            "messages": [
+                                {
+                                    "role": "tool",
+                                    "content": '{"citations": [{"content": "Citation 3"}, {"content": "Citation 4"}]}',
+                                    "end_turn": False,
+                                }
+                            ]
+                        },
+                    },
+                },
+            ]
+        }
+        result = azure_chat_completion_with_data._parse_response(resp)
+        assert result == [
+            (
+                "Here's the answer.",
+                '{"citations": [{"content": "Citation 1"}, {"content": "Citation 2"}]}',
+            ),
+            (
+                "Here's another answer.",
+                '{"citations": [{"content": "Citation 3"}, {"content": "Citation 4"}]}',
+            ),
+        ]


### PR DESCRIPTION
### Motivation and Context

Resolve #2998

Implementation of Azure OpenAI Chat Completion with data feature as AI connector:
https://learn.microsoft.com/en-us/azure/ai-services/openai/use-your-data-quickstart

### Description

* Add `azure_chat_completion_with_data.py` module
  - Add `AzureChatCompletionDataSourceConfig` class to store the `dataSource` parameter for chat with your data API.
  - Add `AzureChatCompletionWithData` class which implemented "complete_chat_with_data_async" method that performs chat with your data API call.

* Update sk_function.py to perform chat with your data API call if the service (connector) has "complete_chat_with_data_async" method and store the citations data as value of `SKContext.objects["tool"]` key.

* Add sample "azure_chat_with_your_data.py".

* Fix `azure_openai_settings_from_dot_env_as_dict` function: If `include_api_version` parameter is False, `azure_openai_settings_from_dot_env` function returns tuple with 3 elements.

### Todos
- [ ] Docstrings for new classes
- [ ] Implement streaming interfaces for `AzureChatCompletionWithData` class

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
