### PR TITLE
.Net: Copy PlannerInstrumentation.cs to InternalUtilities

### DIFF
--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -170,6 +170,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "planning", "planning", "{A7DAB812-81CF-4931-B38C-468A3261C4C8}"
 	ProjectSection(SolutionItems) = preProject
 		src\InternalUtilities\planning\PlannerConfigBase.cs = src\InternalUtilities\planning\PlannerConfigBase.cs
+		src\InternalUtilities\planning\PlannerInstrumentation.cs = src\InternalUtilities\planning\PlannerInstrumentation.cs
 		src\InternalUtilities\planning\PlanningUtilities.props = src\InternalUtilities\planning\PlanningUtilities.props
 		src\InternalUtilities\planning\SemanticMemoryConfig.cs = src\InternalUtilities\planning\SemanticMemoryConfig.cs
 	EndProjectSection

--- a/dotnet/src/InternalUtilities/planning/PlannerInstrumentation.cs
+++ b/dotnet/src/InternalUtilities/planning/PlannerInstrumentation.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable IDE0130
+// ReSharper disable once CheckNamespace - using planners namespace
+namespace Microsoft.SemanticKernel.Planning;
+#pragma warning restore IDE0130
+
+/// <summary>Surrounds the invocation of a planner with logging and metrics.</summary>
+public static class PlannerInstrumentation
+{
+    /// <summary><see cref="ActivitySource"/> for planning-related activities.</summary>
+    private static readonly ActivitySource s_activitySource = new("Microsoft.SemanticKernel.Planning");
+
+    /// <summary><see cref="Meter"/> for planner-related metrics.</summary>
+    private static readonly Meter s_meter = new("Microsoft.SemanticKernel.Planning");
+
+    /// <summary><see cref="Histogram{T}"/> to record plan creation duration.</summary>
+    private static readonly Histogram<double> s_createPlanDuration = s_meter.CreateHistogram<double>(
+        name: "sk.planning.create_plan.duration",
+        unit: "s",
+        description: "Duration time of plan creation.");
+
+    /// <summary>Invokes the supplied <paramref name="createPlanAsync"/> delegate, surrounded by logging and metrics.</summary>
+    public static async Task<TPlan> CreatePlanAsync<TPlanner, TPlan>(
+        Func<TPlanner, string, CancellationToken, Task<TPlan>> createPlanAsync,
+        Func<TPlan, string> planToString,
+        TPlanner planner, string goal, ILogger logger, CancellationToken cancellationToken)
+        where TPlanner : class
+        where TPlan : class
+    {
+        string plannerName = planner.GetType().FullName;
+
+        using var _ = s_activitySource.StartActivity(plannerName);
+
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            logger.LogTrace("Plan creation started. Goal: {Goal}", goal); // Sensitive data, logging as trace, disabled by default
+        }
+        else if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogInformation("Plan creation started.");
+        }
+
+        TagList tags = new() { { "sk.planner.name", plannerName } };
+        long startingTimestamp = Stopwatch.GetTimestamp();
+        try
+        {
+            var plan = await createPlanAsync(planner, goal, cancellationToken).ConfigureAwait(false);
+
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                logger.LogInformation("Plan created. Plan:\n{Plan}", planToString(plan));
+            }
+
+            return plan;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Plan creation failed. Error: {Message}", ex.Message);
+            tags.Add("error.type", ex.GetType().FullName);
+            throw;
+        }
+        finally
+        {
+            TimeSpan duration = new((long)((Stopwatch.GetTimestamp() - startingTimestamp) * (10_000_000.0 / Stopwatch.Frequency)));
+            logger.LogInformation("Plan creation duration: {Duration}ms.", duration.TotalMilliseconds);
+            s_createPlanDuration.Record(duration.TotalSeconds, in tags);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The static PlannerInstrumentation class embodies a pattern for instrumenting planners. Before we complete the transition from the action, sequential, and stepwise planners to the newer planners including the Handlebars planner and the OpenAI stepwise planner, we want to keep the `PlannerInstrumentation.cs` file thus allowing us to code the new planners against the instrumentation pattern.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Copy `PlannerInstrumentation.cs` to `dotnet/src/InternalUtilities/planning/`
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
