### PR TITLE
Python: Set the default plugins on the semantic function. Add a unit test.

### DIFF
--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -170,6 +170,7 @@ class Kernel(KernelBaseModel):
 
         function = self._create_semantic_function(plugin_name, function_name, function_config)
         self.add_plugin(plugin_name, [function])
+        function.set_default_plugin_collection(self.plugins)
 
         return function
 

--- a/python/tests/unit/kernel_extensions/test_import_plugins.py
+++ b/python/tests/unit/kernel_extensions/test_import_plugins.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import os
+import os, random
 
 import semantic_kernel as sk
 import semantic_kernel.connectors.ai.open_ai as sk_oai
-
+from semantic_kernel.plugin_definition import kernel_function, kernel_function_context_parameter
 
 def test_plugin_can_be_imported():
     # create a kernel
@@ -41,3 +41,55 @@ def test_native_plugin_can_be_imported():
     plugin_config = plugin.functions["echoAsync"]
     assert plugin_config.name == "echoAsync"
     assert plugin_config.description == "Echo for input text"
+
+def test_create_semantic_function_succeeds():
+    # create a kernel
+    kernel = sk.Kernel()
+
+    kernel.add_chat_service(
+        "test-completion-service",
+        sk_oai.OpenAIChatCompletion("test", "test", ""),
+    )
+
+    class GenerateNamesPlugin:
+        @kernel_function(description="Generate character names", name="generate_names")
+        def generate_names(self) -> str:
+            """
+            Generate two names.
+            Returns:
+                str
+            """
+            names = {"Hoagie", "Hamilton", "Bacon", "Pizza", "Boots", "Shorts", "Tuna"}
+            first_name = random.choice(list(names))
+            names.remove(first_name)
+            second_name = random.choice(list(names))
+            return f"{first_name}, {second_name}"
+
+    # import plugins
+    _ = kernel.import_plugin(GenerateNamesPlugin(), plugin_name="GenerateNames")
+
+    sk_prompt = """
+    Write a short story about two Corgis on an adventure.
+    The story must be:
+    - G rated
+    - Have a positive message
+    - No sexism, racism or other bias/bigotry
+    - Be exactly {{$paragraph_count}} paragraphs long
+    - Be written in this language: {{$language}}
+    - The two names of the corgis are {{GenerateNames.generate_names}}
+    """
+
+    print(sk_prompt)
+
+    test_func = kernel.create_semantic_function(
+        prompt_template=sk_prompt,
+        function_name="TestFunction",
+        plugin_name="TestPlugin",
+        description="Write a short story.",
+        max_tokens=500,
+        temperature=0.5,
+        top_p=0.5,
+    )
+
+    assert len(test_func.plugins) > 0
+    assert test_func.plugins["GenerateNames"] is not None

--- a/python/tests/unit/kernel_extensions/test_import_plugins.py
+++ b/python/tests/unit/kernel_extensions/test_import_plugins.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import os, random
+import os
+import random
 
 import semantic_kernel as sk
 import semantic_kernel.connectors.ai.open_ai as sk_oai
-from semantic_kernel.plugin_definition import kernel_function, kernel_function_context_parameter
+from semantic_kernel.plugin_definition import kernel_function
+
 
 def test_plugin_can_be_imported():
     # create a kernel
@@ -41,6 +43,7 @@ def test_native_plugin_can_be_imported():
     plugin_config = plugin.functions["echoAsync"]
     assert plugin_config.name == "echoAsync"
     assert plugin_config.description == "Echo for input text"
+
 
 def test_create_semantic_function_succeeds():
     # create a kernel


### PR DESCRIPTION
### Motivation and Context

Fixes #4869. On a created semantic function, the plugins weren't getting set for use for the function.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Set the default plugins for the registered function, and add a unit test.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
