### PR TITLE
Make KernelArguments _wrap_ rather than _be_ a Dictionary<>

### DIFF
--- a/dotnet/src/Extensions/TemplateEngine.Handlebars/HandlebarsPromptTemplate.cs
+++ b/dotnet/src/Extensions/TemplateEngine.Handlebars/HandlebarsPromptTemplate.cs
@@ -64,14 +64,15 @@ internal sealed class HandlebarsPromptTemplate : IPromptTemplate
             }
         }
 
-        if (arguments == null)
+        if (arguments is not null)
         {
-            return result;
-        }
-
-        foreach (var kvp in arguments)
-        {
-            result[kvp.Key] = kvp.Value;
+            foreach (var kvp in arguments)
+            {
+                if (kvp.Value is not null)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
         }
 
         return result;

--- a/dotnet/src/Functions/Functions.OpenAPI/Builders/QueryStringBuilder.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Builders/QueryStringBuilder.cs
@@ -24,7 +24,7 @@ internal static class QueryStringBuilder
     };
 
     ///<inheritdoc/>
-    public static string BuildQueryString(this RestApiOperation operation, IDictionary<string, string> arguments)
+    public static string BuildQueryString(this RestApiOperation operation, IDictionary<string, string?> arguments)
     {
         var segments = new List<string>();
 
@@ -32,7 +32,7 @@ internal static class QueryStringBuilder
 
         foreach (var parameter in parameters)
         {
-            if (!arguments.TryGetValue(parameter.Name, out var argument))
+            if (!arguments.TryGetValue(parameter.Name, out string? argument) || argument is null)
             {
                 //Throw an exception if the parameter is a required one but no value is provided.
                 if (parameter.IsRequired)

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/KernelOpenApiPluginExtensions.cs
@@ -286,14 +286,17 @@ public static class KernelOpenApiPluginExtensions
                 foreach (var parameter in restOperationParameters)
                 {
                     // A try to resolve argument by alternative parameter name
-                    if (!string.IsNullOrEmpty(parameter.AlternativeName) && variables.TryGetValue(parameter.AlternativeName!, out string? value))
+                    if (!string.IsNullOrEmpty(parameter.AlternativeName) &&
+                        variables.TryGetValue(parameter.AlternativeName!, out string? value) &&
+                        value is not null)
                     {
                         arguments.Add(parameter.Name, value);
                         continue;
                     }
 
                     // A try to resolve argument by original parameter name
-                    if (variables.TryGetValue(parameter.Name, out value))
+                    if (variables.TryGetValue(parameter.Name, out value) &&
+                        value is not null)
                     {
                         arguments.Add(parameter.Name, value);
                         continue;

--- a/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperation.cs
@@ -51,7 +51,7 @@ public sealed class RestApiOperation
     /// <summary>
     /// The operation headers.
     /// </summary>
-    public IDictionary<string, string> Headers { get; }
+    public IDictionary<string, string?> Headers { get; }
 
     /// <summary>
     /// The operation parameters.
@@ -87,7 +87,7 @@ public sealed class RestApiOperation
         HttpMethod method,
         string description,
         IList<RestApiOperationParameter> parameters,
-        IDictionary<string, string> headers,
+        IDictionary<string, string?> headers,
         RestApiOperationPayload? payload = null,
         IDictionary<string, RestApiOperationExpectedResponse>? responses = null)
     {
@@ -109,7 +109,7 @@ public sealed class RestApiOperation
     /// <param name="serverUrlOverride">Override for REST API operation server url.</param>
     /// <param name="apiHostUrl">The URL of REST API host.</param>
     /// <returns>The operation Url.</returns>
-    public Uri BuildOperationUrl(IDictionary<string, string> arguments, Uri? serverUrlOverride = null, Uri? apiHostUrl = null)
+    public Uri BuildOperationUrl(IDictionary<string, string?> arguments, Uri? serverUrlOverride = null, Uri? apiHostUrl = null)
     {
         var serverUrl = this.GetServerUrl(serverUrlOverride, apiHostUrl);
 
@@ -123,7 +123,7 @@ public sealed class RestApiOperation
     /// </summary>
     /// <param name="arguments">The operation arguments.</param>
     /// <returns>The rendered request headers.</returns>
-    public IDictionary<string, string> RenderHeaders(IDictionary<string, string> arguments)
+    public IDictionary<string, string> RenderHeaders(IDictionary<string, string?> arguments)
     {
         var headers = new Dictionary<string, string>();
 
@@ -133,16 +133,16 @@ public sealed class RestApiOperation
             var headerValue = header.Value;
 
             //A try to resolve header value in arguments.
-            if (arguments.TryGetValue(headerName, out var value))
+            if (arguments.TryGetValue(headerName, out string? value) && !string.IsNullOrEmpty(value))
             {
-                headers.Add(headerName, value);
+                headers.Add(headerName, value!);
                 continue;
             }
 
             //Header value is already supplied.
             if (!string.IsNullOrEmpty(headerValue))
             {
-                headers.Add(headerName, headerValue);
+                headers.Add(headerName, headerValue!);
                 continue;
             }
 
@@ -177,14 +177,14 @@ public sealed class RestApiOperation
     /// <param name="path">Operation path to replace parameters in.</param>
     /// <param name="arguments">Arguments to replace parameters by.</param>
     /// <returns>Path with replaced parameters</returns>
-    private string ReplacePathParameters(string path, IDictionary<string, string> arguments)
+    private string ReplacePathParameters(string path, IDictionary<string, string?> arguments)
     {
         string ReplaceParameter(Match match)
         {
             var parameterName = match.Groups[1].Value;
 
             //A try to find parameter value in arguments
-            if (arguments.TryGetValue(parameterName, out var value))
+            if (arguments.TryGetValue(parameterName, out string? value) && value is not null)
             {
                 return value;
             }

--- a/dotnet/src/Functions/Functions.OpenAPI/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/OpenApi/OpenApiDocumentParser.cs
@@ -193,7 +193,7 @@ internal sealed class OpenApiDocumentParser : IOpenApiDocumentParser
                 new HttpMethod(method),
                 string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description,
                 CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters),
-                CreateRestApiOperationHeaders(operationItem.Parameters),
+                CreateRestApiOperationHeaders(operationItem.Parameters)!,
                 CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                 CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(item => item.Item1, item => item.Item2)
             );

--- a/dotnet/src/Functions/Functions.OpenAPI/RestApiOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/RestApiOperationRunner.cs
@@ -193,11 +193,7 @@ internal sealed class RestApiOperationRunner
     {
         var contentType = content.Headers.ContentType;
 
-        var mediaType = contentType?.MediaType;
-        if (mediaType is null)
-        {
-            throw new KernelException("No media type available.");
-        }
+        var mediaType = contentType?.MediaType ?? throw new KernelException("No media type available.");
 
         // Obtain the content serializer by media type (e.g., text/plain, application/json, image/jpg)
         if (!s_serializerByContentType.TryGetValue(mediaType, out var serializer))
@@ -308,7 +304,7 @@ internal sealed class RestApiOperationRunner
                 continue;
             }
 
-            if (arguments.TryGetValue(argumentName, out var propertyValue))
+            if (arguments.TryGetValue(argumentName, out string? propertyValue) && propertyValue is not null)
             {
                 result.Add(propertyMetadata.Name, ConvertJsonPropertyValueType(propertyValue, propertyMetadata));
                 continue;

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Builders/QueryStringBuilderTests.cs
@@ -38,9 +38,9 @@ public class QueryStringBuilderTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter> { firstParameterMetadata, secondParameterMetadata },
-            new Dictionary<string, string>());
+            new Dictionary<string, string?>());
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "v1" },
             { "p2", "v2" }
@@ -80,9 +80,9 @@ public class QueryStringBuilderTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter> { firstParameterMetadata, secondParameterMetadata },
-            new Dictionary<string, string>());
+            new Dictionary<string, string?>());
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p2", "v2" }
         };
@@ -121,9 +121,9 @@ public class QueryStringBuilderTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter> { firstParameterMetadata, secondParameterMetadata },
-            new Dictionary<string, string>());
+            new Dictionary<string, string?>());
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p2", "v2" }
         };
