### PR TITLE
Java - Changes constant settings visibility to public

### DIFF
--- a/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/AbstractOpenAIClientSettings.java
+++ b/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/AbstractOpenAIClientSettings.java
@@ -9,7 +9,7 @@ import com.microsoft.semantickernel.exceptions.ConfigurationException;
  */
 public abstract class AbstractOpenAIClientSettings {
 
-    public static final String KEY_SUFFIX = "key";
+    protected static final String KEY_SUFFIX = "key";
 
     /**
      * Check if the settings are valid
@@ -24,4 +24,13 @@ public abstract class AbstractOpenAIClientSettings {
      * @return OpenAI client key
      */
     public abstract String getKey() throws ConfigurationException;
+
+    /**
+     * Get the KEY_SUFFIX value
+     *
+     * @return the KEY_SUFFIX value
+     */
+    public static String getKeySuffix() {
+      return KEY_SUFFIX;
+    }
 }

--- a/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/AzureOpenAISettings.java
+++ b/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/AzureOpenAISettings.java
@@ -7,9 +7,9 @@ import javax.annotation.Nullable;
 
 /** Settings for Azure OpenAI client */
 public class AzureOpenAISettings extends AbstractOpenAIClientSettings {
-    public static final String DEFAULT_SETTINGS_PREFIX = "client.azureopenai";
-    public static final String AZURE_OPEN_AI_ENDPOINT_SUFFIX = "endpoint";
-    public static final String AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX = "deploymentname";
+    private static final String DEFAULT_SETTINGS_PREFIX = "client.azureopenai";
+    private static final String AZURE_OPEN_AI_ENDPOINT_SUFFIX = "endpoint";
+    private static final String AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX = "deploymentname";
 
     @Nullable private final String key;
 
@@ -79,5 +79,32 @@ public class AzureOpenAISettings extends AbstractOpenAIClientSettings {
         }
 
         return true;
+    }
+
+    /**
+     * Get the DEFAULT_SETTINGS_PREFIX value
+     *
+     * @return the DEFAULT_SETTINGS_PREFIX value
+     */
+    public static String getDefaultSettingsPrefix() {
+      return DEFAULT_SETTINGS_PREFIX;
+    }
+
+    /**
+     * Get the AZURE_OPEN_AI_ENDPOINT_SUFFIX value
+     *
+     * @return the AZURE_OPEN_AI_ENDPOINT_SUFFIX value
+     */
+    public static String getAzureOpenAiEndpointSuffix() {
+        return AZURE_OPEN_AI_ENDPOINT_SUFFIX;
+    }
+
+    /**
+     * Get the AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX value
+     *
+     * @return the AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX value
+     */
+    public static String getAzureOpenAiDeploymentNameSuffix() {
+        return AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX;
     }
 }

--- a/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/AzureOpenAISettings.java
+++ b/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/AzureOpenAISettings.java
@@ -7,9 +7,9 @@ import javax.annotation.Nullable;
 
 /** Settings for Azure OpenAI client */
 public class AzureOpenAISettings extends AbstractOpenAIClientSettings {
-    private static final String DEFAULT_SETTINGS_PREFIX = "client.azureopenai";
-    private static final String AZURE_OPEN_AI_ENDPOINT_SUFFIX = "endpoint";
-    private static final String AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX = "deploymentname";
+    public static final String DEFAULT_SETTINGS_PREFIX = "client.azureopenai";
+    public static final String AZURE_OPEN_AI_ENDPOINT_SUFFIX = "endpoint";
+    public static final String AZURE_OPEN_AI_DEPLOYMENT_NAME_SUFFIX = "deploymentname";
 
     @Nullable private final String key;
 

--- a/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/OpenAISettings.java
+++ b/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/OpenAISettings.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 
 public class OpenAISettings extends AbstractOpenAIClientSettings {
     public static final String OPEN_AI_ORGANIZATION_SUFFIX = "organizationid";
-    private static final String DEFAULT_SETTINGS_PREFIX = "client.openai";
+    public static final String DEFAULT_SETTINGS_PREFIX = "client.openai";
 
     @Nullable private final String key;
     @Nullable private final String organizationId;

--- a/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/OpenAISettings.java
+++ b/java/extensions/semantickernel-settings-loader/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/util/OpenAISettings.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 public class OpenAISettings extends AbstractOpenAIClientSettings {
-    public static final String OPEN_AI_ORGANIZATION_SUFFIX = "organizationid";
-    public static final String DEFAULT_SETTINGS_PREFIX = "client.openai";
+    private static final String OPEN_AI_ORGANIZATION_SUFFIX = "organizationid";
+    private static final String DEFAULT_SETTINGS_PREFIX = "client.openai";
 
     @Nullable private final String key;
     @Nullable private final String organizationId;
@@ -47,5 +47,23 @@ public class OpenAISettings extends AbstractOpenAIClientSettings {
                     settingsPrefix + "." + KEY_SUFFIX);
         }
         return true;
+    }
+
+    /**
+     * Get the OPEN_AI_ORGANIZATION_SUFFIX value
+     *
+     * @return the OPEN_AI_ORGANIZATION_SUFFIX value
+     */
+    public static String getOpenAiOrganizationSuffix() {
+        return OPEN_AI_ORGANIZATION_SUFFIX;
+    }
+
+    /**
+     * Get the DEFAULT_SETTINGS_PREFIX value
+     *
+     * @return the DEFAULT_SETTINGS_PREFIX value
+     */
+    public static String getDefaultSettingsPrefix() {
+        return DEFAULT_SETTINGS_PREFIX;
     }
 }


### PR DESCRIPTION
### Motivation and Context

When writing external APIs that enhance the configuration, we need to have access to the settings. This PR turns all the constant settings to public.

AbstractOpenAIClientSettings.KEY_SUFFIX and OpenAISettings.OPEN_AI_ORGANIZATION_SUFFIX are already public, but the other settings are private, which makes it impossible to be used by external APIs.

### Description

External APIs need to have access to all the constant settings to enhance connection.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
