### PR TITLE
.Net: [Fix] .Net: FunctionCallingStepwisePlannerTests.DoesNotThrowWhenPluginFunctionThrowsNonCriticalExceptionAsync is failing

### DIFF
--- a/dotnet/src/IntegrationTests/Fakes/ThrowingEmailPluginFake.cs
+++ b/dotnet/src/IntegrationTests/Fakes/ThrowingEmailPluginFake.cs
@@ -21,19 +21,17 @@ internal sealed class ThrowingEmailPluginFake
         throw new ArgumentException($"Failed to send email to {email_address}");
     }
 
-    [KernelFunction, Description("Lookup an email address for a person given a name")]
-    public Task<string> GetEmailAddressAsync(
-        ILogger logger,
-        [Description("The name of the person to email.")] string? input = null)
-    {
-        // Throw a critical exception for testing
-        throw new InvalidProgramException();
-    }
-
     [KernelFunction, Description("Write a short poem for an e-mail")]
     public Task<string> WritePoemAsync(
         [Description("The topic of the poem.")] string input)
     {
         return Task.FromResult($"Roses are red, violets are blue, {input} is hard, so is this test.");
+    }
+
+    [KernelFunction, Description("Write a joke for an e-mail")]
+    public Task<string> WriteJokeAsync()
+    {
+        // Throw a critical exception for testing
+        throw new InvalidProgramException();
     }
 }

--- a/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
@@ -148,7 +148,7 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
 
     private readonly RedirectOutput _testOutputHelper;
     private readonly IConfigurationRoot _configuration;
-    private readonly ILoggerFactory _logger;
+    private readonly XunitLogger<Kernel> _logger;
 
     public void Dispose()
     {

--- a/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
@@ -72,7 +72,7 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
         }
     }
 
-    [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+    [Fact]
     public async Task DoesNotThrowWhenPluginFunctionThrowsNonCriticalExceptionAsync()
     {
         Kernel kernel = this.InitializeKernel();
@@ -105,7 +105,7 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
 
         // Act & Assert
         // Planner should call ThrowingEmailPluginFake.GetEmailAddressAsync, which throws InvalidProgramException
-        await Assert.ThrowsAsync<InvalidProgramException>(async () => await planner.ExecuteAsync(kernel, "What is Kelly's email address?"));
+        await Assert.ThrowsAsync<InvalidProgramException>(async () => await planner.ExecuteAsync(kernel, "Email a joke to test@example.com"));
     }
 
     private Kernel InitializeKernel()

--- a/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Plugins.Core;
@@ -21,7 +23,9 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
 
     public FunctionCallingStepwisePlannerTests(ITestOutputHelper output)
     {
+        this._logger = new XunitLogger<Kernel>(output);
         this._testOutputHelper = new RedirectOutput(output);
+        Console.SetOut(this._testOutputHelper);
 
         // Load configuration
         this._configuration = new ConfigurationBuilder()
@@ -131,8 +135,9 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
         OpenAIConfiguration? openAIConfiguration = this._configuration.GetSection("Planners:OpenAI").Get<OpenAIConfiguration>();
         Assert.NotNull(openAIConfiguration);
 
-        IKernelBuilder builder = Kernel.CreateBuilder()
-            .AddOpenAIChatCompletion(
+        IKernelBuilder builder = Kernel.CreateBuilder();
+        builder.Services.AddSingleton<ILoggerFactory>(this._logger);
+        builder.AddOpenAIChatCompletion(
                 modelId: openAIConfiguration.ModelId,
                 apiKey: openAIConfiguration.ApiKey);
 
@@ -143,6 +148,7 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
 
     private readonly RedirectOutput _testOutputHelper;
     private readonly IConfigurationRoot _configuration;
+    private readonly ILoggerFactory _logger;
 
     public void Dispose()
     {

--- a/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
@@ -75,8 +75,17 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
     [Fact]
     public async Task DoesNotThrowWhenPluginFunctionThrowsNonCriticalExceptionAsync()
     {
+        // Arrange
         Kernel kernel = this.InitializeKernel();
-        kernel.ImportPluginFromType<ThrowingEmailPluginFake>("Email");
+
+        var emailPluginFake = new ThrowingEmailPluginFake();
+        kernel.Plugins.Add(
+            KernelPluginFactory.CreateFromFunctions(
+            "Email",
+            new[] {
+                KernelFunctionFactory.CreateFromMethod(emailPluginFake.WritePoemAsync),
+                KernelFunctionFactory.CreateFromMethod(emailPluginFake.SendEmailAsync),
+            }));
 
         var planner = new FunctionCallingStepwisePlanner(
             new FunctionCallingStepwisePlannerConfig() { MaxIterations = 5 });
@@ -97,8 +106,17 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
     [Fact]
     public async Task ThrowsWhenPluginFunctionThrowsCriticalExceptionAsync()
     {
+        // Arrange
         Kernel kernel = this.InitializeKernel();
-        kernel.ImportPluginFromType<ThrowingEmailPluginFake>("Email");
+
+        var emailPluginFake = new ThrowingEmailPluginFake();
+        kernel.Plugins.Add(
+            KernelPluginFactory.CreateFromFunctions(
+            "Email",
+            new[] {
+                KernelFunctionFactory.CreateFromMethod(emailPluginFake.WriteJokeAsync),
+                KernelFunctionFactory.CreateFromMethod(emailPluginFake.SendEmailAsync),
+            }));
 
         var planner = new FunctionCallingStepwisePlanner(
             new FunctionCallingStepwisePlannerConfig() { MaxIterations = 5 });

--- a/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
@@ -165,6 +165,7 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
     {
         if (disposing)
         {
+            this._logger.Dispose();
             this._testOutputHelper.Dispose();
         }
     }

--- a/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Stepwise/FunctionCallingStepwisePlannerTests.cs
@@ -104,7 +104,7 @@ public sealed class FunctionCallingStepwisePlannerTests : IDisposable
             new FunctionCallingStepwisePlannerConfig() { MaxIterations = 5 });
 
         // Act & Assert
-        // Planner should call ThrowingEmailPluginFake.GetEmailAddressAsync, which throws InvalidProgramException
+        // Planner should call ThrowingEmailPluginFake.WriteJokeAsync, which throws InvalidProgramException
         await Assert.ThrowsAsync<InvalidProgramException>(async () => await planner.ExecuteAsync(kernel, "Email a joke to test@example.com"));
     }
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Fix for failing integration test (resolves #4534)

When using certain OpenAI models such as `gpt-3.5-turbo-1106`, the model would sometimes opt to call `GetEmailAddressAsync` when it wasn't actually needed. This was causing a critical exception to be thrown (which was by design for a different test case, but in this case was being called unexpectedly and causing the test to fail.)

### Description

<!-- Describe your changes, the overall approach, the underlying design. 
     These notes will help understanding how your code works. Thanks! -->
This change modifies the test scenarios to minimize the possibility of a critical exception being thrown by mistake. Now `WriteJokeAsync` throws the critical exception, so the other test cases (that involve writing/emailing poems) should not encounter it.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
