### PR TITLE
.Net: Add missing CancellationToken to InvokePromptAsync<T>. (#4573)

### DIFF
--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -711,6 +711,32 @@ public static class KernelExtensions
     /// </summary>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="promptTemplate">Prompt template for the function.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The <typeparamref name="T"/> of the function result value.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="kernel"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="promptTemplate"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="promptTemplate"/> is empty or composed entirely of whitespace.</exception>
+    /// <exception cref="KernelFunction">The function failed to invoke successfully.</exception>
+    /// <exception cref="KernelFunctionCanceledException">The <see cref="KernelFunction"/>'s invocation was canceled.</exception>
+    public static Task<T?> InvokePromptAsync<T>(
+        this Kernel kernel,
+        string promptTemplate,
+        CancellationToken cancellationToken = default)
+    {
+        return InvokePromptAsync<T>(
+            kernel,
+            promptTemplate,
+            arguments: null,
+            templateFormat: null,
+            promptTemplateFactory: null,
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Invokes a prompt specified via a prompt template and returns the results of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="promptTemplate">Prompt template for the function.</param>
     /// <param name="arguments">The arguments to pass to the function's invocation, including any <see cref="PromptExecutionSettings"/>.</param>
     /// <param name="templateFormat">The template format of <paramref name="promptTemplate"/>. This must be provided if <paramref name="promptTemplateFactory"/> is not null.</param>
     /// <param name="promptTemplateFactory">
@@ -723,6 +749,7 @@ public static class KernelExtensions
     /// <exception cref="ArgumentException"><paramref name="promptTemplate"/> is empty or composed entirely of whitespace.</exception>
     /// <exception cref="KernelFunction">The function failed to invoke successfully.</exception>
     /// <exception cref="KernelFunctionCanceledException">The <see cref="KernelFunction"/>'s invocation was canceled.</exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<T?> InvokePromptAsync<T>(
         this Kernel kernel,
         string promptTemplate,
@@ -730,7 +757,13 @@ public static class KernelExtensions
         string? templateFormat,
         IPromptTemplateFactory? promptTemplateFactory)
     {
-        return InvokePromptAsync<T>(kernel, promptTemplate, arguments, templateFormat, promptTemplateFactory, CancellationToken.None);
+        return InvokePromptAsync<T>(
+            kernel,
+            promptTemplate,
+            arguments,
+            templateFormat,
+            promptTemplateFactory,
+            CancellationToken.None);
     }
     #endregion
 

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -711,32 +711,6 @@ public static class KernelExtensions
     /// </summary>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="promptTemplate">Prompt template for the function.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>The <typeparamref name="T"/> of the function result value.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="kernel"/> is null.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="promptTemplate"/> is null.</exception>
-    /// <exception cref="ArgumentException"><paramref name="promptTemplate"/> is empty or composed entirely of whitespace.</exception>
-    /// <exception cref="KernelFunction">The function failed to invoke successfully.</exception>
-    /// <exception cref="KernelFunctionCanceledException">The <see cref="KernelFunction"/>'s invocation was canceled.</exception>
-    public static Task<T?> InvokePromptAsync<T>(
-        this Kernel kernel,
-        string promptTemplate,
-        CancellationToken cancellationToken = default)
-    {
-        return InvokePromptAsync<T>(
-            kernel,
-            promptTemplate,
-            arguments: null,
-            templateFormat: null,
-            promptTemplateFactory: null,
-            cancellationToken: cancellationToken);
-    }
-
-    /// <summary>
-    /// Invokes a prompt specified via a prompt template and returns the results of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
-    /// <param name="promptTemplate">Prompt template for the function.</param>
     /// <param name="arguments">The arguments to pass to the function's invocation, including any <see cref="PromptExecutionSettings"/>.</param>
     /// <param name="templateFormat">The template format of <paramref name="promptTemplate"/>. This must be provided if <paramref name="promptTemplateFactory"/> is not null.</param>
     /// <param name="promptTemplateFactory">

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -679,6 +679,7 @@ public static class KernelExtensions
     /// The <see cref="IPromptTemplateFactory"/> to use when interpreting the <paramref name="promptTemplate"/> into a <see cref="IPromptTemplate"/>.
     /// If null, a default factory will be used.
     /// </param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The <typeparamref name="T"/> of the function result value.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="kernel"/> is null.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="promptTemplate"/> is null.</exception>
@@ -690,7 +691,8 @@ public static class KernelExtensions
         string promptTemplate,
         KernelArguments? arguments = null,
         string? templateFormat = null,
-        IPromptTemplateFactory? promptTemplateFactory = null)
+        IPromptTemplateFactory? promptTemplateFactory = null,
+        CancellationToken cancellationToken = default)
     {
         Verify.NotNull(kernel);
         Verify.NotNullOrWhiteSpace(promptTemplate);
@@ -701,7 +703,34 @@ public static class KernelExtensions
             promptTemplateFactory: promptTemplateFactory,
             loggerFactory: kernel.LoggerFactory);
 
-        return kernel.InvokeAsync<T>(function, arguments);
+        return kernel.InvokeAsync<T>(function, arguments, cancellationToken);
+    }
+
+    /// <summary>
+    /// Invokes a prompt specified via a prompt template and returns the results of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="promptTemplate">Prompt template for the function.</param>
+    /// <param name="arguments">The arguments to pass to the function's invocation, including any <see cref="PromptExecutionSettings"/>.</param>
+    /// <param name="templateFormat">The template format of <paramref name="promptTemplate"/>. This must be provided if <paramref name="promptTemplateFactory"/> is not null.</param>
+    /// <param name="promptTemplateFactory">
+    /// The <see cref="IPromptTemplateFactory"/> to use when interpreting the <paramref name="promptTemplate"/> into a <see cref="IPromptTemplate"/>.
+    /// If null, a default factory will be used.
+    /// </param>
+    /// <returns>The <typeparamref name="T"/> of the function result value.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="kernel"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="promptTemplate"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="promptTemplate"/> is empty or composed entirely of whitespace.</exception>
+    /// <exception cref="KernelFunction">The function failed to invoke successfully.</exception>
+    /// <exception cref="KernelFunctionCanceledException">The <see cref="KernelFunction"/>'s invocation was canceled.</exception>
+    public static Task<T?> InvokePromptAsync<T>(
+        this Kernel kernel,
+        string promptTemplate,
+        KernelArguments? arguments,
+        string? templateFormat,
+        IPromptTemplateFactory? promptTemplateFactory)
+    {
+        return InvokePromptAsync<T>(kernel, promptTemplate, arguments, templateFormat, promptTemplateFactory, CancellationToken.None);
     }
     #endregion
 


### PR DESCRIPTION
### Motivation and Context

KernelExtensions.InvokePromptAsync<T>(...) doesn't include a CancellationToken parameter mistakenly as described in #4573 

Closes #4573 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

As @stephentoub mentioned in #4573, adding just a `cancellationToken` causes a _binary breaking change_.
So, this method has two overloads, one with full optional parameters, and a second overload with no optional parameters at all.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
