### PR TITLE
.Net: Refactor IAIServiceSelector to allow for additional parameters in future

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Program.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Program.cs
@@ -21,7 +21,7 @@ public static class Program
         using CancellationTokenSource cancellationTokenSource = new();
         CancellationToken cancelToken = cancellationTokenSource.ConsoleCancellationToken();
 
-        string? defaultFilter = null; // Modify to filter examples
+        string? defaultFilter = "Example62"; // Modify to filter examples
 
         // Check if args[0] is provided
         string? filter = args.Length > 0 ? args[0] : defaultFilter;

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/ISKFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/ISKFunction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +33,11 @@ public interface ISKFunction
     /// Function description. The description is used in combination with embeddings when searching relevant functions.
     /// </summary>
     string Description { get; }
+
+    /// <summary>
+    /// Model request settings.
+    /// </summary>
+    public ReadOnlyCollection<AIRequestSettings> ModelSettings { get; }
 
     /// <summary>
     /// Returns a description of the function, including parameters.

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/ISKFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/ISKFunction.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,7 +37,7 @@ public interface ISKFunction
     /// <summary>
     /// Model request settings.
     /// </summary>
-    public ReadOnlyCollection<AIRequestSettings> ModelSettings { get; }
+    public IEnumerable<AIRequestSettings> ModelSettings { get; }
 
     /// <summary>
     /// Returns a description of the function, including parameters.

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/ISKFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/ISKFunction.cs
@@ -37,7 +37,7 @@ public interface ISKFunction
     /// <summary>
     /// Model request settings.
     /// </summary>
-    public IEnumerable<AIRequestSettings> ModelSettings { get; }
+    IEnumerable<AIRequestSettings> ModelSettings { get; }
 
     /// <summary>
     /// Returns a description of the function, including parameters.

--- a/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Orchestration/SKContext.cs
@@ -63,7 +63,7 @@ public sealed class SKContext
     /// <summary>
     /// AI service provider
     /// </summary>
-    internal IAIServiceProvider ServiceProvider { get; }
+    public IAIServiceProvider ServiceProvider { get; }
 
     /// <summary>
     /// AIService selector implementation

--- a/dotnet/src/SemanticKernel.Abstractions/Services/IAIServiceSelector.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Services/IAIServiceSelector.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-using System.Collections.Generic;
 using Microsoft.SemanticKernel.AI;
+using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Services;
 
 #pragma warning disable IDE0130
@@ -18,9 +18,8 @@ public interface IAIServiceSelector
     /// The returned value is a tuple containing instances of <see cref="IAIService"/> and <see cref="AIRequestSettings"/>
     /// </summary>
     /// <typeparam name="T">Type of AI service to return</typeparam>
-    /// <param name="renderedPrompt">Rendered prompt</param>
-    /// <param name="serviceProvider">AI service provider</param>
-    /// <param name="modelSettings">Collection of model settings</param>
+    /// <param name="context">Semantic Kernel context</param>
+    /// <param name="skfunction">Semantic Kernel callable function interface</param>
     /// <returns></returns>
-    (T?, AIRequestSettings?) SelectAIService<T>(string renderedPrompt, IAIServiceProvider serviceProvider, IReadOnlyList<AIRequestSettings>? modelSettings) where T : IAIService;
+    (T?, AIRequestSettings?) SelectAIService<T>(SKContext context, ISKFunction skfunction) where T : IAIService;
 }

--- a/dotnet/src/SemanticKernel.Abstractions/TemplateEngine/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/TemplateEngine/PromptTemplateConfig.cs
@@ -85,7 +85,6 @@ public class PromptTemplateConfig
 
     /// <summary>
     /// Model request settings.
-    /// Initially only a single model request settings is supported.
     /// </summary>
     [JsonPropertyName("models")]
     [JsonPropertyOrder(4)]

--- a/dotnet/src/SemanticKernel.Core/Functions/DelegatingAIServiceSelector.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/DelegatingAIServiceSelector.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Services;
 
 namespace Microsoft.SemanticKernel.Functions;
@@ -18,8 +18,8 @@ internal class DelegatingAIServiceSelector : IAIServiceSelector
     internal AIRequestSettings? RequestSettings { get; set; }
 
     /// <inheritdoc/>
