### PR TITLE
.Net BugFix #3715 Exception Streaming OpenAI Chat WithData (Example 54)

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithData.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithData.cs
@@ -222,11 +222,13 @@ public sealed class AzureOpenAIChatCompletionWithData : IChatCompletion, ITextCo
                     {
                         yield return (T)(object)message.Content;
                     }
+                    continue;
                 }
 
                 if (typeof(T) == typeof(ChatWithDataStreamingResult))
                 {
                     yield return (T)(object)result;
+                    continue;
                 }
 
                 throw new NotSupportedException($"Type {typeof(T)} is not supported");

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithData.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/AzureOpenAIChatCompletionWithData.cs
@@ -66,7 +66,7 @@ public sealed class AzureOpenAIChatCompletionWithData : IChatCompletion, ITextCo
     {
         Verify.NotNull(chat);
 
-        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettings(executionSettings);
+        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettingsWithData(executionSettings);
 
         ValidateMaxTokens(chatRequestSettings.MaxTokens);
 
@@ -79,7 +79,7 @@ public sealed class AzureOpenAIChatCompletionWithData : IChatCompletion, ITextCo
         PromptExecutionSettings? executionSettings,
         CancellationToken cancellationToken = default)
     {
-        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettings(executionSettings);
+        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettingsWithData(executionSettings);
 
         var chat = this.PrepareChatHistory(text, chatRequestSettings);
 
@@ -94,7 +94,7 @@ public sealed class AzureOpenAIChatCompletionWithData : IChatCompletion, ITextCo
         PromptExecutionSettings? executionSettings = null,
         CancellationToken cancellationToken = default)
     {
-        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettings(executionSettings);
+        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettingsWithData(executionSettings);
 
         var chat = this.PrepareChatHistory(prompt, chatRequestSettings);
 
@@ -107,7 +107,7 @@ public sealed class AzureOpenAIChatCompletionWithData : IChatCompletion, ITextCo
         PromptExecutionSettings? executionSettings = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettings(executionSettings);
+        OpenAIPromptExecutionSettings chatRequestSettings = OpenAIPromptExecutionSettings.FromRequestSettingsWithData(executionSettings);
 
         using var request = this.GetRequest(chat, chatRequestSettings, isStreamEnabled: true);
         using var response = await this.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/ChatWithDataRequest.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionWithData/ChatWithDataRequest.cs
@@ -18,7 +18,7 @@ internal sealed class ChatWithDataRequest
     public bool IsStreamEnabled { get; set; }
 
     [JsonPropertyName("stop")]
-    public IList<string> StopSequences { get; set; } = Array.Empty<string>();
+    public IList<string>? StopSequences { get; set; } = Array.Empty<string>();
 
     [JsonPropertyName("max_tokens")]
     public int? MaxTokens { get; set; }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIPromptExecutionSettings.cs
@@ -68,7 +68,7 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// Sequences where the completion will stop generating further tokens.
     /// </summary>
     [JsonPropertyName("stop_sequences")]
-    public IList<string> StopSequences { get; set; } = Array.Empty<string>();
+    public IList<string>? StopSequences { get; set; } = null;
 
     /// <summary>
     /// How many completions to generate for each prompt. Default is 1.

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIPromptExecutionSettings.cs
@@ -68,7 +68,7 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// Sequences where the completion will stop generating further tokens.
     /// </summary>
     [JsonPropertyName("stop_sequences")]
-    public IList<string>? StopSequences { get; set; } = null;
+    public IList<string>? StopSequences { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// How many completions to generate for each prompt. Default is 1.
@@ -154,6 +154,26 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
         }
 
         throw new ArgumentException($"Invalid request settings, cannot convert to {nameof(OpenAIPromptExecutionSettings)}", nameof(executionSettings));
+    }
+
+    /// <summary>
+    /// Create a new settings object with the values from another settings object.
+    /// </summary>
+    /// <param name="executionSettings">Template configuration</param>
+    /// <param name="defaultMaxTokens">Default max tokens</param>
+    /// <returns>An instance of OpenAIPromptExecutionSettings</returns>
+    public static OpenAIPromptExecutionSettings FromRequestSettingsWithData(PromptExecutionSettings? executionSettings, int? defaultMaxTokens = null)
+    {
+        var requestSettings = FromRequestSettings(executionSettings, defaultMaxTokens);
+
+        if (requestSettings.StopSequences?.Count == 0)
+        {
+            // Azure OpenAI WithData API does not allow to send empty array of stop sequences
+            // Gives back "Validation error at #/stop/str: Input should be a valid string\nValidation error at #/stop/list[str]: List should have at least 1 item after validation, not 0"
+            requestSettings.StopSequences = null;
+        }
+
+        return requestSettings;
     }
 
     #region private ================================================================================


### PR DESCRIPTION
### Motivation and Context

This fixes two bugs 

- While using WithData apis if no stopsequence is provided a BadRequest happens.
- Resolves #3715

### Description

Fix for the above bugs.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: