### PR TITLE
.Net: Pass user field in SK C#

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -714,7 +714,7 @@ internal abstract class ClientCore
             ChoicesPerPrompt = executionSettings.ResultsPerPrompt,
             GenerationSampleCount = executionSettings.ResultsPerPrompt,
             LogProbabilityCount = null,
-            User = null,
+            User = executionSettings.User,
             DeploymentName = deploymentOrModelName
         };
 
@@ -758,6 +758,7 @@ internal abstract class ClientCore
             ChoiceCount = executionSettings.ResultsPerPrompt,
             DeploymentName = deploymentOrModelName,
             Seed = executionSettings.Seed,
+            User = executionSettings.User
         };
 
         switch (executionSettings.ResponseFormat)

--- a/dotnet/src/Connectors/Connectors.OpenAI/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/OpenAIPromptExecutionSettings.cs
@@ -140,6 +140,11 @@ public sealed class OpenAIPromptExecutionSettings : PromptExecutionSettings
     public ToolCallBehavior? ToolCallBehavior { get; set; }
 
     /// <summary>
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse
+    /// </summary>
+    public string? User { get; set; }
+
+    /// <summary>
     /// Default value for chat system property.
     /// </summary>
     internal static string DefaultChatSystemPrompt { get; } = "Assistant is a large language model.";


### PR DESCRIPTION
### Motivation and Context

**Expected behavior**
Gen-AI app developers should be able to populate the user field per request.
This is important to support multi-user applications e.g. a Copilot or Bot that is hosted as a service and used by multiple users that log-in and interact with it. SK [Chat-Copilot](https://github.com/microsoft/chat-copilot) is a good example for that.

**Screenshots**
https://github.com/microsoft/semantic-kernel/blob/f959256229c7d0d821d1df5c8b112ced10ddd5ac/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs#L717
![image](https://github.com/microsoft/semantic-kernel/assets/30771358/a5f5b7d8-d38b-497f-86e6-af346f547aa8)

https://github.com/microsoft/semantic-kernel/blob/f959256229c7d0d821d1df5c8b112ced10ddd5ac/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs#L751
![image](https://github.com/microsoft/semantic-kernel/assets/30771358/7347a775-0b11-4409-9aeb-ad6d46e1ece0)