### PR TITLE
Python: Remove jinja2 built in helpers from custom helpers. Introduce messages custom func helper.

### DIFF
--- a/python/semantic_kernel/prompt_template/utils/handlebars_system_helpers.py
+++ b/python/semantic_kernel/prompt_template/utils/handlebars_system_helpers.py
@@ -6,10 +6,16 @@ import re
 from enum import Enum
 from typing import Callable, Dict
 
-from semantic_kernel.contents.chat_history import ROOT_KEY_MESSAGE
+from semantic_kernel.contents.chat_history import ROOT_KEY_MESSAGE, ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _messages(this, options, *args, **kwargs):
+    if not isinstance(this.context["chat_history"], ChatHistory):
+        return ""
+    return str(this.context["chat_history"])
 
 
 def _message_to_prompt(this, *args, **kwargs):
@@ -163,4 +169,5 @@ HANDLEBAR_SYSTEM_HELPERS: Dict[str, Callable] = {
     "message": _message,
     "message_to_prompt": _message_to_prompt,
     "messageToPrompt": _message_to_prompt,
+    "messages": _messages,
 }

--- a/python/semantic_kernel/prompt_template/utils/jinja2_system_helpers.py
+++ b/python/semantic_kernel/prompt_template/utils/jinja2_system_helpers.py
@@ -1,15 +1,20 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import json
 import logging
 import re
 from enum import Enum
 from typing import Callable, Dict
 
-from semantic_kernel.contents.chat_history import ROOT_KEY_MESSAGE
+from semantic_kernel.contents.chat_history import ROOT_KEY_MESSAGE, ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _messages(chat_history):
+    if not isinstance(chat_history, ChatHistory):
+        return ""
+    return str(chat_history)
 
 
 def _message_to_prompt(context):
@@ -57,65 +62,6 @@ def _array(*args, **kwargs):
     return list(args)
 
 
-def _range(*args, **kwargs):
-    args = list(args)
-    for index, arg in enumerate(args):
-        if not isinstance(arg, int):
-            try:
-                args[index] = int(arg)
-            except ValueError:
-                args.pop(index)
-    if len(args) == 1:
-        return list(range(args[0]))
-    if len(args) == 2:
-        return list(range(args[0], args[1]))
-    if len(args) == 3:
-        return list(range(args[0], args[1], args[2]))
-    return []
-
-
-def _concat(*args, **kwargs):
-    return "".join([str(value) for value in args])
-
-
-def _or(*args, **kwargs):
-    return any(args)
-
-
-def _add(*args, **kwargs):
-    return sum([float(value) for value in args])
-
-
-def _subtract(*args, **kwargs):
-    return float(args[0]) - sum([float(value) for value in args[1:]])
-
-
-def _equals(*args, **kwargs):
-    return args[0] == args[1]
-
-
-def _less_than(*args, **kwargs):
-    return float(args[0]) < float(args[1])
-
-
-def _greater_than(*args, **kwargs):
-    return float(args[0]) > float(args[1])
-
-
-def _less_than_or_equal(*args, **kwargs):
-    return float(args[0]) <= float(args[1])
-
-
-def _greater_than_or_equal(*args, **kwargs):
-    return float(args[0]) >= float(args[1])
-
-
-def _json(*args, **kwargs):
-    if not args:
-        return ""
-    return json.dumps(args[0])
-
-
 def _camel_case(*args, **kwargs):
     return "".join([word.capitalize() for word in args[0].split("_")])
 
