### PR TITLE
.Net: Handlebars Planner - Passing kernel in method signatures instead of constructors

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
@@ -139,12 +139,12 @@ which are not grounded in the original.
 
         kernel.ImportPluginFromObject<TextPlugin>();
 
-        var planner = new HandlebarsPlanner(kernel);
-        var plan = await planner.CreatePlanAsync(ask);
+        var planner = new HandlebarsPlanner();
+        var plan = await planner.CreatePlanAsync(kernel, ask);
 
         Console.WriteLine($" Goal: {ask} \n\n Template: {plan}");
 
-        var result = plan.Invoke(new ContextVariables(), new Dictionary<string, object?>(), CancellationToken.None);
+        var result = plan.Invoke(kernel, new ContextVariables(), new Dictionary<string, object?>(), CancellationToken.None);
         Console.WriteLine(result.GetValue<string>());
     }
 }

--- a/dotnet/samples/KernelSyntaxExamples/Example65_HandlebarsPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example65_HandlebarsPlanner.cs
@@ -94,7 +94,6 @@ public static class Example65_HandlebarsPlanner
         // Older models like gpt-35-turbo are less recommended. They do handle loops but are more prone to syntax errors.
         var allowLoopsInPlan = chatDeploymentName.Contains("gpt-4", StringComparison.OrdinalIgnoreCase);
         var planner = new HandlebarsPlanner(
-            kernel,
             new HandlebarsPlannerConfig()
             {
                 // Change this if you want to test with loops regardless of model selection.
@@ -104,18 +103,18 @@ public static class Example65_HandlebarsPlanner
         Console.WriteLine($"Goal: {goal}");
 
         // Create the plan
-        var plan = await planner.CreatePlanAsync(goal);
+        var plan = await planner.CreatePlanAsync(kernel, goal);
 
+        // Print the prompt template
         if (shouldPrintPrompt)
         {
-            // Print the prompt template
             Console.WriteLine($"\nPrompt template:\n{plan.Prompt}");
         }
 
         Console.WriteLine($"\nOriginal plan:\n{plan}");
 
         // Execute the plan
-        var result = plan.Invoke(new ContextVariables(), new Dictionary<string, object?>(), CancellationToken.None);
+        var result = plan.Invoke(kernel, new ContextVariables(), new Dictionary<string, object?>(), CancellationToken.None);
         Console.WriteLine($"\nResult:\n{result.GetValue<string>()}\n");
     }
 

--- a/dotnet/samples/TelemetryExample/Program.cs
+++ b/dotnet/samples/TelemetryExample/Program.cs
@@ -70,19 +70,19 @@ public sealed class Program
         });
 
         var kernel = GetKernel(loggerFactory);
-        var planner = CreatePlanner(kernel);
+        var planner = CreatePlanner();
 
         using var activity = s_activitySource.StartActivity("Main");
 
         Console.WriteLine("Operation/Trace ID:");
         Console.WriteLine(Activity.Current?.TraceId);
 
-        var plan = await planner.CreatePlanAsync("Write a poem about John Doe, then translate it into Italian.");
+        var plan = await planner.CreatePlanAsync(kernel, "Write a poem about John Doe, then translate it into Italian.");
 
         Console.WriteLine("Original plan:");
         Console.WriteLine(plan.ToString());
 
-        var result = plan.Invoke(new ContextVariables(), new Dictionary<string, object?>(), CancellationToken.None);
+        var result = plan.Invoke(kernel, new ContextVariables(), new Dictionary<string, object?>(), CancellationToken.None);
 
         Console.WriteLine("Result:");
         Console.WriteLine(result.GetValue<string>());
@@ -112,12 +112,9 @@ public sealed class Program
         return kernel;
     }
 
-    private static HandlebarsPlanner CreatePlanner(
-        Kernel kernel,
-        int maxTokens = 1024)
+    private static HandlebarsPlanner CreatePlanner(int maxTokens = 1024)
     {
         var plannerConfig = new HandlebarsPlannerConfig { MaxTokens = maxTokens };
-
-        return new HandlebarsPlanner(kernel, plannerConfig);
+        return new HandlebarsPlanner(plannerConfig);
     }
 }

--- a/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
@@ -38,10 +38,8 @@ public sealed class HandlebarsPlannerTests : IDisposable
         kernel.ImportPluginFromObject(new EmailPluginFake(), expectedPlugin);
         TestHelpers.ImportSamplePlugins(kernel, "FunPlugin");
 
-        var planner = new HandlebarsPlanner(kernel);
-
         // Act
-        var plan = await planner.CreatePlanAsync(prompt);
+        var plan = await new HandlebarsPlanner().CreatePlanAsync(kernel, prompt);
 
         // Assert expected function
         Assert.Contains(
@@ -59,10 +57,8 @@ public sealed class HandlebarsPlannerTests : IDisposable
         Kernel kernel = this.InitializeKernel();
         TestHelpers.ImportSamplePlugins(kernel, "WriterPlugin", "MiscPlugin");
 
-        var planner = new HandlebarsPlanner(kernel);
-
         // Act
-        var plan = await planner.CreatePlanAsync(prompt);
+        var plan = await new HandlebarsPlanner().CreatePlanAsync(kernel, prompt);
 
         // Assert
         Assert.Contains(

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlan.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlan.cs
@@ -13,11 +13,6 @@ namespace Microsoft.SemanticKernel.Planning.Handlebars;
 public sealed class HandlebarsPlan
 {
     /// <summary>
-    /// The kernel instance.
-    /// </summary>
-    private readonly Kernel _kernel;
-
-    /// <summary>
     /// The handlebars template representing the plan.
     /// </summary>
     private readonly string _template;
@@ -30,12 +25,10 @@ public sealed class HandlebarsPlan
     /// <summary>
     /// Initializes a new instance of the <see cref="HandlebarsPlan"/> class.
     /// </summary>
-    /// <param name="kernel">Kernel instance.</param>
     /// <param name="generatedPlan">A Handlebars template representing the generated plan.</param>
     /// <param name="createPlanPromptTemplate">Prompt template used to generate the plan.</param>
-    public HandlebarsPlan(Kernel kernel, string generatedPlan, string createPlanPromptTemplate)
+    public HandlebarsPlan(string generatedPlan, string createPlanPromptTemplate)
     {
-        this._kernel = kernel;
         this._template = generatedPlan;
         this.Prompt = createPlanPromptTemplate;
     }
@@ -52,16 +45,18 @@ public sealed class HandlebarsPlan
     /// <summary>
     /// Invokes the Handlebars plan.
     /// </summary>
+    /// <param name="kernel">The kernel instance.</param>
     /// <param name="contextVariables">The execution context variables.</param>
     /// <param name="variables">The variables.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The plan result.</returns>
     public FunctionResult Invoke(
+        Kernel kernel,
         ContextVariables contextVariables,
         Dictionary<string, object?> variables,
         CancellationToken cancellationToken = default)
     {
-        string? results = HandlebarsTemplateEngineExtensions.Render(this._kernel, contextVariables, this._template, variables, cancellationToken);
+        string? results = HandlebarsTemplateEngineExtensions.Render(kernel, contextVariables, this._template, variables, cancellationToken);
         contextVariables.Update(results);
         return new FunctionResult("HandlebarsPlanner", contextVariables, results?.Trim());
     }

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlanner.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlanner.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.Orchestration;
 

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlanner.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlanner.cs
@@ -24,43 +24,38 @@ public sealed class HandlebarsPlanner
     /// </summary>
     public Stopwatch Stopwatch { get; } = new();
 
-    private readonly Kernel _kernel;
-    private readonly ILogger _logger;
-
     private readonly HandlebarsPlannerConfig _config;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HandlebarsPlanner"/> class.
     /// </summary>
-    /// <param name="kernel">The kernel.</param>
     /// <param name="config">The configuration.</param>
-    public HandlebarsPlanner(Kernel kernel, HandlebarsPlannerConfig? config = default)
+    public HandlebarsPlanner(HandlebarsPlannerConfig? config = default)
     {
-        this._kernel = kernel;
         this._config = config ?? new HandlebarsPlannerConfig();
-        this._logger = kernel.GetService<ILoggerFactory>().CreateLogger(this.GetType());
     }
 
     /// <summary>Creates a plan for the specified goal.</summary>
+    /// <param name="kernel">The kernel.</param>
     /// <param name="goal">The goal for which a plan should be created.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The created plan.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="goal"/> is null.</exception>
     /// <exception cref="ArgumentException"><paramref name="goal"/> is empty or entirely composed of whitespace.</exception>
     /// <exception cref="KernelException">A plan could not be created.</exception>
-    public Task<HandlebarsPlan> CreatePlanAsync(string goal, CancellationToken cancellationToken = default)
+    public Task<HandlebarsPlan> CreatePlanAsync(Kernel kernel, string goal, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(goal);
 
         // TODO (@teresaqhoang): Add instrumentation without depending on planners.core
-        return this.CreatePlanCoreAsync(goal, cancellationToken);
+        return this.CreatePlanCoreAsync(kernel, goal, cancellationToken);
     }
 
-    private async Task<HandlebarsPlan> CreatePlanCoreAsync(string goal, CancellationToken cancellationToken = default)
+    private async Task<HandlebarsPlan> CreatePlanCoreAsync(Kernel kernel, string goal, CancellationToken cancellationToken = default)
     {
-        var availableFunctions = this.GetAvailableFunctionsManual(out var complexParameterTypes, out var complexParameterSchemas, cancellationToken);
-        var createPlanPrompt = this.GetHandlebarsTemplate(this._kernel, goal, availableFunctions, complexParameterTypes, complexParameterSchemas);
-        var chatCompletion = this._kernel.GetService<IChatCompletion>();
+        var availableFunctions = this.GetAvailableFunctionsManual(kernel, out var complexParameterTypes, out var complexParameterSchemas, cancellationToken);
+        var createPlanPrompt = this.GetHandlebarsTemplate(kernel, goal, availableFunctions, complexParameterTypes, complexParameterSchemas);
+        var chatCompletion = kernel.GetService<IChatCompletion>();
 
         // Extract the chat history from the rendered prompt
         string pattern = @"<(user~|system~|assistant~)>(.*?)<\/\1>";
@@ -97,17 +92,19 @@ public sealed class HandlebarsPlanner
         planTemplate = planTemplate.Replace("compare.greaterThanOrEqual", "greaterThanOrEqual");
 
         planTemplate = MinifyHandlebarsTemplate(planTemplate);
-        return new HandlebarsPlan(this._kernel, planTemplate, createPlanPrompt);
+        return new HandlebarsPlan(planTemplate, createPlanPrompt);
     }
 
     private List<KernelFunctionMetadata> GetAvailableFunctionsManual(
+        Kernel kernel,
         out HashSet<HandlebarsParameterTypeMetadata> complexParameterTypes,
         out Dictionary<string, string> complexParameterSchemas,
         CancellationToken cancellationToken = default)
     {
         complexParameterTypes = new();
         complexParameterSchemas = new();
-        var availableFunctions = this._kernel.Plugins.GetFunctionsMetadata()
+
+        var availableFunctions = kernel.Plugins.GetFunctionsMetadata()
             .Where(s => !this._config.ExcludedPlugins.Contains(s.PluginName, StringComparer.OrdinalIgnoreCase)
                 && !this._config.ExcludedFunctions.Contains(s.Name, StringComparer.OrdinalIgnoreCase)
                 && !s.Name.Contains("Planner_Excluded"))

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsTemplateEngineExtensions.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsTemplateEngineExtensions.cs
@@ -19,11 +19,6 @@ namespace Microsoft.SemanticKernel.Planning.Handlebars;
 internal sealed class HandlebarsTemplateEngineExtensions
 {
     /// <summary>
-    /// The key used to store the reserved output type in the dictionary of variables passed to the Handlebars template engine.
-    /// </summary>
-    public const string ReservedOutputTypeKey = "RESERVED_OUTPUT_TYPE";
-
-    /// <summary>
     /// The character used to delimit the plugin name and function name in a Handlebars template.
     /// </summary>
     public const string ReservedNameDelimiter = "-";


### PR DESCRIPTION
…onstructors

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR moves kernel to an execution-time parameter rather than during planner instantiation.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

In HandlebarsPlanner

- Remove Kernel from the constructor
- Add the Kernel as a parameter for each of the methods

In HandlbarsPlan

- Remove Kernel from the constructors
- Add the Kernel as a parameter for each of the methods

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
