### PR TITLE
.Net: Gemini - Async stream parser, read-only tool attempts and minor fixes

### DIFF
--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatGenerationFunctionCallingTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatGenerationFunctionCallingTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -277,8 +278,13 @@ public sealed class GeminiChatGenerationFunctionCallingTests : IDisposable
         {
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
         };
-        executionSettings.ToolCallBehavior.MaximumUseAttempts = 100;
-        executionSettings.ToolCallBehavior.MaximumAutoInvokeAttempts = 10;
+        // used reflection to simplify the test
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumUseAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 100);
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumAutoInvokeAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 10);
 
         // Act
         await client.GenerateChatMessageAsync(chatHistory, executionSettings: executionSettings, kernel: this._kernelWithFunctions);
@@ -313,8 +319,13 @@ public sealed class GeminiChatGenerationFunctionCallingTests : IDisposable
         {
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
         };
-        executionSettings.ToolCallBehavior.MaximumUseAttempts = 1;
-        executionSettings.ToolCallBehavior.MaximumAutoInvokeAttempts = 1;
+        // used reflection to simplify the test
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumUseAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 1);
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumAutoInvokeAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 1);
 
         // Act
         await client.GenerateChatMessageAsync(chatHistory, executionSettings: executionSettings, kernel: this._kernelWithFunctions);
@@ -342,8 +353,13 @@ public sealed class GeminiChatGenerationFunctionCallingTests : IDisposable
         {
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
         };
-        executionSettings.ToolCallBehavior.MaximumUseAttempts = 100;
-        executionSettings.ToolCallBehavior.MaximumAutoInvokeAttempts = 1;
+        // used reflection to simplify the test
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumUseAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 100);
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumAutoInvokeAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 1);
 
         // Act
         var messages =

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
@@ -435,7 +435,7 @@ public sealed class GeminiChatGenerationTests : IDisposable
             return new GeminiChatCompletionClient(
                 httpClient: httpClient ?? this._httpClient,
                 modelId: modelId,
-                bearerKeyProvider: () => bearerKey,
+                bearerTokenProvider: () => Task.FromResult(bearerKey),
                 location: "fake-location",
                 projectId: "fake-project-id");
         }

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatStreamingFunctionCallingTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatStreamingFunctionCallingTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -286,8 +287,13 @@ public sealed class GeminiChatStreamingFunctionCallingTests : IDisposable
         {
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
         };
-        executionSettings.ToolCallBehavior.MaximumUseAttempts = 100;
-        executionSettings.ToolCallBehavior.MaximumAutoInvokeAttempts = 10;
+        // used reflection to simplify the test
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumUseAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 100);
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumAutoInvokeAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 10);
 
         // Act
         await client.StreamGenerateChatMessageAsync(chatHistory, executionSettings: executionSettings, kernel: this._kernelWithFunctions)
@@ -323,8 +329,13 @@ public sealed class GeminiChatStreamingFunctionCallingTests : IDisposable
         {
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
         };
-        executionSettings.ToolCallBehavior.MaximumUseAttempts = 1;
-        executionSettings.ToolCallBehavior.MaximumAutoInvokeAttempts = 1;
+        // used reflection to simplify the test
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumUseAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 1);
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumAutoInvokeAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 1);
 
         // Act
         await client.StreamGenerateChatMessageAsync(chatHistory, executionSettings: executionSettings, kernel: this._kernelWithFunctions)
@@ -353,8 +364,13 @@ public sealed class GeminiChatStreamingFunctionCallingTests : IDisposable
         {
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
         };
-        executionSettings.ToolCallBehavior.MaximumUseAttempts = 100;
-        executionSettings.ToolCallBehavior.MaximumAutoInvokeAttempts = 1;
+        // used reflection to simplify the test
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumUseAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 100);
+        typeof(ToolCallBehavior)
+            .GetField($"<{nameof(ToolCallBehavior.MaximumAutoInvokeAttempts)}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(executionSettings.ToolCallBehavior, 1);
 
         // Act
         var messages =

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatStreamingTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiChatStreamingTests.cs
@@ -368,7 +368,7 @@ public sealed class GeminiChatStreamingTests : IDisposable
             return new GeminiChatCompletionClient(
                 httpClient: httpClient ?? this._httpClient,
                 modelId: modelId,
-                bearerKeyProvider: () => bearerKey,
+                bearerTokenProvider: () => Task.FromResult(bearerKey),
                 location: "fake-location",
                 projectId: "fake-project-id");
         }

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiCountingTokensTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/Clients/GeminiCountingTokensTests.cs
@@ -123,7 +123,7 @@ public sealed class GeminiCountingTokensTests : IDisposable
             return new GeminiTokenCounterClient(
                 httpClient: this._httpClient,
                 modelId: modelId,
-                bearerKeyProvider: () => bearerKey,
+                bearerTokenProvider: () => Task.FromResult(bearerKey),
                 location: "fake-location",
                 projectId: "fake-project-id");
         }

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/GeminiRequestTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/GeminiRequestTests.cs
@@ -245,16 +245,15 @@ public sealed class GeminiRequestTests
         var kvp = KeyValuePair.Create("sampleKey", "sampleValue");
         var expectedArgs = new JsonObject { [kvp.Key] = kvp.Value };
         var toolCallPart = new GeminiPart.FunctionCallPart
-        { FunctionName = "function-name", Arguments = expectedArgs };
+            { FunctionName = "function-name", Arguments = expectedArgs };
         var toolCallPart2 = new GeminiPart.FunctionCallPart
-        { FunctionName = "function2-name", Arguments = expectedArgs };
+            { FunctionName = "function2-name", Arguments = expectedArgs };
         chatHistory.Add(new GeminiChatMessageContent(AuthorRole.Assistant, "tool-message", "model-id", functionsToolCalls: [toolCallPart]));
         chatHistory.Add(new GeminiChatMessageContent(AuthorRole.Assistant, "tool-message2", "model-id2", functionsToolCalls: [toolCallPart2]));
         var executionSettings = new GeminiPromptExecutionSettings();
 
         // Act
         var request = GeminiRequest.FromChatHistoryAndExecutionSettings(chatHistory, executionSettings);
