### PR TITLE
Tweak callbacks on KernelBuilder

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example08_RetryHandler.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example08_RetryHandler.cs
@@ -16,7 +16,7 @@ public static class Example08_RetryHandler
     public static async Task RunAsync()
     {
         // Create a Kernel with the HttpClient
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddLogging(c => c.AddConsole().SetMinimumLevel(LogLevel.Information));
             c.ConfigureHttpClientDefaults(c =>

--- a/dotnet/samples/KernelSyntaxExamples/Example16_CustomLLM.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example16_CustomLLM.cs
@@ -52,7 +52,7 @@ public static class Example16_CustomLLM
     {
         Console.WriteLine("======== Custom LLM - Text Completion - SKFunction ========");
 
-        Kernel kernel = new KernelBuilder().ConfigureServices(c =>
+        Kernel kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddSingleton(ConsoleLogger.LoggerFactory)
             // Add your text completion service as a singleton instance

--- a/dotnet/samples/KernelSyntaxExamples/Example42_KernelBuilder.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example42_KernelBuilder.cs
@@ -31,23 +31,23 @@ public static class Example42_KernelBuilder
             .WithAzureOpenAIChatCompletion(azureOpenAIChatCompletionDeployment, azureOpenAIEndpoint, azureOpenAIKey)
             .Build();
 
-        // For greater flexibility and to incorporate arbitrary services, KernelBuilder.ConfigureServices
-        // provides direct access to an underlying IServiceCollection. Multiple calls to ConfigureServices
+        // For greater flexibility and to incorporate arbitrary services, KernelBuilder.WithServices
+        // provides direct access to an underlying IServiceCollection. Multiple calls to WithServices
         // may be made, each of which may register any number of services.
         Kernel kernel2 = new KernelBuilder()
-            .ConfigureServices(c => c.AddLogging(c => c.AddConsole().SetMinimumLevel(LogLevel.Information)))
-            .ConfigureServices(c =>
+            .WithServices(c => c.AddLogging(c => c.AddConsole().SetMinimumLevel(LogLevel.Information)))
+            .WithServices(c =>
             {
                 c.AddHttpClient();
                 c.AddAzureOpenAIChatCompletion(azureOpenAIChatCompletionDeployment, azureOpenAIEndpoint, azureOpenAIKey);
             })
             .Build();
 
-        // Plugins may also be configured via the corresponding ConfigurePlugins method. There are multiple
-        // overloads of ConfigurePlugins, one of which provides access to the services registered with the
+        // Plugins may also be configured via the corresponding WithPlugins method. There are multiple
+        // overloads of WithPlugins, one of which provides access to the services registered with the
         // builder, such that a plugin can resolve and use those services.
         Kernel kernel3 = new KernelBuilder()
-            .ConfigurePlugins((serviceProvider, plugins) =>
+            .WithPlugins((plugins, serviceProvider) =>
             {
                 ILogger logger = serviceProvider.GetService<ILogger<KernelBuilder>>() ?? (ILogger)NullLogger.Instance;
                 plugins.Add(new KernelPlugin("Example", new[]

--- a/dotnet/samples/KernelSyntaxExamples/Example52_ApimAuth.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example52_ApimAuth.cs
@@ -48,7 +48,7 @@ public static class Example52_ApimAuth
         };
         var openAIClient = new OpenAIClient(apimUri, new BearerTokenCredential(accessToken), clientOptions);
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddLogging(c => c.SetMinimumLevel(LogLevel.Warning).AddConsole());
             c.AddAzureOpenAIChatCompletion(TestConfiguration.AzureOpenAI.ChatDeploymentName, openAIClient);

--- a/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
@@ -24,11 +24,11 @@ public static class Example59_OpenAIFunctionCalling
         // Create kernel with chat completions service and plugins
         Kernel kernel = new KernelBuilder()
             .WithOpenAIChatCompletion(TestConfiguration.OpenAI.ChatModelId, TestConfiguration.OpenAI.ApiKey)
-            .ConfigureServices(services =>
+            .WithServices(services =>
             {
                 services.AddLogging(services => services.AddConsole().SetMinimumLevel(LogLevel.Trace));
             })
-            .ConfigurePlugins(plugins =>
+            .WithPlugins(plugins =>
             {
                 plugins.AddPluginFromObject<TimePlugin>();
                 plugins.AddPluginFromObject<WidgetPlugin>();

--- a/dotnet/src/Connectors/Connectors.AI.HuggingFace/HuggingFaceKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.HuggingFace/HuggingFaceKernelBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class HuggingFaceKernelBuilderExtensions
         Verify.NotNull(builder);
         Verify.NotNull(model);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(serviceId, (serviceProvider, _) =>
                 new HuggingFaceTextCompletion(model, apiKey, HttpClientProvider.GetHttpClient(httpClient, serviceProvider), endpoint));
@@ -84,7 +84,7 @@ public static class HuggingFaceKernelBuilderExtensions
         Verify.NotNull(builder);
         Verify.NotNull(model);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextEmbeddingGeneration>(serviceId, (serviceProvider, _) =>
                 new HuggingFaceTextEmbeddingGeneration(model, HttpClientProvider.GetHttpClient(httpClient, serviceProvider), endpoint));

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/OpenAIServiceCollectionExtensions.cs
@@ -56,7 +56,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(serviceId, (serviceProvider, _) =>
             {
@@ -121,7 +121,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(credentials);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(serviceId, (serviceProvider, _) =>
             {
@@ -181,7 +181,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(deploymentName);
         Verify.NotNull(openAIClient);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(serviceId, (serviceProvider, _) =>
                 new AzureOpenAITextCompletion(
@@ -242,7 +242,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(modelId);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(serviceId, (serviceProvider, _) =>
                 new OpenAITextCompletion(
@@ -301,7 +301,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(modelId);
         Verify.NotNull(openAIClient);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(serviceId, (serviceProvider, _) =>
                 new OpenAITextCompletion(
@@ -365,7 +365,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextEmbeddingGeneration>(serviceId, (serviceProvider, _) =>
                 new AzureOpenAITextEmbeddingGeneration(
@@ -438,7 +438,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(credential);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextEmbeddingGeneration>(serviceId, (serviceProvider, _) =>
                 new AzureOpenAITextEmbeddingGeneration(
@@ -506,7 +506,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(deploymentName);
         Verify.NotNull(openAIClient);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextEmbeddingGeneration>(serviceId, (serviceProvider, _) =>
                 new AzureOpenAITextEmbeddingGeneration(
@@ -569,7 +569,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(modelId);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextEmbeddingGeneration>(serviceId, (serviceProvider, _) =>
                 new OpenAITextEmbeddingGeneration(
@@ -630,7 +630,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(modelId);
         Verify.NotNull(openAIClient);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<ITextEmbeddingGeneration>(serviceId, (serviceProvider, _) =>
                 new OpenAITextEmbeddingGeneration(
@@ -694,7 +694,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             Func<IServiceProvider, object?, AzureOpenAIChatCompletion> factory = (serviceProvider, _) =>
             {
@@ -777,7 +777,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(credentials);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             Func<IServiceProvider, object?, AzureOpenAIChatCompletion> factory = (serviceProvider, _) =>
             {
@@ -855,7 +855,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(deploymentName);
         Verify.NotNull(openAIClient);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             Func<IServiceProvider, object?, AzureOpenAIChatCompletion> factory = (serviceProvider, _) =>
                 new(deploymentName, openAIClient, modelId, serviceProvider.GetService<ILoggerFactory>());
@@ -913,7 +913,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(builder);
         Verify.NotNull(config);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             Func<IServiceProvider, object?, AzureOpenAIChatCompletionWithData> factory = (serviceProvider, _) =>
                 new(config,
@@ -977,7 +977,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(modelId);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             Func<IServiceProvider, object?, OpenAIChatCompletion> factory = (serviceProvider, _) =>
                 new(modelId,
@@ -1042,7 +1042,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(modelId);
         Verify.NotNull(openAIClient);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             Func<IServiceProvider, object?, OpenAIChatCompletion> factory = (serviceProvider, _) =>
                 new(modelId, openAIClient, serviceProvider.GetService<ILoggerFactory>());
@@ -1105,7 +1105,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(endpoint);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<IImageGeneration>(serviceId, (serviceProvider, _) =>
                 new AzureOpenAIImageGeneration(
@@ -1167,7 +1167,7 @@ public static class OpenAIServiceCollectionExtensions
         Verify.NotNull(builder);
         Verify.NotNull(apiKey);
 
-        return builder.ConfigureServices(c =>
+        return builder.WithServices(c =>
         {
             c.AddKeyedSingleton<IImageGeneration>(serviceId, (serviceProvider, _) =>
                 new OpenAIImageGeneration(

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
@@ -48,7 +48,7 @@ public class AIServicesOpenAIExtensionsTests
     {
         // Arrange
         // Act - Assert no exception occurs
-        new KernelBuilder().ConfigureServices(c =>
+        new KernelBuilder().WithServices(c =>
         {
             c.AddAzureOpenAITextCompletion("dep", "https://localhost", "key", serviceId: "one");
             c.AddAzureOpenAITextCompletion("dep", "https://localhost", "key", serviceId: "one");

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/KernelFunctionMetadataExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/KernelFunctionMetadataExtensionsTests.cs
@@ -154,7 +154,7 @@ public sealed class KernelFunctionMetadataExtensionsTests
     {
         // Arrange
         var kernel = new KernelBuilder()
-            .ConfigurePlugins(plugins => plugins.AddPluginFromObject<MyPlugin>("MyPlugin"))
+            .WithPlugins(plugins => plugins.AddPluginFromObject<MyPlugin>("MyPlugin"))
             .Build();
 
         var functionView = kernel.Plugins["MyPlugin"].First().Metadata;

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -182,7 +182,7 @@ public sealed class OpenAICompletionTests : IDisposable
                 serviceId: openAIConfiguration.ServiceId,
                 modelId: openAIConfiguration.ModelId,
                 apiKey: "INVALID_KEY") // Use an invalid API key to force a 401 Unauthorized response
-            .ConfigureServices(c => c.ConfigureHttpClientDefaults(c =>
+            .WithServices(c => c.ConfigureHttpClientDefaults(c =>
                 {
                     // Use a standard resiliency policy, augmented to retry on 401 Unauthorized for this example
                     c.AddStandardResilienceHandler().Configure(o =>
@@ -218,7 +218,7 @@ public sealed class OpenAICompletionTests : IDisposable
             endpoint: azureOpenAIConfiguration.Endpoint,
             apiKey: "INVALID_KEY");
 
-        builder.ConfigureServices(c => c.ConfigureHttpClientDefaults(c =>
+        builder.WithServices(c => c.ConfigureHttpClientDefaults(c =>
             {
                 // Use a standard resiliency policy, augmented to retry on 401 Unauthorized for this example
                 c.AddStandardResilienceHandler().Configure(o =>

--- a/dotnet/src/IntegrationTests/Extensions/KernelFunctionExtensionsTests.cs
+++ b/dotnet/src/IntegrationTests/Extensions/KernelFunctionExtensionsTests.cs
@@ -27,8 +27,8 @@ public sealed class KernelFunctionExtensionsTests : IDisposable
     {
         Kernel target = new KernelBuilder()
             .WithLoggerFactory(this._logger)
-            .ConfigureServices(c => c.AddSingleton<ITextCompletion>(new RedirectTextCompletion()))
-            .ConfigurePlugins(plugins => plugins.AddPluginFromObject<EmailPluginFake>())
+            .WithServices(c => c.AddSingleton<ITextCompletion>(new RedirectTextCompletion()))
+            .WithPlugins(plugins => plugins.AddPluginFromObject<EmailPluginFake>())
             .Build();
 
         var prompt = $"Hey {{{{{nameof(EmailPluginFake)}.GetEmailAddress}}}}";
@@ -45,8 +45,8 @@ public sealed class KernelFunctionExtensionsTests : IDisposable
     {
         Kernel target = new KernelBuilder()
             .WithLoggerFactory(this._logger)
-            .ConfigureServices(c => c.AddSingleton<ITextCompletion>(new RedirectTextCompletion()))
-            .ConfigurePlugins(plugins => plugins.AddPluginFromObject<EmailPluginFake>())
+            .WithServices(c => c.AddSingleton<ITextCompletion>(new RedirectTextCompletion()))
+            .WithPlugins(plugins => plugins.AddPluginFromObject<EmailPluginFake>())
             .Build();
 
         var prompt = $"Hey {{{{{nameof(EmailPluginFake)}.GetEmailAddress \"a person\"}}}}";

--- a/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
@@ -76,7 +76,7 @@ public sealed class HandlebarsPlannerTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        return new KernelBuilder().ConfigureServices(c =>
+        return new KernelBuilder().WithServices(c =>
         {
             if (useChatModel)
             {

--- a/dotnet/src/IntegrationTests/Planners/PlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/PlanTests.cs
@@ -562,7 +562,7 @@ public sealed class PlanTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             if (useChatModel)
             {

--- a/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/SequentialPlanner/SequentialPlannerTests.cs
@@ -114,7 +114,7 @@ public sealed class SequentialPlannerTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        return new KernelBuilder().ConfigureServices(c =>
+        return new KernelBuilder().WithServices(c =>
         {
             if (useChatModel)
             {

--- a/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/StepwisePlanner/StepwisePlannerTests.cs
@@ -143,7 +143,7 @@ public sealed class StepwisePlannerTests : IDisposable
         AzureOpenAIConfiguration? azureOpenAIEmbeddingsConfiguration = this._configuration.GetSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIEmbeddingsConfiguration);
 
-        return new KernelBuilder().ConfigureServices(c =>
+        return new KernelBuilder().WithServices(c =>
         {
             if (useChatModel)
             {

--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SemanticKernel;
 public sealed class Kernel
 {
     /// <summary>Key used by KernelBuilder to store type information into the service provider.</summary>
-    internal const string KernelServiceTypeToKeyMappingsKey = nameof(KernelServiceTypeToKeyMappingsKey);
+    internal const string KernelServiceTypeToKeyMappings = nameof(KernelServiceTypeToKeyMappings);
 
     /// <summary>Dictionary containing ambient data stored in the kernel, lazily-initialized on first access.</summary>
     private Dictionary<string, object?>? _data;
@@ -242,11 +242,11 @@ public sealed class Kernel
             // support AnyKey currently: https://github.com/dotnet/runtime/issues/91466
             // As a workaround, KernelBuilder injects a service containing the type-to-all-keys
             // mapping. We can query for that service and and then use it to try to get a service.
-            if (this.Services.GetKeyedService<Dictionary<Type, HashSet<object?>>>(KernelServiceTypeToKeyMappingsKey) is { } typeToKeyMappings)
+            if (this.Services.GetKeyedService<Dictionary<Type, HashSet<object?>>>(KernelServiceTypeToKeyMappings) is { } typeToKeyMappings)
             {
                 if (typeToKeyMappings.TryGetValue(typeof(T), out HashSet<object?> keys))
                 {
-                    return keys.SelectMany(key => this.Services.GetKeyedServices<T>(key)).Where(s => s is not null)!;
+                    return keys.SelectMany(key => this.Services.GetKeyedServices<T>(key));
                 }
 
                 return Enumerable.Empty<T>();

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/FunctionFromPromptTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/FunctionFromPromptTests.cs
@@ -23,7 +23,7 @@ public class FunctionFromPromptTests
     {
         // Arrange
         var factory = new Mock<Func<IServiceProvider, ITextCompletion>>();
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddSingleton(factory.Object);
         }).Build();
@@ -47,7 +47,7 @@ public class FunctionFromPromptTests
         mockTextCompletion.Setup(c => c.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<PromptExecutionSettings>(), It.IsAny<Kernel>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { mockCompletionResult.Object });
         mockCompletionResult.Setup(cr => cr.GetCompletionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("llmResult");
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("x", mockTextCompletion.Object);
         }).Build();
@@ -80,7 +80,7 @@ public class FunctionFromPromptTests
         mockTextCompletion2.Setup(c => c.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<PromptExecutionSettings>(), It.IsAny<Kernel>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { mockCompletionResult.Object });
         mockCompletionResult.Setup(cr => cr.GetCompletionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("llmResult");
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("service1", mockTextCompletion1.Object);
             c.AddKeyedSingleton("service2", mockTextCompletion2.Object);
@@ -106,7 +106,7 @@ public class FunctionFromPromptTests
         var mockTextCompletion1 = new Mock<ITextCompletion>();
         var mockTextCompletion2 = new Mock<ITextCompletion>();
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("service1", mockTextCompletion1.Object);
             c.AddKeyedSingleton("service2", mockTextCompletion2.Object);
@@ -129,7 +129,7 @@ public class FunctionFromPromptTests
     {
         // Arrange
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var function = KernelFunctionFactory.CreateFromPrompt("Write a simple phrase about UnitTests");
 
         var invoked = 0;
@@ -152,7 +152,7 @@ public class FunctionFromPromptTests
     {
         // Arrange
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var function = KernelFunctionFactory.CreateFromPrompt("Write a simple phrase about UnitTests");
         var input = "Test input";
         var invoked = false;
@@ -175,7 +175,7 @@ public class FunctionFromPromptTests
     {
         // Arrange
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var function = KernelFunctionFactory.CreateFromPrompt("Write a simple phrase about UnitTests");
 
         var invoked = 0;
@@ -198,7 +198,7 @@ public class FunctionFromPromptTests
     {
         // Arrange
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var function = KernelFunctionFactory.CreateFromPrompt("Write a simple phrase about UnitTests");
         var invoked = 0;
 
@@ -224,7 +224,7 @@ public class FunctionFromPromptTests
     {
         // Arrange
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var function = KernelFunctionFactory.CreateFromPrompt("Write a simple phrase about UnitTests");
 
         var invoked = 0;
@@ -246,7 +246,7 @@ public class FunctionFromPromptTests
     public async Task InvokeAsyncChangeVariableInvokingHandlerAsync()
     {
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var prompt = "Write a simple phrase about UnitTests {{$input}}";
         var function = KernelFunctionFactory.CreateFromPrompt(prompt);
 
@@ -269,7 +269,7 @@ public class FunctionFromPromptTests
     public async Task InvokeAsyncChangeVariableInvokedHandlerAsync()
     {
         var (mockTextResult, mockTextCompletion) = this.SetupMocks();
-        var sut = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var sut = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var prompt = "Write a simple phrase about UnitTests {{$input}}";
         var function = KernelFunctionFactory.CreateFromPrompt(prompt);
 
@@ -295,7 +295,7 @@ public class FunctionFromPromptTests
         var mockTextCompletion = this.SetupStreamingMocks<StreamingContent>(
             new TestStreamingContent("chunk1"),
             new TestStreamingContent("chunk2"));
-        var kernel = new KernelBuilder().ConfigureServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
+        var kernel = new KernelBuilder().WithServices(c => c.AddSingleton<ITextCompletion>(mockTextCompletion.Object)).Build();
         var prompt = "Write a simple phrase about UnitTests {{$input}}";
         var sut = KernelFunctionFactory.CreateFromPrompt(prompt);
         var variables = new KernelArguments { { "input", "importance" } };

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/MultipleModelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/MultipleModelTests.cs
@@ -24,7 +24,7 @@ public class MultipleModelTests
         mockTextCompletion2.Setup(c => c.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<PromptExecutionSettings>(), It.IsAny<Kernel>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { mockCompletionResult.Object });
         mockCompletionResult.Setup(cr => cr.GetCompletionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("llmResult");
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("service1", mockTextCompletion1.Object);
             c.AddKeyedSingleton("service2", mockTextCompletion2.Object);
@@ -50,7 +50,7 @@ public class MultipleModelTests
         var mockTextCompletion1 = new Mock<ITextCompletion>();
         var mockTextCompletion2 = new Mock<ITextCompletion>();
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("service1", mockTextCompletion1.Object);
             c.AddKeyedSingleton("service2", mockTextCompletion2.Object);
@@ -84,7 +84,7 @@ public class MultipleModelTests
         mockTextCompletion3.Setup(c => c.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<PromptExecutionSettings>(), It.IsAny<Kernel>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { mockCompletionResult.Object });
         mockCompletionResult.Setup(cr => cr.GetCompletionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("llmResult");
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("service1", mockTextCompletion1.Object);
             c.AddKeyedSingleton("service2", mockTextCompletion2.Object);
@@ -122,7 +122,7 @@ public class MultipleModelTests
         mockTextCompletion3.Setup(c => c.GetCompletionsAsync(It.IsAny<string>(), It.IsAny<PromptExecutionSettings>(), It.IsAny<Kernel>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { mockCompletionResult.Object });
         mockCompletionResult.Setup(cr => cr.GetCompletionAsync(It.IsAny<CancellationToken>())).ReturnsAsync("llmResult");
 
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton("service1", mockTextCompletion1.Object);
             c.AddKeyedSingleton("service2", mockTextCompletion2.Object);

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
@@ -31,7 +31,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationForSingleAIService()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<IAIService>("service1", new AIService());
         }).Build();
@@ -50,7 +50,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationForSingleTextCompletion()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
         }).Build();
@@ -69,7 +69,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationForTextCompletionByServiceId()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
             c.AddKeyedSingleton<ITextCompletion>("service2", new TextCompletion());
@@ -91,7 +91,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItThrowsAnSKExceptionForNotFoundService()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
             c.AddKeyedSingleton<ITextCompletion>("service2", new TextCompletion());
@@ -110,7 +110,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItUsesDefaultServiceForEmptyModelSettings()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
             c.AddKeyedSingleton<ITextCompletion>("service2", new TextCompletion());
@@ -131,7 +131,7 @@ public class OrderedAIServiceConfigurationProviderTests
     {
         // Arrange
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
             c.AddKeyedSingleton<ITextCompletion>("service2", new TextCompletion());
@@ -152,7 +152,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItUsesDefaultServiceAndSettingsEmptyServiceId()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
             c.AddKeyedSingleton<ITextCompletion>("service2", new TextCompletion());
@@ -177,7 +177,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationByOrder(string[] serviceIds, string expectedServiceId)
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>("service1", new TextCompletion());
             c.AddKeyedSingleton<ITextCompletion>("service2", new TextCompletion());
@@ -203,7 +203,7 @@ public class OrderedAIServiceConfigurationProviderTests
     public void ItGetsAIServiceConfigurationForTextCompletionByModelId()
     {
         // Arrange
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddKeyedSingleton<ITextCompletion>(null, new TextCompletion("model1"));
             c.AddKeyedSingleton<ITextCompletion>(null, new TextCompletion("model2"));

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -27,7 +27,7 @@ public class KernelTests
     {
         // Arrange
         var factory = new Mock<Func<IServiceProvider, ITextCompletion>>();
-        var kernel = new KernelBuilder().ConfigureServices(c =>
+        var kernel = new KernelBuilder().WithServices(c =>
         {
             c.AddSingleton<ITextCompletion>(factory.Object);
         }).Build();


### PR DESCRIPTION
After a lengthy discussion, we agreed to largely keep what we have, but rename the methods to be With rather than Configure.  I also changed the order of the arguments to WithPlugins so that all overloads have the plugin collection first for consistency, and I updated the type of the collection to be the more strongly-typed KernelPluginCollection rather than the interface. I also augmented some of the XML comments, tweaked the services workaround, and added a test.

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
