### PR TITLE
.Net: Add CancellationToken to ExecuteAsync methods

### DIFF
--- a/dotnet/src/Functions/Functions.Grpc/Extensions/KernelGrpcExtensions.cs
+++ b/dotnet/src/Functions/Functions.Grpc/Extensions/KernelGrpcExtensions.cs
@@ -147,7 +147,7 @@ public static class KernelGrpcExtensions
     {
         var operationParameters = operation.GetParameters();
 
-        async Task<SKContext> ExecuteAsync(SKContext context)
+        async Task<SKContext> ExecuteAsync(SKContext context, CancellationToken cancellationToken)
         {
             try
             {
@@ -166,8 +166,7 @@ public static class KernelGrpcExtensions
                     throw new KeyNotFoundException($"No variable found in context to use as an argument for the '{parameter.Name}' parameter of the '{pluginName}.{operation.Name}' gRPC function.");
                 }
 
-                //SKFunction should be extended to pass cancellation token for delegateFunction calls.
-                var result = await runner.RunAsync(operation, arguments, CancellationToken.None).ConfigureAwait(false);
+                var result = await runner.RunAsync(operation, arguments, cancellationToken).ConfigureAwait(false);
 
                 if (result != null)
                 {

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
@@ -213,7 +213,7 @@ public static class KernelOpenApiPluginExtensions
 
         var logger = kernel.LoggerFactory is not null ? kernel.LoggerFactory.CreateLogger(typeof(KernelOpenApiPluginExtensions)) : NullLogger.Instance;
 
-        async Task<RestApiOperationResponse> ExecuteAsync(SKContext context)
+        async Task<RestApiOperationResponse> ExecuteAsync(SKContext context, CancellationToken cancellationToken)
         {
             try
             {


### PR DESCRIPTION
### Motivation and Context
Resolves #3541

### Description
Add CancellationToken parameter to ExecuteAsync methods in KernelGrpcExtensions and KernelOpenApiPluginExtensions. Update corresponding tests to check for CancellationToken usage.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
