### PR TITLE
.Net: Populate prompt function variables from template

### DIFF
--- a/dotnet/src/SemanticKernel.Core/PromptTemplate/KernelPromptTemplate.cs
+++ b/dotnet/src/SemanticKernel.Core/PromptTemplate/KernelPromptTemplate.cs
@@ -146,7 +146,7 @@ internal sealed class KernelPromptTemplate : IPromptTemplate
         variableNames.AddRange(codeVariableNames);
 
         // Variables from named arguments e.g. "{{p.bar b = $b}}"
-        var codeNamedArgs = codeTokenBlocks.Where(block => block.Type == BlockTypes.NamedArg).Select(block => ((NamedArgBlock)block).Name).ToList();
+        var codeNamedArgs = codeTokenBlocks.Where(block => block.Type == BlockTypes.NamedArg && ((NamedArgBlock)block).VarBlock is not null).Select(block => ((NamedArgBlock)block).VarBlock!.Name).ToList();
         variableNames.AddRange(codeNamedArgs);
 
         // Add distinct variables found in the template that are not in the prompt config

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/CodeBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/CodeBlock.cs
@@ -38,6 +38,11 @@ internal sealed class CodeBlock : Block, ICodeRendering
         this._tokens = tokens;
     }
 
+    /// <summary>
+    /// Gets the list of blocks.
+    /// </summary>
+    public List<Block> Blocks => this._tokens;
+
     /// <inheritdoc/>
     public override bool IsValid(out string errorMsg)
     {

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/NamedArgBlock.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/NamedArgBlock.cs
@@ -22,6 +22,11 @@ internal sealed class NamedArgBlock : Block, ITextRendering
     internal string Name { get; } = string.Empty;
 
     /// <summary>
+    /// VarBlock associated with this named argument.
+    /// </summary>
+    internal VarBlock? VarBlock { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="NamedArgBlock"/> class.
     /// </summary>
     /// <param name="text">Raw text parsed from the prompt template.</param>
@@ -48,7 +53,7 @@ internal sealed class NamedArgBlock : Block, ITextRendering
 
         if (argValue[0] == Symbols.VarPrefix)
         {
-            this._argValueAsVarBlock = new VarBlock(argValue);
+            this.VarBlock = new VarBlock(argValue);
         }
         else
         {
@@ -70,10 +75,10 @@ internal sealed class NamedArgBlock : Block, ITextRendering
             return this._valBlock!.Render(arguments);
         }
 
-        var valueIsValidVarBlock = this._argValueAsVarBlock != null && this._argValueAsVarBlock.IsValid(out var errorMessage2);
+        var valueIsValidVarBlock = this.VarBlock != null && this.VarBlock.IsValid(out var errorMessage2);
         if (valueIsValidVarBlock)
         {
-            return this._argValueAsVarBlock!.Render(arguments);
+            return this.VarBlock!.Render(arguments);
         }
 
         return string.Empty;
@@ -107,13 +112,13 @@ internal sealed class NamedArgBlock : Block, ITextRendering
             this.Logger.LogError(errorMsg);
             return false;
         }
-        else if (this._argValueAsVarBlock != null && !this._argValueAsVarBlock.IsValid(out var variableErrorMsg))
+        else if (this.VarBlock != null && !this.VarBlock.IsValid(out var variableErrorMsg))
         {
             errorMsg = $"There was an issue with the named argument value for '{this.Name}': {variableErrorMsg}";
             this.Logger.LogError(errorMsg);
             return false;
         }
-        else if (this._valBlock == null && this._argValueAsVarBlock == null)
+        else if (this._valBlock == null && this.VarBlock == null)
         {
             errorMsg = "A named argument must have a value";
             this.Logger.LogError(errorMsg);
@@ -136,7 +141,6 @@ internal sealed class NamedArgBlock : Block, ITextRendering
 
     private readonly VarBlock _argNameAsVarBlock;
     private readonly ValBlock? _valBlock;
-    private readonly VarBlock? _argValueAsVarBlock;
 
     private static string? TrimWhitespace(string? text)
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
@@ -29,14 +29,13 @@ public class KernelFunctionFromPromptTests
         Assert.NotNull(function);
         Assert.NotNull(function.Metadata);
         Assert.NotNull(function.Metadata.Parameters);
-        Assert.Equal(7, function.Metadata.Parameters.Count);
+        Assert.Equal(6, function.Metadata.Parameters.Count);
         Assert.Equal("x11", function.Metadata.Parameters[0].Name);
         Assert.Equal("a", function.Metadata.Parameters[1].Name);
         Assert.Equal("missing", function.Metadata.Parameters[2].Name);
         Assert.Equal("b", function.Metadata.Parameters[3].Name);
-        Assert.Equal("c", function.Metadata.Parameters[4].Name);
-        Assert.Equal("d", function.Metadata.Parameters[5].Name);
-        Assert.Equal("ename", function.Metadata.Parameters[6].Name);
+        Assert.Equal("d", function.Metadata.Parameters[4].Name);
+        Assert.Equal("e", function.Metadata.Parameters[5].Name);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
@@ -20,6 +20,25 @@ namespace SemanticKernel.UnitTests.Functions;
 public class KernelFunctionFromPromptTests
 {
     [Fact]
+    public void ItAddsMissingVariablesForPrompt()
+    {
+        // Arrange & Act
+        var function = KernelFunctionFromPrompt.Create("This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='argument \"c\"' d = $d}}");
+
+        // Assert
+        Assert.NotNull(function);
+        Assert.NotNull(function.Metadata);
+        Assert.NotNull(function.Metadata.Parameters);
+        Assert.Equal(6, function.Metadata.Parameters.Count);
+        Assert.Equal("x11", function.Metadata.Parameters[0].Name);
+        Assert.Equal("a", function.Metadata.Parameters[1].Name);
+        Assert.Equal("missing", function.Metadata.Parameters[2].Name);
+        Assert.Equal("b", function.Metadata.Parameters[3].Name);
+        Assert.Equal("c", function.Metadata.Parameters[4].Name);
+        Assert.Equal("d", function.Metadata.Parameters[5].Name);
+    }
+
+    [Fact]
     public void ItProvidesAccessToFunctionsViaFunctionCollection()
     {
         // Arrange

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
@@ -23,7 +23,7 @@ public class KernelFunctionFromPromptTests
     public void ItAddsMissingVariablesForPrompt()
     {
         // Arrange & Act
-        var function = KernelFunctionFromPrompt.Create("This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.foo c='argument \"c\"' d = $d}} and {{p.baz ename=$e}}");
+        var function = KernelFunctionFromPrompt.Create("This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.foo c='literal \"c\"' d = $d}} and {{p.baz ename=$e}}");
 
         // Assert
         Assert.NotNull(function);

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
@@ -23,19 +23,20 @@ public class KernelFunctionFromPromptTests
     public void ItAddsMissingVariablesForPrompt()
     {
         // Arrange & Act
-        var function = KernelFunctionFromPrompt.Create("This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='argument \"c\"' d = $d}}");
+        var function = KernelFunctionFromPrompt.Create("This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.foo c='argument \"c\"' d = $d}} and {{p.baz ename=$e}}");
 
         // Assert
         Assert.NotNull(function);
         Assert.NotNull(function.Metadata);
         Assert.NotNull(function.Metadata.Parameters);
-        Assert.Equal(6, function.Metadata.Parameters.Count);
+        Assert.Equal(7, function.Metadata.Parameters.Count);
         Assert.Equal("x11", function.Metadata.Parameters[0].Name);
         Assert.Equal("a", function.Metadata.Parameters[1].Name);
         Assert.Equal("missing", function.Metadata.Parameters[2].Name);
         Assert.Equal("b", function.Metadata.Parameters[3].Name);
         Assert.Equal("c", function.Metadata.Parameters[4].Name);
         Assert.Equal("d", function.Metadata.Parameters[5].Name);
+        Assert.Equal("ename", function.Metadata.Parameters[6].Name);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -33,7 +33,7 @@ public sealed class KernelPromptTemplateTests
     public void ItAddsMissingVariables()
     {
         // Arrange
-        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.foo c='argument \"c\"' d = $d}} and {{p.baz ename=$e}}";
+        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.foo c='literal \"c\"' d = $d}} and {{p.baz ename=$e}}";
         var promptTemplateConfig = new PromptTemplateConfig(template);
 
         // Act
@@ -103,7 +103,7 @@ public sealed class KernelPromptTemplateTests
     public async Task ItRendersVariablesValuesAndFunctionsAsync()
     {
         // Arrange
-        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='argument \"c\"' d = $d}}";
+        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='literal \"c\"' d = $d}}";
 
         this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[]
         {
@@ -123,7 +123,7 @@ public sealed class KernelPromptTemplateTests
         var renderedPrompt = await target.RenderAsync(this._kernel, this._arguments);
 
         // Assert
-        Assert.Equal("This is a test template with function that accepts the positional argument 'input' and another one with argument \"c\" and 'd'", renderedPrompt);
+        Assert.Equal("This is a test template with function that accepts the positional argument 'input' and another one with literal \"c\" and 'd'", renderedPrompt);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -40,14 +40,13 @@ public sealed class KernelPromptTemplateTests
         var target = (KernelPromptTemplate)this._factory.Create(promptTemplateConfig);
 
         // Assert
-        Assert.Equal(7, promptTemplateConfig.InputVariables.Count);
+        Assert.Equal(6, promptTemplateConfig.InputVariables.Count);
         Assert.Equal("x11", promptTemplateConfig.InputVariables[0].Name);
         Assert.Equal("a", promptTemplateConfig.InputVariables[1].Name);
         Assert.Equal("missing", promptTemplateConfig.InputVariables[2].Name);
         Assert.Equal("b", promptTemplateConfig.InputVariables[3].Name);
-        Assert.Equal("c", promptTemplateConfig.InputVariables[4].Name);
-        Assert.Equal("d", promptTemplateConfig.InputVariables[5].Name);
-        Assert.Equal("ename", promptTemplateConfig.InputVariables[6].Name);
+        Assert.Equal("d", promptTemplateConfig.InputVariables[4].Name);
+        Assert.Equal("e", promptTemplateConfig.InputVariables[5].Name);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -30,6 +30,26 @@ public sealed class KernelPromptTemplateTests
     }
 
     [Fact]
