### PR TITLE
Python: address sync invoke hanging issue when running a kernel function

### DIFF
--- a/python/notebooks/00-getting-started.ipynb
+++ b/python/notebooks/00-getting-started.ipynb
@@ -116,7 +116,7 @@
     "plugin = kernel.import_semantic_plugin_from_directory(\"../../samples/plugins\", \"FunPlugin\")\n",
     "joke_function = plugin[\"Joke\"]\n",
     "\n",
-    "print(joke_function(\"time travel to dinosaur age\"))"
+    "print(await joke_function(\"time travel to dinosaur age\"))"
    ]
   }
  ],
@@ -136,7 +136,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/08-native-function-inline.ipynb
+++ b/python/notebooks/08-native-function-inline.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "# Run the number generator\n",
     "generate_number_three_or_higher = generate_number_plugin[\"GenerateNumberThreeOrHigher\"]\n",
-    "number_result = generate_number_three_or_higher(6)\n",
+    "number_result = await generate_number_three_or_higher(6)\n",
     "print(number_result)"
    ]
   },
@@ -385,7 +385,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "context_variables[\"paragraph_count\"] = generate_number.invoke(variables=context_variables).result"
+    "paragraph_count = await generate_number.invoke(variables=context_variables)\n",
+    "context_variables[\"paragraph_count\"] = paragraph_count.result"
    ]
   },
   {
@@ -521,7 +522,8 @@
    "outputs": [],
    "source": [
     "context_variables = sk.ContextVariables(variables={\"min\": \"1\", \"max\": \"5\", \"language\": \"Spanish\"})\n",
-    "context_variables[\"paragraph_count\"] = generate_number.invoke(variables=context_variables).result"
+    "paragraph_count = await generate_number.invoke(variables=context_variables)\n",
+    "context_variables[\"paragraph_count\"] = paragraph_count.result"
    ]
   },
   {
@@ -583,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/samples/kernel-syntax-examples/azure_chat_sync_invoke_with_loop.py
+++ b/python/samples/kernel-syntax-examples/azure_chat_sync_invoke_with_loop.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+
+import semantic_kernel as sk
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.semantic_functions.chat_prompt_template import ChatPromptTemplate
+from semantic_kernel.semantic_functions.prompt_template_config import PromptTemplateConfig
+from semantic_kernel.semantic_functions.semantic_function_config import SemanticFunctionConfig
+from semantic_kernel.utils.settings import azure_openai_settings_from_dot_env_as_dict
+
+
+# This example shows how to use the AzureChatCompletion semantic function to invoke the
+# Azure OpenAI chat API synchronously. Underneath the sync invoke is an async invoke, so
+# this is an example/test that the underlying functionality is working properly.
+def azure_open_ai_sync_invoke():
+    kernel = sk.Kernel()
+    aoai_settings_dict = azure_openai_settings_from_dot_env_as_dict(include_deployment=True, include_api_version=True)
+    kernel.add_chat_service("chat_completion", AzureChatCompletion(**aoai_settings_dict))
+    prompt_config = PromptTemplateConfig()
+    prompt_template = ChatPromptTemplate("{{$user_input}}", kernel.prompt_template_engine, prompt_config)
+
+    function_config = SemanticFunctionConfig(prompt_config, prompt_template)
+    chat_function = kernel.register_semantic_function("testfn", "testfn", function_config)
+
+    texts = ["Tell me about the stars", "Tell me about the ocean.", "Tell me about the forest."]
+
+    for i in range(3):
+        text = f"Explain the following in one sentence: {texts[i]}."
+        context = kernel.create_new_context()
+        context["user_input"] = text
+        print(f"User input: {text}")
+        result = chat_function.invoke(context=context)
+        print(result.result)
+
+
+if __name__ == "__main__":
+    azure_open_ai_sync_invoke()


### PR DESCRIPTION
### Motivation and Context

Addresses issue: #4762 

SK Python is mainly async, but we do have a sync invoke on the kernel function. The underlying code is managed by asyncio, and there appears to be an issue managing the event loop when making multiple calls to a kernel function's invoke.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The PR is attempting to better handling the sync function invoke by starting a new event loop if one doesn't exist. If an event loop does exist (by means of running in a Jupyter notebook which does have its own event loop), then a task is returned. The caller should await this to get the result. Only a few notebooks use the sync invoke function method, and those instances were updated and tested to be working.

A new integration test and a kernel syntax example were added to test this sync invoke functionality, to make sure it's working properly. 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
