### PR TITLE
Python: added ollama connector

### DIFF
--- a/python/semantic_kernel/connectors/ai/ai_service_client_base.py
+++ b/python/semantic_kernel/connectors/ai/ai_service_client_base.py
@@ -26,7 +26,7 @@ class AIServiceClientBase(SKBaseModel, ABC):
     ai_model_id: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
     def get_request_settings_class(self) -> "AIRequestSettings":
-        """Create a request settings object."""
+        """Get the request settings class."""
         return AIRequestSettings  # pragma: no cover
 
     def instantiate_request_settings(self, **kwargs) -> "AIRequestSettings":

--- a/python/semantic_kernel/connectors/ai/ollama/ollama_request_settings.py
+++ b/python/semantic_kernel/connectors/ai/ollama/ollama_request_settings.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import Field
+
+from semantic_kernel.connectors.ai.ai_request_settings import AIRequestSettings
+
+
+class OllamaRequestSettings(AIRequestSettings):
+    ai_model_id: str = Field("", alias="model")
+    format: Optional[Literal["json"]] = None
+    options: Optional[Dict[str, Any]] = None
+    stream: bool = False
+
+
+class OllamaTextRequestSettings(OllamaRequestSettings):
+    prompt: Optional[str] = None
+    context: Optional[str] = None
+    system: Optional[str] = None
+    template: Optional[str] = None
+    raw: bool = False
+
+
+class OllamaChatRequestSettings(OllamaRequestSettings):
+    messages: Optional[List[Dict[str, str]]] = None

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -1,0 +1,121 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import json
+import logging
+from typing import Dict, List, Optional, Union
+
+import aiohttp
+from pydantic import HttpUrl
+
+from semantic_kernel.connectors.ai.ai_request_settings import AIRequestSettings
+from semantic_kernel.connectors.ai.ai_service_client_base import AIServiceClientBase
+from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.ollama.ollama_request_settings import OllamaChatRequestSettings
+from semantic_kernel.connectors.ai.text_completion_client_base import (
+    TextCompletionClientBase,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, AIServiceClientBase):
+    """
+    Initializes a new instance of the OllamaChatCompletion class.
+
+    Make sure to have the ollama service running either locally or remotely.
+
+    Arguments:
+        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
+        url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/chat
+    """
+
+    url: HttpUrl = "http://localhost:11434/api/chat"
+    session: Optional[aiohttp.ClientSession] = None
+
+    async def complete_chat_async(
+        self,
+        messages: List[Dict[str, str]],
+        request_settings: OllamaChatRequestSettings,
+        **kwargs,
+    ) -> Union[str, List[str]]:
+        request_settings.messages = messages
+        request_settings.stream = False
+        if self.session:
+            async with self.session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:
+                response.raise_for_status()
+                response_object = await response.json()
+                return response_object.get("message", {"content": None}).get("content", None)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:
+                response.raise_for_status()
+                response_object = await response.json()
+                return response_object.get("message", {"content": None}).get("content", None)
+
+    async def complete_chat_stream_async(
+        self,
+        messages: List[Dict[str, str]],
+        settings: OllamaChatRequestSettings,
+        **kwargs,
+    ):
+        """
+        Streams a text completion using a Ollama model.
+        Note that this method does not support multiple responses.
+
+        Arguments:
+            prompt {str} -- Prompt to complete.
+            request_settings {OllamaChatRequestSettings} -- Request settings.
+
+        Yields:
+            str -- Completion result.
+        """
+        settings.messages = messages
+        settings.stream = True
+        if self.session:
+            async with self.session.post(str(self.url), json=settings.prepare_settings_dict()) as response:
+                response.raise_for_status()
+                async for line in response.content:
+                    body = json.loads(line)
+                    response_part = body.get("message", {"content": None}).get("content", None)
+                    yield response_part
+                    if body.get("done"):
+                        break
+        if not self.session:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(str(self.url), json=settings.prepare_settings_dict()) as response:
+                    response.raise_for_status()
+                    async for line in response.content:
+                        body = json.loads(line)
+                        response_part = body.get("message", {"content": None}).get("content", None)
+                        yield response_part
+                        if body.get("done"):
+                            break
+
+    async def complete_async(
+        self,
+        prompt: str,
+        request_settings: OllamaChatRequestSettings,
+        **kwargs,
+    ) -> Union[str, List[str]]:
+        return await self.complete_chat_async([{"role": "user", "content": prompt}], request_settings, **kwargs)
+
+    async def complete_stream_async(
+        self,
+        prompt: str,
+        request_settings: OllamaChatRequestSettings,
+        **kwargs,
+    ):
+        """
+        Streams a text completion using a Ollama model.
+        Note that this method does not support multiple responses.
+
+        Arguments:
+            prompt {str} -- Prompt to complete.
+            request_settings {OllamaChatRequestSettings} -- Request settings.
+
+        Yields:
+            str -- Completion result.
+        """
+        return await self.complete_chat_stream_async([{"role": "user", "content": prompt}], request_settings, **kwargs)
+
+    def get_request_settings_class(self) -> "AIRequestSettings":
+        return OllamaChatRequestSettings

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -102,7 +102,9 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         Yields:
             str -- Completion result.
         """
-        return await self.complete_chat_stream_async([{"role": "user", "content": prompt}], request_settings, **kwargs)
+        response = self.complete_chat_stream_async([{"role": "user", "content": prompt}], request_settings, **kwargs)
+        async for line in response:
+            yield line
 
     def get_request_settings_class(self) -> "AIRequestSettings":
         return OllamaChatRequestSettings

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -40,6 +40,18 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         request_settings: OllamaChatRequestSettings,
         **kwargs,
     ) -> Union[str, List[str]]:
+        """
+        This is the method that is called from the kernel to get a response from a chat-optimized LLM.
+
+        Arguments:
+            messages {List[ChatMessage]} -- A list of chat messages, that can be rendered into a
+                set of messages, from system, user, assistant and function.
+            settings {AIRequestSettings} -- Settings for the request.
+            logger {Logger} -- A logger to use for logging. (Deprecated)
+
+        Returns:
+            Union[str, List[str]] -- A string or list of strings representing the response(s) from the LLM.
+        """
         request_settings.messages = messages
         request_settings.stream = False
         async with AsyncSession(self.session) as session:
@@ -83,6 +95,17 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         request_settings: OllamaChatRequestSettings,
         **kwargs,
     ) -> Union[str, List[str]]:
+        """
+        This is the method that is called from the kernel to get a response from a text-optimized LLM.
+
+        Arguments:
+            prompt {str} -- The prompt to send to the LLM.
+            settings {AIRequestSettings} -- Settings for the request.
+            logger {Logger} -- A logger to use for logging (deprecated).
+
+            Returns:
+                Union[str, List[str]] -- A string or list of strings representing the response(s) from the LLM.
+        """
         return await self.complete_chat_async([{"role": "user", "content": prompt}], request_settings, **kwargs)
 
     async def complete_stream_async(
@@ -107,4 +130,5 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
             yield line
 
     def get_request_settings_class(self) -> "AIRequestSettings":
+        """Get the request settings class."""
         return OllamaChatRequestSettings

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import json
+import logging
+from typing import List, Optional, Union
+
+import aiohttp
+from pydantic import HttpUrl
+
+from semantic_kernel.connectors.ai.ai_request_settings import AIRequestSettings
+from semantic_kernel.connectors.ai.ai_service_client_base import AIServiceClientBase
+from semantic_kernel.connectors.ai.ollama.ollama_request_settings import OllamaTextRequestSettings
+from semantic_kernel.connectors.ai.text_completion_client_base import (
+    TextCompletionClientBase,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
+    """
+    Initializes a new instance of the OllamaTextCompletion class.
+
+    Make sure to have the ollama service running either locally or remotely.
+
+    Arguments:
+        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
+        url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/generate
+    """
+
+    url: HttpUrl = "http://localhost:11434/api/generate"
+    session: Optional[aiohttp.ClientSession] = None
+
+    async def complete_async(
+        self,
+        prompt: str,
+        request_settings: OllamaTextRequestSettings,
+        **kwargs,
+    ) -> Union[str, List[str]]:
+        request_settings.prompt = prompt
+        request_settings.stream = False
+        if self.session:
+            async with self.session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
+                response.raise_for_status()
+                return await response.text()
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
+                response.raise_for_status()
+                return await response.text()
+
+    async def complete_stream_async(
+        self,
+        prompt: str,
+        request_settings: OllamaTextRequestSettings,
+        **kwargs,
+    ):
+        """
+        Streams a text completion using a Hugging Face model.
+        Note that this method does not support multiple responses.
+
+        Arguments:
+            prompt {str} -- Prompt to complete.
+            request_settings {HuggingFaceRequestSettings} -- Request settings.
+
+        Yields:
+            str -- Completion result.
+        """
+        request_settings.prompt = prompt
+        request_settings.stream = True
+        if self.session:
+            async with self.session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
+                response.raise_for_status()
+                async for line in response.content:
+                    body = json.loads(line)
+                    response_part = body.get("response")
+                    yield response_part
+                    if body.get("done"):
+                        break
+        if not self.session:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
+                    response.raise_for_status()
+                    async for line in response.content:
+                        body = json.loads(line)
+                        response_part = body.get("response")
+                        yield response_part
+                        if body.get("done"):
+                            break
+
+    def get_request_settings_class(self) -> "AIRequestSettings":
+        return OllamaTextRequestSettings

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -38,6 +38,17 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         request_settings: OllamaTextRequestSettings,
         **kwargs,
     ) -> Union[str, List[str]]:
+        """
+        This is the method that is called from the kernel to get a response from a text-optimized LLM.
+
+        Arguments:
+            prompt {str} -- The prompt to send to the LLM.
+            settings {AIRequestSettings} -- Settings for the request.
+            logger {Logger} -- A logger to use for logging (deprecated).
+
+            Returns:
+                Union[str, List[str]] -- A string or list of strings representing the response(s) from the LLM.
+        """
         request_settings.prompt = prompt
         request_settings.stream = False
         async with AsyncSession(self.session) as session:
@@ -75,4 +86,5 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
                         break
 
     def get_request_settings_class(self) -> "AIRequestSettings":
+        """Get the request settings class."""
         return OllamaTextRequestSettings

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import logging
+from typing import List, Optional
+
+import aiohttp
+from numpy import array, ndarray
+from pydantic import HttpUrl
+
+from semantic_kernel.connectors.ai.ai_service_client_base import AIServiceClientBase
+from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import (
+    EmbeddingGeneratorBase,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
+    url: HttpUrl = "http://localhost:11434/api/embeddings"
+    session: Optional[aiohttp.ClientSession] = None
+
+    async def generate_embeddings_async(self, texts: List[str], **kwargs) -> ndarray:
+        """
+        Generates embeddings for a list of texts.
+
+        Arguments:
+            texts {List[str]} -- Texts to generate embeddings for.
+
+        Returns:
+            ndarray -- Embeddings for the texts.
+        """
+        if self.session:
+            async with self.session.post(
+                self.url, json={"model": self.ai_model_id, "texts": texts, "options": kwargs}
+            ) as response:
+                response.raise_for_status()
+                return array(await response.json())
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                self.url, json={"model": self.ai_model_id, "texts": texts, "options": kwargs}
+            ) as response:
+                response.raise_for_status()
+                return array(await response.json())

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -17,6 +17,16 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 
 class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
+    """Ollama embeddings client.
+
+    Make sure to have the ollama service running either locally or remotely.
+
+    Arguments:
+        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
+        url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/chat
+        session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
+    """
+
     url: HttpUrl = "http://localhost:11434/api/embeddings"
     session: Optional[aiohttp.ClientSession] = None
 

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -23,7 +23,7 @@ class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
 
     Arguments:
         ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
-        url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/chat
+        url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/embeddings
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """
 

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -11,6 +11,7 @@ from semantic_kernel.connectors.ai.ai_service_client_base import AIServiceClient
 from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import (
     EmbeddingGeneratorBase,
 )
