### PR TITLE
.Net: Fix for #2432: Qdrant Vector Deletion

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
+
+/// <summary>
+/// Empty qdrant response for requests that return nothing but status / error.
+/// </summary>
+internal sealed class DeleteVectorsResponse : QdrantResponse
+{
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
@@ -5,6 +5,8 @@ namespace Microsoft.SemanticKernel.Connectors.Memory.Qdrant.Http.ApiSchema;
 /// <summary>
 /// Empty qdrant response for requests that return nothing but status / error.
 /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Justification: deserialized by QdrantVectorDbClient.DeleteVectorsByIdAsync & QdrantVectorDbClient.DeleteVectorByPayloadIdAsync
 internal sealed class DeleteVectorsResponse : QdrantResponse
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
@@ -194,7 +194,7 @@ public sealed class QdrantVectorDbClient : IQdrantVectorDbClient
             throw;
         }
 
-        var result = JsonSerializer.Deserialize<QdrantResponse>(responseContent);
+        var result = JsonSerializer.Deserialize<DeleteVectorsResponse>(responseContent);
         if (result?.Status == "ok")
         {
             this._logger.LogDebug("Vector being deleted");
@@ -235,7 +235,7 @@ public sealed class QdrantVectorDbClient : IQdrantVectorDbClient
             throw;
         }
 
-        var result = JsonSerializer.Deserialize<QdrantResponse>(responseContent);
+        var result = JsonSerializer.Deserialize<DeleteVectorsResponse>(responseContent);
         if (result?.Status == "ok")
         {
             this._logger.LogDebug("Vector being deleted");


### PR DESCRIPTION
Currently, all delete requests to Qdrant throw an exception as QdrantResponse is not deserializable because it is abstract. This PR introduces a seperate "empty" response class DeleteVectorsResponse to fix that.

#2432

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible (Let me know if you want serialization tests)
- [x] I didn't break anyone :smile:
