### PR TITLE
Python: Remove sync function invoke. Update other code to use async invoke.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -52,7 +52,8 @@ does not conflict with the First or Second Law.
 Give me the TLDR in exactly 5 words.""")
 
 # Run your prompt
-print(prompt()) # => Robots must not harm humans.
+# Note: functions are run asynchronously
+print(await prompt()) # => Robots must not harm humans.
 ```
 
 # **Semantic functions** are Prompts with input parameters

--- a/python/README.md
+++ b/python/README.md
@@ -25,6 +25,7 @@ AZURE_OPENAI_API_KEY=""
 # Running a prompt
 
 ```python
+import asyncio
 import semantic_kernel as sk
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion, AzureChatCompletion
 
@@ -53,7 +54,11 @@ Give me the TLDR in exactly 5 words.""")
 
 # Run your prompt
 # Note: functions are run asynchronously
-print(await prompt()) # => Robots must not harm humans.
+async def main():
+    print(await prompt()) # => Robots must not harm humans.
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 # **Semantic functions** are Prompts with input parameters
@@ -63,19 +68,19 @@ print(await prompt()) # => Robots must not harm humans.
 summarize = kernel.create_semantic_function("{{$input}}\n\nOne line TLDR with the fewest words.")
 
 # Summarize the laws of thermodynamics
