### PR TITLE
.Net: Avoid creating new JsonSerializerOptions per Serialize/Deserialize

### DIFF
--- a/dotnet/src/Experimental/Orchestration.Flow/FlowSerializer.cs
+++ b/dotnet/src/Experimental/Orchestration.Flow/FlowSerializer.cs
@@ -16,6 +16,13 @@ namespace Microsoft.SemanticKernel.Experimental.Orchestration;
 /// </summary>
 public static class FlowSerializer
 {
+    /// <summary>Options for <see cref="DeserializeFromJson"/>.</summary>
+    private static readonly JsonSerializerOptions s_deserializeOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
     /// <summary>
     /// Deserialize flow from yaml
     /// </summary>
@@ -39,17 +46,8 @@ public static class FlowSerializer
     /// <returns>the <see cref="Flow"/> instance</returns>
     public static Flow? DeserializeFromJson(string json)
     {
-        var options = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-        };
-
-        var flow = JsonSerializer.Deserialize<FlowModel>(json, options);
-        if (flow is null)
-        {
+        var flow = JsonSerializer.Deserialize<FlowModel>(json, s_deserializeOptions) ??
             throw new JsonException("Failed to deserialize flow");
-        }
 
         return UpCast(flow);
     }

--- a/dotnet/src/Functions/Functions.Grpc/GrpcOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.Grpc/GrpcOperationRunner.cs
@@ -24,6 +24,10 @@ namespace Microsoft.SemanticKernel.Functions.Grpc;
 /// </summary>
 internal sealed class GrpcOperationRunner
 {
+    /// <summary>Serialization options that use a camel casing naming policy.</summary>
+    private static readonly JsonSerializerOptions s_camelCaseOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    /// <summary>Deserialization options that use case-insensitive property names.</summary>
+    private static readonly JsonSerializerOptions s_propertyCaseInsensitiveOptions = new() { PropertyNameCaseInsensitive = true };
     /// <summary>
     /// An instance of the HttpClient class.
     /// </summary>
@@ -87,7 +91,7 @@ internal sealed class GrpcOperationRunner
     /// <returns>The converted response.</returns>
     private static JsonObject ConvertResponse(object response, Type responseType)
     {
-        var content = JsonSerializer.Serialize(response, responseType, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var content = JsonSerializer.Serialize(response, responseType, s_camelCaseOptions);
 
         //First iteration allowing to associate additional metadata with the returned content.
         var result = new JsonObject();
@@ -159,7 +163,7 @@ internal sealed class GrpcOperationRunner
         }
 
         //Deserializing JSON payload to gRPC request message
-        var instance = JsonSerializer.Deserialize(payload, type, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var instance = JsonSerializer.Deserialize(payload, type, s_propertyCaseInsensitiveOptions);
         if (instance == null)
         {
             throw new SKException($"Impossible to create gRPC request message for the '{operation.Name}' gRPC operation.");

--- a/dotnet/src/Planners/Planners.Core/Action/ActionPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/ActionPlanner.cs
@@ -40,6 +40,15 @@ public sealed class ActionPlanner : IActionPlanner
     /// </summary>
     private static readonly Regex s_planRegex = new("^[^{}]*(((?'Open'{)[^{}]*)+((?'Close-Open'})[^{}]*)+)*(?(Open)(?!))", RegexOptions.Singleline | RegexOptions.Compiled);
 
+    /// <summary>Deserialization options for use with <see cref="ActionPlanResponse"/>.</summary>
+    private static readonly JsonSerializerOptions s_actionPlayResponseOptions = new()
+    {
+        AllowTrailingCommas = true,
+        DictionaryKeyPolicy = null,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        PropertyNameCaseInsensitive = true,
+    };
+
     // Planner semantic function
     private readonly ISKFunction _plannerFunction;
 
@@ -261,13 +270,7 @@ Goal: tell me a joke.
             string planJson = $"{{{match.Groups["Close"]}}}";
             try
             {
-                return JsonSerializer.Deserialize<ActionPlanResponse?>(planJson, new JsonSerializerOptions
-                {
-                    AllowTrailingCommas = true,
-                    DictionaryKeyPolicy = null,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-                    PropertyNameCaseInsensitive = true,
-                });
+                return JsonSerializer.Deserialize<ActionPlanResponse?>(planJson, s_actionPlayResponseOptions);
             }
             catch (Exception e)
             {

--- a/dotnet/src/SemanticKernel.Core/Planning/Plan.cs
+++ b/dotnet/src/SemanticKernel.Core/Planning/Plan.cs
@@ -167,7 +167,7 @@ public sealed class Plan : ISKFunction
     /// <remarks>If Context is not supplied, plan will not be able to execute.</remarks>
     public static Plan FromJson(string json, IReadOnlyFunctionCollection? functions = null, bool requireFunctions = true)
     {
-        var plan = JsonSerializer.Deserialize<Plan>(json, new JsonSerializerOptions { IncludeFields = true }) ?? new Plan(string.Empty);
+        var plan = JsonSerializer.Deserialize<Plan>(json, s_includeFieldsOptions) ?? new Plan(string.Empty);
 
         if (functions != null)
         {
@@ -184,7 +184,9 @@ public sealed class Plan : ISKFunction
     /// <returns>Plan serialized using JSON format</returns>
     public string ToJson(bool indented = false)
     {
-        return JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = indented });
+        return indented ?
+            JsonSerializer.Serialize(this, s_writeIndentedOptions) :
+            JsonSerializer.Serialize(this);
     }
 
     /// <summary>
@@ -679,6 +681,11 @@ public sealed class Plan : ISKFunction
     }
 
     private static string GetRandomPlanName() => "plan" + Guid.NewGuid().ToString("N");
+
+    /// <summary>Deserialization options for including fields.</summary>
+    private static readonly JsonSerializerOptions s_includeFieldsOptions = new() { IncludeFields = true };
+    /// <summary>Serialization options for writing indented.</summary>
+    private static readonly JsonSerializerOptions s_writeIndentedOptions = new() { WriteIndented = true };
 
     private ISKFunction? Function { get; set; }
 


### PR DESCRIPTION
### Motivation and Context

JsonSerializerOptions is unexpectedly expensive to create and throw away as it gets used as a cache for state gathered as part of the Serialize/Deserialize call.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
