### PR TITLE
.Net Removing remaining public facing records

### DIFF
--- a/dotnet/src/Functions/Functions.OpenAPI/Authentication/OAuthTokenResponse.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Authentication/OAuthTokenResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi.Authentication;
 /// <summary>
 /// Represents the authentication section for an OpenAI plugin.
 /// </summary>
-public record OAuthTokenResponse
+public class OAuthTokenResponse
 {
     /// <summary>
     /// The type of access token.

--- a/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperationPayload.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Model/RestApiOperationPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi.Model;
 /// <summary>
 /// The REST API operation payload.
 /// </summary>
-public record RestApiOperationPayload
+public class RestApiOperationPayload
 {
     /// <summary>
     /// The payload MediaType.

--- a/dotnet/src/Functions/Functions.OpenAPI/OpenAI/OpenAIAuthenticationConfig.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/OpenAI/OpenAIAuthenticationConfig.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi.OpenAI;
 /// <summary>
 /// Represents the authentication section for an OpenAI plugin.
 /// </summary>
-public record OpenAIAuthenticationConfig
+public class OpenAIAuthenticationConfig
 {
     /// <summary>
     /// The type of authentication.


### PR DESCRIPTION
### Motivation and Context

Except from the `Microsoft.SemanticKernel.Connectors.Memory.Postgres.PostgresMemoryEntry` all the other remaining records were changed back to classes.

Resolves #3697 

