### PR TITLE
.Net Passing Kernel instance to FunctionResult

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
@@ -129,7 +129,7 @@ public class LocalExamplePlugin
     public FunctionResult Type10()
     {
         Console.WriteLine("Running function type 10");
-        return new FunctionResult(string.Empty);
+        return new FunctionResult(new Kernel(), string.Empty);
     }
 
     [KernelFunction]
@@ -137,6 +137,6 @@ public class LocalExamplePlugin
     {
         await Task.Delay(0);
         Console.WriteLine("Running function type 10");
-        return new FunctionResult("result");
+        return new FunctionResult(new Kernel(), "result");
     }
 }

--- a/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
@@ -126,17 +126,17 @@ public class LocalExamplePlugin
     }
 
     [KernelFunction]
-    public FunctionResult Type10()
+    public FunctionResult Type10(Kernel kernel)
     {
         Console.WriteLine("Running function type 10");
-        return new FunctionResult(new Kernel(), string.Empty);
+        return new FunctionResult(kernel, string.Empty);
     }
 
     [KernelFunction]
-    public async Task<FunctionResult> Type11Async()
+    public async Task<FunctionResult> Type11Async(Kernel kernel)
     {
         await Task.Delay(0);
         Console.WriteLine("Running function type 10");
-        return new FunctionResult(new Kernel(), "result");
+        return new FunctionResult(kernel, "result");
     }
 }

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlan.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlan.cs
@@ -55,6 +55,6 @@ public sealed class HandlebarsPlan
     {
         string? result = HandlebarsTemplateEngineExtensions.Render(kernel, this._template, arguments, cancellationToken);
 
-        return new FunctionResult("HandlebarsPlanner", result, kernel.Culture);
+        return new FunctionResult(kernel, "HandlebarsPlanner", result);
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/FunctionResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/FunctionResult.cs
@@ -53,31 +53,26 @@ public sealed class FunctionResult
     internal object? Value { get; private set; } = null;
 
     /// <summary>
-    /// The culture configured on the Kernel that executed the function.
-    /// </summary>
-    internal CultureInfo Culture { get; set; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="FunctionResult"/> class.
     /// </summary>
+    /// <param name="kernel">The kernel.</param>
     /// <param name="functionName">Name of executed function.</param>
-    public FunctionResult(string functionName)
+    public FunctionResult(Kernel kernel, string functionName)
     {
+        this._kernel = kernel;
         this.FunctionName = functionName;
-        this.Culture = CultureInfo.InvariantCulture;
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionResult"/> class.
     /// </summary>
+    /// <param name="kernel">The kernel.</param>
     /// <param name="functionName">Name of executed function.</param>
     /// <param name="value">Function result object.</param>
-    /// <param name="culture">The culture configured on the Kernel that executed the function.</param>
-    public FunctionResult(string functionName, object? value, CultureInfo culture)
-        : this(functionName)
+    public FunctionResult(Kernel kernel, string functionName, object? value)
+        : this(kernel, functionName)
     {
         this.Value = value;
-        this.Culture = culture;
     }
 
     /// <summary>
@@ -120,7 +115,7 @@ public sealed class FunctionResult
     /// <inheritdoc/>
     public override string ToString()
     {
-        return ConvertToString(this.Value, this.Culture) ?? string.Empty;
+        return ConvertToString(this.Value, this._kernel.Culture) ?? string.Empty;
     }
 
     private static string? ConvertToString(object? value, CultureInfo culture)
@@ -190,4 +185,6 @@ public sealed class FunctionResult
 
     /// <summary>Converter functions for converting types to strings.</summary>
     private static readonly ConcurrentDictionary<Type, Func<object?, CultureInfo, string?>?> s_converters = new();
+
+    private readonly Kernel _kernel;
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
@@ -118,7 +118,7 @@ public abstract class KernelFunction
             {
                 logger.LogTrace("Function canceled or skipped prior to invocation.");
 
-                return new FunctionResult(this.Name)
+                return new FunctionResult(kernel, this.Name)
                 {
                     IsCancellationRequested = invokingEventArgs.CancelToken.IsCancellationRequested,
                     IsSkipRequested = invokingEventArgs.IsSkipRequested
@@ -231,7 +231,7 @@ public abstract class KernelFunction
         if (eventArgs is not null)
         {
             // Apply any changes from the event handlers to final result.
-            result = new FunctionResult(this.Name, eventArgs.ResultValue, result.Culture)
+            result = new FunctionResult(kernel, this.Name, eventArgs.ResultValue)
             {
                 // Updates the eventArgs metadata during invoked handler execution
                 // will reflect in the result metadata

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -415,25 +415,25 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
 
         if (returnType == typeof(void))
         {
-            return static (_, functionName, _) =>
-                new ValueTask<FunctionResult>(new FunctionResult(functionName));
+            return static (kernel, functionName, _) =>
+                new ValueTask<FunctionResult>(new FunctionResult(kernel, functionName));
         }
 
         if (returnType == typeof(Task))
         {
-            return async static (_, functionName, result) =>
+            return async static (kernel, functionName, result) =>
             {
                 await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
-                return new FunctionResult(functionName);
+                return new FunctionResult(kernel, functionName);
             };
         }
 
         if (returnType == typeof(ValueTask))
         {
-            return async static (_, functionName, result) =>
+            return async static (kernel, functionName, result) =>
             {
                 await ((ValueTask)ThrowIfNullResult(result)).ConfigureAwait(false);
-                return new FunctionResult(functionName);
+                return new FunctionResult(kernel, functionName);
             };
         }
 
@@ -444,7 +444,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
             return static (kernel, functionName, result) =>
             {
                 var resultString = (string?)result;
-                return new ValueTask<FunctionResult>(new FunctionResult(functionName, resultString, kernel.Culture));
+                return new ValueTask<FunctionResult>(new FunctionResult(kernel, functionName, resultString));
             };
         }
 
@@ -453,7 +453,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
             return async static (kernel, functionName, result) =>
             {
                 var resultString = await ((Task<string>)ThrowIfNullResult(result)).ConfigureAwait(false);
-                return new FunctionResult(functionName, resultString, kernel.Culture);
+                return new FunctionResult(kernel, functionName, resultString);
             };
         }
 
@@ -462,16 +462,16 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
             return async static (kernel, functionName, result) =>
             {
                 var resultString = await ((ValueTask<string>)ThrowIfNullResult(result)).ConfigureAwait(false);
-                return new FunctionResult(functionName, resultString, kernel.Culture);
+                return new FunctionResult(kernel, functionName, resultString);
             };
         }
 
         if (returnType == typeof(FunctionResult))
         {
-            return static (_, functionName, result) =>
+            return static (kernel, functionName, result) =>
             {
                 var functionResult = (FunctionResult?)result;
-                return new ValueTask<FunctionResult>(functionResult ?? new FunctionResult(functionName));
+                return new ValueTask<FunctionResult>(functionResult ?? new FunctionResult(kernel, functionName));
             };
         }
 
@@ -499,7 +499,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
         {
             return (kernel, functionName, result) =>
             {
-                return new ValueTask<FunctionResult>(new FunctionResult(functionName, result, kernel.Culture));
+                return new ValueTask<FunctionResult>(new FunctionResult(kernel, functionName, result));
             };
         }
 
@@ -515,7 +515,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
                 await ((Task)ThrowIfNullResult(result)).ConfigureAwait(false);
 
                 var taskResult = Invoke(taskResultGetter, result, Array.Empty<object>());
-                return new FunctionResult(functionName, taskResult, kernel.Culture);
+                return new FunctionResult(kernel, functionName, taskResult);
             };
         }
 
@@ -531,7 +531,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
                 await task.ConfigureAwait(false);
 
                 var taskResult = Invoke(asTaskResultGetter, task, Array.Empty<object>());
-                return new FunctionResult(functionName, taskResult, kernel.Culture);
+                return new FunctionResult(kernel, functionName, taskResult);
             };
         }
 
@@ -552,10 +552,10 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
 
                     if (asyncEnumerator is not null)
                     {
-                        return new ValueTask<FunctionResult>(new FunctionResult(functionName, asyncEnumerator, kernel.Culture));
+                        return new ValueTask<FunctionResult>(new FunctionResult(kernel, functionName, asyncEnumerator));
                     }
 
-                    return new ValueTask<FunctionResult>(new FunctionResult(functionName));
+                    return new ValueTask<FunctionResult>(new FunctionResult(kernel, functionName));
                 };
             }
         }

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -129,7 +129,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
             (var textCompletion, var renderedPrompt, var renderedEventArgs) = await this.RenderPromptAsync(kernel, arguments, cancellationToken).ConfigureAwait(false);
             if (renderedEventArgs?.CancelToken.IsCancellationRequested ?? false)
             {
-                return new FunctionResult(this.Name)
+                return new FunctionResult(kernel, this.Name)
                 {
                     IsCancellationRequested = true
                 };
@@ -141,7 +141,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
 
             var modelResults = completionResults.Select(c => c.ModelResult).ToArray();
 
-            var result = new FunctionResult(this.Name, completion, kernel.Culture);
+            var result = new FunctionResult(kernel, this.Name, completion);
             result.Metadata.Add(AIFunctionResultExtensions.ModelResultsMetadataKey, modelResults);
             result.Metadata.Add(KernelEventArgsExtensions.RenderedPromptMetadataKey, renderedPrompt);
 

--- a/dotnet/src/SemanticKernel.UnitTests/Events/FunctionInvokedEventArgsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Events/FunctionInvokedEventArgsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Globalization;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Events;
 using Xunit;
@@ -12,7 +11,7 @@ public class FunctionInvokedEventArgsTests
     public void ResultValuePropertyShouldBeInitializedByOriginalOne()
     {
         //Arrange
-        var originalResults = new FunctionResult("fake-function-name", 36, CultureInfo.InvariantCulture);
+        var originalResults = new FunctionResult(new Kernel(), "fake-function-name", 36);
 
         var sut = new FunctionInvokedEventArgs(KernelFunctionFactory.CreateFromMethod(() => { }), new KernelArguments(), originalResults);
 
@@ -24,7 +23,7 @@ public class FunctionInvokedEventArgsTests
     public void ResultValuePropertyShouldBeUpdated()
     {
         //Arrange
-        var originalResults = new FunctionResult("fake-function-name", 36, CultureInfo.InvariantCulture);
+        var originalResults = new FunctionResult(new Kernel(), "fake-function-name", 36);
 
         var sut = new FunctionInvokedEventArgs(KernelFunctionFactory.CreateFromMethod(() => { }), new KernelArguments(), originalResults);
 

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/FunctionResultTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/FunctionResultTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Globalization;
 using Microsoft.SemanticKernel;
 using Xunit;
 
@@ -18,7 +17,7 @@ public class FunctionResultTests
         // Arrange
         string key = Guid.NewGuid().ToString();
         string value = Guid.NewGuid().ToString();
-        FunctionResult target = new("functionName");
+        FunctionResult target = new(new Kernel(), "functionName");
 
         // Act
         target.Metadata.Add(key, value);
@@ -33,7 +32,7 @@ public class FunctionResultTests
     {
         // Arrange
         string key = Guid.NewGuid().ToString();
-        FunctionResult target = new("functionName");
+        FunctionResult target = new(new Kernel(), "functionName");
 
         // Act,Assert
         Assert.False(target.TryGetMetadataValue(key, out string result));
@@ -46,7 +45,7 @@ public class FunctionResultTests
         // Arrange
         string key = Guid.NewGuid().ToString();
         int value = 42;
-        FunctionResult target = new("functionName");
+        FunctionResult target = new(new Kernel(), "functionName");
 
         // Act
         target.Metadata.Add(key, value);
@@ -61,7 +60,7 @@ public class FunctionResultTests
     {
         // Arrange
         string value = Guid.NewGuid().ToString();
-        FunctionResult target = new("functionName", value, CultureInfo.InvariantCulture);
+        FunctionResult target = new(new Kernel(), "functionName", value);
 
         // Act,Assert
         Assert.Equal(value, target.GetValue<string>());
@@ -71,7 +70,7 @@ public class FunctionResultTests
     public void GetValueReturnsNullWhenValueIsNull()
     {
         // Arrange
-        FunctionResult target = new("functionName");
+        FunctionResult target = new(new Kernel(), "functionName");
 
         // Act,Assert
         Assert.Null(target.GetValue<string>());
@@ -82,7 +81,7 @@ public class FunctionResultTests
     {
         // Arrange
         int value = 42;
-        FunctionResult target = new("functionName", value, CultureInfo.InvariantCulture);
+        FunctionResult target = new(new Kernel(), "functionName", value);
 
         // Act,Assert
         Assert.Throws<InvalidCastException>(() => target.GetValue<string>());
@@ -96,7 +95,7 @@ public class FunctionResultTests
         string pluginName = Guid.NewGuid().ToString();
 
         // Act
-        FunctionResult target = new(functionName);
+        FunctionResult target = new(new Kernel(), functionName);
 
         // Assert
         Assert.Equal(functionName, target.FunctionName);
@@ -110,7 +109,7 @@ public class FunctionResultTests
         string value = Guid.NewGuid().ToString();
 
         // Act
-        FunctionResult target = new(functionName, value, CultureInfo.InvariantCulture);
+        FunctionResult target = new(new Kernel(), functionName, value);
 
         // Assert
         Assert.Equal(functionName, target.FunctionName);
@@ -122,7 +121,7 @@ public class FunctionResultTests
     {
         // Arrange
         string value = Guid.NewGuid().ToString();
-        FunctionResult target = new("functionName", value, CultureInfo.InvariantCulture);
+        FunctionResult target = new(new Kernel(), "functionName", value);
 
         // Act and Assert
         Assert.Equal(value, target.ToString());

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionTests2.cs
@@ -659,7 +659,7 @@ public sealed class KernelFunctionTests2
     [Fact]
     public async Task ItSupportFunctionResultAsync()
     {
-        FunctionResult Test() => new("function-name", "fake-result", CultureInfo.InvariantCulture);
+        FunctionResult Test() => new(new Kernel(), "function-name", "fake-result");
 
         // Act
         var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
@@ -679,7 +679,7 @@ public sealed class KernelFunctionTests2
         // Arrange
         Task<FunctionResult> Test()
         {
-            var functionResult = new FunctionResult("function-name", "fake-result", CultureInfo.InvariantCulture);
+            var functionResult = new FunctionResult(new Kernel(), "function-name", "fake-result");
             return Task.FromResult(functionResult);
         }
 
@@ -701,7 +701,7 @@ public sealed class KernelFunctionTests2
         // Arrange
         ValueTask<FunctionResult> Test()
         {
-            var functionResult = new FunctionResult("function-name", "fake-result", CultureInfo.InvariantCulture);
+            var functionResult = new FunctionResult(new Kernel(), "function-name", "fake-result");
             return ValueTask.FromResult(functionResult);
         }
 

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionTests3.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionTests3.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -260,21 +259,21 @@ public sealed class KernelFunctionTests3
         [KernelFunction]
         public FunctionResult ReturnsFunctionResult()
         {
-            return new FunctionResult("fake-function-name", "fake-result", CultureInfo.InvariantCulture);
+            return new FunctionResult(new Kernel(), "fake-function-name", "fake-result");
         }
 
         [KernelFunction]
         public async Task<FunctionResult> ReturnsTaskFunctionResultAsync()
         {
             await Task.Delay(0);
-            return new FunctionResult("fake-function-name", "fake-result", CultureInfo.InvariantCulture);
+            return new FunctionResult(new Kernel(), "fake-function-name", "fake-result");
         }
 
         [KernelFunction]
         public async ValueTask<FunctionResult> ReturnsValueTaskFunctionResultAsync()
         {
             await Task.Delay(0);
-            return new FunctionResult("fake-function-name", "fake-result", CultureInfo.InvariantCulture);
+            return new FunctionResult(new Kernel(), "fake-function-name", "fake-result");
         }
 
         [KernelFunction]


### PR DESCRIPTION
### Motivation and Context
Currently, the 'FunctionResult' class requires access to the culture configured on a kernel instance to properly perform complex type to string conversion. Since we are already passing the Kernel everywhere - including kernel functions and connectors - passing an instance of the kernel to the 'FunctionResult' class seems like a natural thing to do.