### PR TITLE
Python: Prevent basic planner function from being added to available function list

### DIFF
--- a/python/semantic_kernel/planning/basic_planner.py
+++ b/python/semantic_kernel/planning/basic_planner.py
@@ -185,11 +185,11 @@ class BasicPlanner:
         """
 
         # Create the semantic function for the planner with the given prompt
+        available_functions_string = self._create_available_functions_string(kernel)
+        
         planner = kernel.create_semantic_function(
             prompt, max_tokens=1000, temperature=0.8
         )
-
-        available_functions_string = self._create_available_functions_string(kernel)
 
         # Create the context for the planner
         context = ContextVariables()


### PR DESCRIPTION
### Motivation and Context

When using `BasicPlanner` and print `context["available_functions"]`, i find a skill that wasn't introduced

![WX20231128-164149@2x](https://github.com/microsoft/semantic-kernel/assets/48514182/a52cabf5-d940-44c5-92b7-acf4266e7402)

it is bacause the `BasicPlanner` will create a semantic function, and this step is before extracting the `context["available_functions"]`.

This problem can be solved by advancing the extraction of `context["available_functions"]`

![WX20231128-164237@2x](https://github.com/microsoft/semantic-kernel/assets/48514182/554060fc-b9c9-4533-a61e-e288069e7656)


### Description

Place extracting the list of available functions  before defining the basic plan.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
