### PR TITLE
.Net: remove serviceId requirement for examples 56 and 58

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example56_TemplateMethodFunctionsWithMultipleArguments.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example56_TemplateMethodFunctionsWithMultipleArguments.cs
@@ -24,9 +24,9 @@ public static class Example56_TemplateMethodFunctionsWithMultipleArguments
         string modelId = TestConfiguration.AzureOpenAI.ChatModelId;
         string endpoint = TestConfiguration.AzureOpenAI.Endpoint;
 
-        if (serviceId == null || apiKey == null || deploymentName == null || modelId == null || endpoint == null)
+        if (apiKey == null || deploymentName == null || modelId == null || endpoint == null)
         {
-            Console.WriteLine("AzureOpenAI serviceId, modelId, endpoint, apiKey, or deploymentName not found. Skipping example.");
+            Console.WriteLine("AzureOpenAI modelId, endpoint, apiKey, or deploymentName not found. Skipping example.");
             return;
         }
 

--- a/dotnet/samples/KernelSyntaxExamples/Example58_ConfigureExecutionSettings.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example58_ConfigureExecutionSettings.cs
@@ -23,9 +23,9 @@ public static class Example58_ConfigureExecutionSettings
         string chatModelId = TestConfiguration.AzureOpenAI.ChatModelId;
         string endpoint = TestConfiguration.AzureOpenAI.Endpoint;
 
-        if (serviceId == null || apiKey == null || chatDeploymentName == null || chatModelId == null || endpoint == null)
+        if (apiKey == null || chatDeploymentName == null || chatModelId == null || endpoint == null)
         {
-            Console.WriteLine("AzureOpenAI serviceId, modelId, endpoint, apiKey, or deploymentName not found. Skipping example.");
+            Console.WriteLine("AzureOpenAI modelId, endpoint, apiKey, or deploymentName not found. Skipping example.");
             return;
         }
 
@@ -77,8 +77,6 @@ public static class Example58_ConfigureExecutionSettings
         Console.WriteLine(result.GetValue<string>());
 
         /* OUTPUT (using gpt4):
-Hello! As an AI language model, I can help you with a variety of
-
 Hello! As an AI language model, I can help you with a variety of tasks, such as:
 
 1. Answering general questions and providing information on a wide range of topics.


### PR DESCRIPTION
### Motivation and Context
ServiceId is not required for Azure Open AI and is not used for examples 56 and 58 yet it is still required to run those examples.

### Description
Remove the necessity to have ServiceId defined in those tests.

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
