### PR TITLE
.Net - Fix Agent Message Ordering for Multimessage Runs

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example75_AgentTools.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example75_AgentTools.cs
@@ -39,7 +39,6 @@ public sealed class Example75_AgentTools : BaseTest
             return;
         }
 
-
         var builder =
             new AgentBuilder()
                 .WithOpenAIChatCompletion(OpenAIFunctionEnabledModel, TestConfiguration.OpenAI.ApiKey)
@@ -80,7 +79,6 @@ public sealed class Example75_AgentTools : BaseTest
             this.WriteLine("OpenAI apiKey not found. Skipping example.");
             return;
         }
-
 
         // REQUIRED:
         //

--- a/dotnet/samples/KernelSyntaxExamples/Example75_AgentTools.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example75_AgentTools.cs
@@ -26,12 +26,12 @@ public sealed class Example75_AgentTools : BaseTest
     private readonly List<IAgent> _agents = new();
 
     /// <summary>
-    /// Show how to utilize code_interpreter and retrieval tools.
+    /// Show how to utilize code_interpreter tool.
     /// </summary>
     [Fact]
-    public async Task RunAsync()
+    public async Task RunCodeInterpreterToolAsync()
     {
-        this.WriteLine("======== Example75_AgentTools ========");
+        this.WriteLine("======== Using CodeInterpreter tool ========");
 
         if (TestConfiguration.OpenAI.ApiKey == null)
         {
@@ -39,16 +39,6 @@ public sealed class Example75_AgentTools : BaseTest
             return;
         }
 
-        // Run agent with 'code_interpreter' tool
-        await RunCodeInterpreterToolAsync();
-
-        // Run agent with 'retrieval' tool
-        await RunRetrievalToolAsync();
-    }
-
-    private async Task RunCodeInterpreterToolAsync()
-    {
-        this.WriteLine("======== Run:CodeInterpreterTool ========");
 
         var builder =
             new AgentBuilder()
@@ -77,9 +67,20 @@ public sealed class Example75_AgentTools : BaseTest
         }
     }
 
-    private async Task RunRetrievalToolAsync()
+    /// <summary>
+    /// Show how to utilize retrieval tool.
+    /// </summary>
+    [Fact]
+    public async Task RunRetrievalToolAsync()
     {
-        this.WriteLine("======== Run:RunRetrievalTool ========");
+        this.WriteLine("======== Using Retrieval tool ========");
+
+        if (TestConfiguration.OpenAI.ApiKey == null)
+        {
+            this.WriteLine("OpenAI apiKey not found. Skipping example.");
+            return;
+        }
+
 
         // REQUIRED:
         //

--- a/dotnet/src/Experimental/Agents/Internal/ChatThread.cs
+++ b/dotnet/src/Experimental/Agents/Internal/ChatThread.cs
@@ -85,11 +85,10 @@ internal sealed class ChatThread : IAgentThread
         // Create run using templated prompt
         var runModel = await this._restContext.CreateRunAsync(this.Id, agent.Id, instructions, agent.Tools, cancellationToken).ConfigureAwait(false);
         var run = new ChatRun(runModel, agent.Kernel, this._restContext);
-        var results = await run.GetResultAsync(cancellationToken).ConfigureAwait(false);
 
-        var messages = await this._restContext.GetMessagesAsync(this.Id, results, cancellationToken).ConfigureAwait(false);
-        foreach (var message in messages)
+        await foreach (var messageId in run.GetResultAsync(cancellationToken).ConfigureAwait(false))
         {
+            var message = await this._restContext.GetMessageAsync(this.Id, messageId, cancellationToken).ConfigureAwait(false);
             yield return new ChatMessage(message);
         }
     }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Observed agent messages not being provided in the expected order.  In practice they appear reversed, but could be anything depending on JSON data.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Changed run processing to return message-ids as `IAsyncEnumerable`, in the order they are generated.

In addition to addressing ordering issue, this also introduces the ability for the first message to be displayed as soon as it is produced (for multi-message runs)...even if the last message is added 30 seconds later.  (In the current version, message-ids are return only after all have been produced.)

Also explored both flavors of `Example75_AgentTools` as separate entry-points.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
