### PR TITLE
.Net TypeConverterFactory utility class

### DIFF
--- a/dotnet/src/InternalUtilities/src/System/TypeConverterFactory.cs
+++ b/dotnet/src/InternalUtilities/src/System/TypeConverterFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Reflection;
 
 namespace Microsoft.SemanticKernel;

--- a/dotnet/src/InternalUtilities/src/System/TypeConverterFactory.cs
+++ b/dotnet/src/InternalUtilities/src/System/TypeConverterFactory.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using System;
+using System.Reflection;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Factory for creating TypeConverter instances based on a provided type.
+/// </summary>
+internal static class TypeConverterFactory
+{
+    /// <summary>
+    /// Returns a TypeConverter instance for the specified type.
+    /// </summary>
+    /// <param name="type">The Type of the object to convert.</param>
+    /// <returns>A TypeConverter instance if a suitable converter is found, otherwise null.</returns>
+    internal static TypeConverter? GetTypeConverter(Type type)
+    {
+        // In an ideal world, this would use TypeDescriptor.GetConverter. However, that is not friendly to
+        // any form of ahead-of-time compilation, as it could end up requiring functionality that was trimmed.
+        // Instead, we just use a hard-coded set of converters for the types we know about and then also support
+        // types that are explicitly attributed with TypeConverterAttribute.
+
+        if (type == typeof(string)) { return new StringConverter(); }
+        if (type == typeof(byte)) { return new ByteConverter(); }
+        if (type == typeof(sbyte)) { return new SByteConverter(); }
+        if (type == typeof(bool)) { return new BooleanConverter(); }
+        if (type == typeof(ushort)) { return new UInt16Converter(); }
+        if (type == typeof(short)) { return new Int16Converter(); }
+        if (type == typeof(char)) { return new CharConverter(); }
+        if (type == typeof(uint)) { return new UInt32Converter(); }
+        if (type == typeof(int)) { return new Int32Converter(); }
+        if (type == typeof(ulong)) { return new UInt64Converter(); }
+        if (type == typeof(long)) { return new Int64Converter(); }
+        if (type == typeof(float)) { return new SingleConverter(); }
+        if (type == typeof(double)) { return new DoubleConverter(); }
+        if (type == typeof(decimal)) { return new DecimalConverter(); }
+        if (type == typeof(TimeSpan)) { return new TimeSpanConverter(); }
+        if (type == typeof(DateTime)) { return new DateTimeConverter(); }
+        if (type == typeof(DateTimeOffset)) { return new DateTimeOffsetConverter(); }
+        if (type == typeof(Uri)) { return new UriTypeConverter(); }
+        if (type == typeof(Guid)) { return new GuidConverter(); }
+        if (type.IsEnum) { return new EnumConverter(type); }
+
+        if (type.GetCustomAttribute<TypeConverterAttribute>() is TypeConverterAttribute tca &&
+            Type.GetType(tca.ConverterTypeName, throwOnError: false) is Type converterType &&
+            Activator.CreateInstance(converterType) is TypeConverter converter)
+        {
+            return converter;
+        }
+
+        return null;
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/FunctionResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/FunctionResult.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Reflection;
 
 #pragma warning disable IDE0130
 namespace Microsoft.SemanticKernel;
@@ -146,7 +145,7 @@ public sealed class FunctionResult
             }
 
             // Look up and use a type converter.
-            if (GetTypeConverter(sourceType) is TypeConverter converter && converter.CanConvertTo(typeof(string)))
+            if (TypeConverterFactory.GetTypeConverter(sourceType) is TypeConverter converter && converter.CanConvertTo(typeof(string)))
             {
                 return (input, cultureInfo) =>
                 {
@@ -156,37 +155,6 @@ public sealed class FunctionResult
 
             return null;
         });
-
-    private static TypeConverter? GetTypeConverter(Type sourceType)
-    {
-        if (sourceType == typeof(byte)) { return new ByteConverter(); }
-        if (sourceType == typeof(sbyte)) { return new SByteConverter(); }
-        if (sourceType == typeof(bool)) { return new BooleanConverter(); }
-        if (sourceType == typeof(ushort)) { return new UInt16Converter(); }
-        if (sourceType == typeof(short)) { return new Int16Converter(); }
-        if (sourceType == typeof(char)) { return new CharConverter(); }
-        if (sourceType == typeof(uint)) { return new UInt32Converter(); }
-        if (sourceType == typeof(int)) { return new Int32Converter(); }
-        if (sourceType == typeof(ulong)) { return new UInt64Converter(); }
-        if (sourceType == typeof(long)) { return new Int64Converter(); }
-        if (sourceType == typeof(float)) { return new SingleConverter(); }
-        if (sourceType == typeof(double)) { return new DoubleConverter(); }
-        if (sourceType == typeof(decimal)) { return new DecimalConverter(); }
-        if (sourceType == typeof(TimeSpan)) { return new TimeSpanConverter(); }
-        if (sourceType == typeof(DateTime)) { return new DateTimeConverter(); }
-        if (sourceType == typeof(DateTimeOffset)) { return new DateTimeOffsetConverter(); }
-        if (sourceType == typeof(Uri)) { return new UriTypeConverter(); }
-        if (sourceType == typeof(Guid)) { return new GuidConverter(); }
-
-        if (sourceType.GetCustomAttribute<TypeConverterAttribute>() is TypeConverterAttribute tca &&
-            Type.GetType(tca.ConverterTypeName, throwOnError: false) is Type converterType &&
-            Activator.CreateInstance(converterType) is TypeConverter converter)
-        {
-            return converter;
-        }
-
-        return null;
-    }
 
     /// <summary>Converter functions for converting types to strings.</summary>
     private static readonly ConcurrentDictionary<Type, Func<object?, CultureInfo, string?>?> s_converters = new();

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -651,7 +651,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
             }
 
             // Finally, look up and use a type converter.  Again, special-case null if it was actually Nullable<T>.
