### PR TITLE
Python: small fix for running prompt without any execution settings

### DIFF
--- a/python/samples/kernel-syntax-examples/rag_with_text_memory_plugin.py
+++ b/python/samples/kernel-syntax-examples/rag_with_text_memory_plugin.py
@@ -3,13 +3,16 @@ import asyncio
 
 import semantic_kernel as sk
 import semantic_kernel.connectors.ai.open_ai as sk_oai
+from semantic_kernel.core_plugins.text_memory_plugin import TextMemoryPlugin
 from semantic_kernel.memory.semantic_text_memory import SemanticTextMemory
+from semantic_kernel.memory.volatile_memory_store import VolatileMemoryStore
+from semantic_kernel.utils.settings import openai_settings_from_dot_env
 
 
 async def main():
     kernel = sk.Kernel()
 
-    api_key, org_id = sk.openai_settings_from_dot_env()
+    api_key, org_id = openai_settings_from_dot_env()
     service_id = "default"
     kernel.add_service(
         sk_oai.OpenAIChatCompletion(service_id=service_id, ai_model_id="gpt-3.5-turbo", api_key=api_key, org_id=org_id)
@@ -17,17 +20,16 @@ async def main():
     embedding_gen = sk_oai.OpenAITextEmbedding(
         service_id="ada", ai_model_id="text-embedding-ada-002", api_key=api_key, org_id=org_id
     )
-    kernel.add_service(embedding_gen)
 
-    memory = SemanticTextMemory(storage=sk.memory.VolatileMemoryStore(), embeddings_generator=embedding_gen)
-    kernel.import_plugin_from_object(sk.core_plugins.TextMemoryPlugin(memory), "TextMemoryPlugin")
+    memory = SemanticTextMemory(storage=VolatileMemoryStore(), embeddings_generator=embedding_gen)
+    kernel.import_plugin_from_object(TextMemoryPlugin(memory), "memory")
 
     await memory.save_information(collection="generic", id="info1", text="My budget for 2024 is $100,000")
 
     result = await kernel.invoke_prompt(
         function_name="budget",
         plugin_name="BudgetPlugin",
-        prompt="{{recall 'budget by year'}} What is my budget for 2024?",
+        prompt="{{memory.recall 'budget by year'}} What is my budget for 2024?",
     )
     print(result)
 

--- a/python/samples/kernel-syntax-examples/rag_with_text_memory_plugin.py
+++ b/python/samples/kernel-syntax-examples/rag_with_text_memory_plugin.py
@@ -21,6 +21,8 @@ async def main():
         service_id="ada", ai_model_id="text-embedding-ada-002", api_key=api_key, org_id=org_id
     )
 
+    kernel.add_service(embedding_gen)
+
     memory = SemanticTextMemory(storage=VolatileMemoryStore(), embeddings_generator=embedding_gen)
     kernel.import_plugin_from_object(TextMemoryPlugin(memory), "memory")
 

--- a/python/semantic_kernel/memory/semantic_text_memory.py
+++ b/python/semantic_kernel/memory/semantic_text_memory.py
@@ -4,9 +4,7 @@ from typing import List, Optional
 
 from pydantic import PrivateAttr
 
-from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import (
-    EmbeddingGeneratorBase,
-)
+from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import EmbeddingGeneratorBase
 from semantic_kernel.memory.memory_query_result import MemoryQueryResult
 from semantic_kernel.memory.memory_record import MemoryRecord
 from semantic_kernel.memory.memory_store_base import MemoryStoreBase
@@ -15,6 +13,7 @@ from semantic_kernel.memory.semantic_text_memory_base import SemanticTextMemoryB
 
 class SemanticTextMemory(SemanticTextMemoryBase):
     _storage: MemoryStoreBase = PrivateAttr()
+    # TODO: replace with kernel and service_selector pattern
     _embeddings_generator: EmbeddingGeneratorBase = PrivateAttr()
 
     def __init__(self, storage: MemoryStoreBase, embeddings_generator: EmbeddingGeneratorBase) -> None:

--- a/python/semantic_kernel/services/ai_service_selector.py
+++ b/python/semantic_kernel/services/ai_service_selector.py
@@ -33,6 +33,8 @@ class AIServiceSelector:
             for id, settings in func_exec_settings.items():
                 if id not in execution_settings_dict:
                     execution_settings_dict[id] = settings
+        if not execution_settings_dict:
+            execution_settings_dict = {"default": PromptExecutionSettings()}
         for service_id, settings in execution_settings_dict.items():
             service = kernel.get_service(service_id, type=(TextCompletionClientBase, ChatCompletionClientBase))
             if service:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
I noticed that when running a piece without any execution settings, it errored out, while it should use 'default' service with the default settings for that service, that is now fixed. 
Small updates to the rag example.
Added TODO: to replace the embedding_generator service in SemanticTextMemory with Kernel and the same service_selector pattern as for KernelFunctions.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
