### PR TITLE
Python: Sets a valid default content filter code to ResponsibleAIPolicyViolation

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/exceptions/content_filter_ai_exception.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/exceptions/content_filter_ai_exception.py
@@ -75,7 +75,9 @@ class ContentFilterAIException(AIException):
         self._param = inner_exception.param
 
         inner_error = inner_exception.body.get("innererror", {})
-        self._content_filter_code = ContentFilterCodes(inner_error.get("code", ""))
+        self._content_filter_code = ContentFilterCodes(
+            inner_error.get("code", ContentFilterCodes.RESPONSIBLE_AI_POLICY_VIOLATION.value)
+        )
         self._content_filter_result = dict(
             [
                 key,


### PR DESCRIPTION
### Motivation and Context

When the RAI response doesn't contain a `code` the class `ContentFilterAIException` would fail to initialize because it was setting `""` as content_filter_code. This sets `"ResponsibleAIPolicyViolation"` instead in that case.

Fixes #4709 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
