### PR TITLE
Python: planner love

### DIFF
--- a/python/notebooks/05-using-the-planner.ipynb
+++ b/python/notebooks/05-using-the-planner.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "7d548e40",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3852961c",
    "metadata": {},
    "outputs": [],
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "11e59885",
    "metadata": {},
    "outputs": [],
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "93bc6103",
    "metadata": {},
    "outputs": [],
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "ca0e7604",
    "metadata": {},
    "outputs": [],
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "20d35ed0",
    "metadata": {},
    "outputs": [],
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "d5697c09",
    "metadata": {},
    "outputs": [],
@@ -177,26 +177,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "b425ba1e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"input\": \"Valentine's Day Date Ideas\",\n",
-      "  \"subtasks\": [\n",
-      "    {\"function\": \"WriterPlugin.Brainstorm\"},\n",
-      "    {\"function\": \"WriterPlugin.EmailTo\", \"args\": {\"recipient\": \"significant_other\"}},\n",
-      "    {\"function\": \"WriterPlugin.Translate\", \"args\": {\"language\": \"French\"}},\n",
-      "    {\"function\": \"TextPlugin.uppercase\"}\n",
-      "  ]\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(basic_plan.generated_plan)"
    ]
@@ -229,43 +213,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "a3161dcf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Plugin: SummarizePlugin, Function: MakeAbstractReadable\n",
-      "Plugin: SummarizePlugin, Function: Summarize\n",
-      "Plugin: SummarizePlugin, Function: Topics\n",
-      "Plugin: SummarizePlugin, Function: Notegen\n",
-      "Plugin: WriterPlugin, Function: NovelChapter\n",
-      "Plugin: WriterPlugin, Function: TwoSentenceSummary\n",
-      "Plugin: WriterPlugin, Function: StoryGen\n",
-      "Plugin: WriterPlugin, Function: EnglishImprover\n",
-      "Plugin: WriterPlugin, Function: Rewrite\n",
-      "Plugin: WriterPlugin, Function: Brainstorm\n",
-      "Plugin: WriterPlugin, Function: Translate\n",
-      "Plugin: WriterPlugin, Function: NovelChapterWithNotes\n",
-      "Plugin: WriterPlugin, Function: AcronymGenerator\n",
-      "Plugin: WriterPlugin, Function: EmailGen\n",
-      "Plugin: WriterPlugin, Function: Acronym\n",
-      "Plugin: WriterPlugin, Function: ShortPoem\n",
-      "Plugin: WriterPlugin, Function: EmailTo\n",
-      "Plugin: WriterPlugin, Function: NovelOutline\n",
-      "Plugin: WriterPlugin, Function: TellMeMore\n",
-      "Plugin: WriterPlugin, Function: AcronymReverse\n",
-      "Plugin: WriterPlugin, Function: Shakespeare\n",
-      "Plugin: TextPlugin, Function: lowercase\n",
-      "Plugin: TextPlugin, Function: trim\n",
-      "Plugin: TextPlugin, Function: trim_end\n",
-      "Plugin: TextPlugin, Function: trim_start\n",
-      "Plugin: TextPlugin, Function: uppercase\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from semantic_kernel.functions.kernel_function_from_prompt import KernelFunctionFromPrompt\n",
     "\n",
@@ -314,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "25abac0d",
    "metadata": {},
    "outputs": [],
@@ -331,27 +282,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "997462e8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "    \"input\": \"Valentine's Day Short Poems\",\n",
-      "    \"subtasks\": [\n",
-      "        {\"function\": \"WriterPlugin.Brainstorm\"},\n",
-      "        {\"function\": \"WriterPlugin.ShortPoem\"},\n",
-      "        {\"function\": \"WriterPlugin.Shakespeare\"},\n",
-      "        {\"function\": \"WriterPlugin.Translate\", \"args\": {\"language\": \"French\"}},\n",
-      "        {\"function\": \"TextPlugin.uppercase\"}\n",
-      "    ]\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(new_plan.generated_plan)"
    ]
@@ -374,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "9384831a",
    "metadata": {},
    "outputs": [],
@@ -384,26 +318,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "9192b186",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1. ÉCOUTEZ ! DES ROSES, ÉCARLATES COMME LE SOLEIL COUCHANT,\n",
-      "   DES VIOLETTES D'AZUR, COMME LE CIEL QUAND LA JOURNÉE EST FINIE.\n",
-      "   EN CE BEAU JOUR DE LA SAINT-VALENTIN, MES PENSÉES SONT À TOI,\n",
-      "   UN CADEAU QUE J'AI OBTENU, UN SECRET À PRÉSERVER.\n",
-      "   NE CRAINS RIEN, BEL AMOUR, CAR CE N'EST QU'UNE DOUCE SURPRISE,\n",
-      "   ET SOIS ASSURÉ, AUCUN SIMPLE DUO DE CRAVATES NE SURGIRA.\n",
-      "\n",
-      "2. L'AMOUR FLOTTE DANS L'AIR, COMME LES CŒURS BATTENT,\n",
-      "   LEUR RYTHME, UN RÉCIT DE PASSION, OH SI DOUX.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(results)"
    ]
@@ -444,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "e2e90624",
    "metadata": {},
    "outputs": [],
@@ -456,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "0d537981",
    "metadata": {},
    "outputs": [],
@@ -474,20 +392,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "e7007418",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Convert a string to uppercase. : {'execution_settings': {}}\n",
-      "None : {'execution_settings': {}}\n",
-      "Translate the input into a language of your choice : {'execution_settings': {}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for step in sequential_plan._steps:\n",
     "    print(step.description, \":\", step._state.__dict__)"
@@ -503,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "88411884",
    "metadata": {},
    "outputs": [],
