### PR TITLE
Python: fixed the broken link

### DIFF
--- a/python/notebooks/05-using-the-planner.ipynb
+++ b/python/notebooks/05-using-the-planner.ipynb
@@ -354,12 +354,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "514aebf0",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
    "id": "a1c66d83",
    "metadata": {},
    "source": [

--- a/python/notebooks/05-using-the-planner.ipynb
+++ b/python/notebooks/05-using-the-planner.ipynb
@@ -354,10 +354,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "514aebf0",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "a1c66d83",
    "metadata": {},
    "source": [
-    "The sequential planner is an XML-based step-by-step planner. You can see the prompt used for it here (https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/planning/sequential_planner/Plugins/SequentialPlanning/skprompt.txt)\n"
+    "The sequential planner is an XML-based step-by-step planner. You can see the prompt used for it here (https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/planners/sequential_planner/Plugins/SequentialPlanning/skprompt.txt))\n"
    ]
   },
   {


### PR DESCRIPTION
### Motivation and Context

Link was expired in the jupiter notebook


### Description

Path was changed from planning to planners and the link was not updated.

https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/**planning**/sequential_planner/Plugins/SequentialPlanning/skprompt.txt

https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/**planners**/sequential_planner/Plugins/SequentialPlanning/skprompt.txt


