### PR TITLE
Fix Assistant managment of Kernel completion service.

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example70_Assistant.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example70_Assistant.cs
@@ -105,9 +105,7 @@ public static class Example70_Assistant
             ["input"] = "Practice makes perfect."
         };
         var result = await kernel.InvokeAsync(assistants.Single(), arguments);
-        var resultValue = result.GetValue<string>();
-
-        var response = JsonSerializer.Deserialize<AssistantResponse>(resultValue ?? string.Empty);
+        var response = result.GetValue<AssistantResponse>();
         Console.WriteLine(
             response?.Response ??
             $"No response from assistant: {assistant.Id}");

--- a/dotnet/src/Experimental/Assistants/AssistantBuilder.Static.cs
+++ b/dotnet/src/Experimental/Assistants/AssistantBuilder.Static.cs
@@ -113,8 +113,7 @@ public partial class AssistantBuilder
         var resultModel =
             await restContext.GetAssistantModelAsync(assistantId, cancellationToken).ConfigureAwait(false) ??
             throw new KernelException($"Unexpected failure retrieving assistant: no result. ({assistantId})");
-        var chatService = new OpenAIChatCompletion(resultModel.Model, apiKey);
 
-        return new Assistant(resultModel, chatService, restContext, plugins);
+        return new Assistant(resultModel, restContext, plugins);
     }
 }

--- a/dotnet/src/Experimental/Assistants/AssistantBuilder.cs
+++ b/dotnet/src/Experimental/Assistants/AssistantBuilder.cs
@@ -51,7 +51,6 @@ public partial class AssistantBuilder
         return
             await Assistant.CreateAsync(
                 new OpenAIRestContext(this._apiKey!, this._httpClientProvider),
-                new OpenAIChatCompletion(this._model.Model, this._apiKey!),
                 this._model,
                 this._plugins,
                 cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Experimental/Assistants/Internal/Assistant.cs
+++ b/dotnet/src/Experimental/Assistants/Internal/Assistant.cs
@@ -3,13 +3,8 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.SemanticKernel.AI.ChatCompletion;
-using Microsoft.SemanticKernel.AI.TextCompletion;
-using Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
 using Microsoft.SemanticKernel.Experimental.Assistants.Extensions;
 using Microsoft.SemanticKernel.Experimental.Assistants.Models;
 
@@ -58,14 +53,12 @@ internal sealed class Assistant : IAssistant
     /// Create a new assistant.
     /// </summary>
     /// <param name="restContext">A context for accessing OpenAI REST endpoint</param>
-    /// <param name="chatService">An OpenAI chat service.</param>
     /// <param name="assistantModel">The assistant definition</param>
     /// <param name="plugins">Plugins to initialize as assistant tools</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>An initialized <see cref="Assistant"> instance.</see></returns>
     public static async Task<IAssistant> CreateAsync(
         OpenAIRestContext restContext,
-        OpenAIChatCompletion chatService,
         AssistantModel assistantModel,
         IEnumerable<IKernelPlugin>? plugins = null,
         CancellationToken cancellationToken = default)
@@ -74,7 +67,7 @@ internal sealed class Assistant : IAssistant
             await restContext.CreateAssistantModelAsync(assistantModel, cancellationToken).ConfigureAwait(false) ??
             throw new KernelException("Unexpected failure creating assistant: no result.");
 
-        return new Assistant(resultModel, chatService, restContext, plugins);
+        return new Assistant(resultModel, restContext, plugins);
     }
 
     /// <summary>
@@ -82,53 +75,65 @@ internal sealed class Assistant : IAssistant
     /// </summary>
     internal Assistant(
         AssistantModel model,
-        OpenAIChatCompletion chatService,
         OpenAIRestContext restContext,
         IEnumerable<IKernelPlugin>? plugins = null)
     {
         this._model = model;
         this._restContext = restContext;
 
-        var services = new ServiceCollection();
-        services.AddSingleton<IChatCompletion>(chatService);
-        services.AddSingleton<ITextCompletion>(chatService);
-        this.Kernel = new Kernel(services.BuildServiceProvider(), plugins is not null ? new KernelPluginCollection(plugins) : null);
+        var builder =
+            new KernelBuilder()
+                .WithOpenAIChatCompletion(this._model.Model, this._restContext.ApiKey);
+
+        if (plugins is not null)
+        {
+            builder.ConfigurePlugins(
+                c =>
+                {
+                    foreach (var plugin in plugins)
+                    {
+                        c.Add(plugin);
+                    }
+                });
+        }
+
+        this.Kernel = builder.Build();
     }
 
-    /// <inheritdoc/>
-    public Task<IChatThread> NewThreadAsync(CancellationToken cancellationToken = default)
-    {
-        return ChatThread.CreateAsync(this._restContext, cancellationToken);
-    }
+/// <inheritdoc/>
+public Task<IChatThread> NewThreadAsync(CancellationToken cancellationToken = default)
+{
+    return ChatThread.CreateAsync(this._restContext, cancellationToken);
+}
 
-    /// <inheritdoc/>
-    public Task<IChatThread> GetThreadAsync(string id, CancellationToken cancellationToken = default)
-    {
-        return ChatThread.GetAsync(this._restContext, id, cancellationToken);
-    }
+/// <inheritdoc/>
+public Task<IChatThread> GetThreadAsync(string id, CancellationToken cancellationToken = default)
+{
+    return ChatThread.GetAsync(this._restContext, id, cancellationToken);
+}
 
-    /// <summary>
-    /// Marshal thread run through <see cref="KernelFunction"/> interface.
-    /// </summary>
-    /// <param name="input">The user input</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>An assistant response (<see cref="AssistantResponse"/></returns>
-    [KernelFunction, Description("Provide input to assistant a response")]
-    public async Task<string> AskAsync(
-        [Description("The input for the assistant.")]
+/// <summary>
+/// Marshal thread run through <see cref="KernelFunction"/> interface.
+/// </summary>
+/// <param name="input">The user input</param>
+/// <param name="cancellationToken">A cancellation token.</param>
+/// <returns>An assistant response (<see cref="AssistantResponse"/></returns>
+[KernelFunction, Description("Provide input to assistant a response")]
+public async Task<AssistantResponse> AskAsync(
+    [Description("The input for the assistant.")]
         string input,
-        CancellationToken cancellationToken = default)
-    {
-        var thread = await this.NewThreadAsync(cancellationToken).ConfigureAwait(false);
-        await thread.AddUserMessageAsync(input, cancellationToken).ConfigureAwait(false);
-        var message = await thread.InvokeAsync(this, cancellationToken).ConfigureAwait(false);
-        var response =
-            new AssistantResponse
-            {
-                ThreadId = thread.Id,
-                Response = string.Concat(message.Select(m => m.Content)),
-            };
+    CancellationToken cancellationToken = default)
+{
+    var thread = await this.NewThreadAsync(cancellationToken).ConfigureAwait(false);
+    await thread.AddUserMessageAsync(input, cancellationToken).ConfigureAwait(false);
+    var message = await thread.InvokeAsync(this, cancellationToken).ConfigureAwait(false);
+    var response =
+        new AssistantResponse
+        {
+            ThreadId = thread.Id,
+            Response = string.Concat(message.Select(m => m.Content)),
+        };
 
-        return JsonSerializer.Serialize(response);
-    }
+    return response;
+}
 }


### PR DESCRIPTION
### Motivation and Context
Experimental assistant API broken

### Description
Recent changes made the ITextCompletion service unreachable.  Creating service in Assistant constructor an overall simplicitation anyway.

https://github.com/microsoft/semantic-kernel/issues/3787

Also addressed JSON serialization that is no longer required (performance).

### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