@@ -513,56 +421,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "36d27aa0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Il était une fois, dans un pays lointain, très lointain,\n",
-      "Vivait un jeune garçon nommé William,\n",
-      "Avec une plume à la main et du parchemin en vue,\n",
-      "Il cherchait à réécrire un conte de puissance.\n",
-      "\n",
-      "Dans cette belle contrée, connue sous le nom de royaume des Inputs,\n",
-      "Un défi lui fut lancé, pour tester son intelligence,\n",
-      "\"Réécrire dans le style de notre cher barde,\n",
-      "Le conte d'un garçon, dans un langage si ardu.\"\n",
-      "\n",
-      "Avec un cœur rempli de zèle shakespearien,\n",
-      "William releva le défi avec grand enthousiasme,\n",
-      "Il réfléchit et médita, puis commença à écrire,\n",
-      "En pentamètre iambique, de toutes ses forces.\n",
-      "\n",
-      "\"Priez, rassemblez-vous, gentes dames et gentilshommes du pays,\n",
-      "En vérité, j'ai un conte à raconter, si grand,\n",
-      "D'un garçon, nommé William, avec une tâche à accomplir,\n",
-      "Réécrire un Input, dans un langage si noble.\"\n",
-      "\n",
-      "Il fit une pause, et avec un geste de sa plume,\n",
-      "Il commença à réécrire, avec une excitation shakespearienne,\n",
-      "\"Il était une fois, dans un pays si beau,\n",
-      "Vivait un garçon, avec un défi rare.\"\n",
-      "\n",
-      "\"Dans ce pays si juste, où les mots coulent,\n",
-      "William cherchait, un conte à offrir,\n",
-      "Avec une plume à la main, et du parchemin en vue,\n",
-      "Il cherchait à réécrire, de toutes ses forces.\"\n",
-      "\n",
-      "Et ainsi, chers lecteurs, le conte se déroula,\n",
-      "Avec des mots de Shakespeare, si audacieux,\n",
-      "Chaque ligne, un vers, avec rythme et rime,\n",
-      "Un conte transformé, à l'époque du barde.\n",
-      "\n",
-      "Alors applaudissons, cet exploit si grand,\n",
-      "Réécrire un Input, à la main de Shakespeare,\n",
-      "En vérité, le garçon nommé William, il réussit,\n",
-      "À faire ressortir, la beauté de la doctrine du barde.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(result)"
    ]
@@ -585,18 +447,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "5bfc0b9f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Overwriting plugin \"ActionPlanner_Excluded\" in collection\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from semantic_kernel.planners import ActionPlanner\n",
     "\n",
@@ -613,21 +467,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "cc12642a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "KernelPlugin(name='text', description=None, functions={'lowercase': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='lowercase', plugin_name='text', description='Convert a string to lowercase.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.lowercase of TextPlugin()>, stream_method=None), 'trim': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='trim', plugin_name='text', description='Trim whitespace from the start and end of a string.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.trim of TextPlugin()>, stream_method=None), 'trim_end': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='trim_end', plugin_name='text', description='Trim whitespace from the end of a string.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.trim_end of TextPlugin()>, stream_method=None), 'trim_start': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='trim_start', plugin_name='text', description='Trim whitespace from the start of a string.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.trim_start of TextPlugin()>, stream_method=None), 'uppercase': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='uppercase', plugin_name='text', description='Convert a string to uppercase.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.uppercase of TextPlugin()>, stream_method=None)})"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from semantic_kernel.core_plugins import MathPlugin, TextPlugin, TimePlugin\n",
     "\n",
@@ -638,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "b938dc0e",
    "metadata": {},
    "outputs": [],
@@ -648,27 +491,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "3aafd268",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WriterPlugin.Shakespeare is missing a description\n",
-      "PlannerPlugin.CreatePlan is missing a description\n",
-      "SequentialPlanner_Excluded.SequentialPlanner_Excluded is missing a description\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "plan = await planner.create_plan(goal=ask)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "42589835",
    "metadata": {},
    "outputs": [],
@@ -678,18 +511,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "dc75e7a9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1100\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(result)"
    ]
@@ -726,21 +551,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "415f7876",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "KernelPlugin(name='WebSearch', description=None, functions={'search': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='search', plugin_name='WebSearch', description='Performs a web search for a given query', parameters=[KernelParameterMetadata(name='query', description='The search query', default_value=None, type_='str', is_required=True, type_object=<class 'str'>), KernelParameterMetadata(name='num_results', description='The number of search results to return', default_value=1, type_='int', is_required=False, type_object=<class 'int'>), KernelParameterMetadata(name='offset', description='The number of search results to skip', default_value=0, type_='int', is_required=False, type_object=<class 'int'>)], is_prompt=False, is_asynchronous=True, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method WebSearchEnginePlugin.search of <semantic_kernel.core_plugins.web_search_engine_plugin.WebSearchEnginePlugin object at 0x11fd2e750>>, stream_method=None)})"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from semantic_kernel.connectors.search_engine import BingConnector\n",
     "from semantic_kernel.core_plugins import WebSearchEnginePlugin\n",
@@ -760,29 +574,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "abe150e0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Overwriting plugin \"time\" in collection\n",
-      "Overwriting plugin \"math\" in collection\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "KernelPlugin(name='math', description=None, functions={'Add': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='Add', plugin_name='math', description='Returns the Addition result of the values provided.', parameters=[KernelParameterMetadata(name='input', description='the first number to add', default_value=None, type_='int', is_required=True, type_object=<class 'int'>), KernelParameterMetadata(name='amount', description='the second number to add', default_value=None, type_='int', is_required=True, type_object=<class 'int'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='the output is a number', default_value=None, type_='int', is_required=True, type_object=None)), method=<bound method MathPlugin.add of <semantic_kernel.core_plugins.math_plugin.MathPlugin object at 0x10ffe8890>>, stream_method=None), 'Subtract': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='Subtract', plugin_name='math', description='Subtracts value to a value', parameters=[KernelParameterMetadata(name='input', description='the first number', default_value=None, type_='int', is_required=True, type_object=<class 'int'>), KernelParameterMetadata(name='amount', description='the number to subtract', default_value=None, type_='int', is_required=True, type_object=<class 'int'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='int', is_required=True, type_object=None)), method=<bound method MathPlugin.subtract of <semantic_kernel.core_plugins.math_plugin.MathPlugin object at 0x10ffe8890>>, stream_method=None)})"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from semantic_kernel.core_plugins.math_plugin import MathPlugin\n",
     "from semantic_kernel.core_plugins.time_plugin import TimePlugin\n",
@@ -793,18 +588,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "06d08549",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Overwriting plugin \"StepwisePlanner\" in collection\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from semantic_kernel.planners.stepwise_planner import StepwisePlanner, StepwisePlannerConfig\n",
     "\n",
@@ -821,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "596ade21",
    "metadata": {},
    "outputs": [],
@@ -833,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "176988ac",
    "metadata": {},
    "outputs": [],
@@ -843,18 +630,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "d00c6f71",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The top 5 teams in the NBA have a combined total of 34 championships. The teams are the Celtics, Lakers, and Warriors.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(result)"
    ]
@@ -869,21 +648,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "7159ca1b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Step: 0\n",
-      "Description: Execute a plan\n",
-      "Function: StepwisePlanner.ExecutePlan\n",
-      "  Output: The top 5 teams in the NBA have a combined total of 34 championships. The teams are the Celtics, Lakers, and Warriors.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for index, step in enumerate(plan._steps):\n",
     "    print(\"Step:\", index)\n",

--- a/python/notebooks/05-using-the-planner.ipynb
+++ b/python/notebooks/05-using-the-planner.ipynb
@@ -23,12 +23,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install semantic-kernel==0.9.2b1"
+    "!python -m pip install -U semantic-kernel "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "7d548e40",
    "metadata": {},
    "outputs": [],
@@ -36,49 +36,49 @@
     "from services import Service\n",
     "\n",
     "# Select a service to use for this notebook (available services: OpenAI, AzureOpenAI, HuggingFace)\n",
-    "selectedService = Service.OpenAI"
+    "selectedService = Service.AzureOpenAI"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "3852961c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from semantic_kernel.prompt_template.input_variable import InputVariable\n",
-    "from semantic_kernel.contents.chat_history import ChatHistory\n",
-    "from semantic_kernel.functions.kernel_arguments import KernelArguments"
+    "from semantic_kernel.contents.chat_history import ChatHistory  # noqa: F401\n",
+    "from semantic_kernel.functions.kernel_arguments import KernelArguments  # noqa: F401\n",
+    "from semantic_kernel.prompt_template.input_variable import InputVariable  # noqa: F401"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "11e59885",
    "metadata": {},
    "outputs": [],
    "source": [
     "import semantic_kernel as sk\n",
-    "import semantic_kernel.connectors.ai.open_ai as sk_oai\n",
+    "import semantic_kernel.connectors.ai.open_ai as sk_oai  # noqa: F401\n",
     "\n",
     "kernel = sk.Kernel()\n",
     "\n",
     "service_id = None\n",
     "if selectedService == Service.OpenAI:\n",
-    "    from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion\n",
-    "\n",
     "    api_key, org_id = sk.openai_settings_from_dot_env()\n",
     "    service_id = \"default\"\n",
     "    kernel.add_service(\n",
-    "        OpenAIChatCompletion(service_id=service_id, ai_model_id=\"gpt-3.5-turbo-1106\", api_key=api_key, org_id=org_id),\n",
+    "        sk_oai.OpenAIChatCompletion(\n",
+    "            service_id=service_id, ai_model_id=\"gpt-3.5-turbo-1106\", api_key=api_key, org_id=org_id\n",
+    "        ),\n",
     "    )\n",
     "elif selectedService == Service.AzureOpenAI:\n",
-    "    from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion\n",
-    "\n",
     "    deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()\n",
     "    service_id = \"default\"\n",
     "    kernel.add_service(\n",
-    "        AzureChatCompletion(service_id=service_id, deployment_name=deployment, endpoint=endpoint, api_key=api_key),\n",
+    "        sk_oai.AzureChatCompletion(\n",
+    "            service_id=service_id, deployment_name=deployment, endpoint=endpoint, api_key=api_key\n",
+    "        ),\n",
     "    )"
    ]
   },
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "93bc6103",
    "metadata": {},
    "outputs": [],
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "ca0e7604",
    "metadata": {},
    "outputs": [],
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "20d35ed0",
    "metadata": {},
    "outputs": [],
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "d5697c09",
    "metadata": {},
    "outputs": [],
@@ -177,10 +177,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b425ba1e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"input\": \"Valentine's Day Date Ideas\",\n",
+      "  \"subtasks\": [\n",
+      "    {\"function\": \"WriterPlugin.Brainstorm\"},\n",
+      "    {\"function\": \"WriterPlugin.EmailTo\", \"args\": {\"recipient\": \"significant_other\"}},\n",
+      "    {\"function\": \"WriterPlugin.Translate\", \"args\": {\"language\": \"French\"}},\n",
+      "    {\"function\": \"TextPlugin.uppercase\"}\n",
+      "  ]\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(basic_plan.generated_plan)"
    ]
@@ -204,44 +220,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "54422ba6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prompt = \"\"\"\n",
-    "{{$input}}\n",
-    "\n",
-    "Rewrite the above in the style of Shakespeare.\n",
-    "\"\"\"\n",
-    "\n",
-    "exec_settings = sk_oai.OpenAIChatPromptExecutionSettings(\n",
-    "    service_id=service_id,\n",
-    "    max_tokens=2000,\n",
-    "    temperature=0.8,\n",
-    ")\n",
-    "\n",
-    "prompt_template_config = sk.PromptTemplateConfig(\n",
-    "    template=prompt,\n",
-    "    function_name=\"shakespeare\",\n",
-    "    plugin_name=\"ShakespearePlugin\",\n",
-    "    name=\"planner\",\n",
-    "    template_format=\"semantic-kernel\",\n",
-    "    input_variables=[\n",
-    "        InputVariable(name=\"input\", description=\"The user input\", is_required=True),\n",
-    "    ],\n",
-    "    execution_settings=exec_settings,\n",
-    ")\n",
-    "\n",
-    "shakespeare_plugin = kernel.create_function_from_prompt(\n",
-    "    function_name=\"shakespeare\",\n",
-    "    plugin_name=\"ShakespearePlugin\",\n",
-    "    prompt_template_config=prompt_template_config,\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "5057cf9b",
    "metadata": {},
