### PR TITLE
.Net: Downgrading version of JsonSchema.Net.Generation package to resolve dependency conflict

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Handlebars.Net.Helpers" Version="2.4.1.4" />
     <PackageVersion Include="Markdig" Version="0.34.0" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.4" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="4.1.1" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="3.5.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="11.3.5" />


### PR DESCRIPTION
Downgrading version of JsonSchema.Net.Generation package to resolve dependency conflict with dotnet-interactive.

### Motivation and Context

We recently upgraded the version of JsonSchema.Net.Generation from major version 3 to 4 and this has caused a collision with dotnet-interactive which ships with JsonSchema.Net version 5.0.0. The PR drops the major version back down to resolve this dependency collision.

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
