### PR TITLE
.Net: Consolidate Planners namespaces into Planning

### DIFF
--- a/dotnet/samples/ApplicationInsightsExample/Program.cs
+++ b/dotnet/samples/ApplicationInsightsExample/Program.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.ApplicationInsights;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Microsoft.SemanticKernel.Plugins.Web;

--- a/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example12_SequentialPlanner.cs
@@ -8,7 +8,6 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Memory;
-using Microsoft.SemanticKernel.Planners;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Microsoft.SemanticKernel.Plugins.Memory;

--- a/dotnet/samples/KernelSyntaxExamples/Example28_ActionPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example28_ActionPlanner.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using RepoUtils;
 
 // ReSharper disable once InconsistentNaming

--- a/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using RepoUtils;
 

--- a/dotnet/samples/KernelSyntaxExamples/Example51_StepwisePlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example51_StepwisePlanner.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Microsoft.SemanticKernel.Plugins.Web;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
@@ -116,7 +116,7 @@ public static class Example51_StepwisePlanner
         Stopwatch sw = new();
         Console.WriteLine("Question: " + question);
 
-        var plannerConfig = new Microsoft.SemanticKernel.Planners.StepwisePlannerConfig();
+        var plannerConfig = new StepwisePlannerConfig();
         plannerConfig.ExcludedFunctions.Add("TranslateMathProblem");
         plannerConfig.ExcludedFunctions.Add("DaysAgo");
         plannerConfig.ExcludedFunctions.Add("DateMatchingLastDayName");
@@ -198,7 +198,7 @@ public static class Example51_StepwisePlanner
                 alsoAsTextCompletion: true,
                 setAsDefault: true);
 
-            maxTokens = ChatMaxTokens ?? (new Microsoft.SemanticKernel.Planners.StepwisePlannerConfig()).MaxTokens;
+            maxTokens = ChatMaxTokens ?? new StepwisePlannerConfig().MaxTokens;
             result.model = model ?? ChatModelOverride ?? TestConfiguration.AzureOpenAI.ChatDeploymentName;
         }
         else
@@ -208,7 +208,7 @@ public static class Example51_StepwisePlanner
                 TestConfiguration.AzureOpenAI.Endpoint,
                 TestConfiguration.AzureOpenAI.ApiKey);
 
-            maxTokens = TextMaxTokens ?? (new Microsoft.SemanticKernel.Planners.StepwisePlannerConfig()).MaxTokens;
+            maxTokens = TextMaxTokens ?? new StepwisePlannerConfig().MaxTokens;
             result.model = model ?? TextModelOverride ?? TestConfiguration.AzureOpenAI.DeploymentName;
         }
 

