### PR TITLE
Java: Fixed invalid links in documentation

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ and frameworks.
 ## Get started
 
 To run the LLM prompts and semantic functions in this kernel, make sure you have
-an [Open AI API Key](https://openai.com/api/)
+an [Open AI API Key](https://openai.com/product/)
 or [Azure Open AI service key](https://learn.microsoft.com/azure/cognitive-services/openai/).
 
 ### Requirements

--- a/java/samples/sample-code/README.md
+++ b/java/samples/sample-code/README.md
@@ -35,7 +35,7 @@ They can then be run by:
 # Configuration
 
 You can define the provider of Open AI by setting the `OPENAI_CLIENT_TYPE`
-property or environment variable to either [`OPENAI`](https://openai.com/api/)
+property or environment variable to either [`OPENAI`](https://openai.com/product/)
 or [`AZURE_OPEN_AI`](https://learn.microsoft.com/azure/cognitive-services/openai/).
 By default, the samples will use the Open AI client.
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Updated OpenAI invalid links in Java documentation from `https://openai.com/api/` to `https://openai.com/product/`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
