### PR TITLE
Python: Remove the left over naming related to FunctionView

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/utils.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/utils.py
@@ -34,12 +34,12 @@ def _describe_tool_call(function: KernelFunction) -> Dict[str, str]:
 
     Assumes that arguments for semantic functions are optional, for native functions required.
     """
-    func_view = function.metadata
+    func_metadata = function.metadata
     return {
         "type": "function",
         "function": {
-            "name": f"{func_view.plugin_name}-{func_view.name}",
-            "description": func_view.description,
+            "name": f"{func_metadata.plugin_name}-{func_metadata.name}",
+            "description": func_metadata.description,
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -48,10 +48,10 @@ def _describe_tool_call(function: KernelFunction) -> Dict[str, str]:
                         "type": parse_param(param.type_),
                         **({"enum": param.enum} if hasattr(param, "enum") else {}),  # Added support for enum
                     }
-                    for param in func_view.parameters
+                    for param in func_metadata.parameters
                     if param.expose
                 },
-                "required": [p.name for p in func_view.parameters if p.required and p.expose],
+                "required": [p.name for p in func_metadata.parameters if p.required and p.expose],
             },
         },
     }
@@ -70,18 +70,18 @@ def _describe_function(function: KernelFunction) -> Dict[str, str]:
     """Create the object used for function_calling.
     Assumes that arguments for semantic functions are optional, for native functions required.
     """
-    func_view = function.metadata
+    func_metadata = function.metadata
     return {
-        "name": f"{func_view.plugin_name}-{func_view.name}",
-        "description": func_view.description,
+        "name": f"{func_metadata.plugin_name}-{func_metadata.name}",
+        "description": func_metadata.description,
         "parameters": {
             "type": "object",
             "properties": {
                 param.name: {"description": param.description, "type": param.type_}
-                for param in func_view.parameters
+                for param in func_metadata.parameters
                 if param.expose
             },
-            "required": [p.name for p in func_view.parameters if p.required],
+            "required": [p.name for p in func_metadata.parameters if p.required],
         },
     }
 

--- a/python/semantic_kernel/events/function_invoked_event_args.py
+++ b/python/semantic_kernel/events/function_invoked_event_args.py
@@ -21,7 +21,7 @@ class FunctionInvokedEventArgs(KernelEventArgs):
     You can then also set the repeat flag to True, to repeat the function execution, possible with updated arguments.
 
     Args:
-        kernel_function_metadata (FunctionView): The function that is being executed.
+        kernel_function_metadata (KernelFunctionMetadata): The function that is being executed.
         arguments (KernelArguments): The arguments that are being passed to the function.
         function_result (FunctionResult): The result of the function execution.
         exception (Optional: Exception): The exception that was raised during the function execution.

--- a/python/semantic_kernel/events/function_invoking_event_args.py
+++ b/python/semantic_kernel/events/function_invoking_event_args.py
@@ -14,7 +14,7 @@ class FunctionInvokingEventArgs(KernelEventArgs):
     make sure to use the update_arguments function, since that also raises the flag that the arguments were updated.
 
     Args:
-        kernel_function_metadata (FunctionView): The function that is being executed.
+        kernel_function_metadata (KernelFunctionMetadata): The function that is being executed.
         arguments (KernelArguments): The arguments that are being passed to the function.
 
     Flags:

--- a/python/semantic_kernel/events/kernel_events_args.py
+++ b/python/semantic_kernel/events/kernel_events_args.py
@@ -16,7 +16,7 @@ class KernelEventArgs(KernelBaseModel):
     make sure to use the update_arguments function, since that also raises the flag that the arguments were updated.
 
     Args:
-        kernel_function_metadata (FunctionView): The function that is being executed.
+        kernel_function_metadata (KernelFunctionMetadata): The function that is being executed.
         arguments (KernelArguments): The arguments that are being passed to the function.
 
     Flags:

--- a/python/semantic_kernel/planners/action_planner/action_planner.py
+++ b/python/semantic_kernel/planners/action_planner/action_planner.py
@@ -182,7 +182,7 @@ class ActionPlanner:
         return dedent(
             """
             [EXAMPLE]
-            - List of functions:            
+            - List of functions:
             // Get the current time.
             TimePlugin.Time
             No parameters.
@@ -256,14 +256,15 @@ class ActionPlanner:
 
     def _create_function_string(self, function: KernelFunctionMetadata) -> str:
         """
-        Takes an instance of FunctionView and returns a string that consists of
+        Takes an instance of KernelFunctionMetadata and returns a string that consists of
         function name, function description and parameters in the following format
         // <function-description>
         <plugin-name>.<function-name>
         Parameter ""<parameter-name>"": <parameter-description> (default value: `default_value`)
         ...
 
-        :param function: An instance of FunctionView for which the string representation needs to be generated
+        :param function: An instance of KernelFunctionMetadata for which the string representation
+            needs to be generated
         :return: string representation of function
         """
 

--- a/python/semantic_kernel/planners/sequential_planner/sequential_planner_extensions.py
+++ b/python/semantic_kernel/planners/sequential_planner/sequential_planner_extensions.py
@@ -16,7 +16,7 @@ from semantic_kernel.planners.sequential_planner.sequential_planner_config impor
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class SequentialPlannerFunctionViewExtension:
+class SequentialPlannerFunctionExtension:
     @staticmethod
     def to_manual_string(function: KernelFunctionMetadata):
         inputs = [
@@ -26,7 +26,7 @@ class SequentialPlannerFunctionViewExtension:
         ]
 
         inputs = "\n".join(inputs)
