### PR TITLE
.Net - Fixed creation of Kernel for Azure Open AI case.

### DIFF
--- a/dotnet/src/Experimental/Agents/Internal/Agent.cs
+++ b/dotnet/src/Experimental/Agents/Internal/Agent.cs
@@ -119,10 +119,9 @@ internal sealed class Agent : IAgent
         IKernelBuilder builder = Kernel.CreateBuilder();
 
         this.Kernel =
-            Kernel
-                .CreateBuilder()
-                .AddOpenAIChatCompletion(this._model.Model, this._restContext.ApiKey)
-                .Build();
+            this._restContext.HasVersion ?
+                builder.AddAzureOpenAIChatCompletion(this._model.Model, this.GetAzureRootEndpoint(), this._restContext.ApiKey).Build() :
+                builder.AddOpenAIChatCompletion(this._model.Model, this._restContext.ApiKey).Build();
 
         if (plugins is not null)
         {
@@ -263,6 +262,12 @@ internal sealed class Agent : IAgent
         }
 
         return factory.Create(config);
+    }
+
+    private string GetAzureRootEndpoint()
+    {
+        var endpointUri = new Uri(this._restContext.Endpoint);
+        return endpointUri.AbsoluteUri.Replace(endpointUri.AbsolutePath, string.Empty);
     }
 
     private void ThrowIfDeleted()

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Milvus/MilvusFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Milvus/MilvusFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Threading.Tasks;
 using Milvus.Client;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Azure Open AI version of semantic kernel always creating OpenAIChatCompletionService internally.  This only affects the use of prompt-functions as plug-ins, not broader agent behavior.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Create AzureOpenAIChatCompletion service based on context definition.
- Updated prompt-funciton agent test to run in AOAI mode
- Verified test execution

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
