### PR TITLE
.Net: Add missing XxFromFunctions members

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
@@ -29,7 +29,7 @@ public static class Example59_OpenAIFunctionCalling
         Kernel kernel = builder.Build();
 
         // Add a plugin with some helper functions we want to allow the model to utilize.
-        kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("HelperFunctions", new[]
+        kernel.ImportPluginFromFunctions("HelperFunctions", new[]
         {
             kernel.CreateFunctionFromMethod(() => DateTime.UtcNow.ToString("R"), "GetCurrentUtcTime", "Retrieves the current time in UTC."),
             kernel.CreateFunctionFromMethod((string cityName) =>
@@ -44,7 +44,7 @@ public static class Example59_OpenAIFunctionCalling
                     "Tel Aviv" => "80 and sunny",
                     _ => "31 and snowing",
                 }, "Get_Weather_For_City", "Gets the current weather for the specified city"),
-        }));
+        });
 
         Console.WriteLine("======== Example 1: Use automated function calling with a non-streaming prompt ========");
         {

--- a/dotnet/src/Experimental/Agents.UnitTests/Extensions/KernelExtensionTests.cs
+++ b/dotnet/src/Experimental/Agents.UnitTests/Extensions/KernelExtensionTests.cs
@@ -20,7 +20,7 @@ public sealed class KernelExtensionTests
         var function = KernelFunctionFactory.CreateFromMethod(() => { }, functionName: "Bogus");
 
         var kernel = new Kernel();
-        kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("Fake", "Fake functions", new[] { function }));
+        kernel.ImportPluginFromFunctions("Fake", new[] { function });
 
         //Act
         var tool = kernel.GetAssistantTool(TwoPartToolName);

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -169,6 +169,37 @@ public static class KernelExtensions
     }
     #endregion
 
+    #region CreatePluginFromFunctions
+    /// <summary>Creates a plugin that contains the specified functions.</summary>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static KernelPlugin CreatePluginFromFunctions(this Kernel kernel, string pluginName, IEnumerable<KernelFunction>? functions) =>
+        CreatePluginFromFunctions(kernel, pluginName, description: null, functions);
+
+    /// <summary>Creates a plugin that contains the specified functions.</summary>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static KernelPlugin CreatePluginFromFunctions(this Kernel kernel, string pluginName, string? description = null, IEnumerable<KernelFunction>? functions = null)
+    {
+        Verify.NotNull(kernel);
+
+        return KernelPluginFactory.CreateFromFunctions(pluginName, description, functions);
+    }
+    #endregion
+
     #region ImportPlugin/AddFromType
     /// <summary>Creates a plugin that wraps a new instance of the specified type <typeparamref name="T"/> and imports it into the <paramref name="kernel"/>'s plugin collection.</summary>
     /// <typeparam name="T">Specifies the type of the object to wrap.</typeparam>
@@ -279,25 +310,6 @@ public static class KernelExtensions
         return plugin;
     }
 
-    /// <summary>Creates a plugin that contains the specified functions and adds it into the plugin collection.</summary>
-    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
-    /// <param name="pluginName">The name for the plugin.</param>
-    /// <param name="description">A description of the plugin.</param>
-    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
-    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
-    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
-    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
-    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
-    public static KernelPlugin AddFromFunctions(this ICollection<KernelPlugin> plugins, string pluginName, string? description, IEnumerable<KernelFunction>? functions = null)
-    {
-        Verify.NotNull(plugins);
-
-        var plugin = new DefaultKernelPlugin(pluginName, description, functions);
-        plugins.Add(plugin);
-        return plugin;
-    }
-
     /// <summary>Creates a plugin that wraps the specified target object and adds it into the plugin collection.</summary>
     /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
     /// <param name="target">The instance of the class to be wrapped.</param>
@@ -313,6 +325,99 @@ public static class KernelExtensions
         Verify.NotNull(plugins);
 
         plugins.Services.AddSingleton(serviceProvider => KernelPluginFactory.CreateFromObject(target, pluginName, serviceProvider?.GetService<ILoggerFactory>()));
