### PR TITLE
.Net: Renamed Azure* classes and methods to AzureOpenAI*

### DIFF
--- a/dotnet/samples/ApplicationInsightsExample/Program.cs
+++ b/dotnet/samples/ApplicationInsightsExample/Program.cs
@@ -112,7 +112,7 @@ public sealed class Program
 
         var kernel = new KernelBuilder()
             .WithLoggerFactory(loggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 Env.Var("AzureOpenAI__ChatDeploymentName"),
                 Env.Var("AzureOpenAI__Endpoint"),
                 Env.Var("AzureOpenAI__ApiKey"))

--- a/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
@@ -73,7 +73,7 @@ internal static class Example12_SequentialPlanner
         Console.WriteLine("======== Sequential Planner - Create and Execute Poetry Plan ========");
         var kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
@@ -265,7 +265,7 @@ internal static class Example12_SequentialPlanner
     {
         var kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
@@ -282,11 +282,11 @@ internal static class Example12_SequentialPlanner
         // use these to generate and store embeddings for the function descriptions.
         var kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
-            .WithAzureTextEmbeddingGenerationService(
+            .WithAzureOpenAITextEmbeddingGenerationService(
                 TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
                 TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
                 TestConfiguration.AzureOpenAIEmbeddings.ApiKey)
@@ -299,7 +299,7 @@ internal static class Example12_SequentialPlanner
     {
         var memoryStorage = new VolatileMemoryStore();
 
-        var textEmbeddingGenerator = new AzureTextEmbeddingGeneration(
+        var textEmbeddingGenerator = new AzureOpenAITextEmbeddingGeneration(
             modelId: TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
             endpoint: TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
             apiKey: TestConfiguration.AzureOpenAIEmbeddings.ApiKey);

--- a/dotnet/samples/KernelSyntaxExamples/Example13_ConversationSummaryPlugin.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example13_ConversationSummaryPlugin.cs
@@ -179,7 +179,7 @@ Jane: Goodbye!
     {
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)

--- a/dotnet/samples/KernelSyntaxExamples/Example17_ChatGPT.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example17_ChatGPT.cs
@@ -59,12 +59,12 @@ public static class Example17_ChatGPT
     {
         Console.WriteLine("======== Azure Open AI - ChatGPT ========");
 
-        AzureChatCompletion azureChatCompletion = new(
+        AzureOpenAIChatCompletion azureOpenAIChatCompletion = new(
             TestConfiguration.AzureOpenAI.ChatDeploymentName,
             TestConfiguration.AzureOpenAI.Endpoint,
             TestConfiguration.AzureOpenAI.ApiKey);
 
-        await StartChatAsync(azureChatCompletion);
+        await StartChatAsync(azureOpenAIChatCompletion);
     }
 
     private static async Task StartChatAsync(IChatCompletion chatGPT)

--- a/dotnet/samples/KernelSyntaxExamples/Example18_DallE.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example18_DallE.cs
@@ -99,7 +99,7 @@ public static class Example18_DallE
             // Add your image generation service
             .WithAzureOpenAIImageGenerationService(TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
             // Add your chat completion service
-            .WithAzureChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
+            .WithAzureOpenAIChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
             .Build();
 
         IImageGeneration dallE = kernel.GetService<IImageGeneration>();

--- a/dotnet/samples/KernelSyntaxExamples/Example26_AADAuth.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example26_AADAuth.cs
@@ -44,8 +44,8 @@ public static class Example26_AADAuth
 
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            // Add Azure chat completion service using DefaultAzureCredential AAD auth
-            .WithAzureChatCompletionService(
+            // Add Azure OpenAI chat completion service using DefaultAzureCredential AAD auth
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 new DefaultAzureCredential(authOptions))

--- a/dotnet/samples/KernelSyntaxExamples/Example27_SemanticFunctionsUsingChatGPT.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example27_SemanticFunctionsUsingChatGPT.cs
@@ -17,7 +17,7 @@ public static class Example27_SemanticFunctionsUsingChatGPT
 
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
+            .WithAzureOpenAIChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
             .Build();
 
         var func = kernel.CreateSemanticFunction(

--- a/dotnet/samples/KernelSyntaxExamples/Example28_ActionPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example28_ActionPlanner.cs
@@ -14,7 +14,7 @@ public static class Example28_ActionPlanner
         Console.WriteLine("======== Action Planner ========");
         var kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)

--- a/dotnet/samples/KernelSyntaxExamples/Example31_CustomPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example31_CustomPlanner.cs
@@ -131,11 +131,11 @@ internal static class Example31_CustomPlanner
     {
         return new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
-            .WithAzureTextEmbeddingGenerationService(
+            .WithAzureOpenAITextEmbeddingGenerationService(
                 TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
@@ -146,7 +146,7 @@ internal static class Example31_CustomPlanner
     {
         return new MemoryBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureTextEmbeddingGenerationService(
+            .WithAzureOpenAITextEmbeddingGenerationService(
                 TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)

--- a/dotnet/samples/KernelSyntaxExamples/Example33_StreamingChat.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example33_StreamingChat.cs
@@ -31,12 +31,12 @@ public static class Example33_StreamingChat
     {
         Console.WriteLine("======== Azure Open AI - ChatGPT Streaming ========");
 
-        AzureChatCompletion azureChatCompletion = new(
+        AzureOpenAIChatCompletion azureOpenAIChatCompletion = new(
            TestConfiguration.AzureOpenAI.ChatDeploymentName,
            TestConfiguration.AzureOpenAI.Endpoint,
            TestConfiguration.AzureOpenAI.ApiKey);
 
-        await StartStreamingChatAsync(azureChatCompletion);
+        await StartStreamingChatAsync(azureOpenAIChatCompletion);
     }
 
     private static async Task StartStreamingChatAsync(IChatCompletion chatCompletion)

--- a/dotnet/samples/KernelSyntaxExamples/Example36_MultiCompletion.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example36_MultiCompletion.cs
@@ -22,7 +22,7 @@ public static class Example36_MultiCompletion
     {
         Console.WriteLine("======== Azure OpenAI - Multiple Chat Completion ========");
 
-        var chatCompletion = new AzureChatCompletion(
+        var chatCompletion = new AzureOpenAIChatCompletion(
             TestConfiguration.AzureOpenAI.ChatDeploymentName,
             TestConfiguration.AzureOpenAI.Endpoint,
             TestConfiguration.AzureOpenAI.ApiKey);

--- a/dotnet/samples/KernelSyntaxExamples/Example37_MultiStreamingCompletion.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example37_MultiStreamingCompletion.cs
@@ -22,7 +22,7 @@ public static class Example37_MultiStreamingCompletion
     {
         Console.WriteLine("======== Azure OpenAI - Multiple Chat Completion - Raw Streaming ========");
 
-        var chatCompletion = new AzureChatCompletion(
+        var chatCompletion = new AzureOpenAIChatCompletion(
             TestConfiguration.AzureOpenAI.ChatDeploymentName,
             TestConfiguration.AzureOpenAI.Endpoint,
             TestConfiguration.AzureOpenAI.ApiKey);

--- a/dotnet/samples/KernelSyntaxExamples/Example42_KernelBuilder.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example42_KernelBuilder.cs
@@ -72,7 +72,7 @@ public static class Example42_KernelBuilder
         // Manually setup all the dependencies to be used by the kernel
         var loggerFactory = NullLoggerFactory.Instance;
         var memoryStorage = new VolatileMemoryStore();
-        var textEmbeddingGenerator = new AzureTextEmbeddingGeneration(
+        var textEmbeddingGenerator = new AzureOpenAITextEmbeddingGeneration(
             modelId: azureOpenAIEmbeddingDeployment,
             endpoint: azureOpenAIEndpoint,
             apiKey: azureOpenAIKey,
@@ -87,7 +87,7 @@ public static class Example42_KernelBuilder
         using var httpHandler = httpHandlerFactory.Create(loggerFactory);
         using var httpClient = new HttpClient(httpHandler);
         var aiServices = new AIServiceCollection();
-        ITextCompletion Factory() => new AzureChatCompletion(
+        ITextCompletion Factory() => new AzureOpenAIChatCompletion(
             modelId: azureOpenAIChatCompletionDeployment,
             endpoint: azureOpenAIEndpoint,
             apiKey: azureOpenAIKey,
@@ -107,7 +107,7 @@ public static class Example42_KernelBuilder
         // The AI services are defined with the builder
 
         var kernel7 = new KernelBuilder()
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 deploymentName: azureOpenAIChatCompletionDeployment,
                 endpoint: azureOpenAIEndpoint,
                 apiKey: azureOpenAIKey,

--- a/dotnet/samples/KernelSyntaxExamples/Example44_MultiChatCompletion.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example44_MultiChatCompletion.cs
@@ -23,12 +23,12 @@ public static class Example44_MultiChatCompletion
     {
         Console.WriteLine("======== Azure OpenAI - Multiple Chat Completion ========");
 
-        AzureChatCompletion azureChatCompletion = new(
+        AzureOpenAIChatCompletion azureOpenAIChatCompletion = new(
             TestConfiguration.AzureOpenAI.ChatDeploymentName,
             TestConfiguration.AzureOpenAI.Endpoint,
             TestConfiguration.AzureOpenAI.ApiKey);
 
-        await RunChatAsync(azureChatCompletion);
+        await RunChatAsync(azureOpenAIChatCompletion);
     }
 
     private static async Task OpenAIMultiChatCompletionAsync()

--- a/dotnet/samples/KernelSyntaxExamples/Example45_MultiStreamingChatCompletion.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example45_MultiStreamingChatCompletion.cs
@@ -27,12 +27,12 @@ public static class Example45_MultiStreamingChatCompletion
     {
         Console.WriteLine("======== Azure OpenAI - Multiple Chat Completion - Raw Streaming ========");
 
-        AzureChatCompletion azureChatCompletion = new(
+        AzureOpenAIChatCompletion azureOpenAIChatCompletion = new(
             TestConfiguration.AzureOpenAI.ChatDeploymentName,
             TestConfiguration.AzureOpenAI.Endpoint,
             TestConfiguration.AzureOpenAI.ApiKey);
 
-        await StreamingChatCompletionAsync(azureChatCompletion);
+        await StreamingChatCompletionAsync(azureOpenAIChatCompletion);
     }
 
     private static async Task OpenAIMultiStreamingChatCompletionAsync()

--- a/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
@@ -59,7 +59,7 @@ after this event Caroline became his wife.""";
         Console.WriteLine("======== Groundedness Checks ========");
         var kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)
@@ -124,7 +124,7 @@ which are not grounded in the original.
 
         var kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey)

--- a/dotnet/samples/KernelSyntaxExamples/Example51_StepwisePlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example51_StepwisePlanner.cs
@@ -202,7 +202,7 @@ public static class Example51_StepwisePlanner
         var maxTokens = 0;
         if (useChat)
         {
-            builder.WithAzureChatCompletionService(
+            builder.WithAzureOpenAIChatCompletionService(
                 model ?? ChatModelOverride ?? TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey,

--- a/dotnet/samples/KernelSyntaxExamples/Example52_ApimAuth.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example52_ApimAuth.cs
@@ -62,7 +62,7 @@ public static class Example52_ApimAuth
         var kernel = new KernelBuilder()
             .WithLoggerFactory(loggerFactory)
             .WithAIService<IChatCompletion>(TestConfiguration.AzureOpenAI.ChatDeploymentName, (loggerFactory) =>
-                new AzureChatCompletion(TestConfiguration.AzureOpenAI.ChatDeploymentName, openAIClient, loggerFactory))
+                new AzureOpenAIChatCompletion(TestConfiguration.AzureOpenAI.ChatDeploymentName, openAIClient, loggerFactory))
             .Build();
 
         // Load semantic plugin defined with prompt templates

--- a/dotnet/samples/KernelSyntaxExamples/Example54_AzureChatCompletionWithData.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example54_AzureChatCompletionWithData.cs
@@ -30,7 +30,7 @@ public static class Example54_AzureChatCompletionWithData
     {
         Console.WriteLine("=== Example with Chat Completion ===");
 
-        var chatCompletion = new AzureChatCompletionWithData(GetCompletionWithDataConfig());
+        var chatCompletion = new AzureOpenAIChatCompletionWithData(GetCompletionWithDataConfig());
         var chatHistory = chatCompletion.CreateNewChat();
 
         // First question without previous context based on uploaded content.
@@ -91,7 +91,7 @@ public static class Example54_AzureChatCompletionWithData
         var completionWithDataConfig = GetCompletionWithDataConfig();
 
         IKernel kernel = new KernelBuilder()
-            .WithAzureChatCompletionService(config: completionWithDataConfig)
+            .WithAzureOpenAIChatCompletionService(config: completionWithDataConfig)
             .Build();
 
         var semanticFunction = kernel.CreateSemanticFunction("Question: {{$input}}");
@@ -120,11 +120,11 @@ public static class Example54_AzureChatCompletionWithData
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureChatCompletionWithDataConfig"/> class.
+    /// Initializes a new instance of the <see cref="AzureOpenAIChatCompletionWithDataConfig"/> class.
     /// </summary>
-    private static AzureChatCompletionWithDataConfig GetCompletionWithDataConfig()
+    private static AzureOpenAIChatCompletionWithDataConfig GetCompletionWithDataConfig()
     {
-        return new AzureChatCompletionWithDataConfig
+        return new AzureOpenAIChatCompletionWithDataConfig
         {
             CompletionModelId = TestConfiguration.AzureOpenAI.ChatDeploymentName,
             CompletionEndpoint = TestConfiguration.AzureOpenAI.Endpoint,

--- a/dotnet/samples/KernelSyntaxExamples/Example56_TemplateNativeFunctionsWithMultipleArguments.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example56_TemplateNativeFunctionsWithMultipleArguments.cs
@@ -27,13 +27,13 @@ public static class Example56_TemplateNativeFunctionsWithMultipleArguments
 
         if (serviceId == null || apiKey == null || deploymentName == null || endpoint == null)
         {
-            Console.WriteLine("Azure serviceId, endpoint, apiKey, or deploymentName not found. Skipping example.");
+            Console.WriteLine("AzureOpenAI serviceId, endpoint, apiKey, or deploymentName not found. Skipping example.");
             return;
         }
 
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 deploymentName: deploymentName,
                 endpoint: endpoint,
                 serviceId: serviceId,

--- a/dotnet/samples/KernelSyntaxExamples/Example58_ConfigureRequestSettings.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example58_ConfigureRequestSettings.cs
@@ -25,13 +25,13 @@ public static class Example58_ConfigureRequestSettings
 
         if (serviceId == null || apiKey == null || chatDeploymentName == null || endpoint == null)
         {
-            Console.WriteLine("Azure serviceId, endpoint, apiKey, or deploymentName not found. Skipping example.");
+            Console.WriteLine("AzureOpenAI serviceId, endpoint, apiKey, or deploymentName not found. Skipping example.");
             return;
         }
 
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 deploymentName: chatDeploymentName,
                 endpoint: endpoint,
                 serviceId: serviceId,

--- a/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
@@ -51,7 +51,7 @@ public static class Example59_OpenAIFunctionCalling
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
             .WithOpenAIChatCompletionService(TestConfiguration.OpenAI.ChatModelId, TestConfiguration.OpenAI.ApiKey, serviceId: "chat")
-            //.WithAzureChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey, serviceId: "chat")
+            //.WithAzureOpenAIChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey, serviceId: "chat")
             .Build();
 
         // Load functions to kernel

--- a/dotnet/samples/KernelSyntaxExamples/Example61_MultipleLLMs.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example61_MultipleLLMs.cs
@@ -22,7 +22,7 @@ public static class Example61_MultipleLLMs
 
         if (apiKey == null || chatDeploymentName == null || endpoint == null)
         {
-            Console.WriteLine("Azure endpoint, apiKey, or deploymentName not found. Skipping example.");
+            Console.WriteLine("AzureOpenAI endpoint, apiKey, or deploymentName not found. Skipping example.");
             return;
         }
 
@@ -37,7 +37,7 @@ public static class Example61_MultipleLLMs
 
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 deploymentName: chatDeploymentName,
                 endpoint: endpoint,
                 serviceId: "AzureOpenAIChat",

--- a/dotnet/samples/KernelSyntaxExamples/Example62_CustomAIServiceSelector.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example62_CustomAIServiceSelector.cs
@@ -28,7 +28,7 @@ public static class Example62_CustomAIServiceSelector
 
         if (apiKey == null || chatDeploymentName == null || endpoint == null)
         {
-            Console.WriteLine("Azure endpoint, apiKey, or deploymentName not found. Skipping example.");
+            Console.WriteLine("AzureOpenAI endpoint, apiKey, or deploymentName not found. Skipping example.");
             return;
         }
 
@@ -43,7 +43,7 @@ public static class Example62_CustomAIServiceSelector
 
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 deploymentName: chatDeploymentName,
                 endpoint: endpoint,
                 serviceId: "AzureOpenAIChat",

--- a/dotnet/samples/KernelSyntaxExamples/Example63_FlowOrchestrator.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example63_FlowOrchestrator.cs
@@ -207,7 +207,7 @@ provides:
         var builder = new KernelBuilder();
 
         return builder
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/AzureOpenAIChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletion/AzureOpenAIChatCompletion.cs
@@ -18,17 +18,17 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
 /// Azure OpenAI chat completion client.
 /// TODO: forward ETW logging to ILogger, see https://learn.microsoft.com/en-us/dotnet/azure/sdk/logging
 /// </summary>
-public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion, ITextCompletion
+public sealed class AzureOpenAIChatCompletion : AzureOpenAIClientBase, IChatCompletion, ITextCompletion
 {
     /// <summary>
-    /// Create an instance of the Azure OpenAI chat completion connector with API key auth
+    /// Create an instance of the <see cref="AzureOpenAIChatCompletion"/> connector with API key auth.
     /// </summary>
     /// <param name="modelId">Azure OpenAI model ID or deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public AzureChatCompletion(
+    public AzureOpenAIChatCompletion(
         string modelId,
         string endpoint,
         string apiKey,
@@ -38,14 +38,14 @@ public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion
     }
 
     /// <summary>
-    /// Create an instance of the Azure OpenAI chat completion connector with AAD auth
+    /// Create an instance of the <see cref="AzureOpenAIChatCompletion"/> connector with AAD auth.
     /// </summary>
     /// <param name="modelId">Azure OpenAI model ID or deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="credentials">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public AzureChatCompletion(
+    public AzureOpenAIChatCompletion(
         string modelId,
         string endpoint,
         TokenCredential credentials,
@@ -55,12 +55,12 @@ public sealed class AzureChatCompletion : AzureOpenAIClientBase, IChatCompletion
     }
 
     /// <summary>
-    /// Creates a new AzureChatCompletion client instance using the specified OpenAIClient
+    /// Creates a new <see cref="AzureOpenAIChatCompletion"/> client instance using the specified <see cref="OpenAIClient"/>.
     /// </summary>
     /// <param name="modelId">Azure OpenAI model ID or deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="openAIClient">Custom <see cref="OpenAIClient"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public AzureChatCompletion(
+    public AzureOpenAIChatCompletion(
         string modelId,
         OpenAIClient openAIClient,
         ILoggerFactory? loggerFactory = null) : base(modelId, openAIClient, loggerFactory)

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithData.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithData.cs
@@ -24,16 +24,16 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletionWithData;
 /// Azure OpenAI Chat Completion with data client.
 /// More information: <see href="https://learn.microsoft.com/en-us/azure/ai-services/openai/use-your-data-quickstart"/>
 /// </summary>
-public sealed class AzureChatCompletionWithData : IChatCompletion, ITextCompletion
+public sealed class AzureOpenAIChatCompletionWithData : IChatCompletion, ITextCompletion
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureChatCompletionWithData"/> class.
+    /// Initializes a new instance of the <see cref="AzureOpenAIChatCompletionWithData"/> class.
     /// </summary>
-    /// <param name="config">Instance of <see cref="AzureChatCompletionWithDataConfig"/> class with completion configuration.</param>
+    /// <param name="config">Instance of <see cref="AzureOpenAIChatCompletionWithDataConfig"/> class with completion configuration.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">Instance of <see cref="ILoggerFactory"/> to use for logging.</param>
-    public AzureChatCompletionWithData(
-        AzureChatCompletionWithDataConfig config,
+    public AzureOpenAIChatCompletionWithData(
+        AzureOpenAIChatCompletionWithDataConfig config,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
@@ -117,12 +117,12 @@ public sealed class AzureChatCompletionWithData : IChatCompletion, ITextCompleti
 
     private const string DefaultApiVersion = "2023-06-01-preview";
 
-    private readonly AzureChatCompletionWithDataConfig _config;
+    private readonly AzureOpenAIChatCompletionWithDataConfig _config;
 
     private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
 
-    private void ValidateConfig(AzureChatCompletionWithDataConfig config)
+    private void ValidateConfig(AzureOpenAIChatCompletionWithDataConfig config)
     {
         Verify.NotNull(config);
 

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithDataConfig.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithDataConfig.cs
@@ -6,7 +6,7 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletionWithData;
 /// Required configuration for Azure OpenAI chat completion with data.
 /// More information: <see href="https://learn.microsoft.com/en-us/azure/ai-services/openai/use-your-data-quickstart"/>
 /// </summary>
-public class AzureChatCompletionWithDataConfig
+public class AzureOpenAIChatCompletionWithDataConfig
 {
     /// <summary>
     /// Azure OpenAI model ID or deployment name, see <see href="https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource"/>

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageGeneration.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageGeneration.cs
@@ -106,12 +106,12 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
 
         if (result.Result is null)
         {
-            throw new SKException("Azure Image Generation null response");
+            throw new SKException("Azure OpenAI Image Generation null response");
         }
 
         if (result.Result.Images.Count == 0)
         {
-            throw new SKException("Azure Image Generation result not found");
+            throw new SKException("Azure OpenAI Image Generation result not found");
         }
 
         return result.Result.Images.First().Url;
@@ -141,7 +141,7 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
         });
 
         var uri = this.GetUri(GenerationImageOperation);
-        var result = await this.ExecutePostRequestAsync<AzureImageGenerationResponse>(uri, requestBody, cancellationToken).ConfigureAwait(false);
+        var result = await this.ExecutePostRequestAsync<AzureOpenAIImageGenerationResponse>(uri, requestBody, cancellationToken).ConfigureAwait(false);
 
         if (result == null || string.IsNullOrWhiteSpace(result.Id))
         {
@@ -157,7 +157,7 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
     /// <param name="operationId">The operationId that identifies the original image generation request.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns></returns>
-    private async Task<AzureImageGenerationResponse> GetImageGenerationResultAsync(string operationId, CancellationToken cancellationToken = default)
+    private async Task<AzureOpenAIImageGenerationResponse> GetImageGenerationResultAsync(string operationId, CancellationToken cancellationToken = default)
     {
         var operationLocation = this.GetUri(GetImageOperation, operationId);
 
@@ -172,9 +172,9 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
 
             using var response = await this.ExecuteRequestAsync(operationLocation, HttpMethod.Get, null, cancellationToken).ConfigureAwait(false);
             var responseJson = await response.Content.ReadAsStringWithExceptionMappingAsync().ConfigureAwait(false);
-            var result = this.JsonDeserialize<AzureImageGenerationResponse>(responseJson);
+            var result = this.JsonDeserialize<AzureOpenAIImageGenerationResponse>(responseJson);
 
-            if (result.Status.Equals(AzureImageOperationStatus.Succeeded, StringComparison.OrdinalIgnoreCase))
+            if (result.Status.Equals(AzureOpenAIImageOperationStatus.Succeeded, StringComparison.OrdinalIgnoreCase))
             {
                 return result;
             }
@@ -208,9 +208,9 @@ public class AzureOpenAIImageGeneration : OpenAIClientBase, IImageGeneration
 
     private bool IsFailedOrCancelled(string status)
     {
-        return status.Equals(AzureImageOperationStatus.Failed, StringComparison.OrdinalIgnoreCase)
-            || status.Equals(AzureImageOperationStatus.Cancelled, StringComparison.OrdinalIgnoreCase)
-            || status.Equals(AzureImageOperationStatus.Deleted, StringComparison.OrdinalIgnoreCase);
+        return status.Equals(AzureOpenAIImageOperationStatus.Failed, StringComparison.OrdinalIgnoreCase)
+            || status.Equals(AzureOpenAIImageOperationStatus.Cancelled, StringComparison.OrdinalIgnoreCase)
+            || status.Equals(AzureOpenAIImageOperationStatus.Deleted, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>Adds headers to use for Azure OpenAI HTTP requests.</summary>

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageGenerationResponse.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageGenerationResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ImageGeneration;
 /// <summary>
 /// Image generation response
 /// </summary>
-public class AzureImageGenerationResponse
+public class AzureOpenAIImageGenerationResponse
 {
     /// <summary>
     /// Image generation result

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageOperationStatus.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ImageGeneration/AzureOpenAIImageOperationStatus.cs
@@ -3,10 +3,10 @@
 namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.ImageGeneration;
 
 /// <summary>
-/// Azure image generation response status
+/// Azure OpenAI image generation response status
 /// <see herf="https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#image-generation" />
 /// </summary>
-public static class AzureImageOperationStatus
+public static class AzureOpenAIImageOperationStatus
 {
     /// <summary>
     /// Image generation Succeeded

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIKernelBuilderExtensions.cs
@@ -161,7 +161,7 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder WithAzureTextEmbeddingGenerationService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureOpenAITextEmbeddingGenerationService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         string apiKey,
@@ -170,7 +170,7 @@ public static class OpenAIKernelBuilderExtensions
         HttpClient? httpClient = null)
     {
         builder.WithAIService<ITextEmbeddingGeneration>(serviceId, (loggerFactory, httpHandlerFactory) =>
-            new AzureTextEmbeddingGeneration(
+            new AzureOpenAITextEmbeddingGeneration(
                 deploymentName,
                 endpoint,
                 apiKey,
@@ -192,7 +192,7 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder WithAzureTextEmbeddingGenerationService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureOpenAITextEmbeddingGenerationService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         TokenCredential credential,
@@ -201,7 +201,7 @@ public static class OpenAIKernelBuilderExtensions
         HttpClient? httpClient = null)
     {
         builder.WithAIService<ITextEmbeddingGeneration>(serviceId, (loggerFactory, httpHandlerFactory) =>
-            new AzureTextEmbeddingGeneration(
+            new AzureOpenAITextEmbeddingGeneration(
                 deploymentName,
                 endpoint,
                 credential,
@@ -259,7 +259,7 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder WithAzureChatCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureOpenAIChatCompletionService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         string apiKey,
@@ -268,7 +268,7 @@ public static class OpenAIKernelBuilderExtensions
         bool setAsDefault = false,
         HttpClient? httpClient = null)
     {
-        AzureChatCompletion Factory(ILoggerFactory loggerFactory, IDelegatingHandlerFactory httpHandlerFactory)
+        AzureOpenAIChatCompletion Factory(ILoggerFactory loggerFactory, IDelegatingHandlerFactory httpHandlerFactory)
         {
             OpenAIClient client = CreateAzureOpenAIClient(loggerFactory, httpHandlerFactory, deploymentName, endpoint, new AzureKeyCredential(apiKey), httpClient);
 
@@ -278,7 +278,7 @@ public static class OpenAIKernelBuilderExtensions
         builder.WithAIService<IChatCompletion>(serviceId, Factory, setAsDefault);
 
         // If the class implements the text completion interface, allow to use it also for semantic functions
-        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletion)))
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureOpenAIChatCompletion)))
         {
             builder.WithAIService<ITextCompletion>(serviceId, Factory, setAsDefault);
         }
@@ -299,7 +299,7 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder WithAzureChatCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureOpenAIChatCompletionService(this KernelBuilder builder,
         string deploymentName,
         string endpoint,
         TokenCredential credentials,
@@ -308,7 +308,7 @@ public static class OpenAIKernelBuilderExtensions
         bool setAsDefault = false,
         HttpClient? httpClient = null)
     {
-        AzureChatCompletion Factory(ILoggerFactory loggerFactory, IDelegatingHandlerFactory httpHandlerFactory)
+        AzureOpenAIChatCompletion Factory(ILoggerFactory loggerFactory, IDelegatingHandlerFactory httpHandlerFactory)
         {
             OpenAIClient client = CreateAzureOpenAIClient(loggerFactory, httpHandlerFactory, deploymentName, endpoint, credentials, httpClient);
 
@@ -318,7 +318,7 @@ public static class OpenAIKernelBuilderExtensions
         builder.WithAIService<IChatCompletion>(serviceId, Factory, setAsDefault);
 
         // If the class implements the text completion interface, allow to use it also for semantic functions
-        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletion)))
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureOpenAIChatCompletion)))
         {
             builder.WithAIService<ITextCompletion>(serviceId, Factory, setAsDefault);
         }
@@ -337,21 +337,21 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder WithAzureChatCompletionService(this KernelBuilder builder,
-        AzureChatCompletionWithDataConfig config,
+    public static KernelBuilder WithAzureOpenAIChatCompletionService(this KernelBuilder builder,
+        AzureOpenAIChatCompletionWithDataConfig config,
         bool alsoAsTextCompletion = true,
         string? serviceId = null,
         bool setAsDefault = false,
         HttpClient? httpClient = null)
     {
-        AzureChatCompletionWithData Factory(ILoggerFactory loggerFactory, IDelegatingHandlerFactory httpHandlerFactory) => new(
+        AzureOpenAIChatCompletionWithData Factory(ILoggerFactory loggerFactory, IDelegatingHandlerFactory httpHandlerFactory) => new(
             config,
             HttpClientProvider.GetHttpClient(httpHandlerFactory, httpClient, loggerFactory),
             loggerFactory);
 
         builder.WithAIService<IChatCompletion>(serviceId, Factory, setAsDefault);
 
-        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletionWithData)))
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureOpenAIChatCompletionWithData)))
         {
             builder.WithAIService<ITextCompletion>(serviceId, Factory, setAsDefault);
         }
@@ -410,14 +410,14 @@ public static class OpenAIKernelBuilderExtensions
     /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <returns>Self instance</returns>
-    public static KernelBuilder WithAzureChatCompletionService(this KernelBuilder builder,
+    public static KernelBuilder WithAzureOpenAIChatCompletionService(this KernelBuilder builder,
         string deploymentName,
         OpenAIClient openAIClient,
         bool alsoAsTextCompletion = true,
         string? serviceId = null,
         bool setAsDefault = false)
     {
-        AzureChatCompletion Factory(ILoggerFactory loggerFactory)
+        AzureOpenAIChatCompletion Factory(ILoggerFactory loggerFactory)
         {
             return new(deploymentName, openAIClient, loggerFactory);
         };
@@ -425,7 +425,7 @@ public static class OpenAIKernelBuilderExtensions
         builder.WithAIService<IChatCompletion>(serviceId, Factory, setAsDefault);
 
         // If the class implements the text completion interface, allow to use it also for semantic functions
-        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletion)))
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureOpenAIChatCompletion)))
         {
             builder.WithAIService<ITextCompletion>(serviceId, Factory, setAsDefault);
         }
@@ -459,7 +459,7 @@ public static class OpenAIKernelBuilderExtensions
         builder.WithAIService<IChatCompletion>(serviceId, Factory, setAsDefault);
 
         // If the class implements the text completion interface, allow to use it also for semantic functions
-        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureChatCompletion)))
+        if (alsoAsTextCompletion && typeof(ITextCompletion).IsAssignableFrom(typeof(AzureOpenAIChatCompletion)))
         {
             builder.WithAIService<ITextCompletion>(serviceId, Factory, setAsDefault);
         }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIMemoryBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class OpenAIMemoryBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static MemoryBuilder WithAzureTextEmbeddingGenerationService(
+    public static MemoryBuilder WithAzureOpenAITextEmbeddingGenerationService(
         this MemoryBuilder builder,
         string deploymentName,
         string endpoint,
@@ -34,7 +34,7 @@ public static class OpenAIMemoryBuilderExtensions
         HttpClient? httpClient = null)
     {
         builder.WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
-            new AzureTextEmbeddingGeneration(
+            new AzureOpenAITextEmbeddingGeneration(
                 deploymentName,
                 endpoint,
                 apiKey,
@@ -56,7 +56,7 @@ public static class OpenAIMemoryBuilderExtensions
     /// <param name="setAsDefault">Whether the service should be the default for its type.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <returns>Self instance</returns>
-    public static MemoryBuilder WithAzureTextEmbeddingGenerationService(
+    public static MemoryBuilder WithAzureOpenAITextEmbeddingGenerationService(
         this MemoryBuilder builder,
         string deploymentName,
         string endpoint,
@@ -66,7 +66,7 @@ public static class OpenAIMemoryBuilderExtensions
         HttpClient? httpClient = null)
     {
         builder.WithTextEmbeddingGeneration((loggerFactory, httpHandlerFactory) =>
-            new AzureTextEmbeddingGeneration(
+            new AzureOpenAITextEmbeddingGeneration(
                 deploymentName,
                 endpoint,
                 credential,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/TextEmbedding/AzureOpenAITextEmbeddingGeneration.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/TextEmbedding/AzureOpenAITextEmbeddingGeneration.cs
@@ -15,17 +15,17 @@ namespace Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
 /// <summary>
 /// Azure OpenAI text embedding service.
 /// </summary>
-public sealed class AzureTextEmbeddingGeneration : AzureOpenAIClientBase, ITextEmbeddingGeneration
+public sealed class AzureOpenAITextEmbeddingGeneration : AzureOpenAIClientBase, ITextEmbeddingGeneration
 {
     /// <summary>
-    /// Creates a new AzureTextCompletion client instance using API Key auth
+    /// Creates a new <see cref="AzureOpenAITextEmbeddingGeneration"/> client instance using API Key auth.
     /// </summary>
     /// <param name="modelId">Azure OpenAI model ID or deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public AzureTextEmbeddingGeneration(
+    public AzureOpenAITextEmbeddingGeneration(
         string modelId,
         string endpoint,
         string apiKey,
@@ -35,14 +35,14 @@ public sealed class AzureTextEmbeddingGeneration : AzureOpenAIClientBase, ITextE
     }
 
     /// <summary>
-    /// Creates a new AzureTextCompletion client instance supporting AAD auth
+    /// Creates a new <see cref="AzureOpenAITextEmbeddingGeneration"/> client instance supporting AAD auth.
     /// </summary>
     /// <param name="modelId">Azure OpenAI model ID or deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="credential">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public AzureTextEmbeddingGeneration(
+    public AzureOpenAITextEmbeddingGeneration(
         string modelId,
         string endpoint,
         TokenCredential credential,

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/TextEmbedding/TextEmbeddingRequest.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/TextEmbedding/TextEmbeddingRequest.cs
@@ -32,6 +32,6 @@ public sealed class OpenAITextEmbeddingRequest : TextEmbeddingRequest
 /// <summary>
 /// An Azure OpenAI embedding request
 /// </summary>
-public sealed class AzureTextEmbeddingRequest : TextEmbeddingRequest
+public sealed class AzureOpenAITextEmbeddingRequest : TextEmbeddingRequest
 {
 }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
@@ -33,7 +33,7 @@ public sealed class PineconeKernelBuilderExtensionsTests : IDisposable
 #pragma warning disable CS0618 // This will be removed in a future release.
         builder.WithPineconeMemoryStore("fake-environment", "fake-api-key", this._httpClient);
 #pragma warning restore CS0618 // This will be removed in a future release.
-        builder.WithAzureTextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-test-host/fake-path", "fake -api-key");
+        builder.WithAzureOpenAITextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-test-host/fake-path", "fake -api-key");
         var kernel = builder.Build(); //This call triggers the internal factory registered by WithPineconeMemoryStore method to create an instance of the PineconeMemoryStore class.
 
         //Act

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantKernelBuilderExtensionsTests.cs
@@ -33,7 +33,7 @@ public sealed class QdrantKernelBuilderExtensionsTests : IDisposable
 #pragma warning disable CS0618 // This will be removed in a future release.
         builder.WithQdrantMemoryStore(this._httpClient, 123);
 #pragma warning restore CS0618 // This will be removed in a future release.
-        builder.WithAzureTextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-text-embedding-generation-host/fake-path", "fake-api-key");
+        builder.WithAzureOpenAITextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-text-embedding-generation-host/fake-path", "fake-api-key");
         var kernel = builder.Build(); //This call triggers the internal factory registered by WithQdrantMemoryStore method to create an instance of the QdrantMemoryStore class.
 
         //Act

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateKernelBuilderExtensionsTests.cs
@@ -47,7 +47,7 @@ public sealed class WeaviateKernelBuilderExtensionsTests : IDisposable
 #pragma warning disable CS0618 // This will be removed in a future release.
         builder.WithWeaviateMemoryStore(this._httpClient, "https://fake-random-test-weaviate-host", "fake-api-key", apiVersion);
 #pragma warning restore CS0618 // This will be removed in a future release.
-        builder.WithAzureTextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-test-host/fake-path", "fake -api-key");
+        builder.WithAzureOpenAITextEmbeddingGenerationService("fake-deployment-name", "https://fake-random-test-host/fake-path", "fake -api-key");
         var kernel = builder.Build(); //This call triggers the internal factory registered by WithWeaviateMemoryStore method to create an instance of the WeaviateMemoryStore class.
 
         //Act

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
@@ -18,7 +18,7 @@ public class AIServicesOpenAIExtensionsTests
     {
         KernelBuilder targetBuilder = new();
         targetBuilder.WithAzureTextCompletionService("depl", "https://url", "key", "azure");
-        targetBuilder.WithAzureTextEmbeddingGenerationService("depl2", "https://url", "key", "azure");
+        targetBuilder.WithAzureOpenAITextEmbeddingGenerationService("depl2", "https://url", "key", "azure");
 
         IKernel targetKernel = targetBuilder.Build();
         Assert.NotNull(targetKernel.GetService<ITextCompletion>("azure"));
@@ -31,7 +31,7 @@ public class AIServicesOpenAIExtensionsTests
         KernelBuilder targetBuilder = new();
         targetBuilder.WithAzureTextCompletionService("depl", "https://url", "key", serviceId: "azure");
         targetBuilder.WithOpenAITextCompletionService("model", "apikey", serviceId: "oai");
-        targetBuilder.WithAzureTextEmbeddingGenerationService("depl2", "https://url2", "key", serviceId: "azure");
+        targetBuilder.WithAzureOpenAITextEmbeddingGenerationService("depl2", "https://url2", "key", serviceId: "azure");
         targetBuilder.WithOpenAITextEmbeddingGenerationService("model2", "apikey2", serviceId: "oai2");
 
         // Assert
@@ -55,14 +55,14 @@ public class AIServicesOpenAIExtensionsTests
         targetBuilder.WithOpenAITextCompletionService("model", "key", serviceId: "one");
         targetBuilder.WithOpenAITextCompletionService("model", "key", serviceId: "one");
 
-        targetBuilder.WithAzureTextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
-        targetBuilder.WithAzureTextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithAzureOpenAITextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithAzureOpenAITextEmbeddingGenerationService("dep", "https://localhost", "key", serviceId: "one");
 
         targetBuilder.WithOpenAITextEmbeddingGenerationService("model", "key", serviceId: "one");
         targetBuilder.WithOpenAITextEmbeddingGenerationService("model", "key", serviceId: "one");
 
-        targetBuilder.WithAzureChatCompletionService("dep", "https://localhost", "key", serviceId: "one");
-        targetBuilder.WithAzureChatCompletionService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithAzureOpenAIChatCompletionService("dep", "https://localhost", "key", serviceId: "one");
+        targetBuilder.WithAzureOpenAIChatCompletionService("dep", "https://localhost", "key", serviceId: "one");
 
         targetBuilder.WithOpenAIChatCompletionService("model", "key", serviceId: "one");
         targetBuilder.WithOpenAIChatCompletionService("model", "key", serviceId: "one");

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithDataTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithDataTests.cs
@@ -11,16 +11,16 @@ using Xunit;
 namespace SemanticKernel.Connectors.UnitTests.OpenAI.ChatCompletionWithData;
 
 /// <summary>
-/// Unit tests for <see cref="AzureChatCompletionWithData"/>
+/// Unit tests for <see cref="AzureOpenAIChatCompletionWithData"/>
 /// </summary>
-public sealed class AzureChatCompletionWithDataTests : IDisposable
+public sealed class AzureOpenAIChatCompletionWithDataTests : IDisposable
 {
-    private readonly AzureChatCompletionWithDataConfig _config;
+    private readonly AzureOpenAIChatCompletionWithDataConfig _config;
 
     private readonly HttpMessageHandlerStub _messageHandlerStub;
     private readonly HttpClient _httpClient;
 
-    public AzureChatCompletionWithDataTests()
+    public AzureOpenAIChatCompletionWithDataTests()
     {
         this._config = this.GetConfig();
 
@@ -33,7 +33,7 @@ public sealed class AzureChatCompletionWithDataTests : IDisposable
     {
         // Arrange
         const string ExpectedUri = "https://fake-completion-endpoint/openai/deployments/fake-completion-model-id/extensions/chat/completions?api-version=fake-api-version";
-        var chatCompletion = new AzureChatCompletionWithData(this._config, this._httpClient);
+        var chatCompletion = new AzureOpenAIChatCompletionWithData(this._config, this._httpClient);
 
         // Act
         await chatCompletion.GetChatCompletionsAsync(new ChatHistory());
@@ -58,7 +58,7 @@ public sealed class AzureChatCompletionWithDataTests : IDisposable
         var config = this.GetConfig();
         config.CompletionApiVersion = string.Empty;
 
-        var chatCompletion = new AzureChatCompletionWithData(config, this._httpClient);
+        var chatCompletion = new AzureOpenAIChatCompletionWithData(config, this._httpClient);
 
         // Act
         await chatCompletion.GetChatCompletionsAsync(new ChatHistory());
@@ -75,9 +75,9 @@ public sealed class AzureChatCompletionWithDataTests : IDisposable
         this._messageHandlerStub.Dispose();
     }
 
-    private AzureChatCompletionWithDataConfig GetConfig()
+    private AzureOpenAIChatCompletionWithDataConfig GetConfig()
     {
-        return new AzureChatCompletionWithDataConfig
+        return new AzureOpenAIChatCompletionWithDataConfig
         {
             CompletionModelId = "fake-completion-model-id",
             CompletionEndpoint = "https://fake-completion-endpoint",

--- a/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/FlowOrchestratorTests.cs
+++ b/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/FlowOrchestratorTests.cs
@@ -107,7 +107,7 @@ steps:
         var builder = new KernelBuilder()
             .WithLoggerFactory(this._logger)
             .WithRetryBasic()
-            .WithAzureChatCompletionService(
+            .WithAzureOpenAIChatCompletionService(
                 deploymentName: azureOpenAIConfiguration.ChatDeploymentName!,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey,

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/AzureOpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/AzureOpenAICompletionTests.cs
@@ -49,7 +49,7 @@ public sealed class AzureOpenAICompletionTests : IDisposable
 
         var target = new KernelBuilder()
              .WithLoggerFactory(this._logger)
-             .WithAzureChatCompletionService(configuration.ChatDeploymentName!, configuration.Endpoint, configuration.ApiKey)
+             .WithAzureOpenAIChatCompletionService(configuration.ChatDeploymentName!, configuration.Endpoint, configuration.ApiKey)
              .WithHttpHandlerFactory(defaultHttpRetryHandlerFactory)
              .Build();
 
@@ -78,7 +78,7 @@ public sealed class AzureOpenAICompletionTests : IDisposable
 
         var target = new KernelBuilder()
              .WithLoggerFactory(this._logger)
-             .WithAzureChatCompletionService(configuration.ChatDeploymentName!, openAIClient)
+             .WithAzureOpenAIChatCompletionService(configuration.ChatDeploymentName!, openAIClient)
              .Build();
 
         // Act

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -461,7 +461,7 @@ public sealed class OpenAICompletionTests : IDisposable
         Assert.NotNull(azureOpenAIConfiguration.Endpoint);
         Assert.NotNull(azureOpenAIConfiguration.ServiceId);
 
-        kernelBuilder.WithAzureChatCompletionService(
+        kernelBuilder.WithAzureOpenAIChatCompletionService(
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             endpoint: azureOpenAIConfiguration.Endpoint,
             apiKey: azureOpenAIConfiguration.ApiKey,

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAITextEmbeddingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAITextEmbeddingTests.cs
@@ -58,7 +58,7 @@ public sealed class OpenAITextEmbeddingTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIConfiguration);
 
-        var embeddingGenerator = new AzureTextEmbeddingGeneration(azureOpenAIConfiguration.DeploymentName,
+        var embeddingGenerator = new AzureOpenAITextEmbeddingGeneration(azureOpenAIConfiguration.DeploymentName,
             azureOpenAIConfiguration.Endpoint,
             azureOpenAIConfiguration.ApiKey);
 

--- a/dotnet/src/IntegrationTests/Planners/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/PlanTests.cs
@@ -513,7 +513,7 @@ public sealed class PlanTests : IDisposable
 
         if (useChatModel)
         {
-            builder.WithAzureChatCompletionService(
+            builder.WithAzureOpenAIChatCompletionService(
                 deploymentName: azureOpenAIConfiguration.ChatDeploymentName!,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey);
@@ -529,7 +529,7 @@ public sealed class PlanTests : IDisposable
         if (useEmbeddings)
         {
             builder
-                .WithAzureTextEmbeddingGenerationService(
+                .WithAzureOpenAITextEmbeddingGenerationService(
                     deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                     endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
                     apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
@@ -122,7 +122,7 @@ public sealed class SequentialPlannerTests : IDisposable
 
         if (useChatModel)
         {
-            builder.WithAzureChatCompletionService(
+            builder.WithAzureOpenAIChatCompletionService(
                 deploymentName: azureOpenAIConfiguration.ChatDeploymentName!,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey);
@@ -137,7 +137,7 @@ public sealed class SequentialPlannerTests : IDisposable
 
         if (useEmbeddings)
         {
-            builder.WithAzureTextEmbeddingGenerationService(
+            builder.WithAzureOpenAITextEmbeddingGenerationService(
                     deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                     endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
                     apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);

--- a/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
@@ -153,7 +153,7 @@ public sealed class StepwisePlannerTests : IDisposable
 
         if (useChatModel)
         {
-            builder.WithAzureChatCompletionService(
+            builder.WithAzureOpenAIChatCompletionService(
                 deploymentName: azureOpenAIConfiguration.ChatDeploymentName!,
                 endpoint: azureOpenAIConfiguration.Endpoint,
                 apiKey: azureOpenAIConfiguration.ApiKey);
@@ -168,7 +168,7 @@ public sealed class StepwisePlannerTests : IDisposable
 
         if (useEmbeddings)
         {
-            builder.WithAzureTextEmbeddingGenerationService(
+            builder.WithAzureOpenAITextEmbeddingGenerationService(
                     deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                     endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
                     apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/3155

This PR contains changes to rename `Azure*` classes and methods to `AzureOpenAI*` to make it clear that they work with OpenAI models. 

Note: `AzureTextCompletion` class and related extension methods remain the same, as they are marked as obsolete in this PR: https://github.com/microsoft/semantic-kernel/pull/3396

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone - this is breaking change, as some public classes and methods were renamed.
