### PR TITLE
User-agent prevents 403 with Cloudflare sites

### DIFF
--- a/python/notebooks/plugins/sk_web_pages_plugin.py
+++ b/python/notebooks/plugins/sk_web_pages_plugin.py
@@ -22,7 +22,7 @@ class WebPagesPlugin:
         """
         if not input:
             raise ValueError("url cannot be `None` or empty")
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(headers={'User-Agent': 'Mozilla/5.0'}) as session:
             async with session.get(input, raise_for_status=True) as response:
                 html = await response.text()
                 soup = BeautifulSoup(html, features="html.parser")


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The sample Notebook that demonstrates integrating SK and Autogen either fails or produces incorrect results if it needs to make requests to sites using Cloudflare as they will return Forbidden (403). Not a big deal, but as a non-python guy, it took me a while to figure out what was going on!

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

The site will return Forbidden (403) unless a user-agent is added to the request. This must be because of "bot" protection or something of that nature provided by Cloudflare. Adding the header "{'User-Agent': 'Mozilla/5.0'}" when creating the http request with aiohttp.ClientSession, was enough to avoid this protection.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