+    public void ItAddsMissingVariables()
+    {
+        // Arrange
+        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='argument \"c\"' d = $d}}";
+        var promptTemplateConfig = new PromptTemplateConfig(template);
+
+        // Act
+        var target = (KernelPromptTemplate)this._factory.Create(promptTemplateConfig);
+
+        // Assert
+        Assert.Equal(6, promptTemplateConfig.InputVariables.Count);
+        Assert.Equal("x11", promptTemplateConfig.InputVariables[0].Name);
+        Assert.Equal("a", promptTemplateConfig.InputVariables[1].Name);
+        Assert.Equal("missing", promptTemplateConfig.InputVariables[2].Name);
+        Assert.Equal("b", promptTemplateConfig.InputVariables[3].Name);
+        Assert.Equal("c", promptTemplateConfig.InputVariables[4].Name);
+        Assert.Equal("d", promptTemplateConfig.InputVariables[5].Name);
+    }
+
+    [Fact]
     public async Task ItRendersVariablesValuesAndFunctionsAsync()
     {
         // Arrange
@@ -293,16 +313,17 @@ public sealed class KernelPromptTemplateTests
     }
 
     [Fact]
-    public async Task ItHandlesSyntaxErrorsAsync()
+    public void ItHandlesSyntaxErrors()
     {
         // Arrange
         this._arguments[KernelArguments.InputParameterName] = "Mario";
         this._arguments["someDate"] = "2023-08-25T00:00:00";
         var template = "foo-{{function input=$input age=42 slogan='Let\\'s-a go!' date=$someDate}}-baz";
-        var target = (KernelPromptTemplate)this._factory.Create(new PromptTemplateConfig(template));
+        //var target = (KernelPromptTemplate)this._factory.Create(new PromptTemplateConfig(template));
 
         // Act
-        var result = await Assert.ThrowsAsync<KernelException>(() => target.RenderAsync(this._kernel, this._arguments));
+        var result = Assert.Throws<KernelException>(() => this._factory.Create(new PromptTemplateConfig(template)));
+        //var result = await Assert.ThrowsAsync<KernelException>(() => target.RenderAsync(this._kernel, this._arguments));
 
         // Assert
         Assert.Equal($"Named argument values need to be prefixed with a quote or {Symbols.VarPrefix}.", result.Message);

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -33,20 +33,71 @@ public sealed class KernelPromptTemplateTests
     public void ItAddsMissingVariables()
     {
         // Arrange
-        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='argument \"c\"' d = $d}}";
+        var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.foo c='argument \"c\"' d = $d}} and {{p.baz ename=$e}}";
         var promptTemplateConfig = new PromptTemplateConfig(template);
 
         // Act
         var target = (KernelPromptTemplate)this._factory.Create(promptTemplateConfig);
 
         // Assert