-
         // Assert
         Assert.Collection(request.Contents,
             c => Assert.Equal(chatHistory[0].Role, c.Role),

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/GeminiRequestTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/GeminiRequestTests.cs
@@ -245,9 +245,9 @@ public sealed class GeminiRequestTests
         var kvp = KeyValuePair.Create("sampleKey", "sampleValue");
         var expectedArgs = new JsonObject { [kvp.Key] = kvp.Value };
         var toolCallPart = new GeminiPart.FunctionCallPart
-            { FunctionName = "function-name", Arguments = expectedArgs };
+        { FunctionName = "function-name", Arguments = expectedArgs };
         var toolCallPart2 = new GeminiPart.FunctionCallPart
-            { FunctionName = "function2-name", Arguments = expectedArgs };
+        { FunctionName = "function2-name", Arguments = expectedArgs };
         chatHistory.Add(new GeminiChatMessageContent(AuthorRole.Assistant, "tool-message", "model-id", functionsToolCalls: [toolCallPart]));
         chatHistory.Add(new GeminiChatMessageContent(AuthorRole.Assistant, "tool-message2", "model-id2", functionsToolCalls: [toolCallPart2]));
         var executionSettings = new GeminiPromptExecutionSettings();

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/GeminiStreamResponseTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/Gemini/GeminiStreamResponseTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.GoogleVertexAI.Core;
 using Xunit;
 
@@ -17,19 +18,19 @@ public sealed class GeminiStreamResponseTests
     private const string StreamTestDataFilePath = "./TestData/chat_stream_response.json";
 
     [Fact]
-    public void SerializationShouldPopulateAllProperties()
+    public async Task SerializationShouldPopulateAllPropertiesAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
         var stream = new MemoryStream();
-        var streamExample = File.ReadAllText(StreamTestDataFilePath);
+        var streamExample = await File.ReadAllTextAsync(StreamTestDataFilePath);
         var sampleResponses = JsonSerializer.Deserialize<List<GeminiResponse>>(streamExample)!;
 
         WriteToStream(stream, streamExample);
 
         // Act
-        var jsonChunks = parser.Parse(stream);
-        var responses = jsonChunks.Select(json => JsonSerializer.Deserialize<GeminiResponse>(json)).ToList();
+        var jsonChunks = await parser.ParseAsync(stream).ToListAsync();
+        var responses = jsonChunks.Select(json => JsonSerializer.Deserialize<GeminiResponse>(json));
 
         // Assert
         // Uses all because Equivalent ignores order

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/StreamJsonParserTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/StreamJsonParserTests.cs
@@ -13,21 +13,21 @@ namespace SemanticKernel.Connectors.GoogleVertexAI.UnitTests.Core;
 public sealed class StreamJsonParserTests
 {
     [Fact]
-    public void ParseWhenStreamIsEmptyReturnsEmptyEnumerable()
+    public async Task ParseWhenStreamIsEmptyReturnsEmptyEnumerableAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
         var stream = new MemoryStream();
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Empty(result);
     }
 
     [Fact]
-    public void ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObject()
+    public async Task ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -36,14 +36,14 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, input);
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Single(result, json => input.Equals(json, StringComparison.Ordinal));
     }
 
     [Fact]
-    public void ParseWhenStreamContainsArrayWithOnlyOneObjectReturnsEnumerableWithOneObject()
+    public async Task ParseWhenStreamContainsArrayWithOnlyOneObjectReturnsEnumerableWithOneObjectAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -52,14 +52,14 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, $"[{input}]");
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Single(result, json => input.Equals(json, StringComparison.Ordinal));
     }
 
     [Fact]
-    public void ParseWhenStreamContainsArrayOfTwoObjectsReturnsEnumerableWithTwoObjects()
+    public async Task ParseWhenStreamContainsArrayOfTwoObjectsReturnsEnumerableWithTwoObjectsAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -69,7 +69,7 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, $"[{firstInput},{secondInput}]");
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Collection(result,
@@ -78,7 +78,7 @@ public sealed class StreamJsonParserTests
     }
 
     [Fact]
-    public void ParseWhenStreamContainsArrayOfTwoObjectsWithNestedObjectsReturnsEnumerableWithTwoObjects()
+    public async Task ParseWhenStreamContainsArrayOfTwoObjectsWithNestedObjectsReturnsEnumerableWithTwoObjectsAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -88,7 +88,7 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, $"[{firstInput},{secondInput}]");
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Collection(result,
@@ -97,7 +97,7 @@ public sealed class StreamJsonParserTests
     }
 
     [Fact]
-    public void ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectWithEscapedQuotes()
+    public async Task ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectWithEscapedQuotesAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -106,14 +106,14 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, input);
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Single(result, json => input.Equals(json, StringComparison.Ordinal));
     }
 
     [Fact]
-    public void ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectWithEscapedBackslash()
+    public async Task ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectWithEscapedBackslashAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -122,14 +122,14 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, input);
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Single(result, json => input.Equals(json, StringComparison.Ordinal));
     }
 
     [Fact]
