### PR TITLE
.Net: Remove the code to load the BasicTemplateEngine by default

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Extensions/KernelSemanticFunctionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Extensions/KernelSemanticFunctionExtensions.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI;
@@ -356,7 +357,7 @@ public static class KernelSemanticFunctionExtensions
             }
         }
 
-        throw new SKException($"Unable to create default prompt template factory. Please provide an implementation of IPromptTemplateFactory or depend on {BasicTemplateFactoryAssemblyName}");
+        return new NullPromptTemplateFactory();
     }
 
     /// <summary>
@@ -376,6 +377,31 @@ public static class KernelSemanticFunctionExtensions
         catch (Exception ex) when (!ex.IsCriticalException())
         {
             return null;
+        }
+    }
+
+    private sealed class NullPromptTemplateFactory : IPromptTemplateFactory
+    {
+        public IPromptTemplate Create(string templateString, PromptTemplateConfig promptTemplateConfig)
+        {
+            return new NullPromptTemplate(templateString);
+        }
+    }
+
+    private sealed class NullPromptTemplate : IPromptTemplate
+    {
+        private readonly string _templateText;
+
+        public NullPromptTemplate(string templateText)
+        {
+            this._templateText = templateText;
+        }
+
+        public IReadOnlyList<ParameterView> Parameters => Array.Empty<ParameterView>();
+
+        public Task<string> RenderAsync(SKContext executionContext, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(this._templateText);
         }
     }
 

--- a/dotnet/src/SemanticKernel.Core/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Core/Kernel.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -77,7 +76,7 @@ public sealed class Kernel : IKernel, IDisposable
         ILoggerFactory? loggerFactory,
         IAIServiceSelector? serviceSelector = null) : this(functionCollection, aiServiceProvider, memory, httpHandlerFactory, loggerFactory, serviceSelector)
     {
-        this.PromptTemplateEngine = promptTemplateEngine ?? this.CreateDefaultPromptTemplateEngine(loggerFactory);
+        this.PromptTemplateEngine = promptTemplateEngine;
     }
 
     /// <summary>
@@ -326,81 +325,4 @@ repeat:
 #pragma warning restore CS1591
 
     #endregion
-
-    #region Private ====================================================================================
-
-    private static bool s_promptTemplateEngineInitialized = false;
-    private static Type? s_promptTemplateEngineType = null;
-
-    /// <summary>
-    /// Create a default prompt template engine.
-    ///
-    /// This is a temporary solution to avoid breaking existing clients.
-    /// There will be a separate task to add support for registering instances of IPromptTemplateEngine and obsoleting the current approach.
-    ///
-    /// </summary>
-    /// <param name="loggerFactory">Logger factory to be used by the template engine</param>
-    /// <returns>Instance of <see cref="IPromptTemplateEngine"/>.</returns>
-    [Obsolete("Provided for backward compatibility. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    private IPromptTemplateEngine CreateDefaultPromptTemplateEngine(ILoggerFactory? loggerFactory = null)
-    {
-        if (!s_promptTemplateEngineInitialized)
-        {
-            s_promptTemplateEngineType = this.GetPromptTemplateEngineType();
-            s_promptTemplateEngineInitialized = true;
-        }
-
-        if (s_promptTemplateEngineType is not null)
-        {
-            var constructor = s_promptTemplateEngineType.GetConstructor(new Type[] { typeof(ILoggerFactory) });
-            if (constructor is not null)
-            {
-#pragma warning disable CS8601 // Null logger factory is OK
-                return (IPromptTemplateEngine)constructor.Invoke(new object[] { loggerFactory });
-#pragma warning restore CS8601
-            }
-        }
-
-        return new NullPromptTemplateEngine();
-    }
-
-    /// <summary>
-    /// Get the prompt template engine type if available
-    /// </summary>
-    /// <returns>The type for the prompt template engine if available</returns>
-    [Obsolete("Provided for backward compatibility. This will be removed in a future release.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    private Type? GetPromptTemplateEngineType()
-    {
-        try
-        {
-            var assembly = Assembly.Load("Microsoft.SemanticKernel.TemplateEngine.Basic");
-
-            return assembly.ExportedTypes.Single(type =>
-                type.Name.Equals("BasicPromptTemplateEngine", StringComparison.Ordinal) &&
-                type.GetInterface(nameof(IPromptTemplateEngine)) is not null);
-        }
-        catch (Exception ex) when (!ex.IsCriticalException())
-        {
-            return null;
-        }
-    }
-
-    #endregion
-}
-
-/// <summary>
-/// No-operation IPromptTemplateEngine which performs no rendering of the template.
-///
-/// This is a temporary solution to avoid breaking existing clients.
-/// </summary>
-[Obsolete("This is used for backward compatibility. This will be removed in a future release.")]
-[EditorBrowsable(EditorBrowsableState.Never)]
-internal sealed class NullPromptTemplateEngine : IPromptTemplateEngine
-{
-    public Task<string> RenderAsync(string templateText, SKContext context, CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult(templateText);
-    }
 }


### PR DESCRIPTION
### Motivation and Context

Start clean-up of the code which loads the basic template package

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
