### PR TITLE
Java - Changes the indentation from 2 to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -369,10 +369,10 @@ csharp_style_expression_bodied_local_functions = false:silent
 [*.java]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = false
-tab_width = 2
+tab_width = 4
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
 ij_smart_tabs = false


### PR DESCRIPTION
### Motivation and Context

All the Java code uses 4 spaces indentation and the .editorconfig mentions 2. So when you have an IDE basing the indentation on the .editorconfig file, it messes things up.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
