### PR TITLE
.Net: Update namespace in Gemini connector files

### DIFF
--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/GeminiKernelFunctionMetadataExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/GeminiKernelFunctionMetadataExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 
-namespace Microsoft.SemanticKernel;
+namespace Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 
 /// <summary>
 /// Extensions for <see cref="KernelFunctionMetadata"/> specific to the Gemini connector.

--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/GeminiPluginCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI/Extensions/GeminiPluginCollectionExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 
-namespace Microsoft.SemanticKernel;
+namespace Microsoft.SemanticKernel.Connectors.GoogleVertexAI;
 
 /// <summary>
 /// Extension methods for <see cref="IReadOnlyKernelPluginCollection"/>.


### PR DESCRIPTION
The namespace has been updated in the GeminiKernelFunctionMetadataExtensions.cs and GeminiPluginCollectionExtensions.cs files. The namespace was amended from 'Microsoft.SemanticKernel' to 'Microsoft.SemanticKernel.Connectors.GoogleVertexAI'..

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