@@ -251,34 +229,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "a3161dcf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plugin: SummarizePlugin, Function: MakeAbstractReadable\n",
+      "Plugin: SummarizePlugin, Function: Summarize\n",
+      "Plugin: SummarizePlugin, Function: Topics\n",
+      "Plugin: SummarizePlugin, Function: Notegen\n",
+      "Plugin: WriterPlugin, Function: NovelChapter\n",
+      "Plugin: WriterPlugin, Function: TwoSentenceSummary\n",
+      "Plugin: WriterPlugin, Function: StoryGen\n",
+      "Plugin: WriterPlugin, Function: EnglishImprover\n",
+      "Plugin: WriterPlugin, Function: Rewrite\n",
+      "Plugin: WriterPlugin, Function: Brainstorm\n",
+      "Plugin: WriterPlugin, Function: Translate\n",
+      "Plugin: WriterPlugin, Function: NovelChapterWithNotes\n",
+      "Plugin: WriterPlugin, Function: AcronymGenerator\n",
+      "Plugin: WriterPlugin, Function: EmailGen\n",
+      "Plugin: WriterPlugin, Function: Acronym\n",
+      "Plugin: WriterPlugin, Function: ShortPoem\n",
+      "Plugin: WriterPlugin, Function: EmailTo\n",
+      "Plugin: WriterPlugin, Function: NovelOutline\n",
+      "Plugin: WriterPlugin, Function: TellMeMore\n",
+      "Plugin: WriterPlugin, Function: AcronymReverse\n",
+      "Plugin: WriterPlugin, Function: Shakespeare\n",
+      "Plugin: TextPlugin, Function: lowercase\n",
+      "Plugin: TextPlugin, Function: trim\n",
+      "Plugin: TextPlugin, Function: trim_end\n",
+      "Plugin: TextPlugin, Function: trim_start\n",
+      "Plugin: TextPlugin, Function: uppercase\n"
+     ]
+    }
+   ],
    "source": [
-    "ask = \"\"\"\n",
-    "Tomorrow is Valentine's day. I need to come up with a few date ideas.\n",
-    "She likes Shakespeare so write using his style. She speaks French so write it in French.\n",
-    "Convert the text to uppercase.\"\"\"\n",
+    "from semantic_kernel.functions.kernel_function_from_prompt import KernelFunctionFromPrompt\n",
     "\n",
-    "# TODO: we cannot add an updated ask to a current plan because the underlying plugins already exist\n",
     "kernel = sk.Kernel()\n",
-    "service_id = None\n",
+    "service_id = \"default\"\n",
     "if selectedService == Service.OpenAI:\n",
-    "    from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion\n",
-    "\n",
     "    api_key, org_id = sk.openai_settings_from_dot_env()\n",
-    "    service_id = \"default\"\n",
     "    kernel.add_service(\n",
-    "        OpenAIChatCompletion(service_id=service_id, ai_model_id=\"gpt-3.5-turbo-1106\", api_key=api_key, org_id=org_id),\n",
+    "        sk_oai.OpenAIChatCompletion(\n",
+    "            service_id=service_id, ai_model_id=\"gpt-3.5-turbo-1106\", api_key=api_key, org_id=org_id\n",
+    "        ),\n",
     "    )\n",
     "elif selectedService == Service.AzureOpenAI:\n",
-    "    from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion\n",
-    "\n",
     "    deployment, api_key, endpoint = sk.azure_openai_settings_from_dot_env()\n",
-    "    service_id = \"default\"\n",
     "    kernel.add_service(\n",
-    "        AzureChatCompletion(service_id=service_id, deployment_name=deployment, endpoint=endpoint, api_key=api_key),\n",
+    "        sk_oai.AzureChatCompletion(\n",
+    "            service_id=service_id, deployment_name=deployment, endpoint=endpoint, api_key=api_key\n",
+    "        ),\n",
     "    )\n",
     "\n",
     "plugins_directory = \"../../samples/plugins/\"\n",
@@ -286,16 +291,67 @@
     "writer_plugin = kernel.import_plugin_from_prompt_directory(plugins_directory, \"WriterPlugin\")\n",
     "text_plugin = kernel.import_plugin_from_object(TextPlugin(), \"TextPlugin\")\n",
     "\n",
-    "planner = BasicPlanner(service_id)\n",
-    "new_plan = await planner.create_plan(ask, kernel, prompt)"
+    "shakespeare_func = KernelFunctionFromPrompt(\n",
+    "    function_name=\"Shakespeare\",\n",
+    "    plugin_name=\"WriterPlugin\",\n",
+    "    prompt=\"\"\"\n",
+    "{{$input}}\n",
+    "\n",
+    "Rewrite the above in the style of Shakespeare.\n",
+    "\"\"\",\n",
+    "    prompt_execution_settings=sk_oai.OpenAIChatPromptExecutionSettings(\n",
+    "        service_id=service_id,\n",
+    "        max_tokens=2000,\n",
+    "        temperature=0.8,\n",
+    "    ),\n",
+    ")\n",
+    "kernel.plugins.add_functions_to_plugin([shakespeare_func], \"WriterPlugin\")\n",
+    "\n",
+    "for plugin in kernel.plugins:\n",
+    "    for function in plugin.functions.values():\n",
+    "        print(f\"Plugin: {plugin.name}, Function: {function.name}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "997462e8",
+   "execution_count": 10,
+   "id": "25abac0d",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "planner = BasicPlanner(service_id)\n",
+    "\n",
+    "ask = \"\"\"\n",
+    "Tomorrow is Valentine's day. I need to come up with a few short poems.\n",
+    "She likes Shakespeare so write using his style. She speaks French so write it in French.\n",
+    "Convert the text to uppercase.\"\"\"\n",
+    "\n",
+    "new_plan = await planner.create_plan(goal=ask, kernel=kernel)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "997462e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"input\": \"Valentine's Day Short Poems\",\n",
+      "    \"subtasks\": [\n",
+      "        {\"function\": \"WriterPlugin.Brainstorm\"},\n",
+      "        {\"function\": \"WriterPlugin.ShortPoem\"},\n",
+      "        {\"function\": \"WriterPlugin.Shakespeare\"},\n",
+      "        {\"function\": \"WriterPlugin.Translate\", \"args\": {\"language\": \"French\"}},\n",
+      "        {\"function\": \"TextPlugin.uppercase\"}\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(new_plan.generated_plan)"
    ]
@@ -318,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "9384831a",
    "metadata": {},
    "outputs": [],
@@ -328,10 +384,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "9192b186",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. ÉCOUTEZ ! DES ROSES, ÉCARLATES COMME LE SOLEIL COUCHANT,\n",
+      "   DES VIOLETTES D'AZUR, COMME LE CIEL QUAND LA JOURNÉE EST FINIE.\n",
+      "   EN CE BEAU JOUR DE LA SAINT-VALENTIN, MES PENSÉES SONT À TOI,\n",
+      "   UN CADEAU QUE J'AI OBTENU, UN SECRET À PRÉSERVER.\n",
+      "   NE CRAINS RIEN, BEL AMOUR, CAR CE N'EST QU'UNE DOUCE SURPRISE,\n",
+      "   ET SOIS ASSURÉ, AUCUN SIMPLE DUO DE CRAVATES NE SURGIRA.\n",
+      "\n",
+      "2. L'AMOUR FLOTTE DANS L'AIR, COMME LES CŒURS BATTENT,\n",
+      "   LEUR RYTHME, UN RÉCIT DE PASSION, OH SI DOUX.\n"
+     ]
+    }
+   ],
    "source": [
     "print(results)"
    ]
@@ -372,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "e2e90624",
    "metadata": {},
    "outputs": [],
@@ -384,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "0d537981",
    "metadata": {},
    "outputs": [],
