### PR TITLE
Added support for BinaryData for ImageContent.

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Memory.Data" Version="8.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ImageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ImageContent.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Mime;
 using System.Text;
 
 namespace Microsoft.SemanticKernel;
@@ -15,6 +16,11 @@ public sealed class ImageContent : KernelContent
     /// The URI of image.
     /// </summary>
     public Uri? Uri { get; set; }
+
+    /// <summary>
+    /// The Data used as DataUri for the image.
+    /// </summary>
+    public BinaryData? Data { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageContent"/> class.
@@ -35,9 +41,43 @@ public sealed class ImageContent : KernelContent
         this.Uri = uri;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageContent"/> class.
+    /// </summary>
+    /// <param name="data">The Data used as DataUri for the image.</param>
+    /// <param name="modelId">The model ID used to generate the content</param>
+    /// <param name="innerContent">Inner content</param>
+    /// <param name="encoding">Encoding of the text</param>
+    /// <param name="metadata">Additional metadata</param>
+    public ImageContent(
+        BinaryData data,
+        string? modelId = null,
+        object? innerContent = null,
+        Encoding? encoding = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+        : base(innerContent, modelId, metadata)
+    {
+        if (data.IsEmpty || string.IsNullOrWhiteSpace(data?.MediaType))
+        {
+            throw new ArgumentNullException(nameof(data), "MediaType is needed for DataUri Images");
+        }
+
+        this.Data = data;
+    }
+
     /// <inheritdoc/>
     public override string ToString()
     {
-        return this.Uri?.ToString() ?? string.Empty;
+        return this.BuildDataUri() ?? this.Uri?.ToString() ?? string.Empty;
+    }
+
+    private string? BuildDataUri()
+    {
+        if (this.Data is null)
+        {
+            return null;
+        }
+
+        return $"data:{this.Data.MediaType};base64,{Convert.ToBase64String(this.Data.ToArray())}";
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="JsonSchema.Net.Generation" />
   </ItemGroup>

--- a/dotnet/src/SemanticKernel.UnitTests/Contents/ImageContentTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Contents/ImageContentTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+
 using Microsoft.SemanticKernel;
+
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Contents;
@@ -12,10 +14,10 @@ namespace SemanticKernel.UnitTests.Contents;
 public sealed class ImageContentTests
 {
     [Fact]
-    public void ToStringReturnsString()
+    public void ToStringForUriReturnsString()
     {
         // Arrange
-        var content1 = new ImageContent(null!);
+        var content1 = new ImageContent((Uri)null!);
         var content2 = new ImageContent(new Uri("https://endpoint/"));
 
         // Act
@@ -25,5 +27,108 @@ public sealed class ImageContentTests
         // Assert
         Assert.Empty(result1);
         Assert.Equal("https://endpoint/", result2);
+    }
+
+    [Fact]
+    public void ToStringForDataUriReturnsDataUriString()
+    {
+        // Arrange
+        var data = BinaryData.FromString("this is a test", "text/plain");
+        var content1 = new ImageContent(data);
+
+        // Act
+        var result1 = content1.ToString();
+        var dataUriToExpect = $"data:{data.MediaType};base64,{Convert.ToBase64String(data.ToArray())}";
+
+        // Assert
+        Assert.Equal(dataUriToExpect, result1);
+    }
+
+    [Fact]
+    public void ToStringForUriAndDataUriReturnsDataUriString()
+    {
+        // Arrange
+        var data = BinaryData.FromString("this is a test", "text/plain");
+        var content1 = new ImageContent(data);
+        content1.Uri = new Uri("https://endpoint/");
+
+        // Act
+        var result1 = content1.ToString();
+        var dataUriToExpect = $"data:{data.MediaType};base64,{Convert.ToBase64String(data.ToArray())}";
+
+        // Assert
+        Assert.Equal(dataUriToExpect, result1);
+    }
+
+    [Fact]
+    public void CreateForNullDataUriOrWithoutMediaTypeThrows()
+    {
+        // Arrange
+        var data = BinaryData.FromString("this is a test", null);
+        var data2 = BinaryData.FromString("this is a test", string.Empty);
+        var data3 = BinaryData.FromString("this is a test", " ");
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(() => new ImageContent((BinaryData)null!));
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(data));
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(data2));
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(data3));
+    }
+
+    [Fact]
+    public void CreateForEmptyDataUriThrows()
+    {
+        // Arrange
+        var data = BinaryData.Empty;
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(data));
+    }
+
+    [Fact]
+    public void ToStringForDataUriFromBytesReturnsDataUriString()
+    {
+        // Arrange
+        var bytes = System.Text.Encoding.UTF8.GetBytes("this is a test");
+        var data = BinaryData.FromBytes(bytes, "text/plain");
+        var content1 = new ImageContent(data);
+
+        // Act
+        var result1 = content1.ToString();
+        var dataUriToExpect = $"data:{data.MediaType};base64,{Convert.ToBase64String(data.ToArray())}";
+
+        // Assert
+        Assert.Equal(dataUriToExpect, result1);
+
+        // Assert throws if mediatype is null
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(BinaryData.FromBytes(bytes, null)));
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(BinaryData.FromBytes(bytes, string.Empty)));
+        Assert.Throws<ArgumentNullException>(() => new ImageContent(BinaryData.FromBytes(bytes, " ")));
+    }
+
+    [Fact]
+    public void ToStringForDataUriFromStreamReturnsDataUriString()
+    {
+        // Arrange
+        var ms = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes("this is a test"));
+        try
+        {
+            var data = BinaryData.FromStream(ms, "text/plain");
+            var content1 = new ImageContent(data);
+
+            // Act
+            var result1 = content1.ToString();
+            var dataUriToExpect = $"data:{data.MediaType};base64,{Convert.ToBase64String(data.ToArray())}";
+
+            // Assert
+            Assert.Equal(dataUriToExpect, result1);
+
+            // Assert throws if mediatype is null
+            Assert.Throws<ArgumentNullException>(() => new ImageContent(BinaryData.FromStream(ms, null)));
+        }
+        finally
+        {
+            ms.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Added Tests

### Motivation and Context

As Described in #4781 right now there is no possibility  in SK to add Images as DataUris to ChatCompletion APIs, although the Azure OpenAI API and the Open AI API both support this.

Fixes #4781

### Description

As per Discussion added overload to the ImageContent ctor that takes BinaryData.
For backward Compat we kept the ctor that takes an URI.

Also the new ctor throws, if the BinaryData is null, empty or if there is not MediaType provided.

I thought about allowing plain, non base64 encoded DataUris with BinaryData.
The Idea was to not encode to base64, if the MediaType is set to "text/plain", but then I decided, that this is not needed, since `Uri` in general allows for DataUris like `new Uri("data:text/plain;http://exmpaledomain.com")` just not for DataUris that are longer than 65520 bytes. I feel like that is ok, for plain DataUris.

We can still add this if needed.

Also as per discussion in the issue, I did not add additional overloads for direct Streams support.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