-    public (T?, AIRequestSettings?) SelectAIService<T>(string renderedPrompt, IAIServiceProvider serviceProvider, IReadOnlyList<AIRequestSettings>? modelSettings) where T : IAIService
+    public (T?, AIRequestSettings?) SelectAIService<T>(SKContext context, ISKFunction skfunction) where T : IAIService
     {
-        return ((T?)this.ServiceFactory?.Invoke() ?? serviceProvider.GetService<T>(null), this.RequestSettings ?? modelSettings?[0]);
+        return ((T?)this.ServiceFactory?.Invoke() ?? context.ServiceProvider.GetService<T>(null), this.RequestSettings ?? skfunction.RequestSettings);
     }
 }

--- a/dotnet/src/SemanticKernel.Core/Functions/InstrumentedSKFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/InstrumentedSKFunction.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
@@ -33,7 +33,7 @@ internal sealed class InstrumentedSKFunction : ISKFunction
     public string Description => this._function.Description;
 
     /// <inheritdoc/>
-    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this._function.ModelSettings;
+    public IEnumerable<AIRequestSettings> ModelSettings => this._function.ModelSettings;
 
     /// <summary>
     /// Initialize a new instance of the <see cref="InstrumentedSKFunction"/> class.

--- a/dotnet/src/SemanticKernel.Core/Functions/InstrumentedSKFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/InstrumentedSKFunction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
@@ -30,6 +31,9 @@ internal sealed class InstrumentedSKFunction : ISKFunction
 
     /// <inheritdoc/>
     public string Description => this._function.Description;
+
+    /// <inheritdoc/>
+    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this._function.ModelSettings;
 
     /// <summary>
     /// Initialize a new instance of the <see cref="InstrumentedSKFunction"/> class.

--- a/dotnet/src/SemanticKernel.Core/Functions/NativeFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/NativeFunction.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -44,6 +45,9 @@ internal sealed class NativeFunction : ISKFunction, IDisposable
 
     /// <inheritdoc/>
     public string Description { get; }
+
+    /// <inheritdoc/>
+    public ReadOnlyCollection<AIRequestSettings> ModelSettings => Array.Empty<AIRequestSettings>().ToList<AIRequestSettings>().AsReadOnly();
 
     /// <summary>
     /// List of function parameters

--- a/dotnet/src/SemanticKernel.Core/Functions/NativeFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/NativeFunction.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -47,7 +46,7 @@ internal sealed class NativeFunction : ISKFunction, IDisposable
     public string Description { get; }
 
     /// <inheritdoc/>
-    public ReadOnlyCollection<AIRequestSettings> ModelSettings => Array.Empty<AIRequestSettings>().ToList<AIRequestSettings>().AsReadOnly();
+    public IEnumerable<AIRequestSettings> ModelSettings => Enumerable.Empty<AIRequestSettings>();
 
     /// <summary>
     /// List of function parameters