@@ -136,23 +82,9 @@ JINJA2_SYSTEM_HELPERS: Dict[str, Callable] = {
     "doubleClose": _double_close,
     "message": _message,
     "message_to_prompt": _message_to_prompt,
+    "messages": _messages,
     "messageToPrompt": _message_to_prompt,
     "array": _array,
-    "range": _range,
-    "concat": _concat,
-    "or": _or,
-    "add": _add,
-    "subtract": _subtract,
-    "equals": _equals,
-    "less_than": _less_than,
-    "lessThan": _less_than,
-    "greater_than": _greater_than,
-    "greaterThan": _greater_than,
-    "less_than_or_equal": _less_than_or_equal,
-    "lessThanOrEqual": _less_than_or_equal,
-    "greater_than_or_equal": _greater_than_or_equal,
-    "greaterThanOrEqual": _greater_than_or_equal,
-    "json": _json,
     "camel_case": _camel_case,
     "camelCase": _camel_case,
     "snake_case": _snake_case,

--- a/python/tests/unit/prompt_template/test_handlebars_prompt_template.py
+++ b/python/tests/unit/prompt_template/test_handlebars_prompt_template.py
@@ -353,3 +353,17 @@ async def test_helpers_lookup(kernel: Kernel):
     target = create_handlebars_prompt_template(template)
     rendered = await target.render(kernel, KernelArguments(test={"test1": "test2"}))
     assert rendered.strip() == """test2"""
+
+
+@mark.asyncio
+async def test_helpers_chat_history_messages(kernel: Kernel):
+    template = """{{messages chat_history}}"""
+    target = create_handlebars_prompt_template(template)
+    chat_history = ChatHistory()
+    chat_history.add_user_message("User message")
+    chat_history.add_assistant_message("Assistant message")
+    rendered = await target.render(kernel, KernelArguments(chat_history=chat_history))
+    assert (
+        rendered.strip()
+        == """<chat_history><message role="user">User message</message><message role="assistant">Assistant message</message></chat_history>"""  # noqa E501
+    )

--- a/python/tests/unit/prompt_template/test_jinja2_prompt_template.py
+++ b/python/tests/unit/prompt_template/test_jinja2_prompt_template.py
@@ -126,38 +126,6 @@ async def test_it_renders_kernel_functions_arg_from_arguments(kernel: Kernel, de
     "function, input, expected",
     [
         ("array", "'test1', 'test2', 'test3'", "['test1', 'test2', 'test3']"),
-        ("range", "5", "[0, 1, 2, 3, 4]"),
-        ("range", "0, 5", "[0, 1, 2, 3, 4]"),
-        ("range", "0, '5'", "[0, 1, 2, 3, 4]"),
-        ("range", "0, 5, 1", "[0, 1, 2, 3, 4]"),
-        ("range", "0, 5, 2", "[0, 2, 4]"),
-        ("range", "0, 5, 1, 1", "[]"),
-        ("range", "'a', 5", "[0, 1, 2, 3, 4]"),
-        ("concat", "'test1', 'test2', 'test3'", "test1test2test3"),
-        ("or", "True, False", "True"),
-        ("add", "1, 2", "3.0"),
-        ("add", "1, 2, 3", "6.0"),
-        ("subtract", "1, 2, 3", "-4.0"),
-        ("equals", "1, 2", "False"),
-        ("equals", "1, 1", "True"),
-        ("equals", "'test1', 'test2'", "False"),
-        ("equals", "'test1', 'test1'", "True"),
-        ("less_than", "1, 2", "True"),
-        ("lessThan", "1, 2", "True"),
-        ("less_than", "2, 1", "False"),
-        ("less_than", "1, 1", "False"),
-        ("greater_than", "2, 1", "True"),
-        ("greaterThan", "2, 1", "True"),
-        ("greater_than", "1, 2", "False"),
-        ("greater_than", "2, 2", "False"),
-        ("less_than_or_equal", "1, 2", "True"),
-        ("lessThanOrEqual", "1, 2", "True"),
-        ("less_than_or_equal", "2, 1", "False"),
-        ("less_than_or_equal", "1, 1", "True"),
-        ("greater_than_or_equal", "1, 2", "False"),
-        ("greaterThanOrEqual", "1, 2", "False"),
-        ("greater_than_or_equal", "2, 1", "True"),
-        ("greater_than_or_equal", "1, 1", "True"),
         ("camel_case", "'test_string'", "TestString"),
         ("camelCase", "'test_string'", "TestString"),
         ("snake_case", "'TestString'", "test_string"),
@@ -167,6 +135,55 @@ async def test_it_renders_kernel_functions_arg_from_arguments(kernel: Kernel, de
 @mark.asyncio
 async def test_helpers(function, input, expected, kernel: Kernel):
     template = f"{{{{ {function}({input}) }}}}"
+    target = create_jinja2_prompt_template(template)
+
+    rendered = await target.render(kernel, None)
+    assert rendered == expected
+
+
+@pytest.mark.parametrize(
+    "function, input, expected",
+    [
+        ("==", "1, 1", "True"),
+        ("==", "1, 2", "False"),
+        (">", "2, 1", "True"),
+        ("<", "1, 2", "True"),
+        ("<=", "1, 2", "True"),
+        (">=", "2, 1", "True"),
+        ("!=", "1, 1", "False"),
+        ("!=", "1, 2", "True"),
+        ("in", "'test', 'test'", "True"),
+        ("not in", "'test', 'test'", "False"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_builtin_test_filters(function, input, expected, kernel: Kernel):
+    input_values = input.split(", ")
+    template = f"""
+        {{%- if {input_values[0]} {function} {input_values[1]} -%}}
+        True
+        {{%- else -%}}
+        False
+        {{%- endif -%}}
+    """
+    target = create_jinja2_prompt_template(template)
+
+    rendered = await target.render(kernel, None)
+    assert rendered == expected
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("5", "[0, 1, 2, 3, 4]"),
+        ("0, 5", "[0, 1, 2, 3, 4]"),
+        ("0, 5, 1", "[0, 1, 2, 3, 4]"),
+        ("0, 5, 2", "[0, 2, 4]"),
+    ],
+)
+@mark.asyncio
+async def test_range_function(input, expected, kernel: Kernel):
+    template = f"{{{{ range({input}) | list }}}}"
     target = create_jinja2_prompt_template(template)
 
     rendered = await target.render(kernel, None)
@@ -228,30 +245,12 @@ async def test_helpers_double_open_close_style_two(kernel: Kernel):
 
 
 @mark.asyncio
-async def test_helpers_json(kernel: Kernel):
-    template = "{{json(input_json)}}"
-    target = create_jinja2_prompt_template(template)
-
-    rendered = await target.render(kernel, KernelArguments(input_json={"key": "value"}))
-    assert rendered == '{"key": "value"}'
-
-
-@mark.asyncio
 async def test_helpers_json_style_two(kernel: Kernel):
     template = "{{input_json | tojson}}"
     target = create_jinja2_prompt_template(template)
 
     rendered = await target.render(kernel, KernelArguments(input_json={"key": "value"}))
     assert rendered == '{"key": "value"}'
-
-
-@mark.asyncio
-async def test_helpers_json_empty(kernel: Kernel):
-    template = "{{json()}}"
-    target = create_jinja2_prompt_template(template)
-
-    rendered = await target.render(kernel, None)
-    assert rendered == ""
 
 
 @mark.asyncio
@@ -343,3 +342,17 @@ async def test_helpers_messageToPrompt_other(kernel: Kernel):
     other_list = ["test1", "test2"]
     rendered = await target.render(kernel, KernelArguments(other_list=other_list))
     assert rendered.strip() == """test1 test2"""
+
+
+@mark.asyncio
+async def test_helpers_chat_history_messages(kernel: Kernel):
+    template = """{{ messages(chat_history) }}"""
+    target = create_jinja2_prompt_template(template)
+    chat_history = ChatHistory()
+    chat_history.add_user_message("User message")
+    chat_history.add_assistant_message("Assistant message")
+    rendered = await target.render(kernel, KernelArguments(chat_history=chat_history))
+    assert (
+        rendered.strip()
+        == """<chat_history><message role="user">User message</message><message role="assistant">Assistant message</message></chat_history>"""  # noqa E501
+    )


### PR DESCRIPTION
### Motivation and Context

Jinja2 has a lot of built-in global functions, filters, and test methods. There's no need to have the overlap between those built-ins and the custom helpers we had defined.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR:
- Removes the overlap custom methods we had added so that one can use the built-in jinja2 filters, tests, and others.
- Add some unit tests to exercise those built-ins, mainly to show how they can be used.
- Introduces a `messages` custom helper function for handlebars and jinja2 which pretty prints the current chat_history.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
