### PR TITLE
.Net: Fixing issues with functions that take a parameter.

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
@@ -35,17 +35,17 @@ public static class Example09_FunctionTypes
         await kernel.InvokeAsync(plugin["type04"]);
         await kernel.InvokeAsync(kernel.Plugins["test"]["type04"]);
 
-        await kernel.InvokeAsync(plugin["type05"]);
-        await kernel.InvokeAsync(kernel.Plugins["test"]["type05"]);
+        await kernel.InvokeAsync(plugin["type05"], new() { ["x"] = "" });
+        await kernel.InvokeAsync(kernel.Plugins["test"]["type05"], new() { ["x"] = "" });
 
-        await kernel.InvokeAsync(plugin["type06"]);
-        await kernel.InvokeAsync(kernel.Plugins["test"]["type06"]);
+        await kernel.InvokeAsync(plugin["type06"], new() { ["x"] = "" });
+        await kernel.InvokeAsync(kernel.Plugins["test"]["type06"], new() { ["x"] = "" });
 
-        await kernel.InvokeAsync(plugin["type07"]);
-        await kernel.InvokeAsync(kernel.Plugins["test"]["type07"]);
+        await kernel.InvokeAsync(plugin["type07"], new() { ["x"] = "" });
+        await kernel.InvokeAsync(kernel.Plugins["test"]["type07"], new() { ["x"] = "" });
 
-        await kernel.InvokeAsync(plugin["type08"]);
-        await kernel.InvokeAsync(kernel.Plugins["test"]["type08"]);
+        await kernel.InvokeAsync(plugin["type08"], new() { ["x"] = "" });
+        await kernel.InvokeAsync(kernel.Plugins["test"]["type08"], new() { ["x"] = "" });
 
         await kernel.InvokeAsync(plugin["type09"]);
         await kernel.InvokeAsync(kernel.Plugins["test"]["type09"]);


### PR DESCRIPTION
### Motivation and Context

In our example named Example09_FunctionTypes there are a few KernelFunction examples that's relying on the special `input` parameter that is no longer supported. This PR fixes the example by specifying a value for the function parameter in the KernelArguments. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
