### PR TITLE
.Net Better repeatability for Agent KernelExample #72 (Example72_AgentCollaboration)

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example72_AgentCollaboration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example72_AgentCollaboration.cs
@@ -110,7 +110,7 @@ public static class Example72_AgentCollaboration
                 Track(
                     await new AgentBuilder()
                         .WithOpenAIChatCompletion(OpenAIFunctionEnabledModel, TestConfiguration.OpenAI.ApiKey)
-                        .WithInstructions("Reply the provided concept and have the copy-writer generate an marketing idea (copy).  Then have the art-director reply to the copy-writer with a review of the copy.  Coordinate the repeated replies between the copy-writer and art-director until the art-director approves the copy.  Respond with the copy when approved by the art-director and summarize why it is good.")
+                        .WithInstructions("Reply the provided concept and have the copy-writer generate an marketing idea (copy).  Then have the art-director reply to the copy-writer with a review of the copy.  Always include the source copy in any message.  Always include the art-director comments when interacting with the copy-writer.  Coordinate the repeated replies between the copy-writer and art-director until the art-director approves the copy.")
                         .WithPlugin(copyWriter.AsPlugin())
                         .WithPlugin(artDirector.AsPlugin())
                         .BuildAsync());
@@ -147,7 +147,7 @@ public static class Example72_AgentCollaboration
             Track(
                 await new AgentBuilder()
                     .WithOpenAIChatCompletion(OpenAIFunctionEnabledModel, TestConfiguration.OpenAI.ApiKey)
-                    .WithInstructions("You are an art director who has opinions about copywriting born of a love for David Ogilvy. The goal is to provide insight on how to refine suggested copy without example.  Always respond to the most recent message by evaluating and providing critique without example.  Always repeat the copy at the beginning.  If copy is acceptable and meets your criteria, say: PRINT IT.")
+                    .WithInstructions("You are an art director who has opinions about copywriting born of a love for David Ogilvy. The goal is to determine is the given copy is acceptable to print, even if it isn't perfect.  If not, provide insight on how to refine suggested copy without example.  Always respond to the most recent message by evaluating and providing critique without example.  Always repeat the copy at the beginning.  If copy is acceptable and meets your criteria, say: PRINT IT.")
                     .WithName("Art Director")
                     .WithDescription("Art Director")
                     .BuildAsync());

--- a/dotnet/samples/KernelSyntaxExamples/Example72_AgentCollaboration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example72_AgentCollaboration.cs
@@ -34,6 +34,10 @@ public static class Example72_AgentCollaboration
             return;
         }
 
+        // NOTE: Either of these examples produce a conversation
+        // whose duration may vary depending on the collaboration dynamics.
+        // It is sometimes possible that agreement is never achieved.
+
         // Explicit collaboration
         await RunCollaborationAsync();
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

`Example72_AgentCollaboration.RunAsPluginsAsync()` prefered to execute as a non-terminating loop since the instruction to the art-director emphasized finding a critique as the overall goal (as opposed to approving copy).

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Tuned prompt for art-director agent and verified with multiple runs.
- Added comment to that either example has an off-chance to not reach agreement
- Tracking further improvements: https://github.com/microsoft/semantic-kernel/issues/4313

> Note: `Example72_AgentCollaboration.RunAsPluginsAsync()` tends to be more iterative than `Example72_AgentCollaboration.RunCollaborationAsync()`

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
