### PR TITLE
.Net: Reduce overheads of XmlPromptParser.TryParse for non-XML

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatCompletionServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatCompletionServiceExtensions.cs
@@ -33,7 +33,7 @@ public static class ChatCompletionServiceExtensions
         CancellationToken cancellationToken = default)
     {
         // Try to parse the text as a chat history
-        if (XmlPromptParser.TryParse(prompt!, out var nodes) && ChatPromptParser.TryParse(nodes, out var chatHistory))
+        if (XmlPromptParser.TryParse(prompt, out var nodes) && ChatPromptParser.TryParse(nodes, out var chatHistory))
         {
             return chatCompletionService.GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
         }
@@ -96,7 +96,7 @@ public static class ChatCompletionServiceExtensions
         CancellationToken cancellationToken = default)
     {
         // Try to parse the text as a chat history
-        if (XmlPromptParser.TryParse(prompt!, out var nodes) && ChatPromptParser.TryParse(nodes, out var chatHistory))
+        if (XmlPromptParser.TryParse(prompt, out var nodes) && ChatPromptParser.TryParse(nodes, out var chatHistory))
         {
             return chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
         }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatCompletionServiceExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatCompletionServiceExtensions.cs
@@ -33,7 +33,7 @@ public static class ChatCompletionServiceExtensions
         CancellationToken cancellationToken = default)
     {
         // Try to parse the text as a chat history
-        if (XmlPromptParser.TryParse(prompt, out var nodes) && ChatPromptParser.TryParse(nodes, out var chatHistory))
+        if (ChatPromptParser.TryParse(prompt, out var chatHistory))
         {
             return chatCompletionService.GetChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
         }
@@ -96,7 +96,7 @@ public static class ChatCompletionServiceExtensions
         CancellationToken cancellationToken = default)
     {
         // Try to parse the text as a chat history
-        if (XmlPromptParser.TryParse(prompt, out var nodes) && ChatPromptParser.TryParse(nodes, out var chatHistory))
+        if (ChatPromptParser.TryParse(prompt, out var chatHistory))
         {
             return chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken);
         }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.ChatCompletion;
 
