### PR TITLE
.Net: Update repo to LangVersion 11

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -6,7 +6,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>

--- a/dotnet/samples/ApplicationInsightsExample/ApplicationInsightsExample.csproj
+++ b/dotnet/samples/ApplicationInsightsExample/ApplicationInsightsExample.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <OutputType>Exe</OutputType>
-    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/dotnet/samples/KernelSyntaxExamples/Example15_TextMemoryPlugin.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example15_TextMemoryPlugin.cs
@@ -171,16 +171,24 @@ public static class Example15_TextMemoryPlugin
         /////////////////////////////////////////////////////////////////////////////////////////////////////
         Console.WriteLine("== PART 1a: Saving Memories through the ISemanticTextMemory object ==");
 
-        Console.WriteLine("Saving memory with key 'info1': \"My name is Andrea\"");
+        Console.WriteLine("""
+            Saving memory with key 'info1': "My name is Andrea"
+            """);
         await textMemory.SaveInformationAsync(MemoryCollectionName, id: "info1", text: "My name is Andrea", cancellationToken: cancellationToken);
 
-        Console.WriteLine("Saving memory with key 'info2': \"I work as a tourist operator\"");
+        Console.WriteLine("""
+            Saving memory with key 'info2': "I work as a tourist operator"
+            """);
         await textMemory.SaveInformationAsync(MemoryCollectionName, id: "info2", text: "I work as a tourist operator", cancellationToken: cancellationToken);
 
-        Console.WriteLine("Saving memory with key 'info3': \"I've been living in Seattle since 2005\"");
+        Console.WriteLine("""
+            Saving memory with key 'info3': "I've been living in Seattle since 2005"
+            """);
         await textMemory.SaveInformationAsync(MemoryCollectionName, id: "info3", text: "I've been living in Seattle since 2005", cancellationToken: cancellationToken);
 
-        Console.WriteLine("Saving memory with key 'info4': \"I visited France and Italy five times since 2015\"");
+        Console.WriteLine("""
+            Saving memory with key 'info4': "I visited France and Italy five times since 2015"
+            """);
         await textMemory.SaveInformationAsync(MemoryCollectionName, id: "info4", text: "I visited France and Italy five times since 2015", cancellationToken: cancellationToken);
 
         // Retrieve a memory
@@ -202,7 +210,9 @@ public static class Example15_TextMemoryPlugin
         var memoryFunctions = kernel.ImportFunctions(memoryPlugin);
 
         // Save a memory with the Kernel
-        Console.WriteLine("Saving memory with key 'info5': \"My family is from New York\"");
+        Console.WriteLine("""
+            Saving memory with key 'info5': "My family is from New York"
+            """);
         await kernel.RunAsync(memoryFunctions["Save"], new()
         {
             [TextMemoryPlugin.CollectionParam] = MemoryCollectionName,

--- a/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example24_OpenApiPlugin_Jira.cs
@@ -100,7 +100,7 @@ public static class Example24_OpenApiPlugin_Jira
             // Set Properties for the AddComment operation in the openAPI.swagger.json
             // Make sure the issue exists in your Jira instance or it will return a 404
             contextVariables.Set("issueKey", "TEST-2");
-            contextVariables.Set(RestApiOperation.PayloadArgumentName, "{\"body\": \"Here is a rad comment\"}");
+            contextVariables.Set(RestApiOperation.PayloadArgumentName, """{"body": "Here is a rad comment"}""");
 
             // Run operation via the semantic kernel
             var result = await kernel.RunAsync(contextVariables, jiraFunctions["AddComment"]);

--- a/dotnet/samples/NCalcPlugins/NCalcPlugins.csproj
+++ b/dotnet/samples/NCalcPlugins/NCalcPlugins.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/MongoDB/MongoDBMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/MongoDB/MongoDBMemoryStoreTests.cs
@@ -177,7 +177,7 @@ public class MongoDBMemoryStoreTests
     public async Task ItCanGetNearestMatchAsync()
     {
         // Arrange
-        const string ExpectedStage = "{ \"$vectorSearch\" : { \"queryVector\" : [1.0], \"path\" : \"embedding\", \"limit\" : 1, \"numCandidates\" : 10, \"index\" : \"default\" } }";
+        const string ExpectedStage = """{ "$vectorSearch" : { "queryVector" : [1.0], "path" : "embedding", "limit" : 1, "numCandidates" : 10, "index" : "default" } }""";
 
         using var memoryStore = new MongoDBMemoryStore(this._mongoClientMock.Object, DatabaseName);
         var memoryRecord = CreateRecord("id");
@@ -198,7 +198,7 @@ public class MongoDBMemoryStoreTests
     public async Task ItCanGetNearestMatchesAsync()
     {
         // Arrange
-        const string ExpectedStage = "{ \"$vectorSearch\" : { \"queryVector\" : [1.0], \"path\" : \"embedding\", \"limit\" : 100, \"numCandidates\" : 1000, \"index\" : \"default\" } }";
+        const string ExpectedStage = """{ "$vectorSearch" : { "queryVector" : [1.0], "path" : "embedding", "limit" : 100, "numCandidates" : 1000, "index" : "default" } }""";
 
         using var memoryStore = new MongoDBMemoryStore(this._mongoClientMock.Object, DatabaseName);
         var (memoryRecords, keys) = CreateRecords(10);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
@@ -27,7 +27,7 @@ public sealed class PineconeKernelBuilderExtensionsTests : IDisposable
     public async Task PineconeMemoryStoreShouldBeProperlyInitializedAsync()
     {
         //Arrange
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("[\"fake-index1\"]", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""["fake-index1"]""", Encoding.UTF8, MediaTypeNames.Application.Json);
 
         var builder = new KernelBuilder();
 #pragma warning disable CS0618 // This will be removed in a future release.

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
@@ -32,7 +32,7 @@ public sealed class PineconeMemoryBuilderExtensionsTests : IDisposable
     {
         // Arrange
         var embeddingGenerationMock = Mock.Of<ITextEmbeddingGeneration>();
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("[\"fake-index1\"]", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""["fake-index1"]""", Encoding.UTF8, MediaTypeNames.Application.Json);
 
         var builder = new MemoryBuilder();
         builder.WithPineconeMemoryStore("fake-environment", "fake-api-key", this._httpClient);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantKernelBuilderExtensionsTests.cs
@@ -27,7 +27,7 @@ public sealed class QdrantKernelBuilderExtensionsTests : IDisposable
     {
         //Arrange
         this._httpClient.BaseAddress = new Uri("https://fake-random-qdrant-host");
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("{\"result\":{\"collections\":[]}}", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""{"result":{"collections":[]}}""", Encoding.UTF8, MediaTypeNames.Application.Json);
 
         var builder = new KernelBuilder();
 #pragma warning disable CS0618 // This will be removed in a future release.

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryBuilderExtensionsTests.cs
@@ -33,7 +33,7 @@ public sealed class QdrantMemoryBuilderExtensionsTests : IDisposable
         var embeddingGenerationMock = Mock.Of<ITextEmbeddingGeneration>();
 
         this._httpClient.BaseAddress = new Uri("https://fake-random-qdrant-host");
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("{\"result\":{\"collections\":[]}}", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""{"result":{"collections":[]}}""", Encoding.UTF8, MediaTypeNames.Application.Json);
 
         var builder = new MemoryBuilder();
         builder.WithQdrantMemoryStore(this._httpClient, 123);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests3.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryStoreTests3.cs
@@ -238,17 +238,19 @@ public class QdrantMemoryStoreTests3
         var metadataId = "metadataId";
         var expectedId = 100;
 
-        var scoredPointJsonWithIntegerId =
-            "{" +
-                "\"result\": " +
-                "   [{" +
-                        "\"id\": " + expectedId + "," +
-                        "\"version\": 0," +
-                        "\"score\": null," +
-                        "\"payload\": {}," +
-                        "\"vector\": null " +
-                    "}]" +
-            "}";
+        var scoredPointJsonWithIntegerId = $$"""
+            {
+                "result": [
+                    {
+                        "id": {{expectedId}},
+                        "version": 0,
+                        "score": null,
+                        "payload": {},
+                        "vector": null
+                    }
+                ]
+            }
+            """;
 
         using (var httpResponseMessage = new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(scoredPointJsonWithIntegerId) })
         {

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/OpenAIChatCompletionTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/OpenAIChatCompletionTests.cs
@@ -154,7 +154,7 @@ public sealed class OpenAIChatCompletionTests : IDisposable
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         { Content = new StringContent(ChatCompletionResponse) };
         var chatHistory = new ChatHistory();
-        chatHistory.AddMessage(AuthorRole.User, "Hello", new Dictionary<string, string>() { { "Name", "SayHello" }, { "Arguments", "{ \"user\": \"John Doe\" }" } });
+        chatHistory.AddMessage(AuthorRole.User, "Hello", new Dictionary<string, string>() { { "Name", "SayHello" }, { "Arguments", """{ "user": "John Doe" }""" } });
 
         // Act
         await chatCompletion.GetChatCompletionsAsync(chatHistory, this._requestSettings);

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/FunctionViewExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/FunctionViewExtensionsTests.cs
@@ -164,7 +164,7 @@ public sealed class FunctionViewExtensionsTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(
-            "{\"type\":\"object\",\"required\":[\"parameter1\",\"parameter2\",\"parameter3\"],\"properties\":{\"parameter1\":{\"type\":\"string\",\"description\":\"String parameter\"},\"parameter2\":{\"enum\":[\"Value1\",\"Value2\"],\"description\":\"Enum parameter\"},\"parameter3\":{\"type\":\"string\",\"format\":\"date-time\",\"description\":\"DateTime parameter\"}}}",
+            """{"type":"object","required":["parameter1","parameter2","parameter3"],"properties":{"parameter1":{"type":"string","description":"String parameter"},"parameter2":{"enum":["Value1","Value2"],"description":"Enum parameter"},"parameter3":{"type":"string","format":"date-time","description":"DateTime parameter"}}}""",
             result.Parameters.ToString()
         );
     }

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/OpenAIFunctionResponseTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/OpenAIFunctionResponseTests.cs
@@ -53,7 +53,7 @@ public sealed class OpenAIFunctionResponseTests
     public void ItCanConvertFromFunctionCallWithParameters()
     {
         // Arrange
-        var sut = new FunctionCall("foo", "{ \"param1\": \"bar\", \"param2\": 5 }");
+        var sut = new FunctionCall("foo", """{ "param1": "bar", "param2": 5 }""");
 
         // Act
         var result = OpenAIFunctionResponse.FromFunctionCall(sut);

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/OpenAIFunctionTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/OpenAIFunctionTests.cs
@@ -49,7 +49,7 @@ public sealed class OpenAIFunctionTests
     [Fact]
     public void ItCanConvertToFunctionDefinitionsWithParameterTypesAndReturnParameterType()
     {
-        string expectedParameterSchema = "{   \"type\": \"object\",   \"required\": [\"param1\", \"param2\"],   \"properties\": {     \"param1\": { \"type\": \"string\", \"description\": \"String param 1\" },     \"param2\": { \"type\": \"integer\", \"description\": \"Int param 2\" }   } } ";
+        string expectedParameterSchema = """{   "type": "object",   "required": ["param1", "param2"],   "properties": {     "param1": { "type": "string", "description": "String param 1" },     "param2": { "type": "integer", "description": "Int param 2" }   } } """;
 
         OpenAIFunctionParameter param1 = new()
         {
@@ -98,7 +98,7 @@ public sealed class OpenAIFunctionTests
     [Fact]
     public void ItCanConvertToFunctionDefinitionsWithParameterTypesAndNoReturnParameterType()
     {
-        string expectedParameterSchema = "{   \"type\": \"object\",   \"required\": [\"param1\", \"param2\"],   \"properties\": {     \"param1\": { \"type\": \"string\", \"description\": \"String param 1\" },     \"param2\": { \"type\": \"integer\", \"description\": \"Int param 2\" }   } } ";
+        string expectedParameterSchema = """{   "type": "object",   "required": ["param1", "param2"],   "properties": {     "param1": { "type": "string", "description": "String param 1" },     "param2": { "type": "integer", "description": "Int param 2" }   } } """;
 
         OpenAIFunctionParameter param1 = new()
         {

--- a/dotnet/src/Experimental/Assistants/Experimental.Assistants.csproj
+++ b/dotnet/src/Experimental/Assistants/Experimental.Assistants.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>Microsoft.SemanticKernel.Experimental.Assistants</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Experimental.Assistants</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />

--- a/dotnet/src/Experimental/Orchestration.Flow/Experimental.Orchestration.Flow.csproj
+++ b/dotnet/src/Experimental/Orchestration.Flow/Experimental.Orchestration.Flow.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>Microsoft.SemanticKernel.Experimental.Orchestration.Flow</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Experimental.Orchestration</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
@@ -311,7 +311,7 @@ public static class KernelOpenApiPluginExtensions
             result += CultureInfo.CurrentCulture.TextInfo.ToTitleCase(formattedToken.ToLower(CultureInfo.CurrentCulture));
         }
 
-        logger.LogInformation("Operation name \"{0}\" converted to \"{1}\" to comply with SK Function name requirements. Use \"{2}\" when invoking function.", operationId, result, result);
+        logger.LogInformation("""Operation name "{0}" converted to "{1}" to comply with SK Function name requirements. Use "{2}" when invoking function.""", operationId, result, result);
 
         return result;
     }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
@@ -193,7 +193,7 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p1", """["a","b","c"]""" },
             { "p2", "[1,2,3]" }
         };
 
@@ -234,7 +234,7 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p1", """["a","b","c"]""" },
             { "p2", "[1,2,3]" }
         };
 
@@ -315,7 +315,7 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p1", """["a","b","c"]""" },
             { "p2", "[1,2,3]" }
         };
 
@@ -356,7 +356,7 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p1", """["a","b","c"]""" },
             { "p2", "[1,2,3]" }
         };
 
@@ -397,7 +397,7 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p1", """["a","b","c"]""" },
             { "p2", "[1,2,3]" }
         };
 
@@ -438,7 +438,7 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\",\"c\"]" },
+            { "p1", """["a","b","c"]""" },
             { "p2", "[1,2,3]" }
         };
 
@@ -483,13 +483,13 @@ public class QueryStringBuilderTests
 
         var arguments = new Dictionary<string, string>
         {
-            { "p1", "[\"a\",\"b\"]" },
+            { "p1", """["a","b"]""" },
             { "p2", "false" },
             { "p3", "[1,2]" },
             { "p4", "[3,4]" },
-            { "p5", "[\"c\",\"d\"]" },
+            { "p5", """["c","d"]""" },
             { "p6", "[5,6]" },
-            { "p7", "[\"e\",\"f\"]" }
+            { "p7", """["e","f"]""" }
         };
 
         var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/JsonPathPluginTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/JsonPathPluginTests.cs
@@ -52,9 +52,8 @@ public class JsonPathPluginTests
     }
 
     [Theory]
-    [InlineData("$..Products[?(@.Price >= 50)].Name", "[\"Anvil\",\"Elbow Grease\"]")] // multiple values
-    [InlineData("$.Manufacturers",
-        "[[{\"Name\":\"Acme Co\",\"Products\":[{\"Name\":\"Anvil\",\"Price\":50}]},{\"Name\":\"Contoso\",\"Products\":[{\"Name\":\"Elbow Grease\",\"Price\":99.95},{\"Name\":\"Headlight Fluid\",\"Price\":4}]}]]")] // complex value
+    [InlineData("$..Products[?(@.Price >= 50)].Name", """["Anvil","Elbow Grease"]""")] // multiple values
+    [InlineData("$.Manufacturers", """[[{"Name":"Acme Co","Products":[{"Name":"Anvil","Price":50}]},{"Name":"Contoso","Products":[{"Name":"Elbow Grease","Price":99.95},{"Name":"Headlight Fluid","Price":4}]}]]""")] // complex value
     public void GetJsonPropertyValueSucceeds(string jsonPath, string expected)
     {
         var target = new JsonPathPlugin();

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV20Tests.cs
@@ -286,7 +286,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         Assert.NotNull(response.Schema);
         Assert.Equal("string", response.Schema.RootElement.GetProperty("type").GetString());
         Assert.Equal(
-            JsonSerializer.Serialize(JsonDocument.Parse("{\"type\": \"string\"}")),
+            JsonSerializer.Serialize(JsonDocument.Parse("""{"type": "string"}""")),
             JsonSerializer.Serialize(response.Schema));
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV30Tests.cs
@@ -360,7 +360,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.NotNull(response.Schema);
         Assert.Equal("string", response.Schema.RootElement.GetProperty("type").GetString());
         Assert.Equal(
-            JsonSerializer.Serialize(JsonDocument.Parse("{\"type\": \"string\"}")),
+            JsonSerializer.Serialize(JsonDocument.Parse("""{"type": "string"}""")),
             JsonSerializer.Serialize(response.Schema));
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/OpenApiDocumentParserV31Tests.cs
@@ -336,7 +336,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         Assert.NotNull(response.Schema);
         Assert.Equal("string", response.Schema.RootElement.GetProperty("type").GetString());
         Assert.Equal(
-            JsonSerializer.Serialize(JsonDocument.Parse("{\"type\": \"string\"}")),
+            JsonSerializer.Serialize(JsonDocument.Parse("""{"type": "string"}""")),
             JsonSerializer.Serialize(response.Schema));
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationResponseTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationResponseTests.cs
@@ -36,9 +36,9 @@ public class RestApiOperationResponseTests
     }
 
     [Theory]
-    [InlineData("fake-content", "application/json", "{\"type\": \"string\"}")]
-    [InlineData("{\"fake\": \"content\"}", "text/plain", "{\"type\": \"string\"}")]
-    [InlineData("{\"fake\": \"content\"}", "application/json", "{\"type\": \"string\"}")]
+    [InlineData("fake-content", "application/json", """{"type": "string"}""")]
+    [InlineData("{\"fake\": \"content\"}", "text/plain", """{"type": "string"}""")]
+    [InlineData("{\"fake\": \"content\"}", "application/json", """{"type": "string"}""")]
     public void ItShouldFailValidationWithSchema(string content, string contentType, string schemaJson)
     {
         //Arrange
@@ -52,10 +52,10 @@ public class RestApiOperationResponseTests
     }
 
     [Theory]
-    [InlineData("\"fake-content\"", "application/json", "{\"type\": \"string\"}")]
-    [InlineData("fake-content", "text/plain", "{\"type\": \"string\"}")]
-    [InlineData("fake-content", "application/xml", "{\"type\": \"string\"}")]
-    [InlineData("fake-content", "image", "{\"type\": \"string\"}")]
+    [InlineData("\"fake-content\"", "application/json", """{"type": "string"}""")]
+    [InlineData("fake-content", "text/plain", """{"type": "string"}""")]
+    [InlineData("fake-content", "application/xml", """{"type": "string"}""")]
+    [InlineData("fake-content", "image", """{"type": "string"}""")]
     public void ItShouldPassValidationWithSchema(string content, string contentType, string schemaJson)
     {
         //Arrange

--- a/dotnet/src/IntegrationTests/Planners/HandlebarsPlanner/HandlebarsTemplateEngineExtensionsTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/HandlebarsPlanner/HandlebarsTemplateEngineExtensionsTests.cs
@@ -103,7 +103,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         // Arrange
         var kernel = this.InitializeKernel();
         var executionContext = kernel.CreateNewContext();
-        var template = "{{concat \"Hello\" \" \" \"World\" \"!\"}}";
+        var template = """{{concat "Hello" " " "World" "!"}}""";
         var variables = new Dictionary<string, object?>();
 
         // Act
@@ -129,7 +129,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         var result = HandlebarsTemplateEngineExtensions.Render(kernel, executionContext, template, variables);
 
         // Assert
-        Assert.Equal("{\"name\":\"Alice\",\"age\":25}", result);
+        Assert.Equal("""{"name":"Alice","age":25}""", result);
     }
 
     [Fact]
@@ -170,7 +170,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         // Arrange
         var kernel = this.InitializeKernel();
         var executionContext = kernel.CreateNewContext();
-        var template = "{{set name=\"x\" value=10}}{{get name=\"x\"}}";
+        var template = """{{set name="x" value=10}}{{get name="x"}}""";
         var variables = new Dictionary<string, object?>();
 
         // Act
@@ -221,7 +221,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         // Arrange
         var kernel = this.InitializeKernel();
         var executionContext = kernel.CreateNewContext();
-        var template = "{{Foo-Combine x=\"Bar\" y=\"Baz\"}}"; // Use positional arguments instead of hashed arguments
+        var template = """{{Foo-Combine x="Bar" y="Baz"}}"""; // Use positional arguments instead of hashed arguments
         var variables = new Dictionary<string, object?>();
         kernel.ImportFunctions(new Foo(), "Foo");
 
@@ -238,7 +238,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         // Arrange
         var kernel = this.InitializeKernel();
         var executionContext = kernel.CreateNewContext();
-        var template = "{{Foo-Combine x=\"Bar\"}}";
+        var template = """{{Foo-Combine x="Bar"}}""";
         var variables = new Dictionary<string, object?>();
         kernel.ImportFunctions(new Foo(), "Foo");
 
@@ -252,7 +252,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         // Arrange
         var kernel = this.InitializeKernel();
         var executionContext = kernel.CreateNewContext();
-        var template = "{{Foo-StringifyInt x=\"twelve\"}}";
+        var template = """{{Foo-StringifyInt x="twelve"}}""";
         var variables = new Dictionary<string, object?>();
         kernel.ImportFunctions(new Foo(), "Foo");
 
@@ -266,7 +266,7 @@ public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
         // Arrange
         var kernel = this.InitializeKernel();
         var executionContext = kernel.CreateNewContext();
-        var template = "{{Foo-Random x=\"random\"}}";
+        var template = """{{Foo-Random x="random"}}""";
         var variables = new Dictionary<string, object?>();
         kernel.ImportFunctions(new Foo(), "Foo");
 

--- a/dotnet/src/IntegrationTests/Plugins/PluginTests.cs
+++ b/dotnet/src/IntegrationTests/Plugins/PluginTests.cs
@@ -113,7 +113,7 @@ public class PluginTests
     [InlineData("https://raw.githubusercontent.com/sisbell/chatgpt-plugin-store/main/manifests/instacart.com.json",
         "Instacart",
         "create",
-        "{\"title\":\"Shopping List\", \"ingredients\": [\"Flour\"], \"question\": \"what ingredients do I need to make chocolate cookies?\", \"partnerName\": \"OpenAI\" }"
+        """{"title":"Shopping List", "ingredients": ["Flour"], "question": "what ingredients do I need to make chocolate cookies?", "partnerName": "OpenAI" }"""
         )]
     public async Task QueryInstacartPluginAsync(
         string pluginEndpoint,
@@ -142,7 +142,7 @@ public class PluginTests
     [InlineData("Plugins/instacart-ai-plugin.json",
         "Instacart",
         "create",
-        "{\"title\":\"Shopping List\", \"ingredients\": [\"Flour\"], \"question\": \"what ingredients do I need to make chocolate cookies?\", \"partnerName\": \"OpenAI\" }"
+        """{"title":"Shopping List", "ingredients": ["Flour"], "question": "what ingredients do I need to make chocolate cookies?", "partnerName": "OpenAI" }"""
         )]
     public async Task QueryInstacartPluginFromStreamAsync(
         string pluginFilePath,
@@ -174,7 +174,7 @@ public class PluginTests
     [InlineData("Plugins/instacart-ai-plugin.json",
         "Instacart",
         "create",
-        "{\"title\":\"Shopping List\", \"ingredients\": [\"Flour\"], \"question\": \"what ingredients do I need to make chocolate cookies?\", \"partnerName\": \"OpenAI\" }"
+        """{"title":"Shopping List", "ingredients": ["Flour"], "question": "what ingredients do I need to make chocolate cookies?", "partnerName": "OpenAI" }"""
         )]
     public async Task QueryInstacartPluginUsingRelativeFilePathAsync(
         string pluginFilePath,

--- a/dotnet/src/IntegrationTests/TemplateLanguage/PromptTemplateEngineTests.cs
+++ b/dotnet/src/IntegrationTests/TemplateLanguage/PromptTemplateEngineTests.cs
@@ -137,7 +137,7 @@ public sealed class PromptTemplateEngineTests : IDisposable
     public async Task ItHandlesNamedArgsAsync()
     {
         // Arrange
-        string template = "Output: {{my.sayAge name=\"Mario\" birthdate=$birthdate exclamation='Wow, that\\'s surprising'}}";
+        string template = """Output: {{my.sayAge name="Mario" birthdate=$birthdate exclamation='Wow, that\'s surprising'}}""";
         var kernel = new KernelBuilder().Build();
         kernel.ImportFunctions(new MyPlugin(), "my");
         var context = kernel.CreateNewContext();

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatHistoryTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatHistoryTests.cs
@@ -25,7 +25,7 @@ public class ChatHistoryTests
 
         // Assert
         Assert.NotNull(chatHistoryJson);
-        Assert.Equal("[{\"Role\":{\"Label\":\"user\"},\"Content\":\"Hello\",\"AdditionalProperties\":null},{\"Role\":{\"Label\":\"assistant\"},\"Content\":\"Hi\",\"AdditionalProperties\":null}]", chatHistoryJson);
+        Assert.Equal("""[{"Role":{"Label":"user"},"Content":"Hello","AdditionalProperties":null},{"Role":{"Label":"assistant"},"Content":"Hi","AdditionalProperties":null}]""", chatHistoryJson);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/HttpContentExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/HttpContentExtensionsTests.cs
@@ -49,14 +49,14 @@ public sealed class HttpContentExtensionsTests : IDisposable
         //Assert
         Assert.False(string.IsNullOrEmpty(result));
 
-        Assert.Equal("{\"details\": \"fake-response-content\"}", result);
+        Assert.Equal("""{"details": "fake-response-content"}""", result);
     }
 
     [Fact]
     public async Task ShouldReturnHttpContentAsStreamAsync()
     {
         //Arrange
-        using var expectedStream = new MemoryStream(Encoding.Default.GetBytes("{\"details\": \"fake-response-content\"}"));
+        using var expectedStream = new MemoryStream("""{"details": "fake-response-content"}"""u8.ToArray());
 
         this._httpMessageHandlerStub.ResponseToReturn.Content = new StreamContent(expectedStream);
 
@@ -72,7 +72,7 @@ public sealed class HttpContentExtensionsTests : IDisposable
 
         using var streamReader = new StreamReader(actualStream);
         var content = await streamReader.ReadToEndAsync();
-        Assert.Equal("{\"details\": \"fake-response-content\"}", content);
+        Assert.Equal("""{"details": "fake-response-content"}""", content);
     }
 
     [Fact]


### PR DESCRIPTION
C# 11 shipped a year ago; there's no reason not to be using it at this point, and it brings with it support for raw string literals, which are particularly valuable when working with lots of JSON, as this repo does.

.NET 8 and C# 12 shipped last week.  We should update the repo to LangVersion 12 in the near future, but we can wait to do so until after v1.0 and give folks some time to update their toolsets.