-    public void ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectWithEscapedBackslashAndQuotes()
+    public async Task ParseWhenStreamContainsOneObjectReturnsEnumerableWithOneObjectWithEscapedBackslashAndQuotesAsync()
     {
         // Arrange
         var parser = new StreamJsonParser();
@@ -138,7 +138,7 @@ public sealed class StreamJsonParserTests
         WriteToStream(stream, input);
 
         // Act
-        var result = parser.ParseAsync(stream);
+        var result = await parser.ParseAsync(stream).ToListAsync();
 
         // Assert
         Assert.Single(result, json => input.Equals(json, StringComparison.Ordinal));

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/VertexAI/VertexAIClientEmbeddingsGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Core/VertexAI/VertexAIClientEmbeddingsGenerationTests.cs
@@ -142,7 +142,7 @@ public sealed class VertexAIClientEmbeddingsGenerationTests : IDisposable
         var client = new VertexAIEmbeddingClient(
             httpClient: this._httpClient,
             modelId: modelId,
-            bearerKeyProvider: () => bearerKey ?? "fake-key",
+            bearerTokenProvider: () => Task.FromResult(bearerKey ?? "fake-key"),
             location: "us-central1",
             projectId: "fake-project-id");
         return client;

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Extensions/VertexAIMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Extensions/VertexAIMemoryBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
 using Moq;
@@ -38,7 +39,7 @@ public sealed class VertexAIMemoryBuilderExtensionsTests
 
         // Act
         var memory = builder
-            .WithVertexAITextEmbeddingGeneration("fake-model", () => "fake-bearer-key", "fake-location", "fake-project")
+            .WithVertexAITextEmbeddingGeneration("fake-model", () => Task.FromResult("fake-bearer-key"), "fake-location", "fake-project")
             .WithMemoryStore(this._mockMemoryStore.Object)
             .Build();
 

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Extensions/VertexAIServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Extensions/VertexAIServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -38,7 +39,7 @@ public sealed class VertexAIServiceCollectionExtensionsTests
         var kernelBuilder = Kernel.CreateBuilder();
 
         // Act
-        kernelBuilder.AddVertexAIGeminiTextGeneration("modelId", () => "apiKey", location: "test2", projectId: "projectId");
+        kernelBuilder.AddVertexAIGeminiTextGeneration("modelId", () => Task.FromResult("apiKey"), location: "test2", projectId: "projectId");
         var kernel = kernelBuilder.Build();
 
         // Assert
@@ -70,7 +71,7 @@ public sealed class VertexAIServiceCollectionExtensionsTests
         var services = new ServiceCollection();
 
         // Act
-        services.AddVertexAIGeminiTextGeneration("modelId", () => "apiKey", location: "test2", projectId: "projectId");
+        services.AddVertexAIGeminiTextGeneration("modelId", () => Task.FromResult("apiKey"), location: "test2", projectId: "projectId");
         var serviceProvider = services.BuildServiceProvider();
 
         // Assert
@@ -102,7 +103,7 @@ public sealed class VertexAIServiceCollectionExtensionsTests
         var kernelBuilder = Kernel.CreateBuilder();
 
         // Act
-        kernelBuilder.AddVertexAIGeminiChatCompletion("modelId", () => "apiKey", location: "test2", projectId: "projectId");
+        kernelBuilder.AddVertexAIGeminiChatCompletion("modelId", () => Task.FromResult("apiKey"), location: "test2", projectId: "projectId");
         var kernel = kernelBuilder.Build();
 
         // Assert
@@ -134,7 +135,7 @@ public sealed class VertexAIServiceCollectionExtensionsTests
         var services = new ServiceCollection();
 
         // Act
-        services.AddVertexAIGeminiChatCompletion("modelId", () => "apiKey", location: "test2", projectId: "projectId");
+        services.AddVertexAIGeminiChatCompletion("modelId", () => Task.FromResult("apiKey"), location: "test2", projectId: "projectId");
         var serviceProvider = services.BuildServiceProvider();
 
         // Assert
@@ -166,7 +167,7 @@ public sealed class VertexAIServiceCollectionExtensionsTests
         var kernelBuilder = Kernel.CreateBuilder();
 
         // Act
-        kernelBuilder.AddVertexAIEmbeddingGeneration("modelId", () => "apiKey", location: "test2", projectId: "projectId");
+        kernelBuilder.AddVertexAIEmbeddingGeneration("modelId", () => Task.FromResult("apiKey"), location: "test2", projectId: "projectId");
         var kernel = kernelBuilder.Build();
 
         // Assert
@@ -198,7 +199,7 @@ public sealed class VertexAIServiceCollectionExtensionsTests
         var services = new ServiceCollection();
 
         // Act
-        services.AddVertexAIEmbeddingGeneration("modelId", () => "apiKey", location: "test2", projectId: "projectId");
+        services.AddVertexAIEmbeddingGeneration("modelId", () => Task.FromResult("apiKey"), location: "test2", projectId: "projectId");
         var serviceProvider = services.BuildServiceProvider();
 
         // Assert

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Services/VertexAIGeminiChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Services/VertexAIGeminiChatCompletionServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 using Microsoft.SemanticKernel.Services;
 using Xunit;
@@ -24,7 +25,7 @@ public sealed class VertexAIGeminiChatCompletionServiceTests
     {
         // Arrange & Act
         string model = "fake-model";
-        var service = new VertexAIGeminiChatCompletionService(model, () => "key", "location", "project");
+        var service = new VertexAIGeminiChatCompletionService(model, () => Task.FromResult("key"), "location", "project");
 
         // Assert
         Assert.Equal(model, service.Attributes[AIServiceExtensions.ModelIdKey]);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Services/VertexAIGeminiTextGenerationServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Services/VertexAIGeminiTextGenerationServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 using Microsoft.SemanticKernel.Services;
 using Xunit;
@@ -24,7 +25,7 @@ public sealed class VertexAIGeminiTextGenerationServiceTests
     {
         // Arrange & Act
         string model = "fake-model";
-        var service = new VertexAIGeminiTextGenerationService(model, () => "key", "location", "project");
+        var service = new VertexAIGeminiTextGenerationService(model, () => Task.FromResult("key"), "location", "project");
 
         // Assert
         Assert.Equal(model, service.Attributes[AIServiceExtensions.ModelIdKey]);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Services/VertexAITextEmbeddingGenerationServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Services/VertexAITextEmbeddingGenerationServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 using Microsoft.SemanticKernel.Services;
 using Xunit;
@@ -24,7 +25,7 @@ public sealed class VertexAITextEmbeddingGenerationServiceTests
     {
         // Arrange & Act
         string model = "fake-model";
-        var service = new VertexAITextEmbeddingGenerationService(model, () => "key", "location", "project");
+        var service = new VertexAITextEmbeddingGenerationService(model, () => Task.FromResult("key"), "location", "project");
 
         // Assert
         Assert.Equal(model, service.Attributes[AIServiceExtensions.ModelIdKey]);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -145,7 +145,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase, IGeminiChatComple
     {
         var state = ValidateInputAndCreateChatCompletionState(chatHistory, kernel, executionSettings);
 
-        for (state.Iteration = 1;; state.Iteration++)
+        for (state.Iteration = 1; ; state.Iteration++)
         {
             var geminiResponse = await this.SendRequestAndReturnValidGeminiResponseAsync(
                     this._chatGenerationEndpoint, state.GeminiRequest, cancellationToken)
@@ -183,7 +183,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase, IGeminiChatComple
     {
         var state = ValidateInputAndCreateChatCompletionState(chatHistory, kernel, executionSettings);
 
-        for (state.Iteration = 1;; state.Iteration++)
+        for (state.Iteration = 1; ; state.Iteration++)
         {
             using var httpRequestMessage = this.CreateHttpRequest(state.GeminiRequest, this._chatStreamingEndpoint);
             using var response = await this.SendRequestAndGetResponseImmediatelyAfterHeadersReadAsync(httpRequestMessage, cancellationToken)
@@ -590,17 +590,17 @@ internal sealed class GeminiChatCompletionClient : ClientBase, IGeminiChatComple
     private static GeminiMetadata GetResponseMetadata(
         GeminiResponse geminiResponse,
         GeminiResponseCandidate candidate) => new()
-    {
-        FinishReason = candidate.FinishReason,
-        Index = candidate.Index,
-        PromptTokenCount = geminiResponse.UsageMetadata?.PromptTokenCount ?? 0,
-        CurrentCandidateTokenCount = candidate.TokenCount,
-        CandidatesTokenCount = geminiResponse.UsageMetadata?.CandidatesTokenCount ?? 0,
-        TotalTokenCount = geminiResponse.UsageMetadata?.TotalTokenCount ?? 0,
-        PromptFeedbackBlockReason = geminiResponse.PromptFeedback?.BlockReason,
-        PromptFeedbackSafetyRatings = geminiResponse.PromptFeedback?.SafetyRatings.ToList(),
-        ResponseSafetyRatings = candidate.SafetyRatings?.ToList(),
-    };
+        {
+            FinishReason = candidate.FinishReason,
+            Index = candidate.Index,
+            PromptTokenCount = geminiResponse.UsageMetadata?.PromptTokenCount ?? 0,
+            CurrentCandidateTokenCount = candidate.TokenCount,
+            CandidatesTokenCount = geminiResponse.UsageMetadata?.CandidatesTokenCount ?? 0,
+            TotalTokenCount = geminiResponse.UsageMetadata?.TotalTokenCount ?? 0,
+            PromptFeedbackBlockReason = geminiResponse.PromptFeedback?.BlockReason,
+            PromptFeedbackSafetyRatings = geminiResponse.PromptFeedback?.SafetyRatings.ToList(),
+            ResponseSafetyRatings = candidate.SafetyRatings?.ToList(),
+        };
 
     private void LogUsageMetadata(GeminiMetadata metadata)
     {

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Clients/GeminiTokenCounterClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/Clients/GeminiTokenCounterClient.cs
@@ -45,21 +45,21 @@ internal sealed class GeminiTokenCounterClient : ClientBase
     /// </summary>
     /// <param name="httpClient">HttpClient instance used to send HTTP requests</param>
     /// <param name="modelId">Id of the model to use to counting tokens</param>
-    /// <param name="bearerKeyProvider">Bearer key provider used for authentication</param>
+    /// <param name="bearerTokenProvider">Bearer key provider used for authentication</param>
     /// <param name="location">The region to process the request</param>
     /// <param name="projectId">Project ID from google cloud</param>
     /// <param name="logger">Logger instance used for logging (optional)</param>
     public GeminiTokenCounterClient(
         HttpClient httpClient,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         ILogger? logger = null)
         : base(
             httpClient: httpClient,
             logger: logger,
-            bearerKeyProvider: bearerKeyProvider)
+            bearerTokenProvider: bearerTokenProvider)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(location);
@@ -84,7 +84,7 @@ internal sealed class GeminiTokenCounterClient : ClientBase
         Verify.NotNullOrWhiteSpace(prompt);
 
         var geminiRequest = CreateGeminiRequest(prompt, executionSettings);
-        using var httpRequestMessage = this.CreateHttpRequest(geminiRequest, this._tokenCountingEndpoint);
+        using var httpRequestMessage = await this.CreateHttpRequestAsync(geminiRequest, this._tokenCountingEndpoint).ConfigureAwait(false);
 
         string body = await this.SendRequestAndGetStringBodyAsync(httpRequestMessage, cancellationToken)
             .ConfigureAwait(false);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiFinishReason.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiFinishReason.cs
@@ -61,15 +61,6 @@ public readonly struct GeminiFinishReason : IEquatable<GeminiFinishReason>
         this.Label = label;
     }
 
-    /// <summary>
-    /// An enumerable collection of GeminiFinishReason.
-    /// </summary>
-    public static IEnumerable<GeminiFinishReason> GetAll() =>
-        typeof(GeminiFinishReason).GetFields(BindingFlags.Public |
-                                             BindingFlags.Static |
-                                             BindingFlags.DeclaredOnly)
-            .Select(f => f.GetValue(null))
-            .Cast<GeminiFinishReason>();
 
     /// <summary>
     /// Represents the equality operator for comparing two instances of <see cref="GeminiFinishReason"/>.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiFinishReason.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiFinishReason.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -41,7 +38,7 @@ public readonly struct GeminiFinishReason : IEquatable<GeminiFinishReason>
     public static GeminiFinishReason Recitation { get; } = new("RECITATION");
 
     /// <summary>
-    /// 	Unknown reason.
+    /// Unknown reason.
     /// </summary>
     public static GeminiFinishReason Other { get; } = new("OTHER");
 
@@ -60,7 +57,6 @@ public readonly struct GeminiFinishReason : IEquatable<GeminiFinishReason>
         Verify.NotNullOrWhiteSpace(label, nameof(label));
         this.Label = label;
     }
-
 
     /// <summary>
     /// Represents the equality operator for comparing two instances of <see cref="GeminiFinishReason"/>.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiMetadata.cs
@@ -22,8 +22,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public GeminiFinishReason? FinishReason
     {
-        get => this.GetValueFromDictionary() as GeminiFinishReason?;
-        internal init => this.SetValueInDictionary(value);
+        get => this.GetValueFromDictionary(nameof(this.FinishReason)) as GeminiFinishReason?;
+        internal init => this.SetValueInDictionary(value, nameof(this.FinishReason));
     }
 
     /// <summary>
@@ -31,8 +31,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public int Index
     {
-        get => (this.GetValueFromDictionary() as int?) ?? 0;
-        internal init => this.SetValueInDictionary(value);
+        get => (this.GetValueFromDictionary(nameof(this.Index)) as int?) ?? 0;
+        internal init => this.SetValueInDictionary(value, nameof(this.Index));
     }
 
     /// <summary>
@@ -40,8 +40,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public int PromptTokenCount
     {
-        get => (this.GetValueFromDictionary() as int?) ?? 0;
-        internal init => this.SetValueInDictionary(value);
+        get => (this.GetValueFromDictionary(nameof(this.PromptTokenCount)) as int?) ?? 0;
+        internal init => this.SetValueInDictionary(value, nameof(this.PromptTokenCount));
     }
 
     /// <summary>
@@ -49,8 +49,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public int CurrentCandidateTokenCount
     {
-        get => (this.GetValueFromDictionary() as int?) ?? 0;
-        internal init => this.SetValueInDictionary(value);
+        get => (this.GetValueFromDictionary(nameof(this.CurrentCandidateTokenCount)) as int?) ?? 0;
+        internal init => this.SetValueInDictionary(value, nameof(this.CurrentCandidateTokenCount));
     }
 
     /// <summary>
@@ -58,8 +58,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public int CandidatesTokenCount
     {
-        get => (this.GetValueFromDictionary() as int?) ?? 0;
-        internal init => this.SetValueInDictionary(value);
+        get => (this.GetValueFromDictionary(nameof(this.CandidatesTokenCount)) as int?) ?? 0;
+        internal init => this.SetValueInDictionary(value, nameof(this.CandidatesTokenCount));
     }
 
     /// <summary>
@@ -67,8 +67,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public int TotalTokenCount
     {
-        get => (this.GetValueFromDictionary() as int?) ?? 0;
-        internal init => this.SetValueInDictionary(value);
+        get => (this.GetValueFromDictionary(nameof(this.TotalTokenCount)) as int?) ?? 0;
+        internal init => this.SetValueInDictionary(value, nameof(this.TotalTokenCount));
     }
 
     /// <summary>
@@ -76,8 +76,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public string? PromptFeedbackBlockReason
     {
-        get => this.GetValueFromDictionary() as string;
-        internal init => this.SetValueInDictionary(value);
+        get => this.GetValueFromDictionary(nameof(this.PromptFeedbackBlockReason)) as string;
+        internal init => this.SetValueInDictionary(value, nameof(this.PromptFeedbackBlockReason));
     }
 
     /// <summary>
@@ -85,8 +85,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public IReadOnlyList<GeminiSafetyRating>? PromptFeedbackSafetyRatings
     {
-        get => this.GetValueFromDictionary() as IReadOnlyList<GeminiSafetyRating>;
-        internal init => this.SetValueInDictionary(value);
+        get => this.GetValueFromDictionary(nameof(this.PromptFeedbackSafetyRatings)) as IReadOnlyList<GeminiSafetyRating>;
+        internal init => this.SetValueInDictionary(value, nameof(this.PromptFeedbackSafetyRatings));
     }
 
     /// <summary>
@@ -94,8 +94,8 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
     /// </summary>
     public IReadOnlyList<GeminiSafetyRating>? ResponseSafetyRatings
     {
-        get => this.GetValueFromDictionary() as IReadOnlyList<GeminiSafetyRating>;
-        internal init => this.SetValueInDictionary(value);
+        get => this.GetValueFromDictionary(nameof(this.ResponseSafetyRatings)) as IReadOnlyList<GeminiSafetyRating>;
+        internal init => this.SetValueInDictionary(value, nameof(this.ResponseSafetyRatings));
     }
 
     /// <summary>
@@ -109,9 +109,9 @@ public sealed class GeminiMetadata : ReadOnlyDictionary<string, object?>
         _ => new GeminiMetadata(dictionary.ToDictionary(pair => pair.Key, pair => pair.Value))
     };
 
-    private void SetValueInDictionary(object? value, [CallerMemberName] string propertyName = "")
+    private void SetValueInDictionary(object? value, string propertyName)
         => this.Dictionary[propertyName] = value;
 
-    private object? GetValueFromDictionary([CallerMemberName] string propertyName = "")
+    private object? GetValueFromDictionary(string propertyName)
         => this.Dictionary.TryGetValue(propertyName, out var value) ? value : null;
 }

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiMetadata.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetyRating.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetyRating.cs
@@ -80,15 +80,7 @@ public readonly struct GeminiSafetyProbability : IEquatable<GeminiSafetyProbabil
         this.Label = label;
     }
 
-    /// <summary>
-    /// An enumerable collection of GeminiSafetyProbability.
-    /// </summary>
-    public static IEnumerable<GeminiSafetyProbability> GetAll() =>
-        typeof(GeminiSafetyProbability).GetFields(BindingFlags.Public |
-                                                  BindingFlags.Static |
-                                                  BindingFlags.DeclaredOnly)
-            .Select(f => f.GetValue(null))
-            .Cast<GeminiSafetyProbability>();
+
 
     /// <summary>
     /// Represents the equality operator for comparing two instances of <see cref="GeminiSafetyProbability"/>.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetyRating.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetyRating.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -79,8 +76,6 @@ public readonly struct GeminiSafetyProbability : IEquatable<GeminiSafetyProbabil
         Verify.NotNullOrWhiteSpace(label, nameof(label));
         this.Label = label;
     }
-
-
 
     /// <summary>
     /// Represents the equality operator for comparing two instances of <see cref="GeminiSafetyProbability"/>.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetySetting.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetySetting.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -121,8 +118,6 @@ public readonly struct GeminiSafetyCategory : IEquatable<GeminiSafetyCategory>
         this.Label = label;
     }
 
-
-
     /// <summary>
     /// Represents the equality operator for comparing two instances of <see cref="GeminiSafetyCategory"/>.
     /// </summary>
@@ -203,8 +198,6 @@ public readonly struct GeminiSafetyThreshold : IEquatable<GeminiSafetyThreshold>
         Verify.NotNullOrWhiteSpace(label, nameof(label));
         this.Label = label;
     }
