### PR TITLE
.Net: Fix OpenAI connector compatibility

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -922,17 +922,17 @@ internal abstract class ClientCore
                 return new ChatRequestToolMessage(message.Content, toolIdString);
             }
 
-            if (message.Items is { Count: > 0 })
+            if (message.Items is { Count: 1 } && message.Items.FirstOrDefault() is TextContent textContent)
             {
-                return new ChatRequestUserMessage(message.Items.Select(static (KernelContent item) => (ChatMessageContentItem)(item switch
-                {
-                    TextContent textContent => new ChatMessageTextContentItem(textContent.Text),
-                    ImageContent imageContent => new ChatMessageImageContentItem(imageContent.Uri),
-                    _ => throw new NotSupportedException($"Unsupported chat message content type '{item.GetType()}'.")
-                })));
+                return new ChatRequestUserMessage(textContent.Text);
             }
 
-            return new ChatRequestUserMessage(message.Content);
+            return new ChatRequestUserMessage(message.Items.Select(static (KernelContent item) => (ChatMessageContentItem)(item switch
+            {
+                TextContent textContent => new ChatMessageTextContentItem(textContent.Text),
+                ImageContent imageContent => new ChatMessageImageContentItem(imageContent.Uri),
+                _ => throw new NotSupportedException($"Unsupported chat message content type '{item.GetType()}'.")
+            })));
         }
 
         if (message.Role == AuthorRole.Assistant)

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/AzureOpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/AzureOpenAIChatCompletionServiceTests.cs
@@ -166,6 +166,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("User Message");
+        chatHistory.AddUserMessage(new ChatMessageContentItemCollection { new ImageContent(new Uri("https://image")), new TextContent("User Message") });
         chatHistory.AddSystemMessage("System Message");
         chatHistory.AddAssistantMessage("Assistant Message");
 
@@ -187,15 +188,20 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var messages = content.GetProperty("messages");
 
         var userMessage = messages[0];
-        var systemMessage = messages[1];
-        var assistantMessage = messages[2];
+        var userMessageCollection = messages[1];
+        var systemMessage = messages[2];
+        var assistantMessage = messages[3];
 
         Assert.Equal("user", userMessage.GetProperty("role").GetString());
+        Assert.Equal("User Message", userMessage.GetProperty("content").GetString());
 
-        var contentItems = userMessage.GetProperty("content");
-        Assert.Equal(1, contentItems.GetArrayLength());
-        Assert.Equal("User Message", contentItems[0].GetProperty("text").GetString());
-        Assert.Equal("text", contentItems[0].GetProperty("type").GetString());
+        Assert.Equal("user", userMessageCollection.GetProperty("role").GetString());
+        var contentItems = userMessageCollection.GetProperty("content");
+        Assert.Equal(2, contentItems.GetArrayLength());
+        Assert.Equal("https://image/", contentItems[0].GetProperty("image_url").GetProperty("url").GetString());
+        Assert.Equal("image_url", contentItems[0].GetProperty("type").GetString());
+        Assert.Equal("User Message", contentItems[1].GetProperty("text").GetString());
+        Assert.Equal("text", contentItems[1].GetProperty("type").GetString());
 
         Assert.Equal("system", systemMessage.GetProperty("role").GetString());
         Assert.Equal("System Message", systemMessage.GetProperty("content").GetString());
@@ -603,12 +609,8 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         Assert.Equal("This is test system message", messages[0].GetProperty("content").GetString());
         Assert.Equal("system", messages[0].GetProperty("role").GetString());
 
+        Assert.Equal("This is test prompt", messages[1].GetProperty("content").GetString());
         Assert.Equal("user", messages[1].GetProperty("role").GetString());
-
-        var contentItems = messages[1].GetProperty("content");
-        Assert.Equal(1, contentItems.GetArrayLength());
-        Assert.Equal("This is test prompt", contentItems[0].GetProperty("text").GetString());
-        Assert.Equal("text", contentItems[0].GetProperty("type").GetString());
     }
 
     public void Dispose()

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/OpenAIChatCompletionServiceTests.cs
@@ -263,12 +263,8 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
         Assert.Equal("Assistant is a large language model.", messages[0].GetProperty("content").GetString());
         Assert.Equal("system", messages[0].GetProperty("role").GetString());
 
+        Assert.Equal("Hello", messages[1].GetProperty("content").GetString());
         Assert.Equal("user", messages[1].GetProperty("role").GetString());
-        var contentItems = messages[1].GetProperty("content");
-
-        Assert.Equal(1, contentItems.GetArrayLength());
-        Assert.Equal("Hello", contentItems[0].GetProperty("text").GetString());
-        Assert.Equal("text", contentItems[0].GetProperty("type").GetString());
     }
 
     public void Dispose()


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Fix #5337

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Improved openai connector compatibility. 
Serialize user messages to strings when they are single text. 
Serialize user messages to array when user message is a collection.
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
