### PR TITLE
Python: Complex Type support for Method functions

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/utils.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/utils.py
@@ -47,7 +47,7 @@ def _describe_tool_call(function: KernelFunction) -> Dict[str, str]:
                     }
                     for param in func_metadata.parameters
                 },
-                "required": [p.name for p in func_metadata.parameters if p.required],
+                "required": [p.name for p in func_metadata.parameters if p.is_required],
             },
         },
     }
@@ -76,7 +76,7 @@ def _describe_function(function: KernelFunction) -> Dict[str, str]:
                 param.name: {"description": param.description, "type": param.type_}
                 for param in func_metadata.parameters
             },
-            "required": [p.name for p in func_metadata.parameters if p.required],
+            "required": [p.name for p in func_metadata.parameters if p.is_required],
         },
     }
 

--- a/python/semantic_kernel/functions/kernel_function_decorator.py
+++ b/python/semantic_kernel/functions/kernel_function_decorator.py
@@ -3,9 +3,9 @@
 
 import logging
 from inspect import Parameter, Signature, isasyncgenfunction, isgeneratorfunction, signature
-from types import NoneType
 from typing import Any, Callable, Dict, Optional
 
+NoneType = type(None)
 logger = logging.getLogger(__name__)
 
 

--- a/python/semantic_kernel/functions/kernel_function_decorator.py
+++ b/python/semantic_kernel/functions/kernel_function_decorator.py
@@ -3,7 +3,7 @@
 
 import logging
 from inspect import Parameter, Signature, isasyncgenfunction, isgeneratorfunction, signature