+
+        return plugins;
+    }
+    #endregion
+
+    #region ImportPlugin/AddFromFunctions
+    /// <summary>Creates a plugin that contains the specified functions and imports it into the <paramref name="kernel"/>'s plugin collection.</summary>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static KernelPlugin ImportPluginFromFunctions(this Kernel kernel, string pluginName, IEnumerable<KernelFunction>? functions) =>
+        ImportPluginFromFunctions(kernel, pluginName, description: null, functions);
+
+    /// <summary>Creates a plugin that contains the specified functions and imports it into the <paramref name="kernel"/>'s plugin collection.</summary>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static KernelPlugin ImportPluginFromFunctions(this Kernel kernel, string pluginName, string? description = null, IEnumerable<KernelFunction>? functions = null)
+    {
+        KernelPlugin plugin = CreatePluginFromFunctions(kernel, pluginName, description, functions);
+        kernel.Plugins.Add(plugin);
+        return plugin;
+    }
+
+    /// <summary>Creates a plugin that contains the specified functions and adds it into the plugin collection.</summary>
+    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static KernelPlugin AddFromFunctions(this ICollection<KernelPlugin> plugins, string pluginName, IEnumerable<KernelFunction>? functions) =>
+        AddFromFunctions(plugins, pluginName, description: null, functions);
+
+    /// <summary>Creates a plugin that contains the specified functions and adds it into the plugin collection.</summary>
+    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing the functions provided in <paramref name="functions"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static KernelPlugin AddFromFunctions(this ICollection<KernelPlugin> plugins, string pluginName, string? description = null, IEnumerable<KernelFunction>? functions = null)
+    {
+        Verify.NotNull(plugins);
+
+        var plugin = new DefaultKernelPlugin(pluginName, description, functions);
+        plugins.Add(plugin);
+        return plugin;
+    }
+
+    /// <summary>Creates a plugin that wraps the specified target object and adds it into the plugin collection.</summary>
+    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>The same instance as <paramref name="plugins"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static IKernelBuilderPlugins AddFromFunctions(this IKernelBuilderPlugins plugins, string pluginName, IEnumerable<KernelFunction>? functions) =>
+        AddFromFunctions(plugins, pluginName, description: null, functions);
+
+    /// <summary>Creates a plugin that wraps the specified target object and adds it into the plugin collection.</summary>
+    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <param name="functions">The initial functions to be available as part of the plugin.</param>
+    /// <returns>The same instance as <paramref name="plugins"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pluginName"/> is an invalid plugin name.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="functions"/> contains a null function.</exception>
+    /// <exception cref="ArgumentException"><paramref name="functions"/> contains two functions with the same name.</exception>
+    public static IKernelBuilderPlugins AddFromFunctions(this IKernelBuilderPlugins plugins, string pluginName, string? description = null, IEnumerable<KernelFunction>? functions = null)
+    {
+        Verify.NotNull(plugins);
+
+        plugins.Services.AddSingleton(KernelPluginFactory.CreateFromFunctions(pluginName, description, functions));
 
         return plugins;
     }

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelExtensionsTests.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Functions;
+
+public class KernelExtensionsTests
+{
+    [Fact]
+    public void CreatePluginFromFunctions()
+    {
+        Kernel kernel = new();
+
+        KernelPlugin plugin = kernel.CreatePluginFromFunctions("coolplugin", new[]
+        {
+            kernel.CreateFunctionFromMethod(() => { }, "Function1"),
+            kernel.CreateFunctionFromMethod(() => { }, "Function2"),
+        });
+
+        Assert.NotNull(plugin);
+        Assert.Empty(kernel.Plugins);
+
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Empty(plugin.Description);
+        Assert.Equal(2, plugin.FunctionCount);
+        Assert.True(plugin.Contains("Function1"));
+        Assert.True(plugin.Contains("Function2"));
+    }
+
+    [Fact]
+    public void CreateEmptyPluginFromFunctions()
+    {
+        Kernel kernel = new();
+
+        KernelPlugin plugin = kernel.CreatePluginFromFunctions("coolplugin");
+
+        Assert.NotNull(plugin);
+        Assert.Empty(kernel.Plugins);
+
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Empty(plugin.Description);
+        Assert.Empty(plugin);
+        Assert.Equal(0, plugin.FunctionCount);
+    }
+
+    [Fact]
+    public void CreatePluginFromDescriptionAndFunctions()
+    {
+        Kernel kernel = new();
+
+        KernelPlugin plugin = kernel.CreatePluginFromFunctions("coolplugin", "the description", new[]
+        {
+            kernel.CreateFunctionFromMethod(() => { }, "Function1"),
+            kernel.CreateFunctionFromMethod(() => { }, "Function2"),
+        });
+
+        Assert.NotNull(plugin);
+        Assert.Empty(kernel.Plugins);
+
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Equal("the description", plugin.Description);
+        Assert.Equal(2, plugin.FunctionCount);
+        Assert.True(plugin.Contains("Function1"));
+        Assert.True(plugin.Contains("Function2"));
+    }
+
+    [Fact]
+    public void ImportPluginFromFunctions()
+    {
+        Kernel kernel = new();
+
+        kernel.ImportPluginFromFunctions("coolplugin", new[]
+        {
+            kernel.CreateFunctionFromMethod(() => { }, "Function1"),
+            kernel.CreateFunctionFromMethod(() => { }, "Function2"),
+        });
+
+        Assert.Single(kernel.Plugins);
+
+        KernelPlugin plugin = kernel.Plugins["coolplugin"];
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Empty(plugin.Description);
+        Assert.NotNull(plugin);
+
+        Assert.Equal(2, plugin.FunctionCount);
+        Assert.True(plugin.Contains("Function1"));
+        Assert.True(plugin.Contains("Function2"));
+    }
+
+    [Fact]
+    public void ImportPluginFromDescriptionAndFunctions()
+    {
+        Kernel kernel = new();
+
+        kernel.ImportPluginFromFunctions("coolplugin", "the description", new[]
+        {
+            kernel.CreateFunctionFromMethod(() => { }, "Function1"),
+            kernel.CreateFunctionFromMethod(() => { }, "Function2"),
+        });
+
+        Assert.Single(kernel.Plugins);
+
+        KernelPlugin plugin = kernel.Plugins["coolplugin"];
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Equal("the description", plugin.Description);
+        Assert.NotNull(plugin);
+
+        Assert.Equal(2, plugin.FunctionCount);
+        Assert.True(plugin.Contains("Function1"));
+        Assert.True(plugin.Contains("Function2"));
+    }
+
+    [Fact]
+    public void AddFromFunctions()
+    {
+        Kernel kernel = new();
+
+        kernel.Plugins.AddFromFunctions("coolplugin", new[]
+        {
+            kernel.CreateFunctionFromMethod(() => { }, "Function1"),
+            kernel.CreateFunctionFromMethod(() => { }, "Function2"),
+        });
+
+        Assert.Single(kernel.Plugins);
+
+        KernelPlugin plugin = kernel.Plugins["coolplugin"];
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Empty(plugin.Description);
+        Assert.NotNull(plugin);
+
+        Assert.Equal(2, plugin.FunctionCount);
+        Assert.True(plugin.Contains("Function1"));
+        Assert.True(plugin.Contains("Function2"));
+    }
+
+    [Fact]
+    public void AddFromDescriptionAndFunctions()
+    {
+        Kernel kernel = new();
+
+        kernel.Plugins.AddFromFunctions("coolplugin", "the description", new[]
+        {
+            kernel.CreateFunctionFromMethod(() => { }, "Function1"),
+            kernel.CreateFunctionFromMethod(() => { }, "Function2"),
+        });
+
+        Assert.Single(kernel.Plugins);
+
+        KernelPlugin plugin = kernel.Plugins["coolplugin"];
+        Assert.Equal("coolplugin", plugin.Name);
+        Assert.Equal("the description", plugin.Description);
+        Assert.NotNull(plugin);
+
+        Assert.Equal(2, plugin.FunctionCount);
+        Assert.True(plugin.Contains("Function1"));
+        Assert.True(plugin.Contains("Function2"));
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromPromptTests.cs
@@ -48,7 +48,7 @@ public class KernelFunctionFromPromptTests
         builder.Services.AddSingleton(factory.Object);
         Kernel kernel = builder.Build();
 
-        kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("jk", functions: new[] { kernel.CreateFunctionFromPrompt(promptTemplate: "Tell me a joke", functionName: "joker", description: "Nice fun") }));
+        kernel.ImportPluginFromFunctions("jk", functions: new[] { kernel.CreateFunctionFromPrompt(promptTemplate: "Tell me a joke", functionName: "joker", description: "Nice fun") });
 
         // Act & Assert - 3 functions, var name is not case sensitive
         Assert.True(kernel.Plugins.TryGetFunction("jk", "joker", out _));
@@ -573,7 +573,7 @@ public class KernelFunctionFromPromptTests
         KernelFunction function1 = KernelFunctionFactory.CreateFromPrompt(new PromptTemplateConfig { Name = "Prompt1", Template = "Prompt1", ExecutionSettings = new() { ["service1"] = new OpenAIPromptExecutionSettings { MaxTokens = 1000 } } });
         KernelFunction function2 = KernelFunctionFactory.CreateFromPrompt(new PromptTemplateConfig { Name = "Prompt2", Template = "Prompt2 {{MyPrompts.Prompt1}}", ExecutionSettings = new() { ["service2"] = new OpenAIPromptExecutionSettings { MaxTokens = 2000 } } });
 
-        kernel.Plugins.AddFromFunctions("MyPrompts", "Prompt1 and Prompt2", new[] { function1, function2 });
+        kernel.ImportPluginFromFunctions("MyPrompts", new[] { function1, function2 });
 
         // Act
         var result = await kernel.InvokeAsync(function2);

--- a/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/KernelTests.cs
@@ -503,7 +503,7 @@ public class KernelTests
         var function = KernelFunctionFactory.CreateFromMethod(() => "fake result", "function");
 
         var kernel = new Kernel();
-        kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         //Act
         var result = await kernel.InvokeAsync("plugin", "function");

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/KernelPromptTemplateTests.cs
@@ -106,11 +106,11 @@ public sealed class KernelPromptTemplateTests
         // Arrange
         var template = "This {{$x11}} {{$a}}{{$missing}} test template {{p.bar $b}} and {{p.food c='literal \"c\"' d = $d}}";
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[]
+        this._kernel.ImportPluginFromFunctions("p", new[]
         {
             KernelFunctionFactory.CreateFromMethod((string input) => "with function that accepts " + input, "bar"),
             KernelFunctionFactory.CreateFromMethod((string c, string d) => "another one with " + c + d, "food"),
-        }));
+        });
 
         var target = (KernelPromptTemplate)this._factory.Create(new PromptTemplateConfig(template));
 
