### PR TITLE
.Net: [Option 2] Chat Prompts - handling in Semantic Function

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example63_ChatCompletionPrompts.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example63_ChatCompletionPrompts.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+
+/**
+ * This example shows how to use chat completion prompts.
+ */
+// ReSharper disable once InconsistentNaming
+public static class Example63_ChatCompletionPrompts
+{
+    public static async Task RunAsync()
+    {
+        const string TextPrompt = "What is Seattle?";
+        const string ChatPrompt = @"
+            <message role=""user"">What is Seattle?</message>
+            <message role=""system"">Respond with JSON.</message>
+        ";
+
+        var kernel = new KernelBuilder()
+            .WithOpenAIChatCompletionService(
+                modelId: TestConfiguration.OpenAI.ChatModelId,
+                apiKey: TestConfiguration.OpenAI.ApiKey)
+            .Build();
+
+        var textSemanticFunction = kernel.CreateSemanticFunction(TextPrompt);
+        var chatSemanticFunction = kernel.CreateSemanticFunction(ChatPrompt);
+
+        var textKernelResult = await kernel.RunAsync(textSemanticFunction);
+        var chatKernelResult = await kernel.RunAsync(chatSemanticFunction);
+
+        Console.WriteLine(textKernelResult);
+        Console.WriteLine(chatKernelResult);
+    }
+}

--- a/dotnet/samples/KernelSyntaxExamples/Example63_ChatCompletionPrompts.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example63_ChatCompletionPrompts.cs
@@ -27,10 +27,40 @@ public static class Example63_ChatCompletionPrompts
         var textSemanticFunction = kernel.CreateSemanticFunction(TextPrompt);
         var chatSemanticFunction = kernel.CreateSemanticFunction(ChatPrompt);
 
-        var textKernelResult = await kernel.RunAsync(textSemanticFunction);
-        var chatKernelResult = await kernel.RunAsync(chatSemanticFunction);
+        var textPromptResult = await kernel.RunAsync(textSemanticFunction);
+        var chatPromptResult = await kernel.RunAsync(chatSemanticFunction);
 
-        Console.WriteLine(textKernelResult);
-        Console.WriteLine(chatKernelResult);
+        Console.WriteLine("Text Prompt:");
+        Console.WriteLine(TextPrompt);
+        Console.WriteLine("Text Prompt Result:");
+        Console.WriteLine(textPromptResult);
+
+        Console.WriteLine();
+
+        Console.WriteLine("Chat Prompt:");
+        Console.WriteLine(ChatPrompt);
+        Console.WriteLine("Chat Prompt Result:");
+        Console.WriteLine(chatPromptResult);
+
+        /*
+        Text Prompt:
+        What is Seattle?
+        Text Prompt Result:
+        Seattle is a city located in the state of Washington in the United States...
+
+        Chat Prompt:
+        <message role="user">What is Seattle?</message>
+        <message role="system">Respond with JSON.</message>
+
+        Chat Prompt Result:
+        {
+          "Seattle": {
+            "Description": "Seattle is a city located in the state of Washington, in the United States...",
+            "Population": "Approximately 753,675 as of 2019",
+            "Area": "142.5 square miles",
+            ...
+          }
+        }
+         */
     }
 }

--- a/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatPromptParser.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.RegularExpressions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Microsoft.SemanticKernel.AI.ChatCompletion;
+
+public static class ChatPromptParser
+{
+    private static readonly Regex s_chatHistoryRegex = new(@"<message role=[""']([^""']+)[""']>\s*([^<]+?)\s*</message>");
+
+    public static bool TryGetChatHistory(string prompt, out ChatHistory? chatHistory)
+    {
+        var matchCollection = s_chatHistoryRegex.Matches(prompt);
+
+        if (matchCollection.Count == 0)
+        {
+            chatHistory = null;
+            return false;
+        }
+
+        chatHistory = new ChatHistory();
+
+        foreach (Match match in matchCollection)
+        {
+            string role = match.Groups[1].Value;
+            string content = match.Groups[2].Value;
+
+            chatHistory.AddMessage(new AuthorRole(role), content);
+        }
+
+        return true;
+    }
+}

--- a/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatPromptParser.cs
@@ -1,14 +1,25 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Text.RegularExpressions;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.SemanticKernel.AI.ChatCompletion;
 
