### PR TITLE
Add IAssistant.GetThreadAsync

### DIFF
--- a/dotnet/src/Experimental/Assistants/IAssistant.cs
+++ b/dotnet/src/Experimental/Assistants/IAssistant.cs
@@ -65,4 +65,11 @@ public interface IAssistant
     /// </summary>
     /// <param name="cancellationToken">A cancellation token</param>
     Task<IChatThread> NewThreadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets an existing assistant chat thread.
+    /// </summary>
+    /// <param name="id">The id of the existing chat thread.</param>
+    /// <param name="cancellationToken">A cancellation token</param>
+    Task<IChatThread> GetThreadAsync(string id, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Experimental/Assistants/Internal/Assistant.cs
+++ b/dotnet/src/Experimental/Assistants/Internal/Assistant.cs
@@ -117,6 +117,12 @@ internal sealed class Assistant : IAssistant
         return ChatThread.CreateAsync(this._restContext, cancellationToken);
     }
 
+    /// <inheritdoc/>
+    public Task<IChatThread> GetThreadAsync(string id, CancellationToken cancellationToken = default)
+    {
+        return ChatThread.GetAsync(this._restContext, id, cancellationToken);
+    }
+
     /// <summary>
     /// Marshal thread run through <see cref="ISKFunction"/> interface.
     /// </summary>


### PR DESCRIPTION
Necessary to be able to continue an existing conversation. Presumably both NewThreadAsync and GetThreadAsync should subsequently move somewhere else, since threads aren't affinitized to a particular assistant.