### PR TITLE
.Net - Fix agent function invocation and examples

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example72_AgentCollaboration.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example72_AgentCollaboration.cs
@@ -149,7 +149,7 @@ public class Example72_AgentCollaboration : BaseTest
         return
             UseOpenAI ?
                 builder.WithOpenAIChatCompletion(OpenAIFunctionEnabledModel, TestConfiguration.OpenAI.ApiKey) :
-                builder.WithAzureOpenAIChatCompletion(TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.DeploymentName, TestConfiguration.AzureOpenAI.ApiKey);
+                builder.WithAzureOpenAIChatCompletion(TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.ApiKey);
     }
 
     private void DisplayMessages(IEnumerable<IChatMessage> messages, IAgent? agent = null)

--- a/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
+++ b/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
@@ -78,13 +78,6 @@
     <Compile Remove="RepoUtils\PlanExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Resources\Agents\ParrotAgent.yaml" />
-    <None Remove="Resources\Agents\ToolAgent.yaml" />
-    <None Remove="Resources\GenerateStory.yaml" />
-    <None Remove="Resources\GenerateStoryHandlebars.yaml" />
-    <None Remove="Resources\travelinfo.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Plugins\ApiManifestPlugins\**\apimanifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
+++ b/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
@@ -14,14 +14,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="RepoUtils\PlanExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="Resources\GenerateStory.yaml" />
-    <None Remove="Resources\GenerateStoryHandlebars.yaml" />
-    <None Remove="Resources\travelinfo.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
@@ -83,13 +75,25 @@
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <Compile Remove="RepoUtils\PlanExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Resources\Agents\ParrotAgent.yaml" />
+    <None Remove="Resources\Agents\ToolAgent.yaml" />
+    <None Remove="Resources\GenerateStory.yaml" />
+    <None Remove="Resources\GenerateStoryHandlebars.yaml" />
+    <None Remove="Resources\travelinfo.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Plugins\ApiManifestPlugins\**\apimanifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Agents\ParrotAgent.yaml" />
+    <EmbeddedResource Include="Resources\Agents\ToolAgent.yaml" />
   </ItemGroup>
 </Project>

--- a/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
+++ b/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
@@ -93,7 +93,6 @@
     <EmbeddedResource Include="Resources\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Agents\ParrotAgent.yaml" />
-    <EmbeddedResource Include="Resources\Agents\ToolAgent.yaml" />
+    <EmbeddedResource Include="Resources\Agents\*" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Experimental/Agents/IChatMessage.cs
+++ b/dotnet/src/Experimental/Agents/IChatMessage.cs
@@ -6,17 +6,17 @@ using System.Collections.ObjectModel;
 namespace Microsoft.SemanticKernel.Experimental.Agents;
 
 /// <summary>
-/// $$$
+/// Describes the message content type
 /// </summary>
 public enum ChatMessageType
 {
     /// <summary>
-    /// $$$
+    /// A message with text content
     /// </summary>
     Text,
 
     /// <summary>
-    /// $$$
+    /// A message that references an image by file-id
     /// </summary>
     Image,
 }
@@ -37,7 +37,7 @@ public interface IChatMessage
     string? AgentId { get; }
 
     /// <summary>
-    /// $$$
+    /// Describes the content-type of the message
     /// </summary>
     ChatMessageType ContentType { get; }
 

--- a/dotnet/src/Experimental/Agents/Internal/Agent.cs
+++ b/dotnet/src/Experimental/Agents/Internal/Agent.cs
@@ -134,7 +134,7 @@ internal sealed class Agent : IAgent
             (this._model.Tools.Any(t => string.Equals(t.Type, ToolRetrieval, StringComparison.OrdinalIgnoreCase)) ? AgentCapability.Retrieval : AgentCapability.None) |
             (this._model.Tools.Any(t => string.Equals(t.Type, ToolCodeInterpreter, StringComparison.OrdinalIgnoreCase)) ? AgentCapability.CodeInterpreter : AgentCapability.None);
 
-        this._tools = [.. this._model.Tools, .. this.Kernel.Plugins.SelectMany(p => p.Select(f => f.ToToolModel(p.Name)))];
+        this._tools = this._model.Tools.Concat(this.Kernel.Plugins.SelectMany(p => p.Select(f => f.ToToolModel(p.Name)))).ToArray();
     }
 
     public AgentPlugin AsPlugin() => this._agentPlugin ??= this.DefinePlugin();

--- a/dotnet/src/Experimental/Agents/Internal/Agent.cs
+++ b/dotnet/src/Experimental/Agents/Internal/Agent.cs
@@ -134,7 +134,7 @@ internal sealed class Agent : IAgent
             (this._model.Tools.Any(t => string.Equals(t.Type, ToolRetrieval, StringComparison.OrdinalIgnoreCase)) ? AgentCapability.Retrieval : AgentCapability.None) |
             (this._model.Tools.Any(t => string.Equals(t.Type, ToolCodeInterpreter, StringComparison.OrdinalIgnoreCase)) ? AgentCapability.CodeInterpreter : AgentCapability.None);
 
-        this._tools = this._model.Tools.Concat(this.Kernel.Plugins.SelectMany(p => p.Select(f => f.ToToolModel(p.Name)))).ToArray();
+        this._tools = [.. this._model.Tools, .. this.Kernel.Plugins.SelectMany(p => p.Select(f => f.ToToolModel(p.Name)))];
     }
 
     public AgentPlugin AsPlugin() => this._agentPlugin ??= this.DefinePlugin();
@@ -221,22 +221,18 @@ internal sealed class Agent : IAgent
     /// </summary>
     /// <param name="input">The user input</param>
     /// <param name="arguments">Arguments for parameterized instructions</param>
-    /// <param name="fileIds">an array of up to 10 file ids to reference for the message</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>An agent response (<see cref="AgentResponse"/></returns>
     private async Task<AgentResponse> AskAsync(
         [Description("The user message provided to the agent.")]
         string input,
         KernelArguments arguments,
-        string[]? fileIds = null,
         CancellationToken cancellationToken = default)
     {
         var thread = await this.NewThreadAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await thread.AddUserMessageAsync(input, fileIds, cancellationToken).ConfigureAwait(false);
-
-            var messages = await thread.InvokeAsync(this, input, arguments, fileIds, cancellationToken).ToArrayAsync(cancellationToken).ConfigureAwait(false);
+            var messages = await thread.InvokeAsync(this, input, arguments, fileIds: null, cancellationToken).ToArrayAsync(cancellationToken).ConfigureAwait(false);
             var response =
                 new AgentResponse
                 {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Noticed that agent examples failing due to resourcing and configuration delta.  As part of this discovered agent as plugin regression from community contribution.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Include agent templates as embedded resources
- Switch from `TestConfiguration.AzureOpenAI.DeploymentName` to `TestConfiguration.AzureOpenAI.ChatDeploymentName` in `Example72_AgentCollaboration`
- Remove `fileIds` from `Agent.AskAsync` (not utilized and resulting in failed run creation) - https://github.com/microsoft/semantic-kernel/pull/5110
- Eliminated user-message duplication
- Added comments to `ChatMessageType`

![image](https://github.com/microsoft/semantic-kernel/assets/66376200/0750a803-d567-448c-a650-144e009307cd)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