-from typing import Callable, Optional, Tuple
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -53,61 +53,58 @@ def kernel_function(
         func.__kernel_function_parameters__ = [
             _parse_parameter(param) for param in func_sig.parameters.values() if param.name != "self"
         ]
-
+        return_param_dict = {}
         if func_sig.return_annotation != Signature.empty:
-            return_description, return_type, return_required = _parse_annotation(func_sig.return_annotation)
-        else:
-            return_description, return_type, return_required = "", "None", False
-        func.__kernel_function_return_type__ = return_type
-        func.__kernel_function_return_description__ = return_description
-        func.__kernel_function_return_required__ = return_required
+            return_param_dict = _parse_annotation(func_sig.return_annotation)
+        func.__kernel_function_return_type__ = return_param_dict.get("type_", "None")
+        func.__kernel_function_return_description__ = return_param_dict.get("description", "")
+        func.__kernel_function_return_required__ = return_param_dict.get("is_required", False)
         return func
 
     return decorator
 
 
-def _parse_parameter(param: Parameter):
+def _parse_parameter(param: Parameter) -> Dict[str, Any]:
     logger.debug(f"Parsing param: {param}")
-    param_description = ""
-    type_ = "str"
-    required = True
+    ret = {}
     if param != Parameter.empty:
-        param_description, type_, required = _parse_annotation(param.annotation)
-    logger.debug(f"{param_description=}, {type_=}, {required=}")
-    return {
-        "name": param.name,
-        "description": param_description,
-        "default_value": param.default if param.default != Parameter.empty else None,
-        "type": type_,
-        "required": required,
-    }
+        ret = _parse_annotation(param.annotation)
+    ret["name"] = param.name
+    if param.default != Parameter.empty:
+        ret["default_value"] = param.default
+    return ret
 
 
-def _parse_annotation(annotation: Parameter) -> Tuple[str, str, bool]:
+def _parse_annotation(annotation: Parameter) -> Dict[str, Any]:
     logger.debug(f"Parsing annotation: {annotation}")
     if isinstance(annotation, str):
         return "", annotation, True
     logger.debug(f"{annotation=}")
-    description = ""
+    ret = _parse_internal_annotation(annotation, True)
     if hasattr(annotation, "__metadata__") and annotation.__metadata__:
-        description = annotation.__metadata__[0]
-    return (description, *_parse_internal_annotation(annotation, True))
+        ret["description"] = annotation.__metadata__[0]
+    return ret
 
 
-def _parse_internal_annotation(annotation: Parameter, required: bool) -> Tuple[str, bool]:
+def _parse_internal_annotation(annotation: Parameter, required: bool) -> Dict[str, Any]:
     logger.debug(f"Internal {annotation=}")
-    logger.debug(f"{annotation=}")
     if hasattr(annotation, "__forward_arg__"):
-        return annotation.__forward_arg__, required
+        return {"type_": annotation.__forward_arg__, "is_required": required}
     if getattr(annotation, "__name__", None) == "Optional":
         required = False
     if hasattr(annotation, "__args__"):
         results = [_parse_internal_annotation(arg, required) for arg in annotation.__args__]
-        str_results = [result[0] for result in results]
+        str_results = [result["type_"] for result in results]
         if "NoneType" in str_results:
             str_results.remove("NoneType")
             required = False
         else:
-            required = not (any(not result[1] for result in results))
-        return ", ".join(str_results), required
-    return getattr(annotation, "__name__", ""), required
+            required = not (any(not result["is_required"] for result in results))
+        return {"type_": ", ".join(str_results), "is_required": required}
+    # if isinstance(annotation, KernelBaseModel):
+    return {
+        "type_": getattr(annotation, "__name__", ""),
+        "type_object": annotation,
+        "is_required": required,
+    }
+    # return {"type_": getattr(annotation, "__name__", ""), "is_required": required}

--- a/python/semantic_kernel/functions/kernel_function_from_prompt.py
+++ b/python/semantic_kernel/functions/kernel_function_from_prompt.py
@@ -29,7 +29,7 @@ PROMPT_RETURN_PARAM = KernelParameterMetadata(
     description="The completion result",
     default_value=None,
     type="FunctionResult",
-    required=True,
+    is_required=True,
 )
 
 

--- a/python/semantic_kernel/functions/kernel_parameter_metadata.py
+++ b/python/semantic_kernel/functions/kernel_parameter_metadata.py
@@ -11,7 +11,8 @@ from semantic_kernel.utils.validation import FUNCTION_PARAM_NAME_REGEX
 
 class KernelParameterMetadata(KernelBaseModel):
     name: str = Field(..., pattern=FUNCTION_PARAM_NAME_REGEX)
-    description: str
-    default_value: Any
+    description: str = ""
+    default_value: Any = None
     type_: Optional[str] = Field(default="str", alias="type")
-    required: Optional[bool] = False
+    is_required: Optional[bool] = False
+    type_object: Any = None

--- a/python/semantic_kernel/planners/stepwise_planner/stepwise_planner.py
+++ b/python/semantic_kernel/planners/stepwise_planner/stepwise_planner.py
@@ -106,7 +106,9 @@ class StepwisePlanner:
             plugin_name="planners",
             description="",
             parameters=[
-                KernelParameterMetadata(name="goal", description="The goal to achieve", default_value="", required=True)
+                KernelParameterMetadata(
+                    name="goal", description="The goal to achieve", default_value="", is_required=True
+                )
             ],
             is_prompt=True,
             is_asynchronous=True,

--- a/python/semantic_kernel/prompt_template/input_variable.py
+++ b/python/semantic_kernel/prompt_template/input_variable.py
@@ -2,14 +2,12 @@
 
 from typing import Any, Optional
 
-from pydantic import Field
-
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 
 
 class InputVariable(KernelBaseModel):
-    name: str = Field(..., alias="name")
-    description: Optional[str] = Field("", alias="description")
-    default: Optional[Any] = Field("", alias="default")
-    is_required: Optional[bool] = Field(True, alias="is_required")
-    json_schema: Optional[str] = Field("", alias="json_schema")
+    name: str
+    description: Optional[str] = ""
+    default: Optional[Any] = ""
+    is_required: Optional[bool] = True
+    json_schema: Optional[str] = ""

--- a/python/semantic_kernel/prompt_template/prompt_template_config.py
+++ b/python/semantic_kernel/prompt_template/prompt_template_config.py
@@ -56,7 +56,7 @@ class PromptTemplateConfig(KernelBaseModel):
                 description=variable.description,
                 default_value=variable.default,
                 type_=variable.json_schema,  # TODO: update to handle complex JSON schemas
-                required=variable.is_required,
+                is_required=variable.is_required,
                 expose=True,
             )
             for variable in self.input_variables

--- a/python/tests/unit/functions/test_kernel_function_decorators.py
+++ b/python/tests/unit/functions/test_kernel_function_decorators.py
@@ -9,9 +9,15 @@ else:
     from typing_extensions import Annotated
 
 from semantic_kernel.functions.kernel_function_decorator import _parse_annotation, kernel_function
+from semantic_kernel.kernel_pydantic import KernelBaseModel
 
 if TYPE_CHECKING:
     from semantic_kernel.functions.kernel_arguments import KernelArguments
+
+
+class InputObject(KernelBaseModel):
+    arg1: str
+    arg2: int
 
 
 class MiscClass:
@@ -62,6 +68,30 @@ class MiscClass:
     def func_return_type_streaming(self, input: str) -> Annotated[AsyncIterable[str], "test return"]:
         yield input
 
