### PR TITLE
Fixing Example48_Example48_GroundednessChecks

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example48_GroundednessChecks.cs
@@ -58,7 +58,7 @@ after this event Caroline became his wife.""";
 
     public static async Task GroundednessCheckingAsync()
     {
-        Console.WriteLine("======== Groundedness Checks ========");
+        Console.WriteLine("\n======== Groundedness Checks ========");
         var kernel = new KernelBuilder()
             .AddAzureOpenAIChatCompletion(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
@@ -100,14 +100,14 @@ her a beggar. My father came to her aid and two years later they married.
 
         var groundingResult = (await kernel.InvokeAsync(reference_check, variables)).ToString();
 
-        Console.WriteLine("======== Reference Check ========");
+        Console.WriteLine("\n======== Reference Check ========");
         Console.WriteLine(groundingResult);
 
         variables[KernelArguments.InputParameterName] = summaryText;
         variables["ungrounded_entities"] = groundingResult;
         var excisionResult = await kernel.InvokeAsync(entity_excision, variables);
 
-        Console.WriteLine("======== Excise Entities ========");
+        Console.WriteLine("\n======== Excise Entities ========");
         Console.WriteLine(excisionResult.GetValue<string>());
     }
 
@@ -115,14 +115,16 @@ her a beggar. My father came to her aid and two years later they married.
     {
         var targetTopic = "people and places";
         var samples = "John, Jane, mother, brother, Paris, Rome";
-        var ask = @$"Make a summary of input text. Then make a list of entities
+        var ask = @$"Make a summary of the following text. Then make a list of entities
 related to {targetTopic} (such as {samples}) which are present in the summary.
 Take this list of entities, and from it make another list of those which are not
 grounded in the original input text. Finally, rewrite your summary to remove the entities
 which are not grounded in the original.
+
+Text:\n{GroundingText};
 ";
 
-        Console.WriteLine("======== Planning - Groundedness Checks ========");
+        Console.WriteLine("\n======== Planning - Groundedness Checks ========");
 
         var kernel = new KernelBuilder()
             .AddAzureOpenAIChatCompletion(
@@ -141,9 +143,11 @@ which are not grounded in the original.
         var planner = new HandlebarsPlanner();
         var plan = await planner.CreatePlanAsync(kernel, ask);
 
-        Console.WriteLine($" Goal: {ask} \n\n Template: {plan}");
+        Console.WriteLine($"======== Goal: ========\n{ask}\n======== Plan ========\n{plan}");
 
         var result = plan.Invoke(kernel, new KernelArguments(), CancellationToken.None);
+
+        Console.WriteLine("======== Result ========");
         Console.WriteLine(result);
     }
 }
@@ -157,18 +161,21 @@ which are not grounded in the original.
 - Zurich
 - Mary
 </entities>
+
 ======== Reference Check ========
 <ungrounded_entities>
 - Milan
 - Zurich
 - Mary
 </ungrounded_entities>
+
 ======== Excise Entities ========
 My father, a respected resident of a city, was a close friend of a merchant named Beaufort who, after a series of
 misfortunes, moved to another city in poverty. My father was upset by his friend's troubles and sought him out,
 finding him in a mean street. Beaufort had saved a small sum of money, but it was not enough to support him and
 his daughter. The daughter procured work to eek out a living, but after ten months her father died, leaving
 her a beggar. My father came to her aid and two years later they married.
+
 ======== Planning - Groundedness Checks ========
 Goal: Make a summary of input text. Then make a list of entities
 related to people and places (such as John, Jane, mother, brother, Paris, Rome) which are present in the summary.
@@ -176,26 +183,30 @@ Take this list of entities, and from it make another list of those which are not
 grounded in the original input text. Finally, rewrite your summary to remove the entities
 which are not grounded in the original.
 
+Text:
+{See GroundingText above}
 
+Plan:
+{{!-- Step 1: Set the input text --}}
+{{set "inputText" "I am by birth a Genevese, and my family is one of the most distinguished of that republic. My ancestors had been for many years counsellors and syndics, and my father had filled several public situations with honour and reputation.He was respected by all who knew him for his integrity and indefatigable attention to public business.He passed his younger days perpetually occupied by the affairs of his country; a variety of circumstances had prevented his marrying early, nor was it until the decline of life that he became a husband and the father of a family. As the circumstances of his marriage illustrate his character, I cannot refrain from relating them.One of his most intimate friends was a merchant who, from a flourishing state, fell, through numerous mischances, into poverty. This man, whose name was Beaufort, was of a proud and unbending disposition and could not bear to live in poverty and oblivion in the same country where he had formerly been distinguished for his rank and magnificence. Having paid his debts, therefore, in the most honourable manner, he retreated with his daughter to the town of Lucerne, where he lived unknown and in wretchedness.My father loved Beaufort with the truest friendship and was deeply grieved by his retreat in these unfortunate circumstances.He bitterly deplored the false pride which led his friend to a conduct so little worthy of the affection that united them.He lost no time in endeavouring to seek him out, with the hope of persuading him to begin the world again through his credit and assistance. Beaufort had taken effectual measures to conceal himself, and it was ten months before my father discovered his abode.Overjoyed at this discovery, he hastened to the house, which was situated in a mean street near the Reuss. But when he entered, misery and despair alone welcomed him. Beaufort had saved but a very small sum of money from the wreck of his fortunes, but it was sufficient to provide him with sustenance for some months, and in the meantime he hoped to procure some respectable employment in a merchant's house. The interval was, consequently, spent in inaction; his grief only became more deep and rankling when he had leisure for reflection, and at length it took so fast hold of his mind that at the end of three months he lay on a bed of sickness, incapable of any exertion. His daughter attended him with the greatest tenderness, but she saw with despair that their little fund was rapidly decreasing and that there was no other prospect of support.But Caroline Beaufort possessed a mind of an uncommon mould, and her courage rose to support her in her adversity. She procured plain work; she plaited straw and by various means contrived to earn a pittance scarcely sufficient to support life. Several months passed in this manner.Her father grew worse; her time was more entirely occupied in attending him; her means of subsistence decreased; and in the tenth month her father died in her arms, leaving her an orphan and a beggar.This last blow overcame her, and she knelt by Beaufort's coffin weeping bitterly, when my father entered the chamber. He came like a protecting spirit to the poor girl, who committed herself to his care; and after the interment of his friend he conducted her to Geneva and placed her under the protection of a relation.Two years after this event Caroline became his wife."}}
 
+{{!-- Step 2: Summarize the input text --}}
+{{set "summary" (SummarizePlugin-Summarize input=(get "inputText"))}}
 
-Steps:
-  - SummarizePlugin.Summarize INPUT='' => RESULT__SUMMARY
-  - GroundingPlugin.ExtractEntities example_entities='John;Jane;mother;brother;Paris;Rome' topic='people and places' INPUT='$RESULT__SUMMARY' => ENTITIES
-  - GroundingPlugin.ReferenceCheckEntities reference_context='$ORIGINAL_TEXT' INPUT='$ENTITIES' => RESULT__UNGROUND_ENTITIES
-  - GroundingPlugin.ExciseEntities ungrounded_entities='$RESULT__UNGROUND_ENTITIES' INPUT='$RESULT__SUMMARY' => RESULT__FINAL_SUMMARY
+{{!-- Step 3: Extract entities related to people and places --}}
+{{set "exampleEntities" (array "John" "Jane" "mother" "brother" "Paris" "Rome")}}
+{{set "extractedEntities" (GroundingPlugin-ExtractEntities input=(get "summary") topic="people and places" example_entities=(get "exampleEntities"))}}
+
+{{!-- Step 4: Check if the extracted entities are grounded in the original text --}}
+{{set "ungroundedEntities" (GroundingPlugin-ReferenceCheckEntities input=(get "extractedEntities") reference_context=(get "inputText"))}}
+
+{{!-- Step 5: Remove ungrounded entities from the summary --}}
+{{set "finalSummary" (GroundingPlugin-ExciseEntities input=(get "summary") ungrounded_entities=(get "ungroundedEntities"))}}
+
+{{!-- Step 6: Output the final summary --}}
+{{json (get "finalSummary")}}
+
 A possible summary is:
-
-
-
-The narrator's father, a respected Genevese politician, befriended Beaufort, a merchant who fell into poverty and hid in Lucerne. After a long search, he found him dying and his daughter Caroline working hard to survive. He took pity on Caroline, buried Beaufort, and married her two years later.
-<ungrounded_entities>
-- narrator
-</ungrounded_entities>
-A possible summary is:
-
-
-
-The father of the story's main character, a respected Genevese politician, befriended Beaufort, a merchant who fell into poverty and hid in Lucerne. After a long search, he found him dying and his daughter Caroline working hard to survive. He took pity on Caroline, buried Beaufort, and married her two years later.
+Born in Geneva to a distinguished family, the narrator's father married late in life. His close friend Beaufort, once wealthy, fell into poverty and moved to another city with his daughter, Caroline. The narrator's father searched for Beaufort, finding him after ten months, only to witness his decline and eventual death. Caroline, now an orphan, was taken in by the narrator's father, who married her two years later.
 == DONE ==
 */

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/CreatePlanPrompt.handlebars
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/CreatePlanPrompt.handlebars
@@ -183,6 +183,7 @@ IMPORTANT: You can only use the helpers that are listed above. Do not use any ot
 - There are no initial variables available to you. You must create them yourself using the `\{{set}}` helper and then access them using `\{{get}}`.
 - Do not make up values. Use the helpers to generate the data you need or extract it from the goal.
 - Keep data well-defined. Each variable should have a unique name. Create and assign each variable only once.
+- Do not pass raw data to helpers. Use variables instead.
 - Be extremely careful about types. For example, if you pass an array to a helper that expects a number, the template will error out.
 {{#if allowLoops}}- Avoid using loops. Try a solution without before you deploy a loop.{{/if}}
 - There is no need to check your results in the template.
@@ -194,7 +195,7 @@ Now take a deep breath and accomplish the task:
 1. Keep the template short and sweet. Be as efficient as possible.
 2. Do not use helpers or functions that were not provided to you, and be especially careful to not assume or make up any helpers or operations that were not explicitly defined already.
 3. If none of the available helpers can achieve the goal, respond with "Additional helpers may be required".
-4. The first steps should always be to initialize any variables you need.
+4. Always start by identifying any important values in the goal. Then, use the `\{{set}}` helper to create variables for each of these values.
 5. The template should use the \{{json}} helper at least once to output the result of the final step.
 6. Don't forget to use the tips and tricks otherwise the template will not work.
 7. Don't close the ``` handlebars block until you're done with all the steps.{{/message}}

--- a/samples/plugins/GroundingPlugin/ExciseEntities/config.json
+++ b/samples/plugins/GroundingPlugin/ExciseEntities/config.json
@@ -14,12 +14,14 @@
     {
       "name": "input",
       "description": "The text from which the entities are to be removed",
-      "default": ""
+      "default": "",
+      "is_required": true
     },
     {
       "name": "ungrounded_entities",
       "description": "The entities to remove. This is a list of strings.",
-      "default": ""
+      "default": "",
+      "is_required": true
     }
   ]
 }

--- a/samples/plugins/GroundingPlugin/ExtractEntities/config.json
+++ b/samples/plugins/GroundingPlugin/ExtractEntities/config.json
@@ -14,12 +14,14 @@
     {
       "name": "input",
       "description": "The text from which the entities are to be extracted",
-      "default": ""
+      "default": "",
+      "is_required": true
     },
     {
       "name": "topic",
       "description": "The topic of interest; the extracted entities should be related to this topic",
-      "default": ""
+      "default": "",
+      "is_required": true
     },
     {
       "name": "example_entities",

--- a/samples/plugins/GroundingPlugin/ReferenceCheckEntities/config.json
+++ b/samples/plugins/GroundingPlugin/ReferenceCheckEntities/config.json
@@ -14,12 +14,14 @@
     {
       "name": "input",
       "description": "The list of entities which are to be checked against the reference context.",
-      "default": ""
+      "default": "",
+      "is_required": true
     },
     {
       "name": "reference_context",
       "description": "The reference context to be used to ground the entities. Only those missing from the reference_context will be returned",
-      "default": ""
+      "default": "",
+      "is_required": true
     }
   ]
 }

--- a/samples/plugins/SummarizePlugin/Summarize/config.json
+++ b/samples/plugins/SummarizePlugin/Summarize/config.json
@@ -14,7 +14,8 @@
     {
       "name": "input",
       "description": "Text to summarize",
-      "default": ""
+      "default": "",
+      "is_required": true
     }
   ]
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR addresses bug #3837, where the plan didn't produce expected Groundedness result.

Fix was to add the GroundingText to the ask (used as the Goal in the planner).   

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

PR also contains small fixes to label parameters in relevant semantic functions as required + some tuning of the CreatePlan prompt to emphasize proper variable usage. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
