### PR TITLE
.Net: Added Stream property to AudioContent model

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/AudioContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/AudioContent.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Microsoft.SemanticKernel.Contents;
 
@@ -15,7 +16,20 @@ public class AudioContent : KernelContent
     /// <summary>
     /// The audio binary data.
     /// </summary>
+    /// <remarks>
+    /// If both <see cref="Data"/> and <see cref="Stream"/> are provided,
+    /// <see cref="Data"/> takes precedence over <see cref="Stream"/>.
+    /// </remarks>
     public BinaryData? Data { get; set; }
+
+    /// <summary>
+    /// The audio stream.
+    /// </summary>
+    /// <remarks>
+    /// If both <see cref="Data"/> and <see cref="Stream"/> are provided,
+    /// <see cref="Data"/> takes precedence over <see cref="Stream"/>.
+    /// </remarks>
+    public Stream? Stream { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AudioContent"/> class.
@@ -32,5 +46,22 @@ public class AudioContent : KernelContent
         : base(innerContent, modelId, metadata)
     {
         this.Data = data;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioContent"/> class.
+    /// </summary>
+    /// <param name="stream">The audio stream.</param>
+    /// <param name="modelId">The model ID used to generate the content.</param>
+    /// <param name="innerContent">Inner content,</param>
+    /// <param name="metadata">Additional metadata</param>
+    public AudioContent(
+        Stream stream,
+        string? modelId = null,
+        object? innerContent = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+        : base(innerContent, modelId, metadata)
+    {
+        this.Stream = stream;
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Added `Stream` property to `AudioContent` model to support not only `BinaryData` as input. This change will allow to use `Stream` for new audio connectors as more efficient way to pass big amount of data to connector.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
