### PR TITLE
.Net - Fix Assistant type conversion for function calling

### DIFF
--- a/dotnet/src/Experimental/Agents/AgentBuilder.cs
+++ b/dotnet/src/Experimental/Agents/AgentBuilder.cs
@@ -310,4 +310,44 @@ public partial class AgentBuilder
 
         return this;
     }
+
+    /// <summary>
+    /// $$$
+    /// </summary>
+    public static async Task<IList<AgentReference>> GetAzureOpenAIAgentsAsync(string endpoint, string apiKey, string? version = null)
+    {
+        endpoint = $"{endpoint}/openai";
+        version ??= "2024-02-15-preview";
+
+        var context = new OpenAIRestContext(endpoint!, apiKey, version);
+        var result = await context.ListAssistantModelsAsync().ConfigureAwait(false);
+
+        return
+           result.Select(
+               m =>
+                   new AgentReference()
+                   {
+                       Id = m.Id,
+                       Name = m.Name
+                   }).ToArray();
+    }
+
+    /// <summary>
+    /// $$$
+    /// </summary>
+    public static async Task<IList<AgentReference>> GetOpenAIAgentsAsync(string apiKey)
+    {
+        var context = new OpenAIRestContext(OpenAIBaseUrl, apiKey);
+
+        var result = await context.ListAssistantModelsAsync().ConfigureAwait(false);
+
+        return
+            result.Select(
+                m =>
+                    new AgentReference()
+                    {
+                        Id = m.Id,
+                        Name = m.Name
+                    }).ToArray();
+    }
 }

--- a/dotnet/src/Experimental/Agents/AgentReference.cs
+++ b/dotnet/src/Experimental/Agents/AgentReference.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Experimental.Agents;
+
+/// <summary>
+/// Response from agent when called as a <see cref="KernelFunction"/>.
+/// </summary>
+public class AgentReference
+{
+    /// <summary>
+    /// The agent identifier (which can be referenced in API endpoints).
+    /// </summary>
+    public string Id { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Name of the agent
+    /// </summary>
+    public string? Name { get; internal set; }
+}

--- a/dotnet/src/Experimental/Agents/Extensions/AssistantsKernelFunctionExtensions.cs
+++ b/dotnet/src/Experimental/Agents/Extensions/AssistantsKernelFunctionExtensions.cs
@@ -74,9 +74,19 @@ internal static class AssistantsKernelFunctionExtensions
             return "string";
         }
 
+        if (type.IsInteger())
+        {
+            return "integer";
+        }
+
         if (type.IsNumber())
         {
             return "number";
+        }
+
+        if (type == typeof(bool))
+        {
+            return "boolean";
         }
 
         if (type.IsEnum)
@@ -84,6 +94,11 @@ internal static class AssistantsKernelFunctionExtensions
             return "enum";
         }
 
-        return type.Name;
+        if (type.IsArray)
+        {
+            return "array";
+        }
+
+        return "object";
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

- Fix to specify function types propertly
- Add support for ability to list agents.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

I experienced both issues and also worked with community who has also experienced / identified both.

https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