-        Assert.Equal(6, promptTemplateConfig.InputVariables.Count);
+        Assert.Equal(7, promptTemplateConfig.InputVariables.Count);
         Assert.Equal("x11", promptTemplateConfig.InputVariables[0].Name);
         Assert.Equal("a", promptTemplateConfig.InputVariables[1].Name);
         Assert.Equal("missing", promptTemplateConfig.InputVariables[2].Name);
         Assert.Equal("b", promptTemplateConfig.InputVariables[3].Name);
         Assert.Equal("c", promptTemplateConfig.InputVariables[4].Name);
         Assert.Equal("d", promptTemplateConfig.InputVariables[5].Name);
+        Assert.Equal("ename", promptTemplateConfig.InputVariables[6].Name);
+    }
+
+    [Fact]
+    public void ItAllowsSameVariableInMultiplePositions()
+    {
+        // Arrange
+        var template = "This {{$a}} {{$a}} and {{p.bar $a}} and {{p.baz a=$a}}";
+        var promptTemplateConfig = new PromptTemplateConfig(template);
+
+        // Act
+        var target = (KernelPromptTemplate)this._factory.Create(promptTemplateConfig);
+
+        // Assert
+        Assert.Single(promptTemplateConfig.InputVariables);
+        Assert.Equal("a", promptTemplateConfig.InputVariables[0].Name);
+    }
+
+    [Fact]
+    public void ItAllowsSameVariableInMultiplePositionsCaseInsenstive()
+    {
+        // Arrange
+        var template = "{{$a}} {{$A}} and {{p.bar $a}} and {{p.baz A=$a}}";
+        var promptTemplateConfig = new PromptTemplateConfig(template);
+
+        // Act
+        var target = (KernelPromptTemplate)this._factory.Create(promptTemplateConfig);
+
+        // Assert
+        Assert.Single(promptTemplateConfig.InputVariables);
+        Assert.Equal("a", promptTemplateConfig.InputVariables[0].Name);
+    }
+
+    [Fact]
+    public void ItDoesNotDuplicateExistingParameters()
+    {
+        // Arrange
+        var template = "This {{$A}} and {{p.bar $B}} and {{p.baz C=$C}}";
+        var promptTemplateConfig = new PromptTemplateConfig(template);
+        promptTemplateConfig.InputVariables.Add(new InputVariable { Name = "a" });
+        promptTemplateConfig.InputVariables.Add(new InputVariable { Name = "b" });
+        promptTemplateConfig.InputVariables.Add(new InputVariable { Name = "c" });
+
+        // Act
+        var target = (KernelPromptTemplate)this._factory.Create(promptTemplateConfig);
+
+        // Assert
+        Assert.Equal(3, promptTemplateConfig.InputVariables.Count);
+        Assert.Equal("a", promptTemplateConfig.InputVariables[0].Name);
+        Assert.Equal("b", promptTemplateConfig.InputVariables[1].Name);
+        Assert.Equal("c", promptTemplateConfig.InputVariables[2].Name);
     }
 
     [Fact]
