### PR TITLE
Python: Add function name and plugin name to invoke prompt. Add unit tests.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
   "[csharp]": {
     "editor.defaultFormatter": "ms-dotnettools.csharp",
     "editor.codeActionsOnSave": {
-      "source.fixAll": true
+      "source.fixAll": "explicit"
     }
   },
   "editor.bracketPairColorization.enabled": true,
@@ -31,15 +31,15 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true,
-      "source.fixAll": true
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
     }
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true,
-      "source.fixAll": true
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
     }
   },
   "typescript.updateImportsOnFileMove.enabled": "always",
@@ -78,7 +78,7 @@
     "editor.formatOnSave": false,
     "editor.tabSize": 4,
     "editor.codeActionsOnSave": {
-      "source.fixAll": false
+      "source.fixAll": "never"
     },
   },
   "emeraldwalk.runonsave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
   "[csharp]": {
     "editor.defaultFormatter": "ms-dotnettools.csharp",
     "editor.codeActionsOnSave": {
-      "source.fixAll": "explicit"
+      "source.fixAll": true
     }
   },
   "editor.bracketPairColorization.enabled": true,
@@ -31,15 +31,15 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit",
-      "source.fixAll": "explicit"
+      "source.organizeImports": true,
+      "source.fixAll": true
     }
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit",
-      "source.fixAll": "explicit"
+      "source.organizeImports": true,
+      "source.fixAll": true
     }
   },
   "typescript.updateImportsOnFileMove.enabled": "always",
@@ -78,7 +78,7 @@
     "editor.formatOnSave": false,
     "editor.tabSize": 4,
     "editor.codeActionsOnSave": {
-      "source.fixAll": "never"
+      "source.fixAll": false
     },
   },
   "emeraldwalk.runonsave": {

--- a/python/samples/kernel-syntax-examples/rag_with_text_memory_plugin.py
+++ b/python/samples/kernel-syntax-examples/rag_with_text_memory_plugin.py
@@ -24,7 +24,11 @@ async def main():
 
     await memory.save_information(collection="generic", id="info1", text="My budget for 2024 is $100,000")
 
-    result = await kernel.invoke_prompt("{{recall 'budget by year'}} What is my budget for 2024?")
+    result = await kernel.invoke_prompt(
+        function_name="budget",
+        plugin_name="BudgetPlugin",
+        prompt="{{recall 'budget by year'}} What is my budget for 2024?",
+    )
     print(result)
 
 

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -349,6 +349,8 @@ class Kernel(KernelBaseModel):
 
     async def invoke_prompt(
         self,
+        function_name: str,
+        plugin_name: str,
         prompt: str,
         arguments: Optional[KernelArguments] = None,
         template_format: Optional[str] = None,
@@ -358,6 +360,8 @@ class Kernel(KernelBaseModel):
         Invoke a function from the provided prompt
 
         Args:
+            function_name (str): The name of the function
+            plugin_name (str): The name of the plugin
             prompt (str): The prompt to use
             arguments (Optional[KernelArguments]): The arguments to pass to the function(s), optional
             template_format (Optional[str]): The format of the prompt template
@@ -371,6 +375,8 @@ class Kernel(KernelBaseModel):
         if not prompt:
             raise TemplateSyntaxError("The prompt is either null or empty.")
         function = KernelFunction.from_prompt(
+            function_name=function_name,
+            plugin_name=plugin_name,
             prompt=prompt,
             template_format=template_format,
         )
@@ -607,8 +613,8 @@ class Kernel(KernelBaseModel):
         Create a Kernel Function from a prompt.
 
         Args:
-            function_name (Optional[str]): The name of the function
-            plugin_name (Optional[str]): The name of the plugin
+            function_name (str): The name of the function
+            plugin_name (str): The name of the plugin
             description (Optional[str]): The description of the function
             prompt (Optional[str]): The prompt template.
             prompt_template_config (Optional[PromptTemplateConfig]): The prompt template configuration

--- a/python/tests/unit/kernel/test_prompt_create_methods.py
+++ b/python/tests/unit/kernel/test_prompt_create_methods.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from semantic_kernel import Kernel
+from semantic_kernel.exceptions.template_engine_exceptions import TemplateSyntaxError
+from semantic_kernel.functions.function_result import FunctionResult
+from semantic_kernel.functions.kernel_function import KernelFunction
+from semantic_kernel.functions.kernel_function_metadata import KernelFunctionMetadata
+
+
+def create_mock_function(name) -> KernelFunction:
+    kernel_function_metadata = KernelFunctionMetadata(
+        name=name,
+        plugin_name="TestPlugin",
+        description="Test",
+        parameters=[],
+        is_prompt=True,
+        is_asynchronous=True,
+    )
+    mock_function = Mock(spec=KernelFunction)
+    mock_function.metadata = kernel_function_metadata
+    mock_function.name = kernel_function_metadata.name
+    mock_function.plugin_name = kernel_function_metadata.plugin_name
+    mock_function.description = kernel_function_metadata.description
+
+    return mock_function
+
+
+@pytest.mark.asyncio
+async def test_invoke_prompt_success():
+    mock_function = create_mock_function("test_function")
+    with patch(
+        "semantic_kernel.kernel.KernelFunction.from_prompt", return_value=MagicMock()
+    ) as mock_from_prompt, patch(
+        "semantic_kernel.kernel.Kernel.invoke",
+        return_value=FunctionResult(function=mock_function.metadata, value="test", metadata={}),
+    ) as mock_invoke:
+        kernel = Kernel()
+        result = await kernel.invoke_prompt(
+            function_name="test_function",
+            plugin_name="test_plugin",
+            prompt="test_prompt",
+            template_format="test_format",
+            arg1="val1",
+        )
+        mock_from_prompt.assert_called_once_with(
+            function_name="test_function",
+            plugin_name="test_plugin",
+            prompt="test_prompt",
+            template_format="test_format",
+        )
+        assert mock_invoke.called
+        assert isinstance(result, FunctionResult)
+
+
+@pytest.mark.asyncio
+async def test_invoke_prompt_no_prompt_error():
+    kernel = Kernel()
+    with pytest.raises(TemplateSyntaxError):
+        await kernel.invoke_prompt(
+            function_name="test_function",
+            plugin_name="test_plugin",
+            prompt="",
+        )


### PR DESCRIPTION
### Motivation and Context

The kernel.invoke_prompt was missing the function name and plugin name args and was failing.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR:
- Adds the required arguments. Closes #5313 
- Adds unit tests. 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