@@ -402,10 +474,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "e7007418",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Convert a string to uppercase. : {'execution_settings': {}}\n",
+      "None : {'execution_settings': {}}\n",
+      "Translate the input into a language of your choice : {'execution_settings': {}}\n"
+     ]
+    }
+   ],
    "source": [
     "for step in sequential_plan._steps:\n",
     "    print(step.description, \":\", step._state.__dict__)"
@@ -421,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "88411884",
    "metadata": {},
    "outputs": [],
@@ -431,10 +513,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "36d27aa0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Il était une fois, dans un pays lointain, très lointain,\n",
+      "Vivait un jeune garçon nommé William,\n",
+      "Avec une plume à la main et du parchemin en vue,\n",
+      "Il cherchait à réécrire un conte de puissance.\n",
+      "\n",
+      "Dans cette belle contrée, connue sous le nom de royaume des Inputs,\n",
+      "Un défi lui fut lancé, pour tester son intelligence,\n",
+      "\"Réécrire dans le style de notre cher barde,\n",
+      "Le conte d'un garçon, dans un langage si ardu.\"\n",
+      "\n",
+      "Avec un cœur rempli de zèle shakespearien,\n",
+      "William releva le défi avec grand enthousiasme,\n",
+      "Il réfléchit et médita, puis commença à écrire,\n",
+      "En pentamètre iambique, de toutes ses forces.\n",
+      "\n",
+      "\"Priez, rassemblez-vous, gentes dames et gentilshommes du pays,\n",
+      "En vérité, j'ai un conte à raconter, si grand,\n",
+      "D'un garçon, nommé William, avec une tâche à accomplir,\n",
+      "Réécrire un Input, dans un langage si noble.\"\n",
+      "\n",
+      "Il fit une pause, et avec un geste de sa plume,\n",
+      "Il commença à réécrire, avec une excitation shakespearienne,\n",
+      "\"Il était une fois, dans un pays si beau,\n",
+      "Vivait un garçon, avec un défi rare.\"\n",
+      "\n",
+      "\"Dans ce pays si juste, où les mots coulent,\n",
+      "William cherchait, un conte à offrir,\n",
+      "Avec une plume à la main, et du parchemin en vue,\n",
+      "Il cherchait à réécrire, de toutes ses forces.\"\n",
+      "\n",
+      "Et ainsi, chers lecteurs, le conte se déroula,\n",
+      "Avec des mots de Shakespeare, si audacieux,\n",
+      "Chaque ligne, un vers, avec rythme et rime,\n",
+      "Un conte transformé, à l'époque du barde.\n",
+      "\n",
+      "Alors applaudissons, cet exploit si grand,\n",
+      "Réécrire un Input, à la main de Shakespeare,\n",
+      "En vérité, le garçon nommé William, il réussit,\n",
+      "À faire ressortir, la beauté de la doctrine du barde.\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]
@@ -457,10 +585,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "5bfc0b9f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Overwriting plugin \"ActionPlanner_Excluded\" in collection\n"
+     ]
+    }
+   ],
    "source": [
     "from semantic_kernel.planners import ActionPlanner\n",
     "\n",
@@ -477,16 +613,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "cc12642a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "KernelPlugin(name='text', description=None, functions={'lowercase': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='lowercase', plugin_name='text', description='Convert a string to lowercase.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.lowercase of TextPlugin()>, stream_method=None), 'trim': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='trim', plugin_name='text', description='Trim whitespace from the start and end of a string.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.trim of TextPlugin()>, stream_method=None), 'trim_end': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='trim_end', plugin_name='text', description='Trim whitespace from the end of a string.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.trim_end of TextPlugin()>, stream_method=None), 'trim_start': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='trim_start', plugin_name='text', description='Trim whitespace from the start of a string.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.trim_start of TextPlugin()>, stream_method=None), 'uppercase': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='uppercase', plugin_name='text', description='Convert a string to uppercase.', parameters=[KernelParameterMetadata(name='input', description='', default_value=None, type_='str', is_required=True, type_object=<class 'str'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method TextPlugin.uppercase of TextPlugin()>, stream_method=None)})"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from semantic_kernel.core_plugins import (\n",
-    "    MathPlugin,\n",
-    "    TextPlugin,\n",
-    "    TimePlugin,\n",
-    ")\n",
+    "from semantic_kernel.core_plugins import MathPlugin, TextPlugin, TimePlugin\n",
     "\n",
     "kernel.import_plugin_from_object(MathPlugin(), \"math\")\n",
     "kernel.import_plugin_from_object(TimePlugin(), \"time\")\n",
@@ -495,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "b938dc0e",
    "metadata": {},
    "outputs": [],
@@ -505,17 +648,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "3aafd268",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WriterPlugin.Shakespeare is missing a description\n",
+      "PlannerPlugin.CreatePlan is missing a description\n",
+      "SequentialPlanner_Excluded.SequentialPlanner_Excluded is missing a description\n"
+     ]
+    }
+   ],
    "source": [
     "plan = await planner.create_plan(goal=ask)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "42589835",
    "metadata": {},
    "outputs": [],
@@ -525,10 +678,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "dc75e7a9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1100\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]
@@ -565,10 +726,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "415f7876",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "KernelPlugin(name='WebSearch', description=None, functions={'search': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='search', plugin_name='WebSearch', description='Performs a web search for a given query', parameters=[KernelParameterMetadata(name='query', description='The search query', default_value=None, type_='str', is_required=True, type_object=<class 'str'>), KernelParameterMetadata(name='num_results', description='The number of search results to return', default_value=1, type_='int', is_required=False, type_object=<class 'int'>), KernelParameterMetadata(name='offset', description='The number of search results to skip', default_value=0, type_='int', is_required=False, type_object=<class 'int'>)], is_prompt=False, is_asynchronous=True, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='str', is_required=True, type_object=None)), method=<bound method WebSearchEnginePlugin.search of <semantic_kernel.core_plugins.web_search_engine_plugin.WebSearchEnginePlugin object at 0x11fd2e750>>, stream_method=None)})"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from semantic_kernel.connectors.search_engine import BingConnector\n",
     "from semantic_kernel.core_plugins import WebSearchEnginePlugin\n",
@@ -588,10 +760,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "abe150e0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Overwriting plugin \"time\" in collection\n",
+      "Overwriting plugin \"math\" in collection\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "KernelPlugin(name='math', description=None, functions={'Add': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='Add', plugin_name='math', description='Returns the Addition result of the values provided.', parameters=[KernelParameterMetadata(name='input', description='the first number to add', default_value=None, type_='int', is_required=True, type_object=<class 'int'>), KernelParameterMetadata(name='amount', description='the second number to add', default_value=None, type_='int', is_required=True, type_object=<class 'int'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='the output is a number', default_value=None, type_='int', is_required=True, type_object=None)), method=<bound method MathPlugin.add of <semantic_kernel.core_plugins.math_plugin.MathPlugin object at 0x10ffe8890>>, stream_method=None), 'Subtract': KernelFunctionFromMethod(metadata=KernelFunctionMetadata(name='Subtract', plugin_name='math', description='Subtracts value to a value', parameters=[KernelParameterMetadata(name='input', description='the first number', default_value=None, type_='int', is_required=True, type_object=<class 'int'>), KernelParameterMetadata(name='amount', description='the number to subtract', default_value=None, type_='int', is_required=True, type_object=<class 'int'>)], is_prompt=False, is_asynchronous=False, return_parameter=KernelParameterMetadata(name='return', description='', default_value=None, type_='int', is_required=True, type_object=None)), method=<bound method MathPlugin.subtract of <semantic_kernel.core_plugins.math_plugin.MathPlugin object at 0x10ffe8890>>, stream_method=None)})"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from semantic_kernel.core_plugins.math_plugin import MathPlugin\n",
     "from semantic_kernel.core_plugins.time_plugin import TimePlugin\n",
