### PR TITLE
Python: add additional handlebars test, to make sure built-in helpers run

### DIFF
--- a/python/tests/unit/prompt_template/test_handlebars_prompt_template.py
+++ b/python/tests/unit/prompt_template/test_handlebars_prompt_template.py
@@ -329,3 +329,27 @@ async def test_helpers_messageToPrompt_other(kernel: Kernel):
     other_list = ["test1", "test2"]
     rendered = await target.render(kernel, KernelArguments(other_list=other_list))
     assert rendered.strip() == """test1 test2"""
+
+
+@mark.asyncio
+async def test_helpers_unless(kernel: Kernel):
+    template = """{{#unless test}}test2{{/unless}}"""
+    target = create_handlebars_prompt_template(template)
+    rendered = await target.render(kernel, KernelArguments(test2="test2"))
+    assert rendered.strip() == """test2"""
+
+
+@mark.asyncio
+async def test_helpers_with(kernel: Kernel):
+    template = """{{#with test}}{{test1}}{{/with}}"""
+    target = create_handlebars_prompt_template(template)
+    rendered = await target.render(kernel, KernelArguments(test={"test1": "test2"}))
+    assert rendered.strip() == """test2"""
+
+
+@mark.asyncio
+async def test_helpers_lookup(kernel: Kernel):
+    template = """{{lookup test 'test1'}}"""
+    target = create_handlebars_prompt_template(template)
+    rendered = await target.render(kernel, KernelArguments(test={"test1": "test2"}))
+    assert rendered.strip() == """test2"""


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
added handlebars tests

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
