### PR TITLE
Python: Fix issue 3643,  Python: Chinese Windows Encoding Must Use GBK

### DIFF
--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -63,6 +63,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 _sys_encoding = locale.getpreferredencoding() if sys.version_info < (3, 11) else locale.getencoding()
 
+
 class Kernel:
     _skill_collection: SkillCollectionBase
     _prompt_template_engine: PromptTemplatingEngine

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -4,6 +4,7 @@ import glob
 import importlib
 import inspect
 import locale
+import sys
 import logging
 import os
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
@@ -60,6 +61,7 @@ T = TypeVar("T")
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+_sys_encoding = locale.getpreferredencoding() if sys.version_info < (3, 11) else locale.getencoding()
 
 class Kernel:
     _skill_collection: SkillCollectionBase
@@ -829,7 +831,7 @@ class Kernel:
         return {}
 
     def import_semantic_skill_from_directory(
-        self, parent_directory: str, skill_directory_name: str, encoding=locale.getencoding()
+        self, parent_directory: str, skill_directory_name: str, encoding: str = _sys_encoding
     ) -> Dict[str, SKFunctionBase]:
         CONFIG_FILE = "config.json"
         PROMPT_FILE = "skprompt.txt"

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -3,6 +3,7 @@
 import glob
 import importlib
 import inspect
+import locale
 import logging
 import os
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
@@ -828,7 +829,7 @@ class Kernel:
         return {}
 
     def import_semantic_skill_from_directory(
-        self, parent_directory: str, skill_directory_name: str
+        self, parent_directory: str, skill_directory_name: str, encoding=locale.getencoding()
     ) -> Dict[str, SKFunctionBase]:
         CONFIG_FILE = "config.json"
         PROMPT_FILE = "skprompt.txt"
@@ -855,11 +856,11 @@ class Kernel:
 
             config = PromptTemplateConfig()
             config_path = os.path.join(directory, CONFIG_FILE)
-            with open(config_path, "r") as config_file:
+            with open(config_path, "r", encoding=encoding) as config_file:
                 config = config.from_json(config_file.read())
 
             # Load Prompt Template
-            with open(prompt_path, "r") as prompt_file:
+            with open(prompt_path, "r", encoding=encoding) as prompt_file:
                 template = PromptTemplate(
                     prompt_file.read(), self.prompt_template_engine, config
                 )


### PR DESCRIPTION
### Motivation and Context

1. This is a issue 3643 and the bug is confirmed.
2. It will solve kernel.import_semantic_skill_from_directory method use encoding by locale.getencoding() problem.
3. When different language prompt gather in one project, and when this server default encoding is not utf-8, it may run the project fail.
4. open issue link https://github.com/microsoft/semantic-kernel/issues/3643

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. it just modify kernel.py file by the following chagning
 > a. import locale  # this is support by build-in, this change will not cause another import error
 > b. add a new parameter encoding into import_semantic_skill_from_directory method, and set a default value of locale.getencoding(), because the following reason:
 >> i. default setting of `open`, will invoke locale.getencoding() when not setting of encoding
 > > ii. initiate parameter in function paramter, will make a fix memory in this function init parameter, it can avoid a dense invoke system setting  

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
