### PR TITLE
.Net: Fixing issue that causes a stack overflow in handlebars planner.

### DIFF
--- a/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/KernelParameterMetadataExtensionsTests.cs
+++ b/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/KernelParameterMetadataExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Runtime.Serialization;
 using Microsoft.SemanticKernel.Planning.Handlebars;
 using Xunit;
 
@@ -67,6 +68,26 @@ public class KernelParameterMetadataExtensionsTests
         Assert.Equal(typeof(int), result.First().Properties[0].ParameterType);
         Assert.Equal("Name", result.First().Properties[1].Name);
         Assert.Equal(typeof(string), result.First().Properties[1].ParameterType);
+    }
+
+    [Fact]
+    public void ReturnsSetWithOneElementForRecursiveClassType()
+    {
+        // Arrange
+        var recursiveClassType = typeof(RecursiveClass);
+
+        // Act
+        var result = recursiveClassType.ToHandlebarsParameterTypeMetadata();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(nameof(RecursiveClass), result.First().Name);
+        Assert.True(result.First().IsComplex);
+        Assert.Equal(2, result.First().Properties.Count);
+        Assert.Equal(nameof(RecursiveClass.Name), result.First().Properties[0].Name);
+        Assert.Equal(typeof(string), result.First().Properties[0].ParameterType);
+        Assert.Equal(nameof(RecursiveClass.Next), result.First().Properties[1].Name);
+        Assert.Equal(typeof(RecursiveClass), result.First().Properties[1].ParameterType);
     }
 
     [Fact]
@@ -302,6 +323,13 @@ public class KernelParameterMetadataExtensionsTests
         public static int Id { get; set; }
         public static SimpleClass Simple { get; set; } = new SimpleClass();
         public static AnotherClass Another { get; set; } = new AnotherClass();
+    }
+
+    private sealed class RecursiveClass
+    {
+        public string Name { get; set; } = "";
+
+        public RecursiveClass Next { get; set; } = new();
     }
 
     #endregion  

--- a/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/KernelParameterMetadataExtensionsTests.cs
+++ b/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/KernelParameterMetadataExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Runtime.Serialization;
 using Microsoft.SemanticKernel.Planning.Handlebars;
 using Xunit;
 

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/Extensions/KernelParameterMetadataExtensions.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/Extensions/KernelParameterMetadataExtensions.cs
@@ -34,6 +34,11 @@ internal static class KernelParameterMetadataExtensions
     /// </summary>
     public static HashSet<HandlebarsParameterTypeMetadata> ToHandlebarsParameterTypeMetadata(this Type type)
     {
+        return type.ToHandlebarsParameterTypeMetadata(new HashSet<Type>());
+    }
+
+    private static HashSet<HandlebarsParameterTypeMetadata> ToHandlebarsParameterTypeMetadata(this Type type, HashSet<Type> processedTypes)
+    {
         var parameterTypes = new HashSet<HandlebarsParameterTypeMetadata>();
         if (type.TryGetGenericResultType(out var taskResultType))
         {
@@ -47,7 +52,8 @@ internal static class KernelParameterMetadataExtensions
                     Properties = resultTypeProperties.Select(p => new KernelParameterMetadata(p.Name) { ParameterType = p.PropertyType }).ToList()
                 });
 
-                parameterTypes.AddNestedComplexTypes(resultTypeProperties);
+                processedTypes.Add(taskResultType);
+                parameterTypes.AddNestedComplexTypes(resultTypeProperties, processedTypes);
             }
         }
         else if (type.IsClass && type != typeof(string))
@@ -62,20 +68,22 @@ internal static class KernelParameterMetadataExtensions
                 Properties = properties.Select(p => new KernelParameterMetadata(p.Name) { ParameterType = p.PropertyType }).ToList()
             });
 
-            parameterTypes.AddNestedComplexTypes(properties);
+            processedTypes.Add(type);
+            parameterTypes.AddNestedComplexTypes(properties, processedTypes);
         }
 
         return parameterTypes;
     }
 
-    private static void AddNestedComplexTypes(this HashSet<HandlebarsParameterTypeMetadata> parameterTypes, PropertyInfo[] properties)
+    private static void AddNestedComplexTypes(this HashSet<HandlebarsParameterTypeMetadata> parameterTypes, PropertyInfo[] properties, HashSet<Type> processedTypes)
     {
         // Add nested complex types
         foreach (var property in properties)
         {
-            if (!parameterTypes.Any(pt => pt.Name == property.PropertyType.Name))
+            // Only convert the property type if we have not already done so.
+            if (!processedTypes.Contains(property.PropertyType))
             {
-                parameterTypes.UnionWith(property.PropertyType.ToHandlebarsParameterTypeMetadata());
+                parameterTypes.UnionWith(property.PropertyType.ToHandlebarsParameterTypeMetadata(processedTypes));
             }
         }
     }

--- a/dotnet/src/Planners/Planners.Handlebars/Handlebars/Extensions/KernelParameterMetadataExtensions.cs
+++ b/dotnet/src/Planners/Planners.Handlebars/Handlebars/Extensions/KernelParameterMetadataExtensions.cs
@@ -73,7 +73,10 @@ internal static class KernelParameterMetadataExtensions
         // Add nested complex types
         foreach (var property in properties)
         {
-            parameterTypes.UnionWith(property.PropertyType.ToHandlebarsParameterTypeMetadata());
+            if (!parameterTypes.Any(pt => pt.Name == property.PropertyType.Name))
+            {
+                parameterTypes.UnionWith(property.PropertyType.ToHandlebarsParameterTypeMetadata());
+            }
         }
     }
 


### PR DESCRIPTION
The handlebars planner converts plugin parameter types to `HandlebarsParameterTypeMetadata` objects by recursively traversing the properties of the type. If the type is itself defined recursively, this causes stack overflow exception. This PR addresses this issue by checking if a given type has already been processed before processing it.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
