### PR TITLE
.Net: Broaden Response ContentType Checking Logic

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
@@ -36,7 +36,7 @@ public static class RestApiOperationResponseExtensions
         return response.ContentType switch
         {
             var ct when ct.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) => ValidateJson(response),
-            var ct when ct.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase),
+            var ct when ct.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase) => ValidateXml(response),
             var ct when ct.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase) || ct.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) => ValidateTextHtml(response),
             _ => true,
         };

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Text.Json;
 using Json.Schema;
 
@@ -34,9 +35,9 @@ public static class RestApiOperationResponseExtensions
 
         return response.ContentType switch
         {
-            "application/json" => ValidateJson(response),
-            "application/xml" => ValidateXml(response),
-            "text/plain" or "text/html" => ValidateTextHtml(response),
+            var ct when ct.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) => ValidateJson(response),
+            var ct when ct.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase),
+            var ct when ct.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase) || ct.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) => ValidateTextHtml(response),
             _ => true,
         };
     }

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
@@ -37,7 +37,7 @@ public static class RestApiOperationResponseExtensions
         {
             var ct when ct.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) => ValidateJson(response),
             var ct when ct.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase) => ValidateXml(response),
-            var ct when ct.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase) or ct.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) => ValidateTextHtml(response),
+            var ct when ct.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase) || ct.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) => ValidateTextHtml(response),
             _ => true,
         };
     }

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
@@ -37,7 +37,7 @@ public static class RestApiOperationResponseExtensions
         {
             var ct when ct.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) => ValidateJson(response),
             var ct when ct.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase) => ValidateXml(response),
-            var ct when ct.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase) || ct.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) => ValidateTextHtml(response),
+            var ct when ct.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase) or ct.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) => ValidateTextHtml(response),
             _ => true,
         };
     }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationResponseTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationResponseTests.cs
@@ -39,6 +39,7 @@ public class RestApiOperationResponseTests
     [InlineData("fake-content", "application/json", "{\"type\": \"string\"}")]
     [InlineData("{\"fake\": \"content\"}", "text/plain", "{\"type\": \"string\"}")]
     [InlineData("{\"fake\": \"content\"}", "application/json", "{\"type\": \"string\"}")]
+    [InlineData("{\"fake\": \"content\"}", "application/json; charset=utf-8", "{\"type\": \"string\"}")]
     public void ItShouldFailValidationWithSchema(string content, string contentType, string schemaJson)
     {
         //Arrange
@@ -56,6 +57,7 @@ public class RestApiOperationResponseTests
     [InlineData("fake-content", "text/plain", "{\"type\": \"string\"}")]
     [InlineData("fake-content", "application/xml", "{\"type\": \"string\"}")]
     [InlineData("fake-content", "image", "{\"type\": \"string\"}")]
+    [InlineData("\"fake-content\"", "application/json; charset=utf-8", "{\"type\": \"string\"}")]
     public void ItShouldPassValidationWithSchema(string content, string contentType, string schemaJson)
     {
         //Arrange


### PR DESCRIPTION
### Motivation and Context

Fix issue opened here https://github.com/microsoft/semantic-kernel/issues/5636

### Description

Change strict string comparison to `BeginsWith` check.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