--- a/dotnet/src/SemanticKernel.Core/Functions/OrderedIAIServiceSelector.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/OrderedIAIServiceSelector.cs
@@ -19,7 +19,7 @@ internal class OrderedIAIServiceSelector : IAIServiceSelector
     {
         var serviceProvider = context.ServiceProvider;
         var modelSettings = skfunction.ModelSettings;
-        if (modelSettings is null || modelSettings.Count == 0)
+        if (modelSettings is null || !modelSettings.Any())
         {
             var service = serviceProvider.GetService<T>(null);
             if (service is not null)

--- a/dotnet/src/SemanticKernel.Core/Functions/OrderedIAIServiceSelector.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/OrderedIAIServiceSelector.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Diagnostics;
+using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Services;
 
 namespace Microsoft.SemanticKernel.Functions;
@@ -15,8 +15,10 @@ namespace Microsoft.SemanticKernel.Functions;
 internal class OrderedIAIServiceSelector : IAIServiceSelector
 {
     /// <inheritdoc/>
-    public (T?, AIRequestSettings?) SelectAIService<T>(string renderedPrompt, IAIServiceProvider serviceProvider, IReadOnlyList<AIRequestSettings>? modelSettings) where T : IAIService
+    public (T?, AIRequestSettings?) SelectAIService<T>(SKContext context, ISKFunction skfunction) where T : IAIService
     {
+        var serviceProvider = context.ServiceProvider;
+        var modelSettings = skfunction.ModelSettings;
         if (modelSettings is null || modelSettings.Count == 0)
         {
             var service = serviceProvider.GetService<T>(null);

--- a/dotnet/src/SemanticKernel.Core/Functions/SemanticFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/SemanticFunction.cs
@@ -181,7 +181,7 @@ internal sealed class SemanticFunction : ISKFunction, IDisposable
             string renderedPrompt = await this._promptTemplate.RenderAsync(context, cancellationToken).ConfigureAwait(false);
 
             var serviceSelector = this._serviceSelector ?? context.ServiceSelector;
-            (var textCompletion, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(renderedPrompt, context.ServiceProvider, this._promptTemplateConfig.ModelSettings);
+            (var textCompletion, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, this);
             Verify.NotNull(textCompletion);
 
             this.CallFunctionInvoking(context, renderedPrompt);

--- a/dotnet/src/SemanticKernel.Core/Functions/SemanticFunction.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/SemanticFunction.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
@@ -42,7 +41,7 @@ internal sealed class SemanticFunction : ISKFunction, IDisposable
     public string Description => this._promptTemplateConfig.Description;
 
     /// <inheritdoc/>
-    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this._promptTemplateConfig.ModelSettings.AsReadOnly();
+    public IEnumerable<AIRequestSettings> ModelSettings => this._promptTemplateConfig.ModelSettings.AsReadOnly();
 
     /// <summary>
     /// List of function parameters

--- a/dotnet/src/SemanticKernel.Core/Planning/InstrumentedPlan.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/InstrumentedPlan.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
@@ -30,7 +30,7 @@ internal sealed class InstrumentedPlan : ISKFunction
     public string Description => this._plan.Description;
 
     /// <inheritdoc/>
-    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this._plan.ModelSettings;
+    public IEnumerable<AIRequestSettings> ModelSettings => this._plan.ModelSettings;
 
     /// <summary>
     /// Initialize a new instance of the <see cref="InstrumentedPlan"/> class.

--- a/dotnet/src/SemanticKernel.Core/Planning/InstrumentedPlan.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/InstrumentedPlan.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
@@ -27,6 +28,9 @@ internal sealed class InstrumentedPlan : ISKFunction
 
     /// <inheritdoc/>
     public string Description => this._plan.Description;
+
+    /// <inheritdoc/>
+    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this._plan.ModelSettings;
 
     /// <summary>
     /// Initialize a new instance of the <see cref="InstrumentedPlan"/> class.

--- a/dotnet/src/SemanticKernel.Core/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/Plan.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
@@ -80,7 +79,7 @@ public sealed class Plan : ISKFunction
 
     /// <inheritdoc/>
     [JsonPropertyName("model_settings")]
-    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this.Function is not null ? this.Function.ModelSettings : Array.Empty<AIRequestSettings>().ToList<AIRequestSettings>().AsReadOnly();
+    public IEnumerable<AIRequestSettings> ModelSettings => this.Function?.ModelSettings ?? Array.Empty<AIRequestSettings>();
 
     #endregion ISKFunction implementation
 

--- a/dotnet/src/SemanticKernel.Core/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/Plan.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
@@ -79,7 +80,7 @@ public sealed class Plan : ISKFunction
 
     /// <inheritdoc/>
     [JsonPropertyName("model_settings")]
-    public List<AIRequestSettings>? ModelSettings { get; private set; }
+    public ReadOnlyCollection<AIRequestSettings> ModelSettings => this.Function is not null ? this.Function.ModelSettings : Array.Empty<AIRequestSettings>().ToList<AIRequestSettings>().AsReadOnly();
 
     #endregion ISKFunction implementation
 

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedIAIServiceConfigurationProviderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedIAIServiceConfigurationProviderTests.cs
@@ -4,11 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Functions;
 using Microsoft.SemanticKernel.Services;
+using Microsoft.SemanticKernel.TemplateEngine;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Functions;
@@ -18,30 +20,27 @@ public class OrderedIAIServiceConfigurationProviderTests
     public void ItThrowsAnSKExceptionForNoServices()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>();
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder().Build();
+        var context = kernel.CreateNewContext();
+        var skfunction = kernel.CreateSemanticFunction("Hello AI");
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
         // Assert
-        Assert.Throws<SKException>(() => configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings));
+        Assert.Throws<SKException>(() => serviceSelector.SelectAIService<ITextCompletion>(context, skfunction));
     }
 
     [Fact]
     public void ItGetsAIServiceConfigurationForSingleAIService()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<IAIService>(new AIService());
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>();
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder().WithAIService<IAIService>("service1", new AIService()).Build();
+        var context = kernel.CreateNewContext();
+        var skfunction = kernel.CreateSemanticFunction("Hello AI");
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<IAIService>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<IAIService>(context, skfunction);
 
         // Assert
         Assert.NotNull(aiService);
@@ -52,15 +51,13 @@ public class OrderedIAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationForSingleTextCompletion()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>(new TextCompletion());
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>();
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder().WithAIService<ITextCompletion>("service1", new TextCompletion()).Build();
+        var context = kernel.CreateNewContext();
+        var skfunction = kernel.CreateSemanticFunction("Hello AI");
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, skfunction);
 
         // Assert
         Assert.NotNull(aiService);
@@ -68,81 +65,61 @@ public class OrderedIAIServiceConfigurationProviderTests
     }
 
     [Fact]
-    public void ItAIServiceConfigurationForTextCompletionByServiceId()
+    public void ItGetsAIServiceConfigurationForTextCompletionByServiceId()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion());
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>();
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder()
+            .WithAIService<ITextCompletion>("service1", new TextCompletion())
+            .WithAIService<ITextCompletion>("service2", new TextCompletion())
+            .Build();
+        var context = kernel.CreateNewContext();
+        var requestSettings = new AIRequestSettings() { ServiceId = "service2" };
+        var skfunction = kernel.CreateSemanticFunction("Hello AI", requestSettings: requestSettings);
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, skfunction);
 
         // Assert
