### PR TITLE
.Net: Fixed KeyNotFoundExeption in Example09.

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example09_FunctionTypes.cs
@@ -52,8 +52,8 @@ public static class Example09_FunctionTypes
         await kernel.InvokeAsync(plugin[nameof(LocalExamplePlugin.TaskInjectingKernelWithInputTextAndStringResult)],
             new()
             {
-                ["textToSummarize"] = @"C# is a modern, versatile language by Microsoft, blending the efficiency of C++ 
-                                            with Visual Basic's simplicity. It's ideal for a wide range of applications, 
+                ["textToSummarize"] = @"C# is a modern, versatile language by Microsoft, blending the efficiency of C++
+                                            with Visual Basic's simplicity. It's ideal for a wide range of applications,
                                             emphasizing type safety, modularity, and modern programming paradigms."
             });
 
@@ -238,6 +238,7 @@ public class LocalExamplePlugin
     /// <summary>
     /// Example how to inject CultureInfo or IFormatProvider in your function
     /// </summary>
+    [KernelFunction]
     public async Task<string> TaskInjectingCultureInfoOrIFormatProviderWithStringResult(CultureInfo cultureInfo, IFormatProvider formatProvider)
     {
         var result = $"Culture Name: {cultureInfo.Name}, FormatProvider Equals CultureInfo?: {formatProvider.Equals(cultureInfo)}";


### PR DESCRIPTION
Added KernelFunction attribute to method TaskInjectingCultureInfoOrIFormatProviderWithStringResult

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Example09 throws KeyNotFoundException.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
