### PR TITLE
[Handlebars] Complex Type Support for OpenAPI plugins

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example65_HandlebarsPlanner.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example65_HandlebarsPlanner.cs
@@ -23,14 +23,17 @@ public static class Example65_HandlebarsPlanner
     {
         s_sampleIndex = 1;
 
-        // Using Complex Types as inputs and outputs
+        // Plugin with Complex Types as inputs and outputs
         await RunLocalDictionaryWithComplexTypesSampleAsync(shouldPrintPrompt: true);
 
-        // Using primitive types as inputs and outputs
+        // Plugin with primitive types as inputs and outputs
         await PlanNotPossibleSampleAsync();
         await RunDictionaryWithBasicTypesSampleAsync();
         await RunPoetrySampleAsync();
         await RunBookSampleAsync();
+
+        // OpenAPI plugin
+        await RunCourseraSampleAsync(true);
     }
 
     private static void WriteSampleHeadingToConsole(string name)
@@ -137,6 +140,12 @@ public static class Example65_HandlebarsPlanner
             */
             Console.WriteLine($"\n{ex.Message}\n");
         }
+    }
+
+    private static async Task RunCourseraSampleAsync(bool shouldPrintPrompt = false)
+    {
+        WriteSampleHeadingToConsole("Coursera");
+        await RunSampleAsync("Show me courses about Artificial Intelligence.", shouldPrintPrompt, CourseraPluginName);
     }
 
     private static async Task RunDictionaryWithBasicTypesSampleAsync(bool shouldPrintPrompt = false)

--- a/dotnet/samples/KernelSyntaxExamples/Program.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Program.cs
@@ -18,7 +18,7 @@ public static class Program
     ///     DefaultFilter = "18"    => run only example 18 (also "180" if there is such test)
     ///     DefaultFilter = "chat"  => run all examples with a name that contains "chat"
     /// </summary>
-    public const string? DefaultFilter = "";
+    public const string? DefaultFilter = "65";
 
     public static async Task Main(string[] args)
     {

--- a/dotnet/samples/KernelSyntaxExamples/Program.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Program.cs
@@ -18,7 +18,7 @@ public static class Program
     ///     DefaultFilter = "18"    => run only example 18 (also "180" if there is such test)
     ///     DefaultFilter = "chat"  => run all examples with a name that contains "chat"
     /// </summary>
-    public const string? DefaultFilter = "65";
+    public const string? DefaultFilter = "";
 
     public static async Task Main(string[] args)
     {

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelperUtils.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelperUtils.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using HandlebarsDotNet;
 
 namespace Microsoft.SemanticKernel.PromptTemplates.Handlebars.Helpers;
@@ -63,5 +65,26 @@ internal static class KernelHelpersUtils
             ulong.TryParse(input, out _) ||
             double.TryParse(input, out _) ||
             decimal.TryParse(input, out _);
+    }
+
+    /// <summary>
+    /// Tries to convert a <see cref="JsonNode"/> object to a specific type.
+    /// </summary>
+    public static object? DeserializeJsonNode(JsonNode? jsonContent)
+    {
+        if (jsonContent?.GetValueKind() == JsonValueKind.Array)
+        {
+            return jsonContent.AsArray();
+        }
+        else if (jsonContent?.GetValueKind() == JsonValueKind.Object)
+        {
+            return jsonContent.AsObject();
+        }
+        else if (jsonContent?.GetValueKind() == JsonValueKind.String)
+        {
+            return jsonContent.GetValue<string>();
+        }
+
+        return jsonContent;
     }
 }

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/PromptTemplates.Handlebars.csproj
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/PromptTemplates.Handlebars.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
+    <ProjectReference Include="..\..\Functions\Functions.OpenApi\Functions.OpenApi.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/CreatePlanPrompt.handlebars
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/CreatePlanPrompt.handlebars
@@ -168,7 +168,7 @@ Output:
 {{~#if ReturnParameter}}
   {{~#if ReturnParameter.ParameterType}} {{ReturnParameter.ParameterType.Name}}
   {{~else}}
-    {{~#if ReturnParameter.Schema}} {{getSchemaReturnTypeName ReturnParameter}}
+    {{~#if ReturnParameter.Schema}} {{getSchemaReturnTypeName ReturnParameter Name}}
     {{else}} string{{/if}}
   {{~/if}}
   {{~#if ReturnParameter.Description}} - {{ReturnParameter.Description}}{{/if}}

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/Extensions/KernelParameterMetadataExtensions.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/Extensions/KernelParameterMetadataExtensions.cs
@@ -91,7 +91,13 @@ internal static class KernelParameterMetadataExtensions
     public static KernelParameterMetadata ParseJsonSchema(this KernelParameterMetadata parameter)
     {
         var schema = parameter.Schema!;
-        var type = schema.RootElement.GetProperty("type").GetString() ?? "object";
+
+        var type = "object";
+        if (schema.RootElement.TryGetProperty("type", out var typeNode))
+        {
+            type = typeNode.GetString()!;
+        }
+
         if (IsPrimitiveOrStringType(type) || type == "null")
         {
             return new(parameter)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR introduces a change to parse json response objects into their expected type. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

This helps fix a bug in the HB planner, where the result of OpenAPI plugins weren't being passed as expected. The planner was assuming the raw result, as defined by the OpenAPI spec, not the result wrapper object.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x ] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
