### PR TITLE
Python: Prevents LLMs from stripping complex function names

### DIFF
--- a/python/semantic_kernel/planning/stepwise_planner/Skills/StepwiseStep/skprompt.txt
+++ b/python/semantic_kernel/planning/stepwise_planner/Skills/StepwiseStep/skprompt.txt
@@ -24,6 +24,18 @@ Here is an example of a valid $JSON_BLOB:
   "action": "functionName",
   "action_variables": {"parameterName": "some value", ...}
 }
+
+Here is another example of a valid $JSON_BLOB:
+{
+  "action": "_Function_.Name",
+  "action_variables": {"parameterName": "some value", ...}
+}
+
+Here is another example of a valid $JSON_BLOB:
+{
+  "action": "FunctionName2",
+  "action_variables": {"parameterName": "some value", ...}
+}
 [END USAGE INSTRUCTIONS]
 [END INSTRUCTION]
 

--- a/python/semantic_kernel/planning/stepwise_planner/Skills/StepwiseStep/skprompt.txt
+++ b/python/semantic_kernel/planning/stepwise_planner/Skills/StepwiseStep/skprompt.txt
@@ -36,6 +36,8 @@ Here is another example of a valid $JSON_BLOB:
   "action": "FunctionName2",
   "action_variables": {"parameterName": "some value", ...}
 }
+
+The $JSON_BLOB must contain an "action_variables" key, with the {"parameterName": "some value", ...} value in the response.
 [END USAGE INSTRUCTIONS]
 [END INSTRUCTION]
 


### PR DESCRIPTION
### Motivation and Context

When using the `StepwisePlanner` planner along with core skills, for example `TextMemorySkill`, the LLMs tend to plans with function names stripped down to the name without the skill name. This makes the plan fail with an exception like:

`Error invoking action recall: (<ErrorCodes.UnknownError: -1>, "The function 'recall' was not found.", None)`

This error is because the completion returned by the planner prompt does not include the fully structured skill function name. Ex.: instead of returning `_GLOBAL_FUNCTIONS_.recall` it returns `recall` or `GLOBAL_FUNCTIONS.recall`.

This is somehow relates #3237

### Description


This change instructs the LLM to keep the skill function name unchanged in its response by adding an example that includes `_` in the name. This approach mimics how the `SequentialPlanner` solves this same issue.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
