### PR TITLE
.Net: Add OpenAIPromptExecutionSettings.ResponseFormat

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -755,6 +755,28 @@ internal abstract class ClientCore
             Seed = executionSettings.Seed,
         };
 
+        switch (executionSettings.ResponseFormat)
+        {
+            case ChatCompletionsResponseFormat formatObject:
+                // If the response format is an Azure SDK ChatCompletionsResponseFormat, just pass it along.
+                options.ResponseFormat = formatObject;
+                break;
+
+            case string formatString:
+                // If the response format is a string, map the ones we know about, and ignore the rest.
+                switch (formatString)
+                {
+                    case "json_object":
+                        options.ResponseFormat = ChatCompletionsResponseFormat.JsonObject;
+                        break;
+
+                    case "text":
+                        options.ResponseFormat = ChatCompletionsResponseFormat.Text;
+                        break;
+                }
+                break;
+        }
+
         executionSettings.ToolCallBehavior?.ConfigureOptions(kernel, options);
         if (executionSettings.TokenSelectionBiases is not null)
         {

--- a/dotnet/src/Connectors/Connectors.OpenAI/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/OpenAIPromptExecutionSettings.cs
@@ -77,6 +77,13 @@ public sealed class OpenAIPromptExecutionSettings : PromptExecutionSettings
     public long? Seed { get; set; }
 
     /// <summary>
+    /// Gets or sets the response format to use for the completion.
+    /// </summary>
+    [Experimental("SKEXP0013")]
+    [JsonPropertyName("response_format")]
+    public object? ResponseFormat { get; set; }
+
+    /// <summary>
     /// The system prompt to use when generating text using a chat model.
     /// Defaults to "Assistant is a large language model."
     /// </summary>


### PR DESCRIPTION
Closes https://github.com/microsoft/semantic-kernel/issues/3540
Closes https://github.com/microsoft/semantic-kernel/issues/3875

I'm not sure what type to use here, so for now I've kept it `object?` and marked it experimental.  If we're ok tying OpenAIPromptExecutionSettings to the Azure SDK, then it'd probably be best to make the property of type `ChatCompletionsResponseFormat?`. Otherwise, if we don't think it'll ever evolve to have more properties, we could make it of type `string?`, or we could add a custom SK type for it. `object?` isn't as user-friendly, but it keeps the doors open to supporting various things.