-        Assert.NotNull(aiService);
-        Assert.Null(defaultRequestSettings);
+        Assert.Equal(context.ServiceProvider.GetService<ITextCompletion>("service2"), aiService);
+        Assert.Equal(requestSettings, defaultRequestSettings);
     }
 
     [Fact]
     public void ItThrowsAnSKExceptionForNotFoundService()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion());
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>
-        {
-            new AIRequestSettings() { ServiceId = "service3" }
-        };
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder()
+            .WithAIService<ITextCompletion>("service1", new TextCompletion())
+            .WithAIService<ITextCompletion>("service2", new TextCompletion())
+            .Build();
+        var context = kernel.CreateNewContext();
+        var requestSettings = new AIRequestSettings() { ServiceId = "service3" };
+        var skfunction = kernel.CreateSemanticFunction("Hello AI", requestSettings: requestSettings);
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
         // Assert
-        Assert.Throws<SKException>(() => configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings));
-    }
-
-    [Fact]
-    public void ItUsesDefaultServiceForNullModelSettings()
-    {
-        // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion(), true);
-        var serviceProvider = serviceCollection.Build();
-        var configurationProvider = new OrderedIAIServiceSelector();
-
-        // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, null);
-
-        // Assert
-        Assert.Equal(serviceProvider.GetService<ITextCompletion>("service2"), aiService);
-        Assert.Null(defaultRequestSettings);
+        Assert.Throws<SKException>(() => serviceSelector.SelectAIService<ITextCompletion>(context, skfunction));
     }
 
     [Fact]
     public void ItUsesDefaultServiceForEmptyModelSettings()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion(), true);
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>();
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder()
+            .WithAIService<ITextCompletion>("service1", new TextCompletion())
+            .WithAIService<ITextCompletion>("service2", new TextCompletion(), true)
+            .Build();
+        var context = kernel.CreateNewContext();
+        var skfunction = kernel.CreateSemanticFunction("Hello AI");
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, skfunction);
 
         // Assert
-        Assert.Equal(serviceProvider.GetService<ITextCompletion>("service2"), aiService);
+        Assert.Equal(context.ServiceProvider.GetService<ITextCompletion>("service2"), aiService);
         Assert.Null(defaultRequestSettings);
     }
 
@@ -150,46 +127,43 @@ public class OrderedIAIServiceConfigurationProviderTests
     public void ItUsesDefaultServiceAndSettings()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion(), true);
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>
-        {
-            new AIRequestSettings()
-        };
-        var configurationProvider = new OrderedIAIServiceSelector();
+        // Arrange
+        var kernel = new KernelBuilder()
+            .WithAIService<ITextCompletion>("service1", new TextCompletion())
+            .WithAIService<ITextCompletion>("service2", new TextCompletion(), true)
+            .Build();
+        var context = kernel.CreateNewContext();
+        var requestSettings = new AIRequestSettings();
+        var skfunction = kernel.CreateSemanticFunction("Hello AI", requestSettings: requestSettings);
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, skfunction);
 
         // Assert