+    @kernel_function()
+    def func_input_object(self, input: InputObject):
+        return input
+
+    @kernel_function()
+    def func_input_object_optional(self, input: Optional[InputObject] = None):
+        return input
+
+    @kernel_function()
+    def func_input_object_annotated(self, input: Annotated[InputObject, "input description"]):
+        return input
+
+    @kernel_function()
+    def func_input_object_annotated_optional(self, input: Annotated[Optional[InputObject], "input description"] = None):
+        return input
+
+    @kernel_function()
+    def func_input_object_union(self, input: Union[InputObject, str]):
+        return input
+
+    @kernel_function()
+    def func_no_typing(self, input):
+        return input
+
 
 def test_func_name_as_name():
     decorator_test = MiscClass()
@@ -97,18 +127,17 @@ def test_kernel_function_param_annotated():
     decorator_test = MiscClass()
     my_func = getattr(decorator_test, "func_input_annotated")
     assert my_func.__kernel_function_parameters__[0]["description"] == "input description"
-    assert my_func.__kernel_function_parameters__[0]["type"] == "str"
-    assert my_func.__kernel_function_parameters__[0]["required"]
-    assert my_func.__kernel_function_parameters__[0]["default_value"] is None
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "str"
+    assert my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0].get("default_value") is None
     assert my_func.__kernel_function_parameters__[0]["name"] == "input"
 
 
 def test_kernel_function_param_optional():
     decorator_test = MiscClass()
     my_func = getattr(decorator_test, "func_input_optional")
-    assert my_func.__kernel_function_parameters__[0]["description"] == ""
-    assert my_func.__kernel_function_parameters__[0]["type"] == "str"
-    assert not my_func.__kernel_function_parameters__[0]["required"]
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "str"
+    assert not my_func.__kernel_function_parameters__[0]["is_required"]
     assert my_func.__kernel_function_parameters__[0]["default_value"] == "test"
     assert my_func.__kernel_function_parameters__[0]["name"] == "input"
 
@@ -117,8 +146,8 @@ def test_kernel_function_param_annotated_optional():
     decorator_test = MiscClass()
     my_func = getattr(decorator_test, "func_input_annotated_optional")
     assert my_func.__kernel_function_parameters__[0]["description"] == "input description"
-    assert my_func.__kernel_function_parameters__[0]["type"] == "str"
-    assert not my_func.__kernel_function_parameters__[0]["required"]
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "str"
+    assert not my_func.__kernel_function_parameters__[0]["is_required"]
     assert my_func.__kernel_function_parameters__[0]["default_value"] == "test"
     assert my_func.__kernel_function_parameters__[0]["name"] == "input"
 
@@ -127,7 +156,6 @@ def test_kernel_function_return_type():
     decorator_test = MiscClass()
     my_func = getattr(decorator_test, "func_return_type")
     assert my_func.__kernel_function_return_type__ == "str"
-    assert my_func.__kernel_function_return_description__ == ""
     assert my_func.__kernel_function_return_required__
     assert not my_func.__kernel_function_streaming__
 
@@ -159,20 +187,80 @@ def test_kernel_function_return_type_streaming():
     assert my_func.__kernel_function_streaming__
 
 
+def test_kernel_function_input_object():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_object")
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "InputObject"
+    assert my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0].get("default_value") is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+    assert my_func.__kernel_function_parameters__[0]["type_object"] == InputObject
+
+
+def test_kernel_function_input_object_optional():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_object_optional")
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "InputObject"
+    assert not my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0]["default_value"] is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+    assert my_func.__kernel_function_parameters__[0]["type_object"] == InputObject
+
+
+def test_kernel_function_input_object_annotated():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_object_annotated")
+    assert my_func.__kernel_function_parameters__[0]["description"] == "input description"
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "InputObject"
+    assert my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0].get("default_value") is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+    assert my_func.__kernel_function_parameters__[0]["type_object"] == InputObject
+
+
+def test_kernel_function_input_object_annotated_optional():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_object_annotated_optional")
+    assert my_func.__kernel_function_parameters__[0]["description"] == "input description"
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "InputObject"
+    assert not my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0]["default_value"] is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+    assert my_func.__kernel_function_parameters__[0]["type_object"] == InputObject
+
+
+def test_kernel_function_input_object_union():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_input_object_union")
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "InputObject, str"
+    assert my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0].get("default_value") is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+
+
+def test_kernel_function_no_typing():
+    decorator_test = MiscClass()
+    my_func = getattr(decorator_test, "func_no_typing")
+    assert my_func.__kernel_function_parameters__[0]["type_"] == "Any"
+    assert my_func.__kernel_function_parameters__[0]["is_required"]
+    assert my_func.__kernel_function_parameters__[0].get("default_value") is None
+    assert my_func.__kernel_function_parameters__[0]["name"] == "input"
+
+
 @pytest.mark.parametrize(
-    ("annotation", "description", "type_", "required"),
+    ("annotation", "description", "type_", "is_required"),
     [
         (Annotated[str, "test"], "test", "str", True),
         (Annotated[Optional[str], "test"], "test", "str", False),
         (Annotated[AsyncIterable[str], "test"], "test", "str", True),
         (Annotated[Optional[Union[str, int]], "test"], "test", "str, int", False),
-        (str, "", "str", True),
-        (Union[str, int, float, "KernelArguments"], "", "str, int, float, KernelArguments", True),
+        (str, None, "str", True),
+        (Union[str, int, float, "KernelArguments"], None, "str, int, float, KernelArguments", True),
     ],
 )
