### PR TITLE
.Net: Remove the artificially created server-url parameter from OpenAPI function parameter view

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example22_OpenApiPlugin_AzureKeyVault.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example22_OpenApiPlugin_AzureKeyVault.cs
@@ -49,11 +49,14 @@ public static class Example22_OpenApiPlugin_AzureKeyVault
         var plugin = await kernel.ImportOpenApiPluginFunctionsAsync(
             PluginResourceNames.AzureKeyVault,
             stream!,
-            new OpenApiFunctionExecutionParameters { AuthCallback = authenticationProvider.AuthenticateRequestAsync });
+            new OpenApiFunctionExecutionParameters
+            {
+                AuthCallback = authenticationProvider.AuthenticateRequestAsync,
+                ServerUrlOverride = new Uri(TestConfiguration.KeyVault.Endpoint),
+            });
 
         // Add arguments for required parameters, arguments for optional ones can be skipped.
         var contextVariables = new ContextVariables();
-        contextVariables.Set("server-url", TestConfiguration.KeyVault.Endpoint);
         contextVariables.Set("secret-name", "<secret-name>");
         contextVariables.Set("api-version", "7.0");
 

--- a/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
@@ -3,23 +3,35 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Functions.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Functions.OpenAPI.Extensions;
+using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 using Microsoft.SemanticKernel.Orchestration;
-
-using Newtonsoft.Json;
 using RepoUtils;
 
