### PR TITLE
.Net: Disable Azure SDK network timeout when a custom HttpClient is supplied

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -749,6 +749,7 @@ internal abstract class ClientCore
         {
             options.Transport = new HttpClientTransport(httpClient);
             options.RetryPolicy = new RetryPolicy(maxRetries: 0); // Disable Azure SDK retry policy if and only if a custom HttpClient is provided.
+            options.Retry.NetworkTimeout = Timeout.InfiniteTimeSpan; // Disable Azure SDK default timeout
         }
 
         return options;


### PR DESCRIPTION
Fixes https://github.com/microsoft/semantic-kernel/issues/5310