-
-
 
     /// <summary>
     /// Determines whether two GeminiSafetyThreshold objects are equal.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetySetting.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/Gemini/GeminiSafetySetting.cs
@@ -121,15 +121,7 @@ public readonly struct GeminiSafetyCategory : IEquatable<GeminiSafetyCategory>
         this.Label = label;
     }
 
-    /// <summary>
-    /// An enumerable collection of GeminiSafetyCategory.
-    /// </summary>
-    public static IEnumerable<GeminiSafetyCategory> GetAll() =>
-        typeof(GeminiSafetyCategory).GetFields(BindingFlags.Public |
-                                               BindingFlags.Static |
-                                               BindingFlags.DeclaredOnly)
-            .Select(f => f.GetValue(null))
-            .Cast<GeminiSafetyCategory>();
+
 
     /// <summary>
     /// Represents the equality operator for comparing two instances of <see cref="GeminiSafetyCategory"/>.
@@ -212,15 +204,7 @@ public readonly struct GeminiSafetyThreshold : IEquatable<GeminiSafetyThreshold>
         this.Label = label;
     }
 
-    /// <summary>
-    /// An enumerable collection of GeminiSafetyCategory.
-    /// </summary>
-    public static IEnumerable<GeminiSafetyThreshold> GetAll() =>
-        typeof(GeminiSafetyThreshold).GetFields(BindingFlags.Public |
-                                                BindingFlags.Static |
-                                                BindingFlags.DeclaredOnly)
-            .Select(f => f.GetValue(null))
-            .Cast<GeminiSafetyThreshold>();
+
 
     /// <summary>
     /// Determines whether two GeminiSafetyThreshold objects are equal.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/GoogleAI/GoogleAIEmbeddingClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/GoogleAI/GoogleAIEmbeddingClient.cs
