### PR TITLE
.Net: Fix default OpenAI execution settings values

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/OpenAIPromptExecutionSettings.cs
@@ -19,16 +19,18 @@ public sealed class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// <summary>
     /// Temperature controls the randomness of the completion.
     /// The higher the temperature, the more random the completion.
+    /// Default is 1.0.
     /// </summary>
     [JsonPropertyName("temperature")]
-    public double Temperature { get; set; }
+    public double Temperature { get; set; } = 1;
 
     /// <summary>
     /// TopP controls the diversity of the completion.
     /// The higher the TopP, the more diverse the completion.
+    /// Default is 1.0.
     /// </summary>
     [JsonPropertyName("top_p")]
-    public double TopP { get; set; }
+    public double TopP { get; set; } = 1;
 
     /// <summary>
     /// Number between -2.0 and 2.0. Positive values penalize new tokens

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/OpenAIPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/OpenAIPromptExecutionSettingsTests.cs
@@ -22,8 +22,8 @@ public class OpenAIPromptExecutionSettingsTests
 
         // Assert
         Assert.NotNull(executionSettings);
-        Assert.Equal(0, executionSettings.Temperature);
-        Assert.Equal(0, executionSettings.TopP);
+        Assert.Equal(1, executionSettings.Temperature);
+        Assert.Equal(1, executionSettings.TopP);
         Assert.Equal(0, executionSettings.FrequencyPenalty);
         Assert.Equal(0, executionSettings.PresencePenalty);
         Assert.Equal(1, executionSettings.ResultsPerPrompt);


### PR DESCRIPTION
Correctly sets the default value for Temperature and TopP to 1 for OpenAI models

Closes #4235

