### PR TITLE
.Net: Ollama connector text embedding support

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;

--- a/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
@@ -18,11 +18,8 @@ public class Example82_OllamaTextEmbeddingGeneration : BaseTest
     {
         this.WriteLine("============= Ollama Text Embedding Generation =============");
 
-        // string modelId = TestConfiguration.Ollama.ModelId;
-        // Uri? baseUri = TestConfiguration.Ollama.BaseUri;
-
-        string modelId = "llama2:7b-chat-q4_K_M";
-        Uri? baseUri = new Uri("http://100.77.129.101:11434");
+        string modelId = TestConfiguration.Ollama.ModelId;
+        Uri? baseUri = TestConfiguration.Ollama.BaseUri;
 
         if (modelId is null || baseUri is null)
         {
@@ -47,7 +44,7 @@ public class Example82_OllamaTextEmbeddingGeneration : BaseTest
 
         var embeddings = await textEmbeddingService.GenerateEmbeddingsAsync(new List<string> { prompt });
 
-        this.WriteLine(embeddings[0]);
+        this.WriteLine(string.Join(", ", embeddings[0].ToArray()));
     }
 
     public Example82_OllamaTextEmbeddingGeneration(ITestOutputHelper output) : base(output)

--- a/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.Ollama;
+using Microsoft.SemanticKernel.Embeddings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Examples;
+
+public class Example82_OllamaTextEmbeddingGeneration : BaseTest
+{
+    [Fact]
+    public Task RunAsync()
+    {
+        this.WriteLine("============= Ollama Text Embedding Generation =============");
+
+        // string modelId = TestConfiguration.Ollama.ModelId;
+        // Uri? baseUri = TestConfiguration.Ollama.BaseUri;
+
+        string modelId = "llama2:7b-chat-q4_K_M";
+        Uri? baseUri = new Uri("http://100.77.129.101:11434");
+
+        if (modelId is null || baseUri is null)
+        {
+            this.WriteLine("Ollama configuration not found. Skipping example.");
+            return Task.CompletedTask;
+        }
+
+        Kernel kernel = Kernel.CreateBuilder()
+            .AddOllamaTextEmbeddingGeneration(modelId, baseUri)
+            .Build();
+
+        return RunSampleAsync(kernel);
+    }
+
+    private async Task RunSampleAsync(Kernel kernel)
+    {
+        this.WriteLine("======== Text Embedding From Prompt ========");
+
+        const string prompt = "Describe what is GIT and why it is useful. Use simple words. Description should be long.";
+
+        var textEmbeddingService = kernel.GetRequiredService<ITextEmbeddingGenerationService>();
+
+        var embeddings = await textEmbeddingService.GenerateEmbeddingsAsync(new List<string> { prompt });
+
+        this.WriteLine(embeddings[0]);
+    }
+
+    public Example82_OllamaTextEmbeddingGeneration(ITestOutputHelper output) : base(output)
+    {
+    }
+}

--- a/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example82_OllamaTextEmbeddingGeneration.cs
@@ -38,11 +38,11 @@ public class Example82_OllamaTextEmbeddingGeneration : BaseTest
     {
         this.WriteLine("======== Text Embedding From Prompt ========");
 
-        const string prompt = "Describe what is GIT and why it is useful. Use simple words. Description should be long.";
+        const string Prompt = "Describe what is GIT and why it is useful. Use simple words. Description should be long.";
 
         var textEmbeddingService = kernel.GetRequiredService<ITextEmbeddingGenerationService>();
 
-        var embeddings = await textEmbeddingService.GenerateEmbeddingsAsync(new List<string> { prompt });
+        var embeddings = await textEmbeddingService.GenerateEmbeddingsAsync(new List<string> { Prompt });
 
         this.WriteLine(string.Join(", ", embeddings[0].ToArray()));
     }

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/IEndpointProvider.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/IEndpointProvider.cs
@@ -10,4 +10,5 @@ internal interface IEndpointProvider
     Uri StreamTextGenerationEndpoint { get; }
     Uri ChatCompletionEndpoint { get; }
     Uri StreamChatCompletionEndpoint { get; }
+    Uri EmbeddingsGenerationEndpoint { get; }
 }

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/IOllamaClient.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/IOllamaClient.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,5 +56,15 @@ internal interface IOllamaClient
     IAsyncEnumerable<StreamingChatMessageContent> StreamGenerateChatMessageAsync(
         ChatHistory chatHistory,
         PromptExecutionSettings? executionSettings = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates embedding vector for provided text asynchronously.
+    /// </summary>
+    /// <param name="text">Text string</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>Embedding vector</returns>
+    Task<ReadOnlyMemory<float>> GenerateTextEmbeddingAsync(
+        string text,
         CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/IOllamaClient.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/IOllamaClient.cs
@@ -59,12 +59,13 @@ internal interface IOllamaClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Generates embedding vector for provided text asynchronously.
+    /// Generates embedding vectors for provided prompts of text asynchronously.
     /// </summary>
-    /// <param name="text">Text string</param>
+    /// <param name="prompts">List of prompt strings.</param>
+    /// <param name="executionSettings"></param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>Embedding vector</returns>
-    Task<ReadOnlyMemory<float>> GenerateTextEmbeddingAsync(
-        string text,
+    /// <returns>List of embedding vectors</returns>
+    Task<IList<ReadOnlyMemory<float>>> GenerateTextEmbeddingAsync(IList<string> prompts,
+        PromptExecutionSettings? executionSettings = null,
         CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingRequest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Text.Json.Serialization;
 

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingRequest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Connectors.Ollama.Core;
+
+internal sealed class OllamaEmbeddingRequest
+{
+    /// <summary>
+    /// Candidate responses from the model.
+    /// </summary>
+    [JsonPropertyName("model")]
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Returns the prompt's feedback related to the content filters.
+    /// </summary>
+    [JsonPropertyName("prompt'")]
+    public string? Prompt { get; set; }
+
+    /// <summary>
+    /// Converts a <see cref="PromptExecutionSettings" /> object to a <see cref="OllamaEmbeddingRequest" /> object.
+    /// </summary>
+    /// <param name="prompt">Prompt to be used for the request.</param>
+    /// <param name="ollamaPromptExecutionSettings">Execution settings to be used for the request.</param>
+    /// <param name="connectorModelId">Model Id to be used for the request if no one is provided in the execution settings.</param>
+    /// <returns>OllamaTextRequest object.</returns>
+    public static OllamaEmbeddingRequest FromPromptAndExecutionSettings(string prompt, OllamaPromptExecutionSettings ollamaPromptExecutionSettings, string connectorModelId)
+    {
+        return new OllamaEmbeddingRequest
+        {
+            Model = ollamaPromptExecutionSettings.ModelId ?? connectorModelId,
+            Prompt = prompt
+        };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingResponse.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Text.Json.Serialization;
 

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Connectors.Ollama.Core;
+
+internal sealed class OllamaEmbeddingResponse : OllamaResponseBase
+{
+    /// <summary>
+    /// Returns the text response data from LLM.
+    /// </summary>
+    [JsonPropertyName("embedding")]
+    public float[]? Embedding { get; set; }
+}

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEmbeddingResponse.cs
@@ -4,6 +4,8 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Ollama.Core;
 
+#pragma warning disable CA1812
+
 internal sealed class OllamaEmbeddingResponse : OllamaResponseBase
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEndpointProvider.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Core/OllamaEndpointProvider.cs
@@ -16,10 +16,12 @@ internal sealed class OllamaEndpointProvider : IEndpointProvider
         this.ChatCompletionEndpoint = new Uri($"{baseUri}api/chat");
         this.StreamChatCompletionEndpoint = new Uri($"{baseUri}api/chat");
         this.StreamTextGenerationEndpoint = new Uri($"{baseUri}api/generate");
+        this.EmbeddingsGenerationEndpoint = new Uri($"{baseUri}api/embeddings");
     }
 
     public Uri TextGenerationEndpoint { get; }
     public Uri StreamTextGenerationEndpoint { get; }
     public Uri ChatCompletionEndpoint { get; }
     public Uri StreamChatCompletionEndpoint { get; }
+    public Uri EmbeddingsGenerationEndpoint { get; }
 }

--- a/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceExtensions.cs
@@ -159,11 +159,10 @@ public static class OllamaServiceExtensions
     /// <summary>
     /// Add Ollama Text Embedding Generation services to the kernel builder.
     /// </summary>
-    /// <param name="builder">The kernel builder.</param>
+    /// <param name="services">The service collection to add the Ollama Text Generation service to.</param>
     /// <param name="modelId">The model for text generation.</param>
     /// <param name="baseUri">The base uri to Ollama hosted service.</param>
-    /// <param name="serviceId">The optional service ID.</param>
-    /// <param name="httpClient">The optional custom HttpClient.</param>
+    /// <param name="serviceId">Optional service ID.</param>
     /// <returns>The updated kernel builder.</returns>
     [Experimental("SKEXP0011")]
     public static IServiceCollection AddOllamaTextEmbeddingGeneration(

--- a/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceExtensions.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.TextGeneration;
 
@@ -122,5 +123,62 @@ public static class OllamaServiceExtensions
                 loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
         return services;
+    }
+
+    /// <summary>
+    /// Add Ollama Text Embedding Generation services to the kernel builder.
+    /// </summary>
+    /// <param name="builder">The kernel builder.</param>
+    /// <param name="modelId">The model for text generation.</param>
+    /// <param name="baseUri">The base uri to Ollama hosted service.</param>
+    /// <param name="serviceId">The optional service ID.</param>
+    /// <param name="httpClient">The optional custom HttpClient.</param>
+    /// <returns>The updated kernel builder.</returns>
+    public static IKernelBuilder AddOllamaTextEmbeddingGeneration(
+        this IKernelBuilder builder,
+        string modelId,
+        Uri baseUri,
+        string? serviceId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNull(modelId);
+
+        builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
+            new OllamaTextEmbeddingGenerationService(
+                model: modelId,
+                baseUri: baseUri,
+                httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Add Ollama Text Embedding Generation services to the kernel builder.
+    /// </summary>
+    /// <param name="builder">The kernel builder.</param>
+    /// <param name="modelId">The model for text generation.</param>
+    /// <param name="baseUri">The base uri to Ollama hosted service.</param>
+    /// <param name="serviceId">The optional service ID.</param>
+    /// <param name="httpClient">The optional custom HttpClient.</param>
+    /// <returns>The updated kernel builder.</returns>
+    public static IKernelBuilder AddOllamaTextEmbeddingGeneration(
+        this IKernelBuilder builder,
+        string modelId,
+        Uri baseUri,
+        string? serviceId = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNull(modelId);
+
+        builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
+            new OllamaTextEmbeddingGenerationService(
+                model: modelId,
+                baseUri: baseUri,
+                httpClient: HttpClientProvider.GetHttpClient(serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
+
+        return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -101,7 +102,7 @@ public static class OllamaServiceExtensions
     /// <summary>
     /// Add Ollama Chat Completion and Text Generation services to the specified service collection.
     /// </summary>
-    /// <param name="services">The service collection to add the Ollma Text Generation service to.</param>
+    /// <param name="services">The service collection to add the Ollama Text Generation service to.</param>
     /// <param name="modelId">The model for text generation.</param>
     /// <param name="baseUri">The base uri to Ollama hosted service.</param>
     /// <param name="serviceId">Optional service ID.</param>
@@ -134,6 +135,7 @@ public static class OllamaServiceExtensions
     /// <param name="serviceId">The optional service ID.</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated kernel builder.</returns>
+    [Experimental("SKEXP0011")]
     public static IKernelBuilder AddOllamaTextEmbeddingGeneration(
         this IKernelBuilder builder,
         string modelId,
@@ -163,22 +165,21 @@ public static class OllamaServiceExtensions
     /// <param name="serviceId">The optional service ID.</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated kernel builder.</returns>
-    public static IKernelBuilder AddOllamaTextEmbeddingGeneration(
-        this IKernelBuilder builder,
+    [Experimental("SKEXP0011")]
+    public static IServiceCollection AddOllamaTextEmbeddingGeneration(
+        this IServiceCollection services,
         string modelId,
         Uri baseUri,
         string? serviceId = null)
     {
-        Verify.NotNull(builder);
+        Verify.NotNull(services);
         Verify.NotNull(modelId);
 
-        builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
+        return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new OllamaTextEmbeddingGenerationService(
                 model: modelId,
                 baseUri: baseUri,
                 httpClient: HttpClientProvider.GetHttpClient(serviceProvider),
                 loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
-
-        return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;

--- a/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.Ollama.Core;
+using Microsoft.SemanticKernel.Embeddings;
+using Microsoft.SemanticKernel.Http;
+using Microsoft.SemanticKernel.Services;
+
+namespace Microsoft.SemanticKernel.Connectors.Ollama;
+
+/// <summary>
+/// Represents a embedding generation service using Ollama Original API.
+/// </summary>
+public sealed class OllamaTextEmbeddingGenerationService : ITextEmbeddingGenerationService
+{
+    private Dictionary<string, object?> AttributesInternal { get; } = new();
+
+    /// <summary>
+    /// Initializes a new instance of the OllamaTextEmbeddingGenerationService class.
+    /// </summary>
+    /// <param name="model">The Ollama model for the chat completion service.</param>
+    /// <param name="baseUri">The base uri including the port where Ollama server is hosted</param>
+    /// <param name="httpClient">Optional HTTP client to be used for communication with the Ollama API.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public OllamaTextEmbeddingGenerationService(
+        string model,
+        Uri baseUri,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNullOrWhiteSpace(model);
+
+        this.Client = new OllamaClient(
+            modelId: model,
+            httpRequestFactory: new OllamaHttpRequestFactory(),
+#pragma warning disable CA2000
+            httpClient: HttpClientProvider.GetHttpClient(httpClient),
+#pragma warning restore CA2000
+            endpointProvider: new OllamaEndpointProvider(baseUri),
+            logger: loggerFactory?.CreateLogger(typeof(OllamaChatCompletionService))
+        );
+
+        this.AttributesInternal.Add(AIServiceExtensions.ModelIdKey, model);
+    }
+
+    private OllamaClient Client { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, object?> Attributes => this.AttributesInternal;
+
+    public Task<IList<ReadOnlyMemory<float>>> GenerateEmbeddingsAsync(
+        IList<string> data,
+        Kernel? kernel = null,
+        CancellationToken cancellationToken = default)
+    {
+        return this.Client.GenerateTextEmbeddingAsync(data, cancellationToken: cancellationToken);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace Microsoft.SemanticKernel.Connectors.Ollama;
 /// <summary>
 /// Represents a embedding generation service using Ollama Original API.
 /// </summary>
+[Experimental("SKEXP0011")]
 public sealed class OllamaTextEmbeddingGenerationService : ITextEmbeddingGenerationService
 {
     private Dictionary<string, object?> AttributesInternal { get; } = new();

--- a/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/TextEmbedding/OllamaTextEmbeddingGenerationService.cs
@@ -55,6 +55,7 @@ public sealed class OllamaTextEmbeddingGenerationService : ITextEmbeddingGenerat
     /// <inheritdoc />
     public IReadOnlyDictionary<string, object?> Attributes => this.AttributesInternal;
 
+    /// <inheritdoc/>
     public Task<IList<ReadOnlyMemory<float>>> GenerateEmbeddingsAsync(
         IList<string> data,
         Kernel? kernel = null,


### PR DESCRIPTION
### Motivation and Context
This PR adds Ollama text embedding support

### Description

Referenced existing implementation of OllamaTextGeneration service and OpenAITextEmbeddingGenerationService for implementation. I have also added a sample (Example82_OllamaTextEmbeddingGenerationService), Tested locally against ollama llama2:7b

- Examples may need to be re-numbered as 80, 81, 82 already exist in master
- I wasn't able to run all tests as I don't have OpenAI access

![image](https://github.com/microsoft/semantic-kernel/assets/33104478/0aba99fc-9a76-4387-87c7-d1b2ffe9cce2)

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