@@ -151,12 +151,12 @@ public class QueryStringBuilderTests
                 style: RestApiOperationParameterStyle.Form)
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", $"p1_value{specialSymbol}" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var queryString = operation.BuildQueryString(arguments);
@@ -191,13 +191,13 @@ public class QueryStringBuilderTests
                 arrayItemType: "integer")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\",\"c\"]" },
             { "p2", "[1,2,3]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -232,13 +232,13 @@ public class QueryStringBuilderTests
                 arrayItemType: "integer")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\",\"c\"]" },
             { "p2", "[1,2,3]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -272,13 +272,13 @@ public class QueryStringBuilderTests
                 style: RestApiOperationParameterStyle.Form)
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "v1" },
             { "p2", "true" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -313,13 +313,13 @@ public class QueryStringBuilderTests
                 arrayItemType: "integer")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\",\"c\"]" },
             { "p2", "[1,2,3]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -354,13 +354,13 @@ public class QueryStringBuilderTests
                 arrayItemType: "integer")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\",\"c\"]" },
             { "p2", "[1,2,3]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -395,13 +395,13 @@ public class QueryStringBuilderTests
                 arrayItemType: "integer")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\",\"c\"]" },
             { "p2", "[1,2,3]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -436,13 +436,13 @@ public class QueryStringBuilderTests
                 arrayItemType: "integer")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\",\"c\"]" },
             { "p2", "[1,2,3]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);
@@ -481,7 +481,7 @@ public class QueryStringBuilderTests
             new(name : "p7", type : "array", isRequired : true, expand : true, location : RestApiOperationParameterLocation.Query, style : RestApiOperationParameterStyle.PipeDelimited),
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "p1", "[\"a\",\"b\"]" },
             { "p2", "false" },