-        qualified_name = SequentialPlannerFunctionViewExtension.to_fully_qualified_name(function)
+        qualified_name = SequentialPlannerFunctionExtension.to_fully_qualified_name(function)
 
         return f"{qualified_name}:\n  description: {function.description}\n  inputs:\n " f" {inputs}"
 
@@ -60,7 +60,7 @@ class SequentialPlannerKernelExtension:
         else:
             functions = await config.get_available_functions(config, semantic_query)
 
-        return "\n\n".join([SequentialPlannerFunctionViewExtension.to_manual_string(func) for func in functions])
+        return "\n\n".join([SequentialPlannerFunctionExtension.to_manual_string(func) for func in functions])
 
     @staticmethod
     async def get_available_functions(
@@ -133,7 +133,7 @@ class SequentialPlannerKernelExtension:
                 (
                     func
                     for func in available_functions
-                    if SequentialPlannerFunctionViewExtension.to_fully_qualified_name(func) == memory_entry.id
+                    if SequentialPlannerFunctionExtension.to_fully_qualified_name(func) == memory_entry.id
                 ),
                 None,
             )
@@ -141,7 +141,7 @@ class SequentialPlannerKernelExtension:
                 logger.debug(
                     "Found relevant function. Relevance Score: {0}, Function: {1}".format(
                         memory_entry.relevance,
-                        SequentialPlannerFunctionViewExtension.to_fully_qualified_name(function),
+                        SequentialPlannerFunctionExtension.to_fully_qualified_name(function),
                     )
                 )
                 relevant_functions.append(function)
@@ -163,10 +163,10 @@ class SequentialPlannerKernelExtension:
             )
 
         for function in available_functions:
-            function_name = SequentialPlannerFunctionViewExtension.to_fully_qualified_name(function)
+            function_name = SequentialPlannerFunctionExtension.to_fully_qualified_name(function)
             key = function_name
             description = function.description or function_name
-            text_to_embed = SequentialPlannerFunctionViewExtension.to_embedding_string(function)
+            text_to_embed = SequentialPlannerFunctionExtension.to_embedding_string(function)
 
             # It'd be nice if there were a saveIfNotExists method on the memory interface
             memory_entry = await kernel.memory.get(

--- a/python/semantic_kernel/planners/sequential_planner/sequential_planner_parser.py
+++ b/python/semantic_kernel/planners/sequential_planner/sequential_planner_parser.py
@@ -91,8 +91,8 @@ class SequentialPlanParser:
                             function_outputs = []
                             function_results = []
 
-                            view = plugin_function.metadata
-                            for p in view.parameters:
+                            metadata = plugin_function.metadata
+                            for p in metadata.parameters:
                                 function_variables[p.name] = p.default_value
 
                             for attr in child_node.attrib:

--- a/python/tests/unit/planners/sequential_planner/test_sequential_planner_extensions.py
+++ b/python/tests/unit/planners/sequential_planner/test_sequential_planner_extensions.py
@@ -16,7 +16,7 @@ from semantic_kernel.planners.sequential_planner.sequential_planner_config impor
     SequentialPlannerConfig,
 )
 from semantic_kernel.planners.sequential_planner.sequential_planner_extensions import (
-    SequentialPlannerFunctionViewExtension,
+    SequentialPlannerFunctionExtension,
     SequentialPlannerKernelExtension,
 )
 
@@ -88,7 +88,7 @@ async def test_can_call_get_available_functions_with_functions():
 
     memory_query_result = MemoryQueryResult(
         is_reference=False,
-        id=SequentialPlannerFunctionViewExtension.to_fully_qualified_name(kernel_function_metadata),
+        id=SequentialPlannerFunctionExtension.to_fully_qualified_name(kernel_function_metadata),
         text="text",
         description="description",
         external_source_name="sourceName",
@@ -128,7 +128,7 @@ async def test_can_call_get_available_functions_with_functions():
 
 @pytest.mark.asyncio
 async def test_can_call_get_available_functions_with_functions_and_relevancy():
-    # Arrange FunctionView
+    # Arrange KernelFunctionMetadata
     functions_list = []
     kernel_function_metadata = KernelFunctionMetadata(
         name="functionName",
@@ -152,7 +152,7 @@ async def test_can_call_get_available_functions_with_functions_and_relevancy():
     # Arrange Mock Memory and Result
     memory_query_result = MemoryQueryResult(
         is_reference=False,
-        id=SequentialPlannerFunctionViewExtension.to_fully_qualified_name(kernel_function_metadata),
+        id=SequentialPlannerFunctionExtension.to_fully_qualified_name(kernel_function_metadata),
         text="text",
         description="description",
         external_source_name="sourceName",


### PR DESCRIPTION
### Motivation and Context

After closing the large feature branch (#5077) there were a few leftover names that need to be updated to remove things like "FunctionView" (replaced with KernelFunctionMetadata). 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Updates are:
- Rename a few classes, methods and docstrings to remove references to FunctionView. Closes #4628

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
