### PR TITLE
Python: Fix the default_services parameter not working in the prompt …

### DIFF
--- a/python/semantic_kernel/semantic_functions/prompt_template_config.py
+++ b/python/semantic_kernel/semantic_functions/prompt_template_config.py
@@ -47,7 +47,7 @@ class PromptTemplateConfig:
     @staticmethod
     def from_dict(data: dict) -> "PromptTemplateConfig":
         config = PromptTemplateConfig()
-        keys = ["schema", "type", "description"]
+        keys = ["schema", "type", "description", "default_services"]
         for key in keys:
             if key in data:
                 setattr(config, key, data[key])
@@ -64,7 +64,6 @@ class PromptTemplateConfig:
             "number_of_responses",
             "stop_sequences",
             "token_selection_biases",
-            "default_services",
             "chat_system_prompt",
             "function_call",
         ]


### PR DESCRIPTION
### Motivation and Context

When I have multiple AI services, I want to be able to specify the AI service used by the semantic plugin.

For example:
```python
kernel.add_text_completion_service(
    'text_completion_1',
    OpenAITextCompletion(
        ai_model_id = text_completion_model_id,
        async_client= async_client
    )
)

kernel.add_text_completion_service(
    'text_completion_2',
    OpenAITextCompletion(
        ai_model_id = text_completion_model_id,
        async_client= async_client
    )
)
```
In this case, I can specify the name of the AI service in the `config.json` of the semantic plugin.
```json
{
    ...
    "default_services": ["text_completion_2"]
    ...
}
```

### Description

In the from_dict method of PromptTemplateConfig, the default_services parameter has been added to the keys list.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
