### PR TITLE
Python: Fix OYD tool message parsing

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/models/chat/azure_chat_with_data_response.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/models/chat/azure_chat_with_data_response.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 """Azure OpenAI Chat With Data Streaming Response class."""
-from typing import Tuple
 import json
+from typing import Tuple
 
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
@@ -35,11 +35,12 @@ class AzureChatWithDataStreamResponse:
                 if message.choices and len(message.choices) > 0:
                     delta = message.choices[0].delta
                     if delta and delta.model_extra and "context" in delta.model_extra:
-                        for m in delta.model_extra["context"].get("messages", []):
-                            if m.get("role") == "tool":
-                                self._tool_message = m.get("content", "")
-                                break
-                        if not self._tool_message:
+                        if "messages" in delta.model_extra["context"]:
+                            for m in delta.model_extra["context"]["messages"]:
+                                if m.get("role") == "tool":
+                                    self._tool_message = m.get("content", "")
+                                    break
+                        else:
                             self._tool_message = json.dumps(delta.model_extra["context"])
                         break
                     else:

--- a/python/semantic_kernel/connectors/ai/open_ai/utils.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -200,10 +201,13 @@ def _parse_message(
     else:
         tool_content = None
         if message.model_extra and "context" in message.model_extra:
-            for m in message.model_extra["context"].get("messages", []):
-                if m["role"] == "tool":
-                    tool_content = m.get("content", None)
-                    break
+            if "messages" in message.model_extra["context"]:
+                for m in message.model_extra["context"]["messages"]:
+                    if m.get("role") == "tool":
+                        tool_content = m.get("content", None)
+                        break
+            else:
+                tool_content = json.dumps(message.model_extra["context"])
         return (content, tool_content, function_call)
 
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
A recent OYD service deployment changed the schema for the "tool" message containing citations, this cause the OYD response parsing to fail. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Updated OYD response parser to accept both schemas for citations and pass gracefully on to the assistant message deltas if no tool message can be extracted. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
