### PR TITLE
Function Calling Stepwise Planner - Bug Fixes

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example66_FunctionCallingStepwisePlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example66_FunctionCallingStepwisePlanner.cs
@@ -47,9 +47,9 @@ public static class Example66_FunctionCallingStepwisePlanner
         Kernel kernel = Kernel.CreateBuilder()
             .AddAzureOpenAIChatCompletion(
                 TestConfiguration.AzureOpenAI.ChatDeploymentName,
-                TestConfiguration.AzureOpenAI.ChatModelId,
                 TestConfiguration.AzureOpenAI.Endpoint,
-                TestConfiguration.AzureOpenAI.ApiKey)
+                TestConfiguration.AzureOpenAI.ApiKey,
+                modelId: TestConfiguration.AzureOpenAI.ChatModelId)
             .Build();
 
         kernel.ImportPluginFromType<EmailPlugin>();

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -696,8 +696,8 @@ internal abstract class ClientCore
         }
         else if (message.Role == AuthorRole.User)
         {
-            var functionName = openAIMessage?.Name;
-            if (functionName is null && message.Metadata?.TryGetValue(OpenAIChatMessageContent.FunctionNameProperty, out object? functionNameFromMetadata) is true)
+            string? functionName = null;
+            if (message.Metadata?.TryGetValue(OpenAIChatMessageContent.FunctionNameProperty, out object? functionNameFromMetadata) is true)
             {
                 functionName = functionNameFromMetadata?.ToString();
             }
@@ -709,14 +709,12 @@ internal abstract class ClientCore
             requestMessage = new ChatRequestAssistantMessage(message.Content)
             {
                 FunctionCall = openAIMessage?.FunctionCall,
-                Name = openAIMessage?.Name
             };
         }
         else if (string.Equals(message.Role.Label, "function", StringComparison.OrdinalIgnoreCase))
         {
-            var functionName = openAIMessage?.Name;
-
-            if (functionName is null && message.Metadata?.TryGetValue(OpenAIChatMessageContent.FunctionNameProperty, out object? functionNameFromMetadata) is true)
+            string? functionName = null;
+            if (message.Metadata?.TryGetValue(OpenAIChatMessageContent.FunctionNameProperty, out object? functionNameFromMetadata) is true)
             {
                 functionName = functionNameFromMetadata?.ToString();
             }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
@@ -49,13 +49,6 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
     public IReadOnlyList<ChatCompletionsToolCall> ToolCalls { get; }
 
     /// <summary>
-    /// The name of the author of this message. `name` is required if role is `function`,
-    /// and it should be the name of the function whose response is in the `content`.
-    /// May contain a-z, A-Z, 0-9, and underscores, with a maximum length of 64 characters.
-    /// </summary>
-    public string Name { get; set; } = string.Empty;
-
-    /// <summary>
     /// Retrieve the resulting function from the chat result.
     /// </summary>
     /// <returns>The <see cref="OpenAIFunctionResponse"/>, or null if no function was returned by the model.</returns>

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/GeneratePlan.yaml
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/GeneratePlan.yaml
@@ -23,15 +23,7 @@ input_variables:
   - name:          goal
     description:   The goal to satisfy
 execution_settings:
-  - model_id:          gpt-4
-    temperature:       0.0
-    top_p:             0.0
-    presence_penalty:  0.0
-    frequency_penalty: 0.0
-    max_tokens:        256
-    stop_sequences:    []
-  - model_id:          gpt-3.5-turbo
-    temperature:       0.0
+  - temperature:       0.0
     top_p:             0.0
     presence_penalty:  0.0
     frequency_penalty: 0.0


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Addresses multiple issues/regressions in the planner code

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
- Remove model ID from prompt YAML, to allow planner to work with any model ID
- Remove unnecessary `OpenAIChatMessageContent.Name` property - we were never setting this property, and always just pulling the name value from the function call metadata. 
  - Removing this also fixes an issue where we were putting an empty string for 'name' rather than null, causing an OpenAI model exception.
- Fix incorrect ordering of parameters in example code

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
