### PR TITLE
.Net: Address API review feedback on Kernel.GetService

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example18_DallE.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example18_DallE.cs
@@ -31,7 +31,7 @@ public static class Example18_DallE
             .WithOpenAIChatCompletion(TestConfiguration.OpenAI.ChatModelId, TestConfiguration.OpenAI.ApiKey)
             .Build();
 
-        ITextToImageService dallE = kernel.GetService<ITextToImageService>();
+        ITextToImageService dallE = kernel.GetRequiredService<ITextToImageService>();
 
         var imageDescription = "A cute baby sea otter";
         var image = await dallE.GenerateImageAsync(imageDescription, 256, 256);
@@ -48,7 +48,7 @@ public static class Example18_DallE
 
         Console.WriteLine("======== Chat with images ========");
 
-        IChatCompletionService chatGPT = kernel.GetService<IChatCompletionService>();
+        IChatCompletionService chatGPT = kernel.GetRequiredService<IChatCompletionService>();
         var chatHistory = new ChatHistory(
            "You're chatting with a user. Instead of replying directly to the user" +
            " provide the description of an image that expresses what you want to say." +
@@ -100,7 +100,7 @@ public static class Example18_DallE
             .WithAzureOpenAIChatCompletion(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.ChatModelId, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
             .Build();
 
-        ITextToImageService dallE = kernel.GetService<ITextToImageService>();
+        ITextToImageService dallE = kernel.GetRequiredService<ITextToImageService>();
         var imageDescription = "A cute baby sea otter";
         var image = await dallE.GenerateImageAsync(imageDescription, 256, 256);
 
@@ -116,7 +116,7 @@ public static class Example18_DallE
 
         Console.WriteLine("======== Chat with images ========");
 
-        IChatCompletionService chatGPT = kernel.GetService<IChatCompletionService>();
+        IChatCompletionService chatGPT = kernel.GetRequiredService<IChatCompletionService>();
         var chatHistory = new ChatHistory(
             "You're chatting with a user. Instead of replying directly to the user" +
             " provide the description of an image that expresses what you want to say." +

--- a/dotnet/samples/KernelSyntaxExamples/Example26_AADAuth.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example26_AADAuth.cs
@@ -51,7 +51,7 @@ public static class Example26_AADAuth
                 new DefaultAzureCredential(authOptions))
         .Build();
 
-        IChatCompletionService chatGPT = kernel.GetService<IChatCompletionService>();
+        IChatCompletionService chatGPT = kernel.GetRequiredService<IChatCompletionService>();
         var chatHistory = new ChatHistory();
 
         // User message

--- a/dotnet/samples/KernelSyntaxExamples/Example30_ChatWithPrompts.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example30_ChatWithPrompts.cs
@@ -98,7 +98,7 @@ public static class Example30_ChatWithPrompts
         Console.WriteLine($"------------------------------------\n{userMessage}");
 
         // Client used to request answers
-        var chatCompletion = kernel.GetService<IChatCompletionService>();
+        var chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
 
         // The full chat history. Depending on your scenario, you can pass the full chat if useful,
         // or create a new one every time, assuming that the "system message" contains all the

--- a/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
@@ -38,7 +38,7 @@ public static class Example59_OpenAIFunctionCalling
         // Load additional functions into the kernel
         await kernel.ImportPluginFromOpenAIAsync("KlarnaShoppingPlugin", new Uri("https://www.klarna.com/.well-known/ai-plugin.json"));
 
-        var chatCompletionService = kernel.GetService<IChatCompletionService>();
+        var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
         var chatHistory = new ChatHistory();
         var executionSettings = new OpenAIPromptExecutionSettings();
 

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AIServicesOpenAIExtensionsTests.cs
@@ -22,8 +22,8 @@ public class AIServicesOpenAIExtensionsTests
             .WithAzureOpenAITextEmbeddingGeneration("depl2", "model2", "https://url", "key", "azure")
             .Build();
 
-        Assert.NotNull(targetKernel.GetService<ITextGenerationService>("azure"));
-        Assert.NotNull(targetKernel.GetService<ITextEmbeddingGeneration>("azure"));
+        Assert.NotNull(targetKernel.GetRequiredService<ITextGenerationService>("azure"));
+        Assert.NotNull(targetKernel.GetRequiredService<ITextEmbeddingGeneration>("azure"));
     }
 
     [Fact]
@@ -37,10 +37,10 @@ public class AIServicesOpenAIExtensionsTests
             .Build();
 
         // Assert
-        Assert.NotNull(targetKernel.GetService<ITextGenerationService>("azure"));
-        Assert.NotNull(targetKernel.GetService<ITextGenerationService>("oai"));
-        Assert.NotNull(targetKernel.GetService<ITextEmbeddingGeneration>("azure"));
-        Assert.NotNull(targetKernel.GetService<ITextGenerationService>("oai"));
+        Assert.NotNull(targetKernel.GetRequiredService<ITextGenerationService>("azure"));
+        Assert.NotNull(targetKernel.GetRequiredService<ITextGenerationService>("oai"));
+        Assert.NotNull(targetKernel.GetRequiredService<ITextEmbeddingGeneration>("azure"));
+        Assert.NotNull(targetKernel.GetRequiredService<ITextGenerationService>("oai"));
     }
 
     [Fact]

