### PR TITLE
.Net: Update 03-semantic-function-inline.ipynb

### DIFF
--- a/dotnet/notebooks/03-semantic-function-inline.ipynb
+++ b/dotnet/notebooks/03-semantic-function-inline.ipynb
@@ -153,6 +153,7 @@
    },
    "outputs": [],
    "source": [
+    "using Microsoft.SemanticKernel.TemplateEngine.Basic;\n\n",
     "var promptTemplateFactory = new BasicPromptTemplateFactory();\n",
     "var promptTemplate = promptTemplateFactory.Create(\n",
     "    skPrompt,                        // Prompt template defined in natural language\n",


### PR DESCRIPTION
add missing using statement: using Microsoft.SemanticKernel.TemplateEngine.Basic;

### Motivation and Context

 Why is this change required? step 4 in the notebook was erroring due to missing using statement
  https://github.com/microsoft/semantic-kernel/issues/3656


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
N/a - just added a using statement.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