--- a/dotnet/samples/KernelSyntaxExamples/Example65_HandlebarsPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example65_HandlebarsPlanner.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Diagnostics;
-using Microsoft.SemanticKernel.Planners.Handlebars;
+using Microsoft.SemanticKernel.Planning.Handlebars;
 using RepoUtils;
 
 /**

--- a/dotnet/samples/KernelSyntaxExamples/Example66_FunctionCallingStepwisePlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example66_FunctionCallingStepwisePlanner.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Plugins;
 using RepoUtils;

--- a/dotnet/src/IntegrationTests/Planners/HandlebarsPlanner/HandlebarsPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/HandlebarsPlanner/HandlebarsPlannerTests.cs
@@ -6,14 +6,16 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners.Handlebars;
+using Microsoft.SemanticKernel.Planning.Handlebars;
 using SemanticKernel.IntegrationTests.Fakes;
 using SemanticKernel.IntegrationTests.TestSettings;
 using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners.HandlebarsPlanner;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planners.Handlebars;
+#pragma warning restore IDE0130
 
 public sealed class HandlebarsPlannerTests : IDisposable
 {
@@ -41,7 +43,7 @@ public sealed class HandlebarsPlannerTests : IDisposable
         kernel.ImportPluginFromObject(new EmailPluginFake(), expectedPlugin);
         TestHelpers.ImportSamplePlugins(kernel, "FunPlugin");
 
-        var planner = new Microsoft.SemanticKernel.Planners.Handlebars.HandlebarsPlanner(kernel);
+        var planner = new HandlebarsPlanner(kernel);
 
         // Act
         var plan = await planner.CreatePlanAsync(prompt);
@@ -62,7 +64,7 @@ public sealed class HandlebarsPlannerTests : IDisposable
         Kernel kernel = this.InitializeKernel();
         TestHelpers.ImportSamplePlugins(kernel, "WriterPlugin", "MiscPlugin");
 
-        var planner = new Microsoft.SemanticKernel.Planners.Handlebars.HandlebarsPlanner(kernel);
+        var planner = new HandlebarsPlanner(kernel);
 
         // Act
         var plan = await planner.CreatePlanAsync(prompt);

--- a/dotnet/src/IntegrationTests/Planners/HandlebarsPlanner/HandlebarsTemplateEngineExtensionsTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/HandlebarsPlanner/HandlebarsTemplateEngineExtensionsTests.cs
@@ -10,12 +10,14 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Diagnostics;
-using Microsoft.SemanticKernel.Planners.Handlebars;
+using Microsoft.SemanticKernel.Planning.Handlebars;
 using SemanticKernel.IntegrationTests.TestSettings;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners.HandlebarsPlanner;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planners.Handlebars;
+#pragma warning restore IDE0130
 
 public sealed class HandlebarsTemplateEngineExtensionsTests : IDisposable
 {

--- a/dotnet/src/IntegrationTests/Planners/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/PlanTests.cs
@@ -15,7 +15,9 @@ using SemanticKernel.IntegrationTests.TestSettings;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planning;
+#pragma warning restore IDE0130
 
 public sealed class PlanTests : IDisposable
 {

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlanParserTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlanParserTests.cs
@@ -2,15 +2,15 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
-using Microsoft.SemanticKernel.Planners.Sequential;
 using Microsoft.SemanticKernel.Planning;
 using SemanticKernel.IntegrationTests.Fakes;
 using SemanticKernel.IntegrationTests.TestSettings;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners.SequentialPlanner;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planners.Sequential;
+#pragma warning restore IDE0130
 
 public class SequentialPlanParserTests
 {

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Memory;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Memory;
 using SemanticKernel.IntegrationTests.Fakes;
 using SemanticKernel.IntegrationTests.TestSettings;
@@ -16,7 +16,9 @@ using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners.SequentialPlanner;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planners.Sequential;
+#pragma warning restore IDE0130
 
 public sealed class SequentialPlannerTests : IDisposable
 {
@@ -45,7 +47,7 @@ public sealed class SequentialPlannerTests : IDisposable
         kernel.ImportPluginFromObject<EmailPluginFake>();
         TestHelpers.ImportSamplePlugins(kernel, "FunPlugin");
 
-        var planner = new Microsoft.SemanticKernel.Planners.SequentialPlanner(kernel);
+        var planner = new SequentialPlanner(kernel);
 
         // Act
         var plan = await planner.CreatePlanAsync(prompt);
@@ -66,7 +68,7 @@ public sealed class SequentialPlannerTests : IDisposable
         Kernel kernel = this.InitializeKernel();
         TestHelpers.ImportSamplePlugins(kernel, "WriterPlugin", "MiscPlugin");
 
-        var planner = new Microsoft.SemanticKernel.Planners.SequentialPlanner(kernel);
+        var planner = new SequentialPlanner(kernel);
 
         // Act
         var plan = await planner.CreatePlanAsync(prompt);
@@ -95,8 +97,8 @@ public sealed class SequentialPlannerTests : IDisposable
         // Import all sample plugins available for demonstration purposes.
         TestHelpers.ImportAllSamplePlugins(kernel);
 
-        var planner = new Microsoft.SemanticKernel.Planners.SequentialPlanner(kernel,
-            new SequentialPlannerConfig { SemanticMemoryConfig = new() { RelevancyThreshold = 0.65, MaxRelevantFunctions = 30, Memory = memory } });
+        var planner = new SequentialPlanner(kernel,
+            new() { SemanticMemoryConfig = new() { RelevancyThreshold = 0.65, MaxRelevantFunctions = 30, Memory = memory } });
 
         // Act
         var plan = await planner.CreatePlanAsync(prompt);

--- a/dotnet/src/IntegrationTests/Planners/StepwisePlanner/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/StepwisePlanner/FunctionCallingStepwisePlannerTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Microsoft.SemanticKernel.Plugins.Web;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
@@ -14,7 +14,9 @@ using SemanticKernel.IntegrationTests.TestSettings;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners.StepwisePlanner;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planners.Stepwise;
+#pragma warning restore IDE0130
 
 public sealed class FunctionCallingStepwisePlannerTests : IDisposable
 {

--- a/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Functions.OpenAPI.OpenAI;
-using Microsoft.SemanticKernel.Planners;
+using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Microsoft.SemanticKernel.Plugins.Web;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
@@ -17,7 +17,9 @@ using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SemanticKernel.IntegrationTests.Planners.StepwisePlanner;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace SemanticKernel.IntegrationTests.Planners.Stepwise;
+#pragma warning restore IDE0130
 
 public sealed class StepwisePlannerTests : IDisposable
 {
@@ -54,7 +56,7 @@ public sealed class StepwisePlannerTests : IDisposable
         kernel.ImportPluginFromObject(webSearchEnginePlugin, "WebSearch");
         kernel.ImportPluginFromObject<TimePlugin>("time");
 
-        var planner = new Microsoft.SemanticKernel.Planners.StepwisePlanner(kernel, new StepwisePlannerConfig() { MaxIterations = 10 });
+        var planner = new StepwisePlanner(kernel, new() { MaxIterations = 10 });
 
         // Act
         var plan = planner.CreatePlan(prompt);
@@ -80,7 +82,7 @@ public sealed class StepwisePlannerTests : IDisposable
         kernel.ImportPluginFromObject(webSearchEnginePlugin, "WebSearch");
         kernel.ImportPluginFromObject<TimePlugin>("time");
 
-        var planner = new Microsoft.SemanticKernel.Planners.StepwisePlanner(kernel, new StepwisePlannerConfig() { MaxIterations = 10 });
+        var planner = new StepwisePlanner(kernel, new() { MaxIterations = 10 });
 
         // Act
         var plan = planner.CreatePlan(prompt);
@@ -109,7 +111,7 @@ public sealed class StepwisePlannerTests : IDisposable
         kernel.ImportPluginFromObject<FileIOPlugin>("FileIO");
         kernel.ImportPluginFromObject<HttpPlugin>("Http");
 
-        var planner = new Microsoft.SemanticKernel.Planners.StepwisePlanner(kernel, new() { MaxTokens = 1000 });
+        var planner = new StepwisePlanner(kernel, new() { MaxTokens = 1000 });
 
         // Act
         var plan = planner.CreatePlan("I need to buy a new brush for my cat. Can you show me options?");
@@ -127,7 +129,7 @@ public sealed class StepwisePlannerTests : IDisposable
 
         _ = await kernel.ImportPluginFromOpenAIAsync("Klarna", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"), new OpenAIFunctionExecutionParameters(enableDynamicOperationPayload: true));
 
-        var planner = new Microsoft.SemanticKernel.Planners.StepwisePlanner(kernel);
+        var planner = new StepwisePlanner(kernel);
 
         // Act
         var plan = planner.CreatePlan("I need to buy a new brush for my cat. Can you show me options?");

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Action/ActionPlannerTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Action/ActionPlannerTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using Xunit;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace Microsoft.SemanticKernel.Planners.Action.UnitTests;
+namespace Microsoft.SemanticKernel.Planning.Action.UnitTests;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public sealed class ActionPlannerTests

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Extensions/ReadOnlyFunctionCollectionExtensionsTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Extensions/ReadOnlyFunctionCollectionExtensionsTests.cs
@@ -7,7 +7,7 @@ using Moq;
 using Xunit;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace Microsoft.SemanticKernel.Planners.UnitTests;
+namespace Microsoft.SemanticKernel.Planning.UnitTests;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public class ReadOnlyFunctionCollectionExtensionsTests

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Sequential/SequentialPlanParserTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Sequential/SequentialPlanParserTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace Microsoft.SemanticKernel.Planners.Sequential.UnitTests;
+namespace Microsoft.SemanticKernel.Planning.Sequential.UnitTests;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public class SequentialPlanParserTests

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Sequential/SequentialPlannerTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Sequential/SequentialPlannerTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using Xunit;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace Microsoft.SemanticKernel.Planners.Sequential.UnitTests;
+namespace Microsoft.SemanticKernel.Planning.Sequential.UnitTests;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public sealed class SequentialPlannerTests

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Stepwise/ParseResultTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Stepwise/ParseResultTests.cs
@@ -5,7 +5,7 @@ using Moq;
 using Xunit;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace Microsoft.SemanticKernel.Planners.Stepwise.UnitTests;
+namespace Microsoft.SemanticKernel.Planning.Stepwise.UnitTests;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public sealed class ParseResultTests

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Stepwise/StepwisePlannerTests.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Stepwise/StepwisePlannerTests.cs
@@ -5,7 +5,7 @@ using Moq;
 using Xunit;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
-namespace Microsoft.SemanticKernel.Planners.Stepwise.UnitTests;
+namespace Microsoft.SemanticKernel.Planning.Stepwise.UnitTests;
 #pragma warning restore IDE0130 // Namespace does not match folder structure
 
 public sealed class StepwisePlannerTests

--- a/dotnet/src/Planners/Planners.Core.UnitTests/XunitHelpers/TestConsoleLogger.cs
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/XunitHelpers/TestConsoleLogger.cs
@@ -2,7 +2,9 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.SemanticKernel.Planners.UnitTests.XunitHelpers;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.SemanticKernel.Planning.UnitTests.XunitHelpers;
+#pragma warning restore IDE0130
 
 /// <summary>
 /// Basic logger printing to console

--- a/dotnet/src/Planners/Planners.Core/Action/ActionPlanResponse.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/ActionPlanResponse.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.SemanticKernel.Planners.Action;
+namespace Microsoft.SemanticKernel.Planning.Action;
 
 /// <summary>
 /// Plan data structure returned by the basic planner semantic function

--- a/dotnet/src/Planners/Planners.Core/Action/ActionPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/ActionPlanner.cs
@@ -13,12 +13,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Planners.Action;
-using Microsoft.SemanticKernel.Planning;
+using Microsoft.SemanticKernel.Planning.Action;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Action/ActionPlannerConfig.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/ActionPlannerConfig.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Action/ActionPlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/ActionPlannerExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Action/IActionPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/IActionPlanner.cs
@@ -3,11 +3,10 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Diagnostics;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Action/InstrumentedActionPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Action/InstrumentedActionPlanner.cs
@@ -7,11 +7,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Extensions/FunctionViewExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Extensions/FunctionViewExtensions.cs
@@ -3,7 +3,7 @@
 using System.Linq;
 
 #pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Extensions/PromptTemplateConfigExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Extensions/PromptTemplateConfigExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.TemplateEngine;
 
 #pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
@@ -15,7 +15,7 @@ using Microsoft.SemanticKernel.Extensions;
 using Microsoft.SemanticKernel.Memory;
 
 #pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsParameterTypeView.cs
+++ b/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsParameterTypeView.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SemanticKernel.Planners.Handlebars;
+namespace Microsoft.SemanticKernel.Planning.Handlebars;
 
 internal sealed class HandlebarsParameterTypeView
 {

--- a/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlan.cs
+++ b/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlan.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.SemanticKernel.Orchestration;
 
-namespace Microsoft.SemanticKernel.Planners.Handlebars;
+namespace Microsoft.SemanticKernel.Planning.Handlebars;
 
 /// <summary>
 /// Represents a Handlebars plan.

--- a/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlanner.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 
-namespace Microsoft.SemanticKernel.Planners.Handlebars;
+namespace Microsoft.SemanticKernel.Planning.Handlebars;
 
 /// <summary>
 /// Represents a Handlebars planner.

--- a/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlannerConfig.cs
+++ b/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlannerConfig.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.SemanticKernel.Planners.Handlebars;
+namespace Microsoft.SemanticKernel.Planning.Handlebars;
 
 /// <summary>
 /// Configuration for Handlebars planner instances.

--- a/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsPlannerExtensions.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Reflection;
 
-namespace Microsoft.SemanticKernel.Planners.Handlebars;
+namespace Microsoft.SemanticKernel.Planning.Handlebars;
 
 /// <summary>
 /// Extension methods for the <see cref="HandlebarsPlanner"/> interface.

--- a/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsTemplateEngineExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Handlebars/HandlebarsTemplateEngineExtensions.cs
@@ -11,7 +11,7 @@ using HandlebarsDotNet.Compiler;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
 
-namespace Microsoft.SemanticKernel.Planners.Handlebars;
+namespace Microsoft.SemanticKernel.Planning.Handlebars;
 
 /// <summary>
 /// Provides extension methods for rendering Handlebars templates in the context of a Semantic Kernel.

--- a/dotnet/src/Planners/Planners.Core/PlannerConfigBase.cs
+++ b/dotnet/src/Planners/Planners.Core/PlannerConfigBase.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Planners.Core.csproj
+++ b/dotnet/src/Planners/Planners.Core/Planners.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- THIS PROPERTY GROUP MUST COME FIRST -->
     <AssemblyName>Microsoft.SemanticKernel.Planners.Core</AssemblyName>
-    <RootNamespace>Microsoft.SemanticKernel.Planners</RootNamespace>
+    <RootNamespace>Microsoft.SemanticKernel.Planning</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/dotnet/src/Planners/Planners.Core/SemanticMemoryConfig.cs
+++ b/dotnet/src/Planners/Planners.Core/SemanticMemoryConfig.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Memory;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Sequential/ISequentialPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Sequential/ISequentialPlanner.cs
@@ -3,11 +3,10 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Diagnostics;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Sequential/InstrumentedSequentialPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Sequential/InstrumentedSequentialPlanner.cs
@@ -7,11 +7,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlanParser.cs
+++ b/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlanParser.cs
@@ -6,9 +6,10 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Planning;
 
-namespace Microsoft.SemanticKernel.Planners.Sequential;
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.SemanticKernel.Planning;
+#pragma warning restore IDE0130
 
 /// <summary>
 /// Parse sequential plan text into a plan.

--- a/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlanner.cs
@@ -5,12 +5,10 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Planners.Sequential;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlannerConfig.cs
+++ b/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlannerConfig.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Sequential/SequentialPlannerExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/ChatHistoryExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/ChatHistoryExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.SemanticKernel.Text;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/IStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/IStepwisePlanner.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.SemanticKernel.Diagnostics;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/InstrumentedStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/InstrumentedStepwisePlanner.cs
@@ -5,11 +5,10 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.Planning;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/StepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/StepwisePlanner.cs
@@ -15,13 +15,12 @@ using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using Microsoft.SemanticKernel.Diagnostics;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Services;
 using Microsoft.SemanticKernel.TemplateEngine;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/StepwisePlannerConfig.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/StepwisePlannerConfig.cs
@@ -4,7 +4,7 @@ using Microsoft.SemanticKernel.TemplateEngine;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/StepwisePlannerExtensions.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/StepwisePlannerExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Stepwise/SystemStep.cs
+++ b/dotnet/src/Planners/Planners.Core/Stepwise/SystemStep.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.Core/Utils/EmbeddedResource.cs
+++ b/dotnet/src/Planners/Planners.Core/Utils/EmbeddedResource.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Reflection;
 
 #pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 internal static class EmbeddedResource

--- a/dotnet/src/Planners/Planners.OpenAI/Planners.OpenAI.csproj
+++ b/dotnet/src/Planners/Planners.OpenAI/Planners.OpenAI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- THIS PROPERTY GROUP MUST COME FIRST -->
     <AssemblyName>Microsoft.SemanticKernel.Planners.OpenAI</AssemblyName>
-    <RootNamespace>Microsoft.SemanticKernel.Planners</RootNamespace>
+    <RootNamespace>Microsoft.SemanticKernel.Planning</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
@@ -18,7 +18,7 @@ using Microsoft.SemanticKernel.TemplateEngine;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlannerConfig.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlannerConfig.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel.Connectors.AI.OpenAI;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlannerResult.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlannerResult.cs
@@ -4,7 +4,7 @@ using Microsoft.SemanticKernel.AI.ChatCompletion;
 
 #pragma warning disable IDE0130
 // ReSharper disable once CheckNamespace - Using NS of Plan
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 /// <summary>

--- a/dotnet/src/Planners/Planners.OpenAI/Utils/EmbeddedResource.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Utils/EmbeddedResource.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Reflection;
 
 #pragma warning disable IDE0130
-namespace Microsoft.SemanticKernel.Planners;
+namespace Microsoft.SemanticKernel.Planning;
 #pragma warning restore IDE0130
 
 internal static class EmbeddedResource


### PR DESCRIPTION
Contributes to https://github.com/microsoft/semantic-kernel/issues/3151

There's currently both Microsoft.SemanticKernel.Planning and Microsoft.SemanticKernel.Planners. It's confusing for there to be a distinction between the two, especially since you need the former in order to do anything meaningful with the latter.  This just consolidates the latter into the former.  One less namespace to reason about.