### PR TITLE
.Net: Unnecessary helper method is removed

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
@@ -42,7 +41,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         await function.InvokeAsync(this._kernel);
@@ -62,7 +61,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel);
@@ -84,7 +83,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel);
@@ -107,7 +106,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel);
@@ -128,7 +127,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel);
@@ -153,7 +152,7 @@ public sealed class KernelFunctionFromMethodTests1
         arguments["someVar"] = s_expected;
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -182,7 +181,7 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Act
         Func<string, string?> method = Test;
-        var function = KernelFunctionFactory.CreateFromMethod(Method(method), method.Target, loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(method, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -212,7 +211,7 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Act
         Func<string, Task> method = TestAsync;
-        var function = KernelFunctionFactory.CreateFromMethod(Method(method), method.Target, loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(method, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -240,7 +239,7 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Act
         Action<string> method = Test;
-        var function = KernelFunctionFactory.CreateFromMethod(Method(method), method.Target, loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(method, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -268,7 +267,7 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Act
         Func<string, string> method = Test;
-        var function = KernelFunctionFactory.CreateFromMethod(Method(method), method.Target, loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(method, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -295,7 +294,7 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Act
         Func<string, Task<string>> method = Test;
-        var function = KernelFunctionFactory.CreateFromMethod(Method(method), method.Target, loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(method, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -322,7 +321,7 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Act
         Action<Kernel> method = Test;
-        var function = KernelFunctionFactory.CreateFromMethod(Method(method), method.Target);
+        var function = KernelFunctionFactory.CreateFromMethod(method);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -347,7 +346,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments(s_expected);
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -371,7 +370,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments(s_expected);
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -397,7 +396,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("test");
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(Test, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -421,7 +420,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments(string.Empty);
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestAsync), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestAsync, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -445,7 +444,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments(string.Empty);
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestAsync), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestAsync, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -471,7 +470,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments();
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestAsync), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestAsync, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -497,7 +496,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("x y z");
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestAsync), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestAsync, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -521,7 +520,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments();
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestAsync), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestAsync, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var result = await function.InvokeAsync(this._kernel, arguments);
@@ -540,7 +539,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("input value");
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -558,7 +557,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("input value");
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -576,7 +575,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("42") { ["orother"] = 8 };
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -594,7 +593,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("input value") { ["other"] = "other value" };
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -612,7 +611,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("input value") { ["other"] = "other value" };
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -630,7 +629,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments("input value");
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -646,7 +645,7 @@ public sealed class KernelFunctionFromMethodTests1
         FunctionResult Test() => new(s_nopFunction, "fake-result", CultureInfo.InvariantCulture);
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel);
@@ -668,7 +667,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel);
@@ -690,7 +689,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel);
@@ -716,7 +715,7 @@ public sealed class KernelFunctionFromMethodTests1
         arguments["f"] = DayOfWeek.Monday;
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -735,7 +734,7 @@ public sealed class KernelFunctionFromMethodTests1
         arguments["mct"] = "42";
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -885,7 +884,7 @@ public sealed class KernelFunctionFromMethodTests1
         }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
 
         await function.InvokeAsync(this._kernel, arguments: new() { { "a", 10 } }); // Passing value for the 'a' parameter only.
     }
@@ -932,7 +931,7 @@ public sealed class KernelFunctionFromMethodTests1
         arguments["g"] = "7e08cc00-1d71-4558-81ed-69929499dxyz";
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
         Assert.NotNull(function);
 
         var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => function.InvokeAsync(this._kernel, arguments));
@@ -965,7 +964,7 @@ public sealed class KernelFunctionFromMethodTests1
         static string Test(Guid id, string name, int old) => $"{id} {name} {old}";
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(Test));
+        var function = KernelFunctionFactory.CreateFromMethod(Test);
 
         // Assert
         Assert.Contains("Test", function.Name, StringComparison.Ordinal);
@@ -984,10 +983,10 @@ public sealed class KernelFunctionFromMethodTests1
         static string TestString(string str) => str;
         static bool TestBool(bool flag) => flag;
 
-        var function1 = KernelFunctionFactory.CreateFromMethod(Method(TestInt));
-        var function2 = KernelFunctionFactory.CreateFromMethod(Method(TestDouble));
-        var function3 = KernelFunctionFactory.CreateFromMethod(Method(TestString));
-        var function4 = KernelFunctionFactory.CreateFromMethod(Method(TestBool));
+        var function1 = KernelFunctionFactory.CreateFromMethod(TestInt);
+        var function2 = KernelFunctionFactory.CreateFromMethod(TestDouble);
+        var function3 = KernelFunctionFactory.CreateFromMethod(TestString);
+        var function4 = KernelFunctionFactory.CreateFromMethod(TestBool);
 
         // Act
         FunctionResult result1 = await function1.InvokeAsync(this._kernel, new("42"));
@@ -1018,7 +1017,7 @@ public sealed class KernelFunctionFromMethodTests1
         var arguments = new KernelArguments();
         arguments["instance"] = "42";
 
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestCustomType));
+        var function = KernelFunctionFactory.CreateFromMethod(TestCustomType);
 
         // Act
         FunctionResult result = await function.InvokeAsync(this._kernel, arguments);