-def test_annotation_parsing(annotation, description, type_, required):
-    out_description, out_type_, out_required = _parse_annotation(annotation)
+def test_annotation_parsing(annotation, description, type_, is_required):
+    annotations = _parse_annotation(annotation)
 
-    assert out_description == description
-    assert out_type_ == type_
-    assert out_required == required
+    assert description == annotations.get("description")
+    assert type_ == annotations["type_"]
+    assert is_required == annotations["is_required"]

--- a/python/tests/unit/functions/test_kernel_function_from_method.py
+++ b/python/tests/unit/functions/test_kernel_function_from_method.py
@@ -55,7 +55,7 @@ def test_init_native_function_without_input_description():
             "name": "arguments",
             "description": "Param 1 description",
             "default_value": "default_param1_value",
-            "required": True,
+            "is_required": True,
         }
     ]
 

--- a/python/tests/unit/functions/test_kernel_function_from_method.py
+++ b/python/tests/unit/functions/test_kernel_function_from_method.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 import sys
-from typing import AsyncIterable, Iterable, Optional
+from typing import AsyncIterable, Iterable, Optional, Union
 
 from semantic_kernel.exceptions.function_exceptions import FunctionExecutionException
+from semantic_kernel.kernel_pydantic import KernelBaseModel
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -33,12 +34,12 @@ def test_init_native_function_with_input_description():
     assert native_function.parameters[0].description == "input"
     assert not native_function.parameters[0].default_value
     assert native_function.parameters[0].type_ == "str"
-    assert native_function.parameters[0].required is True
+    assert native_function.parameters[0].is_required is True
     assert native_function.parameters[1].name == "arguments"
     assert native_function.parameters[1].description == ""
     assert not native_function.parameters[1].default_value
     assert native_function.parameters[1].type_ == "KernelArguments"
-    assert native_function.parameters[1].required is True
+    assert native_function.parameters[1].is_required is True
 
 
 def test_init_native_function_without_input_description():
@@ -67,7 +68,7 @@ def test_init_native_function_without_input_description():
     assert native_function.parameters[0].description == "Param 1 description"
     assert native_function.parameters[0].default_value == "default_param1_value"
     assert native_function.parameters[0].type_ == "str"
-    assert native_function.parameters[0].required is True
+    assert native_function.parameters[0].is_required is True
 
 
 def test_init_native_function_from_kernel_function_decorator():
@@ -89,7 +90,7 @@ def test_init_native_function_from_kernel_function_decorator():
     assert native_function.parameters[0].description == "Test input description"
     assert native_function.parameters[0].default_value == "test_default_value"
     assert native_function.parameters[0].type_ == "str"
-    assert native_function.parameters[0].required is False
+    assert native_function.parameters[0].is_required is False
 
 
 def test_init_native_function_from_kernel_function_decorator_defaults():
@@ -227,3 +228,88 @@ async def test_required_param_not_supplied():
 
     result = await func.invoke(kernel=None, arguments=KernelArguments())
     assert isinstance(result.metadata["error"], FunctionExecutionException)
