### PR TITLE
.Net: Remove KernelBuilder.ConfigurePlugins and WithCulture

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
@@ -29,12 +29,9 @@ public static class Example59_OpenAIFunctionCalling
             {
                 services.AddLogging(services => services.AddConsole().SetMinimumLevel(LogLevel.Trace));
             })
-            .ConfigurePlugins(plugins =>
-            {
-                plugins.AddPluginFromObject<TimePlugin>();
-                plugins.AddPluginFromObject<WidgetPlugin>();
-            })
             .Build();
+        var time = kernel.ImportPluginFromObject<TimePlugin>();
+        var widget = kernel.ImportPluginFromObject<WidgetPlugin>();
 
         // Load additional functions into the kernel
         await kernel.ImportPluginFromOpenAIAsync("KlarnaShoppingPlugin", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"));
@@ -44,7 +41,7 @@ public static class Example59_OpenAIFunctionCalling
         var executionSettings = new OpenAIPromptExecutionSettings();
 
         // Set FunctionCall to the result of FunctionCallBehavior.RequireFunction with a specific function to force the model to use that function.
-        executionSettings.FunctionCallBehavior = FunctionCallBehavior.RequireFunction(kernel.Plugins["TimePlugin"]["Date"].Metadata.ToOpenAIFunction(), autoInvoke: true);
+        executionSettings.FunctionCallBehavior = FunctionCallBehavior.RequireFunction(time["Date"].Metadata.ToOpenAIFunction(), autoInvoke: true);
         await CompleteChatWithFunctionsAsync("What day is today?", chatHistory, chatCompletion, kernel, executionSettings);
 
         // Set FunctionCall to FunctionCallBehavior.ProvideKernelFunctions to let the model choose the best function to use from all available in the kernel.
@@ -54,7 +51,7 @@ public static class Example59_OpenAIFunctionCalling
         await StreamingCompleteChatWithFunctionsAsync("What computer tablets are available for under $200?", chatHistory, chatCompletion, kernel, executionSettings);
 
         // This sample relies on the AI picking the correct color from an enum
-        executionSettings.FunctionCallBehavior = FunctionCallBehavior.RequireFunction(kernel.Plugins["WidgetPlugin"]["CreateWidget"].Metadata.ToOpenAIFunction(), autoInvoke: true);
+        executionSettings.FunctionCallBehavior = FunctionCallBehavior.RequireFunction(widget["CreateWidget"].Metadata.ToOpenAIFunction(), autoInvoke: true);
         await CompleteChatWithFunctionsAsync("Create a lime widget called foo", chatHistory, chatCompletion, kernel, executionSettings);
         await CompleteChatWithFunctionsAsync("Create a scarlet widget called bar", chatHistory, chatCompletion, kernel, executionSettings);
     }

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/KernelFunctionMetadataExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/KernelFunctionMetadataExtensionsTests.cs
@@ -153,9 +153,8 @@ public sealed class KernelFunctionMetadataExtensionsTests
     public void ItCanCreateValidOpenAIFunctionManual()
     {
         // Arrange
-        var kernel = new KernelBuilder()
-            .ConfigurePlugins(plugins => plugins.AddPluginFromObject<MyPlugin>("MyPlugin"))
-            .Build();
+        var kernel = new Kernel();
+        kernel.ImportPluginFromObject<MyPlugin>();
 
         var functionView = kernel.Plugins["MyPlugin"].First().Metadata;
 

--- a/dotnet/src/IntegrationTests/Extensions/KernelFunctionExtensionsTests.cs
+++ b/dotnet/src/IntegrationTests/Extensions/KernelFunctionExtensionsTests.cs
@@ -29,8 +29,8 @@ public sealed class KernelFunctionExtensionsTests : IDisposable
         Kernel target = new KernelBuilder()
             .WithLoggerFactory(this._logger)
             .ConfigureServices(c => c.AddSingleton<ITextCompletion>(new RedirectTextCompletion()))
-            .ConfigurePlugins(plugins => plugins.AddPluginFromObject<EmailPluginFake>())
             .Build();
+        target.ImportPluginFromObject<EmailPluginFake>();
 
         var prompt = $"Hey {{{{{nameof(EmailPluginFake)}.GetEmailAddress}}}}";
 
@@ -47,8 +47,8 @@ public sealed class KernelFunctionExtensionsTests : IDisposable
         Kernel target = new KernelBuilder()
             .WithLoggerFactory(this._logger)
             .ConfigureServices(c => c.AddSingleton<ITextCompletion>(new RedirectTextCompletion()))
-            .ConfigurePlugins(plugins => plugins.AddPluginFromObject<EmailPluginFake>())
             .Build();
+        target.ImportPluginFromObject<EmailPluginFake>();
 
         var prompt = $"Hey {{{{{nameof(EmailPluginFake)}.GetEmailAddress \"a person\"}}}}";
 

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelBuilderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelBuilderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,51 +22,15 @@ public class KernelBuilderTests
     {
         KernelBuilder builder = new();
         Assert.NotSame(builder.Build(), builder.Build());
-
-        builder.WithCulture(CultureInfo.InvariantCulture);
-        Assert.NotSame(builder.Build(), builder.Build());
     }
 
     [Fact]
     public void ItReturnsItselfFromWitherMethods()
     {
         KernelBuilder builder = new();
-        Assert.Same(builder, builder.WithCulture(CultureInfo.InvariantCulture));
         Assert.Same(builder, builder.WithLoggerFactory(NullLoggerFactory.Instance));
         Assert.Same(builder, builder.WithAIServiceSelector(null));
-        Assert.Same(builder, builder.ConfigurePlugins(plugins => { }));
-        Assert.Same(builder, builder.ConfigurePlugins((serviceProvider, plugins) => { }));
         Assert.Same(builder, builder.ConfigureServices(services => { }));
-    }
-
-    [Fact]
-    public void ItSupportsResettingCulture()
-    {
-        CultureInfo last = new("fr-FR");
-
-        KernelBuilder builder = new KernelBuilder().WithCulture(CultureInfo.CurrentCulture);
-        Assert.Same(CultureInfo.CurrentCulture, builder.Build().Culture);
-
-        builder.WithCulture(null);
-        Assert.Same(CultureInfo.InvariantCulture, builder.Build().Culture);
-
-        builder.WithCulture(last);
-        Assert.Same(last, builder.Build().Culture);
-    }
-
-    [Fact]
-    public void ItSupportsOverwritingCulture()
-    {
-        CultureInfo last = new("fr-FR");
-
-        Kernel kernel = new KernelBuilder()
-            .WithCulture(CultureInfo.InvariantCulture)
-            .WithCulture(null)
-            .WithCulture(CultureInfo.CurrentCulture)
-            .WithCulture(last)
-            .Build();
-
-        Assert.Same(last, kernel.Culture);
     }
 
     [Fact]
@@ -83,98 +46,6 @@ public class KernelBuilderTests
             .Build();
 
         Assert.Same(loggerFactory2, kernel.GetService<ILoggerFactory>());
-    }
-
-    [Fact]
-    public void ItPropagatesPluginsToBuiltKernel()
-    {
-        IKernelPlugin plugin1 = new KernelPlugin("plugin1");
-        IKernelPlugin plugin2 = new KernelPlugin("plugin2");
-
-        Kernel kernel = new KernelBuilder()
-            .ConfigurePlugins(plugins =>
-            {
-                Assert.NotNull(plugins);
-                Assert.Empty(plugins);
-                plugins.Add(plugin1);
-                plugins.Add(plugin2);
-            })
-            .Build();
-
-        Assert.Contains(plugin1, kernel.Plugins);
-        Assert.Contains(plugin2, kernel.Plugins);
-    }
-
-    [Fact]
-    public void ItAugmentsPluginsWithMultipleCalls()
-    {
-        IKernelPlugin plugin1 = new KernelPlugin("plugin1");
-        IKernelPlugin plugin2 = new KernelPlugin("plugin2");
-
-        // Delegate taking just plugins
-        Kernel kernel = new KernelBuilder()
-            .ConfigurePlugins(plugins =>
-            {
-                Assert.NotNull(plugins);
-                Assert.Empty(plugins);
-                plugins.Add(plugin1);
-            })
-            .ConfigurePlugins(plugins =>
-            {
-                Assert.Single(plugins);
-                plugins.Add(plugin2);
-            })
-            .Build();
-        Assert.Contains(plugin1, kernel.Plugins);
-        Assert.Contains(plugin2, kernel.Plugins);
-
-        // Delegate taking just serviceProvider and plugins
-        kernel = new KernelBuilder()
-            .ConfigurePlugins((_, plugins) =>
-            {
-                Assert.NotNull(plugins);
-                Assert.Empty(plugins);
-                plugins.Add(plugin1);
-            })
-            .ConfigurePlugins((_, plugins) =>
-            {
-                Assert.Single(plugins);
-                plugins.Add(plugin2);
-            })
-            .Build();
-        Assert.Contains(plugin1, kernel.Plugins);
-        Assert.Contains(plugin2, kernel.Plugins);
-
-        // Both combined
-        kernel = new KernelBuilder()
-            .ConfigurePlugins(plugins =>
-            {
-                Assert.NotNull(plugins);
-                Assert.Empty(plugins);
-                plugins.Add(plugin1);
-            })
-            .ConfigurePlugins((_, plugins) =>
-            {
-                Assert.Single(plugins);
-                plugins.Add(plugin2);
-            })
-            .Build();
-        Assert.Contains(plugin1, kernel.Plugins);
-        Assert.Contains(plugin2, kernel.Plugins);
-    }
-
-    [Fact]
-    public void ItSuppliesBuiltServiceProviderToConfigurePlugins()
-    {
-        using ILoggerFactory loggerFactory = new LoggerFactory();
-
-        Kernel kernel = new KernelBuilder()
-            .WithLoggerFactory(loggerFactory)
-            .ConfigurePlugins((serviceProvider, plugins) =>
-            {
-                Assert.Same(loggerFactory, serviceProvider.GetService(typeof(ILoggerFactory)));
-            })
-            .Build();
     }
 
     [Fact]
@@ -222,12 +93,9 @@ public class KernelBuilderTests
     {
         KernelBuilder builder = new();
 
-        Assert.Throws<ArgumentNullException>(() => builder.ConfigurePlugins((Action<ICollection<IKernelPlugin>>)null!));
-        Assert.Throws<ArgumentNullException>(() => builder.ConfigurePlugins((Action<IServiceProvider, ICollection<IKernelPlugin>>)null!));
         Assert.Throws<ArgumentNullException>(() => builder.ConfigureServices(null!));
 
         builder.WithLoggerFactory(null);
-        builder.WithCulture(null);
         builder.WithAIServiceSelector(null);
 
         builder.Build();

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -525,7 +525,7 @@ public class KernelTests
     }
 
     [Fact]
-    public void CurrentCultureShouldBeReturnedIfNoCultureWasAssociatedWithKernel()
+    public void InvariantCultureShouldBeReturnedIfNoCultureWasAssociatedWithKernel()
     {
         //Arrange
         var kernel = new Kernel();
@@ -534,8 +534,7 @@ public class KernelTests
         var culture = kernel.Culture;
 
         //Assert
-        Assert.NotNull(culture);
-        Assert.Equal(CultureInfo.CurrentCulture, culture);
+        Assert.Same(CultureInfo.InvariantCulture, culture);
     }
 
     [Fact]


### PR DESCRIPTION
We'd added it for symmetry with ConfigureServices, but it actually leads to messier code (in its brief lifetime we've already seen it cause some confusion), and the asymmetry just reflects the existing asymmetry that Kernel.Plugins is mutable, so while you use KernelBuilder to compose what becomes an immutable set of services, plugins can be added once the Kernel has been constructed. I considered just having a KernelBuilder.Plugins property, but that brings other complications, namely that we want to just transfer the built up collection to the kernel, but because we want each built Kernel to have its own unique copy, we'd have to do more complicated tracking to ensure we didn't pass the same collection to two different builds while also avoiding unnecessary copying of the collection when it was only built up once.

I also removed WithCulture. It's also mutable on Kernel and can thus be changed after the Kernel is built, but it'll likely be rare to do so. And by getting rid of it, the only things that remain on KernelBuilder are about building up the immutable set of services.  All the builder was doing was setting the property after the Kernel was constructed, anyway.

We can always add back such things later.  Keeping it simpler for now.