### PR TITLE
.Net: Remove Polly as a dependency

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -50,7 +50,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageVersion Include="xretry" Version="1.9.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="Polly" Version="8.2.0" />
     <!-- Plugins -->
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.0" />

--- a/dotnet/samples/KernelSyntaxExamples/Example08_RetryHandler.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example08_RetryHandler.cs
@@ -29,7 +29,7 @@ public static class Example08_RetryHandler
 
         var logger = kernel.LoggerFactory.CreateLogger(typeof(Example08_RetryHandler));
 
-        const string Question = "How popular is the Polly library?";
+        const string Question = "How do I add a standard resilience handler in IHttpClientBuilder??";
         logger.LogInformation("Question: {Question}", Question);
 
         // The call to OpenAI will fail and be retried a few times before eventually failing.

--- a/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
+++ b/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
@@ -36,7 +36,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Polly" />
     <PackageReference Include="SharpToken" />
     <PackageReference Include="Microsoft.ML.Tokenizers" />
     <PackageReference Include="Microsoft.DeepDev.TokenizerLib" />


### PR DESCRIPTION
### Motivation and Context

Removing Polly as it's no longer used and will nevertheless need to be updated by dependabot e.g. https://github.com/microsoft/semantic-kernel/pull/4614.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
