### PR TITLE
.Net: Change approach to loading the default IPromptTemplateFactory

### DIFF
--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/AggregatorPromptTemplateFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/AggregatorPromptTemplateFactory.cs
@@ -81,7 +81,7 @@ public class AggregatorPromptTemplateFactory : IPromptTemplateFactory
                 .Where(t => type.IsAssignableFrom(t)
                     && !t.IsInterface
                     && !t.IsAbstract
-                    && !t.IsNotPublic
+                    && t.IsPublic
                     && t.GetConstructor(new Type[] { typeof(ILoggerFactory) }) != null);
             var factories = types.Select(t => (IPromptTemplateFactory)Activator.CreateInstance(t, kernel.LoggerFactory)).ToArray();
 

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/AggregatorPromptTemplateFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/AggregatorPromptTemplateFactory.cs
@@ -81,6 +81,7 @@ public class AggregatorPromptTemplateFactory : IPromptTemplateFactory
                 .Where(t => type.IsAssignableFrom(t)
                     && !t.IsInterface
                     && !t.IsAbstract
+                    && !t.IsNotPublic
                     && t.GetConstructor(new Type[] { typeof(ILoggerFactory) }) != null);
             var factories = types.Select(t => (IPromptTemplateFactory)Activator.CreateInstance(t, kernel.LoggerFactory)).ToArray();
 


### PR DESCRIPTION
### Motivation and Context

Resolves #3353 

### Description

Load all available implementations of `IPromptTemplateFactory`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
