### PR TITLE
.Net: Remove use of ConcurrentBag from planner extensions

### DIFF
--- a/dotnet/src/Planners/Planners.Core/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -196,7 +195,7 @@ public static class ReadOnlyFunctionCollectionPlannerExtensions
         ILogger logger,
         CancellationToken cancellationToken = default)
     {
-        var relevantFunctions = new ConcurrentBag<FunctionView>();
+        var relevantFunctions = new List<FunctionView>();
         await foreach (var memoryEntry in memories.WithCancellation(cancellationToken))
         {
             var function = availableFunctions.FirstOrDefault(x => x.ToFullyQualifiedName() == memoryEntry.Metadata.Id);


### PR DESCRIPTION
### Motivation and Context

It's not being used concurrently. It can just be a List.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