@@ -492,7 +492,7 @@ public class QueryStringBuilderTests
             { "p7", "[\"e\",\"f\"]" }
         };
 
-        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string>());
+        var operation = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "fake_path", HttpMethod.Get, "fake_description", metadata, new Dictionary<string, string?>());
 
         // Act
         var result = operation.BuildQueryString(arguments);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/RestApiOperationExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/Extensions/RestApiOperationExtensionsTests.cs
@@ -274,7 +274,7 @@ public class RestApiOperationExtensionsTests
                     method: new HttpMethod(method),
                     description: "fake-description",
                     parameters: new List<RestApiOperationParameter>(),
-                    headers: new Dictionary<string, string>(),
+                    headers: new Dictionary<string, string?>(),
                     payload: payload);
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationRunnerTests.cs
@@ -65,7 +65,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new Dictionary<string, string?>(),
             payload: null
         );
 
@@ -137,7 +137,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             HttpMethod.Post,
             "fake-description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>(),
+            new Dictionary<string, string?>(),
             payload: null
         );
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenAPI/RestApiOperationTests.cs
@@ -22,10 +22,10 @@ public class RestApiOperationTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>()
+            new Dictionary<string, string?>()
         );
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new Dictionary<string, string?>();
 
         // Act
         var url = sut.BuildOperationUrl(arguments);
@@ -45,12 +45,12 @@ public class RestApiOperationTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>()
+            new Dictionary<string, string?>()
         );
 
         var fakeHostUrlOverride = "https://fake-random-test-host-override";
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new Dictionary<string, string?>();
 
         // Act
         var url = sut.BuildOperationUrl(arguments, serverUrlOverride: new Uri(fakeHostUrlOverride));
@@ -70,10 +70,10 @@ public class RestApiOperationTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter>(),
-            new Dictionary<string, string>()
+            new Dictionary<string, string?>()
         );
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "fake-path-parameter", "fake-path-value" }
         };
@@ -104,9 +104,9 @@ public class RestApiOperationTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter> { parameterMetadata },
-            new Dictionary<string, string>());
+            new Dictionary<string, string?>());
 
-        var arguments = new Dictionary<string, string>();
+        var arguments = new Dictionary<string, string?>();
 
         // Act
         var url = sut.BuildOperationUrl(arguments);
@@ -141,11 +141,11 @@ public class RestApiOperationTests
             HttpMethod.Get,
             "fake_description",
             new List<RestApiOperationParameter> { firstParameterMetadata, secondParameterMetadata },