@@ -186,7 +186,7 @@ public sealed class KernelPromptTemplateTests
             canary = input;
         }
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") }));
+        this._kernel.ImportPluginFromFunctions("p", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") });
 
         var template = "This is a test template that references variable that does not have argument. {{p.bar $foo}}.";
 
@@ -210,7 +210,7 @@ public sealed class KernelPromptTemplateTests
             canary = input;
         }
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") }));
+        this._kernel.ImportPluginFromFunctions("p", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") });
 
         var template = "This is a test template that references variable that have null argument{{p.bar $foo}}.";
 
@@ -236,7 +236,7 @@ public sealed class KernelPromptTemplateTests
             canary = input;
         }
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") }));
+        this._kernel.ImportPluginFromFunctions("p", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") });
 
         var template = "This is a test template that {{$zoo}}references variables that have null arguments{{p.bar $foo}}.";
 
@@ -265,7 +265,7 @@ public sealed class KernelPromptTemplateTests
             canary = input;
         }
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") }));
+        this._kernel.ImportPluginFromFunctions("p", new[] { KernelFunctionFactory.CreateFromMethod(Foo, "bar") });
 
         var template = "This is a test template that {{$zoo}}references variables that do not have arguments{{p.bar $foo}}.";
 
@@ -292,7 +292,7 @@ public sealed class KernelPromptTemplateTests
 
         var func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { func });
 
         this._arguments[InputParameterName] = "INPUT-BAR";
 
