### PR TITLE
.Net: Removed Connectors.OpenAI dependency from PromptTemplates.Handlebars project

### DIFF
--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
@@ -197,7 +197,7 @@ internal static class KernelFunctionHelpers
     private static object? ParseResult(FunctionResult result)
     {
         var resultAsObject = result.GetValue<object?>();
-        if (resultAsObject is not null && resultAsObject is ChatMessageContent chatMessageContent)
+        if (resultAsObject is ChatMessageContent chatMessageContent)
         {
             resultAsObject = chatMessageContent.Content;
         }

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Threading;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
-using Microsoft.SemanticKernel.Connectors.OpenAI;
 
 namespace Microsoft.SemanticKernel.PromptTemplates.Handlebars.Helpers;
 
@@ -191,16 +190,16 @@ internal static class KernelFunctionHelpers
     }
 
     /// <summary>
-    /// Parse the <see cref="FunctionResult"/> into an object, extracting the appropriate value if the return type is <see cref="OpenAIChatMessageContent"/>.
+    /// Parse the <see cref="FunctionResult"/> into an object, extracting the appropriate value if the return type is <see cref="ChatMessageContent"/>.
     /// </summary>
     /// <param name="result">Function result.</param>
     /// <returns>Deserialized object</returns>
     private static object? ParseResult(FunctionResult result)
     {
         var resultAsObject = result.GetValue<object?>();
-        if (result.ValueType is not null && resultAsObject is not null && result.ValueType == typeof(OpenAIChatMessageContent))
+        if (resultAsObject is not null && resultAsObject is ChatMessageContent chatMessageContent)
         {
-            resultAsObject = ((OpenAIChatMessageContent)resultAsObject).Content;
+            resultAsObject = chatMessageContent.Content;
         }
 
         return resultAsObject;

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/PromptTemplates.Handlebars.csproj
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/PromptTemplates.Handlebars.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Removed Connectors.OpenAI dependency from PromptTemplates.Handlebars project.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
