### PR TITLE
Python: fix deployment name parameter when using base_url

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion.py
@@ -30,6 +30,7 @@ class AzureChatCompletion(
     @overload
     def __init__(
         self,
+        deployment_name: str,
         base_url: Union[HttpsUrl, str],
         api_version: str = DEFAULT_AZURE_API_VERSION,
         api_key: Optional[str] = None,
@@ -98,7 +99,7 @@ class AzureChatCompletion(
 
     def __init__(
         self,
-        deployment_name: Optional[str] = None,
+        deployment_name: str,
         endpoint: Optional[Union[HttpsUrl, str]] = None,
         base_url: Optional[Union[HttpsUrl, str]] = None,
         api_version: str = DEFAULT_AZURE_API_VERSION,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Small fix, deployment_name is always needed, also when using base_url for openai.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