@@ -318,7 +318,7 @@ public sealed class KernelPromptTemplateTests
 
         var func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { func });
 
         this._arguments["myVar"] = "BAR";
         var template = "foo-{{plugin.function $myVar}}-baz";
@@ -348,7 +348,7 @@ public sealed class KernelPromptTemplateTests
 
         var func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { func });
 
         this._arguments[InputParameterName] = "Mario";
         this._arguments["someDate"] = "2023-08-25T00:00:00";
@@ -395,7 +395,7 @@ public sealed class KernelPromptTemplateTests
 
         KernelFunction func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { func });
 
         this._arguments[InputParameterName] = "Mario";
         this._arguments["someDate"] = "2023-08-25T00:00:00";
@@ -461,7 +461,7 @@ public sealed class KernelPromptTemplateTests
 
         KernelFunction func = KernelFunctionFactory.CreateFromMethod(MyFunctionAsync, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { func }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { func });
 
         this._arguments["myVar"] = "BAR";
 
@@ -497,7 +497,7 @@ public sealed class KernelPromptTemplateTests
         "f");
 
         this._kernel.Culture = new CultureInfo("fr-FR"); //In French culture, a comma is used as a decimal separator, and a slash is used as a date separator. See the Assert below.
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[] { func }));
+        this._kernel.ImportPluginFromFunctions("p", new[] { func });
 
         var template = "int:{{$i}}, double:{{$d}}, {{p.f $s g=$g}}, DateTime:{{$dt}}, enum:{{$e}}";
 

