### PR TITLE
.Net Gemini enable SSE

### DIFF
--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/GoogleAI/GoogleAIEndpointProvider.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/GoogleAI/GoogleAIEndpointProvider.cs
@@ -36,7 +36,7 @@ internal sealed class GoogleAIEndpointProvider : IEndpointProvider
 
     /// <inheritdoc />
     public Uri GetGeminiStreamTextGenerationEndpoint(string modelId)
-        => new($"{ModelsEndpoint.AbsoluteUri}{modelId}:streamGenerateContent?key={this._apiKey}");
+        => new($"{ModelsEndpoint.AbsoluteUri}{modelId}:streamGenerateContent?key={this._apiKey}&alt=sse");
 
     /// <inheritdoc />
     public Uri GetGeminiChatCompletionEndpoint(string modelId)

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/VertexAI/VertexAIEndpointProvider.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/VertexAI/VertexAIEndpointProvider.cs
@@ -36,7 +36,7 @@ internal sealed class VertexAIEndpointProvider : IEndpointProvider
 
     /// <inheritdoc />
     public Uri GetGeminiStreamTextGenerationEndpoint(string modelId)
-        => new($"{this.ModelsEndpoint.AbsoluteUri}{modelId}:streamGenerateContent");
+        => new($"{this.ModelsEndpoint.AbsoluteUri}{modelId}:streamGenerateContent?alt=sse");
 
     /// <inheritdoc />
     public Uri GetGeminiChatCompletionEndpoint(string modelId)


### PR DESCRIPTION
The stream text generation endpoint in GoogleAIEndpointProvider and VertexAIEndpointProvider has been updated. The stream generation URL now includes the additional parameter 'alt=sse'. This ensures correct data formatting for Server-Sent Events.

@RogerBarreto 
#4680 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
