### PR TITLE
Java: optionally allow/disallow missing functions in sequential planner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -472,6 +472,9 @@ java/.mvn/wrapper/maven-wrapper.jar
 # Java settings
 conf.properties
 
+# Intellij configuration
+*.iml
+
 # Playwright
 playwright-report/
 

--- a/java/extensions/semantickernel-planners/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlanParser.java
+++ b/java/extensions/semantickernel-planners/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlanParser.java
@@ -48,6 +48,26 @@ public class SequentialPlanParser {
     // result for a plan.
     private static final String AppendToResultTag = "appendToResult".toLowerCase(Locale.ROOT);
 
+
+
+    /**
+     * Convert a plan xml string to a plan
+     *
+     * @param xmlString The plan xml string
+     * @param goal The goal for the plan
+     * @param skills The skills to use
+     * @return The plan
+     * @throws PlanningException If the plan xml is invalid
+     */
+    public static Plan toPlanFromXml(
+        String xmlString,
+        String goal,
+        ReadOnlySkillCollection skills
+    ) throws PlanningException {
+      // to maintain backward compatibility -- uses the preexisting signature and behavior
+      return toPlanFromXml(xmlString, goal, skills, true);
+    }
+
     /**
      * Convert a plan xml string to a plan
      *

--- a/java/extensions/semantickernel-planners/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlanner.java
+++ b/java/extensions/semantickernel-planners/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlanner.java
@@ -119,10 +119,12 @@ public class SequentialPlanner {
 
                                 LOGGER.debug("Plan result: " + planResultString);
 
-                                Plan plan =
-                                        SequentialPlanParser.toPlanFromXml(
-                                                planResultString, goal, context.getSkills());
-                                return plan;
+                                return SequentialPlanParser.toPlanFromXml(
+                                    planResultString,
+                                    goal,
+                                    context.getSkills(),
+                                    config.getAllowMissingFunctions()
+                                );
                             });
         } catch (Exception e) {
             throw new PlanningException(

--- a/java/extensions/semantickernel-planners/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlannerRequestSettings.java
+++ b/java/extensions/semantickernel-planners/src/main/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlannerRequestSettings.java
@@ -53,19 +53,26 @@ public class SequentialPlannerRequestSettings {
     /// </summary>
     private int maxTokens = 1024;
 
+    /// <summary>
+    /// Whether to allow missing functions in the plan.
+    /// </summary>
+    private boolean allowMissingFunctions = false;
+
     public SequentialPlannerRequestSettings(
             @Nullable Float relevancyThreshold,
             int maxRelevantFunctions,
             Set<String> excludedSkills,
             Set<String> excludedFunctions,
             Set<String> includedFunctions,
-            int maxTokens) {
+            int maxTokens,
+            boolean allowMissingFunctions) {
         this.relevancyThreshold = relevancyThreshold;
         this.maxRelevantFunctions = maxRelevantFunctions;
         this.excludedSkills = Collections.unmodifiableSet(excludedSkills);
         this.excludedFunctions = Collections.unmodifiableSet(excludedFunctions);
         this.includedFunctions = Collections.unmodifiableSet(includedFunctions);
         this.maxTokens = maxTokens;
+        this.allowMissingFunctions = allowMissingFunctions;
     }
 
     public SequentialPlannerRequestSettings() {}
@@ -95,6 +102,10 @@ public class SequentialPlannerRequestSettings {
         return maxTokens;
     }
 
+    public boolean getAllowMissingFunctions() {
+      return allowMissingFunctions;
+    }
+
     public SequentialPlannerRequestSettings addExcludedFunctions(String function) {
         HashSet<String> ex = new HashSet<>(excludedFunctions);
         ex.add(function);
@@ -104,7 +115,8 @@ public class SequentialPlannerRequestSettings {
                 excludedSkills,
                 ex,
                 includedFunctions,
-                maxTokens);
+                maxTokens,
+                allowMissingFunctions);
     }
 
     public SequentialPlannerRequestSettings addExcludedSkillName(String skillName) {
@@ -116,6 +128,7 @@ public class SequentialPlannerRequestSettings {
                 ex,
                 excludedFunctions,
                 includedFunctions,
-                maxTokens);
+                maxTokens,
+                allowMissingFunctions);
     }
 }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example12_SequentialPlanner.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example12_SequentialPlanner.java
@@ -215,7 +215,8 @@ public class Example12_SequentialPlanner {
                 Set.of(),
                 Set.of(),
                 Set.of(),
-                maxTokens
+                maxTokens,
+                false
         ), null);
     }
 }

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlannerTest.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/planner/sequentialplanner/SequentialPlannerTest.java
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.planner.sequentialplanner;
+
+import static com.microsoft.semantickernel.DefaultKernelTest.mockCompletionOpenAIAsyncClient;
+
+import com.azure.ai.openai.OpenAIAsyncClient;
+import com.microsoft.semantickernel.Kernel;
+import com.microsoft.semantickernel.SKBuilders;
+import com.microsoft.semantickernel.planner.PlanningException;
+import com.microsoft.semantickernel.planner.actionplanner.Plan;
+import com.microsoft.semantickernel.skilldefinition.annotations.DefineSKFunction;
+import com.microsoft.semantickernel.skilldefinition.annotations.SKFunctionParameters;
+import com.microsoft.semantickernel.textcompletion.TextCompletion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.util.function.Tuples;
+import java.util.HashSet;
+
+public class SequentialPlannerTest {
+
+  public static class SkillWithSomeArgs {
+
+    @DefineSKFunction(name = "aFunction")
+    public String aFunction(
+        @SKFunctionParameters(
+            name = "input1",
+            description = "The first input to the function")
+        String input1,
+        @SKFunctionParameters(
+            name = "input2",
+            description = "The second input to the function")
+        String input2) {
+      return "A-RESULT";
+    }
+  }
+
+  @Test
+  public void inputsAreCorrectlyPassed() {
+    String planXml = "<plan>\n"
+        + "    <function.SkillWithSomeArgs.aFunction input1=\"Cleopatra\" input2=\"Anthony\" />\n"
+        + "    </plan>";
+    Kernel kernel = mockKernelWithPlan(planXml);
+
+    SkillWithSomeArgs skill = Mockito.spy(new SkillWithSomeArgs());
+    kernel.importSkill(skill, "SkillWithSomeArgs");
+
+    SequentialPlanner planner = new SequentialPlanner(kernel,
+        new SequentialPlannerRequestSettings(), null);
+
+    String goal = "Write a poem about Cleopatra.";
+
+    Plan plan = planner.createPlanAsync(goal).block();
+    String planResult = plan.invokeAsync(goal).block().getResult();
+
+    Assertions.assertEquals("A-RESULT", planResult);
+
+    Mockito.verify(skill, Mockito.atLeastOnce()).aFunction("Cleopatra", "Anthony");
+  }
+
+  @Test
+  public void givenDefaultSettings_WhenPlanWithMissingFunctionsIsGenerated_ShouldThrow() {
+    String planXml = "<plan>\n"
+        + "    <function.SkillWithSomeArgs.aFunction input1=\"Cleopatra\" input2=\"Anthony\" />\n"
+        + "    </plan>";
+    Kernel kernel = mockKernelWithPlan(planXml); // don't load any skills & functions
+
+    SequentialPlanner planner = new SequentialPlanner(kernel,
+        new SequentialPlannerRequestSettings(), null);
+
+    String goal = "Write a poem about Cleopatra.";
+
+    Assertions.assertThrows(PlanningException.class, planner.createPlanAsync(goal)::block);
+  }
+
+  @Test
+  public void givenAllowMissingFunctionsSetting_WhenPlanWithMissingFunctionsIsGenerated_ShouldNotThrow() {
+    String planXml = "<plan>\n"
+        + "    <function.SkillWithSomeArgs.aFunction input1=\"Cleopatra\" input2=\"Anthony\" />\n"
+        + "    </plan>";
+    Kernel kernel = mockKernelWithPlan(planXml); // don't load any skills & functions
+
+    SequentialPlannerRequestSettings settings = new SequentialPlannerRequestSettings(
+        null,
+        10,
+        new HashSet<>(),
+        new HashSet<>(),
+        new HashSet<>(),
+        1024,
+        true
+    );
+    SequentialPlanner planner = new SequentialPlanner(kernel, settings, null);
+
+    String goal = "Write a poem about Cleopatra.";
+
+    Plan plan = planner.createPlanAsync(goal).block();
+    String planResult = plan.invokeAsync(goal).block().getResult();
+  }
+
+  private static Kernel mockKernelWithPlan(String planXml) {
+    OpenAIAsyncClient client = mockCompletionOpenAIAsyncClient(Tuples.of("plan", planXml));
+
+    TextCompletion textCompletion = SKBuilders.textCompletion()
+        .withModelId("text-davinci-002")
+        .withOpenAIClient(client)
+        .build();
+
+    return SKBuilders.kernel().withDefaultAIService(textCompletion).build();
+  }
+}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This is to resolve #2855 -- when using the java `SequentialPlanner`, the planner will return a plan with missing skills. This enables a configuration setting to allow/disallow the missing functions. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

This PR adds
* The configuration setting to allow/disallow missing functions. I set the default to false (throw on a missing function), technically a breaking change from what was previously implemented. Given this branch is still prerelease, I decided that's the better default configuration, and the breaking change should be okay. 
* The logic in the plan parser; to throw when `allowMissingFunctions=true` and the plan has a missing function. 
* Unit tests for the SequentialPlanner that bring its tests to parity with the other Planner unit tests and test the desired behavior for this setting when it is on or off. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