@@ -602,10 +793,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "06d08549",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Overwriting plugin \"StepwisePlanner\" in collection\n"
+     ]
+    }
+   ],
    "source": [
     "from semantic_kernel.planners.stepwise_planner import StepwisePlanner, StepwisePlannerConfig\n",
     "\n",
@@ -622,32 +821,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "596ade21",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ask = \"\"\"How many total championships combined do the top 5 teams in the NBA have?\"\"\"\n",
+    "ask = \"\"\"How many total championships combined do the top 5 teams in the NBA have? And which teams are they?\"\"\"\n",
     "\n",
     "plan = planner.create_plan(goal=ask)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "176988ac",
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await plan.invoke()"
+    "result = await plan.invoke(kernel)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "d00c6f71",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The top 5 teams in the NBA have a combined total of 34 championships. The teams are the Celtics, Lakers, and Warriors.\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]
@@ -662,18 +869,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "7159ca1b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Step: 0\n",
+      "Description: Execute a plan\n",
+      "Function: StepwisePlanner.ExecutePlan\n",
+      "  Output: The top 5 teams in the NBA have a combined total of 34 championships. The teams are the Celtics, Lakers, and Warriors.\n"
+     ]
+    }
+   ],
    "source": [
     "for index, step in enumerate(plan._steps):\n",
     "    print(\"Step:\", index)\n",
     "    print(\"Description:\", step.description)\n",
     "    print(\"Function:\", step.plugin_name + \".\" + step._function.name)\n",
-    "    if len(step._outputs) > 0:\n",
-    "        print(\"  Output:\\n\", str.replace(result[step._outputs[0]], \"\\n\", \"\\n  \"))"
+    "    print(f\"  Output: {','.join(str(res) for res in result.metadata['results'])}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82a52451",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -692,7 +917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -619,6 +619,14 @@ class Kernel(KernelBaseModel):
             raise KernelFunctionNotFoundError(f"Function '{function_name}' not found in plugin '{plugin_name}'")
         return self.plugins[plugin_name][function_name]
 
+    def func_from_fully_qualified_function_name(self, fully_qualified_function_name: str) -> KernelFunction:
+        plugin_name, function_name = fully_qualified_function_name.split("-", maxsplit=1)
+        if plugin_name not in self.plugins:
+            raise KernelPluginNotFoundError(f"Plugin '{plugin_name}' not found")
+        if function_name not in self.plugins[plugin_name]:
+            raise KernelFunctionNotFoundError(f"Function '{function_name}' not found in plugin '{plugin_name}'")
+        return self.plugins[plugin_name][function_name]
+
     def create_function_from_prompt(
         self,
         function_name: str,

--- a/python/semantic_kernel/planners/basic_planner.py
+++ b/python/semantic_kernel/planners/basic_planner.py
@@ -153,7 +153,7 @@ class BasicPlanner:
         for name in list(all_functions_descriptions_dict.keys()):
             available_functions_string += name + "\n"
             description = all_functions_descriptions_dict[name] or ""
-            available_functions_string += "description: " + description + "\n"
+            available_functions_string += "description: " + description + "\n" if description else ""
             available_functions_string += "args:\n"
 
             # Add the parameters for each function
@@ -225,8 +225,7 @@ class BasicPlanner:
 
         for subtask in subtasks:
             plugin_name, function_name = subtask["function"].split(".")
-            kernel_function = kernel.plugins[plugin_name][function_name]
-
+            kernel_function = kernel.func(plugin_name, function_name)
             # Get the arguments dictionary for the function
             args = subtask.get("args", None)
             if args:

--- a/python/semantic_kernel/planners/plan.py
+++ b/python/semantic_kernel/planners/plan.py
@@ -135,7 +135,7 @@ class Plan:
 
         Args:
             input (str, optional): The input to the plan. Defaults to None.
-            context (KernelContext, optional): The context to use. Defaults to None.
+            arguments (KernelArguments, optional): The context to use. Defaults to None.
             settings (PromptExecutionSettings, optional): The AI request settings to use. Defaults to None.
             memory (SemanticTextMemoryBase, optional): The memory to use. Defaults to None.
             **kwargs: Additional keyword arguments.

--- a/python/semantic_kernel/planners/sequential_planner/sequential_planner.py
+++ b/python/semantic_kernel/planners/sequential_planner/sequential_planner.py
@@ -111,14 +111,12 @@ class SequentialPlanner:
         plan_result_string = str(plan_result).strip()
 
         try:
-            get_plugin_function = self.config.get_plugin_function or SequentialPlanParser.get_plugin_function(
-                self._kernel
-            )
             plan = SequentialPlanParser.to_plan_from_xml(
-                plan_result_string,
-                goal,
-                get_plugin_function,
-                self.config.allow_missing_functions,
+                xml_string=plan_result_string,
+                goal=goal,
+                kernel=self._kernel,
+                get_plugin_function=self.config.get_plugin_function,
+                allow_missing_functions=self.config.allow_missing_functions,
             )
 
             if len(plan._steps) == 0:

--- a/python/semantic_kernel/planners/sequential_planner/sequential_planner.py
+++ b/python/semantic_kernel/planners/sequential_planner/sequential_planner.py
@@ -105,8 +105,7 @@ class SequentialPlanner:
         if isinstance(plan_result, FunctionResult) and "exception" in plan_result.metadata:
             raise PlannerCreatePlanError(
                 f"Error creating plan for goal: {plan_result.metadata['exception']}",
-                plan_result.metadata["exception"],
-            )
+            ) from plan_result.metadata["exception"]
 
         plan_result_string = str(plan_result).strip()
 

--- a/python/semantic_kernel/planners/sequential_planner/sequential_planner_parser.py
+++ b/python/semantic_kernel/planners/sequential_planner/sequential_planner_parser.py
@@ -6,6 +6,7 @@ from typing import Callable, Optional, Tuple
 from defusedxml import ElementTree as ET
 
 from semantic_kernel.exceptions import PlannerInvalidPlanError
+from semantic_kernel.exceptions.kernel_exceptions import KernelFunctionNotFoundError, KernelPluginNotFoundError
 from semantic_kernel.functions.kernel_arguments import KernelArguments
 from semantic_kernel.functions.kernel_function import KernelFunction
 from semantic_kernel.kernel import Kernel
@@ -21,24 +22,11 @@ APPEND_TO_RESULT_TAG = "appendToResult"
 
 class SequentialPlanParser:
     @staticmethod
-    def get_plugin_function(
-        kernel: Kernel,
-    ) -> Callable[[str, str], Optional[KernelFunction]]:
-        def function(plugin_name: str, function_name: str) -> Optional[KernelFunction]:
-            if not kernel.plugins:
-                return None
-            try:
-                return kernel.plugins[plugin_name][function_name]
-            except KeyError:
-                return None
-
-        return function
-
-    @staticmethod
     def to_plan_from_xml(
         xml_string: str,
         goal: str,
-        get_plugin_function: Callable[[str, str], Optional[KernelFunction]],
+        kernel: Kernel,
+        get_plugin_function: Optional[Callable[[str, str], Optional[KernelFunction]]] = None,
         allow_missing_functions: bool = False,
     ):
         xml_string = "<xml>" + xml_string + "</xml>"
@@ -63,52 +51,62 @@ class SequentialPlanParser:
         plan = Plan.from_goal(goal)
         for solution_node in solution:
             for child_node in solution_node:
-                if child_node.tag == "#text" or child_node.tag == "#comment":
+                if (
+                    child_node.tag == "#text"
+                    or child_node.tag == "#comment"
+                    or (not child_node.tag.startswith(FUNCTION_TAG))
+                ):
                     continue
 
-                if child_node.tag.startswith(FUNCTION_TAG):
-                    plugin_function_name = child_node.tag.split(FUNCTION_TAG)[1]
-                    (
-                        plugin_name,
-                        function_name,
-                    ) = SequentialPlanParser.get_plugin_function_names(plugin_function_name)
-
-                    if function_name:
-                        plugin_function = get_plugin_function(plugin_name, function_name)
-
-                        if plugin_function is not None:
-                            plan_step = Plan.from_function(plugin_function)
-
-                            function_variables = KernelArguments()
-                            function_outputs = []
-                            function_results = []
-
-                            metadata = plugin_function.metadata
-                            for p in metadata.parameters:
-                                function_variables[p.name] = p.default_value
-
-                            for attr in child_node.attrib:
-                                if attr == SET_CONTEXT_VARIABLE_TAG:
-                                    function_outputs.append(child_node.attrib[attr])
-                                elif attr == APPEND_TO_RESULT_TAG:
-                                    function_outputs.append(child_node.attrib[attr])
-                                    function_results.append(child_node.attrib[attr])
-                                else:
-                                    function_variables[attr] = child_node.attrib[attr]
-
-                            plan_step._outputs = function_outputs
-                            plan_step._parameters = function_variables
-
-                            for result in function_results:
-                                plan._outputs.append(result)
-
-                            plan.add_steps([plan_step])
-                        elif allow_missing_functions:
+                plugin_function_name = child_node.tag.split(FUNCTION_TAG)[1]
+                if get_plugin_function:
+                    try:
+                        func = get_plugin_function(
+                            *SequentialPlanParser.get_plugin_function_names(plugin_function_name)
+                        )
+                    except Exception as exc:
+                        if allow_missing_functions:
                             plan.add_steps([Plan.from_goal(plugin_function_name)])
+                            continue
+                        else:
+                            raise PlannerInvalidPlanError(f"Failed to find function '{plugin_function_name}'.") from exc
+                else:
+                    try:
+                        func = kernel.func_from_fully_qualified_function_name(plugin_function_name)
+                    except (KernelFunctionNotFoundError, KernelPluginNotFoundError) as exc:
+                        if allow_missing_functions:
+                            plan.add_steps([Plan.from_goal(plugin_function_name)])
+                            continue
                         else:
                             raise PlannerInvalidPlanError(
-                                f"Failed to find function '{plugin_function_name}' in plugin '{plugin_name}'.",
-                            )
+                                f"Failed to find function '{plugin_function_name}'.",
+                            ) from exc
+
+                plan_step = Plan.from_function(func)
+
+                function_variables = KernelArguments()
+                function_outputs = []
+                function_results = []
+
+                for p in func.metadata.parameters:
+                    function_variables[p.name] = p.default_value
+
+                for attr in child_node.attrib:
+                    if attr == SET_CONTEXT_VARIABLE_TAG:
+                        function_outputs.append(child_node.attrib[attr])
+                    elif attr == APPEND_TO_RESULT_TAG:
+                        function_outputs.append(child_node.attrib[attr])
+                        function_results.append(child_node.attrib[attr])
+                    else:
+                        function_variables[attr] = child_node.attrib[attr]
+
+                plan_step._outputs = function_outputs
+                plan_step._parameters = function_variables
+
+                for result in function_results:
+                    plan._outputs.append(result)
+
+                plan.add_steps([plan_step])
 
         return plan
 