--- a/dotnet/src/Functions/Functions.OpenAPI/Extensions/OpenApiKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenAPI/Extensions/OpenApiKernelExtensions.cs
@@ -112,7 +112,7 @@ public static class OpenApiKernelExtensions
 
         var openApiSpec = await DocumentLoader.LoadDocumentFromFilePathAsync(
             filePath,
-            kernel.GetService<ILoggerFactory>().CreateLogger(typeof(OpenApiKernelExtensions)),
+            kernel.LoggerFactory.CreateLogger(typeof(OpenApiKernelExtensions)),
             cancellationToken).ConfigureAwait(false);
 
         return await CreateOpenApiPluginAsync(

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlanner.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/HandlebarsPlanner.cs
@@ -51,7 +51,7 @@ public sealed class HandlebarsPlanner
     {
         var availableFunctions = this.GetAvailableFunctionsManual(kernel, out var complexParameterTypes, out var complexParameterSchemas, cancellationToken);
         var createPlanPrompt = this.GetHandlebarsTemplate(kernel, goal, availableFunctions, complexParameterTypes, complexParameterSchemas);
-        var chatCompletionService = kernel.GetService<IChatCompletionService>();
+        var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
 
         // Extract the chat history from the rendered prompt
         string pattern = @"<(user~|system~|assistant~)>(.*?)<\/\1>";

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
@@ -45,7 +45,7 @@ public sealed class FunctionCallingStepwisePlanner
     {
         Verify.NotNullOrWhiteSpace(question);
         Verify.NotNull(kernel);
-        IChatCompletionService chatCompletion = kernel.GetService<IChatCompletionService>();
+        IChatCompletionService chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
         ILoggerFactory loggerFactory = kernel.LoggerFactory;
         ILogger logger = loggerFactory.CreateLogger(this.GetType());
         var promptTemplateFactory = new KernelPromptTemplateFactory(loggerFactory);

--- a/dotnet/src/SemanticKernel.Abstractions/Services/OrderedAIServiceSelector.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Services/OrderedAIServiceSelector.cs
@@ -61,7 +61,7 @@ internal sealed class OrderedAIServiceSelector : IAIServiceSelector
 
             if (defaultExecutionSettings is not null)
             {
-                return (kernel.GetService<T>(), defaultExecutionSettings);
+                return (kernel.GetRequiredService<T>(), defaultExecutionSettings);
             }
         }
 

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -210,7 +210,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
 
     private async Task<(ITextGenerationService, string, PromptRenderedEventArgs?)> RenderPromptAsync(Kernel kernel, KernelArguments arguments, CancellationToken cancellationToken)
     {
-        var serviceSelector = kernel.GetService<IAIServiceSelector>();
+        var serviceSelector = kernel.ServiceSelector;
         (var textGeneration, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextGenerationService>(kernel, this, arguments);
         Verify.NotNull(textGeneration);
 

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelBuilderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelBuilderTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.AI.TextGeneration;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.ChatCompletion;
@@ -96,7 +97,7 @@ public class KernelBuilderTests
             .WithLoggerFactory(loggerFactory2)
             .Build();
 
-        Assert.Same(loggerFactory2, kernel.GetService<ILoggerFactory>());
+        Assert.Same(loggerFactory2, kernel.GetRequiredService<ILoggerFactory>());
         Assert.Same(loggerFactory2, kernel.LoggerFactory);
     }
 
@@ -104,8 +105,37 @@ public class KernelBuilderTests
     public void ItDefaultsLoggerFactoryToNullLoggerFactory()
     {
         Kernel kernel = new KernelBuilder().Build();
-        Assert.Same(NullLoggerFactory.Instance, kernel.GetService<ILoggerFactory>());
+        Assert.Throws<KernelException>(() => kernel.GetRequiredService<ILoggerFactory>());
         Assert.Same(NullLoggerFactory.Instance, kernel.LoggerFactory);
+    }
+
+    [Fact]
+    public void ItDefaultsServiceSelectorToSingleton()
+    {
+        Kernel kernel = new KernelBuilder().Build();
+        Assert.Null(kernel.Services.GetService<IAIServiceSelector>());
+        Assert.NotNull(kernel.ServiceSelector);
+        Assert.Same(kernel.ServiceSelector, kernel.ServiceSelector);
+        Assert.Throws<KernelException>(() => kernel.GetRequiredService<IAIServiceSelector>());
+
+        kernel = new Kernel();
+        Assert.Null(kernel.Services.GetService<IAIServiceSelector>());
+        Assert.NotNull(kernel.ServiceSelector);
+        Assert.Same(kernel.ServiceSelector, kernel.ServiceSelector);
+        Assert.Throws<KernelException>(() => kernel.GetRequiredService<IAIServiceSelector>());
+
+        NopServiceSelector selector = new();
+
+        kernel = new KernelBuilder().WithAIServiceSelector(selector).Build();
+        Assert.Same(selector, kernel.Services.GetService<IAIServiceSelector>());
+        Assert.Same(selector, kernel.ServiceSelector);
+        Assert.Same(selector, kernel.GetRequiredService<IAIServiceSelector>());
+    }
+
+    private sealed class NopServiceSelector : IAIServiceSelector
+    {
+        (T?, PromptExecutionSettings?) IAIServiceSelector.SelectAIService<T>(Kernel kernel, KernelFunction function, KernelArguments arguments) where T : class =>
+            throw new NotImplementedException();
     }
 
     [Fact]
@@ -214,8 +244,8 @@ public class KernelBuilderTests
             })
             .Build();
 
-        Assert.IsType<OpenAIChatCompletionService>(kernel.GetService<IChatCompletionService>("openai"));
-        Assert.IsType<AzureOpenAITextGenerationService>(kernel.GetService<ITextGenerationService>("azureopenai"));
+        Assert.IsType<OpenAIChatCompletionService>(kernel.GetRequiredService<IChatCompletionService>("openai"));
+        Assert.IsType<AzureOpenAITextGenerationService>(kernel.GetRequiredService<ITextGenerationService>("azureopenai"));
 
         Assert.Equal(2, kernel.GetAllServices<ITextGenerationService>().Count());
         Assert.Single(kernel.GetAllServices<IChatCompletionService>());
@@ -273,8 +303,8 @@ public class KernelBuilderTests
 
         Assert.NotNull(k);
         Assert.Same(plugins, k.Plugins);
-        Assert.IsAssignableFrom<IChatCompletionService>(k.GetService<IChatCompletionService>("azureopenai1"));
-        Assert.IsAssignableFrom<IChatCompletionService>(k.GetService<IChatCompletionService>("azureopenai2"));
+        Assert.IsAssignableFrom<IChatCompletionService>(k.GetRequiredService<IChatCompletionService>("azureopenai1"));
+        Assert.IsAssignableFrom<IChatCompletionService>(k.GetRequiredService<IChatCompletionService>("azureopenai2"));
 
         // This should be 4, not 2. However, there is currently a limitation with Microsoft.Extensions.DependencyInjection
         // that prevents GetAllServices from enumerating named services. KernelBuilder works around this,

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/OrderedAIServiceConfigurationProviderTests.cs
@@ -84,7 +84,7 @@ public class OrderedAIServiceConfigurationProviderTests
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextGenerationService>(kernel, function, new KernelArguments());
 
         // Assert
-        Assert.Equal(kernel.GetService<ITextGenerationService>("service2"), aiService);
+        Assert.Equal(kernel.GetRequiredService<ITextGenerationService>("service2"), aiService);
         Assert.Equal(executionSettings, defaultExecutionSettings);
     }
 
