### PR TITLE
Python: Fix create func from prompt missing args

### DIFF
--- a/python/notebooks/third_party/weaviate-persistent-memory.ipynb
+++ b/python/notebooks/third_party/weaviate-persistent-memory.ipynb
@@ -340,7 +340,11 @@
     "        },\n",
     "    )\n",
     "\n",
-    "    chat_func = kernel.create_function_from_prompt(prompt_template_config=prompt_template_config)\n",
+    "    chat_func = kernel.create_function_from_prompt(\n",
+    "        function_name=\"chat_with_memory\",\n",
+    "        plugin_name=\"TextMemoryPlugin\",\n",
+    "        prompt_template_config=prompt_template_config,\n",
+    "    )\n",
     "\n",
     "    return chat_func"
    ]

--- a/python/samples/kernel-syntax-examples/bing_plugin_examples.py
+++ b/python/samples/kernel-syntax-examples/bing_plugin_examples.py
@@ -64,6 +64,8 @@ async def example2(kernel: sk.Kernel, service_id: str):
     print(question)
 
     oracle = kernel.create_function_from_prompt(
+        function_name="oracle",
+        plugin_name="OraclePlugin",
         template=prompt,
         execution_settings=sk_oai.OpenAIChatPromptExecutionSettings(
             service_id=service_id, max_tokens=150, temperature=0, top_p=1

--- a/python/samples/kernel-syntax-examples/bing_search_plugin.py
+++ b/python/samples/kernel-syntax-examples/bing_search_plugin.py
@@ -57,7 +57,11 @@ async def main():
     )
 
     question = "What is Semantic Kernel?"
-    qna = kernel.create_function_from_prompt(prompt_template_config=prompt_template_config)
+    qna = kernel.create_function_from_prompt(
+        function_name="qna",
+        plugin_name="WebSearch",
+        prompt_template_config=prompt_template_config,
+    )
     result = await qna.invoke(kernel, question=question, num_results=10, offset=0)
 
     print(f"Question: {question}\n")

--- a/python/samples/kernel-syntax-examples/google_palm_chat_with_memory.py
+++ b/python/samples/kernel-syntax-examples/google_palm_chat_with_memory.py
@@ -51,7 +51,11 @@ async def setup_chat_with_memory(
         },
     )
 
-    chat_func = kernel.create_function_from_prompt(prompt_template_config=prompt_template_config)
+    chat_func = kernel.create_function_from_prompt(
+        function_name="chat_with_memory",
+        plugin_name="TextMemoryPlugin",
+        prompt_template_config=prompt_template_config,
+    )
 
     return chat_func
 

--- a/python/samples/kernel-syntax-examples/memory.py
+++ b/python/samples/kernel-syntax-examples/memory.py
@@ -51,7 +51,11 @@ async def setup_chat_with_memory(
         },
     )
 
-    chat_func = kernel.create_function_from_prompt(prompt_template_config=prompt_template_config)
+    chat_func = kernel.create_function_from_prompt(
+        function_name="chat_with_memory",
+        plugin_name="TextMemoryPlugin",
+        prompt_template_config=prompt_template_config,
+    )
 
     return chat_func
 

--- a/python/samples/kernel-syntax-examples/self-critique_rag.py
+++ b/python/samples/kernel-syntax-examples/self-critique_rag.py
@@ -97,8 +97,8 @@ Remember, just answer Grounded or Ungrounded or Unclear: """.strip()
     user_input = "Do I live in Seattle?"
     print(f"Question: {user_input}")
     req_settings = kernel.get_service("dv").get_prompt_execution_settings_class()(service_id="dv")
-    chat_func = kernel.create_function_from_prompt(sk_prompt_rag, prompt_execution_settings=req_settings)
-    self_critique_func = kernel.create_function_from_prompt(sk_prompt_rag_sc, prompt_execution_settings=req_settings)
+    chat_func = kernel.create_function_from_prompt(function_name="rag", plugin_name="RagPlugin",prompt=sk_prompt_rag, prompt_execution_settings=req_settings)
+    self_critique_func = kernel.create_function_from_prompt(function_name="self_critique_rag", plugin_name="RagPlugin",prompt=sk_prompt_rag_sc, prompt_execution_settings=req_settings)
 
     chat_history = ChatHistory()
     chat_history.add_user_message(user_input)

--- a/python/samples/kernel-syntax-examples/self-critique_rag.py
+++ b/python/samples/kernel-syntax-examples/self-critique_rag.py
@@ -97,8 +97,15 @@ Remember, just answer Grounded or Ungrounded or Unclear: """.strip()
     user_input = "Do I live in Seattle?"
     print(f"Question: {user_input}")
     req_settings = kernel.get_service("dv").get_prompt_execution_settings_class()(service_id="dv")
-    chat_func = kernel.create_function_from_prompt(function_name="rag", plugin_name="RagPlugin",prompt=sk_prompt_rag, prompt_execution_settings=req_settings)
-    self_critique_func = kernel.create_function_from_prompt(function_name="self_critique_rag", plugin_name="RagPlugin",prompt=sk_prompt_rag_sc, prompt_execution_settings=req_settings)
+    chat_func = kernel.create_function_from_prompt(
+        function_name="rag", plugin_name="RagPlugin", prompt=sk_prompt_rag, prompt_execution_settings=req_settings
+    )
+    self_critique_func = kernel.create_function_from_prompt(
+        function_name="self_critique_rag",
+        plugin_name="RagPlugin",
+        prompt=sk_prompt_rag_sc,
+        prompt_execution_settings=req_settings,
+    )
 
     chat_history = ChatHistory()
     chat_history.add_user_message(user_input)

--- a/python/samples/kernel-syntax-examples/template_language.py
+++ b/python/samples/kernel-syntax-examples/template_language.py
@@ -41,6 +41,8 @@ async def main():
     print(rendered_prompt)
 
     kind_of_day = kernel.create_function_from_prompt(
+        function_name="kind_of_day",
+        plugin_name="TimePlugin",
         template=function_definition,
         execution_settings=sk_oai.OpenAIChatPromptExecutionSettings(service_id=service_id, max_tokens=100),
         function_name="kind_of_day",

--- a/python/samples/kernel-syntax-examples/template_language.py
+++ b/python/samples/kernel-syntax-examples/template_language.py
@@ -41,7 +41,6 @@ async def main():
     print(rendered_prompt)
 
     kind_of_day = kernel.create_function_from_prompt(
-        function_name="kind_of_day",
         plugin_name="TimePlugin",
         template=function_definition,
         execution_settings=sk_oai.OpenAIChatPromptExecutionSettings(service_id=service_id, max_tokens=100),


### PR DESCRIPTION
### Motivation and Context

There were missing function_name and plugin_name args from the create function from prompt method in several kernel examples.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adding in the missing parameters.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
