### PR TITLE
.Net: Aligning the SK agent HTTP stack behavior with the SK one

### DIFF
--- a/dotnet/src/Experimental/Agents/Extensions/OpenAIRestExtensions.cs
+++ b/dotnet/src/Experimental/Agents/Extensions/OpenAIRestExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Experimental.Agents.Exceptions;
 using Microsoft.SemanticKernel.Experimental.Agents.Internal;
+using Microsoft.SemanticKernel.Http;
 
 namespace Microsoft.SemanticKernel.Experimental.Agents;
 
@@ -25,13 +26,9 @@ internal static partial class OpenAIRestExtensions
         request.Headers.Add(HeaderNameAuthorization, $"Bearer {context.ApiKey}");
         request.Headers.Add(HeaderNameOpenAIAssistant, HeaderOpenAIValueAssistant);
 
-        using var response = await context.GetHttpClient().SendAsync(request, cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new AgentException($"Unexpected failure: {response.StatusCode} [{url}]");
-        }
+        using var response = await context.GetHttpClient().SendWithSuccessCheckAsync(request, cancellationToken).ConfigureAwait(false);
 
-        string responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var responseBody = await response.Content.ReadAsStringWithExceptionMappingAsync().ConfigureAwait(false);
 
         // Common case is for failure exception to be raised by REST invocation.
         // Null result is a logical possibility, but unlikely edge case.
@@ -60,13 +57,10 @@ internal static partial class OpenAIRestExtensions
         request.Headers.Add(HeaderNameAuthorization, $"Bearer {context.ApiKey}");
         request.Headers.Add(HeaderNameOpenAIAssistant, HeaderOpenAIValueAssistant);
 
-        using var response = await context.GetHttpClient().SendAsync(request, cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new AgentException($"Unexpected failure: {response.StatusCode} [{url}]");
-        }
+        using var response = await context.GetHttpClient().SendWithSuccessCheckAsync(request, cancellationToken).ConfigureAwait(false);
 
-        string responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var responseBody = await response.Content.ReadAsStringWithExceptionMappingAsync().ConfigureAwait(false);
+
         return
             JsonSerializer.Deserialize<TResult>(responseBody) ??
             throw new AgentException($"Null result processing: {typeof(TResult).Name}");
@@ -82,10 +76,6 @@ internal static partial class OpenAIRestExtensions
         request.Headers.Add(HeaderNameAuthorization, $"Bearer {context.ApiKey}");
         request.Headers.Add(HeaderNameOpenAIAssistant, HeaderOpenAIValueAssistant);
 
-        using var response = await context.GetHttpClient().SendAsync(request, cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new AgentException($"Unexpected failure: {response.StatusCode} [{url}]");
-        }
+        using var response = await context.GetHttpClient().SendWithSuccessCheckAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
### Motivation and Context

Aligning the SK agent HTTP stack behavior with the SK one, where HttpClaimrException and RequestFailedException (thrown by AzureSDK) are translated into HttpOperationException. Doing so hides SK/Agent internal implementation details (whether requests are sent via vanilla HttpClient or third-party client library) from SK/Agent consumer code without losing original exception details. Additionally, this will future-proof the SK/Agent consumer code, as it will require only one catch block - catch(HttpOperationException ex), which once added, will work regardless of the connector (currently, only OpenAI) used to access LLM.

ADR for similar changes in SK - https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0004-error-handling.md