### PR TITLE
Python: Fix - Action Planner breaking when parameters are not explicitly given in the ask

### DIFF
--- a/python/semantic_kernel/planners/action_planner/action_planner.py
+++ b/python/semantic_kernel/planners/action_planner/action_planner.py
@@ -148,7 +148,6 @@ class ActionPlanner:
             )
             plan = Plan(description=goal, function=function_ref)
 
-
         if "parameters" in generated_plan['plan']:
             for key, val in generated_plan["plan"]["parameters"].items():
                 logger.info(f"Parameter {key}: {val}")


### PR DESCRIPTION
Solution to the issue: Python: Action Planner breaking when parameters are not explicitly given in the ask
https://github.com/microsoft/semantic-kernel/issues/5583

### Motivation and Context

  1. What problem does it solve? 
A. The action planner breaks when the user does not provide specific parameters in the ask/goal
  2. What scenario does it contribute to? 
A. In cases when user may not explicitly mention any parameters in the ask/goal
  3. If it fixes an open issue, please link to the issue here. 
A. It fixes the issue https://github.com/microsoft/semantic-kernel/issues/5583

### Description

Just adding an IF condition before iterating through the generated_plan variable to check if parameters are present or not does the job