### PR TITLE
Java: Make input parameter of createNewChat method a system message in ChatHistory

### DIFF
--- a/java/connectors/semantickernel-connectors-ai-openai/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/java/connectors/semantickernel-connectors-ai-openai/src/main/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletion.java
@@ -42,14 +42,15 @@ public class OpenAIChatCompletion extends ClientBase implements ChatCompletion<O
     public Mono<List<String>> completeAsync(
             @Nonnull String text, @Nonnull CompletionRequestSettings requestSettings) {
         ChatRequestSettings chatRequestSettings = new ChatRequestSettings(requestSettings);
-        return generateMessageAsync(createNewChat(text), chatRequestSettings).map(Arrays::asList);
+        return generateMessageAsync(internalCreateNewChat(null, text), chatRequestSettings)
+                .map(Arrays::asList);
     }
 
     @Override
     public Flux<String> completeStreamAsync(
             @Nonnull String text, @Nonnull CompletionRequestSettings requestSettings) {
         ChatRequestSettings chatRequestSettings = new ChatRequestSettings(requestSettings);
-        return generateMessageStream(createNewChat(text), chatRequestSettings);
+        return generateMessageStream(internalCreateNewChat(null, text), chatRequestSettings);
     }
 
     @Override
@@ -181,7 +182,7 @@ public class OpenAIChatCompletion extends ClientBase implements ChatCompletion<O
 
     @Override
     public OpenAIChatHistory createNewChat(@Nullable String instructions) {
-        return internalCreateNewChat(instructions);
+        return internalCreateNewChat(instructions, null);
     }
 
     @Override
@@ -234,14 +235,18 @@ public class OpenAIChatCompletion extends ClientBase implements ChatCompletion<O
      * Create a new empty chat instance
      *
      * @param instructions Optional chat instructions for the AI service
+     * @param userMessage Optional user message to start the chat
      * @return Chat object
      */
-    private static OpenAIChatHistory internalCreateNewChat(@Nullable String instructions) {
+    private static OpenAIChatHistory internalCreateNewChat(
+            @Nullable String instructions, @Nullable String userMessage) {
         if (instructions == null) {
-            instructions = "";
+            instructions = "Assistant is a large language model.";
         }
-        OpenAIChatHistory history = new OpenAIChatHistory("Assistant is a large language model.");
-        history.addUserMessage(instructions);
+        OpenAIChatHistory history = new OpenAIChatHistory(instructions);
+        if (userMessage != null) {
+            history.addUserMessage(userMessage);
+        }
         return history;
     }
 }

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletionTest.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/connectors/ai/openai/chatcompletion/OpenAIChatCompletionTest.java
@@ -11,6 +11,7 @@ import com.microsoft.semantickernel.SKBuilders;
 import com.microsoft.semantickernel.ai.AIException;
 import com.microsoft.semantickernel.chatcompletion.ChatCompletion;
 import com.microsoft.semantickernel.chatcompletion.ChatHistory;
+import com.microsoft.semantickernel.chatcompletion.ChatHistory.AuthorRoles;
 import com.microsoft.semantickernel.syntaxexamples.Example17ChatGPTTest;
 import com.microsoft.semantickernel.textcompletion.CompletionRequestSettings;
 import com.microsoft.semantickernel.textcompletion.TextCompletion;
@@ -74,10 +75,14 @@ public class OpenAIChatCompletionTest {
 
         OpenAIChatHistory chatHistory =
                 chatGPT.createNewChat("You are a librarian, expert about books");
+        ChatHistory.Message createdMessage = chatHistory.getMessages().get(0);
+        Assertions.assertEquals(AuthorRoles.System, createdMessage.getAuthorRoles());
+        Assertions.assertEquals(
+                "You are a librarian, expert about books", createdMessage.getContent());
 
         // First user message
         chatHistory.addUserMessage(message);
-        ChatHistory.Message createdMessage = chatHistory.getLastMessage().get();
+        createdMessage = chatHistory.getLastMessage().get();
         Assertions.assertEquals(ChatHistory.AuthorRoles.User, createdMessage.getAuthorRoles());
         Assertions.assertEquals(message, createdMessage.getContent());
 

--- a/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/syntaxexamples/Example17ChatGPTTest.java
+++ b/java/semantickernel-core/src/test/java/com/microsoft/semantickernel/syntaxexamples/Example17ChatGPTTest.java
@@ -11,6 +11,7 @@ import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.SKBuilders;
 import com.microsoft.semantickernel.chatcompletion.ChatCompletion;
 import com.microsoft.semantickernel.chatcompletion.ChatHistory;
+import com.microsoft.semantickernel.chatcompletion.ChatHistory.AuthorRoles;
 import com.microsoft.semantickernel.connectors.ai.openai.chatcompletion.OpenAIChatHistory;
 import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
@@ -48,11 +49,14 @@ public class Example17ChatGPTTest {
 
         OpenAIChatHistory chatHistory =
                 chatGPT.createNewChat("You are a librarian, expert about books");
+        ChatHistory.Message createdMessage = chatHistory.getMessages().get(0);
+        Assertions.assertEquals(AuthorRoles.System, createdMessage.getAuthorRoles());
+        Assertions.assertEquals(
+                "You are a librarian, expert about books", createdMessage.getContent());
 
         // First user message
         chatHistory.addUserMessage(message);
-        ChatHistory.Message createdMessage =
-                chatHistory.getMessages().get(chatHistory.getMessages().size() - 1);
+        createdMessage = chatHistory.getMessages().get(chatHistory.getMessages().size() - 1);
         Assertions.assertEquals(ChatHistory.AuthorRoles.User, createdMessage.getAuthorRoles());
         Assertions.assertEquals(message, createdMessage.getContent());
 


### PR DESCRIPTION
### Motivation and Context

This PR fixes #3735.

The issue was that the current implementation of the `createNewChat` in `OpenAIChatCompletion` class was using the `instructions` input parameter as a _user message_, instead of a _system message_.

### Description

I've added a new parameter to the `internalCreateNewChat` method called `userMessage` so that the behavior of `completeAsync` and `completeStreamAsync` methods stay the same.

Then updated the `internalCreateNewChat` method so that it only uses a hard coded system message when it was not provided. And correctly inserts `instructions` and `userMessage` parameters with correct roles in the newly created `ChatHistory`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
