### PR TITLE
.Net Gemini refactor chat system messages handling

### DIFF
--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatGenerationTests.cs
@@ -241,6 +241,22 @@ public sealed class GeminiClientChatGenerationTests : IDisposable
     }
 
     [Fact]
+    public async Task ShouldThrowKernelExceptionIfChatHistoryContainsOnlyManySystemMessagesAsync()
+    {
+        // Arrange
+        string modelId = "fake-model";
+        string apiKey = "fake-api-key";
+        var client = this.CreateChatCompletionClient(modelId, apiKey);
+        var chatHistory = new ChatHistory("System message");
+        chatHistory.AddSystemMessage("System message 2");
+        chatHistory.AddSystemMessage("System message 3");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<KernelException>(
+            () => client.GenerateChatMessageAsync(chatHistory));
+    }
+
+    [Fact]
     public async Task ShouldThrowNotSupportedIfChatHistoryHaveIncorrectOrderAsync()
     {
         // Arrange
@@ -256,6 +272,33 @@ public sealed class GeminiClientChatGenerationTests : IDisposable
         // Act & Assert
         await Assert.ThrowsAsync<NotSupportedException>(
             () => client.GenerateChatMessageAsync(chatHistory));
+    }
+
+    [Fact]
+    public async Task ShouldPassMergedSystemMessagesToRequestAsync()
+    {
+        // Arrange
+        string modelId = "fake-model";
+        string apiKey = "fake-api-key";
+        var client = this.CreateChatCompletionClient(modelId, apiKey);
+        string[] systemMessages = ["System message", "System message 2", "System message 3"];
+        var chatHistory = new ChatHistory("System message");
+        chatHistory.AddSystemMessage("System message 2");
+        chatHistory.AddSystemMessage("System message 3");
+        chatHistory.AddUserMessage("Hello");
+
+        // Act
+        await client.GenerateChatMessageAsync(chatHistory);
+
+        // Assert
+        GeminiRequest? request = JsonSerializer.Deserialize<GeminiRequest>(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(request);
+        var systemMessage = request.Contents[0].Parts[0].Text;
+        var messageRole = request.Contents[0].Role;
+        Assert.Equal(AuthorRole.User, messageRole);
+        Assert.Contains(systemMessages[0], systemMessage, StringComparison.Ordinal);
+        Assert.Contains(systemMessages[1], systemMessage, StringComparison.Ordinal);
+        Assert.Contains(systemMessages[2], systemMessage, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatStreamingTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatStreamingTests.cs
@@ -241,6 +241,33 @@ public sealed class GeminiClientChatStreamingTests : IDisposable
         Assert.Equal(executionSettings.TopP, geminiRequest.Configuration!.TopP);
     }
 
+    [Fact]
+    public async Task ShouldPassMergedSystemMessagesToRequestAsync()
+    {
+        // Arrange
+        string modelId = "fake-model";
+        string apiKey = "fake-api-key";
+        var client = this.CreateChatCompletionClient(modelId, apiKey);
+        string[] systemMessages = ["System message", "System message 2", "System message 3"];
+        var chatHistory = new ChatHistory("System message");
+        chatHistory.AddSystemMessage("System message 2");
+        chatHistory.AddSystemMessage("System message 3");
+        chatHistory.AddUserMessage("Hello");
+
+        // Act
+        await client.StreamGenerateChatMessageAsync(chatHistory).ToListAsync();
+
+        // Assert
+        GeminiRequest? request = JsonSerializer.Deserialize<GeminiRequest>(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(request);
+        var systemMessage = request.Contents[0].Parts[0].Text;
+        var messageRole = request.Contents[0].Role;
+        Assert.Equal(AuthorRole.User, messageRole);
+        Assert.Contains(systemMessages[0], systemMessage, StringComparison.Ordinal);
+        Assert.Contains(systemMessages[1], systemMessage, StringComparison.Ordinal);
+        Assert.Contains(systemMessages[2], systemMessage, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-15)]

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatStreamingTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatStreamingTests.cs
@@ -242,16 +242,14 @@ public sealed class GeminiClientChatStreamingTests : IDisposable
     }
 
     [Fact]
-    public async Task ShouldPassMergedSystemMessagesToRequestAsync()
+    public async Task ShouldPassConvertedSystemMessageToUserMessageToRequestAsync()
     {
         // Arrange
         string modelId = "fake-model";
         string apiKey = "fake-api-key";
         var client = this.CreateChatCompletionClient(modelId, apiKey);
-        string[] systemMessages = ["System message", "System message 2", "System message 3"];
-        var chatHistory = new ChatHistory("System message");
-        chatHistory.AddSystemMessage("System message 2");
-        chatHistory.AddSystemMessage("System message 3");
+        string message = "System message";
+        var chatHistory = new ChatHistory(message);
         chatHistory.AddUserMessage("Hello");
 
         // Act
@@ -263,9 +261,7 @@ public sealed class GeminiClientChatStreamingTests : IDisposable
         var systemMessage = request.Contents[0].Parts[0].Text;
         var messageRole = request.Contents[0].Role;
         Assert.Equal(AuthorRole.User, messageRole);
-        Assert.Contains(systemMessages[0], systemMessage, StringComparison.Ordinal);
-        Assert.Contains(systemMessages[1], systemMessage, StringComparison.Ordinal);
-        Assert.Contains(systemMessages[2], systemMessage, StringComparison.Ordinal);
+        Assert.Equal(message, systemMessage);
     }
 
     [Theory]

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
@@ -105,13 +105,13 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
                 throw new KernelException("Chat history can't contain only system messages.");
             }
 
-            chatHistory = PrepareChatHistoryWithSystemMessages(chatHistory, systemMessages);
+            MergeSystemMessagesToOneUserMessageInChatHistory(chatHistory, systemMessages);
         }
 
         ValidateChatHistoryMessagesOrder(chatHistory);
     }
 
