### PR TITLE
.Net: Guard some LogXx calls to avoid overheads when not logging

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/AzureOpenAIClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/AzureOpenAIClientCore.cs
@@ -105,6 +105,9 @@ internal sealed class AzureOpenAIClientCore : ClientCore
     /// <param name="callerMemberName">Caller member name. Populated automatically by runtime.</param>
     internal void LogActionDetails([CallerMemberName] string? callerMemberName = default)
     {
-        this.Logger.LogInformation("Action: {Action}. Azure OpenAI Deployment Name: {DeploymentName}.", callerMemberName, this.DeploymentOrModelName);
+        if (this.Logger.IsEnabled(LogLevel.Information))
+        {
+            this.Logger.LogInformation("Action: {Action}. Azure OpenAI Deployment Name: {DeploymentName}.", callerMemberName, this.DeploymentOrModelName);
+        }
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientCore.cs
@@ -674,9 +674,12 @@ internal abstract class ClientCore
     /// <param name="usage">Instance of <see cref="CompletionsUsage"/> with usage details.</param>
     private void CaptureUsageDetails(CompletionsUsage usage)
     {
-        this.Logger.LogInformation(
-            "Prompt tokens: {PromptTokens}. Completion tokens: {CompletionTokens}. Total tokens: {TotalTokens}.",
-            usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens);
+        if (this.Logger.IsEnabled(LogLevel.Information))
+        {
+            this.Logger.LogInformation(
+                "Prompt tokens: {PromptTokens}. Completion tokens: {CompletionTokens}. Total tokens: {TotalTokens}.",
+                usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens);
+        }
 
         s_promptTokensCounter.Add(usage.PromptTokens);
         s_completionTokensCounter.Add(usage.CompletionTokens);

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/OpenAIClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/OpenAIClientCore.cs
@@ -80,6 +80,9 @@ internal sealed class OpenAIClientCore : ClientCore
     /// <param name="callerMemberName">Caller member name. Populated automatically by runtime.</param>
     internal void LogActionDetails([CallerMemberName] string? callerMemberName = default)
     {
-        this.Logger.LogInformation("Action: {Action}. OpenAI Model ID: {ModelId}.", callerMemberName, this.DeploymentOrModelName);
+        if (this.Logger.IsEnabled(LogLevel.Information))
+        {
+            this.Logger.LogInformation("Action: {Action}. OpenAI Model ID: {ModelId}.", callerMemberName, this.DeploymentOrModelName);
+        }
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAITextToImageClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/CustomClient/OpenAITextToImageClientCore.cs
@@ -130,7 +130,10 @@ internal sealed class OpenAITextToImageClientCore
 
         var response = await this._httpClient.SendWithSuccessCheckAsync(request, cancellationToken).ConfigureAwait(false);
 
-        this._logger.LogDebug("HTTP response: {0} {1}", (int)response.StatusCode, response.StatusCode.ToString("G"));
+        if (this._logger.IsEnabled(LogLevel.Debug))
+        {
+            this._logger.LogDebug("HTTP response: {0} {1}", (int)response.StatusCode, response.StatusCode.ToString("G"));
+        }
 
         return response;
     }

--- a/dotnet/src/SemanticKernel.Core/PromptTemplate/KernelPromptTemplate.cs
+++ b/dotnet/src/SemanticKernel.Core/PromptTemplate/KernelPromptTemplate.cs
@@ -62,7 +62,11 @@ public sealed class KernelPromptTemplate : IPromptTemplate
     /// <returns>A list of all the blocks, ie the template tokenized in text, variables and function calls</returns>
     private List<Block> ExtractBlocks(string? templateText, bool validate = true)
     {
-        this._logger.LogTrace("Extracting blocks from template: {0}", templateText);
+        if (this._logger.IsEnabled(LogLevel.Trace))
+        {
+            this._logger.LogTrace("Extracting blocks from template: {0}", templateText);
+        }
+
         var blocks = this._tokenizer.Tokenize(templateText);
 
         if (validate)
@@ -89,7 +93,10 @@ public sealed class KernelPromptTemplate : IPromptTemplate
     /// <returns>The prompt template ready to be used for an AI request.</returns>
     private async Task<string> RenderAsync(List<Block> blocks, Kernel kernel, KernelArguments? arguments, CancellationToken cancellationToken = default)
     {
-        this._logger.LogTrace("Rendering list of {0} blocks", blocks.Count);
+        if (this._logger.IsEnabled(LogLevel.Trace))
+        {
+            this._logger.LogTrace("Rendering list of {0} blocks", blocks.Count);
+        }
 
         var result = new StringBuilder();
         foreach (var block in blocks)
@@ -114,7 +121,10 @@ public sealed class KernelPromptTemplate : IPromptTemplate
         string resultString = result.ToString();
 
         // Sensitive data, logging as trace, disabled by default
-        this._logger.LogTrace("Rendered prompt: {0}", resultString);
+        if (this._logger.IsEnabled(LogLevel.Trace))
+        {
+            this._logger.LogTrace("Rendered prompt: {0}", resultString);
+        }
 
         return resultString;
     }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/CodeBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/CodeBlock.cs
@@ -77,7 +77,10 @@ internal sealed class CodeBlock : Block, ICodeRendering
             throw new KernelException(error);
         }
 
-        this.Logger.LogTrace("Rendering code: `{Content}`", this.Content);
+        if (this.Logger.IsEnabled(LogLevel.Trace))
+        {
+            this.Logger.LogTrace("Rendering code: `{Content}`", this.Content);
+        }
 
         return this._tokens[0].Type switch
         {
@@ -157,7 +160,10 @@ internal sealed class CodeBlock : Block, ICodeRendering
         var firstArg = this._tokens[1];
 
         // Sensitive data, logging as trace, disabled by default
-        this.Logger.LogTrace("Passing variable/value: `{Content}`", firstArg.Content);
+        if (this.Logger.IsEnabled(LogLevel.Trace))
+        {
+            this.Logger.LogTrace("Passing variable/value: `{Content}`", firstArg.Content);
+        }
 
         var namedArgsStartIndex = 1;
         if (firstArg.Type is not BlockTypes.NamedArg)
@@ -181,7 +187,10 @@ internal sealed class CodeBlock : Block, ICodeRendering
             }
 
             // Sensitive data, logging as trace, disabled by default
-            this.Logger.LogTrace("Passing variable/value: `{Content}`", arg.Content);
+            if (this.Logger.IsEnabled(LogLevel.Trace))
+            {
+                this.Logger.LogTrace("Passing variable/value: `{Content}`", arg.Content);
+            }
 
             arguments[arg.Name] = arg.GetValue(arguments);
         }


### PR DESCRIPTION
These calls are all allocating even when logging at the particular log level is disabled. Guard them with IsEnabled checks to avoid that.