### PR TITLE
Java: Remove KernelFunctionCollection from public API

### DIFF
--- a/java/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/java/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -267,7 +267,7 @@ public class OpenAIChatCompletion implements ChatCompletionService {
         String pluginName = parts.length > 0 ? parts[0] : "";
         String fnName = parts.length > 1 ? parts[1] : "";
         JsonNode parameters = jsonNode.get("parameters");
-        KernelFunction<?> kernelFunction = kernel.getPlugins().getFunction(pluginName, fnName);
+        KernelFunction<?> kernelFunction = kernel.getFunction(pluginName, fnName);
         if (kernelFunction == null) {
             return Mono.empty();
         }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example07_BingAndGooglePlugins.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example07_BingAndGooglePlugins.java
@@ -88,7 +88,7 @@ public class Example07_BingAndGooglePlugins {
             .withVariable("query", question)
             .build();
 
-        var function = kernel.getPlugins().getFunction(searchPluginName, "search");
+        var function = kernel.getFunction(searchPluginName, "search");
         var result = kernel.invokeAsync(function).withArguments(kernelArguments).block();
 
         System.out.println(question);

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example09_FunctionTypes.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example09_FunctionTypes.java
@@ -1,7 +1,5 @@
 package com.microsoft.semantickernel.samples.syntaxexamples;
 
-import static com.microsoft.semantickernel.orchestration.contextvariables.ContextVariableTypes.convert;
-
 import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
@@ -14,11 +12,13 @@ import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariab
 import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariableType;
 import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariableTypeConverter;
 import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariableTypeConverter.NoopConverter;
+import static com.microsoft.semantickernel.orchestration.contextvariables.ContextVariableTypes.convert;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.plugin.annotations.DefineKernelFunction;
 import com.microsoft.semantickernel.plugin.annotations.KernelFunctionParameter;
 import com.microsoft.semantickernel.textcompletion.TextGenerationService;
+
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -29,6 +29,7 @@ import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
 import reactor.core.publisher.Mono;
 
 public class Example09_FunctionTypes {
@@ -328,8 +329,7 @@ public class Example09_FunctionTypes {
         // You can also use the kernel.Plugins collection to invoke a function
         kernel
             .invokeAsync(
-                kernel.getPlugins()
-                    .getFunction("Examples", "NoInputWithVoidResult"))
+                kernel.getFunction("Examples", "NoInputWithVoidResult"))
             .block();
     }
 

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example42_KernelBuilder.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example42_KernelBuilder.java
@@ -7,11 +7,12 @@ import com.azure.core.credential.KeyCredential;
 import com.azure.core.http.HttpClient;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.chatcompletion.ChatCompletionService;
-import com.microsoft.semantickernel.plugin.KernelPluginCollection;
 import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.samples.plugins.ConversationSummaryPlugin;
 import com.microsoft.semantickernel.services.OrderedAIServiceSelector;
 import com.microsoft.semantickernel.textcompletion.TextGenerationService;
+
+import java.util.ArrayList;
 
 public class Example42_KernelBuilder {
 
@@ -67,7 +68,7 @@ public class Example42_KernelBuilder {
         // using the public constructor that's available for anyone to use directly if desired.
         Kernel kernel = new Kernel(
             new OrderedAIServiceSelector(),
-            new KernelPluginCollection(),
+            new ArrayList<>(),
             null
         );
     }

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example69_MutableKernelPlugin.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example69_MutableKernelPlugin.java
@@ -29,9 +29,9 @@ public class Example69_MutableKernelPlugin {
             Time.class.getMethod("date"), new Time(), "dateFunction", null, null, null));
 
         Kernel kernel = Kernel.builder().build();
-        kernel.getPlugins().add(plugin);
+        kernel.addPlugin(plugin);
 
-        var result = kernel.invokeAsync(kernel.getPlugins().getFunction("Plugin", "dateFunction"))
+        var result = kernel.invokeAsync(kernel.getFunction("Plugin", "dateFunction"))
             .block();
 
         System.out.println("Result: " + result.getResult());

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/KernelPluginCollection.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/KernelPluginCollection.java
@@ -1,32 +1,32 @@
-package com.microsoft.semantickernel.plugin;
+package com.microsoft.semantickernel;
 
 import com.microsoft.semantickernel.orchestration.KernelFunction;
 import com.microsoft.semantickernel.orchestration.KernelFunctionMetadata;
 import com.microsoft.semantickernel.orchestration.contextvariables.CaseInsensitiveMap;
+import com.microsoft.semantickernel.plugin.KernelPlugin;
+
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KernelPluginCollection implements Iterable<KernelPlugin> {
+class KernelPluginCollection {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KernelPluginCollection.class);
 
     private final Map<String, KernelPlugin> plugins = new CaseInsensitiveMap<>();
 
-    public KernelPluginCollection() {
-        this(Collections.emptyList());
+    KernelPluginCollection() {
     }
 
-    public KernelPluginCollection(List<KernelPlugin> plugins) {
+    KernelPluginCollection(List<KernelPlugin> plugins) {
         plugins.forEach(plugin -> this.plugins.put(plugin.getName(), plugin));
     }
 
-    public KernelFunction<?> getFunction(String pluginName, String functionName) {
+    KernelFunction<?> getFunction(String pluginName, String functionName) {
         KernelPlugin plugin = plugins.get(pluginName);
         if (plugin == null) {
             throw new IllegalArgumentException("Failed to find plugin " + pluginName);
@@ -40,23 +40,28 @@ public class KernelPluginCollection implements Iterable<KernelPlugin> {
         return function;
     }
 
-    public List<KernelFunctionMetadata> getFunctionsMetadata() {
+    List<KernelFunction<?>> getFunctions() {
+        return plugins.values().stream()
+            .flatMap(plugin -> plugin.getFunctions().values().stream())
+            .collect(Collectors.toList());
+    }
+
+    List<KernelFunctionMetadata<?>> getFunctionsMetadata() {
         return plugins.values().stream()
             .flatMap(plugin -> plugin.getFunctions().values().stream())
             .map(KernelFunction::getMetadata)
             .collect(Collectors.toList());
     }
 
-    @Override
-    public Iterator<KernelPlugin> iterator() {
-        return plugins.values().iterator();
-    }
-
-    public List<KernelPlugin> getPlugins() {
+    List<KernelPlugin> getPlugins() {
         return new ArrayList<>(plugins.values());
     }
 
-    public void add(KernelPlugin plugin) {
+    KernelPlugin getPlugin(String pluginName) {
+        return plugins.get(pluginName);
+    }
+
+    void add(KernelPlugin plugin) {
         if (plugins.containsKey(plugin.getName())) {
             LOGGER.warn("Plugin {} already exists, overwriting existing plugin", plugin.getName());
         }

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromPrompt.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/semanticfunctions/KernelFunctionFromPrompt.java
@@ -26,15 +26,19 @@ import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariab
 import com.microsoft.semantickernel.plugin.KernelParameterMetadata;
 import com.microsoft.semantickernel.services.AIServiceSelection;
 import com.microsoft.semantickernel.textcompletion.TextGenerationService;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -343,7 +347,7 @@ public class KernelFunctionFromPrompt<T> extends KernelFunction<T> {
                 KernelFunction<T> kernelFunction;
                 try {
                     // unchecked cast
-                    kernelFunction = (KernelFunction<T>) kernel.getPlugins()
+                    kernelFunction = (KernelFunction<T>) kernel
                         .getFunction(pluginName, fnName);
                 } catch (IllegalArgumentException | ClassCastException e) {
                     return Mono.error(new SKException(e.getMessage(), e));

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/templateengine/semantickernel/blocks/CodeBlock.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/templateengine/semantickernel/blocks/CodeBlock.java
@@ -12,12 +12,16 @@ import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariab
 import com.microsoft.semantickernel.orchestration.contextvariables.ContextVariableTypes;
 import com.microsoft.semantickernel.templateengine.semantickernel.TemplateException;
 import com.microsoft.semantickernel.templateengine.semantickernel.TemplateException.ErrorCodes;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import reactor.core.publisher.Mono;
 
 public final class CodeBlock extends Block implements CodeRendering {
@@ -164,7 +168,7 @@ public final class CodeBlock extends Block implements CodeRendering {
         Block firstArg = this.tokens.get(1);
 
         // Get the function metadata
-        KernelFunctionMetadata<?> functionMetadata = kernel.getPlugins()
+        KernelFunctionMetadata<?> functionMetadata = kernel
             .getFunction(fBlock.getPluginName(), fBlock.getFunctionName()).getMetadata();
 
         // Check if the function has parameters to be set


### PR DESCRIPTION
### Motivation and Context
Simplify the API

### Description
Use KernelFunctionCollection internally from Kernel. Add a couple of methods to Kernel to add/get a KernelPlugin
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
