### PR TITLE
.Net: BugFix Serializing and Deserializing ChatHistory with ToolCalling details Update OpenAI Connector to use FunctionToolCallsProperty and add ChatHistoryTests

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -303,13 +303,6 @@ internal abstract class ClientCore
             {
                 ChatCompletionsFunctionToolCall toolCall = result.ToolCalls[i];
 
-                // We currently only know about function tool calls. If it's anything else, we'll respond with an error.
-                //if (toolCall is not ChatCompletionsFunctionToolCall functionToolCall)
-                //{
-                //    AddResponseMessage(chatOptions, chat, result: null, "Error: Tool call was not a function call.", toolCall.Id, this.Logger);
-                //    continue;
-                //}
-
                 // Parse the function call arguments.
                 OpenAIFunctionToolCall? openAIFunctionToolCall;
                 try

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -301,20 +301,20 @@ internal abstract class ClientCore
             // If we successfully execute it, we'll add the result. If we don't, we'll add an error.
             for (int i = 0; i < result.ToolCalls.Count; i++)
             {
-                ChatCompletionsToolCall toolCall = result.ToolCalls[i];
+                ChatCompletionsFunctionToolCall toolCall = result.ToolCalls[i];
 
                 // We currently only know about function tool calls. If it's anything else, we'll respond with an error.
-                if (toolCall is not ChatCompletionsFunctionToolCall functionToolCall)
-                {
-                    AddResponseMessage(chatOptions, chat, result: null, "Error: Tool call was not a function call.", toolCall.Id, this.Logger);
-                    continue;
-                }
+                //if (toolCall is not ChatCompletionsFunctionToolCall functionToolCall)
+                //{
+                //    AddResponseMessage(chatOptions, chat, result: null, "Error: Tool call was not a function call.", toolCall.Id, this.Logger);
+                //    continue;
+                //}
 
                 // Parse the function call arguments.
                 OpenAIFunctionToolCall? openAIFunctionToolCall;
                 try
                 {
-                    openAIFunctionToolCall = new(functionToolCall);
+                    openAIFunctionToolCall = new(toolCall);
                 }
                 catch (JsonException)
                 {
@@ -551,7 +551,7 @@ internal abstract class ClientCore
                 AddResponseMessage(chatOptions, chat, streamedRole, toolCall, metadata, functionResult as string ?? JsonSerializer.Serialize(functionResult), errorMessage: null, this.Logger);
 
                 static void AddResponseMessage(
-                    ChatCompletionsOptions chatOptions, ChatHistory chat, ChatRole? streamedRole, ChatCompletionsToolCall tool, IReadOnlyDictionary<string, object?>? metadata,
+                    ChatCompletionsOptions chatOptions, ChatHistory chat, ChatRole? streamedRole, ChatCompletionsFunctionToolCall tool, IReadOnlyDictionary<string, object?>? metadata,
                     string? result, string? errorMessage, ILogger logger)
                 {
                     if (errorMessage is not null && logger.IsEnabled(LogLevel.Debug))
@@ -840,10 +840,10 @@ internal abstract class ClientCore
         {
             var asstMessage = new ChatRequestAssistantMessage(message.Content);
 
-            IEnumerable<ChatCompletionsToolCall>? tools = (message as OpenAIChatMessageContent)?.ToolCalls;
+            IEnumerable<ChatCompletionsFunctionToolCall>? tools = (message as OpenAIChatMessageContent)?.ToolCalls;
             if (tools is null && message.Metadata?.TryGetValue(OpenAIChatMessageContent.ToolCallsProperty, out object? toolCallsObject) is true)
             {
-                tools = toolCallsObject as IEnumerable<ChatCompletionsToolCall>;
+                tools = toolCallsObject as IEnumerable<ChatCompletionsFunctionToolCall>;
                 if (tools is null && toolCallsObject is JsonElement { ValueKind: JsonValueKind.Array } array)
                 {
                     int length = array.GetArrayLength();
@@ -867,7 +867,7 @@ internal abstract class ClientCore
 
             if (tools is not null)
             {
-                foreach (ChatCompletionsToolCall tool in tools)
+                foreach (ChatCompletionsFunctionToolCall tool in tools)
                 {
                     asstMessage.ToolCalls.Add(tool);
                 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -301,13 +301,20 @@ internal abstract class ClientCore
             // If we successfully execute it, we'll add the result. If we don't, we'll add an error.
             for (int i = 0; i < result.ToolCalls.Count; i++)
             {
-                ChatCompletionsFunctionToolCall toolCall = result.ToolCalls[i];
+                ChatCompletionsToolCall toolCall = result.ToolCalls[i];
+
+                // We currently only know about function tool calls. If it's anything else, we'll respond with an error.
+                if (toolCall is not ChatCompletionsFunctionToolCall functionToolCall)
+                {
+                    AddResponseMessage(chatOptions, chat, result: null, "Error: Tool call was not a function call.", toolCall.Id, this.Logger);
+                    continue;
+                }
 
                 // Parse the function call arguments.
                 OpenAIFunctionToolCall? openAIFunctionToolCall;
                 try
                 {
-                    openAIFunctionToolCall = new(toolCall);
+                    openAIFunctionToolCall = new(functionToolCall);
                 }
                 catch (JsonException)
                 {
@@ -833,8 +840,8 @@ internal abstract class ClientCore
         {
             var asstMessage = new ChatRequestAssistantMessage(message.Content);
 
-            IEnumerable<ChatCompletionsFunctionToolCall>? tools = (message as OpenAIChatMessageContent)?.ToolCalls;
-            if (tools is null && message.Metadata?.TryGetValue(OpenAIChatMessageContent.ToolCallsProperty, out object? toolCallsObject) is true)
+            IEnumerable<ChatCompletionsToolCall>? tools = (message as OpenAIChatMessageContent)?.ToolCalls;
+            if (tools is null && message.Metadata?.TryGetValue(OpenAIChatMessageContent.FunctionToolCallsProperty, out object? toolCallsObject) is true)
             {
                 tools = toolCallsObject as IEnumerable<ChatCompletionsFunctionToolCall>;
                 if (tools is null && toolCallsObject is JsonElement { ValueKind: JsonValueKind.Array } array)
@@ -860,7 +867,7 @@ internal abstract class ClientCore
 
             if (tools is not null)
             {
-                foreach (ChatCompletionsFunctionToolCall tool in tools)
+                foreach (ChatCompletionsToolCall tool in tools)
                 {
                     asstMessage.ToolCalls.Add(tool);
                 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -551,7 +551,7 @@ internal abstract class ClientCore
                 AddResponseMessage(chatOptions, chat, streamedRole, toolCall, metadata, functionResult as string ?? JsonSerializer.Serialize(functionResult), errorMessage: null, this.Logger);
 
                 static void AddResponseMessage(
-                    ChatCompletionsOptions chatOptions, ChatHistory chat, ChatRole? streamedRole, ChatCompletionsFunctionToolCall tool, IReadOnlyDictionary<string, object?>? metadata,
+                    ChatCompletionsOptions chatOptions, ChatHistory chat, ChatRole? streamedRole, ChatCompletionsToolCall tool, IReadOnlyDictionary<string, object?>? metadata,
                     string? result, string? errorMessage, ILogger logger)
                 {
                     if (errorMessage is not null && logger.IsEnabled(LogLevel.Debug))
@@ -847,7 +847,7 @@ internal abstract class ClientCore
                 if (tools is null && toolCallsObject is JsonElement { ValueKind: JsonValueKind.Array } array)
                 {
                     int length = array.GetArrayLength();
-                    var ftcs = new List<ChatCompletionsFunctionToolCall>(length);
+                    var ftcs = new List<ChatCompletionsToolCall>(length);
                     for (int i = 0; i < length; i++)
                     {
                         JsonElement e = array[i];

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
@@ -21,12 +21,12 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
     /// <summary>
     /// Gets the metadata key for the list of <see cref="ChatCompletionsFunctionToolCall"/>.
     /// </summary>
-    public static string FunctionToolCallsProperty => $"{nameof(ChatResponseMessage)}.FunctionToolCalls";
+    internal static string FunctionToolCallsProperty => $"{nameof(ChatResponseMessage)}.FunctionToolCalls";
 
     /// <summary>
     /// Gets the metadata key for the list of <see cref="ChatCompletionsToolCall"/>.
     /// </summary>
-    public static string ToolCallsProperty => $"{nameof(ChatResponseMessage)}.ToolCalls";
+    internal static string ToolCallsProperty => $"{nameof(ChatResponseMessage)}.ToolCalls";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenAIChatMessageContent"/> class.

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
@@ -19,12 +19,12 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
     public static string ToolIdProperty => $"{nameof(ChatCompletionsToolCall)}.{nameof(ChatCompletionsToolCall.Id)}";
 
     /// <summary>
-    /// Gets the metadata key for the <see cref="ChatCompletionsToolCall.Id"/> name property.
+    /// Gets the metadata key for the list of <see cref="ChatCompletionsFunctionToolCall"/>.
     /// </summary>
     public static string FunctionToolCallsProperty => $"{nameof(ChatResponseMessage)}.FunctionToolCalls";
 
     /// <summary>
-    /// Gets the metadata key for the <see cref="ChatCompletionsToolCall.Id"/> name property.
+    /// Gets the metadata key for the list of <see cref="ChatCompletionsToolCall"/>.
     /// </summary>
     public static string ToolCallsProperty => $"{nameof(ChatResponseMessage)}.ToolCalls";
 
@@ -35,9 +35,9 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
     /// <param name="modelId">The model ID used to generate the content</param>
     /// <param name="metadata">Additional metadata</param>
     internal OpenAIChatMessageContent(ChatResponseMessage chatMessage, string modelId, IReadOnlyDictionary<string, object?>? metadata = null)
-        : base(new AuthorRole(chatMessage.Role.ToString()), chatMessage.Content, modelId, chatMessage, System.Text.Encoding.UTF8, CreateMetadataDictionary(chatMessage.ToolCalls.OfType<ChatCompletionsFunctionToolCall>().ToList(), metadata))
+        : base(new AuthorRole(chatMessage.Role.ToString()), chatMessage.Content, modelId, chatMessage, System.Text.Encoding.UTF8, CreateMetadataDictionary(chatMessage.ToolCalls, metadata))
     {
-        this.ToolCalls = chatMessage.ToolCalls.OfType<ChatCompletionsToolCall>().ToList();
+        this.ToolCalls = chatMessage.ToolCalls;
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
@@ -26,7 +26,7 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
     /// <summary>
     /// Gets the metadata key for the list of <see cref="ChatCompletionsToolCall"/>.
     /// </summary>
-    internal static string ToolCallsProperty => $"{nameof(ChatResponseMessage)}.ToolCalls";
+    public static string ToolCallsProperty => $"{nameof(ChatResponseMessage)}.{nameof(ChatResponseMessage.ToolCalls)}";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenAIChatMessageContent"/> class.

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIChatMessageContent.cs
@@ -24,11 +24,6 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
     internal static string FunctionToolCallsProperty => $"{nameof(ChatResponseMessage)}.FunctionToolCalls";
 
     /// <summary>
-    /// Gets the metadata key for the list of <see cref="ChatCompletionsToolCall"/>.
-    /// </summary>
-    public static string ToolCallsProperty => $"{nameof(ChatResponseMessage)}.{nameof(ChatResponseMessage.ToolCalls)}";
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="OpenAIChatMessageContent"/> class.
     /// </summary>
     /// <param name="chatMessage">Azure SDK chat message</param>
@@ -117,7 +112,6 @@ public sealed class OpenAIChatMessageContent : ChatMessageContent
 
             // Add the additional entry.
             newDictionary.Add(FunctionToolCallsProperty, toolCalls.OfType<ChatCompletionsFunctionToolCall>().ToList());
-            newDictionary.Add(ToolCallsProperty, toolCalls);
 
             return newDictionary;
         }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIFunctionToolCall.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIFunctionToolCall.cs
@@ -176,5 +176,5 @@ public sealed class OpenAIFunctionToolCall
         s_type?.SetValue(c, "function");
         return c;
     }
-    private static readonly PropertyInfo? s_type = typeof(ChatCompletionsToolCall).GetProperty("Type", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+    private static readonly PropertyInfo? s_type = typeof(ChatCompletionsFunctionToolCall).GetProperty("Type", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIFunctionToolCall.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/OpenAIFunctionToolCall.cs
@@ -176,5 +176,5 @@ public sealed class OpenAIFunctionToolCall
         s_type?.SetValue(c, "function");
         return c;
     }
-    private static readonly PropertyInfo? s_type = typeof(ChatCompletionsFunctionToolCall).GetProperty("Type", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+    private static readonly PropertyInfo? s_type = typeof(ChatCompletionsToolCall).GetProperty("Type", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 }

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/ChatHistoryTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/ChatHistoryTests.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Connectors.OpenAI;
+
+public sealed class ChatHistoryTests : IDisposable
+{
+    private readonly IKernelBuilder _kernelBuilder;
+    private readonly XunitLogger<Kernel> _logger;
+    private readonly RedirectOutput _testOutputHelper;
+    private readonly IConfigurationRoot _configuration;
+    private static readonly JsonSerializerOptions s_jsonOptionsCache = new() { WriteIndented = true };
+    public ChatHistoryTests(ITestOutputHelper output)
+    {
+        this._logger = new XunitLogger<Kernel>(output);
+        this._testOutputHelper = new RedirectOutput(output);
+        Console.SetOut(this._testOutputHelper);
+
+        // Load configuration
+        this._configuration = new ConfigurationBuilder()
+            .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+            .AddEnvironmentVariables()
+            .AddUserSecrets<OpenAICompletionTests>()
+            .Build();
+
+        this._kernelBuilder = Kernel.CreateBuilder();
+    }
+
+    [Fact]
+    public async Task ItSerializesAndDeserializesChatHistoryAsync()
+    {
+        // Arrange
+        this._kernelBuilder.Services.AddSingleton<ILoggerFactory>(this._logger);
+        var builder = this._kernelBuilder;
+        this.ConfigureAzureOpenAIChatAsText(builder);
+        builder.Plugins.AddFromType<FakePlugin>();
+        var kernel = builder.Build();
+
+        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        ChatHistory history = new();
+
+        history.AddUserMessage("Make me a special poem");
+        var historyBeforeJson = JsonSerializer.Serialize(history.ToList(), s_jsonOptionsCache);
+        var service = kernel.GetRequiredService<IChatCompletionService>();
+        ChatMessageContent result = await service.GetChatMessageContentAsync(history, settings, kernel);
+        history.AddUserMessage("Ok thank you");
+
+        ChatMessageContent resultOriginalWorking = await service.GetChatMessageContentAsync(history, settings, kernel);
+        var historyJson = JsonSerializer.Serialize(history, s_jsonOptionsCache);
+        var historyAfterSerialization = JsonSerializer.Deserialize<ChatHistory>(historyJson);
+        ChatMessageContent shouldNotThrow = await service.GetChatMessageContentAsync(historyAfterSerialization!, settings, kernel);
+    }
+
+    private void ConfigureAzureOpenAIChatAsText(IKernelBuilder kernelBuilder)
+    {
+        var azureOpenAIConfiguration = this._configuration.GetSection("Planners:AzureOpenAI").Get<AzureOpenAIConfiguration>();
+
+        Assert.NotNull(azureOpenAIConfiguration);
+        Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
+        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
+        Assert.NotNull(azureOpenAIConfiguration.Endpoint);
+        Assert.NotNull(azureOpenAIConfiguration.ServiceId);
+
+        kernelBuilder.AddAzureOpenAIChatCompletion(
+            deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
+            modelId: azureOpenAIConfiguration.ChatModelId,
+            endpoint: azureOpenAIConfiguration.Endpoint,
+            apiKey: azureOpenAIConfiguration.ApiKey,
+            httpClient: new HttpClient(new MyHttpMessageHandler()),
+            serviceId: azureOpenAIConfiguration.ServiceId);
+    }
+
+    public class FakePlugin
+    {
+        [KernelFunction, Description("creates a special poem")]
+        public string CreateSpecialPoem()
+        {
+            return "ABCDE";
+        }
+    }
+
+    public class MyHttpMessageHandler : DelegatingHandler
+    {
+        public MyHttpMessageHandler()
+        {
+            this.InnerHandler = new HttpClientHandler();
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string? requestContent = await request.Content!.ReadAsStringAsync(cancellationToken);
+
+            return await base.SendAsync(request!, cancellationToken);
+        }
+    }
+
+    public void Dispose()
+    {
+        this.Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    ~ChatHistoryTests()
+    {
+        this.Dispose(false);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this._logger.Dispose();
+            this._testOutputHelper.Dispose();
+        }
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/ChatHistoryTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/ChatHistoryTests.cs
@@ -56,6 +56,7 @@ public sealed class ChatHistoryTests : IDisposable
         OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
         ChatHistory history = new();
 
+        // Act
         history.AddUserMessage("Make me a special poem");
         var historyBeforeJson = JsonSerializer.Serialize(history.ToList(), s_jsonOptionsCache);
         var service = kernel.GetRequiredService<IChatCompletionService>();
@@ -65,7 +66,10 @@ public sealed class ChatHistoryTests : IDisposable
         ChatMessageContent resultOriginalWorking = await service.GetChatMessageContentAsync(history, settings, kernel);
         var historyJson = JsonSerializer.Serialize(history, s_jsonOptionsCache);
         var historyAfterSerialization = JsonSerializer.Deserialize<ChatHistory>(historyJson);
-        ChatMessageContent shouldNotThrow = await service.GetChatMessageContentAsync(historyAfterSerialization!, settings, kernel);
+        var exception = await Record.ExceptionAsync(() => service.GetChatMessageContentAsync(historyAfterSerialization!, settings, kernel));
+
+        // Assert
+        Assert.Null(exception);
     }
 
     private void ConfigureAzureOpenAIChatAsText(IKernelBuilder kernelBuilder)

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/ChatHistoryTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/ChatHistoryTests.cs
@@ -25,12 +25,15 @@ public sealed class ChatHistoryTests : IDisposable
     private readonly XunitLogger<Kernel> _logger;
     private readonly RedirectOutput _testOutputHelper;
     private readonly IConfigurationRoot _configuration;
+    private readonly HttpClient _httpClient;
+    private readonly MyHttpMessageHandler _myHttpMessageHandler = new();
     private static readonly JsonSerializerOptions s_jsonOptionsCache = new() { WriteIndented = true };
     public ChatHistoryTests(ITestOutputHelper output)
     {
         this._logger = new XunitLogger<Kernel>(output);
         this._testOutputHelper = new RedirectOutput(output);
         Console.SetOut(this._testOutputHelper);
+        this._httpClient = new HttpClient(this._myHttpMessageHandler);
 
         // Load configuration
         this._configuration = new ConfigurationBuilder()
@@ -87,7 +90,7 @@ public sealed class ChatHistoryTests : IDisposable
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
             apiKey: azureOpenAIConfiguration.ApiKey,
-            httpClient: new HttpClient(new MyHttpMessageHandler()),
+            httpClient: this._httpClient,
             serviceId: azureOpenAIConfiguration.ServiceId);
     }
 
@@ -130,6 +133,8 @@ public sealed class ChatHistoryTests : IDisposable
     {
         if (disposing)
         {
+            this._httpClient.Dispose();
+            this._myHttpMessageHandler.Dispose();
             this._logger.Dispose();
             this._testOutputHelper.Dispose();
         }


### PR DESCRIPTION
Serializing the ToolCalls was losing the details about Name and Arguments, and serializing this lack of content back was rendering ToolCalls as an invalid history message and giving the Issue Error.

Resolves #4336 

Next PR, moving the Integration Tests as Unit Tests
## Summary
This pull request updates the OpenAI Connector to use the FunctionToolCallsProperty metadata key instead of the ToolCallsProperty metadata key. This change allows for the use of a list of ChatCompletionsFunctionToolCall objects instead of ChatCompletionsToolCall objects. Additionally, a new integration test, ChatHistoryTests.cs, is added to the IntegrationTests/Connectors/OpenAI directory. The test file contains tests for the ChatHistory feature of the OpenAI Connector, ensuring that the feature returns the expected results and handles errors correctly.

## Changes
- Update ClientCore.cs to use FunctionToolCallsProperty instead of ToolCallsProperty
- Update OpenAIChatMessageContent.cs to use FunctionToolCallsProperty instead of ToolCallsProperty
- Add ChatHistoryTests.cs to IntegrationTests/Connectors/OpenAI directory
- Implement tests for ChatHistory feature of OpenAI Connector
- Dispose of logger and test output helper in ChatHistoryTests.cs

---
*Powered by [Microsoft Semantic Kernel](https://github.com/microsoft/semantic-kernel)*