+/// <summary>
+/// Parser for chat completion prompts.
+/// </summary>
 public static class ChatPromptParser
 {
+    /// <summary>
+    /// Regex to fetch value from "role" attribute and content inside "message" tag.
+    /// </summary>
     private static readonly Regex s_chatHistoryRegex = new(@"<message role=[""']([^""']+)[""']>\s*([^<]+?)\s*</message>");
 
+    /// <summary>
+    /// Tries to get instance of <see cref="ChatHistory"/> from given prompt.
+    /// </summary>
+    /// <param name="prompt">Prompt to parse.</param>
+    /// <param name="chatHistory">Instance of <see cref="ChatHistory"/> if given prompt is chat prompt, otherwise null.</param>
+    /// <returns>Boolean flag that indicates if given prompt is chat prompt or not.</returns>
     public static bool TryGetChatHistory(string prompt, out ChatHistory? chatHistory)
     {
         var matchCollection = s_chatHistoryRegex.Matches(prompt);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatPromptParserTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatPromptParserTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 
 namespace SemanticKernel.UnitTests.AI.ChatCompletion;
 
+/// <summary>
+/// Unit tests for <see cref="ChatPromptParser"/> class.
+/// </summary>
 public class ChatPromptParserTests
 {
     [Theory]

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatPromptParserTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatPromptParserTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.AI.ChatCompletion;
+
+public class ChatPromptParserTests
+{
+    [Theory]
+    [InlineData("This is plain prompt", false)]
+    [InlineData("<message>This is not completed chat prompt</message>", false)]
+    [InlineData("<message role=\"system\">This is completed chat prompt</message>", true)]
+    [InlineData("<message role=\"system\">System message</message><message role=\"user\">User message</message>", true)]
+    public void ChatPromptIdentificationWorksCorrectly(string prompt, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, ChatPromptParser.TryGetChatHistory(prompt, out _));
+    }
+
+    [Theory]
+    [InlineData("This is plain prompt", null)]
+    [InlineData("<message>This is not completed chat prompt</message>", null)]
+    public void ItReturnsNullChatHistoryWhenPromptIsNotChatPrompt(string prompt, ChatHistory? expectedChatHistory)
+    {
+        // Act
+        var result = ChatPromptParser.TryGetChatHistory(prompt, out var chatHistory);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(expectedChatHistory, chatHistory);
+    }
+
+    [Fact]
+    public void ItReturnsChatHistoryWhenPromptIsChatPrompt()
+    {
+        // Arrange
+        const string Prompt = @"
+<message role=""system"">
+Test with role in double quotes and content in new line.
+</message>
+
+<message role='user'>Test with role in single quotes and content in the same line.</message>
+
+<message role=""assistant"">
+Test with multiline content.
+Second line.
+</message>
+
+<message role='system'>
+    Test line with tab.
+</message>
+";
+
+        var expectedChatHistory = new ChatHistory();
+        expectedChatHistory.AddSystemMessage("Test with role in double quotes and content in new line.");
+        expectedChatHistory.AddUserMessage("Test with role in single quotes and content in the same line.");
+        expectedChatHistory.AddAssistantMessage("Test with multiline content.\nSecond line.");
+        expectedChatHistory.AddSystemMessage("Test line with tab.");
+
+        // Act
+        var result = ChatPromptParser.TryGetChatHistory(Prompt, out var actualChatHistory);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(actualChatHistory);
+
+        for (var i = 0; i < expectedChatHistory.Count; i++)
+        {
+            this.AssertChatMessage(expectedChatHistory[i], actualChatHistory[i]);
+        }
+    }
+
+    private void AssertChatMessage(ChatMessageBase expectedMessage, ChatMessageBase actualMessage)
+    {
+        Assert.Equal(expectedMessage.Role, actualMessage.Role);
+        Assert.Equal(expectedMessage.Content, actualMessage.Content);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/SemanticFunctionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/SemanticFunctionTests.cs
@@ -534,7 +534,7 @@ public class SemanticFunctionTests
         return method.Method;
     }
 
-    private class TestChatMessage : ChatMessageBase
+    private sealed class TestChatMessage : ChatMessageBase
     {
         public TestChatMessage(AuthorRole role, string content) : base(role, content)
         {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

ADR (option 2): https://github.com/microsoft/semantic-kernel/pull/3338

The logic in this approach performs prompt parsing on Semantic Function level. 

Pros:
 - New connectors of a new type or existing ones don't have to implement the mapping functionality

Cons:
 - The `SemanticFunction` class has to be changed every time a new completion type needs to be supported by SK
 - Prompts can be run by Kernel.RunAsync method only.

Demo:
```
Text Prompt:
What is Seattle?
Text Prompt Result:
Seattle is a city located in the state of Washington in the United States...

Chat Prompt:
<message role="user">What is Seattle?</message>
<message role="system">Respond with JSON.</message>

Chat Prompt Result:
{
  "Seattle": {
    "Description": "Seattle is a city located in the state of Washington, in the United States...",
    "Population": "Approximately 753,675 as of 2019",
    "Area": "142.5 square miles",
    ...
  }
}
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
