### PR TITLE
.Net: CancelKernelEventArgs is marked with SKEXP0003 Experimental Attribute instead of SKEXP0004

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Events/CancelKernelEventArgs.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Events/CancelKernelEventArgs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// Provides an <see cref="EventArgs"/> for cancelable operations related
 /// to <see cref="Kernel"/>-based operations.
 /// </summary>
-[Experimental("SKEXP0003")]
+[Experimental("SKEXP0004")]
 public abstract class CancelKernelEventArgs : KernelEventArgs
 {
     /// <summary>


### PR DESCRIPTION
### Motivation and Context
Closes #4650

### Description

Replace [Experimental("SKEXP0003")] by [Experimental("SKEXP0004")] above CancelKernelEventArgs type, to follow [documentation](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/docs/EXPERIMENTS.md)

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
