### PR TITLE
.Net: adding "missing" httpclient parameter regarding issue #5065

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/OpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/OpenAIServiceCollectionExtensions.cs
@@ -706,7 +706,8 @@ public static class OpenAIServiceCollectionExtensions
         string endpoint,
         string apiKey,
         string? serviceId = null,
-        string? modelId = null)
+        string? modelId = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(deploymentName);
@@ -718,7 +719,7 @@ public static class OpenAIServiceCollectionExtensions
             OpenAIClient client = CreateAzureOpenAIClient(
                 endpoint,
                 new AzureKeyCredential(apiKey),
-                HttpClientProvider.GetHttpClient(serviceProvider));
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider));
 
             return new(deploymentName, client, modelId, serviceProvider.GetService<ILoggerFactory>());
         };
@@ -786,7 +787,8 @@ public static class OpenAIServiceCollectionExtensions
         string endpoint,
         TokenCredential credentials,
         string? serviceId = null,
-        string? modelId = null)
+        string? modelId = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(deploymentName);
@@ -798,7 +800,7 @@ public static class OpenAIServiceCollectionExtensions
             OpenAIClient client = CreateAzureOpenAIClient(
                 endpoint,
                 credentials,
-                HttpClientProvider.GetHttpClient(serviceProvider));
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider));
 
             return new(deploymentName, client, modelId, serviceProvider.GetService<ILoggerFactory>());
         };
@@ -974,7 +976,8 @@ public static class OpenAIServiceCollectionExtensions
         string modelId,
         string apiKey,
         string? orgId = null,
-        string? serviceId = null)
+        string? serviceId = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(modelId);
@@ -984,7 +987,7 @@ public static class OpenAIServiceCollectionExtensions
             new(modelId,
                 apiKey,
                 orgId,
-                HttpClientProvider.GetHttpClient(serviceProvider),
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
                 serviceProvider.GetService<ILoggerFactory>());
 
         services.AddKeyedSingleton<IChatCompletionService>(serviceId, factory);


### PR DESCRIPTION
### Motivation and Context
See https://github.com/microsoft/semantic-kernel/issues/5065

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
adds HttpClient optional parameter to make Service AzureOpenAi & OpenAI methods of the builder homogeneous to those of the kernel.

### Contribution Checklist
- [X ] The code builds clean without any errors or warnings
- [ X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ X] All unit tests pass, and I have added new tests where possible
- [ X] I didn't break anyone :smile:
