### PR TITLE
Python: add missing ai_model_id in ollama request

### DIFF
--- a/python/semantic_kernel/connectors/ai/ai_service_client_base.py
+++ b/python/semantic_kernel/connectors/ai/ai_service_client_base.py
@@ -19,7 +19,7 @@ class AIServiceClientBase(SKBaseModel, ABC):
 
     Has a ai_model_id, any other fields have to be defined by the subclasses.
 
-    The ai_model_id can refer to a specific model, like 'gpt-35-turbo' for OpenAI,
+    The ai_model_id can refer to a specific model, like 'gpt-35-turbo' for OpenAI or 'llama2' for Ollama,
     or can just be a string that is used to identify the service.
     """
 

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -30,7 +30,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
     Make sure to have the ollama service running either locally or remotely.
 
     Arguments:
-        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library, defaults to llama2
+        ai_model_id {str} -- Ollama model name, defaults to llama2 (the most popular model at https://ollama.ai/library)
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/chat
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -34,6 +34,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/chat
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """
+
     ai_model_id: str = "llama2"
     url: HttpUrl = "http://localhost:11434/api/chat"
     session: Optional[aiohttp.ClientSession] = None

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -56,9 +56,10 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         Returns:
             Union[str, List[str]] -- A string or list of strings representing the response(s) from the LLM.
         """
-        request_settings.ai_model_id = self.ai_model_id
         request_settings.messages = messages
         request_settings.stream = False
+        if request_settings.ai_model_id is None:
+            request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:
                 response.raise_for_status()
@@ -68,7 +69,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
     async def complete_chat_stream_async(
         self,
         messages: List[Dict[str, str]],
-        settings: OllamaChatRequestSettings,
+        request_settings: OllamaChatRequestSettings,
         **kwargs,
     ):
         """
@@ -82,10 +83,12 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         Yields:
             str -- Completion result.
         """
-        settings.messages = messages
-        settings.stream = True
+        request_settings.messages = messages
+        request_settings.stream = True
+        if request_settings.ai_model_id is None:
+            request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
-            async with session.post(str(self.url), json=settings.prepare_settings_dict()) as response:
+            async with session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:
                 response.raise_for_status()
                 async for line in response.content:
                     body = json.loads(line)

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -59,7 +59,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         """
         request_settings.messages = messages
         request_settings.stream = False
-        if request_settings.ai_model_id is None:
+        if request_settings.ai_model_id == '':
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -59,7 +59,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         """
         request_settings.messages = messages
         request_settings.stream = False
-        if request_settings.ai_model_id == '':
+        if not request_settings.ai_model_id:
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:
@@ -86,7 +86,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         """
         request_settings.messages = messages
         request_settings.stream = True
-        if request_settings.ai_model_id is None:
+        if not request_settings.ai_model_id:
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(str(self.url), json=request_settings.prepare_settings_dict()) as response:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -30,11 +30,11 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
     Make sure to have the ollama service running either locally or remotely.
 
     Arguments:
-        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
+        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library, defaults to llama2
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/chat
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """
-
+    ai_model_id: str = "llama2"
     url: HttpUrl = "http://localhost:11434/api/chat"
     session: Optional[aiohttp.ClientSession] = None
 
@@ -56,6 +56,7 @@ class OllamaChatCompletion(TextCompletionClientBase, ChatCompletionClientBase, A
         Returns:
             Union[str, List[str]] -- A string or list of strings representing the response(s) from the LLM.
         """
+        request_settings.ai_model_id = self.ai_model_id
         request_settings.messages = messages
         request_settings.stream = False
         async with AsyncSession(self.session) as session:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -30,6 +30,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/generate
     """
+
     ai_model_id: str = "llama2"
     url: HttpUrl = "http://localhost:11434/api/generate"
     session: Optional[aiohttp.ClientSession] = None
@@ -53,7 +54,9 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = False
+<<<<<<< HEAD
         if request_settings.ai_model_id == '':
+        if not request_settings.ai_model_id :
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
@@ -79,7 +82,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = True
-        if request_settings.ai_model_id == '':
+        if not request_settings.ai_model_id:
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -54,8 +54,6 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = False
-<<<<<<< HEAD
-        if request_settings.ai_model_id == '':
         if not request_settings.ai_model_id :
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -53,7 +53,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = False
-        if request_settings.ai_model_id is None:
+        if request_settings.ai_model_id == '':
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
@@ -79,7 +79,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = True
-        if request_settings.ai_model_id is None:
+        if request_settings.ai_model_id == '':
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -30,7 +30,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/generate
     """
-
+    ai_model_id: str = "llama2"
     url: HttpUrl = "http://localhost:11434/api/generate"
     session: Optional[aiohttp.ClientSession] = None
 
@@ -53,6 +53,8 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = False
+        if request_settings.ai_model_id is None:
+            request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
                 response.raise_for_status()
@@ -77,6 +79,8 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = True
+        if request_settings.ai_model_id is None:
+            request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:
                 response.raise_for_status()

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -27,7 +27,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
     Make sure to have the ollama service running either locally or remotely.
 
     Arguments:
-        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
+        ai_model_id {str} -- Ollama model name, defaults to llama2 (the most popular model at https://ollama.ai/library)
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/generate
     """
 
@@ -54,7 +54,7 @@ class OllamaTextCompletion(TextCompletionClientBase, AIServiceClientBase):
         """
         request_settings.prompt = prompt
         request_settings.stream = False
-        if not request_settings.ai_model_id :
+        if not request_settings.ai_model_id:
             request_settings.ai_model_id = self.ai_model_id
         async with AsyncSession(self.session) as session:
             async with session.post(self.url, json=request_settings.prepare_settings_dict()) as response:

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -22,7 +22,7 @@ class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
     Make sure to have the ollama service running either locally or remotely.
 
     Arguments:
-        ai_model_id {str} -- Ollama model name, see https://ollama.ai/library
+        ai_model_id {str} -- defaults to llama2 (the most popular model at https://ollama.ai/library)
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/embeddings
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -26,7 +26,7 @@ class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/embeddings
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """
-
+    ai_model_id: str = "llama2"
     url: HttpUrl = "http://localhost:11434/api/embeddings"
     session: Optional[aiohttp.ClientSession] = None
 

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -26,6 +26,7 @@ class OllamaTextEmbedding(EmbeddingGeneratorBase, AIServiceClientBase):
         url {Optional[Union[str, HttpUrl]]} -- URL of the Ollama server, defaults to http://localhost:11434/api/embeddings
         session {Optional[aiohttp.ClientSession]} -- Optional client session to use for requests.
     """
+
     ai_model_id: str = "llama2"
     url: HttpUrl = "http://localhost:11434/api/embeddings"
     session: Optional[aiohttp.ClientSession] = None


### PR DESCRIPTION
### Motivation and Context
I installed `semantic-kernel==0.4.5.dev0` and `ollama 0.1.20e`. and want to test sk with ollama. 
and got error when i write a sample code.
```
Error description: '400, message='Bad Request', url=URL('http://192.168.11.2:11434/api/chat')'
```
I dived in to the call stack and found it's caused by missing ai_model_id, so I make some little changes and it works well.
here is current version with bug, we can see the model id is empty. 
<img width="1471" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/15059493/f2e564a4-d5b9-4123-897c-0bbe07ab2a30">
after fix, it works well
<img width="2032" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/15059493/8b2171f4-4337-4d96-8dfc-57ec7f05f24e">

it is related to #4527 .

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
