### PR TITLE
.Net: Decoupling form OpenApi

### DIFF
--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationResponseConverterTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationResponseConverterTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.Plugins.OpenApi;
+using Microsoft.SemanticKernel;
 using Xunit;
 
 namespace SemanticKernel.Functions.UnitTests.OpenApi;

--- a/dotnet/src/Planners/Planners.OpenAI/Planners.OpenAI.csproj
+++ b/dotnet/src/Planners/Planners.OpenAI/Planners.OpenAI.csproj
@@ -32,7 +32,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
-    <ProjectReference Include="..\..\Functions\Functions.OpenApi\Functions.OpenApi.csproj" />
     <ProjectReference Include="..\..\Functions\Functions.Yaml\Functions.Yaml.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
-using Microsoft.SemanticKernel.Plugins.OpenApi;
 
 namespace Microsoft.SemanticKernel.Planning;
 

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel;
 
-namespace Microsoft.SemanticKernel.Plugins.OpenApi;
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// The REST API operation response.
@@ -23,7 +23,7 @@ public sealed class RestApiOperationResponse
     /// <summary>
     /// The expected schema of the response as advertised in the OpenAPI operation.
     /// </summary>
-    public KernelJsonSchema? ExpectedSchema { get; internal set; }
+    public KernelJsonSchema? ExpectedSchema { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RestApiOperationResponse"/> class.

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponseConverter.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponseConverter.cs
@@ -4,7 +4,7 @@ using System;
 using System.ComponentModel;
 using System.Globalization;
 
-namespace Microsoft.SemanticKernel.Plugins.OpenApi;
+namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Converts a object of <see cref="RestApiOperationResponse"/> type to string type.


### PR DESCRIPTION
1. The `RestApiOperationResponse` class and its converter have been moved to the abstraction layer to prevent unnecessary coupling of other projects with the OpenApi one.  
2. The unnecessary coupling to the OpenApi project has been removed from the planners project.