-            new Dictionary<string, string>());
+            new Dictionary<string, string?>());
 
         var fakeHostUrlOverride = "https://fake-random-test-host-override";
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "fake-path", "fake-path-value" },
         };
@@ -161,13 +161,13 @@ public class RestApiOperationTests
     public void ItShouldRenderHeaderValuesFromArguments()
     {
         // Arrange
-        var rawHeaders = new Dictionary<string, string>
+        var rawHeaders = new Dictionary<string, string?>
         {
             { "fake_header_one", string.Empty },
             { "fake_header_two", string.Empty }
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "fake_header_one", "fake_header_one_value" },
             { "fake_header_two", "fake_header_two_value" }
@@ -192,7 +192,7 @@ public class RestApiOperationTests
     public void ItShouldUseHeaderValuesIfTheyAreAlreadyProvided()
     {
         // Arrange
-        var rawHeaders = new Dictionary<string, string>
+        var rawHeaders = new Dictionary<string, string?>
         {
             { "fake_header_one", "fake_header_one_value" },
             { "fake_header_two", "fake_header_two_value" }
@@ -202,7 +202,7 @@ public class RestApiOperationTests
             rawHeaders);
 
         // Act
-        var headers = sut.RenderHeaders(new Dictionary<string, string>());
+        var headers = sut.RenderHeaders(new Dictionary<string, string?>());
 
         // Assert
         Assert.Equal(2, headers.Count);
@@ -218,7 +218,7 @@ public class RestApiOperationTests
     public void ItShouldThrowExceptionIfHeadersHaveNoValuesAndHeadersMetadataNotSupplied()
     {
         // Arrange
-        var rawHeaders = new Dictionary<string, string>
+        var rawHeaders = new Dictionary<string, string?>
         {
             { "fake_header_one", string.Empty },
             { "fake_header_two", string.Empty }
@@ -229,7 +229,7 @@ public class RestApiOperationTests
         var sut = new RestApiOperation("fake_id", new Uri("http://fake_url"), "fake_path", HttpMethod.Get, "fake_description", metadata, rawHeaders);
 
         // Act
-        void Act() => sut.RenderHeaders(new Dictionary<string, string>());
+        void Act() => sut.RenderHeaders(new Dictionary<string, string?>());
 
         // Assert
         Assert.Throws<KernelException>(Act);
@@ -239,7 +239,7 @@ public class RestApiOperationTests
     public void ShouldThrowExceptionIfNoValueProvidedForRequiredHeader()
     {
         // Arrange
-        var rawHeaders = new Dictionary<string, string>
+        var rawHeaders = new Dictionary<string, string?>
         {
             { "fake_header_one", string.Empty },
             { "fake_header_two", string.Empty }
@@ -254,7 +254,7 @@ public class RestApiOperationTests
         var sut = new RestApiOperation("fake_id", new Uri("http://fake_url"), "fake_path", HttpMethod.Get, "fake_description", metadata, rawHeaders);
 
         // Act
-        void Act() => sut.RenderHeaders(new Dictionary<string, string>());
+        void Act() => sut.RenderHeaders(new Dictionary<string, string?>());
 
         // Assert
         Assert.Throws<KernelException>(Act);
@@ -264,7 +264,7 @@ public class RestApiOperationTests
     public void ItShouldSkipOptionalHeaderHavingNeitherValueNorDefaultValue()
     {
         // Arrange
-        var rawHeaders = new Dictionary<string, string>
+        var rawHeaders = new Dictionary<string, string?>
         {
             { "fake_header_one", string.Empty },
             { "fake_header_two", string.Empty }
@@ -276,7 +276,7 @@ public class RestApiOperationTests
             new(name : "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple)
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "fake_header_one", "fake_header_one_value" }
         };
@@ -297,7 +297,7 @@ public class RestApiOperationTests
     public void ShouldUseDefaultValueForOptionalHeaderIfNoValueProvided()
     {
         // Arrange
-        var rawHeaders = new Dictionary<string, string>
+        var rawHeaders = new Dictionary<string, string?>
         {
             { "fake_header_one", string.Empty },
             { "fake_header_two", string.Empty }
@@ -309,7 +309,7 @@ public class RestApiOperationTests
             new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple, defaultValue: "fake_header_two_default_value")
         };
 
-        var arguments = new Dictionary<string, string>
+        var arguments = new Dictionary<string, string?>
         {
             { "fake_header_one", "fake_header_one_value" } //Argument is only provided for the first parameter and not for the second one
         };

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsTemplateEngineExtensions.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsTemplateEngineExtensions.cs
@@ -418,15 +418,7 @@ internal sealed class HandlebarsTemplateEngineExtensions
         foreach (var v in variables)
         {
             var value = v.Value ?? "";
-            var varString = !KernelParameterMetadataExtensions.IsPrimitiveOrStringType(value.GetType()) ? JsonSerializer.Serialize(value) : value.ToString();
-            if (state.ContainsKey(v.Key))
-            {
-                state[v.Key] = varString;
-            }
-            else
-            {
-                state.Add(v.Key, varString);
-            }
+            state[v.Key] = !KernelParameterMetadataExtensions.IsPrimitiveOrStringType(value.GetType()) ? JsonSerializer.Serialize(value) : value.ToString();
         }
     }
 

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelArguments.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelArguments.cs
@@ -1,18 +1,28 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.SemanticKernel.AI;
 
+#pragma warning disable CA1710 // Identifiers should have correct suffix
 #pragma warning disable IDE0130
+
 namespace Microsoft.SemanticKernel;
-#pragma warning restore IDE0130
 
 /// <summary>
-/// Represents arguments for various SK component methods, such as KernelFunction.InvokeAsync, Kernel.InvokeAsync, IPromptTemplate.RenderAsync, and more.
+/// Provides a collection of arguments for operations such as <see cref="KernelFunction.InvokeAsync"/>,
+/// and <see cref="IPromptTemplate.RenderAsync"/>.
 /// </summary>
-public sealed class KernelArguments : Dictionary<string, string>
+/// <remarks>
+/// A <see cref="KernelArguments"/> is a dictionary of argument names and values. It also carries a
+/// <see cref="PromptExecutionSettings"/>, accessible via the <see cref="ExecutionSettings"/> property.
+/// </remarks>
+public sealed class KernelArguments : IDictionary<string, string?>, IReadOnlyDictionary<string, string?>
 {
+    /// <summary>Dictionary of name/values for all the arguments in the instance.</summary>
+    private readonly Dictionary<string, string?> _arguments;
+
     /// <summary>
     /// The main input parameter name.
     /// </summary>
@@ -22,8 +32,9 @@ public sealed class KernelArguments : Dictionary<string, string>
     /// Initializes a new instance of the <see cref="KernelArguments"/> class with the specified AI request settings.
     /// </summary>
     /// <param name="executionSettings">The prompt execution settings.</param>
-    public KernelArguments(PromptExecutionSettings? executionSettings = null) : base(StringComparer.OrdinalIgnoreCase)
+    public KernelArguments(PromptExecutionSettings? executionSettings = null)
     {
+        this._arguments = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         this.ExecutionSettings = executionSettings;
     }
 
@@ -31,22 +42,155 @@ public sealed class KernelArguments : Dictionary<string, string>
     /// Initializes a new instance of the <see cref="KernelArguments"/> class that contains elements copied from the specified <see cref="IDictionary{TKey, TValue}"/>
     /// </summary>
     /// <param name="source">The <see cref="IDictionary{TKey, TValue}"/> whose elements are copied the new <see cref="KernelArguments"/>.</param>
-    public KernelArguments(IDictionary<string, string> source) : this()
+    /// <remarks>If the source is a <see cref="KernelArguments"/>, its elements and <see cref="ExecutionSettings"/> are copied to this instance.</remarks>
+    public KernelArguments(IDictionary<string, string?> source)
     {
-        foreach (var x in source) { this[x.Key] = x.Value; }
+        Verify.NotNull(source);
+
+        this._arguments = new Dictionary<string, string?>(source, StringComparer.OrdinalIgnoreCase);
+        this.ExecutionSettings = (source as KernelArguments)?.ExecutionSettings;
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="KernelArguments"/> class that contains AI request settings and elements copied from the specified <see cref="KernelArguments"/>
-    /// </summary>
-    /// <param name="other">The <see cref="KernelArguments"/> whose AI request setting and elements are copied to the new <see cref="KernelArguments"/>.</param>
-    public KernelArguments(KernelArguments other) : this(other as IDictionary<string, string>)
-    {
-        this.ExecutionSettings = other.ExecutionSettings;
-    }
-
-    /// <summary>
-    /// Gets or sets the prompt execution settings
+    /// Gets or sets the prompt execution settings.
     /// </summary>
     public PromptExecutionSettings? ExecutionSettings { get; set; }
+
+    /// <summary>
+    /// Gets the number of arguments contained in the <see cref="KernelArguments"/>.
+    /// </summary>
+    public int Count => this._arguments.Count;
+
+    /// <summary>Adds the specified argument name and value to the <see cref="KernelArguments"/>.</summary>
+    /// <param name="name">The name of the argument to add.</param>
+    /// <param name="value">The value of the argument to add.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    /// <exception cref="ArgumentException">An argument with the same name already exists in the <see cref="KernelArguments"/>.</exception>
+    public void Add(string name, string value)
+    {
+        Verify.NotNull(name);
+        this._arguments.Add(name, value);
+    }
+
+    /// <summary>Removes the argument value with the specified name from the <see cref="KernelArguments"/>.</summary>
+    /// <param name="name">The name of the argument value to remove.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    public bool Remove(string name)
+    {
+        Verify.NotNull(name);
+        return this._arguments.Remove(name);
+    }
+
+    /// <summary>Removes all arguments names and values from the <see cref="KernelArguments"/>.</summary>
+    /// <remarks>
+    /// This does not affect the <see cref="ExecutionSettings"/> property. To clear it as well, set it to null.
+    /// </remarks>
+    public void Clear() => this._arguments.Clear();
+
+    /// <summary>Determines whether the <see cref="KernelArguments"/> contains an argument with the specified name.</summary>
+    /// <param name="name">The name of the argument to locate.</param>
+    /// <returns>true if the arguments contains an argument with the specified named; otherwise, false.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    public bool ContainsName(string name)
+    {
+        Verify.NotNull(name);
+        return this._arguments.ContainsKey(name);
+    }
+
+    /// <summary>Gets the value associated with the specified argument name.</summary>
+    /// <param name="name">The name of the argument value to get.</param>
+    /// <param name="value">
+    /// When this method returns, contains the value associated with the specified name,
+    /// if the name is found; otherwise, null.
+    /// </param>
+    /// <returns>true if the arguments contains an argument with the specified name; otherwise, false.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    public bool TryGetValue(string name, out string? value)
+    {
+        Verify.NotNull(name);
+        return this._arguments.TryGetValue(name, out value);
+    }
+
+    /// <summary>Gets or sets the value associated with the specified argument name.</summary>
+    /// <param name="name">The name of the argument value to get or set.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    public string? this[string name]
+    {
+        get
+        {
+            Verify.NotNull(name);
+            return this._arguments[name];
+        }
+        set
+        {
+            Verify.NotNull(name);
+            this._arguments[name] = value;
+        }
+    }
+
+    /// <summary>Gets an <see cref="ICollection{String}"/> of all of the arguments' names.</summary>
+    public ICollection<string> Names => this._arguments.Keys;
+
+    /// <summary>Gets an <see cref="ICollection{String}"/> of all of the arguments' values.</summary>
+    public ICollection<string?> Values => this._arguments.Values;
+
+    #region Interface implementations
+    /// <inheritdoc/>
+    ICollection<string> IDictionary<string, string?>.Keys => this._arguments.Keys;
+
+    /// <inheritdoc/>
+    IEnumerable<string> IReadOnlyDictionary<string, string?>.Keys => this._arguments.Keys;
+
+    /// <inheritdoc/>
+    IEnumerable<string?> IReadOnlyDictionary<string, string?>.Values => this._arguments.Values;
+
+    /// <inheritdoc/>
+    bool ICollection<KeyValuePair<string, string?>>.IsReadOnly => false;
+
+    /// <inheritdoc/>
+    string? IReadOnlyDictionary<string, string?>.this[string key] => this._arguments[key];
+
+    /// <inheritdoc/>
+    string? IDictionary<string, string?>.this[string key]
+    {
+        get => this._arguments[key];
+        set => this._arguments[key] = value;
+    }
+
+    /// <inheritdoc/>
+    void IDictionary<string, string?>.Add(string key, string? value) => this._arguments.Add(key, value);
+
+    /// <inheritdoc/>
+    bool IDictionary<string, string?>.ContainsKey(string key) => this._arguments.ContainsKey(key);
+
+    /// <inheritdoc/>
+    bool IDictionary<string, string?>.Remove(string key) => this._arguments.Remove(key);
+
+    /// <inheritdoc/>
+    bool IDictionary<string, string?>.TryGetValue(string key, out string? value) => this._arguments.TryGetValue(key, out value);
+
+    /// <inheritdoc/>
+    void ICollection<KeyValuePair<string, string?>>.Add(KeyValuePair<string, string?> item) => this._arguments.Add(item.Key, item.Value);
+
+    /// <inheritdoc/>
+    bool ICollection<KeyValuePair<string, string?>>.Contains(KeyValuePair<string, string?> item) => ((ICollection<KeyValuePair<string, string?>>)this._arguments).Contains(item);
+
+    /// <inheritdoc/>
+    void ICollection<KeyValuePair<string, string?>>.CopyTo(KeyValuePair<string, string?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, string?>>)this._arguments).CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    bool ICollection<KeyValuePair<string, string?>>.Remove(KeyValuePair<string, string?> item) => this._arguments.Remove(item.Key);
+
+    /// <inheritdoc/>
+    IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator() => this._arguments.GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => this._arguments.GetEnumerator();
+
+    /// <inheritdoc/>
+    bool IReadOnlyDictionary<string, string?>.ContainsKey(string key) => this._arguments.ContainsKey(key);
+
+    /// <inheritdoc/>
+    bool IReadOnlyDictionary<string, string?>.TryGetValue(string key, out string? value) => this._arguments.TryGetValue(key, out value);
+    #endregion
 }

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -359,14 +359,15 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
                 // 3. Otherwise, use "input" if this is the first (or only) parameter.
                 if (fallBackToInput)
                 {
-                    return Process(arguments.TryGetValue(KernelArguments.InputParameterName, out string? input) ? input : string.Empty);
+                    arguments.TryGetValue(KernelArguments.InputParameterName, out string? input);
+                    return Process(input);
                 }
 
                 // 4. Otherwise, fail.
                 throw new KernelException($"Missing value for parameter '{name}'",
                     new ArgumentException("Missing value function parameter", name));
 
-                object? Process(string value)
+                object? Process(string? value)
                 {
                     if (type == typeof(string))
                     {
@@ -618,7 +619,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
     /// Parsing is first attempted using the current culture, and if that fails, it tries again
     /// with the invariant culture. If both fail, an exception is thrown.
     /// </remarks>
-    private static Func<string, CultureInfo, object?>? GetParser(Type targetType) =>
+    private static Func<string?, CultureInfo, object?>? GetParser(Type targetType) =>
         s_parsers.GetOrAdd(targetType, static targetType =>
         {
             // Strings just parse to themselves.
@@ -726,7 +727,7 @@ internal sealed class KernelFunctionFromMethod : KernelFunction
     private static readonly Regex s_invalidNameCharsRegex = new("[^0-9A-Za-z_]");
 
     /// <summary>Parser functions for converting strings to parameter types.</summary>
-    private static readonly ConcurrentDictionary<Type, Func<string, CultureInfo, object?>?> s_parsers = new();
+    private static readonly ConcurrentDictionary<Type, Func<string?, CultureInfo, object?>?> s_parsers = new();
 
     #endregion
 }

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -214,7 +214,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     {
         foreach (var parameter in this._promptConfig.InputParameters)
         {
-            if (!arguments.ContainsKey(parameter.Name) && parameter.DefaultValue != null)
+            if (!arguments.ContainsName(parameter.Name) && parameter.DefaultValue != null)
             {
                 arguments[parameter.Name] = parameter.DefaultValue;
             }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/VarBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/VarBlock.cs
@@ -75,7 +75,7 @@ internal sealed class VarBlock : Block, ITextRendering
 
         if (arguments.TryGetValue(this.Name, out string? value))
         {
-            return value;
+            return value ?? string.Empty;
         }
 
         this.Logger.LogWarning("Variable `{0}{1}` not found", Symbols.VarPrefix, this.Name);

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelArgumentsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelArgumentsTests.cs
@@ -27,7 +27,7 @@ public class KernelArgumentsTests
         KernelArguments sut = new(executionSettings) { };
 
         // Assert
-        Assert.Equal(executionSettings, sut.ExecutionSettings);
+        Assert.Same(executionSettings, sut.ExecutionSettings);
         Assert.Empty(sut);
     }
 
@@ -55,7 +55,7 @@ public class KernelArgumentsTests
         KernelArguments sut = new(executionSettings) { { "fake-key", "fake-value" } };
 
         // Assert
-        Assert.Equal(executionSettings, sut.ExecutionSettings);
+        Assert.Same(executionSettings, sut.ExecutionSettings);
 
         var argument = Assert.Single(sut);
         Assert.Equal("fake-key", argument.Key);
@@ -68,31 +68,31 @@ public class KernelArgumentsTests
         //Constructor 1
         var executionSettings = new PromptExecutionSettings();
         KernelArguments sut = new(executionSettings) { { "FAKE-key", "fake-value" } };
-        Assert.True(sut.ContainsKey("fake-key"));
+        Assert.True(sut.ContainsName("fake-key"));
 
         //Constructor 2
-        IDictionary<string, string> source = new Dictionary<string, string> { { "FAKE-key", "fake-value" } };
+        IDictionary<string, string?> source = new Dictionary<string, string?> { { "FAKE-key", "fake-value" } };
         sut = new(source);
-        Assert.True(sut.ContainsKey("fake-key"));
+        Assert.True(sut.ContainsName("fake-key"));
 
         //Constructor 3
         KernelArguments other = new() { { "FAKE-key", "fake-value" } };
         sut = new(other);
-        Assert.True(sut.ContainsKey("fake-key"));
+        Assert.True(sut.ContainsName("fake-key"));
     }
 
     [Fact]
     public void ItCanBeInitializedFromIDictionary()
     {
         // Arrange
-        IDictionary<string, string> source = new Dictionary<string, string> { { "fake-key", "fake-value" } };
+        IDictionary<string, string?> source = new Dictionary<string, string?> { { "fake-key", "fake-value" } };
 
         // Act
         KernelArguments sut = new(source);
 
         // Assert
         Assert.Single(sut);
-        Assert.True(sut.ContainsKey("fake-key"));
+        Assert.True(sut.ContainsName("fake-key"));
         Assert.Equal("fake-value", sut["fake-key"]);
 
         Assert.Null(sut.ExecutionSettings);
@@ -110,9 +110,9 @@ public class KernelArgumentsTests
 
         // Assert
         Assert.Single(sut);
-        Assert.True(sut.ContainsKey("fake-key"));
+        Assert.True(sut.ContainsName("fake-key"));
         Assert.Equal("fake-value", sut["fake-key"]);
 
-        Assert.Equal(executionSettings, sut.ExecutionSettings);
+        Assert.Same(executionSettings, sut.ExecutionSettings);
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionTests2.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionTests2.cs
@@ -863,7 +863,7 @@ public sealed class KernelFunctionTests2
         var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => function.InvokeAsync(this._kernel, arguments));
 
         //Assert
-        AssertExtensions.AssertIsArgumentOutOfRange(ex, "g", arguments["g"]);
+        AssertExtensions.AssertIsArgumentOutOfRange(ex, "g", arguments["g"]!);
     }
 
     [Fact]


### PR DESCRIPTION
Having it just implement the interfaces makes it more future proof should we ever want to do anything special in any of the methods in the implementation. It also lets us change "key" to "name". Also fix the nullability of its value and propagate those changes to address resulting warnings.