@@ -10,9 +11,32 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 /// </summary>
 internal static class ChatPromptParser
 {
-    internal const string RequiredTagOpeningToBeValid = "<message";
     private const string MessageTagName = "message";
     private const string RoleAttributeName = "role";
+
+    /// <summary>
+    /// Parses a prompt for an XML representation of a <see cref="ChatHistory"/>.
+    /// </summary>
+    /// <param name="prompt">The prompt to parse.</param>
+    /// <param name="chatHistory">The parsed <see cref="ChatHistory"/>, or null if it couldn't be parsed.</param>
+    /// <returns>true if the history could be parsed; otherwise, false.</returns>
+    public static bool TryParse(string prompt, [NotNullWhen(true)] out ChatHistory? chatHistory)
+    {
+        // Parse the input string into nodes and then those nodes into a chat history.
+        // The XML parsing is expensive, so we do a quick up-front check to make sure
+        // the text contains "<message", as that's required in any valid XML prompt.
+        const string MessageTagStart = "<" + MessageTagName;
+        if (prompt is not null &&
+            prompt.IndexOf(MessageTagStart, StringComparison.OrdinalIgnoreCase) >= 0 &&
+            XmlPromptParser.TryParse(prompt, out var nodes) &&
+            TryParse(nodes, out chatHistory))
+        {
+            return true;
+        }
+
+        chatHistory = null;
+        return false;
+    }
 
     /// <summary>
     /// Parses collection of <see cref="PromptNode"/> instances and sets output as <see cref="ChatHistory"/>.
@@ -20,9 +44,9 @@ internal static class ChatPromptParser
     /// <param name="nodes">Collection of <see cref="PromptNode"/> to parse.</param>
     /// <param name="chatHistory">Parsing output as <see cref="ChatHistory"/>.</param>
     /// <returns>Returns true if parsing was successful, otherwise false.</returns>
-    public static bool TryParse(List<PromptNode> nodes, out ChatHistory chatHistory)
+    private static bool TryParse(List<PromptNode> nodes, [NotNullWhen(true)] out ChatHistory? chatHistory)
     {
-        chatHistory = new ChatHistory();
+        chatHistory = null;
 
         foreach (var node in nodes)
         {
@@ -31,11 +55,11 @@ internal static class ChatPromptParser
                 var role = node.Attributes[RoleAttributeName];
                 var content = node.Content!;
 
-                chatHistory.AddMessage(new AuthorRole(role), content);
+                (chatHistory ??= new()).AddMessage(new AuthorRole(role), content);
             }
         }
 
-        return chatHistory.Count != 0;
+        return chatHistory is not null;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
@@ -10,6 +10,7 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 /// </summary>
 internal static class ChatPromptParser
 {
+    internal const string RequiredTagOpeningToBeValid = "<message";
     private const string MessageTagName = "message";
     private const string RoleAttributeName = "role";
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextGeneration/TextGenerationExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextGeneration/TextGenerationExtensions.cs
@@ -50,7 +50,7 @@ public static class TextGenerationExtensions
         CancellationToken cancellationToken = default)
     {
         if (textGenerationService is IChatCompletionService chatCompletion
-            && XmlPromptParser.TryParse(prompt!, out var nodes)
+            && XmlPromptParser.TryParse(prompt, out var nodes)
             && ChatPromptParser.TryParse(nodes, out var chatHistory))
         {
             var chatMessage = await chatCompletion.GetChatMessageContentAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
@@ -83,7 +83,7 @@ public static class TextGenerationExtensions
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (textGenerationService is IChatCompletionService chatCompletion
-            && XmlPromptParser.TryParse(prompt!, out var nodes)
+            && XmlPromptParser.TryParse(prompt, out var nodes)
             && ChatPromptParser.TryParse(nodes, out var chatHistory))
         {
             await foreach (var chatMessage in chatCompletion.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken))

--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextGeneration/TextGenerationExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextGeneration/TextGenerationExtensions.cs
@@ -50,8 +50,7 @@ public static class TextGenerationExtensions
         CancellationToken cancellationToken = default)
     {
         if (textGenerationService is IChatCompletionService chatCompletion
-            && XmlPromptParser.TryParse(prompt, out var nodes)
-            && ChatPromptParser.TryParse(nodes, out var chatHistory))
+            && ChatPromptParser.TryParse(prompt, out var chatHistory))
         {
             var chatMessage = await chatCompletion.GetChatMessageContentAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false);
             return new TextContent(chatMessage.Content, chatMessage.ModelId, chatMessage.InnerContent, chatMessage.Encoding, chatMessage.Metadata);
@@ -83,8 +82,7 @@ public static class TextGenerationExtensions
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (textGenerationService is IChatCompletionService chatCompletion
-            && XmlPromptParser.TryParse(prompt, out var nodes)
-            && ChatPromptParser.TryParse(nodes, out var chatHistory))
+            && ChatPromptParser.TryParse(prompt, out var chatHistory))
         {
             await foreach (var chatMessage in chatCompletion.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken))
             {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/XmlPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/XmlPromptParser.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Xml;
-using Microsoft.SemanticKernel.AI.ChatCompletion;
 
 namespace Microsoft.SemanticKernel;
 
@@ -27,14 +26,13 @@ internal static class XmlPromptParser
         // exception is thrown. Try to avoid it in the common case where the prompt is obviously not XML.
         // To be valid XML, at a minimum:
         // - the string would need to be non-null
-        // - it would need to contain a the start of a tag; we also focus on the specific expected XML format, which must have a "message" tag
+        // - it would need to contain a the start of a tag
         // - it would need to contain a closing tag, which could include either </ or />
-        const string Required = ChatPromptParser.RequiredTagOpeningToBeValid;
         int startPos;
         if (prompt is null ||
-            (startPos = prompt.IndexOf(Required, StringComparison.OrdinalIgnoreCase)) < 0 ||
-            (prompt.IndexOf("</", startPos + Required.Length, StringComparison.Ordinal) < 0 &&
-             prompt.IndexOf("/>", startPos + Required.Length, StringComparison.Ordinal) < 0))
+            (startPos = prompt.IndexOf('<')) < 0 ||
+            (prompt.IndexOf("</", startPos + 1, StringComparison.Ordinal) < 0 &&
+             prompt.IndexOf("/>", startPos + 1, StringComparison.Ordinal) < 0))
         {
             return false;
         }

--- a/dotnet/src/SemanticKernel.UnitTests/Prompt/XmlPromptParserTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Prompt/XmlPromptParserTests.cs
@@ -15,14 +15,14 @@ public class XmlPromptParserTests
     [Theory]
     [InlineData("This is plain prompt")]
     [InlineData("<message This is invalid chat prompt>")]
-    public void ItReturnsEmptyListWhenPromptIsPlainText(string prompt)
+    public void ItReturnsNullListWhenPromptIsPlainText(string prompt)
     {
         // Act
         var result = XmlPromptParser.TryParse(prompt, out var nodes);
 
         // Assert
         Assert.False(result);
-        Assert.Empty(nodes);
+        Assert.Null(nodes);
     }
 
     [Fact]


### PR DESCRIPTION
We're currently paying _a lot_ to try to parse an XML prompt, in particular for the common case when it's not actually.