-    private static ChatHistory PrepareChatHistoryWithSystemMessages(ChatHistory chatHistory, List<ChatMessageContent> systemMessages)
+    private static void MergeSystemMessagesToOneUserMessageInChatHistory(ChatHistory chatHistory, List<ChatMessageContent> systemMessages)
     {
         // TODO: This solution is needed due to the fact that Gemini API doesn't support system messages. Maybe in the future we will be able to remove it.
         var systemMessageBuilder = new StringBuilder();
@@ -134,8 +134,6 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
             chatHistory.Insert(0, new ChatMessageContent(AuthorRole.User, systemMessageBuilder.ToString()));
             chatHistory.Insert(1, new ChatMessageContent(AuthorRole.Assistant, "OK"));
         }
-
-        return chatHistory;
     }
 
     private static void ValidateChatHistoryMessagesOrder(ChatHistory chatHistory)

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
@@ -120,16 +120,18 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
             chatHistory.Remove(message);
             if (!string.IsNullOrWhiteSpace(message.Content))
             {
+                if (systemMessageBuilder.Length > 0)
+                {
+                    systemMessageBuilder.Append(separator);
+                }
+
                 systemMessageBuilder.Append(message.Content);
-                systemMessageBuilder.Append(separator);
             }
         }
 
         if (systemMessageBuilder.Length > 0)
         {
-            string content = systemMessageBuilder.ToString();
-            content = content.Remove(content.LastIndexOf(separator, StringComparison.Ordinal));
-            chatHistory.Insert(0, new ChatMessageContent(AuthorRole.User, content));
+            chatHistory.Insert(0, new ChatMessageContent(AuthorRole.User, systemMessageBuilder.ToString()));
             chatHistory.Insert(1, new ChatMessageContent(AuthorRole.Assistant, "OK"));
         }
 

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
@@ -96,6 +96,8 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
     {
         Verify.NotNullOrEmpty(chatHistory);
 
+        chatHistory = new ChatHistory(chatHistory);
+
         if (chatHistory.Where(message => message.Role == AuthorRole.System).ToList() is { Count: > 0 } systemMessages)
         {
             if (chatHistory.Count == systemMessages.Count)
@@ -112,9 +114,7 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
     private static ChatHistory PrepareChatHistoryWithSystemMessages(ChatHistory chatHistory, List<ChatMessageContent> systemMessages)
     {
         // TODO: This solution is needed due to the fact that Gemini API doesn't support system messages. Maybe in the future we will be able to remove it.
-        chatHistory = new ChatHistory(chatHistory);
         var systemMessageBuilder = new StringBuilder();
-        string separator = "\n-----\n";
         foreach (var message in systemMessages)
         {
             chatHistory.Remove(message);
@@ -122,7 +122,7 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
             {
                 if (systemMessageBuilder.Length > 0)
                 {
-                    systemMessageBuilder.Append(separator);
+                    systemMessageBuilder.Append("\n-----\n");
                 }
 
                 systemMessageBuilder.Append(message.Content);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
@@ -109,7 +109,7 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
         ValidateChatHistoryMessagesOrder(chatHistory);
     }
 
-    private static ChatHistory PrepareChatHistoryWithSystemMessages(ChatHistory chatHistory, IEnumerable<ChatMessageContent> systemMessages)
+    private static ChatHistory PrepareChatHistoryWithSystemMessages(ChatHistory chatHistory, List<ChatMessageContent> systemMessages)
     {
         // TODO: This solution is needed due to the fact that Gemini API doesn't support system messages. Maybe in the future we will be able to remove it.
         chatHistory = new ChatHistory(chatHistory);


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

~~Gemini chat client could handle only one system message. Exception was thrown if there were more than one system message.~~
Lacks of some tests, and ref to chathistory param.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

~~Fixes handling multiple system messages. Added revelant unit tests.~~
Refactoring and new unit tests.
State of connector progress https://github.com/microsoft/semantic-kernel/issues/4680

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