-            if (GetTypeConverter(targetType) is TypeConverter converter && converter.CanConvertFrom(typeof(string)))
+            if (TypeConverterFactory.GetTypeConverter(targetType) is TypeConverter converter && converter.CanConvertFrom(typeof(string)))
             {
                 return (input, cultureInfo) =>
                 {
@@ -676,42 +676,6 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
             // Unsupported type.
             return null;
         });
-
-    private static TypeConverter? GetTypeConverter(Type targetType)
-    {
-        // In an ideal world, this would use TypeDescriptor.GetConverter. However, that is not friendly to
-        // any form of ahead-of-time compilation, as it could end up requiring functionality that was trimmed.
-        // Instead, we just use a hard-coded set of converters for the types we know about and then also support
-        // types that are explicitly attributed with TypeConverterAttribute.
-
-        if (targetType == typeof(byte)) { return new ByteConverter(); }
-        if (targetType == typeof(sbyte)) { return new SByteConverter(); }
-        if (targetType == typeof(bool)) { return new BooleanConverter(); }
-        if (targetType == typeof(ushort)) { return new UInt16Converter(); }
-        if (targetType == typeof(short)) { return new Int16Converter(); }
-        if (targetType == typeof(char)) { return new CharConverter(); }
-        if (targetType == typeof(uint)) { return new UInt32Converter(); }
-        if (targetType == typeof(int)) { return new Int32Converter(); }
-        if (targetType == typeof(ulong)) { return new UInt64Converter(); }
-        if (targetType == typeof(long)) { return new Int64Converter(); }
-        if (targetType == typeof(float)) { return new SingleConverter(); }
-        if (targetType == typeof(double)) { return new DoubleConverter(); }
-        if (targetType == typeof(decimal)) { return new DecimalConverter(); }
-        if (targetType == typeof(TimeSpan)) { return new TimeSpanConverter(); }
-        if (targetType == typeof(DateTime)) { return new DateTimeConverter(); }
-        if (targetType == typeof(DateTimeOffset)) { return new DateTimeOffsetConverter(); }
-        if (targetType == typeof(Uri)) { return new UriTypeConverter(); }
-        if (targetType == typeof(Guid)) { return new GuidConverter(); }
-
-        if (targetType.GetCustomAttribute<TypeConverterAttribute>() is TypeConverterAttribute tca &&
-            Type.GetType(tca.ConverterTypeName, throwOnError: false) is Type converterType &&
-            Activator.CreateInstance(converterType) is TypeConverter converter)
-        {
-            return converter;
-        }
-
-        return null;
-    }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => string.IsNullOrWhiteSpace(this.Description) ? this.Name : $"{this.Name} ({this.Description})";


### PR DESCRIPTION
### Motivation and Context

SK has two places where type conversion functionality is required: the 'FunctionResult' and 'KernelFunctionFromMethod' classes. In both cases, the functionality for searching and instantiating type converters is the same, so it makes sense to have it in one place for reuse.