### PR TITLE
.Net: Remove IOrderedEnumerable from method signatures

### DIFF
--- a/dotnet/src/Planners/Planners.Core/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
@@ -67,7 +67,7 @@ public static class ReadOnlyFunctionCollectionPlannerExtensions
         ILogger? logger = null,
         CancellationToken cancellationToken = default)
     {
-        IOrderedEnumerable<FunctionView> availableFunctions = await functions.GetFunctionsAsync(config, semanticQuery, logger, cancellationToken).ConfigureAwait(false);
+        IEnumerable<FunctionView> availableFunctions = await functions.GetFunctionsAsync(config, semanticQuery, logger, cancellationToken).ConfigureAwait(false);
 
         return string.Join("\n\n", availableFunctions.Select(x => x.ToManualString()));
     }
@@ -101,7 +101,7 @@ public static class ReadOnlyFunctionCollectionPlannerExtensions
             return schema;
         }
 
-        IOrderedEnumerable<FunctionView> availableFunctions = await functions.GetFunctionsAsync(config, semanticQuery, logger, cancellationToken).ConfigureAwait(false);
+        IEnumerable<FunctionView> availableFunctions = await functions.GetFunctionsAsync(config, semanticQuery, logger, cancellationToken).ConfigureAwait(false);
         var manuals = availableFunctions.Select(x => x.ToJsonSchemaManual(schemaBuilderDelegate, includeOutputSchema));
         return JsonSerializer.Serialize(manuals);
     }
@@ -115,7 +115,7 @@ public static class ReadOnlyFunctionCollectionPlannerExtensions
     /// <param name="logger">The logger to use for logging.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A list of functions that are available to the user based on the semantic query and the excluded plugins and functions.</returns>
-    public static async Task<IOrderedEnumerable<FunctionView>> GetFunctionsAsync(
+    public static async Task<IEnumerable<FunctionView>> GetFunctionsAsync(
         this IReadOnlyFunctionCollection functions,
         PlannerConfigBase config,
         string? semanticQuery,
@@ -137,7 +137,7 @@ public static class ReadOnlyFunctionCollectionPlannerExtensions
     /// <param name="logger">The logger to use for logging.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A list of functions that are available to the user based on the semantic query and the excluded plugins and functions.</returns>
-    public static async Task<IOrderedEnumerable<FunctionView>> GetAvailableFunctionsAsync(
+    public static async Task<IEnumerable<FunctionView>> GetAvailableFunctionsAsync(
         this IReadOnlyFunctionCollection functions,
         PlannerConfigBase config,
         string? semanticQuery = null,

--- a/dotnet/src/Planners/Planners.Core/PlannerConfigBase.cs
+++ b/dotnet/src/Planners/Planners.Core/PlannerConfigBase.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,7 +44,7 @@ public abstract class PlannerConfigBase
     /// If set, this function takes precedence over <see cref="Memory"/>.
     /// Setting <see cref="ExcludedPlugins"/>, <see cref="ExcludedFunctions"/> will be used to filter the results.
     /// </summary>
-    public Func<PlannerConfigBase, string?, CancellationToken, Task<IOrderedEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
+    public Func<PlannerConfigBase, string?, CancellationToken, Task<IEnumerable<FunctionView>>>? GetAvailableFunctionsAsync { get; set; }
 
     /// <summary>
     /// Callback to get a function by name (optional).


### PR DESCRIPTION
### Motivation and Context

It's incredibly unusual for public API in .NET to use LINQ's IOrderedEnumerable, especially in an interface where doing so is forcing an implementation to use OrderBy.  These should just be IEnumerable.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
