### PR TITLE
Python: Support for cases where "logprobs" does not exist（OpenAITextCompletionBase）

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
@@ -144,5 +144,5 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
     def _get_metadata_from_text_choice(self, choice: CompletionChoice) -> Dict[str, Any]:
         """Get metadata from a completion choice."""
         return {
-            "logprobs": choice.logprobs,
+            "logprobs": getattr(choice, "logprobs", None),
         }


### PR DESCRIPTION
### Motivation and Context

1. Why is this change required?

An error has occurred. This is the same issue as the following: Azure OpenAI API may not include logprobs.

The recent change only modified OpenAIChatCompletionBase. However, it turns out that this issue also occurs with OpenAITextCompletionBase. Therefore, I propose to make a similar fix.

https://github.com/microsoft/semantic-kernel/issues/4923

2. What problem does it solve?

Non-existent property lobprobs is referenced when using Azure OpenAI Text Completion.

3. What scenario does it contribute to?

When using Azure OpenAI TextCompletion

4. If it fixes an open issue, please link to the issue here.

https://github.com/microsoft/semantic-kernel/issues/5070

### Description

Azure OpenAI ChatCompletion does not return logprobs.(It seems that there are cases where it is returned, but I have not encountered that case yet.)
Thus, the following code would be "AttributeError: 'Choice' object has no attribute 'logprobs'".

`class OpenAITextCompletionBase`

```python
    def _get_metadata_from_text_choice(self, choice: CompletionChoice) -> Dict[str, Any]:
        """Get metadata from a completion choice."""
        return {
            "logprobs": choice.logprobs,
        }
```

do the following

```python
    def _get_metadata_from_text_choice(self, choice: CompletionChoice) -> Dict[str, Any]:
        """Get metadata from a completion choice."""
        return {
            "logprobs": getattr(choice, "logprobs", None),
        }
```

### Contribution Checklist

- [-] The code builds clean without any errors or warnings
- [-] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [-] All unit tests pass, and I have added new tests where possible
- [-] I didn't break anyone :smile:
