### PR TITLE
Python: add missing init from prompt_template folder

### DIFF
--- a/python/semantic_kernel/prompt_template/__init__.py
+++ b/python/semantic_kernel/prompt_template/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.prompt_template.input_variable import InputVariable
+from semantic_kernel.prompt_template.kernel_prompt_template import KernelPromptTemplate
+from semantic_kernel.prompt_template.prompt_template_config import PromptTemplateConfig
+
+__all__ = [
+    "KernelPromptTemplate",
+    "InputVariable",
+    "PromptTemplateConfig",
+]


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
adds a __init__ file to the prompt_template folder which exposes the most important classes from the files.

fixes #5172 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