@@ -319,11 +370,9 @@ public sealed class KernelPromptTemplateTests
         this._arguments[KernelArguments.InputParameterName] = "Mario";
         this._arguments["someDate"] = "2023-08-25T00:00:00";
         var template = "foo-{{function input=$input age=42 slogan='Let\\'s-a go!' date=$someDate}}-baz";
-        //var target = (KernelPromptTemplate)this._factory.Create(new PromptTemplateConfig(template));
 
         // Act
         var result = Assert.Throws<KernelException>(() => this._factory.Create(new PromptTemplateConfig(template)));
-        //var result = await Assert.ThrowsAsync<KernelException>(() => target.RenderAsync(this._kernel, this._arguments));
 
         // Assert
         Assert.Equal($"Named argument values need to be prefixed with a quote or {Symbols.VarPrefix}.", result.Message);

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -66,7 +66,7 @@ public sealed class KernelPromptTemplateTests
     }
 
     [Fact]
-    public void ItAllowsSameVariableInMultiplePositionsCaseInsenstive()
+    public void ItAllowsSameVariableInMultiplePositionsCaseInsensitive()
     {
         // Arrange
         var template = "{{$a}} {{$A}} and {{p.bar $a}} and {{p.baz A=$a}}";


### PR DESCRIPTION
### Motivation and Context

A common usage pattern is to call `var function = KernelFunctionFactory.CreateFromPrompt((prompt)`. 

This PR fixes the issue whereby the function created from a prompt does not contain valid parameter metadata.

### Description

- When a `IPromptTemplate` instance is created for a prompt using the `semantic-kernel` template format, the template will be parsed and the associated `PromptTemplateConfig` will be updated with any missing arguments
- **Note: This is only supported when using the `semantic-kernel` template format**

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
