### PR TITLE
.Net: Sets serialization depth to 128

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelJsonSchema.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelJsonSchema.cs
@@ -14,6 +14,8 @@ public sealed class KernelJsonSchema
 {
     /// <summary>Converter for serializing/deserializing JsonSchema instances.</summary>
     private static readonly SchemaJsonConverter s_jsonSchemaConverter = new();
+    /// <summary>Serialization settings for <see cref="JsonSerializer"/></summary>
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { MaxDepth = 128 };
     /// <summary>The schema stored as a string.</summary>
     private string? _schemaAsString;
 
@@ -21,7 +23,7 @@ public sealed class KernelJsonSchema
     /// <param name="jsonSchema">The JSON Schema as a string.</param>
     /// <returns>A parsed <see cref="KernelJsonSchema"/>, or null if <paramref name="jsonSchema"/> is null or empty.</returns>
     internal static KernelJsonSchema? ParseOrNull(string? jsonSchema) =>
-        !string.IsNullOrEmpty(jsonSchema) ? new(JsonSerializer.Deserialize<JsonElement>(jsonSchema!)) :
+        !string.IsNullOrEmpty(jsonSchema) ? new(JsonSerializer.Deserialize<JsonElement>(jsonSchema!, s_jsonSerializerOptions)) :
         null;
 
     /// <summary>Parses a JSON Schema for a parameter type.</summary>
@@ -30,21 +32,21 @@ public sealed class KernelJsonSchema
     /// <exception cref="ArgumentException"><paramref name="jsonSchema"/> is null.</exception>
     /// <exception cref="JsonException">The JSON is invalid.</exception>
     public static KernelJsonSchema Parse(string jsonSchema) =>
-        new(JsonSerializer.SerializeToElement(JsonSchema.FromText(jsonSchema)));
+        new(JsonSerializer.SerializeToElement(JsonSchema.FromText(jsonSchema, s_jsonSerializerOptions), s_jsonSerializerOptions));
 
     /// <summary>Parses a JSON Schema for a parameter type.</summary>
     /// <param name="jsonSchema">The JSON Schema as a sequence of UTF16 chars.</param>
     /// <returns>A parsed <see cref="KernelJsonSchema"/>.</returns>
     /// <exception cref="JsonException">The JSON is invalid.</exception>
     public static KernelJsonSchema Parse(ReadOnlySpan<char> jsonSchema) =>
-        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(jsonSchema)));
+        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(jsonSchema, s_jsonSerializerOptions), s_jsonSerializerOptions));
 
     /// <summary>Parses a JSON Schema for a parameter type.</summary>
     /// <param name="utf8JsonSchema">The JSON Schema as a sequence of UTF8 bytes.</param>
     /// <returns>A parsed <see cref="KernelJsonSchema"/>.</returns>
     /// <exception cref="JsonException">The JSON is invalid.</exception>
     public static KernelJsonSchema Parse(ReadOnlySpan<byte> utf8JsonSchema) =>
-        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(utf8JsonSchema)));
+        new(JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonSchema>(utf8JsonSchema, s_jsonSerializerOptions), s_jsonSerializerOptions));
 
     /// <summary>Initializes a new instance from the specified <see cref="JsonElement"/>.</summary>
     /// <param name="jsonSchema">The schema to be stored.</param>


### PR DESCRIPTION
### Motivation and Context

-fixes #4991

### Description

- Sets the serialization depth to 128
- Changes can be tested on the branch linked in the issue description.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
