### PR TITLE
.Net: Fix bug to allow activation of JSON mode through execution_settings

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -788,18 +788,15 @@ internal abstract class ClientCore
                 if (formatElement.ValueKind == JsonValueKind.String)
                 {
                     string formatString = formatElement.GetString() ?? "";
-                    if (formatString != null)
+                    switch (formatString)
                     {
-                        switch (formatString)
-                        {
-                            case "json_object":
-                                options.ResponseFormat = ChatCompletionsResponseFormat.JsonObject;
-                                break;
+                        case "json_object":
+                            options.ResponseFormat = ChatCompletionsResponseFormat.JsonObject;
+                            break;
 
-                            case "text":
-                                options.ResponseFormat = ChatCompletionsResponseFormat.Text;
-                                break;
-                        }
+                        case "text":
+                            options.ResponseFormat = ChatCompletionsResponseFormat.Text;
+                            break;
                     }
                 }
                 break;

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -783,7 +783,7 @@ internal abstract class ClientCore
                 break;
 
             case JsonElement formatElement:
-                // This is a workaround for the issue caused by ResponseFormat being defined as object?
+                // This is a workaround for a type mismatch when deserializing a JSON into an object? type property.
                 // Handling only string formatElement.
                 if (formatElement.ValueKind == JsonValueKind.String)
                 {

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -783,7 +783,8 @@ internal abstract class ClientCore
                 break;
 
             case JsonElement formatElement:
-                // If the response format is a JsonElement, extract the value as a string and process it accordingly.
+                // This is a workaround for the issue caused by ResponseFormat being defined as object?
+                // Handling only string formatElement.
                 if (formatElement.ValueKind == JsonValueKind.String)
                 {
                     string formatString = formatElement.GetString();

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -787,16 +787,19 @@ internal abstract class ClientCore
                 // Handling only string formatElement.
                 if (formatElement.ValueKind == JsonValueKind.String)
                 {
-                    string formatString = formatElement.GetString();
-                    switch (formatString)
+                    string? formatString = formatElement.GetString();
+                    if (formatString != null)
                     {
-                        case "json_object":
-                            options.ResponseFormat = ChatCompletionsResponseFormat.JsonObject;
-                            break;
+                        switch (formatString)
+                        {
+                            case "json_object":
+                                options.ResponseFormat = ChatCompletionsResponseFormat.JsonObject;
+                                break;
 
-                        case "text":
-                            options.ResponseFormat = ChatCompletionsResponseFormat.Text;
-                            break;
+                            case "text":
+                                options.ResponseFormat = ChatCompletionsResponseFormat.Text;
+                                break;
+                        }
                     }
                 }
                 break;

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -787,7 +787,7 @@ internal abstract class ClientCore
                 // Handling only string formatElement.
                 if (formatElement.ValueKind == JsonValueKind.String)
                 {
-                    string? formatString = formatElement.GetString();
+                    string formatString = formatElement.GetString() ?? "";
                     if (formatString != null)
                     {
                         switch (formatString)

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -781,6 +781,24 @@ internal abstract class ClientCore
                         break;
                 }
                 break;
+
+            case JsonElement formatElement:
+                // If the response format is a JsonElement, extract the value as a string and process it accordingly.
+                if (formatElement.ValueKind == JsonValueKind.String)
+                {
+                    string formatString = formatElement.GetString();
+                    switch (formatString)
+                    {
+                        case "json_object":
+                            options.ResponseFormat = ChatCompletionsResponseFormat.JsonObject;
+                            break;
+
+                        case "text":
+                            options.ResponseFormat = ChatCompletionsResponseFormat.Text;
+                            break;
+                    }
+                }
+                break;
         }
 
         executionSettings.ToolCallBehavior?.ConfigureOptions(kernel, options);


### PR DESCRIPTION
### Motivation and Context
Closes [#4719](https://github.com/microsoft/semantic-kernel/issues/4719)

**Issue**

- When setting the `execution_settings` from YAML or `config.txt`, the `response_format` field is not recognized, and thus the JSON mode cannot be activated.

**Root Cause**
- The issue arises because the `ResponseFormat` property, which is of type `object?`, stores values as `JsonElement` types when read from the aforementioned files.
- The `CreateChatCompletionOptions` method does not account for this and performs type checking directly against types such as `string`, leading to improper conditional branching.
- As a result, the `ChatCompletionsOptions`'s `ResponseFormat` value remains unassigned, preventing the activation of JSON mode.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR addresses the problem by adjusting the type checks to properly recognize the `JsonElement` objects.
 This ensures that when `ResponseFormat` is set, the request sent to OpenAI is correct, and JSON mode can be utilized.

Please let me know if any further changes or discussions are needed regarding this pull request.
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
