### PR TITLE
Python: Update Python notebooks to use release 0.3.15

### DIFF
--- a/python/notebooks/00-getting-started.ipynb
+++ b/python/notebooks/00-getting-started.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/01-basic-loading-the-kernel.ipynb
+++ b/python/notebooks/01-basic-loading-the-kernel.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/02-running-prompts-from-file.ipynb
+++ b/python/notebooks/02-running-prompts-from-file.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/03-semantic-function-inline.ipynb
+++ b/python/notebooks/03-semantic-function-inline.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/04-context-variables-chat.ipynb
+++ b/python/notebooks/04-context-variables-chat.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/05-using-the-planner.ipynb
+++ b/python/notebooks/05-using-the-planner.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "kernel = sk.Kernel()\n",
     "\n",
-    "useAzureOpenAI = True\n",
+    "useAzureOpenAI = False\n",
     "\n",
     "# Configure AI backend used by the kernel\n",
     "if useAzureOpenAI:\n",
@@ -628,14 +628,6 @@
     "    if len(step._outputs) > 0:\n",
     "        print( \"  Output:\\n\", str.replace(result[step._outputs[0]],\"\\n\", \"\\n  \"))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4652ac81",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/python/notebooks/06-memory-and-embeddings.ipynb
+++ b/python/notebooks/06-memory-and-embeddings.ipynb
@@ -28,7 +28,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!python -m pip install semantic-kernel==0.3.10.dev0"
+        "!python -m pip install semantic-kernel==0.3.15.dev0"
       ]
     },
     {

--- a/python/notebooks/07-hugging-face-for-skills.ipynb
+++ b/python/notebooks/07-hugging-face-for-skills.ipynb
@@ -20,7 +20,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!python -m pip install semantic-kernel==0.3.10.dev0\n",
+        "!python -m pip install semantic-kernel==0.3.15.dev0\n",
         "\n",
         "# Note that additional dependencies are required for the Hugging Face connectors:\n",
         "!python -m pip install torch==2.0.0\n",

--- a/python/notebooks/08-native-function-inline.ipynb
+++ b/python/notebooks/08-native-function-inline.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/09-groundedness-checking.ipynb
+++ b/python/notebooks/09-groundedness-checking.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "kernel = sk.Kernel()\n",
     "\n",
-    "useAzureOpenAI = True\n",
+    "useAzureOpenAI = False\n",
     "\n",
     "# Configure AI service used by the kernel\n",
     "if useAzureOpenAI:\n",

--- a/python/notebooks/10-multiple-results-per-prompt.ipynb
+++ b/python/notebooks/10-multiple-results-per-prompt.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {

--- a/python/notebooks/11-streaming-completions.ipynb
+++ b/python/notebooks/11-streaming-completions.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.3.10.dev0"
+    "!python -m pip install semantic-kernel==0.3.15.dev0"
    ]
   },
   {


### PR DESCRIPTION
### Motivation and Context

Python Notebooks were out of date

### Description

- Bump the version
- Use OpenAI default in all notebooks

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
