### PR TITLE
Python: updated telemetry key names

### DIFF
--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,7 +1,11 @@
+from semantic_kernel.connectors import telemetry
+
+
 [run]
 source = semantic_kernel
 omit = 
     semantic_kernel/connectors/memory/*
+    semantic_kernel/connectors/telemetry.py
     semantic_kernel/utils/settings.py
     semantic_kernel/utils/null_logger.py
     semantic_kernel/utils/logging.py

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import os
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 TELEMETRY_DISABLED_ENV_VAR = "AZURE_TELEMETRY_DISABLED"
 
@@ -9,11 +9,15 @@ IS_TELEMETRY_ENABLED = os.environ.get(TELEMETRY_DISABLED_ENV_VAR, "false").lower
 
 HTTP_USER_AGENT = "Semantic-Kernel"
 
+try:
+    version_info = version("semantic-kernel")
+except PackageNotFoundError:
+    version_info = "dev"
+
 APP_INFO = (
     {
-        "name": HTTP_USER_AGENT,
-        "version": version("semantic-kernel"),
-        "url": "",
+        "UserAgent": HTTP_USER_AGENT,
+        "Semantic-Kernel-Version": f"python-{version_info}",
     }
     if IS_TELEMETRY_ENABLED
     else None


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Updates the name of the app info key to Semantic-Kernel-Version to match dotnet, closes #5038 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
