### PR TITLE
.Net: KernelArguments as a type for the 'arguments' parameter

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/TemplateEngine/Handlebars/HandlebarsPromptTemplateTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/TemplateEngine/Handlebars/HandlebarsPromptTemplateTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -16,13 +15,13 @@ public sealed class HandlebarsPromptTemplateTests
 {
     private readonly HandlebarsPromptTemplateFactory _factory;
     private readonly Kernel _kernel;
-    private readonly IDictionary<string, string> _arguments;
+    private readonly KernelArguments _arguments;
 
     public HandlebarsPromptTemplateTests()
     {
         this._factory = new HandlebarsPromptTemplateFactory(TestConsoleLogger.LoggerFactory);
         this._kernel = new Kernel();
-        this._arguments = new Dictionary<string, string>();
+        this._arguments = new KernelArguments();
         this._arguments["input"] = Guid.NewGuid().ToString("X");
     }
 

--- a/dotnet/src/Extensions/TemplateEngine.Handlebars/HandlebarsPromptTemplate.cs
+++ b/dotnet/src/Extensions/TemplateEngine.Handlebars/HandlebarsPromptTemplate.cs
@@ -24,7 +24,7 @@ internal class HandlebarsPromptTemplate : IPromptTemplate
     }
 
     /// <inheritdoc/>