-/// <summary>
-/// This sample shows how to connect the Semantic Kernel to Jira as an Open Api plugin based on the Open Api schema.
-/// This format of registering the plugin and its operations, and subsequently executing those operations can be applied
-/// to an Open Api plugin that follows the Open Api Schema.
-/// </summary>
 // ReSharper disable once InconsistentNaming
 public static class Example24_OpenApiPlugin_Jira
 {
+    /// <summary>
+    /// This sample shows how to connect the Semantic Kernel to Jira as an Open Api plugin based on the Open Api schema.
+    /// This format of registering the plugin and its operations, and subsequently executing those operations can be applied
+    /// to an Open Api plugin that follows the Open Api Schema.
+    /// To use this example, there are a few requirements:
+    /// 1. You must have a Jira instance that you can authenticate to with your email and api key.
+    ///    Follow the instructions here to get your api key:
+    ///    https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+    /// 2. You must create a new project in your Jira instance and create two issues named TEST-1 and TEST-2 respectively.
+    ///    Follow the instructions here to create a new project and issues:
+    ///    https://support.atlassian.com/jira-software-cloud/docs/create-a-new-project/
+    ///    https://support.atlassian.com/jira-software-cloud/docs/create-an-issue-and-a-sub-task/
+    /// 3. You can find your domain under the "Products" tab in your account management page.
+    ///    To go to your account management page, click on your profile picture in the top right corner of your Jira
+    ///    instance then select "Manage account".
+    /// 4. Configure the secrets as described by the ReadMe.md in the dotnet/samples/KernelSyntaxExamples folder.
+    /// </summary>
     public static async Task RunAsync()
     {
         var kernel = new KernelBuilder().WithLoggerFactory(ConsoleLogger.LoggerFactory).Build();
@@ -27,7 +39,6 @@ public static class Example24_OpenApiPlugin_Jira
 
         // Change <your-domain> to a jira instance you have access to with your authentication credentials
         string serverUrl = $"https://{TestConfiguration.Jira.Domain}.atlassian.net/rest/api/latest/";
-        contextVariables.Set("server-url", serverUrl);
 
         IDictionary<string, ISKFunction> jiraFunctions;
         var tokenProvider = new BasicAuthenticationProvider(() =>
@@ -43,38 +54,64 @@ public static class Example24_OpenApiPlugin_Jira
         if (useLocalFile)
         {
             var apiPluginFile = "./../../../Plugins/JiraPlugin/openapi.json";
-            jiraFunctions = await kernel.ImportOpenApiPluginFunctionsAsync("jiraPlugin", apiPluginFile, new OpenApiFunctionExecutionParameters(authCallback: tokenProvider.AuthenticateRequestAsync));
+            jiraFunctions = await kernel.ImportOpenApiPluginFunctionsAsync(
+                "jiraPlugin",
+                apiPluginFile,
+                new OpenApiFunctionExecutionParameters(
+                    authCallback: tokenProvider.AuthenticateRequestAsync,
+                    serverUrlOverride: new Uri(serverUrl)
+                )
+            );
         }
         else
         {
             var apiPluginRawFileURL = new Uri("https://raw.githubusercontent.com/microsoft/PowerPlatformConnectors/dev/certified-connectors/JIRA/apiDefinition.swagger.json");
-            jiraFunctions = await kernel.ImportOpenApiPluginFunctionsAsync("jiraPlugin", apiPluginRawFileURL, new OpenApiFunctionExecutionParameters(httpClient, tokenProvider.AuthenticateRequestAsync));
+            jiraFunctions = await kernel.ImportOpenApiPluginFunctionsAsync(
+                "jiraPlugin",
+                apiPluginRawFileURL,
+                new OpenApiFunctionExecutionParameters(
+                    httpClient, tokenProvider.AuthenticateRequestAsync,
+                    serverUrlOverride: new Uri(serverUrl)
+                )
+            );
         }
 
         // GetIssue Function
         {
             // Set Properties for the Get Issue operation in the openAPI.swagger.json
-            contextVariables.Set("issueKey", "SKTES-2");
+            // Make sure the issue exists in your Jira instance or it will return a 404
+            contextVariables.Set("issueKey", "TEST-1");
 
             // Run operation via the semantic kernel
             var result = await kernel.RunAsync(contextVariables, jiraFunctions["GetIssue"]);
 
             Console.WriteLine("\n\n\n");
-            var formattedContent = JsonConvert.SerializeObject(JsonConvert.DeserializeObject(result.GetValue<string>()!), Formatting.Indented);
+            var formattedContent = JsonSerializer.Serialize(
+                result.GetValue<RestApiOperationResponse>(),
+                new JsonSerializerOptions()
+                {
+                    WriteIndented = true
+                });
             Console.WriteLine("GetIssue jiraPlugin response: \n{0}", formattedContent);
         }
 
         // AddComment Function
         {
             // Set Properties for the AddComment operation in the openAPI.swagger.json
-            contextVariables.Set("issueKey", "SKTES-1");
-            contextVariables.Set("body", "Here is a rad comment");
+            // Make sure the issue exists in your Jira instance or it will return a 404
+            contextVariables.Set("issueKey", "TEST-2");
+            contextVariables.Set(RestApiOperation.PayloadArgumentName, "{\"body\": \"Here is a rad comment\"}");
 
             // Run operation via the semantic kernel
             var result = await kernel.RunAsync(contextVariables, jiraFunctions["AddComment"]);
 
             Console.WriteLine("\n\n\n");
-            var formattedContent = JsonConvert.SerializeObject(JsonConvert.DeserializeObject(result.GetValue<string>()!), Formatting.Indented);
+            var formattedContent = JsonSerializer.Serialize(
+                result.GetValue<RestApiOperationResponse>(),
+                new JsonSerializerOptions()
+                {
+                    WriteIndented = true
+                });
             Console.WriteLine("AddComment jiraPlugin response: \n{0}", formattedContent);
         }
     }

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
@@ -203,10 +203,8 @@ public static class KernelOpenApiPluginExtensions
         CancellationToken cancellationToken = default)
     {
         var restOperationParameters = operation.GetParameters(
-            executionParameters?.ServerUrlOverride,
             executionParameters?.EnableDynamicPayload ?? false,
-            executionParameters?.EnablePayloadNamespacing ?? false,
-            documentUri
+            executionParameters?.EnablePayloadNamespacing ?? false
         );
 
         var logger = kernel.LoggerFactory is not null ? kernel.LoggerFactory.CreateLogger(typeof(KernelOpenApiPluginExtensions)) : NullLogger.Instance;

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/RestApiOperationExtensions.cs
@@ -21,7 +21,6 @@ internal static class RestApiOperationExtensions
     /// Returns list of REST API operation parameters.
     /// </summary>
     /// <param name="operation">The REST API operation.</param>
-    /// <param name="serverUrlOverride">The server URL override.</param>
     /// <param name="addPayloadParamsFromMetadata">Determines whether to include the operation payload parameters from payload metadata.
     /// If false, the 'payload' and 'content-type' artificial parameters are added instead.
     /// </param>
@@ -31,37 +30,15 @@ internal static class RestApiOperationExtensions
     /// would be resolved from the same 'email' argument, which is incorrect. However, by employing namespaces,
     /// the parameters 'sender.email' and 'receiver.mail' will be correctly resolved from arguments with the same names.
     /// </param>
-    /// <param name="documentUri">The URI of OpenApi document.</param>
     /// <returns>The list of parameters.</returns>
     public static IReadOnlyList<RestApiOperationParameter> GetParameters(
         this RestApiOperation operation,
-        Uri? serverUrlOverride = null,
         bool addPayloadParamsFromMetadata = false,
-        bool enablePayloadNamespacing = false,
-        Uri? documentUri = null)
+        bool enablePayloadNamespacing = false)
     {
-        string? serverUrlString = null;
-        Uri? serverUrl = serverUrlOverride ?? operation.ServerUrl ?? documentUri;
+        var parameters = new List<RestApiOperationParameter>(operation.Parameters);
 
-        if (serverUrl is not null)
-        {
-            serverUrlString = $"{serverUrl.GetLeftPart(UriPartial.Authority)}/";
-        }
-
-        var parameters = new List<RestApiOperationParameter>(operation.Parameters)
-        {
-            // Register the "server-url" parameter if override is provided
-            new(
-                name: RestApiOperation.ServerUrlArgumentName,
-                type: "string",
-                isRequired: false,
-                expand: false,
-                RestApiOperationParameterLocation.Path,
-                RestApiOperationParameterStyle.Simple,
-                defaultValue: serverUrlString)
-        };
-
-        //Add payload parameters
+        // Add payload parameters
         if (operation.Method == HttpMethod.Put || operation.Method == HttpMethod.Post)
         {
             parameters.AddRange(GetPayloadParameters(operation, addPayloadParamsFromMetadata, enablePayloadNamespacing));

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/RestApiOperationExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;

--- a/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperation.cs
@@ -15,11 +15,6 @@ namespace Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 public sealed class RestApiOperation
 {
     /// <summary>
-    /// An artificial parameter that is added to be able to override REST API operation server url.
-    /// </summary>
-    public const string ServerUrlArgumentName = "server-url";
-
-    /// <summary>
     /// An artificial parameter to be used for operation having "text/plain" payload media type.
     /// </summary>
     public const string PayloadArgumentName = "payload";
@@ -109,7 +104,7 @@ public sealed class RestApiOperation
     /// <returns>The operation Url.</returns>
     public Uri BuildOperationUrl(IDictionary<string, string> arguments, Uri? serverUrlOverride = null, Uri? apiHostUrl = null)
     {
-        var serverUrl = this.GetServerUrl(arguments, serverUrlOverride, apiHostUrl);
+        var serverUrl = this.GetServerUrl(serverUrlOverride, apiHostUrl);
 
         var path = this.ReplacePathParameters(this.Path, arguments);
 
@@ -203,22 +198,16 @@ public sealed class RestApiOperation
     /// <summary>
     /// Returns operation server Url.
     /// </summary>
-    /// <param name="arguments">The operation arguments.</param>
     /// <param name="serverUrlOverride">Override for REST API operation server url.</param>
     /// <param name="apiHostUrl">The URL of REST API host.</param>
     /// <returns>The operation server url.</returns>
-    private Uri GetServerUrl(IDictionary<string, string> arguments, Uri? serverUrlOverride, Uri? apiHostUrl)
+    private Uri GetServerUrl(Uri? serverUrlOverride, Uri? apiHostUrl)
     {
         string serverUrlString;
 
         if (serverUrlOverride is not null)
         {
             serverUrlString = serverUrlOverride.AbsoluteUri;
-        }
-        else if (arguments.TryGetValue(ServerUrlArgumentName, out string serverUrlFromArgument))
-        {
-            // Override defined server url - https://api.example.com/v1 by the one from arguments.
-            serverUrlString = serverUrlFromArgument;
         }
         else
         {

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/KernelOpenApiPluginExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/KernelOpenApiPluginExtensionsTests.cs
@@ -104,14 +104,6 @@ public sealed class KernelOpenApiPluginExtensionsTests : IDisposable
         var result = await this._kernel.RunAsync(setSecretFunction, variables);
 
         // Assert
-        Assert.NotNull(setSecretFunction);
-
-        var functionView = setSecretFunction.Describe();
-        Assert.NotNull(functionView);
-
-        var serverUrlParameter = functionView.Parameters.First(p => p.Name == "server_url");
-        Assert.Equal(ServerUrlOverride, serverUrlParameter.DefaultValue);
-
         Assert.NotNull(messageHandlerStub.RequestUri);
         Assert.StartsWith(ServerUrlOverride, messageHandlerStub.RequestUri.AbsoluteUri, StringComparison.Ordinal);
     }
@@ -142,14 +134,6 @@ public sealed class KernelOpenApiPluginExtensionsTests : IDisposable
         var result = await this._kernel.RunAsync(setSecretFunction, variables);
 
         // Assert
-        Assert.NotNull(setSecretFunction);
-
-        var functionView = setSecretFunction.Describe();
-        Assert.NotNull(functionView);
-
-        var serverUrlParameter = functionView.Parameters.First(p => p.Name == "server_url");
-        Assert.Equal(ServerUrlFromDocument, serverUrlParameter.DefaultValue);
-
         Assert.NotNull(messageHandlerStub.RequestUri);
         Assert.StartsWith(ServerUrlFromDocument, messageHandlerStub.RequestUri.AbsoluteUri, StringComparison.Ordinal);
     }
@@ -187,14 +171,6 @@ public sealed class KernelOpenApiPluginExtensionsTests : IDisposable
         var result = await this._kernel.RunAsync(setSecretFunction, variables);
 
         // Assert
-        Assert.NotNull(setSecretFunction);
-
-        var functionView = setSecretFunction.Describe();
-        Assert.NotNull(functionView);
-
-        var serverUrlParameter = functionView.Parameters.First(p => p.Name == "server_url");
-        Assert.Equal(expectedServerUrl, serverUrlParameter.DefaultValue);
-
         Assert.NotNull(messageHandlerStub.RequestUri);
         Assert.StartsWith(expectedServerUrl, messageHandlerStub.RequestUri.AbsoluteUri, StringComparison.Ordinal);
     }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/RestApiOperationExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/RestApiOperationExtensionsTests.cs
@@ -14,54 +14,6 @@ public class RestApiOperationExtensionsTests
     [Theory]
     [InlineData("PUT")]
     [InlineData("POST")]
-    [InlineData("GET")]
-    public void ItShouldAddServerUrlParameterWithDefaultValueFromOperation(string method)
-    {
-        //Arrange
-        var payload = CreateTestJsonPayload();
-
-        var operation = CreateTestOperation(method, payload, new Uri("https://fake-random-test-host"));
-
-        //Act
-        var parameters = operation.GetParameters();
-
-        //Assert
-        Assert.NotNull(parameters);
-
-        var serverUrl = parameters.FirstOrDefault(p => p.Name == "server-url");
-        Assert.NotNull(serverUrl);
-        Assert.Equal("string", serverUrl.Type);
-        Assert.False(serverUrl.IsRequired);
-        Assert.Equal("https://fake-random-test-host/", serverUrl.DefaultValue);
-    }
-
-    [Theory]
-    [InlineData("PUT")]
-    [InlineData("POST")]
-    [InlineData("GET")]
-    public void ItShouldAddServerUrlParameterWithDefaultValueFromOverrideParameter(string method)
-    {
-        //Arrange
-        var payload = CreateTestJsonPayload();
-
-        var operation = CreateTestOperation(method, payload);
-
-        //Act
-        var parameters = operation.GetParameters(serverUrlOverride: new Uri("https://fake-random-test-host"));
-
-        //Assert
-        Assert.NotNull(parameters);
-
-        var serverUrl = parameters.FirstOrDefault(p => p.Name == "server-url");
-        Assert.NotNull(serverUrl);
-        Assert.Equal("string", serverUrl.Type);
-        Assert.False(serverUrl.IsRequired);
-        Assert.Equal("https://fake-random-test-host/", serverUrl.DefaultValue);
-    }
-
-    [Theory]
-    [InlineData("PUT")]
-    [InlineData("POST")]
     public void ItShouldAddPayloadAndContentTypeParametersByDefault(string method)
     {
         //Arrange
@@ -191,7 +143,7 @@ public class RestApiOperationExtensionsTests
         //Assert
         Assert.NotNull(parameters);
 
-        Assert.Equal(6, parameters.Count); //5(props from payload) + 1('server-url' property)
+        Assert.Equal(5, parameters.Count); //5 props from payload
 
         var name = parameters.FirstOrDefault(p => p.Name == "name");
         Assert.NotNull(name);
@@ -240,7 +192,7 @@ public class RestApiOperationExtensionsTests
         //Assert
         Assert.NotNull(parameters);
 
-        Assert.Equal(6, parameters.Count); //5(props from payload) + 1('server-url' property)
+        Assert.Equal(5, parameters.Count); //5 props from payload
 
         var name = parameters.FirstOrDefault(p => p.Name == "name");
         Assert.NotNull(name);
@@ -285,23 +237,6 @@ public class RestApiOperationExtensionsTests
         Assert.Throws<SKException>(() => operation.GetParameters(addPayloadParamsFromMetadata: true, enablePayloadNamespacing: true));
     }
 
-    [Fact]
-    public void ItShouldSetAlternativeNameToParametersForGetOperation()
-    {
-        //Arrange
-        var operation = CreateTestOperation("GET");
-
-        //Act
-        var parameters = operation.GetParameters(addPayloadParamsFromMetadata: true);
-
-        //Assert
-        Assert.NotNull(parameters);
-
-        var serverUrlProp = parameters.FirstOrDefault(p => p.Name == "server-url");
-        Assert.NotNull(serverUrlProp);
-        Assert.Equal("server_url", serverUrlProp.AlternativeName);
-    }
-
     [Theory]
     [InlineData("PUT")]
     [InlineData("POST")]
@@ -320,10 +255,6 @@ public class RestApiOperationExtensionsTests
 
         //Assert
         Assert.NotNull(parameters);
-
-        var serverUrlProp = parameters.FirstOrDefault(p => p.Name == "server-url");
-        Assert.NotNull(serverUrlProp);
-        Assert.Equal("server_url", serverUrlProp.AlternativeName);
 
         var placeProp = parameters.FirstOrDefault(p => p.Name == "place");
         Assert.NotNull(placeProp);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
@@ -111,11 +111,6 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         Assert.Equal(RestApiOperationParameterLocation.Query, apiVersionParameter.Location);
         Assert.Equal("7.0", apiVersionParameter.DefaultValue);
 
-        var serverUrlParameter = parameters.Single(p => p.Name == "server-url"); //'server-url' artificial parameter.
-        Assert.False(serverUrlParameter.IsRequired);
-        Assert.Equal(RestApiOperationParameterLocation.Path, serverUrlParameter.Location);
-        Assert.Equal("https://my-key-vault.vault.azure.net/", serverUrlParameter.DefaultValue);
-
         var payloadParameter = parameters.Single(p => p.Name == "payload"); //'payload' artificial parameter.
         Assert.True(payloadParameter.IsRequired);
         Assert.Equal(RestApiOperationParameterLocation.Body, payloadParameter.Location);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
@@ -114,11 +114,6 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.Equal(RestApiOperationParameterLocation.Query, apiVersionParameter.Location);
         Assert.Equal("7.0", apiVersionParameter.DefaultValue);
 
-        var serverUrlParameter = parameters.Single(p => p.Name == "server-url"); //'server-url' artificial parameter.
-        Assert.False(serverUrlParameter.IsRequired);
-        Assert.Equal(RestApiOperationParameterLocation.Path, serverUrlParameter.Location);
-        Assert.Equal("https://my-key-vault.vault.azure.net/", serverUrlParameter.DefaultValue);
-
         var payloadParameter = parameters.Single(p => p.Name == "payload"); //'payload' artificial parameter.
         Assert.True(payloadParameter.IsRequired);
         Assert.Equal(RestApiOperationParameterLocation.Body, payloadParameter.Location);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
@@ -112,11 +112,6 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         Assert.Equal(RestApiOperationParameterLocation.Query, apiVersionParameter.Location);
         Assert.Equal("7.0", apiVersionParameter.DefaultValue);
 
-        var serverUrlParameter = parameters.Single(p => p.Name == "server-url"); //'server-url' artificial parameter.
-        Assert.False(serverUrlParameter.IsRequired);
-        Assert.Equal(RestApiOperationParameterLocation.Path, serverUrlParameter.Location);
-        Assert.Equal("https://my-key-vault.vault.azure.net/", serverUrlParameter.DefaultValue);
-
         var payloadParameter = parameters.Single(p => p.Name == "payload"); //'payload' artificial parameter.
         Assert.True(payloadParameter.IsRequired);
         Assert.Equal(RestApiOperationParameterLocation.Body, payloadParameter.Location);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationTests.cs
@@ -48,16 +48,15 @@ public class RestApiOperationTests
             new Dictionary<string, string>()
         );
 
-        var arguments = new Dictionary<string, string>
-        {
-            { "server-url", "https://fake-random-test-host-override" }
-        };
+        var fakeHostUrlOverride = "https://fake-random-test-host-override";
+
+        var arguments = new Dictionary<string, string>();
 
         // Act
-        var url = sut.BuildOperationUrl(arguments);
+        var url = sut.BuildOperationUrl(arguments, serverUrlOverride: new Uri(fakeHostUrlOverride));
 
         // Assert
-        Assert.Equal("https://fake-random-test-host-override/", url.OriginalString);
+        Assert.Equal(fakeHostUrlOverride, url.OriginalString.TrimEnd('/'));
     }
 
     [Fact]
@@ -144,17 +143,18 @@ public class RestApiOperationTests
             new List<RestApiOperationParameter> { firstParameterMetadata, secondParameterMetadata },
             new Dictionary<string, string>());
 
+        var fakeHostUrlOverride = "https://fake-random-test-host-override";
+
         var arguments = new Dictionary<string, string>
         {
-            { "server-url", "https://fake-random-test-host-override" },
             { "fake-path", "fake-path-value" },
         };
 
         // Act
-        var url = sut.BuildOperationUrl(arguments);
+        var url = sut.BuildOperationUrl(arguments, serverUrlOverride: new Uri(fakeHostUrlOverride));
 
         // Assert
-        Assert.Equal("https://fake-random-test-host-override/fake-path-value/", url.OriginalString);
+        Assert.Equal($"{fakeHostUrlOverride}/fake-path-value/", url.OriginalString);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The kernel will artificially add a parameter named `serverl-url` to the parameter view of an OpenAPI function when the function is registered to the kernel. The optional `server-url` parameter allows planners to dynamically provide an alternative server url to override the one that is registered with the plugin. The flexibility offered by this parameter can occasionally lead to confusion among planners, causing them to create plans that fail to execute.

Local plugins and OpenAPI plugins should be indifferent to the planners. We are removing this artificially created parameter to improve the performance of planners in creating valid function calls regardless of the function type.

We are aware that there are OpenAPI plugins that require `server-url` override, such as the Jira plugin and the Azure Key Vault plugin. For these plugins, it's still possible to provide a server url at import/registration time, through the optional `OpenAIFunctionExecutionParameters` parameter (please refer to the updated kernel syntax example 22 and 24).

Tracked by: https://github.com/microsoft/semantic-kernel/issues/3083

### Description
1. Remove the `server-url` from the parameter view of OpenAPI functions.
2. Update unit tests.
3. Update kernel syntax example 22 and 24.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
