### PR TITLE
Python: Update default value in TextMemorySkill

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "semantic-kernel"
-version = "0.4.1.dev"
-description = ""
+version = "0.4.2.dev"
+description = "Semantic Kernel Python SDK"
 authors = ["Microsoft <SK-Support@microsoft.com>"]
 readme = "pip/README.md"
 packages = [{include = "semantic_kernel"}]

--- a/python/semantic_kernel/core_skills/text_memory_skill.py
+++ b/python/semantic_kernel/core_skills/text_memory_skill.py
@@ -16,8 +16,8 @@ class TextMemorySkill(SKBaseModel):
     KEY_PARAM: ClassVar[str] = "key"
     LIMIT_PARAM: ClassVar[str] = "limit"
     DEFAULT_COLLECTION: ClassVar[str] = "generic"
-    DEFAULT_RELEVANCE: ClassVar[float] = 0.75
-    DEFAULT_LIMIT: ClassVar[int] = 1
+    DEFAULT_RELEVANCE: ClassVar[float] = "0.75"
+    DEFAULT_LIMIT: ClassVar[int] = "1"
 
     # @staticmethod
     @sk_function(


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

The input along with its default value of the `ContextVariable` must be a valid string. Otherwise, an validation error will be thrown saying that "Input should be a valid string".

In this PR:
1. I changed the default value of the `TextMemorySkill` from `int` and `float` to `str`.
2. I also updated the description and the version number of the SDK.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