-        Assert.Equal(serviceProvider.GetService<ITextCompletion>("service2"), aiService);
-        Assert.Equal(modelSettings[0], defaultRequestSettings);
+        Assert.Equal(context.ServiceProvider.GetService<ITextCompletion>("service2"), aiService);
+        Assert.Equal(requestSettings, defaultRequestSettings);
     }
 
     [Fact]
     public void ItUsesDefaultServiceAndSettingsEmptyServiceId()
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion(), true);
-        var serviceProvider = serviceCollection.Build();
-        var modelSettings = new List<AIRequestSettings>
-        {
-            new AIRequestSettings() { ServiceId = "" }
-        };
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var kernel = new KernelBuilder()
+            .WithAIService<ITextCompletion>("service1", new TextCompletion())
+            .WithAIService<ITextCompletion>("service2", new TextCompletion(), true)
+            .Build();
+        var context = kernel.CreateNewContext();
+        var requestSettings = new AIRequestSettings() { ServiceId = "" };
+        var skfunction = kernel.CreateSemanticFunction("Hello AI", requestSettings: requestSettings);
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, skfunction);
 
         // Assert
-        Assert.Equal(serviceProvider.GetService<ITextCompletion>("service2"), aiService);
-        Assert.Equal(modelSettings[0], defaultRequestSettings);
+        Assert.Equal(context.ServiceProvider.GetService<ITextCompletion>("service2"), aiService);
+        Assert.Equal(requestSettings, defaultRequestSettings);
     }
 
     [Theory]
@@ -200,24 +174,25 @@ public class OrderedIAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationByOrder(string[] serviceIds, string expectedServiceId)
     {
         // Arrange
-        var renderedPrompt = "Hello AI, what can you do for me?";
-        var serviceCollection = new AIServiceCollection();
-        serviceCollection.SetService<ITextCompletion>("service1", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service2", new TextCompletion());
-        serviceCollection.SetService<ITextCompletion>("service3", new TextCompletion());
-        var serviceProvider = serviceCollection.Build();
+        var kernel = new KernelBuilder()
+            .WithAIService<ITextCompletion>("service1", new TextCompletion())
+            .WithAIService<ITextCompletion>("service2", new TextCompletion())
+            .WithAIService<ITextCompletion>("service3", new TextCompletion())
+            .Build();
+        var context = kernel.CreateNewContext();
         var modelSettings = new List<AIRequestSettings>();
         foreach (var serviceId in serviceIds)
         {
             modelSettings.Add(new AIRequestSettings() { ServiceId = serviceId });
         }
-        var configurationProvider = new OrderedIAIServiceSelector();
+        var skfunction = kernel.CreateSemanticFunction("Hello AI", promptTemplateConfig: new PromptTemplateConfig() { ModelSettings = modelSettings });
+        var serviceSelector = new OrderedIAIServiceSelector();
 
         // Act
-        (var aiService, var defaultRequestSettings) = configurationProvider.SelectAIService<ITextCompletion>(renderedPrompt, serviceProvider, modelSettings);
+        (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(context, skfunction);
 
         // Assert
-        Assert.Equal(serviceProvider.GetService<ITextCompletion>(expectedServiceId), aiService);
+        Assert.Equal(context.ServiceProvider.GetService<ITextCompletion>(expectedServiceId), aiService);
         Assert.Equal(expectedServiceId, defaultRequestSettings!.ServiceId);
     }
 


### PR DESCRIPTION
### Motivation and Context

If we need to pass additional information to `IAIServiceSelector` in future we want to avoid this being a breaking change.

Changing the signature to pass:

1. `SKContext` - This contains all information about the Kernel execution context
2. `ISKFunction` - This has been extended to provide access to the model settings 

### Description

Example `IAIServiceSelector` implementation.

```csharp
public class ByModelIdAIServiceSelector : IAIServiceSelector
{
    private readonly string _openAIModelId;

    public ByModelIdAIServiceSelector(string openAIModelId)
    {
        this._openAIModelId = openAIModelId;
    }

    public (T?, AIRequestSettings?) SelectAIService<T>(SKContext context, ISKFunction skfunction) where T : IAIService
    {
        foreach (var model in skfunction.ModelSettings)
        {
            if (model is OpenAIRequestSettings openAIModel)
            {
                if (openAIModel.ModelId == this._openAIModelId)
                {
                    var service = context.ServiceProvider.GetService<T>(openAIModel.ServiceId);
                    if (service is not null)
                    {
                        return (service, model);
                    }
                }
            }
        }

        throw new SKException("Unable to find AI service to handled request.");
    }
}
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
