### PR TITLE
Rename example 03 to "Arguments"

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example03_Arguments.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example03_Arguments.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Plugins;
 
+/*
+ * This example shows how to use kernel arguments when invoking functions.
+ */
 // ReSharper disable once InconsistentNaming
-public static class Example03_Variables
+public static class Example03_Arguments
 {
     public static async Task RunAsync()
     {
-        Console.WriteLine("======== Variables ========");
+        Console.WriteLine("======== Arguments ========");
 
         Kernel kernel = new();
         var textPlugin = kernel.ImportPluginFromType<StaticTextPlugin>();
@@ -21,14 +24,14 @@ public static class Example03_Variables
             ["day"] = DateTimeOffset.Now.ToString("dddd", CultureInfo.CurrentCulture)
         };
 
-        // ** Different ways of executing function with arguments **
+        // ** Different ways of executing functions with arguments **
 
         // Specify and get the value type as generic parameter
         string? resultValue = await kernel.InvokeAsync<string>(textPlugin["AppendDay"], arguments);
         Console.WriteLine($"string -> {resultValue}");
 
         // If you need to access the result metadata, you can use the non-generic version to get the FunctionResult
-        var functionResult = await kernel.InvokeAsync(textPlugin["AppendDay"], arguments);
+        FunctionResult functionResult = await kernel.InvokeAsync(textPlugin["AppendDay"], arguments);
         var metadata = functionResult.Metadata;
 
         // Specify the type from the FunctionResult


### PR DESCRIPTION
### Motivation and Context
We now use the term "kernel arguments" instead of "context variables".

### Description
Rename test accordingly.

### Contribution Checklist
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