--- a/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/TemplateEngine/Blocks/CodeBlockTests.cs
@@ -34,7 +34,7 @@ public class CodeBlockTests
         static void method() => throw new FormatException("error");
         var function = KernelFunctionFactory.CreateFromMethod(method, "function", "description");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         var target = new CodeBlock("plugin.function");
 
@@ -194,7 +194,7 @@ public class CodeBlockTests
         },
         "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         // Act
         var codeBlock = new CodeBlock(new List<Block> { funcId, varBlock }, "");
@@ -222,7 +222,7 @@ public class CodeBlockTests
         },
         "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         // Act
         var codeBlock = new CodeBlock(new List<Block> { funcBlock, valBlock }, "");
@@ -259,7 +259,7 @@ public class CodeBlockTests
         },
         "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         // Act
         var codeBlock = new CodeBlock(new List<Block> { funcId, namedArgBlock1, namedArgBlock2 }, "");
@@ -282,10 +282,10 @@ public class CodeBlockTests
         var varBlock = new VarBlock("$var");
         var namedArgBlock = new NamedArgBlock("p1=$a1");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("p", "description", new[] { KernelFunctionFactory.CreateFromMethod((object p1) =>
+        this._kernel.ImportPluginFromFunctions("p", new[] { KernelFunctionFactory.CreateFromMethod((object p1) =>
         {
             canary = p1;
-        }, "f") }));
+        }, "f") });
 
         // Act
         var functionWithPositionedArgument = new CodeBlock(new List<Block> { funcId, varBlock }, "");
@@ -323,7 +323,7 @@ public class CodeBlockTests
 
         var function = KernelFunctionFactory.CreateFromMethod((string foo, string baz) => { }, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         // Act
         var codeBlock = new CodeBlock(new List<Block> { funcId, namedArgBlock1, namedArgBlock2 }, "");
@@ -363,7 +363,7 @@ public class CodeBlockTests
 
         var function = KernelFunctionFactory.CreateFromMethod(() => { }, "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         // Act
         var codeBlock = new CodeBlock(blockList, "");
@@ -392,15 +392,13 @@ public class CodeBlockTests
             new ValBlock($"'{FooValue}'")
         };
 
-        kernel.Plugins.Add(
-            KernelPluginFactory.CreateFromFunctions("Plugin1", functions: new[]
+        kernel.ImportPluginFromFunctions("Plugin1", functions: new[]
                 {
                     kernel.CreateFunctionFromPrompt(
                         promptTemplate: $"\"This {{{{${parameterName}}}}}",
                         functionName: "Function1")
                 }
-            )
-        );
+            );
 
         kernel.PromptRendering += (object? sender, PromptRenderingEventArgs e) =>
         {
@@ -438,15 +436,13 @@ public class CodeBlockTests
             new NamedArgBlock("x12='new'") // Extra parameters are ignored
         };
 
-        kernel.Plugins.Add(
-            KernelPluginFactory.CreateFromFunctions("Plugin1", functions: new[]
+        kernel.ImportPluginFromFunctions("Plugin1", functions: new[]
                 {
                     kernel.CreateFunctionFromPrompt(
                         promptTemplate: "\"This {{$x11}}",
                         functionName: "Function1")
                 }
-            )
-        );
+            );
 
         kernel.PromptRendering += (object? sender, PromptRenderingEventArgs e) =>
         {
@@ -490,7 +486,7 @@ public class CodeBlockTests
         },
         "function");
 
-        this._kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("plugin", "description", new[] { function }));
+        this._kernel.ImportPluginFromFunctions("plugin", new[] { function });
 
         // Act
         var codeBlock = new CodeBlock(new List<Block> { funcId, namedArgBlock1, namedArgBlock2 }, "");


### PR DESCRIPTION
Following the same pattern used by FromType and FromObject