### PR TITLE
Python: streaming fix for Python: SK 0.5.0 breaks streaming #4925

### DIFF
--- a/python/semantic_kernel/orchestration/kernel_function.py
+++ b/python/semantic_kernel/orchestration/kernel_function.py
@@ -263,6 +263,7 @@ class KernelFunction(KernelBaseModel):
                 except Exception as e:
                     # TODO: "critical exceptions"
                     context.fail(str(e), e)
+                return
 
             try:
                 chat_prompt = function_config.prompt_template


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Issue was raised that streaming when using chat but not a chat_prompt_template failed because it did not return after doing the branch for non-chat-prompt-template, this fixes that.

Fixes #4925 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
