### PR TITLE
.Net: [Agents] Abstraction for streaming

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/BaseTest.cs
+++ b/dotnet/samples/KernelSyntaxExamples/BaseTest.cs
@@ -47,6 +47,6 @@ public abstract class BaseTest
     /// <param name="target">Target object to write</param>
     protected void Write(object? target = null)
     {
-        this.Output.WriteLine(target ?? string.Empty);
+        this.Output.Write(target ?? string.Empty);
     }
 }

--- a/dotnet/src/Experimental/Agents/KernelAgent.cs
+++ b/dotnet/src/Experimental/Agents/KernelAgent.cs
@@ -42,4 +42,14 @@ public abstract class KernelAgent
     /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
     /// <returns>List of messages representing the agent's response.</returns>
     public abstract Task<IReadOnlyList<ChatMessageContent>> InvokeAsync(IReadOnlyList<ChatMessageContent> messages, PromptExecutionSettings? executionSettings = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invokes the agent to process the given messages and generate a response as a stream.
+    /// </summary>
+    /// <param name="messages">A list of the messages for the agent to process.</param>
+    /// <param name="executionSettings">The AI execution settings (optional).</param>
+    /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <returns>List of messages representing the agent's response.</returns>
+    /// <returns>Streaming list of content updates representing the agent's response.</returns>
+    public abstract IAsyncEnumerable<StreamingChatMessageContent> InvokeStreamingAsync(IReadOnlyList<ChatMessageContent> messages, PromptExecutionSettings? executionSettings = null, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
@@ -99,7 +99,7 @@ public class ChatMessageContent : KernelContent
     /// </summary>
     /// <remarks>
     /// The source is corresponds to the entity that generated this message.
-    /// The property is intended to be used by agents to associate themselves with the messages they generate.
+    /// The property is intended to be used by agents to associate themselves with the messages they generate or by a user who created it.
     /// </remarks>
     [Experimental("SKEXP0101")]
     [JsonIgnore]

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -30,6 +31,17 @@ public class StreamingChatMessageContent : StreamingKernelContent
     /// </summary>
     [JsonIgnore]
     public Encoding Encoding { get; set; }
+
+    /// <summary>
+    /// Represents the source of the message.
+    /// </summary>
+    /// <remarks>
+    /// The source is corresponds to the entity that generated this message.
+    /// The property is intended to be used by agents to associate themselves with the messages they generate or by a user who created it.
+    /// </remarks>
+    [Experimental("SKEXP0101")]
+    [JsonIgnore]
+    public object? Source { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamingChatMessageContent"/> class.


### PR DESCRIPTION
### Motivation, Context and Description
Today, the agent abstraction lacks streaming capabilities that would enable agents to stream content provided by LLM back to the calling code. This PR introduces the first step in this direction by reusing chat completion API streaming building blocks, such as StreamingChatMessageContent, StreamingKernelContent, and so on. Later, when the OpenAI Assistants API supports streaming, the abstraction will need to be revised to support streaming for both chat completion and assistant APIs.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
