### PR TITLE
explicitly name init variables used in AzureOpenAIClientCore create from openai connectors

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/ChatCompletion/AzureOpenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/ChatCompletion/AzureOpenAIChatCompletionService.cs
@@ -38,7 +38,12 @@ public sealed class AzureOpenAIChatCompletionService : IChatCompletionService, I
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, endpoint, apiKey, httpClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            endpoint: endpoint,
+            apiKey: apiKey,
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
@@ -60,7 +65,12 @@ public sealed class AzureOpenAIChatCompletionService : IChatCompletionService, I
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, endpoint, credentials, httpClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            endpoint: endpoint,
+            credential: credentials,
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
 
@@ -77,7 +87,10 @@ public sealed class AzureOpenAIChatCompletionService : IChatCompletionService, I
         string? modelId = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, openAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            openAIClient: openAIClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
 

--- a/dotnet/src/Connectors/Connectors.OpenAI/OpenAIMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/OpenAIMemoryBuilderExtensions.cs
@@ -35,12 +35,12 @@ public static class OpenAIMemoryBuilderExtensions
     {
         return builder.WithTextEmbeddingGeneration((loggerFactory, httpClient) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                modelId,
-                endpoint,
-                apiKey,
-                HttpClientProvider.GetHttpClient(httpClient),
-                loggerFactory));
+                deploymentName: deploymentName,
+                endpoint: endpoint,
+                apiKey: apiKey,
+                modelId: modelId,
+                httpClient: httpClient,
+                loggerFactory: loggerFactory));
     }
 
     /// <summary>
@@ -65,12 +65,12 @@ public static class OpenAIMemoryBuilderExtensions
     {
         return builder.WithTextEmbeddingGeneration((loggerFactory, httpClient) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                endpoint,
-                credential,
-                modelId,
-                HttpClientProvider.GetHttpClient(httpClient),
-                loggerFactory));
+                deploymentName: deploymentName,
+                endpoint: endpoint,
+                credential: credential,
+                modelId: modelId,
+                httpClient: httpClient,
+                loggerFactory: loggerFactory));
     }
 
     /// <summary>
@@ -93,10 +93,10 @@ public static class OpenAIMemoryBuilderExtensions
     {
         return builder.WithTextEmbeddingGeneration((loggerFactory, httpClient) =>
             new OpenAITextEmbeddingGenerationService(
-                modelId,
-                apiKey,
-                orgId,
-                HttpClientProvider.GetHttpClient(httpClient),
-                loggerFactory));
+                modelId: modelId,
+                apiKey: apiKey,
+                organization: orgId,
+                httpClient: HttpClientProvider.GetHttpClient(httpClient),
+                loggerFactory: loggerFactory));
     }
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/OpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/OpenAIServiceCollectionExtensions.cs
@@ -358,12 +358,12 @@ public static class OpenAIServiceCollectionExtensions
 
         builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                endpoint,
-                apiKey,
-                modelId,
-                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
-                serviceProvider.GetService<ILoggerFactory>()));
+                deploymentName: deploymentName,
+                endpoint: endpoint,
+                apiKey: apiKey,
+                modelId: modelId,
+                httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
         return builder;
     }
@@ -394,12 +394,12 @@ public static class OpenAIServiceCollectionExtensions
 
         return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                endpoint,
-                apiKey,
-                modelId,
-                HttpClientProvider.GetHttpClient(serviceProvider),
-                serviceProvider.GetService<ILoggerFactory>()));
+                deploymentName: deploymentName,
+                endpoint: endpoint,
+                apiKey: apiKey,
+                modelId: modelId,
+                httpClient: HttpClientProvider.GetHttpClient(serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
     }
 
     /// <summary>
@@ -430,12 +430,12 @@ public static class OpenAIServiceCollectionExtensions
 
         builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                endpoint,
-                credential,
-                modelId,
-                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
-                serviceProvider.GetService<ILoggerFactory>()));
+                deploymentName: deploymentName,
+                endpoint: endpoint,
+                credential: credential,
+                modelId: modelId,
+                httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
         return builder;
     }
@@ -466,12 +466,12 @@ public static class OpenAIServiceCollectionExtensions
 
         return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                endpoint,
-                credential,
-                modelId,
-                HttpClientProvider.GetHttpClient(serviceProvider),
-                serviceProvider.GetService<ILoggerFactory>()));
+                deploymentName: deploymentName,
+                endpoint: endpoint,
+                credential: credential,
+                modelId: modelId,
+                httpClient: HttpClientProvider.GetHttpClient(serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
     }
 
     /// <summary>
@@ -497,10 +497,10 @@ public static class OpenAIServiceCollectionExtensions
 
         builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                openAIClient,
-                modelId,
-                serviceProvider.GetService<ILoggerFactory>()));
+                deploymentName: deploymentName,
+                openAIClient: openAIClient,
+                modelId: modelId,
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
         return builder;
     }
@@ -528,10 +528,10 @@ public static class OpenAIServiceCollectionExtensions
 
         return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new AzureOpenAITextEmbeddingGenerationService(
-                deploymentName,
-                openAIClient,
-                modelId,
-                serviceProvider.GetService<ILoggerFactory>()));
+                deploymentName: deploymentName,
+                openAIClient: openAIClient,
+                modelId: modelId,
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/TextEmbedding/AzureOpenAITextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/TextEmbedding/AzureOpenAITextEmbeddingGenerationService.cs
@@ -39,7 +39,12 @@ public sealed class AzureOpenAITextEmbeddingGenerationService : ITextEmbeddingGe
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, endpoint, apiKey, httpClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
+        this._core = new(
+            deploymentName: deploymentName, 
+            endpoint: endpoint, 
+            apiKey: apiKey, 
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
@@ -61,7 +66,12 @@ public sealed class AzureOpenAITextEmbeddingGenerationService : ITextEmbeddingGe
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, endpoint, credential, httpClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
+        this._core = new(
+            deploymentName: deploymentName, 
+            endpoint: endpoint, 
+            credential: credential, 
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
@@ -79,7 +89,10 @@ public sealed class AzureOpenAITextEmbeddingGenerationService : ITextEmbeddingGe
         string? modelId = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, openAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            openAIClient: openAIClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }

--- a/dotnet/src/Connectors/Connectors.OpenAI/TextGeneration/AzureOpenAITextGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/TextGeneration/AzureOpenAITextGenerationService.cs
@@ -39,7 +39,12 @@ public sealed class AzureOpenAITextGenerationService : ITextGenerationService
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, endpoint, apiKey, httpClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextGenerationService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            endpoint: endpoint,
+            apiKey: apiKey,
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAITextGenerationService)));
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
 
@@ -60,7 +65,12 @@ public sealed class AzureOpenAITextGenerationService : ITextGenerationService
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, endpoint, credential, httpClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextGenerationService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            endpoint: endpoint,
+            credential: credential,
+            httpClient: httpClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAITextGenerationService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
@@ -78,7 +88,10 @@ public sealed class AzureOpenAITextGenerationService : ITextGenerationService
         string? modelId = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, openAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextGenerationService)));
+        this._core = new(
+            deploymentName: deploymentName,
+            openAIClient: openAIClient,
+            logger: loggerFactory?.CreateLogger(typeof(AzureOpenAITextGenerationService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? Inconsistent variable ordering causes multiple connectors to fail at create time.
  3. What problem does it solve?
  4. What scenario does it contribute to?
  5. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
