### PR TITLE
.Net: Allow to exclude operations when importing and OpenAPI swagger

### DIFF
--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
@@ -150,7 +150,11 @@ public static class KernelOpenApiPluginExtensions
 
         using (var documentStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(pluginJson)))
         {
-            var operations = await parser.ParseAsync(documentStream, executionParameters?.IgnoreNonCompliantErrors ?? false, cancellationToken).ConfigureAwait(false);
+            var operations = await parser.ParseAsync(
+                documentStream,
+                executionParameters?.IgnoreNonCompliantErrors ?? false,
+                executionParameters?.OperationsToExclude,
+                cancellationToken).ConfigureAwait(false);
 
             var runner = new RestApiOperationRunner(
                 httpClient,

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/OpenApiFunctionExecutionParameters.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/OpenApiFunctionExecutionParameters.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Functions.OpenAPI.Authentication;
@@ -55,6 +56,11 @@ public class OpenApiFunctionExecutionParameters
     public bool EnablePayloadNamespacing { get; set; }
 
     /// <summary>
+    /// Optional list of HTTP operations to skip when importing the OpenAPI document.
+    /// </summary>
+    public IList<string> OperationsToExclude { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="OpenApiFunctionExecutionParameters"/> class.
     /// </summary>
     /// <param name="httpClient">The HttpClient to use for sending HTTP requests.</param>
@@ -68,6 +74,7 @@ public class OpenApiFunctionExecutionParameters
     /// If false, the operation payload must be provided via the 'payload' context variable.</param>
     /// <param name="enablePayloadNamespacing">Determines whether payload parameter names are augmented with namespaces.
     /// Namespaces prevent naming conflicts by adding the parent parameter name as a prefix, separated by dots.</param>
+    /// <param name="operationsToExclude">Optional list of operations not to import, e.g. in case they are not supported</param>
     public OpenApiFunctionExecutionParameters(
         HttpClient? httpClient = null,
         AuthenticateRequestAsyncCallback? authCallback = null,
@@ -75,7 +82,8 @@ public class OpenApiFunctionExecutionParameters
         string userAgent = Telemetry.HttpUserAgent,
         bool ignoreNonCompliantErrors = false,
         bool enableDynamicOperationPayload = false,
-        bool enablePayloadNamespacing = false)
+        bool enablePayloadNamespacing = false,
+        IList<string>? operationsToExclude = null)
     {
         this.HttpClient = httpClient;
         this.AuthCallback = authCallback;
@@ -84,5 +92,6 @@ public class OpenApiFunctionExecutionParameters
         this.IgnoreNonCompliantErrors = ignoreNonCompliantErrors;
         this.EnableDynamicPayload = enableDynamicOperationPayload;
         this.EnablePayloadNamespacing = enablePayloadNamespacing;
+        this.OperationsToExclude = operationsToExclude ?? new List<string>();
     }
 }

--- a/dotnet/src/Functions/Functions.OpenAPI/OpenApi/IOpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/OpenApi/IOpenApiDocumentParser.cs
@@ -20,7 +20,12 @@ internal interface IOpenApiDocumentParser
     /// <param name="ignoreNonCompliantErrors">Flag indicating whether to ignore non-compliant errors.
     /// If set to true, the parser will not throw exceptions for non-compliant documents.
     /// Please note that enabling this option may result in incomplete or inaccurate parsing results.</param>
+    /// <param name="operationsToExclude">Optional list of operations not to import, e.g. in case they are not supported</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>List of rest operations.</returns>
-    Task<IList<RestApiOperation>> ParseAsync(Stream stream, bool ignoreNonCompliantErrors = false, CancellationToken cancellationToken = default);
+    Task<IList<RestApiOperation>> ParseAsync(
+        Stream stream,
+        bool ignoreNonCompliantErrors = false,
+        IList<string>? operationsToExclude = null,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
### Motivation and Context

When importing OpenAPI plugins, there can be operations not supported by SK, triggering an exception.


For instance, SK currently supports only "application/json" and "text/plain" media types, and `kernel.ImportOpenApiPluginFunctionsAsync` throws an exception when encountering an operation that uses "multipart/form-data" (`SKException($"Neither of the media types of {operationId} is supported.")`).

### Description

Add new option to `OpenApiFunctionExecutionParameters` allowing to exclude some operations, e.g. those that would otherwise cause an exception.