### PR TITLE
.Net: input_parameters should be input_variables to match prompt serialization

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplate/Handlebars/HandlebarsPromptTemplateTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplate/Handlebars/HandlebarsPromptTemplateTests.cs
@@ -7,7 +7,6 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.PromptTemplate.Handlebars;
 using SemanticKernel.Extensions.UnitTests.XunitHelpers;
 using Xunit;
-using static Microsoft.SemanticKernel.PromptTemplateConfig;
 
 namespace SemanticKernel.Extensions.UnitTests.PromptTemplate.Handlebars;
 

--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplate/Handlebars/HandlebarsPromptTemplateTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplate/Handlebars/HandlebarsPromptTemplateTests.cs
@@ -81,13 +81,13 @@ public sealed class HandlebarsPromptTemplateTests
         {
             TemplateFormat = HandlebarsPromptTemplateFactory.HandlebarsTemplateFormat
         };
-        promptConfig.InputParameters.Add(new InputParameter()
+        promptConfig.InputVariables.Add(new InputVariable()
         {
             Name = "bar",
             Description = "Bar",
             DefaultValue = "Bar"
         });
-        promptConfig.InputParameters.Add(new InputParameter()
+        promptConfig.InputVariables.Add(new InputVariable()
         {
             Name = "baz",
             Description = "Baz",

--- a/dotnet/src/Extensions/PromptTemplate.Handlebars/HandlebarsPromptTemplate.cs
+++ b/dotnet/src/Extensions/PromptTemplate.Handlebars/HandlebarsPromptTemplate.cs
@@ -56,7 +56,7 @@ internal sealed class HandlebarsPromptTemplate : IPromptTemplate
     {
         Dictionary<string, object?> result = new();
 
-        foreach (var p in this._promptModel.InputParameters)
+        foreach (var p in this._promptModel.InputVariables)
         {
             if (!string.IsNullOrEmpty(p.DefaultValue))
             {

--- a/dotnet/src/Functions/Functions.UnitTests/Yaml/Functions/KernelFunctionYamlTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Yaml/Functions/KernelFunctionYamlTests.cs
@@ -77,7 +77,7 @@ public class KernelFunctionYamlTests
     template:        Say hello world to {{$name}} in {{$language}}
     description:     Say hello to the specified person using the specified language
     name:            SayHello
-    input_parameters:
+    input_variables:
       - name:          name
         description:   The name of the person to greet
         default_value: John
@@ -91,7 +91,7 @@ public class KernelFunctionYamlTests
     template:        Say hello world to {{$name}} in {{$language}}
     description:     Say hello to the specified person using the specified language
     name:            SayHello
-    input_parameters:
+    input_variables:
       - name:          name
         description:   The name of the person to greet
         default_value: John
@@ -120,7 +120,7 @@ public class KernelFunctionYamlTests
     template:        Say hello world to {{$name}} in {{$language}}
     description:     Say hello to the specified person using the specified language
     name:            SayHello
-    input_parameters:
+    input_variables:
       - name:          name
         description:   The name of the person to greet
         default_value: John

--- a/dotnet/src/Functions/Functions.UnitTests/Yaml/PromptExecutionSettingsNodeDeserializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Yaml/PromptExecutionSettingsNodeDeserializerTests.cs
@@ -28,8 +28,8 @@ public sealed class PromptExecutionSettingsNodeDeserializerTests
         Assert.NotNull(semanticFunctionConfig);
         Assert.Equal("SayHello", semanticFunctionConfig.Name);
         Assert.Equal("Say hello to the specified person using the specified language", semanticFunctionConfig.Description);
-        Assert.Equal(2, semanticFunctionConfig.InputParameters.Count);
-        Assert.Equal("language", semanticFunctionConfig.InputParameters[1].Name);
+        Assert.Equal(2, semanticFunctionConfig.InputVariables.Count);
+        Assert.Equal("language", semanticFunctionConfig.InputVariables[1].Name);
         Assert.Equal(2, semanticFunctionConfig.ExecutionSettings.Count);
         Assert.Equal("gpt-3.5", semanticFunctionConfig.ExecutionSettings[1].ModelId);
     }
@@ -39,7 +39,7 @@ public sealed class PromptExecutionSettingsNodeDeserializerTests
     template:        Say hello world to {{$name}} in {{$language}}
     description:     Say hello to the specified person using the specified language
     name:            SayHello
-    input_parameters:
+    input_variables:
       - name:          name
         description:   The name of the person to greet
         default_value: John

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/InputVariable.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/InputVariable.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Input variable for prompt functions.
+/// </summary>
+public sealed class InputVariable
+{
+    /// <summary>
+    /// Name of the variable to pass to the prompt function.
+    /// e.g. when using "{{$input}}" the name is "input", when using "{{$style}}" the name is "style", etc.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Variable description for UI applications and planners. Localization is not supported here.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default value when nothing is provided.
+    /// </summary>
+    [JsonPropertyName("default_value")]
+    public string DefaultValue { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True to indicate the input variable is required. True by default.
+    /// </summary>
+    [JsonPropertyName("is_required")]
+    public bool IsRequired { get; set; } = true;
+}

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/OutputVariable.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/OutputVariable.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Output variable return from a prompt functions.
+/// </summary>
+public sealed class OutputVariable
+{
+    /// <summary>
+    /// Variable description for UI applications and planners. Localization is not supported here.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+}

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
@@ -51,6 +51,12 @@ public sealed class PromptTemplateConfig
     public List<InputVariable> InputVariables { get; set; } = new();
 
     /// <summary>
+    /// Output variable.
+    /// </summary>
+    [JsonPropertyName("output_variable")]
+    public OutputVariable? OutputVariable { get; set; }
+
+    /// <summary>
     /// Prompt execution settings.
     /// </summary>
     [JsonPropertyName("execution_settings")]
@@ -69,37 +75,6 @@ public sealed class PromptTemplateConfig
     public PromptTemplateConfig(string template)
     {
         this.Template = template;
-    }
-
-    /// <summary>
-    /// Input variable for prompt functions.
-    /// </summary>
-    public class InputVariable
-    {
-        /// <summary>
-        /// Name of the variable to pass to the prompt function.
-        /// e.g. when using "{{$input}}" the name is "input", when using "{{$style}}" the name is "style", etc.
-        /// </summary>
-        [JsonPropertyName("name")]
-        public string Name { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Variable description for UI applications and planners. Localization is not supported here.
-        /// </summary>
-        [JsonPropertyName("description")]
-        public string Description { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Default value when nothing is provided.
-        /// </summary>
-        [JsonPropertyName("default_value")]
-        public string DefaultValue { get; set; } = string.Empty;
-
-        /// <summary>
-        /// True to indicate the input variable is required. True by default.
-        /// </summary>
-        [JsonPropertyName("is_required")]
-        public bool IsRequired { get; set; } = true;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
@@ -77,14 +77,14 @@ public sealed class PromptTemplateConfig
     public class InputVariable
     {
         /// <summary>
-        /// Name of the parameter to pass to the function.
+        /// Name of the variable to pass to the prompt function.
         /// e.g. when using "{{$input}}" the name is "input", when using "{{$style}}" the name is "style", etc.
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Parameter description for UI apps and planner. Localization is not supported here.
+        /// Variable description for UI applications and planners. Localization is not supported here.
         /// </summary>
         [JsonPropertyName("description")]
         public string Description { get; set; } = string.Empty;
@@ -96,14 +96,14 @@ public sealed class PromptTemplateConfig
         public string DefaultValue { get; set; } = string.Empty;
 
         /// <summary>
-        /// True to indeicate the input parameter is required. True by default.
+        /// True to indicate the input variable is required. True by default.
         /// </summary>
         [JsonPropertyName("is_required")]
         public bool IsRequired { get; set; } = true;
     }
 
     /// <summary>
-    /// Return the input parameters metadata.
+    /// Return the input variables metadata.
     /// </summary>
     internal List<KernelParameterMetadata> GetKernelParametersMetadata()
     {

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
@@ -45,10 +45,10 @@ public sealed class PromptTemplateConfig
     public string Description { get; set; } = string.Empty;
 
     /// <summary>
-    /// Input parameters.
+    /// Input variables.
     /// </summary>
-    [JsonPropertyName("input_parameters")]
-    public List<InputParameter> InputParameters { get; set; } = new();
+    [JsonPropertyName("input_variables")]
+    public List<InputVariable> InputVariables { get; set; } = new();
 
     /// <summary>
     /// Prompt execution settings.
@@ -72,9 +72,9 @@ public sealed class PromptTemplateConfig
     }
 
     /// <summary>
-    /// Input parameter for prompt functions.
+    /// Input variable for prompt functions.
     /// </summary>
-    public class InputParameter
+    public class InputVariable
     {
         /// <summary>
         /// Name of the parameter to pass to the function.
@@ -107,7 +107,7 @@ public sealed class PromptTemplateConfig
     /// </summary>
     internal List<KernelParameterMetadata> GetKernelParametersMetadata()
     {
-        return this.InputParameters.Select(p => new KernelParameterMetadata(p.Name)
+        return this.InputVariables.Select(p => new KernelParameterMetadata(p.Name)
         {
             Description = p.Description,
             DefaultValue = p.DefaultValue

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -202,7 +202,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <summary>Add default values to the arguments if an argument is not defined</summary>
     private void AddDefaultValues(KernelArguments arguments)
     {
-        foreach (var parameter in this._promptConfig.InputParameters)
+        foreach (var parameter in this._promptConfig.InputVariables)
         {
             if (!arguments.ContainsName(parameter.Name) && parameter.DefaultValue != null)
             {

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/PromptTemplateConfigTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/PromptTemplateConfigTests.cs
@@ -91,8 +91,7 @@ public class PromptTemplateConfigTests
       ]
     }
   ]
-}
-        ";
+}";
 
         // Act
         var promptTemplateConfig = JsonSerializer.Deserialize<PromptTemplateConfig>(configPayload);
@@ -127,8 +126,7 @@ public class PromptTemplateConfigTests
       ]
     }
   ]
-}
-        ";
+}";
 
         // Act
         var promptTemplateConfig = JsonSerializer.Deserialize<PromptTemplateConfig>(configPayload);
@@ -137,5 +135,58 @@ public class PromptTemplateConfigTests
         Assert.NotNull(promptTemplateConfig);
         Assert.NotNull(promptTemplateConfig.ExecutionSettings?.FirstOrDefault<PromptExecutionSettings>());
         Assert.Equal("gpt-4", promptTemplateConfig?.ExecutionSettings.FirstOrDefault<PromptExecutionSettings>()?.ModelId);
+    }
+
+    [Fact]
+    public void DeserializingExpectInputVariables()
+    {
+        // Arrange
+        string configPayload = @"
+{
+  ""description"": ""function description"",
+  ""input_variables"":
+    [
+        {
+            ""name"": ""input variable name"",
+            ""description"": ""input variable description"",
+            ""default_value"": ""default value"",
+            ""is_required"": true
+        }
+    ]
+}";
+
+        // Act
+        var promptTemplateConfig = JsonSerializer.Deserialize<PromptTemplateConfig>(configPayload);
+
+        // Assert
+        Assert.NotNull(promptTemplateConfig);
+        Assert.NotNull(promptTemplateConfig.InputVariables);
+        Assert.Single(promptTemplateConfig.InputVariables);
+        Assert.Equal("input variable name", promptTemplateConfig.InputVariables[0].Name);
+        Assert.Equal("input variable description", promptTemplateConfig.InputVariables[0].Description);
+        Assert.Equal("default value", promptTemplateConfig.InputVariables[0].DefaultValue);
+        Assert.True(promptTemplateConfig.InputVariables[0].IsRequired);
+    }
+
+    [Fact]
+    public void DeserializingExpectOutputVariable()
+    {
+        // Arrange
+        string configPayload = @"
+{
+  ""description"": ""function description"",
+  ""output_variable"": 
+    {
+        ""description"": ""output variable description""
+    }
+}";
+
+        // Act
+        var promptTemplateConfig = JsonSerializer.Deserialize<PromptTemplateConfig>(configPayload);
+
+        // Assert
+        Assert.NotNull(promptTemplateConfig);
+        Assert.NotNull(promptTemplateConfig.OutputVariable);
+        Assert.Equal("output variable description", promptTemplateConfig.OutputVariable.Description);
     }
 }

--- a/samples/plugins/FunPlugin/Joke/config.json
+++ b/samples/plugins/FunPlugin/Joke/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "Joke subject",

--- a/samples/plugins/FunPlugin/Limerick/config.json
+++ b/samples/plugins/FunPlugin/Limerick/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "name",
       "description": "",

--- a/samples/plugins/GroundingPlugin/ExciseEntities/config.json
+++ b/samples/plugins/GroundingPlugin/ExciseEntities/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "The text from which the entities are to be removed",

--- a/samples/plugins/GroundingPlugin/ExtractEntities/config.json
+++ b/samples/plugins/GroundingPlugin/ExtractEntities/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "The text from which the entities are to be extracted",

--- a/samples/plugins/GroundingPlugin/ReferenceCheckEntities/config.json
+++ b/samples/plugins/GroundingPlugin/ReferenceCheckEntities/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "The list of entities which are to be checked against the reference context.",

--- a/samples/plugins/MiscPlugin/Continue/config.json
+++ b/samples/plugins/MiscPlugin/Continue/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "The text to continue.",

--- a/samples/plugins/MiscPlugin/ElementAtIndex/config.json
+++ b/samples/plugins/MiscPlugin/ElementAtIndex/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "The input array or list",

--- a/samples/plugins/SummarizePlugin/Summarize/config.json
+++ b/samples/plugins/SummarizePlugin/Summarize/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "Text to summarize",

--- a/samples/plugins/WriterPlugin/Brainstorm/config.json
+++ b/samples/plugins/WriterPlugin/Brainstorm/config.json
@@ -11,7 +11,7 @@
       "stop_sequences": ["##END##"]
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "A topic description or goal.",

--- a/samples/plugins/WriterPlugin/NovelChapter/config.json
+++ b/samples/plugins/WriterPlugin/NovelChapter/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "A synopsis of what the chapter should be about.",

--- a/samples/plugins/WriterPlugin/NovelChapterWithNotes/config.json
+++ b/samples/plugins/WriterPlugin/NovelChapterWithNotes/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "What the novel should be about.",

--- a/samples/plugins/WriterPlugin/NovelOutline/config.json
+++ b/samples/plugins/WriterPlugin/NovelOutline/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "What the novel should be about.",

--- a/samples/plugins/WriterPlugin/ShortPoem/config.json
+++ b/samples/plugins/WriterPlugin/ShortPoem/config.json
@@ -10,7 +10,7 @@
       "frequency_penalty": 0.0
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "The scenario to turn into a poem.",

--- a/samples/plugins/WriterPlugin/Translate/config.json
+++ b/samples/plugins/WriterPlugin/Translate/config.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "input_parameters": [
+  "input_variables": [
     {
       "name": "input",
       "description": "Text to translate",


### PR DESCRIPTION
### Motivation and Context

Closes #3953 
Closes #3958 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
