### PR TITLE
Revert "Failed links are temporarily excluded from the link-checking action"

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -26,9 +26,6 @@
     },
     {
       "pattern": "^https://platform.openai.com"
-    },
-    {
-      "pattern": "^https://www.microsoft.com/en-us"
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
Reverting commit 70ac836339b09d972aef691b86b138883c092f38 that skipped the link check for all links starting from "https://www.microsoft.com/en-us/msrc/" since the issue has resolved itself, and the configuration is no longer necessary.