### PR TITLE
Python: Windows Text Parsing of Prompt Templates kernel.py

### DIFF
--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -863,11 +863,11 @@ class Kernel:
 
             config = PromptTemplateConfig()
             config_path = os.path.join(directory, CONFIG_FILE)
-            with open(config_path, "r") as config_file:
+            with open(config_path, "r", encoding='utf-8') as config_file:
                 config = config.from_json(config_file.read())
 
             # Load Prompt Template
-            with open(prompt_path, "r") as prompt_file:
+            with open(prompt_path, "r", encoding='utf-8') as prompt_file:
                 template = PromptTemplate(
                     prompt_file.read(), self.prompt_template_engine, config
                 )


### PR DESCRIPTION
fixing issue with reading

### Motivation and Context


Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  By default on windows, the character mapping for reading the prompt templates does not cover a wide range of characters, causing parsing failures when trying to read templates on windows when characters that utf-8 encodings handle.

By stetting it so that the encoding is set to utf-8 it makes it so that by default the package can read a larger set of characters without throwing an error.

  2. What problem does it solve?
  
Allows for a wide range of templates and kinds of text are in the template without throwing an error when using semantic kernel python on windows.

  3. What scenario does it contribute to?
  
Usage of Semantic Kernel on windows machines that covers a large number of potential characters in the template. Especially important for few-shot examples when the input text is natural language. 

  4. If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/semantic-kernel/issues/3471

### Description

Change the opening of the template and config file to by default use utf-8 encoding by default 

### Contribution Checklist



- [Yes] The code builds clean without any errors or warnings
- [ Small change, I can't share internal examples, but can find something simple examples if needed.] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [Yes ] All unit tests pass, and I have added new tests where possible
- [Should not have broken anyone] I didn't break anyone :smile:

If you need me to make changes or revisions let me know.