@@ -1048,7 +1047,7 @@ public sealed class KernelFunctionFromMethodTests1
             yield return 3;
         }
 
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestAsyncEnumerableTypeAsync));
+        var function = KernelFunctionFactory.CreateFromMethod(TestAsyncEnumerableTypeAsync);
 
         // Act
         FunctionResult result = await function.InvokeAsync(this._kernel, new KernelArguments());
@@ -1083,10 +1082,5 @@ public sealed class KernelFunctionFromMethodTests1
 
         // Assert
         Assert.Same(expected, actual);
-    }
-
-    private static MethodInfo Method(Delegate method)
-    {
-        return method.Method;
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionMetadataTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionMetadataTests.cs
@@ -71,7 +71,7 @@ public class KernelFunctionMetadataTests
     public void ItSupportsValidFunctionName()
     {
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(ValidFunctionName), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(ValidFunctionName, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         var fv = function.Metadata;
@@ -84,7 +84,7 @@ public class KernelFunctionMetadataTests
     public void ItSupportsValidFunctionAsyncName()
     {
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(ValidFunctionNameAsync), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(ValidFunctionNameAsync, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
         KernelFunctionMetadata fv = function.Metadata;
 
@@ -101,7 +101,7 @@ public class KernelFunctionMetadataTests
         { }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestFunctionName), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestFunctionName, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         KernelFunctionMetadata fv = function.Metadata;
@@ -122,7 +122,7 @@ public class KernelFunctionMetadataTests
         { }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestFunctionName), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestFunctionName, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         KernelFunctionMetadata fv = function.Metadata;
@@ -144,7 +144,7 @@ public class KernelFunctionMetadataTests
         static void TestFunctionName(int p1, int p2) { }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestFunctionName), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestFunctionName, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         KernelFunctionMetadata fv = function.Metadata;
@@ -166,7 +166,7 @@ public class KernelFunctionMetadataTests
         static void TestFunctionName() { }
 
         // Act
-        var function = KernelFunctionFactory.CreateFromMethod(Method(TestFunctionName), loggerFactory: this._logger.Object);
+        var function = KernelFunctionFactory.CreateFromMethod(TestFunctionName, loggerFactory: this._logger.Object);
         Assert.NotNull(function);
 
         KernelFunctionMetadata fv = function.Metadata;
@@ -181,12 +181,7 @@ public class KernelFunctionMetadataTests
     private static void ValidFunctionName() { }
     private static async Task ValidFunctionNameAsync()
     {
-        var function = KernelFunctionFactory.CreateFromMethod(Method(ValidFunctionName));
+        var function = KernelFunctionFactory.CreateFromMethod(ValidFunctionName);
         var result = await function.InvokeAsync(new());
-    }
-
-    private static MethodInfo Method(Delegate method)
-    {
-        return method.Method;
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -220,7 +220,7 @@ public sealed class KernelPromptTemplateTests
             return $"F({input})";
         }
 
-        var func = KernelFunctionFactory.CreateFromMethod(Method(MyFunctionAsync), this, "function");
+        var func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
 
@@ -246,7 +246,7 @@ public sealed class KernelPromptTemplateTests
             return $"F({input})";
         }
 
-        var func = KernelFunctionFactory.CreateFromMethod(Method(MyFunctionAsync), this, "function");
+        var func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
 
@@ -276,7 +276,7 @@ public sealed class KernelPromptTemplateTests
             return $"[{dateStr}] {input} ({age}): \"{slogan}\"";
         }
 
-        var func = KernelFunctionFactory.CreateFromMethod(Method(MyFunctionAsync), this, "function");
+        var func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
 
@@ -324,7 +324,7 @@ public sealed class KernelPromptTemplateTests
             return $"[{dateStr}] {input} ({age}): \"{slogan}\"";
         }
 
-        KernelFunction func = KernelFunctionFactory.CreateFromMethod(Method(MyFunctionAsync), this, "function");
+        KernelFunction func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
 
@@ -365,9 +365,9 @@ public sealed class KernelPromptTemplateTests
 
         var functions = new List<KernelFunction>()
         {
-            KernelFunctionFactory.CreateFromMethod(Method(MyFunction1Async), this, "func1"),
-            KernelFunctionFactory.CreateFromMethod(Method(MyFunction2Async), this, "func2"),
-            KernelFunctionFactory.CreateFromMethod(Method(MyFunction3Async), this, "func3")
+            KernelFunctionFactory.CreateFromMethod(MyFunction1Async, "func1"),
+            KernelFunctionFactory.CreateFromMethod(MyFunction2Async, "func2"),
+            KernelFunctionFactory.CreateFromMethod(MyFunction3Async, "func3")
         };
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", functions));
@@ -390,7 +390,7 @@ public sealed class KernelPromptTemplateTests
             return Task.FromResult(input);
         }
 
-        KernelFunction func = KernelFunctionFactory.CreateFromMethod(Method(MyFunctionAsync), this, "function");
+        KernelFunction func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
 
@@ -447,10 +447,5 @@ public sealed class KernelPromptTemplateTests
 
         // Assert
         Assert.Equal("int:42, double:36,6, string:test, Guid:7ac656b1-c917-41c8-9ff5-e8f0eb51fbac, DateTime:05/12/2023 17:52, enum:Monday", result);
-    }
-
-    private static MethodInfo Method(Delegate method)
-    {
-        return method.Method;
     }
 }


### PR DESCRIPTION
Unnecessary helper method - `private static MethodInfo Method(Delegate method)` is removed from a few unit tests.