-    public async Task<string> RenderAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default)
+    public async Task<string> RenderAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default)
     {
         var handlebars = HandlebarsDotNet.Handlebars.Create();
 
@@ -34,8 +34,7 @@ internal class HandlebarsPromptTemplate : IPromptTemplate
             {
                 handlebars.RegisterHelper($"{plugin.Name}_{function.Name}", (writer, hcontext, parameters) =>
                 {
-                    KernelArguments? functionArguments = arguments is not null ? new KernelArguments(arguments) : null;
-                    var result = function.InvokeAsync(kernel, functionArguments).GetAwaiter().GetResult();
+                    var result = function.InvokeAsync(kernel, arguments).GetAwaiter().GetResult();
                     writer.WriteSafeString(result.ToString());
                 });
             }
@@ -53,7 +52,7 @@ internal class HandlebarsPromptTemplate : IPromptTemplate
     private readonly ILogger _logger;
     private readonly PromptTemplateConfig _promptModel;
 
-    private Dictionary<string, string> GetVariables(IDictionary<string, string>? arguments)
+    private Dictionary<string, string> GetVariables(KernelArguments? arguments)
     {
         Dictionary<string, string> result = new();
 

--- a/dotnet/src/Functions/Functions.Grpc/GrpcOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.Grpc/GrpcOperationRunner.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net.Http;
@@ -48,7 +47,7 @@ internal sealed class GrpcOperationRunner
     /// <param name="arguments">The operation arguments.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The result of the operation run.</returns>
-    public async Task<JsonObject> RunAsync(GrpcOperation operation, IDictionary<string, string> arguments, CancellationToken cancellationToken = default)
+    public async Task<JsonObject> RunAsync(GrpcOperation operation, KernelArguments arguments, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(operation);
         Verify.NotNull(arguments);
@@ -105,7 +104,7 @@ internal sealed class GrpcOperationRunner
     /// <param name="operation">The gRPC operation.</param>
     /// <param name="arguments">The gRPC operation arguments.</param>
     /// <returns>The channel address.</returns>
-    private string GetAddress(GrpcOperation operation, IDictionary<string, string> arguments)
+    private string GetAddress(GrpcOperation operation, KernelArguments arguments)
     {
         if (!arguments.TryGetValue(GrpcOperation.AddressArgumentName, out string? address))
         {
@@ -153,7 +152,7 @@ internal sealed class GrpcOperationRunner
     /// <param name="type">The operation request data type.</param>
     /// <param name="arguments">The operation arguments.</param>
     /// <returns>The operation request instance.</returns>
-    private object GenerateOperationRequest(GrpcOperation operation, Type type, IDictionary<string, string> arguments)
+    private object GenerateOperationRequest(GrpcOperation operation, Type type, KernelArguments arguments)
     {
         //Getting 'payload' argument to by used as gRPC request message
         if (!arguments.TryGetValue(GrpcOperation.PayloadArgumentName, out var payload))

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
@@ -282,7 +282,7 @@ public static class KernelOpenApiPluginExtensions
             try
             {
                 // Extract function arguments from context
-                var arguments = new Dictionary<string, string>();
+                var arguments = new KernelArguments();
                 foreach (var parameter in restOperationParameters)
                 {
                     // A try to resolve argument by alternative parameter name

--- a/dotnet/src/Functions/Functions.OpenAPI/HttpContentFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/HttpContentFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Functions.OpenAPI.Model;
 
@@ -12,4 +11,4 @@ namespace Microsoft.SemanticKernel.Functions.OpenAPI;
 /// <param name="payload">The operation payload metadata.</param>
 /// <param name="arguments">The operation arguments.</param>
 /// <returns>The HTTP content representing the operation payload.</returns>
-internal delegate HttpContent HttpContentFactory(RestApiOperationPayload? payload, IDictionary<string, string> arguments);
+internal delegate HttpContent HttpContentFactory(RestApiOperationPayload? payload, KernelArguments arguments);

--- a/dotnet/src/Functions/Functions.OpenAPI/RestApiOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/RestApiOperationRunner.cs
@@ -121,7 +121,7 @@ internal sealed class RestApiOperationRunner
     /// <returns>The task execution result.</returns>
     public Task<RestApiOperationResponse> RunAsync(
         RestApiOperation operation,
-        IDictionary<string, string> arguments,
+        KernelArguments arguments,
         RestApiOperationRunOptions? options = null,
         CancellationToken cancellationToken = default)
     {
@@ -230,7 +230,7 @@ internal sealed class RestApiOperationRunner
     /// <param name="operation">The operation.</param>
     /// <param name="arguments">The payload arguments.</param>
     /// <returns>The HttpContent representing the payload.</returns>
-    private HttpContent? BuildOperationPayload(RestApiOperation operation, IDictionary<string, string> arguments)
+    private HttpContent? BuildOperationPayload(RestApiOperation operation, KernelArguments arguments)
     {
         if (operation?.Method != HttpMethod.Put && operation?.Method != HttpMethod.Post)
         {
@@ -262,7 +262,7 @@ internal sealed class RestApiOperationRunner
     /// <param name="payloadMetadata">The payload meta-data.</param>
     /// <param name="arguments">The payload arguments.</param>
     /// <returns>The HttpContent representing the payload.</returns>
-    private HttpContent BuildJsonPayload(RestApiOperationPayload? payloadMetadata, IDictionary<string, string> arguments)
+    private HttpContent BuildJsonPayload(RestApiOperationPayload? payloadMetadata, KernelArguments arguments)
     {
         //Build operation payload dynamically
         if (this._enableDynamicPayload)
@@ -293,7 +293,7 @@ internal sealed class RestApiOperationRunner
     /// <param name="arguments">The arguments.</param>
     /// <param name="propertyNamespace">The namespace to add to the property name.</param>
     /// <returns>The JSON object.</returns>
-    private JsonObject BuildJsonObject(IList<RestApiOperationPayloadProperty> properties, IDictionary<string, string> arguments, string? propertyNamespace = null)
+    private JsonObject BuildJsonObject(IList<RestApiOperationPayloadProperty> properties, KernelArguments arguments, string? propertyNamespace = null)
     {
         var result = new JsonObject();
 
@@ -372,7 +372,7 @@ internal sealed class RestApiOperationRunner
     /// <param name="payloadMetadata">The payload meta-data.</param>
     /// <param name="arguments">The payload arguments.</param>
     /// <returns>The HttpContent representing the payload.</returns>
-    private HttpContent BuildPlainTextPayload(RestApiOperationPayload? payloadMetadata, IDictionary<string, string> arguments)
+    private HttpContent BuildPlainTextPayload(RestApiOperationPayload? payloadMetadata, KernelArguments arguments)
     {
         if (!arguments.TryGetValue(RestApiOperation.PayloadArgumentName, out var propertyValue))
         {
@@ -406,7 +406,7 @@ internal sealed class RestApiOperationRunner
     /// <param name="serverUrlOverride">Override for REST API operation server url.</param>
     /// <param name="apiHostUrl">The URL of REST API host.</param>
     /// <returns>The operation Url.</returns>
-    private Uri BuildsOperationUrl(RestApiOperation operation, IDictionary<string, string> arguments, Uri? serverUrlOverride = null, Uri? apiHostUrl = null)
+    private Uri BuildsOperationUrl(RestApiOperation operation, KernelArguments arguments, Uri? serverUrlOverride = null, Uri? apiHostUrl = null)
     {
         var url = operation.BuildOperationUrl(arguments, serverUrlOverride, apiHostUrl);
 

--- a/dotnet/src/Functions/Functions.UnitTests/Grpc/GrpcRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Grpc/GrpcRunnerTests.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Functions.Grpc;
 using Microsoft.SemanticKernel.Functions.Grpc.Model;
 using Xunit;
@@ -57,7 +58,7 @@ public sealed class GrpcRunnerTests : IDisposable
         operation.Package = "greet";
         operation.Address = "https://fake-random-test-host";
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("payload", JsonSerializer.Serialize(new { name = "author" }));
 
         // Act
@@ -87,7 +88,7 @@ public sealed class GrpcRunnerTests : IDisposable
         operation.Package = "greet";
         operation.Address = "https://fake-random-test-host";
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("payload", JsonSerializer.Serialize(new { name = "author" }));
         arguments.Add("address", "https://fake-random-test-host-from-args");
 
@@ -121,7 +122,7 @@ public sealed class GrpcRunnerTests : IDisposable
         operation.Package = "greet";
         operation.Address = "https://fake-random-test-host";
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("payload", JsonSerializer.Serialize(new { name = "author" }));
 
         // Act

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationRunnerTests.cs
@@ -65,7 +65,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
@@ -78,7 +78,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             }
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", JsonSerializer.Serialize(payload) },
             { "content-type", "application/json" }
@@ -137,11 +137,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", "fake-input-value" },
             { "content-type", "text/plain"}
@@ -181,7 +181,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldAddHeadersToHttpRequestAsync()
     {
         // Arrange
-        var headers = new Dictionary<string, string>
+        var headers = new KernelArguments
         {
             { "fake-header", string.Empty }
         };
@@ -196,7 +196,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             headers
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "fake-header", "fake-header-value" }
         };
@@ -217,7 +217,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldAddUserAgentHeaderToHttpRequestIfConfiguredAsync()
     {
         // Arrange
-        var headers = new Dictionary<string, string>
+        var headers = new KernelArguments
         {
             { "fake-header", string.Empty }
         };
@@ -232,7 +232,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             headers
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "fake-header", "fake-header-value" }
         };
@@ -274,11 +274,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("name", "fake-name-value");
         arguments.Add("enabled", "true");
 
@@ -337,11 +337,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("name", "fake-string-value");
         arguments.Add("enabled", "true");
         arguments.Add("cardinality", "8");
@@ -425,11 +425,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("upn", "fake-sender-upn");
         arguments.Add("receiver.upn", "fake-receiver-upn");
         arguments.Add("receiver.alternative.upn", "fake-receiver-alternative-upn");
@@ -494,11 +494,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
 
         var sut = new RestApiOperationRunner(
             this._httpClient,
@@ -522,11 +522,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
 
         var sut = new RestApiOperationRunner(
             this._httpClient,
@@ -554,11 +554,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", "fake-input-value" },
         };
@@ -595,11 +595,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", "fake-input-value" },
             { "content-type", $"{contentType}" },
@@ -642,11 +642,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
 
         var sut = new RestApiOperationRunner(
             this._httpClient,
@@ -689,11 +689,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments.Add("upn", "fake-sender-upn");
 
         var sut = new RestApiOperationRunner(
@@ -746,11 +746,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Get,
             "fake-description",
             new List<RestApiOperationParameter>() { firstParameter, secondParameter },
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "p1", "v1" },
             { "p2", "v2" },
@@ -795,11 +795,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Get,
             "fake-description",
             new List<RestApiOperationParameter>() { firstParameter, secondParameter },
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "p1", "v1" },
             { "p2", "v2" },
@@ -844,11 +844,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Get,
             "fake-description",
             new List<RestApiOperationParameter>() { firstParameter, secondParameter },
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "p2", "v2" }, //Providing argument for the required parameter only
         };
@@ -884,11 +884,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Get,
             "fake-description",
             new List<RestApiOperationParameter>() { parameter },
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>(); //Providing no arguments
+        var arguments = new KernelArguments(); //Providing no arguments
 
         var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
 
@@ -916,11 +916,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", JsonSerializer.Serialize(new { value = "fake-value" }) },
             { "content-type", "application/json" }
@@ -959,11 +959,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", JsonSerializer.Serialize(new { value = "fake-value" }) },
             { "content-type", "application/json" }
@@ -995,11 +995,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             payload: null
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new KernelArguments
         {
             { "payload", JsonSerializer.Serialize(new { value = "fake-value" }) },
             { "content-type", "application/json" }
@@ -1067,7 +1067,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Get,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new KernelArguments(),
             null,
             responses.ToDictionary(item => item.Item1, item => item.Item2)
         );
@@ -1075,7 +1075,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);
 
         // Act
-        var result = await sut.RunAsync(operation, new Dictionary<string, string>());
+        var result = await sut.RunAsync(operation, new KernelArguments());
 
         Assert.NotNull(result);
         var expected = responses.First(r => r.Item1 == expectedStatusCode).Item2.Schema;

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsTemplateEngineExtensions.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsTemplateEngineExtensions.cs
@@ -42,7 +42,7 @@ internal sealed class HandlebarsTemplateEngineExtensions
                 NoEscape = true
             });
 
-        var state = new Dictionary<string, string>();
+        var state = new KernelArguments();
 
         // Add helpers for each function
         foreach (KernelFunctionMetadata function in kernel.Plugins.GetFunctionsMetadata())
@@ -59,7 +59,7 @@ internal sealed class HandlebarsTemplateEngineExtensions
 
     private static void RegisterFunctionAsHelper(
         Kernel kernel,
-        IDictionary<string, string> state,
+        KernelArguments state,
         IHandlebars handlebarsInstance,
         KernelFunctionMetadata functionMetadata,
         Dictionary<string, object?> arguments,
@@ -413,7 +413,7 @@ internal sealed class HandlebarsTemplateEngineExtensions
     /// </summary>
     /// <param name="variables">Dictionary of variables passed to the Handlebars template engine.</param>
     /// <param name="state">The execution state.</param>
-    private static void InitializeState(Dictionary<string, object?> variables, IDictionary<string, string> state)
+    private static void InitializeState(Dictionary<string, object?> variables, KernelArguments state)
     {
         foreach (var v in variables)
         {
@@ -436,7 +436,7 @@ internal sealed class HandlebarsTemplateEngineExtensions
     private static object? InvokeSKFunction(
         Kernel kernel,
         KernelFunction function,
-        IDictionary<string, string> state,
+        KernelArguments state,
         CancellationToken cancellationToken = default)
     {
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -177,7 +176,7 @@ public sealed class FunctionCallingStepwisePlanner
     {
         var chatHistory = this._chatCompletion.CreateNewChat();
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         string functionsManual = await this.GetFunctionsManualAsync(cancellationToken).ConfigureAwait(false);
         arguments[AvailableFunctionsKey] = functionsManual;
         string systemMessage = await this._promptTemplateFactory.Create(new PromptTemplateConfig(this._initialPlanPrompt)).RenderAsync(this._kernel, arguments, cancellationToken).ConfigureAwait(false);
@@ -196,7 +195,7 @@ public sealed class FunctionCallingStepwisePlanner
         var chatHistory = this._chatCompletion.CreateNewChat();
 
         // Add system message with context about the initial goal/plan
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments[GoalKey] = goal;
         arguments[InitialPlanKey] = initialPlan;
         var systemMessage = await this._promptTemplateFactory.Create(new PromptTemplateConfig(this._stepPrompt)).RenderAsync(this._kernel, arguments, cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/IPromptTemplate.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/IPromptTemplate.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,5 +19,5 @@ public interface IPromptTemplate
     /// <param name="arguments">The arguments.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Prompt rendered to string</returns>
-    public Task<string> RenderAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default);
+    public Task<string> RenderAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/SemanticKernel.Core/PromptTemplate/KernelPromptTemplate.cs
+++ b/dotnet/src/SemanticKernel.Core/PromptTemplate/KernelPromptTemplate.cs
@@ -45,7 +45,7 @@ public sealed class KernelPromptTemplate : IPromptTemplate
     }
 
     /// <inheritdoc/>
-    public async Task<string> RenderAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default)
+    public async Task<string> RenderAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default)
     {
         return await this.RenderAsync(this._blocks.Value, kernel, arguments, cancellationToken).ConfigureAwait(false);
     }
@@ -90,7 +90,7 @@ public sealed class KernelPromptTemplate : IPromptTemplate
     /// <param name="arguments">The arguments.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The prompt template ready to be used for an AI request.</returns>
-    internal async Task<string> RenderAsync(IList<Block> blocks, Kernel kernel, IDictionary<string, string>? arguments, CancellationToken cancellationToken = default)
+    internal async Task<string> RenderAsync(IList<Block> blocks, Kernel kernel, KernelArguments? arguments, CancellationToken cancellationToken = default)
     {
         this._logger.LogTrace("Rendering list of {0} blocks", blocks.Count);
         var tasks = new List<Task<string>>(blocks.Count);
@@ -131,7 +131,7 @@ public sealed class KernelPromptTemplate : IPromptTemplate
     /// <param name="blocks">List of blocks, typically all the blocks found in a template.</param>
     /// <param name="arguments">Arguments to use for rendering.</param>
     /// <returns>An updated list of blocks where Variable Blocks have rendered to Text Blocks.</returns>
-    internal IList<Block> RenderVariables(IList<Block> blocks, IDictionary<string, string>? arguments)
+    internal IList<Block> RenderVariables(IList<Block> blocks, KernelArguments? arguments)
     {
         this._logger.LogTrace("Rendering variables");
         return blocks.Select(block => block.Type != BlockTypes.Variable

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/CodeBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/CodeBlock.cs
@@ -70,7 +70,7 @@ internal sealed class CodeBlock : Block, ICodeRendering
     }
 
     /// <inheritdoc/>
-    public async Task<string> RenderCodeAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default)
+    public async Task<string> RenderCodeAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default)
     {
         if (!this._validated && !this.IsValid(out var error))
         {
@@ -92,19 +92,17 @@ internal sealed class CodeBlock : Block, ICodeRendering
     private bool _validated;
     private readonly List<Block> _tokens;
 
-    private async Task<string> RenderFunctionCallAsync(FunctionIdBlock fBlock, Kernel kernel, IDictionary<string, string>? arguments)
+    private async Task<string> RenderFunctionCallAsync(FunctionIdBlock fBlock, Kernel kernel, KernelArguments? arguments)
     {
         // If the code syntax is {{functionName $varName}} use $varName instead of $input
         // If the code syntax is {{functionName 'value'}} use "value" instead of $input
         if (this._tokens.Count > 1)
         {
-            arguments = this.EnrichFunctionArguments(arguments ?? new Dictionary<string, string>());
+            arguments = this.EnrichFunctionArguments(arguments ?? new KernelArguments());
         }
         try
         {
-            KernelArguments? kernelArguments = arguments is not null ? new KernelArguments(arguments) : null;
-
-            var result = await kernel.InvokeAsync(fBlock.PluginName, fBlock.FunctionName, kernelArguments).ConfigureAwait(false);
+            var result = await kernel.InvokeAsync(fBlock.PluginName, fBlock.FunctionName, arguments).ConfigureAwait(false);
 
             return result.ToString();
         }
@@ -145,7 +143,7 @@ internal sealed class CodeBlock : Block, ICodeRendering
         return true;
     }
 
-    private IDictionary<string, string> EnrichFunctionArguments(IDictionary<string, string> arguments)
+    private KernelArguments EnrichFunctionArguments(KernelArguments arguments)
     {
         // Clone the context to avoid unexpected and hard to test input mutation
         var firstArg = this._tokens[1];

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/FunctionIdBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/FunctionIdBlock.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
@@ -54,7 +53,7 @@ internal sealed class FunctionIdBlock : Block, ITextRendering
     }
 
     /// <inheritdoc/>
-    public string Render(IDictionary<string, string>? arguments)
+    public string Render(KernelArguments? arguments)
     {
         return this.Content;
     }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ICodeRendering.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ICodeRendering.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,5 +17,5 @@ internal interface ICodeRendering
     /// <param name="arguments">The arguments</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Rendered content</returns>
-    public Task<string> RenderCodeAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default);
+    public Task<string> RenderCodeAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ITextRendering.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ITextRendering.cs
@@ -1,7 +1,4 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Collections.Generic;
-
 namespace Microsoft.SemanticKernel.TemplateEngine.Blocks;
 
 /// <summary>
@@ -10,9 +7,9 @@ namespace Microsoft.SemanticKernel.TemplateEngine.Blocks;
 internal interface ITextRendering
 {
     /// <summary>
-    /// Render the block using only the given variables.
+    /// Render the block using only the given arguments.
     /// </summary>
-    /// <param name="arguments">Optional arguments used to render the block</param>
+    /// <param name="arguments">Optional arguments the block rendering</param>
     /// <returns>Rendered content</returns>
-    public string Render(IDictionary<string, string>? arguments);
+    public string Render(KernelArguments? arguments);
 }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/NamedArgBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/NamedArgBlock.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
@@ -63,7 +62,7 @@ internal sealed class NamedArgBlock : Block, ITextRendering
     /// </summary>
     /// <param name="arguments">Arguments to use for rendering the named argument value when the value is a <see cref="VarBlock"/>.</param>
     /// <returns></returns>
-    internal string GetValue(IDictionary<string, string>? arguments)
+    internal string GetValue(KernelArguments? arguments)
     {
         var valueIsValidValBlock = this._valBlock != null && this._valBlock.IsValid(out var errorMessage);
         if (valueIsValidValBlock)
@@ -81,7 +80,7 @@ internal sealed class NamedArgBlock : Block, ITextRendering
     }
 
     /// <inheritdoc/>
-    public string Render(IDictionary<string, string>? arguments)
+    public string Render(KernelArguments? arguments)
     {
         return this.Content;
     }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/TextBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/TextBlock.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.SemanticKernel.TemplateEngine.Blocks;
@@ -26,7 +25,7 @@ internal sealed class TextBlock : Block, ITextRendering
     }
 
     /// <inheritdoc/>
-    public string Render(IDictionary<string, string>? arguments)
+    public string Render(KernelArguments? arguments)
     {
         return this.Content;
     }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ValBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ValBlock.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.SemanticKernel.TemplateEngine.Blocks;
@@ -62,7 +61,7 @@ internal sealed class ValBlock : Block, ITextRendering
 #pragma warning restore CA2254
 
     /// <inheritdoc/>
-    public string Render(IDictionary<string, string>? arguments)
+    public string Render(KernelArguments? arguments)
     {
         return this._value;
     }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/VarBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/VarBlock.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
@@ -63,7 +62,7 @@ internal sealed class VarBlock : Block, ITextRendering
 #pragma warning restore CA2254
 
     /// <inheritdoc/>
-    public string Render(IDictionary<string, string>? arguments)
+    public string Render(KernelArguments? arguments)
     {
         if (arguments == null) { return string.Empty; }
 

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/AggregatorPromptTemplateFactoryTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/AggregatorPromptTemplateFactoryTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -67,7 +66,7 @@ public sealed class AggregatorPromptTemplateFactoryTests
             this._promptModel = promptConfig;
         }
 
-        public Task<string> RenderAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default)
+        public Task<string> RenderAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(this._promptModel.Template);
         }
@@ -95,7 +94,7 @@ public sealed class AggregatorPromptTemplateFactoryTests
             this._promptModel = promptConfig;
         }
 
-        public Task<string> RenderAsync(Kernel kernel, IDictionary<string, string>? arguments = null, CancellationToken cancellationToken = default)
+        public Task<string> RenderAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(this._promptModel.Template);
         }

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -18,7 +18,7 @@ public sealed class KernelPromptTemplateTests
 {
     private const string DateFormat = "M/d/yyyy";
     private readonly KernelPromptTemplateFactory _factory;
-    private readonly IDictionary<string, string> _arguments;
+    private readonly KernelArguments _arguments;
     private readonly ITestOutputHelper _logger;
     private readonly Kernel _kernel;
 
@@ -26,7 +26,7 @@ public sealed class KernelPromptTemplateTests
     {
         this._logger = testOutputHelper;
         this._factory = new KernelPromptTemplateFactory(TestConsoleLogger.LoggerFactory);
-        this._arguments = new Dictionary<string, string>();
+        this._arguments = new KernelArguments();
         this._arguments["input"] = Guid.NewGuid().ToString("X");
         this._kernel = new Kernel();
     }

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -120,7 +120,7 @@ public class CodeBlockTests
     public async Task ItRendersCodeBlockConsistingOfJustAVarBlock1Async()
     {
         // Arrange
-        var arguments = new Dictionary<string, string> { ["varName"] = "foo" };
+        var arguments = new KernelArguments { ["varName"] = "foo" };
 
         // Act
         var codeBlock = new CodeBlock("$varName");
@@ -134,7 +134,7 @@ public class CodeBlockTests
     public async Task ItRendersCodeBlockConsistingOfJustAVarBlock2Async()
     {
         // Arrange
-        var arguments = new Dictionary<string, string> { ["varName"] = "bar" };
+        var arguments = new KernelArguments { ["varName"] = "bar" };
         var varBlock = new VarBlock("$varName");
 
         // Act
@@ -179,7 +179,7 @@ public class CodeBlockTests
         const string Var = "varName";
         const string VarValue = "varValue";
 
-        var arguments = new Dictionary<string, string> { [Var] = VarValue };
+        var arguments = new KernelArguments { [Var] = VarValue };
         var funcId = new FunctionIdBlock("plugin.function");
         var varBlock = new VarBlock($"${Var}");
 
@@ -238,7 +238,7 @@ public class CodeBlockTests
         const string FooValue = "bar";
         const string BobValue = "bob's value";
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments["bob"] = BobValue;
         arguments["input"] = Value;
 

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/VarBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/VarBlockTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.TemplateEngine.Blocks;
 using Xunit;
@@ -54,7 +53,7 @@ public class VarBlockTests
     {
         // Arrange
         var target = new VarBlock("  $var \n ");
-        var arguments = new Dictionary<string, string>()
+        var arguments = new KernelArguments()
         {
             ["foo"] = "bar"
         };
@@ -71,7 +70,7 @@ public class VarBlockTests
     {
         // Arrange
         var target = new VarBlock("  $var \n ");
-        var arguments = new Dictionary<string, string>()
+        var arguments = new KernelArguments()
         {
             ["foo"] = "bar",
             ["var"] = "able",
@@ -88,7 +87,7 @@ public class VarBlockTests
     public void ItThrowsIfTheVarNameIsEmpty()
     {
         // Arrange
-        var arguments = new Dictionary<string, string>()
+        var arguments = new KernelArguments()
         {
             ["foo"] = "bar",
             ["var"] = "able",
@@ -148,7 +147,7 @@ public class VarBlockTests
     {
         // Arrange
         var target = new VarBlock($" ${name} ");
-        var arguments = new Dictionary<string, string> { [name] = "value" };
+        var arguments = new KernelArguments { [name] = "value" };
 
         // Act
         var result = target.Render(arguments);

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/CodeTokenizerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/CodeTokenizerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.TemplateEngine;
 using Microsoft.SemanticKernel.TemplateEngine.Blocks;
@@ -121,7 +120,7 @@ public class CodeTokenizerTests
     {
         // Arrange
         var template1 = "x.y first=$foo second='bar'";
-        var arguments = new Dictionary<string, string>();
+        var arguments = new KernelArguments();
         arguments["foo"] = "fooValue";
 
         // Act


### PR DESCRIPTION
### Motivation and Context

Some of the SK components, such as 'Kernel' and 'KernelFunction,' use the 'KernelArguments' class for their API arguments parameter. Meanwhile, other SK components, such as 'HandlebarsPromptTemplate' and 'KernelPromptTemplate,' utilize IDictionary<string, string> as the type for the 'arguments' parameter in their API. This PR changes the type of the 'arguments' parameter from IDictionary<string, string> to 'KernelArguments' to achieve consistency among all SK components.