+
+
+@pytest.mark.asyncio
+async def test_service_execution_with_complex_object():
+    kernel = Kernel()
+
+    class InputObject(KernelBaseModel):
+        arg1: str
+        arg2: int
+
+    @kernel_function(name="function")
+    def my_function(input_obj: InputObject) -> str:
+        assert input_obj is not None
+        assert isinstance(input_obj, InputObject)
+        assert input_obj.arg1 == "test"
+        assert input_obj.arg2 == 5
+        return f"{input_obj.arg1} {input_obj.arg2}"
+
+    func = KernelFunction.from_method(my_function, "test")
+
+    arguments = KernelArguments(input_obj=InputObject(arg1="test", arg2=5))
+    result = await func.invoke(kernel, arguments)
+    assert result.value == "test 5"
+
+
+class InputObject(KernelBaseModel):
+    arg1: str
+    arg2: int
+
+
+@pytest.mark.asyncio
+async def test_service_execution_with_complex_object_from_str():
+    kernel = Kernel()
+
+    @kernel_function(name="function")
+    def my_function(input_obj: InputObject) -> str:
+        assert input_obj is not None
+        assert isinstance(input_obj, InputObject)
+        assert input_obj.arg1 == "test"
+        assert input_obj.arg2 == 5
+        return f"{input_obj.arg1} {input_obj.arg2}"
+
+    func = KernelFunction.from_method(my_function, "test")
+
+    arguments = KernelArguments(input_obj={"arg1": "test", "arg2": 5})
+    result = await func.invoke(kernel, arguments)
+    assert result.value == "test 5"
+
+
+@pytest.mark.asyncio
+async def test_service_execution_with_complex_object_from_str_mixed():
+    kernel = Kernel()
+
+    @kernel_function(name="function")
+    def my_function(input_obj: InputObject, input_str: str) -> str:
+        assert input_obj is not None
+        assert isinstance(input_obj, InputObject)
+        assert input_obj.arg1 == "test"
+        assert input_obj.arg2 == 5
+        return f"{input_obj.arg1} {input_str} {input_obj.arg2}"
+
+    func = KernelFunction.from_method(my_function, "test")
+
+    arguments = KernelArguments(input_obj={"arg1": "test", "arg2": 5}, input_str="test2")
+    result = await func.invoke(kernel, arguments)
+    assert result.value == "test test2 5"
+
+
+@pytest.mark.asyncio
+async def test_service_execution_with_complex_object_from_str_mixed_multi():
+    kernel = Kernel()
+
+    @kernel_function(name="function")
+    def my_function(input_obj: InputObject, input_str: Union[str, int]) -> str:
+        assert input_obj is not None
+        assert isinstance(input_obj, InputObject)
+        assert input_obj.arg1 == "test"
+        assert input_obj.arg2 == 5
+        return f"{input_obj.arg1} {input_str} {input_obj.arg2}"
+
+    func = KernelFunction.from_method(my_function, "test")
+
+    arguments = KernelArguments(input_obj={"arg1": "test", "arg2": 5}, input_str="test2")
+    result = await func.invoke(kernel, arguments)
+    assert result.value == "test test2 5"

--- a/python/tests/unit/functions/test_kernel_parameter_metadata.py
+++ b/python/tests/unit/functions/test_kernel_parameter_metadata.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.functions.kernel_parameter_metadata import KernelParameterMetadata
+
+
+def test_kernel_parameter_metadata_init():
+    metadata = KernelParameterMetadata(
+        name="test",
+        description="description",
+        is_required=True,
+        type="str",
+        default_value="default",
+    )
+
+    assert metadata.name == "test"
+    assert metadata.description == "description"
+    assert metadata.is_required is True
+    assert metadata.default_value == "default"

--- a/python/tests/unit/prompt_template/test_prompt_templates.py
+++ b/python/tests/unit/prompt_template/test_prompt_templates.py
@@ -69,7 +69,7 @@ def test_get_kernel_parameter_metadata_with_variables():
     assert metadata[0].description == "A variable"
     assert metadata[0].default_value == "default_val"
     assert metadata[0].type_ == "string"
-    assert metadata[0].required is True
+    assert metadata[0].is_required is True
 
 
 def test_restore():

--- a/python/tests/unit/test_serialization.py
+++ b/python/tests/unit/test_serialization.py
@@ -89,7 +89,7 @@ def kernel_factory() -> t.Callable[[t.Type[_Serializable]], _Serializable]:
             description="bar",
             default_value="baz",
             type="string",
-            required=True,
+            is_required=True,
         ),
         KernelFunctionMetadata: KernelFunctionMetadata(
             name="foo",


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Added support for complex types (classes) for KernelFunctionFromMethod.

Implements #4635 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
This PR adds a field to the KernelParameterMetadata class for type_object
When that field is filled and supplied by a KernelFunctionFromMethod decorator, it is used during invoke to cast the type.
It checks if it is a pydantic type and calls `model_validate_json` in that case, otherwise invokes it directly as a init (like with a str), this then also casts strs to ints for example.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