+from semantic_kernel.connectors.ai.ollama.utils import AsyncSession
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -29,13 +30,7 @@ class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
         Returns:
             ndarray -- Embeddings for the texts.
         """
-        if self.session:
-            async with self.session.post(
-                self.url, json={"model": self.ai_model_id, "texts": texts, "options": kwargs}
-            ) as response:
-                response.raise_for_status()
-                return array(await response.json())
-        async with aiohttp.ClientSession() as session:
+        async with AsyncSession(self.session) as session:
             async with session.post(
                 self.url, json={"model": self.ai_model_id, "texts": texts, "options": kwargs}
             ) as response:

--- a/python/semantic_kernel/connectors/ai/ollama/utils.py
+++ b/python/semantic_kernel/connectors/ai/ollama/utils.py
@@ -1,0 +1,12 @@
+import aiohttp
+
+
+class AsyncSession:
+    def __init__(self, session: aiohttp.ClientSession = None):
+        self._session = session if session else aiohttp.ClientSession()
+
+    async def __aenter__(self):
+        return await self._session.__aenter__()
+
+    async def __aexit__(self, *args, **kwargs):
+        await self._session.close()

--- a/python/tests/unit/ai/ollama/services/test_ollama_chat_completion.py
+++ b/python/tests/unit/ai/ollama/services/test_ollama_chat_completion.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from semantic_kernel.connectors.ai.ollama.ollama_request_settings import OllamaChatRequestSettings
+from semantic_kernel.connectors.ai.ollama.services.ollama_chat_completion import OllamaChatCompletion
+
+
+@pytest.fixture
+def mock_session():
+    with patch("aiohttp.ClientSession.get", new_callable=MagicMock) as mock_get:
+        mock_get.return_value.__aenter__.return_value.json = MagicMock(return_value={"response": "test_response"})
+        yield mock_get
+
+
+class MockResponse:
+    def __init__(self, response, status=200):
+        self._response = response
+        self.status = status
+
+    async def text(self):
+        return self._response
+
+    async def json(self):
+        return self._response
+
+    def raise_for_status(self):
+        pass
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_complete_chat_async(mock_post):
+    mock_post.return_value = MockResponse(response={"message": {"content": "test_response"}})
+    ollama = OllamaChatCompletion(ai_model_id="test_model")
+    response = await ollama.complete_chat_async(
+        [{"role": "user", "message": "test_prompt"}],
+        OllamaChatRequestSettings(ai_model_id="test-model", options={"test": "test"}),
+    )
+    assert response == "test_response"
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_complete_async(mock_post):
+    mock_post.return_value = MockResponse(response={"message": {"content": "test_response"}})
+    ollama = OllamaChatCompletion(ai_model_id="test_model")
+    response = await ollama.complete_async(
+        "test_prompt",
+        OllamaChatRequestSettings(ai_model_id="test-model", options={"test": "test"}),
+    )
+    assert response == "test_response"

--- a/python/tests/unit/ai/ollama/services/test_ollama_chat_completion.py
+++ b/python/tests/unit/ai/ollama/services/test_ollama_chat_completion.py
@@ -1,37 +1,16 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from semantic_kernel.connectors.ai.ollama.ollama_request_settings import OllamaChatRequestSettings
 from semantic_kernel.connectors.ai.ollama.services.ollama_chat_completion import OllamaChatCompletion
+from tests.unit.ai.ollama.utils import MockResponse
 
 
-@pytest.fixture
-def mock_session():
-    with patch("aiohttp.ClientSession.get", new_callable=MagicMock) as mock_get:
-        mock_get.return_value.__aenter__.return_value.json = MagicMock(return_value={"response": "test_response"})
-        yield mock_get
-
-
-class MockResponse:
-    def __init__(self, response, status=200):
-        self._response = response
-        self.status = status
-
-    async def text(self):
-        return self._response
-
-    async def json(self):
-        return self._response
-
-    def raise_for_status(self):
-        pass
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def __aenter__(self):
-        return self
+def test_settings():
+    ollama = OllamaChatCompletion(ai_model_id="test_model")
+    settings = ollama.get_request_settings_class()
+    assert settings == OllamaChatRequestSettings
 
 
 @pytest.mark.asyncio
@@ -40,10 +19,19 @@ async def test_complete_chat_async(mock_post):
     mock_post.return_value = MockResponse(response={"message": {"content": "test_response"}})
     ollama = OllamaChatCompletion(ai_model_id="test_model")
     response = await ollama.complete_chat_async(
-        [{"role": "user", "message": "test_prompt"}],
-        OllamaChatRequestSettings(ai_model_id="test-model", options={"test": "test"}),
+        [{"role": "user", "content": "test_prompt"}],
+        OllamaChatRequestSettings(ai_model_id="test_model", options={"test": "test"}),
     )
     assert response == "test_response"
+    mock_post.assert_called_once_with(
+        "http://localhost:11434/api/chat",
+        json={
+            "model": "test_model",
+            "messages": [{"role": "user", "content": "test_prompt"}],
+            "options": {"test": "test"},
+            "stream": False,
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -56,3 +44,49 @@ async def test_complete_async(mock_post):
         OllamaChatRequestSettings(ai_model_id="test-model", options={"test": "test"}),
     )
     assert response == "test_response"
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_complete_chat_stream_async(mock_post):
+    mock_post.return_value = MockResponse(response={"message": {"content": "test_response"}})
+    ollama = OllamaChatCompletion(ai_model_id="test_model")
+    response = ollama.complete_chat_stream_async(
+        [{"role": "user", "content": "test_prompt"}],
+        OllamaChatRequestSettings(ai_model_id="test_model", options={"test": "test"}),
+    )
+    async for line in response:
+        if line:
+            assert line == "test_response"
+    mock_post.assert_called_once_with(
+        "http://localhost:11434/api/chat",
+        json={
+            "model": "test_model",
+            "messages": [{"role": "user", "content": "test_prompt"}],
+            "options": {"test": "test"},
+            "stream": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_complete_stream_async(mock_post):
+    mock_post.return_value = MockResponse(response={"message": {"content": "test_response"}})
+    ollama = OllamaChatCompletion(ai_model_id="test_model")
+    response = ollama.complete_stream_async(
+        "test_prompt",
+        OllamaChatRequestSettings(ai_model_id="test_model", options={"test": "test"}),
+    )
+    async for line in response:
+        if line:
+            assert line == "test_response"
+    mock_post.assert_called_once_with(
+        "http://localhost:11434/api/chat",
+        json={
+            "model": "test_model",
+            "options": {"test": "test"},
+            "stream": True,
+            "messages": [{"role": "user", "content": "test_prompt"}],
+        },
+    )

--- a/python/tests/unit/ai/ollama/services/test_ollama_test_completion.py
+++ b/python/tests/unit/ai/ollama/services/test_ollama_test_completion.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+import pytest
+
+from semantic_kernel.connectors.ai.ollama.ollama_request_settings import OllamaTextRequestSettings
+from semantic_kernel.connectors.ai.ollama.services.ollama_text_completion import OllamaTextCompletion
+from tests.unit.ai.ollama.utils import MockResponse
+
+
+def test_settings():
+    ollama = OllamaTextCompletion(ai_model_id="test_model")
+    settings = ollama.get_request_settings_class()
+    assert settings == OllamaTextRequestSettings
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_complete_async(mock_post):
+    mock_post.return_value = MockResponse(response="test_response")
+    ollama = OllamaTextCompletion(ai_model_id="test_model")
+    response = await ollama.complete_async(
+        "test_prompt",
+        OllamaTextRequestSettings(ai_model_id="test-model", options={"test": "test"}),
+    )
+    assert response == "test_response"
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_complete_stream_async(mock_post):
+    mock_post.return_value = MockResponse(response={"response": "test_response"})
+    ollama = OllamaTextCompletion(ai_model_id="test_model")
+    response = ollama.complete_stream_async(
+        "test_prompt",
+        OllamaTextRequestSettings(ai_model_id="test_model", options={"test": "test"}),
+    )
+    async for line in response:
+        if line:
+            assert line == "test_response"
+    mock_post.assert_called_once_with(
+        "http://localhost:11434/api/generate",
+        json={
+            "model": "test_model",
+            "options": {"test": "test"},
+            "stream": True,
+            "prompt": "test_prompt",
+            "raw": False,
+        },
+    )

--- a/python/tests/unit/ai/ollama/services/test_ollama_text_embedding.py
+++ b/python/tests/unit/ai/ollama/services/test_ollama_text_embedding.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+import pytest
+from numpy import array
+
+from semantic_kernel.connectors.ai.ollama.services.ollama_text_embedding import OllamaTextEmbedding
+from tests.unit.ai.ollama.utils import MockResponse
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.post")
+async def test_embedding(mock_post):
+    mock_post.return_value = MockResponse(response=[0.1, 0.2, 0.3])
+    ollama = OllamaTextEmbedding(ai_model_id="test_model")
+    response = await ollama.generate_embeddings_async(
+        ["test_prompt"],
+    )
+    assert response.all() == array([0.1, 0.2, 0.3]).all()
+    mock_post.assert_called_once_with(
+        "http://localhost:11434/api/embeddings",
+        json={
+            "model": "test_model",
+            "texts": ["test_prompt"],
+            "options": {},
+        },
+    )

--- a/python/tests/unit/ai/ollama/utils.py
+++ b/python/tests/unit/ai/ollama/utils.py
@@ -1,0 +1,27 @@
+import json
+
+
+class MockResponse:
+    def __init__(self, response, status=200):
+        self._response = response
+        self.status = status
+
+    async def text(self):
+        return self._response
+
+    async def json(self):
+        return self._response
+
+    def raise_for_status(self):
+        pass
+
+    @property
+    async def content(self):
+        yield json.dumps(self._response).encode("utf-8")
+        yield json.dumps({"done": True}).encode("utf-8")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def __aenter__(self):
+        return self


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Ollama is a great way to run several smaller models locally, this connector allows that to be used with SK.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Added services and request settings for Ollama.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
