### PR TITLE
.Net: Improved Audio API by adding default setting values

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AudioToText/OpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AudioToText/OpenAIAudioToTextExecutionSettings.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Text;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 /// <summary>
 /// Execution settings for OpenAI audio-to-text request.
 /// </summary>
+[Experimental("SKEXP0005")]
 public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
 {
     /// <summary>
@@ -93,6 +95,14 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
     }
 
     /// <summary>
+    /// Creates an instance of <see cref="OpenAIAudioToTextExecutionSettings"/> class with default filename - "file.mp3".
+    /// </summary>
+    public OpenAIAudioToTextExecutionSettings()
+        : this(DefaultFilename)
+    {
+    }
+
+    /// <summary>
     /// Creates an instance of <see cref="OpenAIAudioToTextExecutionSettings"/> class.
     /// </summary>
     /// <param name="filename">Filename or identifier associated with audio data. Should be in format {filename}.{extension}</param>
@@ -124,7 +134,7 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
     {
         if (executionSettings is null)
         {
-            return null;
+            return new OpenAIAudioToTextExecutionSettings();
         }
 
         if (executionSettings is OpenAIAudioToTextExecutionSettings settings)
@@ -145,6 +155,8 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
     }
 
     #region private ================================================================================
+
+    private const string DefaultFilename = "file.mp3";
 
     private float _temperature = 0;
     private string _responseFormat = "json";

--- a/dotnet/src/Connectors/Connectors.OpenAI/TextToAudio/OpenAITextToAudioExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/TextToAudio/OpenAITextToAudioExecutionSettings.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Text;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 /// <summary>
 /// Execution settings for OpenAI text-to-audio request.
 /// </summary>
+[Experimental("SKEXP0005")]
 public sealed class OpenAITextToAudioExecutionSettings : PromptExecutionSettings
 {
     /// <summary>
@@ -59,6 +61,14 @@ public sealed class OpenAITextToAudioExecutionSettings : PromptExecutionSettings
     }
 
     /// <summary>
+    /// Creates an instance of <see cref="OpenAITextToAudioExecutionSettings"/> class with default voice - "alloy".
+    /// </summary>
+    public OpenAITextToAudioExecutionSettings()
+        : this(DefaultVoice)
+    {
+    }
+
+    /// <summary>
     /// Creates an instance of <see cref="OpenAITextToAudioExecutionSettings"/> class.
     /// </summary>
     /// <param name="voice">The voice to use when generating the audio. Supported voices are alloy, echo, fable, onyx, nova, and shimmer.</param>
@@ -88,7 +98,7 @@ public sealed class OpenAITextToAudioExecutionSettings : PromptExecutionSettings
     {
         if (executionSettings is null)
         {
-            return null;
+            return new OpenAITextToAudioExecutionSettings();
         }
 
         if (executionSettings is OpenAITextToAudioExecutionSettings settings)
@@ -109,6 +119,8 @@ public sealed class OpenAITextToAudioExecutionSettings : PromptExecutionSettings
     }
 
     #region private ================================================================================
+
+    private const string DefaultVoice = "alloy";
 
     private float _speed = 1.0f;
     private string _responseFormat = "mp3";

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AudioToText/AzureOpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AudioToText/AzureOpenAIAudioToTextServiceTests.cs
@@ -121,7 +121,6 @@ public sealed class AzureOpenAIAudioToTextServiceTests : IDisposable
 
     public static TheoryData<OpenAIAudioToTextExecutionSettings?, Type> ExecutionSettings => new()
     {
-        { null, typeof(ArgumentNullException) },
         { new OpenAIAudioToTextExecutionSettings(""), typeof(ArgumentException) },
         { new OpenAIAudioToTextExecutionSettings("file"), typeof(ArgumentException) }
     };

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AudioToText/OpenAIAudioToTextExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AudioToText/OpenAIAudioToTextExecutionSettingsTests.cs
@@ -13,9 +13,9 @@ namespace SemanticKernel.Connectors.UnitTests.OpenAI.AudioToText;
 public sealed class OpenAIAudioToTextExecutionSettingsTests
 {
     [Fact]
-    public void ItReturnsNullWhenSettingsAreNull()
+    public void ItReturnsDefaultSettingsWhenSettingsAreNull()
     {
-        Assert.Null(OpenAIAudioToTextExecutionSettings.FromExecutionSettings(null));
+        Assert.NotNull(OpenAIAudioToTextExecutionSettings.FromExecutionSettings(null));
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/AzureOpenAITextToAudioServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/AzureOpenAITextToAudioServiceTests.cs
@@ -124,7 +124,6 @@ public sealed class AzureOpenAITextToAudioServiceTests : IDisposable
 
     public static TheoryData<OpenAITextToAudioExecutionSettings?, Type> ExecutionSettings => new()
     {
-        { null, typeof(ArgumentNullException) },
         { new OpenAITextToAudioExecutionSettings(""), typeof(ArgumentException) },
     };
 }

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/OpenAITextToAudioExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/OpenAITextToAudioExecutionSettingsTests.cs
@@ -13,9 +13,9 @@ namespace SemanticKernel.Connectors.UnitTests.OpenAI.TextToAudio;
 public sealed class OpenAITextToAudioExecutionSettingsTests
 {
     [Fact]
-    public void ItReturnsNullWhenSettingsAreNull()
+    public void ItReturnsDefaultSettingsWhenSettingsAreNull()
     {
-        Assert.Null(OpenAITextToAudioExecutionSettings.FromExecutionSettings(null));
+        Assert.NotNull(OpenAITextToAudioExecutionSettings.FromExecutionSettings(null));
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/OpenAITextToAudioServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/OpenAITextToAudioServiceTests.cs
@@ -123,7 +123,6 @@ public sealed class OpenAITextToAudioServiceTests : IDisposable
 
     public static TheoryData<OpenAITextToAudioExecutionSettings?, Type> ExecutionSettings => new()
     {
-        { null, typeof(ArgumentNullException) },
         { new OpenAITextToAudioExecutionSettings(""), typeof(ArgumentException) },
     };
 }

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAITextToAudioTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAITextToAudioTests.cs
@@ -39,7 +39,7 @@ public sealed class OpenAITextToAudioTests : IDisposable
         var service = new OpenAITextToAudioService(openAIConfiguration.ModelId, openAIConfiguration.ApiKey);
 
         // Act
-        var result = await service.GetAudioContentAsync("The sun rises in the east and sets in the west.", new OpenAITextToAudioExecutionSettings("alloy"));
+        var result = await service.GetAudioContentAsync("The sun rises in the east and sets in the west.");
 
         // Assert
         Assert.NotNull(result?.Data);
@@ -59,7 +59,7 @@ public sealed class OpenAITextToAudioTests : IDisposable
             azureOpenAIConfiguration.ApiKey);
 
         // Act
-        var result = await service.GetAudioContentAsync("The sun rises in the east and sets in the west.", new OpenAITextToAudioExecutionSettings("alloy"));
+        var result = await service.GetAudioContentAsync("The sun rises in the east and sets in the west.");
 
         // Assert
         Assert.NotNull(result?.Data);


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Current audio interfaces have optional execution settings parameters in order to be able to use audio API through Kernel in the future, where execution settings are optional. But when using audio services directly, this is not user friendly, because when optional execution settings are not configured, services will throw an error. 

In case of text-to-audio service, required field is voice. This PR sets default value to `alloy` with the ability to overwrite.
For audio-to-text service, required field is filename. This PR sets default value to `file.mp3` with the ability to overwrite. 

With these changes execution settings are no longer required (they are optional) for text-to-audio and audio-to-text conversion.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
