### PR TITLE
Python: test added for multiple settings in one prompt function

### DIFF
--- a/python/tests/unit/functions/test_kernel_function_from_prompt.py
+++ b/python/tests/unit/functions/test_kernel_function_from_prompt.py
@@ -266,3 +266,23 @@ async def test_invoke_defaults():
         mock.return_value = [ChatMessageContent(role="assistant", content="test", metadata={})]
         result = await function.invoke(kernel=kernel)
         assert str(result) == "test"
+
+
+def test_create_with_multiple_settings():
+    function = KernelFunctionFromPrompt(
+        function_name="test",
+        plugin_name="test",
+        prompt_template_config=PromptTemplateConfig(
+            template="test",
+            execution_settings=[
+                PromptExecutionSettings(service_id="test", temperature=0.0),
+                PromptExecutionSettings(service_id="test2", temperature=1.0),
+            ],
+        ),
+    )
+    assert (
+        function.prompt_template.prompt_template_config.execution_settings["test"].extension_data["temperature"] == 0.0
+    )
+    assert (
+        function.prompt_template.prompt_template_config.execution_settings["test2"].extension_data["temperature"] == 1.0
+    )


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
adds a test to demonstrate multiple settings for a single prompt, should be tested for yaml based functions as well, closes #4552 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