@@ -54,7 +54,7 @@ internal sealed class GoogleAIEmbeddingClient : ClientBase
         Verify.NotNullOrEmpty(data);
 
         var geminiRequest = this.GetEmbeddingRequest(data);
-        using var httpRequestMessage = this.CreateHttpRequest(geminiRequest, this._embeddingEndpoint);
+        using var httpRequestMessage = await this.CreateHttpRequestAsync(geminiRequest, this._embeddingEndpoint).ConfigureAwait(false);
 
         string body = await this.SendRequestAndGetStringBodyAsync(httpRequestMessage, cancellationToken)
             .ConfigureAwait(false);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/StreamJsonParser.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/StreamJsonParser.cs
@@ -31,13 +31,13 @@ internal sealed class StreamJsonParser
         [EnumeratorCancellation] CancellationToken ct = default)
     {
         using var reader = new StreamReader(stream, Encoding.UTF8);
-        while (await this.ExtractNextJsonObjectAsync(reader, validateJson, ct).ConfigureAwait(false) is { } json)
+        while (await this.ExtractNextJsonStringAsync(reader, validateJson, ct).ConfigureAwait(false) is { } json)
         {
             yield return json;
         }
     }
 
-    private async Task<string?> ExtractNextJsonObjectAsync(
+    private async Task<string?> ExtractNextJsonStringAsync(
         TextReader reader,
         bool validateJson,
         CancellationToken ct)

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/StreamJsonParser.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/StreamJsonParser.cs
@@ -3,8 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Connectors.GoogleVertexAI.Core;
 
@@ -13,26 +16,36 @@ namespace Microsoft.SemanticKernel.Connectors.GoogleVertexAI.Core;
 /// </summary>
 internal sealed class StreamJsonParser
 {
+    private readonly char[] _buffer = new char[1];
+
     /// <summary>
     /// Parses a Stream containing JSON data and yields the individual JSON objects.
     /// </summary>
     /// <param name="stream">The Stream containing the JSON data.</param>
     /// <param name="validateJson">Set to true to enable JSON validation. Default is false.</param>
+    /// <param name="ct">The cancellation token.</param>
     /// <returns>An enumerable collection of string representing the individual JSON objects.</returns>
-    public IEnumerable<string> Parse(Stream stream, bool validateJson = false)
+    public async IAsyncEnumerable<string> ParseAsync(
+        Stream stream,
+        bool validateJson = false,
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
         using var reader = new StreamReader(stream, Encoding.UTF8);
-        while (ExtractNextJsonObject(reader, validateJson) is { } json)
+        while (await this.ExtractNextJsonObjectAsync(reader, validateJson, ct).ConfigureAwait(false) is { } json)
         {
             yield return json;
         }
     }
 
-    private static string? ExtractNextJsonObject(TextReader reader, bool validateJson)
+    private async Task<string?> ExtractNextJsonObjectAsync(
+        TextReader reader,
+        bool validateJson,
+        CancellationToken ct)
     {
         JsonParserState state = new();
-        while ((state.CharacterInt = reader.Read()) != -1)
+        while (!ct.IsCancellationRequested && await reader.ReadAsync(this._buffer, 0, 1).ConfigureAwait(false) > 0)
         {
+            state.CurrentCharacter = this._buffer[0];
             if (IsEscapedCharacterInsideQuotes(state))
             {
                 continue;
@@ -104,8 +117,7 @@ internal sealed class StreamJsonParser
         public bool InsideQuotes { get; set; }
         public bool IsEscaping { get; set; }
         public bool IsCompleteJson { get; private set; }
-        public int CharacterInt { get; set; }
-        public char CurrentCharacter => (char)this.CharacterInt;
+        public char CurrentCharacter { get; set; }
 
         public void AppendToJsonObject()
         {

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/VertexAI/VertexAIEmbeddingClient.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Core/VertexAI/VertexAIEmbeddingClient.cs
@@ -23,21 +23,21 @@ internal sealed class VertexAIEmbeddingClient : ClientBase
     /// </summary>
     /// <param name="httpClient">HttpClient instance used to send HTTP requests</param>
     /// <param name="modelId">Embeddings generation model id</param>
-    /// <param name="bearerKeyProvider">Bearer key provider used for authentication</param>
+    /// <param name="bearerTokenProvider">Bearer key provider used for authentication</param>
     /// <param name="location">The region to process the request</param>
     /// <param name="projectId">Project ID from google cloud</param>
     /// <param name="logger">Logger instance used for logging (optional)</param>
     public VertexAIEmbeddingClient(
         HttpClient httpClient,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         ILogger? logger = null)
         : base(
             httpClient: httpClient,
             logger: logger,
-            bearerKeyProvider: bearerKeyProvider)
+            bearerTokenProvider: bearerTokenProvider)
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(location);
@@ -60,7 +60,7 @@ internal sealed class VertexAIEmbeddingClient : ClientBase
         Verify.NotNullOrEmpty(data);
 
         var geminiRequest = GetEmbeddingRequest(data);
-        using var httpRequestMessage = this.CreateHttpRequest(geminiRequest, this._embeddingEndpoint);
+        using var httpRequestMessage = await this.CreateHttpRequestAsync(geminiRequest, this._embeddingEndpoint).ConfigureAwait(false);
 
         string body = await this.SendRequestAndGetStringBodyAsync(httpRequestMessage, cancellationToken)
             .ConfigureAwait(false);

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/VertexAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/VertexAIKernelBuilderExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -22,21 +23,21 @@ public static class VertexAIKernelBuilderExtensions
     /// </summary>
     /// <param name="builder">The kernel builder.</param>
     /// <param name="modelId">The model for text generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="serviceId">The optional service ID.</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated kernel builder.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static IKernelBuilder AddVertexAIGeminiTextGeneration(
         this IKernelBuilder builder,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         string? serviceId = null,
@@ -44,14 +45,14 @@ public static class VertexAIKernelBuilderExtensions
     {
         Verify.NotNull(builder);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         builder.Services.AddKeyedSingleton<ITextGenerationService>(serviceId, (serviceProvider, _) =>
             new VertexAIGeminiTextGenerationService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
@@ -101,21 +102,21 @@ public static class VertexAIKernelBuilderExtensions
     /// </summary>
     /// <param name="builder">The kernel builder.</param>
     /// <param name="modelId">The model for text generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="serviceId">The optional service ID.</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated kernel builder.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static IKernelBuilder AddVertexAIGeminiChatCompletion(
         this IKernelBuilder builder,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         string? serviceId = null,
@@ -123,14 +124,14 @@ public static class VertexAIKernelBuilderExtensions
     {
         Verify.NotNull(builder);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
             new VertexAIGeminiChatCompletionService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
@@ -180,21 +181,21 @@ public static class VertexAIKernelBuilderExtensions
     /// </summary>
     /// <param name="builder">The kernel builder.</param>
     /// <param name="modelId">The model for text generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="serviceId">The optional service ID.</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated kernel builder.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static IKernelBuilder AddVertexAIEmbeddingGeneration(
         this IKernelBuilder builder,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         string? serviceId = null,
@@ -202,14 +203,14 @@ public static class VertexAIKernelBuilderExtensions
     {
         Verify.NotNull(builder);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new VertexAITextEmbeddingGenerationService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/VertexAIMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/VertexAIMemoryBuilderExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
@@ -18,34 +19,34 @@ public static class VertexAIMemoryBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="MemoryBuilder"/> instance</param>
     /// <param name="modelId">The model for text generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="httpClient">The optional custom HttpClient.</param>
     /// <returns>The updated memory builder.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static MemoryBuilder WithVertexAITextEmbeddingGeneration(
         this MemoryBuilder builder,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         HttpClient? httpClient = null)
     {
         Verify.NotNull(builder);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         return builder.WithTextEmbeddingGeneration((loggerFactory, builderHttpClient) =>
             new VertexAITextEmbeddingGenerationService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(httpClient ?? builderHttpClient),

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/VertexAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/VertexAIServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -21,34 +22,34 @@ public static class VertexAIServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to add the Gemini Text Generation service to.</param>
     /// <param name="modelId">The model for text generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="serviceId">Optional service ID.</param>
     /// <returns>The updated service collection.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static IServiceCollection AddVertexAIGeminiTextGeneration(
         this IServiceCollection services,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         string? serviceId = null)
     {
         Verify.NotNull(services);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         return services.AddKeyedSingleton<ITextGenerationService>(serviceId, (serviceProvider, _) =>
             new VertexAIGeminiTextGenerationService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(serviceProvider),
@@ -94,34 +95,34 @@ public static class VertexAIServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to add the Gemini Text Generation service to.</param>
     /// <param name="modelId">The model for text generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="serviceId">Optional service ID.</param>
     /// <returns>The updated service collection.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static IServiceCollection AddVertexAIGeminiChatCompletion(
         this IServiceCollection services,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         string? serviceId = null)
     {
         Verify.NotNull(services);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
             new VertexAIGeminiChatCompletionService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(serviceProvider),
@@ -169,34 +170,34 @@ public static class VertexAIServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to add the Gemini Embeddings Generation service to.</param>
     /// <param name="modelId">The model for embeddings generation.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="serviceId">Optional service ID.</param>
     /// <returns>The updated service collection.</returns>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public static IServiceCollection AddVertexAIEmbeddingGeneration(
         this IServiceCollection services,
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         string? serviceId = null)
     {
         Verify.NotNull(services);
         Verify.NotNull(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNull(location);
         Verify.NotNull(projectId);
 
         return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new VertexAITextEmbeddingGenerationService(
                 modelId: modelId,
-                bearerKeyProvider: bearerKeyProvider,
+                bearerTokenProvider: bearerTokenProvider,
                 location: location,
                 projectId: projectId,
                 httpClient: HttpClientProvider.GetHttpClient(serviceProvider),

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Services/VertexAIGeminiChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Services/VertexAIGeminiChatCompletionService.cs
@@ -37,7 +37,7 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
         string projectId,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
-        : this(modelId, () => bearerKey, location, projectId, httpClient, loggerFactory)
+        : this(modelId, () => Task.FromResult(bearerKey), location, projectId, httpClient, loggerFactory)
     {
         Verify.NotNullOrWhiteSpace(bearerKey);
     }
@@ -46,26 +46,26 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
     /// Initializes a new instance of the <see cref="VertexAIGeminiChatCompletionService"/> class.
     /// </summary>
     /// <param name="modelId">The Gemini model for the chat completion service.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The region to process the request</param>
     /// <param name="projectId">Your project ID</param>
     /// <param name="httpClient">Optional HTTP client to be used for communication with the Gemini API.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public VertexAIGeminiChatCompletionService(
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNullOrWhiteSpace(location);
         Verify.NotNullOrWhiteSpace(projectId);
 
@@ -74,7 +74,7 @@ public sealed class VertexAIGeminiChatCompletionService : IChatCompletionService
             httpClient: HttpClientProvider.GetHttpClient(httpClient),
 #pragma warning restore CA2000
             modelId: modelId,
-            bearerKeyProvider: bearerKeyProvider,
+            bearerTokenProvider: bearerTokenProvider,
             location: location,
             projectId: projectId,
             logger: loggerFactory?.CreateLogger(typeof(VertexAIGeminiChatCompletionService)));

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Services/VertexAIGeminiTextGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Services/VertexAIGeminiTextGenerationService.cs
@@ -37,7 +37,7 @@ public sealed class VertexAIGeminiTextGenerationService : ITextGenerationService
         string projectId,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
-        : this(modelId, () => bearerKey, location, projectId, httpClient, loggerFactory)
+        : this(modelId, () => Task.FromResult(bearerKey), location, projectId, httpClient, loggerFactory)
     {
         Verify.NotNullOrWhiteSpace(bearerKey);
     }
@@ -46,26 +46,26 @@ public sealed class VertexAIGeminiTextGenerationService : ITextGenerationService
     /// Initializes a new instance of the <see cref="VertexAIGeminiTextGenerationService"/> class.
     /// </summary>
     /// <param name="modelId">The model identifier.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The region to process the request.</param>
     /// <param name="projectId">Your Project Id.</param>
     /// <param name="httpClient">The optional HTTP client.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public VertexAIGeminiTextGenerationService(
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNullOrWhiteSpace(location);
         Verify.NotNullOrWhiteSpace(projectId);
 
@@ -74,7 +74,7 @@ public sealed class VertexAIGeminiTextGenerationService : ITextGenerationService
             httpClient: HttpClientProvider.GetHttpClient(httpClient),
 #pragma warning restore CA2000
             modelId: modelId,
-            bearerKeyProvider: bearerKeyProvider,
+            bearerTokenProvider: bearerTokenProvider,
             location: location,
             projectId: projectId,
             logger: loggerFactory?.CreateLogger(typeof(VertexAIGeminiTextGenerationService))));

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Services/VertexAITextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Services/VertexAITextEmbeddingGenerationService.cs
@@ -37,7 +37,7 @@ public sealed class VertexAITextEmbeddingGenerationService : ITextEmbeddingGener
         string projectId,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
-        : this(modelId, () => bearerKey, location, projectId, httpClient, loggerFactory)
+        : this(modelId, () => Task.FromResult(bearerKey), location, projectId, httpClient, loggerFactory)
     {
         Verify.NotNullOrWhiteSpace(bearerKey);
     }
@@ -46,26 +46,26 @@ public sealed class VertexAITextEmbeddingGenerationService : ITextEmbeddingGener
     /// Initializes a new instance of the <see cref="VertexAITextEmbeddingGenerationService"/> class.
     /// </summary>
     /// <param name="modelId">The model identifier.</param>
-    /// <param name="bearerKeyProvider">The Bearer Key provider for authentication.</param>
+    /// <param name="bearerTokenProvider">The Bearer Key provider for authentication.</param>
     /// <param name="location">The location to process the request.</param>
     /// <param name="projectId">Your Project Id.</param>
     /// <param name="httpClient">The optional HTTP client.</param>
     /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
     /// <remarks>
-    /// This <paramref name="bearerKeyProvider"/> will be called on every request,
+    /// This <paramref name="bearerTokenProvider"/> will be called on every request,
     /// when providing the token consider using caching strategy and refresh token logic
     /// when it is expired or close to expiration.
     /// </remarks>
     public VertexAITextEmbeddingGenerationService(
         string modelId,
-        Func<string> bearerKeyProvider,
+        Func<Task<string>> bearerTokenProvider,
         string location,
         string projectId,
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNullOrWhiteSpace(modelId);
-        Verify.NotNull(bearerKeyProvider);
+        Verify.NotNull(bearerTokenProvider);
         Verify.NotNullOrWhiteSpace(location);
         Verify.NotNullOrWhiteSpace(projectId);
 
@@ -74,7 +74,7 @@ public sealed class VertexAITextEmbeddingGenerationService : ITextEmbeddingGener
             httpClient: HttpClientProvider.GetHttpClient(httpClient),
 #pragma warning restore CA2000
             modelId: modelId,
-            bearerKeyProvider: bearerKeyProvider,
+            bearerTokenProvider: bearerTokenProvider,
             location: location,
             projectId: projectId,
             logger: loggerFactory?.CreateLogger(typeof(VertexAITextEmbeddingGenerationService)));

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/ToolCallBehavior.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/ToolCallBehavior.cs
@@ -80,13 +80,13 @@ public abstract class ToolCallBehavior
     /// if this is 1, the first request will include the tools, but the subsequent response sending back the tool's result
     /// will not include the tools for further use.
     /// </remarks>
-    public int MaximumUseAttempts { get; set; } = int.MaxValue;
+    public int MaximumUseAttempts { get; } = int.MaxValue;
 
     /// <summary>Gets how many tool call request/response roundtrips are supported with auto-invocation.</summary>
     /// <remarks>
     /// To disable auto invocation, this can be set to 0.
     /// </remarks>
-    public int MaximumAutoInvokeAttempts { get; set; }
+    public int MaximumAutoInvokeAttempts { get; }
 
     /// <summary>
     /// Gets whether validation against a specified list is required before allowing the model to request a function from the kernel.


### PR DESCRIPTION
Changed StreamJsonParser to async
Made read-only MaximumUseAttempts and MaximumAutoInvokeAttempts in ToolBehavior
Removed CallerMemberName from GeminiMetadata and used nameof instead.
Removed GetAll from FinishReason, SafetyRating and SafetySetting
Refactor bearer key logic to handle generating tokens async. Renamed from bearer key to bearer token.

@RogerBarreto 