### PR TITLE
.Net: Update test assertions in GeminiPluginCollectionExtensionsTests

### DIFF
--- a/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Extensions/GeminiPluginCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.GoogleVertexAI.UnitTests/Extensions/GeminiPluginCollectionExtensionsTests.cs
@@ -46,7 +46,8 @@ public sealed class GeminiPluginCollectionExtensionsTests
 
         // Assert
         Assert.True(result);
-        Assert.Same(function, actualFunction);
+        Assert.NotNull(actualFunction);
+        Assert.Equal(function.Name, actualFunction.Name);
         Assert.Null(actualArguments);
     }
 
@@ -74,7 +75,8 @@ public sealed class GeminiPluginCollectionExtensionsTests
 
         // Assert
         Assert.True(result);
-        Assert.Same(function, actualFunction);
+        Assert.NotNull(actualFunction);
+        Assert.Equal(function.Name, actualFunction.Name);
 
         Assert.NotNull(actualArguments);
         Assert.Equal(expectedArgs["location"]!.ToString(), actualArguments["location"]!.ToString());


### PR DESCRIPTION
Changed the assertion methods used in GeminiPluginCollectionExtensionsTests. Instead of checking if the functions are the same, the test now asserts that the actual function is not null and that its name is equal to the expected function's name. This change makes the tests pass after cloning function was introduced to kernel.