@@ -123,7 +123,7 @@ public class OrderedAIServiceConfigurationProviderTests
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextGenerationService>(kernel, function, new KernelArguments());
 
         // Assert
-        Assert.Equal(kernel.GetService<ITextGenerationService>("service2"), aiService);
+        Assert.Equal(kernel.GetRequiredService<ITextGenerationService>("service2"), aiService);
         Assert.Null(defaultExecutionSettings);
     }
 
@@ -145,7 +145,7 @@ public class OrderedAIServiceConfigurationProviderTests
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextGenerationService>(kernel, function, new KernelArguments());
 
         // Assert
-        Assert.Equal(kernel.GetService<ITextGenerationService>("service2"), aiService);
+        Assert.Equal(kernel.GetRequiredService<ITextGenerationService>("service2"), aiService);
         Assert.Equal(executionSettings, defaultExecutionSettings);
     }
 
@@ -166,7 +166,7 @@ public class OrderedAIServiceConfigurationProviderTests
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextGenerationService>(kernel, function, new KernelArguments());
 
         // Assert
-        Assert.Equal(kernel.GetService<ITextGenerationService>("service2"), aiService);
+        Assert.Equal(kernel.GetRequiredService<ITextGenerationService>("service2"), aiService);
         Assert.Equal(executionSettings, defaultExecutionSettings);
     }
 
@@ -197,7 +197,7 @@ public class OrderedAIServiceConfigurationProviderTests
         (var aiService, var defaultExecutionSettings) = serviceSelector.SelectAIService<ITextGenerationService>(kernel, function, new KernelArguments());
 
         // Assert
-        Assert.Equal(kernel.GetService<ITextGenerationService>(expectedServiceId), aiService);
+        Assert.Equal(kernel.GetRequiredService<ITextGenerationService>(expectedServiceId), aiService);
         if (!string.IsNullOrEmpty(defaultExecutionSettings!.ServiceId))
         {
             Assert.Equal(expectedServiceId, defaultExecutionSettings!.ServiceId);


### PR DESCRIPTION
- Renames it to GetRequiredService
- Removes backstop for ILoggerFactory/IAIServiceSelector so that it's behavior is effectively the same as IServiceProvider.GetRequiredService. Once we can remove the workaround for the lack of GetKeyedServices working for any key, this will effectively just become a call to this.Services.Get{Required}KeyedService.
- Adds dedicated property for ServiceSelector that will default to the singleton instance