-print(summarize("""
+print(await summarize("""
 1st Law of Thermodynamics - Energy cannot be created or destroyed.
 2nd Law of Thermodynamics - For a spontaneous process, the entropy of the universe increases.
 3rd Law of Thermodynamics - A perfect crystal at zero Kelvin has zero entropy."""))
 
 # Summarize the laws of motion
-print(summarize("""
+print(await summarize("""
 1. An object at rest remains at rest, and an object in motion remains in motion at constant speed and in a straight line unless acted on by an unbalanced force.
 2. The acceleration of an object depends on the mass of the object and the amount of force applied.
 3. Whenever one object exerts a force on another object, the second object exerts an equal and opposite on the first."""))
 
 # Summarize the law of universal gravitation
-print(summarize("""
+print(await summarize("""
 Every point mass attracts every single other point mass by a force acting along the line intersecting both points.
 The force is proportional to the product of the two masses and inversely proportional to the square of the distance between them."""))
 

--- a/python/notebooks/00-getting-started.ipynb
+++ b/python/notebooks/00-getting-started.ipynb
@@ -116,7 +116,7 @@
     "plugin = kernel.import_semantic_plugin_from_directory(\"../../samples/plugins\", \"FunPlugin\")\n",
     "joke_function = plugin[\"Joke\"]\n",
     "\n",
-    "print(joke_function(\"time travel to dinosaur age\"))"
+    "print(await joke_function(\"time travel to dinosaur age\"))"
    ]
   }
  ],

--- a/python/notebooks/02-running-prompts-from-file.ipynb
+++ b/python/notebooks/02-running-prompts-from-file.ipynb
@@ -162,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await jokeFunction.invoke_async(\"time travel to dinosaur age\")\n",
+    "result = await jokeFunction.invoke(\"travel to dinosaur age\")\n",
     "print(result)"
    ]
   },
@@ -192,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/03-semantic-function-inline.ipynb
+++ b/python/notebooks/03-semantic-function-inline.ipynb
@@ -158,8 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# If needed, async is available too: summary = await summarize.invoke_async(input_text)\n",
-    "summary = summarize(input_text)\n",
+    "summary = await summarize(input_text)\n",
     "\n",
     "print(summary)"
    ]
@@ -249,7 +248,7 @@
     "\n",
     "tldr_function = kernel.create_semantic_function(prompt_template=sk_prompt, max_tokens=200, temperature=0, top_p=0.5)\n",
     "\n",
-    "summary = tldr_function(text)\n",
+    "summary = await tldr_function(text)\n",
     "\n",
     "print(f\"Output: {summary}\")  # Output: Robots must not harm humans."
    ]
@@ -271,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/04-context-variables-chat.ipynb
+++ b/python/notebooks/04-context-variables-chat.ipynb
@@ -148,7 +148,7 @@
    "outputs": [],
    "source": [
     "context[\"user_input\"] = \"Hi, I'm looking for book suggestions\"\n",
-    "bot_answer = await chat_function.invoke_async(context=context)\n",
+    "bot_answer = await chat_function.invoke(context=context)\n",
     "print(bot_answer)"
    ]
   },
@@ -194,7 +194,7 @@
     "    context[\"user_input\"] = input_text\n",
     "\n",
     "    # Process the user message and get an answer\n",
-    "    answer = await chat_function.invoke_async(context=context)\n",
+    "    answer = await chat_function.invoke(context=context)\n",
     "\n",
     "    # Show the response\n",
     "    print(f\"ChatBot: {answer}\")\n",
@@ -279,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/05-using-the-planner.ipynb
+++ b/python/notebooks/05-using-the-planner.ipynb
@@ -359,7 +359,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await sequential_plan.invoke_async()"
+    "result = await sequential_plan.invoke()"
    ]
   },
   {
@@ -455,7 +455,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await plan.invoke_async()"
+    "result = await plan.invoke()"
    ]
   },
   {
@@ -616,7 +616,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await plan.invoke_async()"
+    "result = await plan.invoke()"
    ]
   },
   {
@@ -669,7 +669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/08-native-function-inline.ipynb
+++ b/python/notebooks/08-native-function-inline.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "# Run the number generator\n",
     "generate_number_three_or_higher = generate_number_plugin[\"GenerateNumberThreeOrHigher\"]\n",
-    "number_result = generate_number_three_or_higher(6)\n",
+    "number_result = await generate_number_three_or_higher(6)\n",
     "print(number_result)"
    ]
   },
@@ -192,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "story = await corgi_story.invoke_async(input=number_result.result)"
+    "story = await corgi_story.invoke(input=number_result.result)"
    ]
   },
   {
@@ -385,7 +385,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "context_variables[\"paragraph_count\"] = generate_number.invoke(variables=context_variables).result"
+    "num = await generate_number.invoke(variables=context_variables)\n",
+    "context_variables[\"paragraph_count\"] = num.result"
    ]
   },
   {
@@ -396,7 +397,7 @@
    "outputs": [],
    "source": [
     "# Pass the output to the semantic story function\n",
-    "story = await corgi_story.invoke_async(variables=context_variables)"
+    "story = await corgi_story.invoke(variables=context_variables)"
    ]
   },
   {
@@ -521,7 +522,8 @@
    "outputs": [],
    "source": [
     "context_variables = sk.ContextVariables(variables={\"min\": \"1\", \"max\": \"5\", \"language\": \"Spanish\"})\n",
-    "context_variables[\"paragraph_count\"] = generate_number.invoke(variables=context_variables).result"
+    "num = await generate_number.invoke(variables=context_variables)\n",
+    "context_variables[\"paragraph_count\"] = str(num.result)"
    ]
   },
   {
@@ -532,7 +534,7 @@
    "outputs": [],
    "source": [
     "# Pass the output to the semantic story function\n",
-    "story = await corgi_story.invoke_async(variables=context_variables)"
+    "story = await corgi_story.invoke(variables=context_variables)"
    ]
   },
   {

--- a/python/notebooks/09-groundedness-checking.ipynb
+++ b/python/notebooks/09-groundedness-checking.ipynb
@@ -248,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "extraction_result = entity_extraction(summary_text, context=context)\n",
+    "extraction_result = await entity_extraction(summary_text, context=context)\n",
     "\n",
     "print(extraction_result.result)"
    ]
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grounding_result = reference_check(extraction_result.result, context=context)\n",
+    "grounding_result = await reference_check(extraction_result.result, context=context)\n",
     "\n",
     "print(grounding_result.result)"
    ]
@@ -336,7 +336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "excision_result = entity_excision(summary_text, context=context)\n",
+    "excision_result = await entity_excision(summary_text, context=context)\n",
     "\n",
     "print(excision_result.result)"
    ]
@@ -358,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/python/samples/kernel-syntax-examples/action_planner.py
+++ b/python/samples/kernel-syntax-examples/action_planner.py
@@ -33,7 +33,7 @@ async def main():
     plan = await planner.create_plan(goal=ask)
 
     # ask the action planner to execute the identified function.
-    result = await plan.invoke_async()
+    result = await plan.invoke()
     print(result)
     """
     Output:

--- a/python/samples/kernel-syntax-examples/bing_search_plugin.py
+++ b/python/samples/kernel-syntax-examples/bing_search_plugin.py
@@ -27,7 +27,7 @@ async def main():
 
     prompt = "Who is Leonardo DiCaprio's current girlfriend?"
     search = web_plugin["searchAsync"]
-    result = await search.invoke_async(prompt)
+    result = await search.invoke(prompt)
     print(result)
 
     """
@@ -48,7 +48,7 @@ async def main():
     context = kernel.create_new_context()
     context["num_results"] = "10"
     context["offset"] = "0"
-    result = await qna.invoke_async(context=context)
+    result = await qna.invoke(context=context)
     print(result)
 
     """

--- a/python/samples/kernel-syntax-examples/google_search_plugin.py
+++ b/python/samples/kernel-syntax-examples/google_search_plugin.py
@@ -41,7 +41,7 @@ async def main():
     search = web_plugin["searchAsync"]
 
     # By default, only one search result is provided
-    result = await search.invoke_async(prompt)
+    result = await search.invoke(prompt)
     print(result)
 
     """
@@ -70,7 +70,7 @@ async def main():
     context["num_results"] = "10"
     context["offset"] = "0"
 
-    result = await qna.invoke_async(context=context)
+    result = await qna.invoke(context=context)
     print(result)
 
     """

--- a/python/samples/kernel-syntax-examples/openapi_example/openapi_client.py
+++ b/python/samples/kernel-syntax-examples/openapi_example/openapi_client.py
@@ -19,6 +19,6 @@ if __name__ == "__main__":
     )
     result = asyncio.run(
         # Call the function defined in openapi.yaml
-        openapi_plugin["helloWorld"].invoke_async(variables=context_variables)
+        openapi_plugin["helloWorld"].invoke(variables=context_variables)
     )
     print(result)

--- a/python/samples/kernel-syntax-examples/sequential_planner.py
+++ b/python/samples/kernel-syntax-examples/sequential_planner.py
@@ -31,7 +31,7 @@ async def main():
     plan = await planner.create_plan(goal=ask)
 
     # ask the sequential planner to execute the identified function.
-    result = await plan.invoke_async()
+    result = await plan.invoke()
 
     for step in plan._steps:
         print(step.description, ":", step._state.__dict__)

--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
@@ -85,7 +85,7 @@ class HuggingFaceTextCompletion(TextCompletionClientBase, AIServiceClientBase):
 
         Arguments:
             prompt {str} -- The prompt to send to the LLM.
-            settings {HuggingFaceRequestSettings} -- Settings for the request.
+            settings {HuggingFacePromptExecutionSettings} -- Settings for the request.
 
         Returns:
             List[TextContent] -- A list of TextContent objects representing the response(s) from the LLM.

--- a/python/semantic_kernel/connectors/ai/open_ai/utils.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/utils.py
@@ -138,7 +138,7 @@ async def chat_completion_with_function_call(
             current_call_count: the current number of function calls executed.
 
     returns:
-        the context with the result of the chat completion, just like a regular invoke_async/run_async.
+        the context with the result of the chat completion, just like a regular invoke/run_async.
     """
     if log:
         logger.warning("The `log` parameter is deprecated. Please use the `logging` module instead.")
@@ -154,7 +154,7 @@ async def chat_completion_with_function_call(
     settings = chat_function._chat_prompt_template.prompt_config.execution_settings
     if current_call_count >= max_function_calls:
         settings.functions = []
-    context = await chat_function.invoke_async(
+    context = await chat_function.invoke(
         context=context,
         # when the maximum number of function calls is reached, execute the chat function without Functions.
         settings=settings,

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -292,7 +292,7 @@ class Kernel:
                         logger.info(f"{skip_message} {pipeline_step}: {func.plugin_name}.{func.name}.")
                         break
 
-                    context = await func.invoke_async(input=None, context=context, **kwargs)
+                    context = await func.invoke(input=None, context=context, **kwargs)
 
                     if context.error_occurred:
                         logger.error(

--- a/python/semantic_kernel/orchestration/kernel_function.py
+++ b/python/semantic_kernel/orchestration/kernel_function.py
@@ -325,7 +325,7 @@ class KernelFunction(KernelFunctionBase):
             variables {ContextVariables} -- The variables for the function
             context {Optional[KernelContext]} -- The context for the function
             memory {Optional[SemanticTextMemoryBase]} -- The memory for the function
-            settings {Optional[AIRequestSettings]} -- The settings for the function
+            settings {Optional[PromptExecutionSettings]} -- The settings for the function
             log {Optional[Any]} -- A logger to use for logging. (Optional)
 
         Returns:
@@ -361,7 +361,7 @@ class KernelFunction(KernelFunctionBase):
             variables {ContextVariables} -- The variables for the function
             context {Optional[KernelContext]} -- The context for the function
             memory {Optional[SemanticTextMemoryBase]} -- The memory for the function
-            settings {Optional[AIRequestSettings]} -- The settings for the function
+            settings {Optional[PromptExecutionSettings]} -- The settings for the function
             kwargs {Dict[str, Any]} -- Additional keyword arguments
 
         Returns:

--- a/python/semantic_kernel/orchestration/kernel_function.py
+++ b/python/semantic_kernel/orchestration/kernel_function.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import platform
 import sys
-from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
@@ -37,6 +36,7 @@ from semantic_kernel.semantic_functions.semantic_function_config import (
 if TYPE_CHECKING:
     from semantic_kernel.orchestration.kernel_context import KernelContext
 
+# TODO: is this needed anymore after sync code removal?
 if platform.system() == "Windows" and sys.version_info >= (3, 8, 0):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
@@ -307,7 +307,7 @@ class KernelFunction(KernelFunctionBase):
             parameters=self._parameters,
         )
 
-    def __call__(
+    async def __call__(
         self,
         input: Optional[str] = None,
         variables: ContextVariables = None,
@@ -316,9 +316,27 @@ class KernelFunction(KernelFunctionBase):
         settings: Optional[AIRequestSettings] = None,
         log: Optional[Any] = None,
     ) -> "KernelContext":
+        """
+        Override the call operator to allow calling the function directly
+        This operator is run asynchronously.
+
+        Arguments:
+            input {Optional[str]} -- The input to the function
+            variables {ContextVariables} -- The variables for the function
+            context {Optional[KernelContext]} -- The context for the function
+            memory {Optional[SemanticTextMemoryBase]} -- The memory for the function
+            settings {Optional[AIRequestSettings]} -- The settings for the function
+            log {Optional[Any]} -- A logger to use for logging. (Optional)
+
+        Returns:
+            KernelContext -- The context for the function
+
+        Raises:
+            KernelException -- If the function is not semantic
+        """
         if log:
             logger.warning("The `log` parameter is deprecated. Please use the `logging` module instead.")
-        return self.invoke(
+        return await self.invoke(
             input=input,
             variables=variables,
             context=context,
@@ -326,57 +344,7 @@ class KernelFunction(KernelFunctionBase):
             settings=settings,
         )
 
-    def invoke(
-        self,
-        input: Optional[str] = None,
-        variables: ContextVariables = None,
-        context: Optional["KernelContext"] = None,
-        memory: Optional[SemanticTextMemoryBase] = None,
-        settings: Optional[AIRequestSettings] = None,
-        log: Optional[Any] = None,
-    ) -> "KernelContext":
-        from semantic_kernel.orchestration.kernel_context import KernelContext
-
-        if log:
-            logger.warning("The `log` parameter is deprecated. Please use the `logging` module instead.")
-
-        if context is None:
-            context = KernelContext(
-                variables=ContextVariables("") if variables is None else variables,
-                plugin_collection=self._plugin_collection,
-                memory=memory if memory is not None else NullMemory.instance,
-            )
-        else:
-            # If context is passed, we need to merge the variables
-            if variables is not None:
-                context.variables = variables.merge_or_overwrite(new_vars=context.variables, overwrite=False)
-            if memory is not None:
-                context.memory = memory
-
-        if input is not None:
-            context.variables.update(input)
-
-        try:
-            loop = asyncio.get_running_loop() if asyncio.get_event_loop().is_running() else None
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-
-            def run_coroutine():
-                if self.is_semantic:
-                    return self._invoke_semantic(context, settings)
-                else:
-                    return self._invoke_native(context)
-
-            return self.run_async_in_executor(run_coroutine)
-        else:
-            if self.is_semantic:
-                return asyncio.run(self._invoke_semantic(context, settings))
-            else:
-                return asyncio.run(self._invoke_native(context))
-
-    async def invoke_async(
+    async def invoke(
         self,
         input: Optional[str] = None,
         variables: ContextVariables = None,
@@ -385,6 +353,23 @@ class KernelFunction(KernelFunctionBase):
         settings: Optional[AIRequestSettings] = None,
         **kwargs: Dict[str, Any],
     ) -> "KernelContext":
+        """
+        Invoke the function asynchronously
+
+        Arguments:
+            input {Optional[str]} -- The input to the function
+            variables {ContextVariables} -- The variables for the function
+            context {Optional[KernelContext]} -- The context for the function
+            memory {Optional[SemanticTextMemoryBase]} -- The memory for the function
+            settings {Optional[AIRequestSettings]} -- The settings for the function
+            kwargs {Dict[str, Any]} -- Additional keyword arguments
+
+        Returns:
+            KernelContext -- The context for the function
+
+        Raises:
+            KernelException -- If there is a problem invoking the function
+        """
         from semantic_kernel.orchestration.kernel_context import KernelContext
 
         if context is None:
@@ -524,30 +509,3 @@ class KernelFunction(KernelFunctionBase):
 
     def _trace_function_type_Call(self, type: Enum) -> None:
         logger.debug(f"Executing function type {type}: {type.name}")
-
-    """
-    Async code wrapper to allow running async code inside external
-    event loops such as Jupyter notebooks.
-    """
-
-    def run_async_in_executor(self, coroutine_func: Callable[[], Any]) -> Any:
-        """
-        A unified method for async execution for more efficient and safer thread management
-
-        Arguments:
-            coroutine_func {Callable[[], Any]} -- The coroutine to run
-
-        Returns:
-            Any -- The result of the coroutine
-        """
-
-        def run_async_in_thread():
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            result = loop.run_until_complete(coroutine_func())
-            loop.close()
-            return result
-
-        with ThreadPoolExecutor() as executor:
-            future = executor.submit(run_async_in_thread)
-            return future.result()

--- a/python/semantic_kernel/orchestration/kernel_function_base.py
+++ b/python/semantic_kernel/orchestration/kernel_function_base.py
@@ -93,30 +93,7 @@ class KernelFunctionBase(KernelBaseModel):
         pass
 
     @abstractmethod
-    def invoke(
-        self,
-        input: Optional[str] = None,
-        variables: ContextVariables = None,
-        context: Optional["KernelContext"] = None,
-        memory: Optional[SemanticTextMemoryBase] = None,
-        settings: Optional[AIRequestSettings] = None,
-    ) -> "KernelContext":
-        """
-        Invokes the function with an explicit string input
-        Keyword Arguments:
-            input {str} -- The explicit string input (default: {None})
-            variables {ContextVariables} -- The custom input
-            context {KernelContext} -- The context to use
-            memory: {SemanticTextMemoryBase} -- The memory to use
-            settings {AIRequestSettings} -- LLM completion settings
-        Returns:
-            KernelContext -- The updated context, potentially a new one if
-            context switching is implemented.
-        """
-        pass
-
-    @abstractmethod
-    async def invoke_async(
+    async def invoke(
         self,
         input: Optional[str] = None,
         variables: ContextVariables = None,

--- a/python/semantic_kernel/planning/action_planner/action_planner.py
+++ b/python/semantic_kernel/planning/action_planner/action_planner.py
@@ -88,7 +88,7 @@ class ActionPlanner:
 
         self._context.variables.update(goal)
 
-        generated_plan_raw = await self._planner_function.invoke_async(context=self._context)
+        generated_plan_raw = await self._planner_function.invoke(context=self._context)
         generated_plan_raw_str = str(generated_plan_raw)
 
         if not generated_plan_raw or not generated_plan_raw_str:

--- a/python/semantic_kernel/planning/basic_planner.py
+++ b/python/semantic_kernel/planning/basic_planner.py
@@ -192,7 +192,7 @@ class BasicPlanner:
         # Add the goal to the context
         context["goal"] = goal
         context["available_functions"] = available_functions_string
-        generated_plan = await planner.invoke_async(variables=context)
+        generated_plan = await planner.invoke(variables=context)
         return Plan(prompt=prompt, goal=goal, plan=generated_plan)
 
     async def execute_plan(self, plan: Plan, kernel: Kernel) -> str:
@@ -219,10 +219,10 @@ class BasicPlanner:
             if args:
                 for key, value in args.items():
                     context[key] = value
-                output = await kernel_function.invoke_async(variables=context)
+                output = await kernel_function.invoke(variables=context)
 
             else:
-                output = await kernel_function.invoke_async(variables=context)
+                output = await kernel_function.invoke(variables=context)
 
             # Override the input context variable with the output of the function
             context["input"] = output.result

--- a/python/semantic_kernel/planning/plan.py
+++ b/python/semantic_kernel/planning/plan.py
@@ -145,7 +145,7 @@ class Plan(KernelFunctionBase):
         Args:
             input (str, optional): The input to the plan. Defaults to None.
             context (KernelContext, optional): The context to use. Defaults to None.
-            settings (AIRequestSettings, optional): The AI request settings to use. Defaults to None.
+            settings (PromptExecutionSettings, optional): The AI request settings to use. Defaults to None.
             memory (SemanticTextMemoryBase, optional): The memory to use. Defaults to None.
             **kwargs: Additional keyword arguments.
 

--- a/python/semantic_kernel/planning/plan.py
+++ b/python/semantic_kernel/planning/plan.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import asyncio
 import logging
 import re
 import threading
@@ -131,7 +130,7 @@ class Plan(KernelFunctionBase):
         plan.set_function(function)
         return plan
 
-    async def invoke_async(
+    async def invoke(
         self,
         input: Optional[str] = None,
         context: Optional[KernelContext] = None,
@@ -140,6 +139,19 @@ class Plan(KernelFunctionBase):
         **kwargs,
         # TODO: cancellation_token: CancellationToken,
     ) -> KernelContext:
+        """
+        Invoke the plan asynchronously.
+
+        Args:
+            input (str, optional): The input to the plan. Defaults to None.
+            context (KernelContext, optional): The context to use. Defaults to None.
+            settings (AIRequestSettings, optional): The AI request settings to use. Defaults to None.
+            memory (SemanticTextMemoryBase, optional): The memory to use. Defaults to None.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            KernelContext: The updated context.
+        """
         if kwargs.get("logger"):
             logger.warning("The `logger` parameter is deprecated. Please use the `logging` module instead.")
         if input is not None and input != "":
@@ -153,7 +165,7 @@ class Plan(KernelFunctionBase):
             )
 
         if self._function is not None:
-            result = await self._function.invoke_async(context=context, settings=settings)
+            result = await self._function.invoke(context=context, settings=settings)
             if result.error_occurred:
                 logger.error(
                     "Something went wrong in plan step {0}.{1}:'{2}'".format(
@@ -170,56 +182,6 @@ class Plan(KernelFunctionBase):
                 await self.invoke_next_step(function_context)
                 self.update_context_with_outputs(context)
 
-        return context
-
-    def invoke(
-        self,
-        input: Optional[str] = None,
-        context: Optional[KernelContext] = None,
-        settings: Optional[AIRequestSettings] = None,
-        memory: Optional[SemanticTextMemoryBase] = None,
-        **kwargs,
-    ) -> KernelContext:
-        if kwargs.get("logger"):
-            logger.warning("The `logger` parameter is deprecated. Please use the `logging` module instead.")
-        if input is not None and input != "":
-            self._state.update(input)
-
-        if context is None:
-            context = KernelContext(
-                variables=self._state,
-                plugin_collection=ReadOnlyPluginCollection(),
-                memory=memory or NullMemory(),
-            )
-
-        if self._function is not None:
-            result = self._function.invoke(context=context, settings=settings)
-            if result.error_occurred:
-                logger.error(
-                    result.last_exception,
-                    "Something went wrong in plan step {0}.{1}:'{2}'".format(
-                        self.plugin_name, self.name, context.last_error_description
-                    ),
-                )
-                return result
-            context.variables.update(result.result)
-        else:
-            # loop through steps until completion
-            while self.has_next_step:
-                # Check if there is an event loop
-                try:
-                    loop = asyncio.get_running_loop()
-                except RuntimeError:
-                    loop = None
-                function_context = context
-                self.add_variables_to_context(self._state, function_context)
-
-                # Handle "asyncio.run() cannot be called from a running event loop"
-                if loop and loop.is_running():
-                    self._runThread(self.invoke_next_step(function_context))
-                else:
-                    asyncio.run(self.invoke_next_step(function_context))
-                self.update_context_with_outputs(context)
         return context
 
     def set_ai_configuration(
@@ -310,7 +272,7 @@ class Plan(KernelFunctionBase):
                 memory=context.memory,
                 plugin_collection=context.plugins,
             )
-            result = await step.invoke_async(context=func_context)
+            result = await step.invoke(context=func_context)
             result_value = result.result
 
             if result.error_occurred:

--- a/python/semantic_kernel/planning/sequential_planner/sequential_planner.py
+++ b/python/semantic_kernel/planning/sequential_planner/sequential_planner.py
@@ -86,7 +86,7 @@ class SequentialPlanner:
 
         self._context.variables.update(goal)
 
-        plan_result = await self._function_flow_function.invoke_async(context=self._context)
+        plan_result = await self._function_flow_function.invoke(context=self._context)
 
         if plan_result.error_occurred:
             raise PlanningException(

--- a/python/semantic_kernel/planning/stepwise_planner/stepwise_planner.py
+++ b/python/semantic_kernel/planning/stepwise_planner/stepwise_planner.py
@@ -130,7 +130,7 @@ class StepwisePlanner:
 
                 context.variables.set("agent_scratch_pad", scratch_pad)
 
-                llm_response = await self._system_step_function.invoke_async(context=context)
+                llm_response = await self._system_step_function.invoke(context=context)
 
                 if llm_response.error_occurred:
                     raise PlanningException(
@@ -313,7 +313,7 @@ class StepwisePlanner:
             function = self._kernel.func(target_function.plugin_name, target_function.name)
             action_context = self.create_action_context(action_variables)
 
-            result = await function.invoke_async(context=action_context)
+            result = await function.invoke(context=action_context)
 
             if result.error_occurred:
                 logger.error(f"Error occurred: {result.last_exception}")

--- a/python/semantic_kernel/template_engine/blocks/code_block.py
+++ b/python/semantic_kernel/template_engine/blocks/code_block.py
@@ -102,7 +102,7 @@ class CodeBlock(Block):
             input_value = self._tokens[1].render(variables_clone)
             variables_clone.update(input_value)
 
-        result = await function.invoke_async(variables=variables_clone, memory=context.memory)
+        result = await function.invoke(variables=variables_clone, memory=context.memory)
 
         if result.error_occurred:
             error_msg = (

--- a/python/semantic_kernel/text/function_extension.py
+++ b/python/semantic_kernel/text/function_extension.py
@@ -15,7 +15,7 @@ async def aggregate_chunked_results(
     results = []
     for chunk in chunked_results:
         context.variables.update(chunk)
-        context = await func.invoke_async(context=context)
+        context = await func.invoke(context=context)
 
         results.append(str(context.variables))
 

--- a/python/tests/integration/planning/stepwise_planner/test_stepwise_planner.py
+++ b/python/tests/integration/planning/stepwise_planner/test_stepwise_planner.py
@@ -163,7 +163,7 @@ async def test_can_execute_stepwise_plan(
 
     # Act
     plan = planner.create_plan(prompt)
-    result = await plan.invoke_async()
+    result = await plan.invoke()
 
     steps_taken_string = result.variables["steps_taken"]
     assert steps_taken_string is not None

--- a/python/tests/unit/kernel_extensions/test_register_functions.py
+++ b/python/tests/unit/kernel_extensions/test_register_functions.py
@@ -19,14 +19,16 @@ def decorated_native_function(arg1: str) -> str:
     return "test"
 
 
-def test_register_valid_native_function():
+@pytest.mark.asyncio
+async def test_register_valid_native_function():
     kernel = Kernel()
 
     registered_func = kernel.register_native_function("TestPlugin", decorated_native_function)
 
     assert isinstance(registered_func, KernelFunctionBase)
     assert kernel.plugins.get_native_function("TestPlugin", "getLightStatus") == registered_func
-    assert registered_func.invoke("testtest").result == "test"
+    func_result = await registered_func.invoke("testtest")
+    assert func_result.result == "test"
 
 
 def test_register_undecorated_native_function():

--- a/python/tests/unit/planning/action_planner/test_action_planner.py
+++ b/python/tests/unit/planning/action_planner/test_action_planner.py
@@ -75,7 +75,7 @@ async def test_plan_creation():
 
     return_context.variables.update(plan_str)
 
-    mock_function.invoke_async.return_value = return_context
+    mock_function.invoke.return_value = return_context
 
     kernel.create_semantic_function.return_value = mock_function
     kernel.create_new_context.return_value = context
@@ -115,7 +115,7 @@ def mock_context(plugins_input):
 
         _context = KernelContext.model_construct(variables=ContextVariables(), memory=memory, plugin_collection=plugins)
         _context.variables.update("MOCK FUNCTION CALLED")
-        mock_function.invoke_async.return_value = _context
+        mock_function.invoke.return_value = _context
         mock_functions.append(mock_function)
 
     plugins.get_function.side_effect = lambda plugin_name, function_name: next(
@@ -205,7 +205,7 @@ async def test_invalid_json_throw():
 
     return_context.variables.update(plan_str)
 
-    mock_function.invoke_async.return_value = return_context
+    mock_function.invoke.return_value = return_context
 
     kernel.create_semantic_function.return_value = mock_function
     kernel.create_new_context.return_value = context
@@ -239,7 +239,7 @@ async def test_empty_goal_throw():
     return_context = KernelContext.model_construct(
         variables=ContextVariables(), memory=memory, plugin_collection=plugins
     )
-    mock_function.invoke_async.return_value = return_context
+    mock_function.invoke.return_value = return_context
 
     kernel.create_semantic_function.return_value = mock_function
     kernel.create_new_context.return_value = context

--- a/python/tests/unit/planning/sequential_planner/test_sequential_planner.py
+++ b/python/tests/unit/planning/sequential_planner/test_sequential_planner.py
@@ -53,7 +53,7 @@ async def test_it_can_create_plan(goal):
 
         context = KernelContext.model_construct(variables=ContextVariables(), memory=memory, plugin_collection=plugins)
         context.variables.update("MOCK FUNCTION CALLED")
-        mock_function.invoke_async.return_value = context
+        mock_function.invoke.return_value = context
         mock_functions.append(mock_function)
 
     plugins.get_function.side_effect = lambda plugin_name, function_name: next(
@@ -80,7 +80,7 @@ async def test_it_can_create_plan(goal):
     return_context.variables.update(plan_string)
 
     mock_function_flow_function = Mock(spec=KernelFunctionBase)
-    mock_function_flow_function.invoke_async.return_value = return_context
+    mock_function_flow_function.invoke.return_value = return_context
 
     kernel.plugins = plugins
     kernel.create_new_context.return_value = context
@@ -131,7 +131,7 @@ async def test_invalid_xml_throws():
     context = KernelContext.model_construct(variables=ContextVariables(), memory=memory, plugin_collection=plugins)
 
     mock_function_flow_function = Mock(spec=KernelFunctionBase)
-    mock_function_flow_function.invoke_async.return_value = return_context
+    mock_function_flow_function.invoke.return_value = return_context
 
     kernel.plugins = plugins
     kernel.create_new_context.return_value = context

--- a/python/tests/unit/planning/sequential_planner/test_sequential_planner_parser.py
+++ b/python/tests/unit/planning/sequential_planner/test_sequential_planner_parser.py
@@ -33,7 +33,7 @@ def create_kernel_and_functions_mock(functions) -> Kernel:
 
         result = kernel.create_new_context()
         result.variables.update(result_string)
-        mock_function.invoke_async.return_value = result
+        mock_function.invoke.return_value = result
         kernel._plugin_collection.add_semantic_function(mock_function)
 
     return kernel

--- a/python/tests/unit/planning/test_plan_execution.py
+++ b/python/tests/unit/planning/test_plan_execution.py
@@ -8,20 +8,22 @@ from semantic_kernel.core_plugins.text_plugin import TextPlugin
 from semantic_kernel.planning import Plan
 
 
-def test_invoke_empty_plan():
+@pytest.mark.asyncio
+async def test_invoke_empty_plan():
     plan = Plan()
-    result = plan.invoke()
+    result = await plan.invoke()
     assert result.result == ""
 
 
 @pytest.mark.asyncio
 async def test_invoke_empty_plan_async():
     plan = Plan()
-    result = await plan.invoke_async()
+    result = await plan.invoke()
     assert result.result == ""
 
 
-def test_invoke_plan_constructed_with_function():
+@pytest.mark.asyncio
+async def test_invoke_plan_constructed_with_function():
     # create a kernel
     kernel = sk.Kernel()
 
@@ -35,7 +37,7 @@ def test_invoke_plan_constructed_with_function():
     context["input"] = "hello world "
 
     plan = Plan(name="test", function=test_function)
-    result = plan.invoke(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD "
 
 
@@ -54,11 +56,12 @@ async def test_invoke_plan_constructed_with_function_async():
     context["input"] = "hello world "
 
     plan = Plan(name="test", function=test_function)
-    result = await plan.invoke_async(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD "
 
 
-def test_invoke_empty_plan_with_added_function_step():
+@pytest.mark.asyncio
+async def test_invoke_empty_plan_with_added_function_step():
     # create a kernel
     kernel = sk.Kernel()
 
@@ -73,7 +76,7 @@ def test_invoke_empty_plan_with_added_function_step():
 
     plan = Plan(name="test")
     plan.add_steps([test_function])
-    result = plan.invoke(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD "
 
 
@@ -93,11 +96,12 @@ async def test_invoke_empty_plan_with_added_function_step_async():
 
     plan = Plan(name="test")
     plan.add_steps([test_function])
-    result = await plan.invoke_async(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD "
 
 
-def test_invoke_empty_plan_with_added_plan_step():
+@pytest.mark.asyncio
+async def test_invoke_empty_plan_with_added_plan_step():
     # create a kernel
     kernel = sk.Kernel()
 
@@ -113,7 +117,7 @@ def test_invoke_empty_plan_with_added_plan_step():
     plan = Plan(name="test")
     new_step = Plan(name="test", function=test_function)
     plan.add_steps([new_step])
-    result = plan.invoke(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD "
 
 
@@ -134,11 +138,12 @@ async def test_invoke_empty_plan_with_added_plan_step_async():
     plan = Plan(name="test")
     new_step = Plan(name="test", function=test_function)
     plan.add_steps([new_step])
-    result = await plan.invoke_async(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD "
 
 
-def test_invoke_multi_step_plan():
+@pytest.mark.asyncio
+async def test_invoke_multi_step_plan():
     # create a kernel
     kernel = sk.Kernel()
 
@@ -156,7 +161,7 @@ def test_invoke_multi_step_plan():
     new_step = Plan(name="test", function=test_function)
     new_step2 = Plan(name="test", function=test_function2)
     plan.add_steps([new_step, new_step2])
-    result = plan.invoke(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD"
 
 
@@ -179,7 +184,7 @@ async def test_invoke_multi_step_plan_async():
     new_step = Plan(name="test", function=test_function)
     new_step2 = Plan(name="test", function=test_function2)
     plan.add_steps([new_step, new_step2])
-    result = await plan.invoke_async(context=context)
+    result = await plan.invoke(context=context)
     assert result.result == "HELLO WORLD"
 
 
@@ -207,5 +212,5 @@ async def test_invoke_multi_step_plan_async_with_variables():
     new_step2 = Plan(name="test", function=test_function2, parameters=context2.variables)
 
     plan.add_steps([new_step, new_step2])
-    result = await plan.invoke_async(input="2")
+    result = await plan.invoke(input="2")
     assert result.result == "7"

--- a/python/tests/unit/test_kernel.py
+++ b/python/tests/unit/test_kernel.py
@@ -27,7 +27,7 @@ async def test_run_async_handles_pre_invocation(pipeline_count):
     kernel = Kernel()
 
     mock_function = create_mock_function("test_function")
-    mock_function.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function.invoke = AsyncMock(side_effect=lambda input, context: context)
     kernel._plugin_collection.add_semantic_function(mock_function)
 
     invoked = 0
@@ -44,7 +44,7 @@ async def test_run_async_handles_pre_invocation(pipeline_count):
 
     # Assert
     assert invoked == pipeline_count
-    assert mock_function.invoke_async.call_count == pipeline_count
+    assert mock_function.invoke.call_count == pipeline_count
 
 
 @pytest.mark.asyncio
@@ -53,9 +53,9 @@ async def test_run_async_pre_invocation_skip_dont_trigger_invoked_handler():
     kernel = Kernel()
 
     mock_function1 = create_mock_function(name="SkipMe")
-    mock_function1.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function1.invoke = AsyncMock(side_effect=lambda input, context: context)
     mock_function2 = create_mock_function(name="DontSkipMe")
-    mock_function2.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function2.invoke = AsyncMock(side_effect=lambda input, context: context)
     invoked = 0
     invoking = 0
     invoked_function_name = ""
@@ -90,7 +90,7 @@ async def test_run_async_handles_post_invocation(pipeline_count):
     kernel = Kernel()
 
     mock_function = create_mock_function("test_function")
-    mock_function.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function.invoke = AsyncMock(side_effect=lambda input, context: context)
     invoked = 0
 
     def invoked_handler(sender, e):
@@ -105,8 +105,8 @@ async def test_run_async_handles_post_invocation(pipeline_count):
 
     # Assert
     assert invoked == pipeline_count
-    mock_function.invoke_async.assert_called()
-    assert mock_function.invoke_async.call_count == pipeline_count
+    mock_function.invoke.assert_called()
+    assert mock_function.invoke.call_count == pipeline_count
 
 
 @pytest.mark.asyncio
@@ -115,7 +115,7 @@ async def test_run_async_post_invocation_repeat_is_working():
     kernel = Kernel()
 
     mock_function = create_mock_function(name="RepeatMe")
-    mock_function.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function.invoke = AsyncMock(side_effect=lambda input, context: context)
 
     invoked = 0
     repeat_times = 0
@@ -144,7 +144,7 @@ async def test_run_async_change_variable_invoking_handler():
     kernel = Kernel()
 
     mock_function = create_mock_function("test_function")
-    mock_function.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function.invoke = AsyncMock(side_effect=lambda input, context: context)
 
     original_input = "Importance"
     new_input = "Problems"
@@ -170,7 +170,7 @@ async def test_run_async_change_variable_invoked_handler():
     kernel = Kernel()
 
     mock_function = create_mock_function("test_function")
-    mock_function.invoke_async = AsyncMock(side_effect=lambda input, context: context)
+    mock_function.invoke = AsyncMock(side_effect=lambda input, context: context)
 
     original_input = "Importance"
     new_input = "Problems"


### PR DESCRIPTION
### Motivation and Context

Completes #4794. 

Most of SK Python is written with async code; however, there were some code paths that masked the underlying async code and made it look like a sync function invoke. In reality, asyncio spun up event loops and attempted to manage them properly. This becomes tricky when running a Jupyter notebook as they have their own event loop.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR removes the ability to call a kernel function synchronously. Since the majority of the code base is written with async methods, and to match dotnet, which is async, we're removing the sync function invoke and its dependent code. Some Planners were also run synchronously -- these were updated to run asynchronously. Kernel examples, notebooks, docs, and tests were updated accordingly. 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
