### PR TITLE
Move SKPlugin.FromXXX methods to SKPluginFactory

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example70_Assistant.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example70_Assistant.cs
@@ -56,7 +56,7 @@ public static class Example70_Assistant
     {
         Console.WriteLine("======== Run:WithNativeFunctions ========");
 
-        ISKPlugin plugin = SKPlugin.FromObject(new MenuPlugin(), nameof(MenuPlugin));
+        ISKPlugin plugin = SKPluginFactory.CreateFromObject(new MenuPlugin(), nameof(MenuPlugin));
 
         await ChatAsync(
             "Assistants.ToolAssistant.yaml",

--- a/dotnet/samples/KernelSyntaxExamples/Example71_AssistantDelegation.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example71_AssistantDelegation.cs
@@ -29,7 +29,7 @@ public static class Example71_AssistantDelegation
             return;
         }
 
-        var plugin = SKPlugin.FromObject(new MenuPlugin(), nameof(MenuPlugin));
+        var plugin = SKPluginFactory.CreateFromObject(new MenuPlugin(), nameof(MenuPlugin));
 
         var menuAssistant =
             await AssistantBuilder.FromDefinitionAsync(
@@ -65,7 +65,7 @@ public static class Example71_AssistantDelegation
 
             foreach (var assistant in assistants)
             {
-                plugins.Add(SKPlugin.FromObject(assistant, assistant.Id));
+                plugins.Add(SKPluginFactory.CreateFromObject(assistant, assistant.Id));
             }
 
             return plugins;

--- a/dotnet/src/SemanticKernel.Core/Functions/SKPlugin.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/SKPlugin.cs
@@ -3,12 +3,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
-using Microsoft.Extensions.Logging;
 
 #pragma warning disable IDE0130
 
@@ -123,59 +120,4 @@ public sealed class SKPlugin : ISKPlugin
 
         public ISKFunction[] Functions => this._plugin._functions.Values.OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase).ToArray();
     }
-
-    #region Factory Methods
-    /// <summary>Creates a plugin that wraps a new instance of the specified type <typeparamref name="T"/>.</summary>
-    /// <typeparam name="T">Specifies the type of the object to wrap.</typeparam>
-    /// <param name="pluginName">
-    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the type of the <typeparamref name="T"/>.
-    /// </param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    /// <remarks>
-    /// Public methods that have the <see cref="SKFunctionFromPrompt"/> attribute will be included in the plugin.
-    /// </remarks>
-    public static ISKPlugin FromObject<T>(string? pluginName = null, ILoggerFactory? loggerFactory = null) where T : new() =>
-        FromObject(new T(), pluginName, loggerFactory);
-
-    /// <summary>Creates a plugin that wraps the specified target object.</summary>
-    /// <param name="target">The instance of the class to be wrapped.</param>
-    /// <param name="pluginName">
-    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the type of the <paramref name="target"/>.
-    /// </param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    /// <remarks>
-    /// Public methods that have the <see cref="SKFunctionFromPrompt"/> attribute will be included in the plugin.
-    /// Attributed methods must all have different names. Overloads are not supported.
-    /// </remarks>
-    public static ISKPlugin FromObject(object target, string? pluginName = null, ILoggerFactory? loggerFactory = null)
-    {
-        Verify.NotNull(target);
-
-        pluginName ??= target.GetType().Name;
-        Verify.ValidPluginName(pluginName);
-
-        MethodInfo[] methods = target.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-
-        // Filter out non-SKFunctions and fail if two functions have the same name (with or without the same casing).
-        SKPlugin plugin = new(pluginName, target.GetType().GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description);
-        foreach (MethodInfo method in methods)
-        {
-            if (method.GetCustomAttribute<SKFunctionAttribute>() is not null)
-            {
-                plugin.AddFunctionFromMethod(method, target, loggerFactory: loggerFactory);
-            }
-        }
-
-        if (loggerFactory is not null)
-        {
-            ILogger logger = loggerFactory.CreateLogger(target.GetType());
-            if (logger.IsEnabled(LogLevel.Trace))
-            {
-                logger.LogTrace("Created plugin {PluginName} with {IncludedFunctions} out of {TotalMethods} methods found.", pluginName, plugin.FunctionCount, methods.Length);
-            }
-        }
-
-        return plugin;
-    }
-    #endregion
 }

--- a/dotnet/src/SemanticKernel.Core/Functions/SKPluginFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/SKPluginFactory.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable IDE0130
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Provides a factory for creating <see cref="ISKPlugin"/> instances.
+/// </summary>
+public static class SKPluginFactory
+{
+    /// <summary>Creates a plugin that wraps a new instance of the specified type <typeparamref name="T"/>.</summary>
+    /// <typeparam name="T">Specifies the type of the object to wrap.</typeparam>
+    /// <param name="pluginName">
+    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the type of the <typeparamref name="T"/>.
+    /// </param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <remarks>
+    /// Public methods that have the <see cref="SKFunctionFromPrompt"/> attribute will be included in the plugin.
+    /// </remarks>
+    public static ISKPlugin CreateFromObject<T>(string? pluginName = null, ILoggerFactory? loggerFactory = null) where T : new() =>
+        CreateFromObject(new T(), pluginName, loggerFactory);
+
+    /// <summary>Creates a plugin that wraps the specified target object.</summary>
+    /// <param name="target">The instance of the class to be wrapped.</param>
+    /// <param name="pluginName">
+    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the type of the <paramref name="target"/>.
+    /// </param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <remarks>
+    /// Public methods that have the <see cref="SKFunctionFromPrompt"/> attribute will be included in the plugin.
+    /// Attributed methods must all have different names. Overloads are not supported.
+    /// </remarks>
+    public static ISKPlugin CreateFromObject(object target, string? pluginName = null, ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNull(target);
+
+        pluginName ??= target.GetType().Name;
+        Verify.ValidPluginName(pluginName);
+
+        MethodInfo[] methods = target.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+
+        // Filter out non-SKFunctions and fail if two functions have the same name (with or without the same casing).
+        SKPlugin plugin = new(pluginName, target.GetType().GetCustomAttribute<DescriptionAttribute>(inherit: true)?.Description);
+        foreach (MethodInfo method in methods)
+        {
+            if (method.GetCustomAttribute<SKFunctionAttribute>() is not null)
+            {
+                plugin.AddFunctionFromMethod(method, target, loggerFactory: loggerFactory);
+            }
+        }
+
+        if (loggerFactory is not null)
+        {
+            ILogger logger = loggerFactory.CreateLogger(target.GetType());
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Created plugin {PluginName} with {IncludedFunctions} out of {TotalMethods} methods found.", pluginName, plugin.FunctionCount, methods.Length);
+            }
+        }
+
+        return plugin;
+    }
+}

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -152,7 +152,7 @@ public static class KernelExtensions
     {
         Verify.NotNull(kernel);
 
-        return SKPlugin.FromObject<T>(pluginName, kernel.LoggerFactory);
+        return SKPluginFactory.CreateFromObject<T>(pluginName, kernel.LoggerFactory);
     }
 
     /// <summary>Creates a plugin that wraps the specified target object.</summary>
@@ -168,7 +168,7 @@ public static class KernelExtensions
     {
         Verify.NotNull(kernel);
 
-        return SKPlugin.FromObject(target, pluginName, kernel.LoggerFactory);
+        return SKPluginFactory.CreateFromObject(target, pluginName, kernel.LoggerFactory);
     }
     #endregion
 


### PR DESCRIPTION
### Motivation and Context

To be consistent with `SKFunctionFactory`

### Description

Move SKPlugin.FromXXX methods to SKPluginFactory

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
