### PR TITLE
.Net Preventing arguments collection

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -267,4 +267,32 @@ public class CodeBlockTests
         Assert.Equal(BobValue, actualBaz);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task ItDoesNotMutateOriginalArgumentsAsync()
+    {
+        // Arrange
+        const string Value = "value";
+        const string FooValue = "bar";
+        const string BobValue = "bob's value";
+
+        var arguments = new KernelArguments();
+        arguments["bob"] = BobValue;
+        arguments[KernelArguments.InputParameterName] = Value;
+
+        var funcId = new FunctionIdBlock("plugin.function");
+        var namedArgBlock1 = new NamedArgBlock($"foo='{FooValue}'");
+        var namedArgBlock2 = new NamedArgBlock("baz=$bob");
+
+        var function = KernelFunctionFactory.CreateFromMethod((string foo, string baz) => { }, "function");
+
+        this._kernel.Plugins.Add(new KernelPlugin("plugin", new[] { function }));
+
+        // Act
+        var codeBlock = new CodeBlock(new List<Block> { funcId, namedArgBlock1, namedArgBlock2 }, "");
+        await codeBlock.RenderCodeAsync(this._kernel, arguments);
+
+        // Assert
+        Assert.Equal(2, arguments.Count);
+    }
 }


### PR DESCRIPTION
Prevent the mutation of the arguments collection, `KernelArguments`, by ensuring that the `KernelPromptTemplate` does not add resolved prompt variables back to the collection.