### PR TITLE
Respect updates to tools made by tools within a single exchange

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -295,6 +295,12 @@ internal abstract class ClientCore
 
         for (int iteration = 1; ; iteration++)
         {
+            if (iteration > 1)
+            {
+                // Tools might import or remove plugins themselves, so we need to reflect that within the current exchange.
+                chatExecutionSettings.ToolCallBehavior?.ConfigureOptions(kernel, chatOptions);
+            }
+
             // Make the request.
             var responseData = (await RunRequestAsync(() => this.Client.GetChatCompletionsAsync(chatOptions, cancellationToken)).ConfigureAwait(false)).Value;
             this.CaptureUsageDetails(responseData.Usage);


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? _Inability to load or remove plugins within a single exchange seriously limits usability with no apparent reason._
  2. What problem does it solve? _Tools will be able to modify Kernel in the next completion, not after the next user message like today._
  3. What scenario does it contribute to? _When tools must load some plugins._
  4. If it fixes an open issue, please link to the issue here. https://github.com/microsoft/semantic-kernel/issues/4785
-->

### Description

This one liner updates the tools to be sent to completion API in every subsequent interaction within the same user message completion. This is incredibly powerful, since the AI model will be able to dynamically navigate through the plugins; the result of one plugin will make some other plugins available in the same completion series.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