--- a/python/semantic_kernel/planners/stepwise_planner/Plugins/StepwiseStep/skprompt.txt
+++ b/python/semantic_kernel/planners/stepwise_planner/Plugins/StepwiseStep/skprompt.txt
@@ -21,19 +21,19 @@ IMPORTANT: Use only the available functions listed in the [AVAILABLE FUNCTIONS] 
 
 Here is an example of a valid $JSON_BLOB:
 {
-  "action": "functionName",
+  "action": "pluginName-functionName",
   "action_variables": {"parameterName": "some value", ...}
 }
 
 Here is another example of a valid $JSON_BLOB:
 {
-  "action": "_Function_.Name",
+  "action": "Plugin-Function",
   "action_variables": {"parameterName": "some value", ...}
 }
 
 Here is another example of a valid $JSON_BLOB:
 {
-  "action": "FunctionName2",
+  "action": "Plugin-FunctionName2",
   "action_variables": {"parameterName": "some value", ...}
 }
 
@@ -48,7 +48,7 @@ the input question I must answer
 To solve this problem, I should carefully analyze the given question and identify the necessary steps. Any facts I discover earlier in my thought process should be repeated here to keep them readily available.
 [ACTION]
 {
-  "action": "functionName",
+  "action": "plugin-functionName",
   "action_variables": {"parameterName": "some value", ...}
 }
 [OBSERVATION]

--- a/python/semantic_kernel/planners/stepwise_planner/__init__.py
+++ b/python/semantic_kernel/planners/stepwise_planner/__init__.py
@@ -1,5 +1,4 @@
 from semantic_kernel.planners.stepwise_planner.stepwise_planner import StepwisePlanner
+from semantic_kernel.planners.stepwise_planner.stepwise_planner_config import StepwisePlannerConfig
 
-__all__ = [
-    "StepwisePlanner",
-]
+__all__ = ["StepwisePlanner", "StepwisePlannerConfig"]

