### PR TITLE
.Net Gemini - Adjusted exceptions to comply with ADR

### DIFF
--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatGenerationTests.cs
@@ -217,19 +217,19 @@ public sealed class GeminiClientChatGenerationTests : IDisposable
     }
 
     [Fact]
-    public async Task ShouldThrowKernelExceptionIfChatHistoryContainsOnlySystemMessageAsync()
+    public async Task ShouldThrowInvalidOperationExceptionIfChatHistoryContainsOnlySystemMessageAsync()
     {
         // Arrange
         var client = this.CreateChatCompletionClient();
         var chatHistory = new ChatHistory("System message");
 
         // Act & Assert
-        await Assert.ThrowsAsync<KernelException>(
+        await Assert.ThrowsAsync<InvalidOperationException>(
             () => client.GenerateChatMessageAsync(chatHistory));
     }
 
     [Fact]
-    public async Task ShouldThrowKernelExceptionIfChatHistoryContainsOnlyManySystemMessagesAsync()
+    public async Task ShouldThrowInvalidOperationExceptionIfChatHistoryContainsOnlyManySystemMessagesAsync()
     {
         // Arrange
         var client = this.CreateChatCompletionClient();
@@ -238,12 +238,12 @@ public sealed class GeminiClientChatGenerationTests : IDisposable
         chatHistory.AddSystemMessage("System message 3");
 
         // Act & Assert
-        await Assert.ThrowsAsync<KernelException>(
+        await Assert.ThrowsAsync<InvalidOperationException>(
             () => client.GenerateChatMessageAsync(chatHistory));
     }
 
     [Fact]
-    public async Task ShouldThrowKernelExceptionIfChatHistoryContainsMoreThanOneSystemMessageAsync()
+    public async Task ShouldThrowInvalidOperationExceptionIfChatHistoryContainsMoreThanOneSystemMessageAsync()
     {
         var client = this.CreateChatCompletionClient();
         var chatHistory = new ChatHistory("System message");
@@ -252,7 +252,7 @@ public sealed class GeminiClientChatGenerationTests : IDisposable
         chatHistory.AddUserMessage("hello");
 
         // Act & Assert
-        await Assert.ThrowsAsync<KernelException>(
+        await Assert.ThrowsAsync<InvalidOperationException>(
             () => client.GenerateChatMessageAsync(chatHistory));
     }
 

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Common/GeminiClientChatGenerationTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 using Moq;

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Common/GeminiChatCompletionClient.cs
@@ -101,13 +101,13 @@ internal class GeminiChatCompletionClient : GeminiClient, IGeminiChatCompletionC
         {
             if (chatHistory.Count == systemMessages.Count)
             {
-                throw new KernelException("Chat history can't contain only system messages.");
+                throw new InvalidOperationException("Chat history can't contain only system messages.");
             }
 
             if (systemMessages.Count > 1)
             {
-                throw new KernelException("Chat history can't contain more than one system message. " +
-                                          "Only the first system message will be processed but will be converted to the user message before sending to the Gemini api.");
+                throw new InvalidOperationException("Chat history can't contain more than one system message. " +
+                                                    "Only the first system message will be processed but will be converted to the user message before sending to the Gemini api.");
             }
 
             ConvertSystemMessageToUserMessageInChatHistory(chatHistory, systemMessages[0]);


### PR DESCRIPTION
Updated the exception types thrown by the GeminiChatCompletionClient and its corresponding unit tests. KernelException was replaced with InvalidOperationException.

State of connector progress https://github.com/microsoft/semantic-kernel/issues/4680

@RogerBarreto 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
