### PR TITLE
.Net: Fix ordered service selector

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -203,9 +203,9 @@ public sealed class Kernel
                     return (T)(object)NullLoggerFactory.Instance;
                 }
 
-                if (typeof(T) == typeof(IAIServiceSelector) || typeof(T) == typeof(OrderedIAIServiceSelector))
+                if (typeof(T) == typeof(IAIServiceSelector) || typeof(T) == typeof(OrderedAIServiceSelector))
                 {
-                    return (T)(object)OrderedIAIServiceSelector.Instance;
+                    return (T)(object)OrderedAIServiceSelector.Instance;
                 }
             }
         }

--- a/dotnet/src/SemanticKernel.Abstractions/Services/OrderedAIServiceSelector.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Services/OrderedAIServiceSelector.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel.AI;
@@ -12,9 +11,9 @@ namespace Microsoft.SemanticKernel.Services;
 /// Implementation of <see cref="IAIServiceSelector"/> that selects the AI service based on the order of the model settings.
 /// Uses the service id to select the preferred service provider and then returns the service and associated model settings.
 /// </summary>
-internal sealed class OrderedIAIServiceSelector : IAIServiceSelector
+internal sealed class OrderedAIServiceSelector : IAIServiceSelector
 {
-    public static OrderedIAIServiceSelector Instance { get; } = new();
+    public static OrderedAIServiceSelector Instance { get; } = new();
 
     /// <inheritdoc/>
     public (T?, PromptExecutionSettings?) SelectAIService<T>(Kernel kernel, ContextVariables variables, KernelFunction function) where T : class, IAIService
@@ -47,7 +46,7 @@ internal sealed class OrderedIAIServiceSelector : IAIServiceSelector
                 }
                 else if (!string.IsNullOrEmpty(model.ModelId))
                 {
-                    var service = this.GetServiceByModelId<T>(kernel.Services, model.ModelId!);
+                    var service = this.GetServiceByModelId<T>(kernel, model.ModelId!);
                     if (service is not null)
                     {
                         return (service, model);
@@ -72,9 +71,9 @@ internal sealed class OrderedIAIServiceSelector : IAIServiceSelector
             $"Service of type {typeof(T)} and names {names} not registered.");
     }
 
-    private T? GetServiceByModelId<T>(IServiceProvider serviceProvider, string modelId) where T : IAIService
+    private T? GetServiceByModelId<T>(Kernel kernel, string modelId) where T : class, IAIService
     {
-        var services = serviceProvider.GetServices<T>();
+        var services = kernel.GetAllServices<T>();
         foreach (var service in services)
         {
             string? serviceModelId = service.GetModelId();

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
@@ -223,6 +223,7 @@ public class OrderedAIServiceConfigurationProviderTests
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);
 
         // Assert
+        Assert.NotNull(aiService);
         Assert.Equal("model2", aiService.GetModelId());
         Assert.Equal(executionSettings, defaultExecutionSettings);
     }

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
@@ -13,7 +13,7 @@ using Microsoft.SemanticKernel.Services;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Functions;
-public class OrderedIAIServiceConfigurationProviderTests
+public class OrderedAIServiceConfigurationProviderTests
 {
     [Fact]
     public void ItThrowsAnSKExceptionForNoServices()
@@ -21,7 +21,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         // Arrange
         var kernel = new Kernel();
         var function = KernelFunctionFactory.CreateFromPrompt("Hello AI");
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         // Assert
@@ -37,7 +37,7 @@ public class OrderedIAIServiceConfigurationProviderTests
             c.AddKeyedSingleton<IAIService>("service1", new AIService());
         }).Build();
         var function = kernel.CreateFunctionFromPrompt("Hello AI");
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<IAIService>(kernel, new ContextVariables(), function);
@@ -57,7 +57,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         }).Build();
         var variables = new ContextVariables();
         var function = kernel.CreateFunctionFromPrompt("Hello AI");
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);
@@ -79,7 +79,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         var variables = new ContextVariables();
         var executionSettings = new PromptExecutionSettings() { ServiceId = "service2" };
         var function = kernel.CreateFunctionFromPrompt("Hello AI", executionSettings: executionSettings);
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);
@@ -101,7 +101,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         var variables = new ContextVariables();
         var executionSettings = new PromptExecutionSettings() { ServiceId = "service3" };
         var function = kernel.CreateFunctionFromPrompt("Hello AI", executionSettings: executionSettings);
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         // Assert
@@ -119,7 +119,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         }).Build();
         var variables = new ContextVariables();
         var function = kernel.CreateFunctionFromPrompt("Hello AI");
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);
@@ -142,7 +142,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         var variables = new ContextVariables();
         var executionSettings = new PromptExecutionSettings();
         var function = kernel.CreateFunctionFromPrompt("Hello AI", executionSettings: executionSettings);
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);
@@ -164,7 +164,7 @@ public class OrderedIAIServiceConfigurationProviderTests
         var variables = new ContextVariables();
         var executionSettings = new PromptExecutionSettings() { ServiceId = "" };
         var function = kernel.CreateFunctionFromPrompt("Hello AI", executionSettings: executionSettings);
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);
@@ -195,7 +195,7 @@ public class OrderedIAIServiceConfigurationProviderTests
             executionSettings.Add(new PromptExecutionSettings() { ServiceId = serviceId });
         }
         var function = kernel.CreateFunctionFromPrompt(promptConfig: new PromptTemplateConfig() { Template = "Hello AI", ExecutionSettings = executionSettings });
-        var serviceSelector = new OrderedIAIServiceSelector();
+        var serviceSelector = new OrderedAIServiceSelector();
 
         // Act
         (var aiService, var defaultRequestSettings) = serviceSelector.SelectAIService<ITextCompletion>(kernel, variables, function);


### PR DESCRIPTION
### Motivation and Context

Selecting by model id was broken

### Description

Use `Kernel.GetAllServices` when searching for a service by model id

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