--- a/python/tests/integration/planning/sequential_planner/test_sequential_plan_parser.py
+++ b/python/tests/integration/planning/sequential_planner/test_sequential_plan_parser.py
@@ -38,11 +38,7 @@ async def test_can_call_to_plan_from_xml(get_aoai_config):
 """
     goal = "Summarize an input, translate to french, and e-mail to John Doe"
 
-    plan = SequentialPlanParser.to_plan_from_xml(
-        plan_string,
-        goal,
-        SequentialPlanParser.get_plugin_function(kernel),
-    )
+    plan = SequentialPlanParser.to_plan_from_xml(plan_string, goal, kernel)
 
     assert plan is not None
     assert plan.description == "Summarize an input, translate to french, and e-mail to John Doe"

--- a/python/tests/unit/planners/sequential_planner/test_sequential_planner.py
+++ b/python/tests/unit/planners/sequential_planner/test_sequential_planner.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -29,14 +29,8 @@ def create_mock_function(kernel_function_metadata: KernelFunctionMetadata):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("goal", ["Write a poem or joke and send it in an e-mail to Kai."])
-async def test_it_can_create_plan(goal):
+async def test_it_can_create_plan(goal, kernel: Kernel):
     # Arrange
-    kernel = Mock(spec=Kernel)
-    kernel.prompt_template_engine = Mock()
-
-    memory = Mock(spec=SemanticTextMemoryBase)
-    kernel.memory = memory
-
     input = [
         ("SendEmail", "email", "Send an e-mail", False),
         ("GetEmailAddress", "email", "Get an e-mail address", False),
@@ -86,20 +80,19 @@ async def test_it_can_create_plan(goal):
         value=plan_string,
         metadata={},
     )
-    kernel.create_function_from_prompt.return_value = mock_function_flow_function
+    with patch("semantic_kernel.kernel.Kernel.create_function_from_prompt", return_value=mock_function_flow_function):
+        planner = SequentialPlanner(kernel, service_id="test")
 
-    planner = SequentialPlanner(kernel, service_id="test")
+        # Act
+        plan = await planner.create_plan(goal)
 
-    # Act
-    plan = await planner.create_plan(goal)
-
-    # Assert
-    assert plan.description == goal
-    assert any(step.name in expected_functions and step.plugin_name in expected_plugins for step in plan._steps)
-    for expected_function in expected_functions:
-        assert any(step.name == expected_function for step in plan._steps)
-    for expectedPlugin in expected_plugins:
-        assert any(step.plugin_name == expectedPlugin for step in plan._steps)
+        # Assert
+        assert plan.description == goal
+        assert any(step.name in expected_functions and step.plugin_name in expected_plugins for step in plan._steps)
+        for expected_function in expected_functions:
+            assert any(step.name == expected_function for step in plan._steps)
+        for expectedPlugin in expected_plugins:
+            assert any(step.plugin_name == expectedPlugin for step in plan._steps)
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/planners/sequential_planner/test_sequential_planner_parser.py
+++ b/python/tests/unit/planners/sequential_planner/test_sequential_planner_parser.py
@@ -79,9 +79,9 @@ def test_can_call_to_plan_from_xml():
     goal = "Summarize an input, translate to french, and e-mail to John Doe"
 
     plan = SequentialPlanParser.to_plan_from_xml(
-        plan_string,
-        goal,
-        SequentialPlanParser.get_plugin_function(kernel),
+        xml_string=plan_string,
+        goal=goal,
+        kernel=kernel,
     )
 
     assert plan is not None
@@ -112,11 +112,7 @@ def test_invalid_plan_execute_plan_returns_invalid_result():
 
     # Act and Assert
     with pytest.raises(PlannerInvalidPlanError):
-        SequentialPlanParser.to_plan_from_xml(
-            "<someTag>",
-            "Solve the equation x^2 = 2.",
-            SequentialPlanParser.get_plugin_function(kernel),
-        )
+        SequentialPlanParser.to_plan_from_xml("<someTag>", "Solve the equation x^2 = 2.", kernel)
 
 
 def test_can_create_plan_with_text_nodes():
@@ -137,7 +133,7 @@ def test_can_create_plan_with_text_nodes():
     plan = SequentialPlanParser.to_plan_from_xml(
         plan_text,
         goal_text,
-        SequentialPlanParser.get_plugin_function(kernel),
+        kernel,
     )
 
     # Assert
@@ -178,10 +174,10 @@ def test_can_create_plan_with_invalid_function_nodes(plan_text, allow_missing_fu
     # Act and Assert
     if allow_missing_functions:
         plan = SequentialPlanParser.to_plan_from_xml(
-            plan_text,
-            "",
-            SequentialPlanParser.get_plugin_function(kernel),
-            allow_missing_functions,
+            xml_string=plan_text,
+            goal="",
+            kernel=kernel,
+            allow_missing_functions=allow_missing_functions,
         )
 
         # Assert
@@ -200,8 +196,7 @@ def test_can_create_plan_with_invalid_function_nodes(plan_text, allow_missing_fu
             SequentialPlanParser.to_plan_from_xml(
                 plan_text,
                 "",
-                SequentialPlanParser.get_plugin_function(kernel),
-                allow_missing_functions,
+                kernel,
             )
 
 
@@ -236,17 +231,17 @@ def test_can_create_plan_with_other_text():
     plan1 = SequentialPlanParser.to_plan_from_xml(
         plan_text1,
         goal_text,
-        SequentialPlanParser.get_plugin_function(kernel),
+        kernel,
     )
     plan2 = SequentialPlanParser.to_plan_from_xml(
         plan_text2,
         goal_text,
-        SequentialPlanParser.get_plugin_function(kernel),
+        kernel,
     )
     plan3 = SequentialPlanParser.to_plan_from_xml(
         plan_text3,
         goal_text,
-        SequentialPlanParser.get_plugin_function(kernel),
+        kernel,
     )
 
     # Assert
@@ -310,7 +305,7 @@ def test_can_create_plan_with_open_api_plugin(plan_text):
     plan = SequentialPlanParser.to_plan_from_xml(
         plan_text,
         "",
-        SequentialPlanParser.get_plugin_function(kernel),
+        kernel,
     )
 
     # Assert
@@ -337,7 +332,7 @@ def test_can_create_plan_with_ignored_nodes():
     plan = SequentialPlanParser.to_plan_from_xml(
         plan_text,
         goal_text,
-        SequentialPlanParser.get_plugin_function(kernel),
+        kernel,
     )
 
     # Assert

--- a/samples/plugins/WriterPlugin/Brainstorm/skprompt.txt
+++ b/samples/plugins/WriterPlugin/Brainstorm/skprompt.txt
@@ -4,5 +4,5 @@ Must: only one list.
 Must: end list with ##END##
 Should: no more than 10 items.
 Should: at least 3 items.
-Topic: {{$INPUT}}
+Topic: {{$input}}
 Start.


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Based on #5474 went into the `using-the-planner` notebook and made sure it works with the latest code.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Moved all the planners to use '-' in line with the current work on new templates and planners, once that is in several extension classes can be changed.
Encountered several small bugs left over from changes over the last months.
Got through the whole notebook with results.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
