### PR TITLE
Python: fix annotated missing sys.version

### DIFF
--- a/python/semantic_kernel/connectors/openapi/kernel_openapi.py
+++ b/python/semantic_kernel/connectors/openapi/kernel_openapi.py
@@ -1,6 +1,13 @@
 import json
 import logging
-from typing import Annotated, Dict, Mapping, Optional, Union
+import sys
+from typing import Dict, Mapping, Optional, Union
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
+    
 from urllib.parse import urljoin
 
 import aiohttp

--- a/python/semantic_kernel/core_plugins/conversation_summary_plugin.py
+++ b/python/semantic_kernel/core_plugins/conversation_summary_plugin.py
@@ -2,7 +2,7 @@
 import sys
 from typing import TYPE_CHECKING
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
     from typing_extensions import Annotated

--- a/python/semantic_kernel/core_plugins/http_plugin.py
+++ b/python/semantic_kernel/core_plugins/http_plugin.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
     from typing_extensions import Annotated

--- a/python/semantic_kernel/planners/action_planner/action_planner.py
+++ b/python/semantic_kernel/planners/action_planner/action_planner.py
@@ -4,9 +4,14 @@ import itertools
 import json
 import logging
 import os
+import sys
 from textwrap import dedent
-from typing import Annotated, List, Optional
+from typing import List, Optional
 
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 import regex
 
 from semantic_kernel import Kernel

--- a/python/tests/unit/functions/test_native_function.py
+++ b/python/tests/unit/functions/test_native_function.py
@@ -2,7 +2,7 @@
 import sys
 from typing import TYPE_CHECKING, Optional
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
     from typing_extensions import Annotated


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Some of the Annotated imports were not using typing_extention for py3.8

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
