### PR TITLE
.Net: Update README.md

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -42,7 +42,7 @@ var prompt = @"{{$input}}
 
 One line TLDR with the fewest words.";
 
-var summarize = kernel.CreateSemanticFunction(prompt, executionSettings: new OpenAIPromptExecutionSettings { MaxTokens = 100 });
+var summarize = kernel.CreateSemanticFunction(prompt, requestSettings: new OpenAIRequestSettings() { MaxTokens = 100 });
 
 string text1 = @"
 1st Law of Thermodynamics - Energy cannot be created or destroyed.
@@ -81,8 +81,8 @@ string summarizePrompt = @"{{$input}}
 
 Give me a TLDR with the fewest words.";
 
-var translator = kernel.CreateSemanticFunction(translationPrompt, executionSettings: new OpenAIPromptExecutionSettings { MaxTokens = 200 });
-var summarize = kernel.CreateSemanticFunction(summarizePrompt, executionSettings: new OpenAIPromptExecutionSettings { MaxTokens = 100 });
+var translator = kernel.CreateSemanticFunction(translationPrompt, requestSettings: new OpenAIRequestSettings() { MaxTokens = 200 });
+var summarize = kernel.CreateSemanticFunction(summarizePrompt, requestSettings: new OpenAIRequestSettings() { MaxTokens = 100 });
 
 string inputText = @"
 1st Law of Thermodynamics - Energy cannot be created or destroyed.


### PR DESCRIPTION
OpenAIPromptExecutionSettings is no longer available in Microsoft.SemanticKernel 1.0.0-beta8, instead OpenAIRequestSettings is available.

### Motivation and Context
The README file does not execute as expected. As I was working through it, I had to figure out that the original object is no longer in use. Changing it to the updated OpenAIRequestSettings will allow users to use the README file easier.

https://github.com/microsoft/semantic-kernel/issues/3750

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
