### PR TITLE
.Net: Support work and school accounts for Microsoft Graph Connector

### DIFF
--- a/dotnet/src/Plugins/Plugins.MsGraph/Connectors/CredentialManagers/LocalUserMSALCredentialManager.cs
+++ b/dotnet/src/Plugins/Plugins.MsGraph/Connectors/CredentialManagers/LocalUserMSALCredentialManager.cs
@@ -93,7 +93,7 @@ public sealed class LocalUserMSALCredentialManager
             {
                 IPublicClientApplication newPublicApp = PublicClientApplicationBuilder.Create(clientId)
                     .WithRedirectUri(redirectUri.ToString())
-                    .WithTenantId(tenantId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
                     .Build();
                 this._cacheHelper.RegisterCache(newPublicApp.UserTokenCache);
                 return newPublicApp;


### PR DESCRIPTION
### Motivation and Context

- fixes #4962

### Description

Observed this while introducing API Manifest based plugins. The change allows logging in with both personal and work/school accounts.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
