### PR TITLE
fixing README.md example in python

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -80,6 +80,8 @@ prompt_template_config = sk.PromptTemplateConfig(
 )
 
 function = kernel.create_function_from_prompt(
+    function_name="tldr_function",
+    plugin_name="tldr_plugin",
     prompt_template_config=prompt_template_config,
 )
 
@@ -98,8 +100,10 @@ if __name__ == "__main__":
 ```python
 # Create a reusable function summarize function
 summarize = kernel.create_function_from_prompt(
-    template="{{$input}}\n\nOne line TLDR with the fewest words."
-    execution_settings=req_settings,
+        function_name="tldr_function",
+        plugin_name="tldr_plugin",
+        prompt="{{$input}}\n\nOne line TLDR with the fewest words.",
+        prompt_template_settings=req_settings,
 )
 
 # Summarize the laws of thermodynamics


### PR DESCRIPTION
### Motivation and Context

This pull request fixed the example on the "get started guide" discussed [here](https://github.com/microsoft/semantic-kernel/discussions/5307). Even though the maintainer closed the discussion and said that it was fixed, people kept finding the same error. 

### Description

Add the missing argument in the function [`create_function_from_prompt`](https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/kernel.py), and fix the names on the second example.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
