### PR TITLE
.Net: Moved Microsoft.SemanticKernel.Events classes to Microsoft.SemanticKernel

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example57_KernelHooks.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example57_KernelHooks.cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
-using Microsoft.SemanticKernel.Events;
 using RepoUtils;
 
 // ReSharper disable once InconsistentNaming

--- a/dotnet/src/SemanticKernel.Abstractions/Events/CancelKernelEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/CancelKernelEventArgs.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.SemanticKernel.Events;
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Provides an <see cref="EventArgs"/> for cancelable operations related

--- a/dotnet/src/SemanticKernel.Abstractions/Events/FunctionInvokedEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/FunctionInvokedEventArgs.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace Microsoft.SemanticKernel.Events;
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Provides a <see cref="CancelKernelEventArgs"/> used in events just after a function is invoked.

--- a/dotnet/src/SemanticKernel.Abstractions/Events/FunctionInvokingEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/FunctionInvokingEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.SemanticKernel.Events;
+
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Provides a <see cref="CancelKernelEventArgs"/> used in events just before a function is invoked.

--- a/dotnet/src/SemanticKernel.Abstractions/Events/KernelEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/KernelEventArgs.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.SemanticKernel.Events;
+namespace Microsoft.SemanticKernel;
 
 /// <summary>Provides an <see cref="EventArgs"/> for operations related to <see cref="Kernel"/>-based operations.</summary>
 public abstract class KernelEventArgs : EventArgs

--- a/dotnet/src/SemanticKernel.Abstractions/Events/PromptRenderedEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/PromptRenderedEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.SemanticKernel.Events;
+
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Provides a <see cref="CancelKernelEventArgs"/> used in events raised just after a prompt has been rendered.

--- a/dotnet/src/SemanticKernel.Abstractions/Events/PromptRenderingEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/PromptRenderingEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.SemanticKernel.Events;
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Provides a <see cref="KernelEventArgs"/> used in events raised just before a prompt is rendered.

--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.Events;
 using Microsoft.SemanticKernel.Services;
 
 namespace Microsoft.SemanticKernel;

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.ChatCompletion;
-using Microsoft.SemanticKernel.Events;
 using Microsoft.SemanticKernel.Services;
 using Microsoft.SemanticKernel.TextGeneration;
 

--- a/dotnet/src/SemanticKernel.UnitTests/Events/FunctionInvokedEventArgsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Events/FunctionInvokedEventArgsTests.cs
@@ -2,7 +2,6 @@
 
 using System.Globalization;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Events;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Events;

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/FunctionFromMethodTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/FunctionFromMethodTests.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Events;
 using Xunit;
 
 // ReSharper disable StringLiteralTypo

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Events;
 using Microsoft.SemanticKernel.TextGeneration;
 using Moq;
 using Xunit;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/3894

Moved event args classes from `Microsoft.SemanticKernel.Events` to root namespace `Microsoft.SemanticKernel`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
