### PR TITLE
.Net: MistralAI Function calling for chat completion requests

### DIFF
--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Connectors.MistralAI.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Connectors.MistralAI.UnitTests.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>SKEXP0020</NoWarn>
+    <NoWarn>SKEXP0070</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/TestData/function_call_response.json
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/TestData/function_call_response.json
@@ -1,0 +1,30 @@
+﻿{
+  "id": "c83737dce9de47c888cb4a119a477d63",
+  "object": "chat.completion",
+  "created": 1711202281,
+  "model": "mistral-small-latest",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+          {
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\": \"Paris\", \"unit\": \"celsius\"}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls",
+      "logprobs": null
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 118,
+    "total_tokens": 149,
+    "completion_tokens": 31
+  }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 using System.Diagnostics.CodeAnalysis;
 
 // This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]
+[assembly: Experimental("SKEXP0070")]

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/ChatCompletionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/ChatCompletionRequest.cs
@@ -23,6 +23,7 @@ internal sealed class ChatCompletionRequest
     public double TopP { get; set; } = 1;
 
     [JsonPropertyName("max_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? MaxTokens { get; set; }
 
     [JsonPropertyName("stream")]
@@ -31,15 +32,43 @@ internal sealed class ChatCompletionRequest
     [JsonPropertyName("safe_prompt")]
     public bool SafePrompt { get; set; } = false;
 
+    [JsonPropertyName("tools")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IList<MistralTool>? Tools { get; set; }
+
+    [JsonPropertyName("tool_choice")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ToolChoice { get; set; }
+
     [JsonPropertyName("random_seed")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? RandomSeed { get; set; }
 
     /// <summary>
     /// Construct an instance of <see cref="ChatCompletionRequest"/>.
     /// </summary>
     /// <param name="model">ID of the model to use.</param>
+    [JsonConstructor]
     internal ChatCompletionRequest(string model)
     {
         this.Model = model;
+    }
+
+    /// <summary>
+    /// Add a tool to the request.
+    /// </summary>
+    internal void AddTool(MistralTool tool)
+    {
+        this.Tools ??= new List<MistralTool>();
+        this.Tools.Add(tool);
+    }
+
+    /// <summary>
+    /// Add a message to the request.
+    /// </summary>
+    /// <param name="message"></param>
+    internal void AddMessage(MistralChatMessage message)
+    {
+        this.Messages.Add(message);
     }
 }

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralChatChoice.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralChatChoice.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
@@ -15,6 +17,25 @@ internal class MistralChatChoice
     [JsonPropertyName("message")]
     public MistralChatMessage? Message { get; set; }
 
+    /// <summary>
+    /// The reason the chat completion was finished.
+    /// Enum: "stop" "length" "model_length" "error" "tool_calls"
+    /// </summary>
     [JsonPropertyName("finish_reason")]
     public string? FinishReason { get; set; }
+
+    /// <summary>
+    /// Returns true if the finish reason is "tool_calls"
+    /// </summary>
+    public bool IsToolCall => this.FinishReason?.Equals("tool_calls", StringComparison.Ordinal) ?? false;
+
+    /// <summary>
+    /// Returns the number of tool calls
+    /// </summary>
+    public int ToolCallCount => this.Message?.ToolCalls?.Count ?? 0;
+
+    /// <summary>
+    /// Return the list of tools calls
+    /// </summary>
+    public IList<MistralToolCall>? ToolCalls => this.Message?.ToolCalls;
 }

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralChatChoice.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralChatChoice.cs
@@ -27,15 +27,15 @@ internal class MistralChatChoice
     /// <summary>
     /// Returns true if the finish reason is "tool_calls"
     /// </summary>
-    public bool IsToolCall => this.FinishReason?.Equals("tool_calls", StringComparison.Ordinal) ?? false;
+    internal bool IsToolCall => this.FinishReason?.Equals("tool_calls", StringComparison.Ordinal) ?? false;
 
     /// <summary>
     /// Returns the number of tool calls
     /// </summary>
-    public int ToolCallCount => this.Message?.ToolCalls?.Count ?? 0;
+    internal int ToolCallCount => this.Message?.ToolCalls?.Count ?? 0;
 
     /// <summary>
     /// Return the list of tools calls
     /// </summary>
-    public IList<MistralToolCall>? ToolCalls => this.Message?.ToolCalls;
+    internal IList<MistralToolCall>? ToolCalls => this.Message?.ToolCalls;
 }

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralChatMessage.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralChatMessage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
@@ -10,10 +11,15 @@ namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
 internal class MistralChatMessage
 {
     [JsonPropertyName("role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Role { get; set; }
 
     [JsonPropertyName("content")]
     public string Content { get; set; }
+
+    [JsonPropertyName("tool_calls")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IList<MistralToolCall>? ToolCalls { get; set; }
 
     /// <summary>
     /// Construct an instance of <see cref="MistralChatMessage"/>.
@@ -23,9 +29,9 @@ internal class MistralChatMessage
     [JsonConstructor]
     internal MistralChatMessage(string? role, string content)
     {
-        if (role is not null && role is not "system" && role is not "user" && role is not "assistant")
+        if (role is not null && role is not "system" && role is not "user" && role is not "assistant" && role is not "tool")
         {
-            throw new System.ArgumentException($"Role must be one of: system, user, assistant. {role} is an invalid role.", nameof(role));
+            throw new System.ArgumentException($"Role must be one of: system, user, assistant or tool. {role} is an invalid role.", nameof(role));
         }
 
         this.Role = role;

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -47,14 +48,144 @@ internal sealed class MistralClient
 
         string modelId = executionSettings?.ModelId ?? this._modelId;
         var mistralExecutionSettings = MistralAIPromptExecutionSettings.FromExecutionSettings(executionSettings);
-        var request = this.CreateChatCompletionRequest(modelId, stream: false, chatHistory, mistralExecutionSettings);
+        var chatRequest = this.CreateChatCompletionRequest(modelId, stream: false, chatHistory, mistralExecutionSettings, kernel);
         var endpoint = this.GetEndpoint(mistralExecutionSettings, path: "chat/completions");
+        var autoInvoke = kernel is not null && mistralExecutionSettings.ToolCallBehavior?.MaximumAutoInvokeAttempts > 0 && s_inflightAutoInvokes.Value < MaxInflightAutoInvokes;
 
-        using var httpRequestMessage = this.CreatePost(request, endpoint, this._apiKey, stream: false);
+        for (int iteration = 1; ; iteration++)
+        {
+            using var httpRequestMessage = this.CreatePost(chatRequest, endpoint, this._apiKey, stream: false);
+            var responseData = await this.SendRequestAsync<ChatCompletionResponse>(httpRequestMessage, cancellationToken).ConfigureAwait(false);
+            if (responseData is null || responseData.Choices is null || responseData.Choices.Count == 0)
+            {
+                throw new KernelException("Chat completions not found");
+            }
 
-        var response = await this.SendRequestAsync<ChatCompletionResponse>(httpRequestMessage, cancellationToken).ConfigureAwait(false);
+            // If we don't want to attempt to invoke any functions, just return the result.
+            // Or if we are auto-invoking but we somehow end up with other than 1 choice even though only 1 was requested, similarly bail.
+            if (!autoInvoke || responseData.Choices.Count != 1)
+            {
+                return ToChatMessageContent(modelId, responseData);
+            }
 
-        return response.Choices.Select(chatChoice => new ChatMessageContent(new AuthorRole(chatChoice.Message!.Role!), chatChoice.Message!.Content, this._modelId, chatChoice, Encoding.UTF8, GetChatChoiceMetadata(response, chatChoice))).ToList();
+            // Get our single result and extract the function call information. If this isn't a function call, or if it is
+            // but we're unable to find the function or extract the relevant information, just return the single result.
+            // Note that we don't check the FinishReason and instead check whether there are any tool calls, as the service
+            // may return a FinishReason of "stop" even if there are tool calls to be made, in particular if a required tool
+            // is specified.
+            MistralChatChoice chatChoice = responseData.Choices[0];
+            if (!chatChoice.IsToolCall)
+            {
+                return ToChatMessageContent(modelId, responseData);
+            }
+
+            if (this._logger.IsEnabled(LogLevel.Debug))
+            {
+                this._logger.LogDebug("Tool requests: {Requests}", chatChoice.ToolCallCount);
+            }
+            if (this._logger.IsEnabled(LogLevel.Trace))
+            {
+                this._logger.LogTrace("Function call requests: {Requests}", string.Join(", ", chatChoice.ToolCalls.Select(tc => $"{tc.Function?.Name}({tc.Function?.Parameters})")));
+            }
+
+            Debug.Assert(kernel is not null);
+
+            // Add the original assistant message to the chatOptions; this is required for the service
+            // to understand the tool call responses. Also add the result message to the caller's chat
+            // history: if they don't want it, they can remove it, but this makes the data available,
+            // including metadata like usage.
+            chatRequest.AddMessage(chatChoice.Message!);
+            chatHistory.Add(ToChatMessageContent(modelId, responseData, chatChoice));
+
+            // We must send back a response for every tool call, regardless of whether we successfully executed it or not.
+            // If we successfully execute it, we'll add the result. If we don't, we'll add an error.
+            for (int i = 0; i < chatChoice.ToolCallCount; i++)
+            {
+                var toolCall = chatChoice.ToolCalls![i];
+
+                // We currently only know about function tool calls. If it's anything else, we'll respond with an error.
+                if (toolCall.Function is null)
+                {
+                    this.AddResponseMessage(chatRequest, chatHistory, toolCall, result: null, "Error: Tool call was not a function call.");
+                    continue;
+                }
+
+                // Make sure the requested function is one we requested. If we're permitting any kernel function to be invoked,
+                // then we don't need to check this, as it'll be handled when we look up the function in the kernel to be able
+                // to invoke it. If we're permitting only a specific list of functions, though, then we need to explicitly check.
+                if (mistralExecutionSettings.ToolCallBehavior?.AllowAnyRequestedKernelFunction is not true &&
+                    !IsRequestableTool(chatRequest, toolCall.Function!))
+                {
+                    this.AddResponseMessage(chatRequest, chatHistory, toolCall, result: null, "Error: Function call chatRequest for a function that wasn't defined.");
+                    continue;
+                }
+
+                // Find the function in the kernel and populate the arguments.
+                if (!kernel!.Plugins.TryGetFunctionAndArguments(kernel, toolCall.Function, out KernelFunction? function, out KernelArguments? functionArgs))
+                {
+                    this.AddResponseMessage(chatRequest, chatHistory, toolCall, result: null, "Error: Requested function could not be found.");
+                    continue;
+                }
+
+                // Now, invoke the function, and add the resulting tool call message to the chat options.
+                s_inflightAutoInvokes.Value++;
+                object? functionResult;
+                try
+                {
+                    // Note that we explicitly do not use executionSettings here; those pertain to the all-up operation and not necessarily to any
+                    // further calls made as part of this function invocation. In particular, we must not use function calling settings naively here,
+                    // as the called function could in turn telling the model about itself as a possible candidate for invocation.
+                    functionResult = (await function.InvokeAsync(kernel, functionArgs, cancellationToken: cancellationToken).ConfigureAwait(false)).GetValue<object>() ?? string.Empty;
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception e)
+#pragma warning restore CA1031
+                {
+                    this.AddResponseMessage(chatRequest, chatHistory, toolCall, result: null, $"Error: Exception while invoking function. {e.Message}");
+                    continue;
+                }
+                finally
+                {
+                    s_inflightAutoInvokes.Value--;
+                }
+
+                var stringResult = ProcessFunctionResult(functionResult, mistralExecutionSettings.ToolCallBehavior);
+
+                this.AddResponseMessage(chatRequest, chatHistory, toolCall, result: stringResult, errorMessage: null);
+            }
+
+            // Update tool use information for the next go-around based on having completed another iteration.
+            Debug.Assert(mistralExecutionSettings.ToolCallBehavior is not null);
+
+            // Set the tool choice to none. If we end up wanting to use tools, we'll reset it to the desired value.
+            chatRequest.ToolChoice = "none";
+            chatRequest.Tools?.Clear();
+
+            if (iteration >= mistralExecutionSettings.ToolCallBehavior!.MaximumUseAttempts)
+            {
+                // Don't add any tools as we've reached the maximum attempts limit.
+                if (this._logger.IsEnabled(LogLevel.Debug))
+                {
+                    this._logger.LogDebug("Maximum use ({MaximumUse}) reached; removing the tool.", mistralExecutionSettings.ToolCallBehavior!.MaximumUseAttempts);
+                }
+            }
+            else
+            {
+                // Regenerate the tool list as necessary. The invocation of the function(s) could have augmented
+                // what functions are available in the kernel.
+                mistralExecutionSettings.ToolCallBehavior.ConfigureRequest(kernel, chatRequest);
+            }
+
+            // Disable auto invocation if we've exceeded the allowed limit.
+            if (iteration >= mistralExecutionSettings.ToolCallBehavior!.MaximumAutoInvokeAttempts)
+            {
+                autoInvoke = false;
+                if (this._logger.IsEnabled(LogLevel.Debug))
+                {
+                    this._logger.LogDebug("Maximum auto-invoke ({MaximumAutoInvoke}) reached.", mistralExecutionSettings.ToolCallBehavior!.MaximumAutoInvokeAttempts);
+                }
+            }
+        }
     }
 
     internal async IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(ChatHistory chatHistory, [EnumeratorCancellation] CancellationToken cancellationToken, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null)
@@ -136,10 +267,33 @@ internal sealed class MistralClient
     private const int SseDataLength = 5;
 
     /// <summary>
+    /// The maximum number of auto-invokes that can be in-flight at any given time as part of the current
+    /// asynchronous chain of execution.
+    /// </summary>
+    /// <remarks>
+    /// This is a fail-safe mechanism. If someone accidentally manages to set up execution settings in such a way that
+    /// auto-invocation is invoked recursively, and in particular where a prompt function is able to auto-invoke itself,
+    /// we could end up in an infinite loop. This const is a backstop against that happening. We should never come close
+    /// to this limit, but if we do, auto-invoke will be disabled for the current flow in order to prevent runaway execution.
+    /// With the current setup, the way this could possibly happen is if a prompt function is configured with built-in
+    /// execution settings that opt-in to auto-invocation of everything in the kernel, in which case the invocation of that
+    /// prompt function could advertize itself as a candidate for auto-invocation. We don't want to outright block that,
+    /// if that's something a developer has asked to do (e.g. it might be invoked with different arguments than its parent
+    /// was invoked with), but we do want to limit it. This limit is arbitrary and can be tweaked in the future and/or made
+    /// configurable should need arise.
+    /// </remarks>
+    private const int MaxInflightAutoInvokes = 5;
+
+    /// <summary>Tracking <see cref="AsyncLocal{Int32}"/> for <see cref="MaxInflightAutoInvokes"/>.</summary>
+    private static readonly AsyncLocal<int> s_inflightAutoInvokes = new();
+
+    /// <summary>
     /// Messages are required and the first prompt role should be user or system.
     /// </summary>
     private void ValidateChatHistory(ChatHistory chatHistory)
     {
+        Verify.NotNull(chatHistory);
+
         if (chatHistory.Count == 0)
         {
             throw new ArgumentException("Chat history must contain at least one message", nameof(chatHistory));
@@ -151,7 +305,7 @@ internal sealed class MistralClient
         }
     }
 
-    private ChatCompletionRequest CreateChatCompletionRequest(string modelId, bool stream, ChatHistory chatHistory, MistralAIPromptExecutionSettings? executionSettings)
+    private ChatCompletionRequest CreateChatCompletionRequest(string modelId, bool stream, ChatHistory chatHistory, MistralAIPromptExecutionSettings? executionSettings, Kernel? kernel = null)
     {
         var request = new ChatCompletionRequest(modelId)
         {
@@ -166,6 +320,11 @@ internal sealed class MistralClient
             request.MaxTokens = executionSettings.MaxTokens;
             request.SafePrompt = executionSettings.SafePrompt;
             request.RandomSeed = executionSettings.RandomSeed;
+
+            if (executionSettings.ToolCallBehavior is not null)
+            {
+                executionSettings.ToolCallBehavior.ConfigureRequest(kernel, request);
+            }
         }
 
         return request;
@@ -209,6 +368,21 @@ internal sealed class MistralClient
         return new Uri($"{endpoint}{separator}{path}");
     }
 
+    /// <summary>Checks if a tool call is for a function that was defined.</summary>
+    private static bool IsRequestableTool(ChatCompletionRequest request, MistralFunction func)
+    {
+        var tools = request.Tools;
+        for (int i = 0; i < tools?.Count; i++)
+        {
+            if (string.Equals(tools[i].Function.Name, func.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static T DeserializeResponse<T>(string body)
     {
         try
@@ -230,6 +404,31 @@ internal sealed class MistralClient
         }
     }
 
+    private static List<ChatMessageContent> ToChatMessageContent(string modelId, ChatCompletionResponse response)
+    {
+        return response.Choices.Select(chatChoice => ToChatMessageContent(modelId, response, chatChoice)).ToList();
+    }
+
+    private void AddResponseMessage(ChatCompletionRequest chatRequest, ChatHistory chat, MistralToolCall toolCall, string? result, string? errorMessage)
+    {
+        // Log any error
+        if (errorMessage is not null && this._logger.IsEnabled(LogLevel.Debug))
+        {
+            Debug.Assert(result is null);
+            this._logger.LogDebug("Failed to handle tool request ({ToolId}). {Error}", toolCall.Function?.Name, errorMessage);
+        }
+
+        // Add the tool response message to both the chat options and to the chat history.
+        result ??= errorMessage ?? string.Empty;
+        chatRequest.AddMessage(new MistralChatMessage(AuthorRole.Tool.ToString(), result));
+        chat.AddMessage(AuthorRole.Tool, result, metadata: new Dictionary<string, object?> { { nameof(MistralToolCall.Function), toolCall.Function } });
+    }
+
+    private static ChatMessageContent ToChatMessageContent(string modelId, ChatCompletionResponse response, MistralChatChoice chatChoice)
+    {
+        return new ChatMessageContent(new AuthorRole(chatChoice.Message!.Role!), chatChoice.Message!.Content, modelId, chatChoice, Encoding.UTF8, GetChatChoiceMetadata(response, chatChoice));
+    }
+
     private static Dictionary<string, object?> GetChatChoiceMetadata(ChatCompletionResponse completionResponse, MistralChatChoice chatChoice)
     {
         return new Dictionary<string, object?>(6)
@@ -243,5 +442,33 @@ internal sealed class MistralClient
             { nameof(chatChoice.FinishReason), chatChoice.FinishReason },
         };
     }
+
+    /// <summary>
+    /// Processes the function result.
+    /// </summary>
+    /// <param name="functionResult">The result of the function call.</param>
+    /// <param name="toolCallBehavior">The ToolCallBehavior object containing optional settings like JsonSerializerOptions.TypeInfoResolver.</param>
+    /// <returns>A string representation of the function result.</returns>
+    private static string? ProcessFunctionResult(object functionResult, MistralAIToolCallBehavior? toolCallBehavior)
+    {
+        if (functionResult is string stringResult)
+        {
+            return stringResult;
+        }
+
+        // This is an optimization to use ChatMessageContent content directly  
+        // without unnecessary serialization of the whole message content class.  
+        if (functionResult is ChatMessageContent chatMessageContent)
+        {
+            return chatMessageContent.ToString();
+        }
+
+        // For polymorphic serialization of unknown in advance child classes of the KernelContent class,  
+        // a corresponding JsonTypeInfoResolver should be provided via the JsonSerializerOptions.TypeInfoResolver property.  
+        // For more details about the polymorphic serialization, see the article at:  
+        // https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-8-0
+        return JsonSerializer.Serialize(functionResult, toolCallBehavior?.ToolCallResultSerializerOptions);
+    }
+
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralFunction.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralFunction.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Json.Schema;
+using Json.Schema.Generation;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+/// <summary>
+/// A function to be used in the chat completion request.
+/// </summary>
+internal class MistralFunction
+{
+    /// <summary>
+    /// The name of the function to be called.Must be a-z,A-Z,0-9 or contain underscores and dashes, with a maximum length of 64.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The description of the function to help the model determine when and how to invoke it.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The function parameters, defined using a JSON Schema object. If omitted, the function is considered to have an empty parameter list.
+    /// </summary>
+    [JsonPropertyName("parameters")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public MistralParameters? Parameters { get; set; }
+
+    /// <summary>
+    /// The arguments provided by the model to call the function.
+    /// </summary>
+    [JsonPropertyName("arguments")]
+    public string? Arguments { get; set; }
+
+    /// <summary>Gets the separator used between the plugin name and the function name, if a plugin name is present.</summary>
+    /// <remarks>This separator was previously <c>_</c>, but has been changed to <c>-</c> to better align to the behavior elsewhere in SK and in response
+    /// to developers who want to use underscores in their function or plugin names. We plan to make this setting configurable in the future.</remarks>
+    public static char NameSeparator { get; set; } = '-';
+
+    /// <summary>Gets the name of the plugin with which the function is associated, if any.</summary>
+    [JsonIgnore]
+    public string? PluginName { get; }
+
+    /// <summary>Gets the name of the function.</summary>
+    [JsonIgnore]
+    public string FunctionName { get; }
+
+    /// <summary>
+    /// Construct an instance of <see cref="MistralFunction"/>.
+    /// </summary>
+    [JsonConstructorAttribute]
+    public MistralFunction(string name, string description, MistralParameters? parameters)
+    {
+        ValidFunctionName(name);
+
+        var parts = name.Split(NameSeparator);
+
+        this.Name = name;
+        this.PluginName = (parts.Length == 1) ? null : parts[0];
+        this.FunctionName = (parts.Length == 1) ? parts[0] : parts[1];
+        this.Description = description;
+        this.Parameters = parameters;
+    }
+
+    /// <summary>
+    /// Construct an instance of <see cref="MistralFunction"/>.
+    /// </summary>
+    public MistralFunction(KernelFunctionMetadata metadata)
+    {
+        var name = string.IsNullOrEmpty(metadata.PluginName) ? metadata.Name : $"{metadata.PluginName}-{metadata.Name}";
+        ValidFunctionName(name);
+
+        this.Name = name;
+        this.PluginName = metadata.PluginName;
+        this.FunctionName = metadata.Name;
+        this.Description = metadata.Description;
+        this.Parameters = ToMistralParameters(metadata);
+    }
+
+    #region private
+
+    private static readonly Regex s_asciiLettersDigitsUnderscoresRegex = new("^[0-9A-Za-z_-]*$");
+
+    private static void ValidFunctionName(string name)
+    {
+        Verify.NotNull(name, nameof(name));
+        Verify.True(name.Length <= 64, "The name of the function must be less than or equal to 64 characters.", nameof(name));
+
+        if (!s_asciiLettersDigitsUnderscoresRegex.IsMatch(name))
+        {
+            throw new ArgumentException($"A function name can contain only ASCII letters, digits, dashes and underscores: '{name}' is not a valid name.");
+        }
+    }
+
+    private static MistralParameters ToMistralParameters(KernelFunctionMetadata metadata)
+    {
+        var parameters = new MistralParameters();
+
+        if (metadata.Parameters is { Count: > 0 })
+        {
+            foreach (var parameter in metadata.Parameters)
+            {
+                parameters.Properties.Add(parameter.Name, parameter.Schema ?? GetDefaultSchemaForTypelessParameter(parameter.Description));
+                if (parameter.IsRequired)
+                {
+                    parameters.Required.Add(parameter.Name);
+                }
+            }
+        }
+
+        return parameters;
+    }
+
+    /// <summary>Gets a <see cref="KernelJsonSchema"/> for a typeless parameter with the specified description, defaulting to typeof(string)</summary>
+    private static KernelJsonSchema GetDefaultSchemaForTypelessParameter(string? description)
+    {
+        // If there's a description, incorporate it.
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            return KernelJsonSchema.Parse(JsonSerializer.Serialize(
+                new JsonSchemaBuilder()
+                .FromType(typeof(string))
+                .Description(description!)
+                .Build()));
+        }
+
+        // Otherwise, we can use a cached schema for a string with no description.
+        return s_stringNoDescriptionSchema;
+    }
+
+    /// <summary>
+    /// Cached schema for a string without a description.
+    /// </summary>
+    private static readonly KernelJsonSchema s_stringNoDescriptionSchema = KernelJsonSchema.Parse("{\"type\":\"string\"}");
+
+    #endregion
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralParameters.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralParameters.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+/// <summary>
+/// Represents the parameters of a MistralAI function.
+/// </summary>
+internal class MistralParameters
+{
+    /// <summary>
+    /// Gets or sets the type of the parameters. This is always "object".
+    /// </summary>
+    public string Type => "object";
+
+    /// <summary>
+    /// Gets or sets the JSOn schema of the properties.
+    /// </summary>
+    public IDictionary<string, KernelJsonSchema> Properties { get; set; } = new Dictionary<string, KernelJsonSchema>();
+
+    /// <summary>
+    /// Gets or sets the list of required properties.
+    /// </summary>
+    public IList<string> Required { get; set; } = new List<string>();
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralPropertyType.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralPropertyType.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+/// <summary>
+/// Represents the type of a MistralAI property.
+/// </summary>
+internal class MistralPropertyType
+{
+    /// <summary>
+    /// Gets or sets the type of the property.
+    /// </summary>
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the property.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of possible values for the property.
+    /// </summary>
+    public IList<string>? Enum { get; set; }
+
+    public MistralPropertyType(string type, string? description = null, IList<string>? @enum = null)
+    {
+        Verify.NotNull(type, nameof(type));
+
+        this.Type = type;
+        this.Description = description;
+        this.Enum = @enum;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralTool.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralTool.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+/// <summary>
+/// A tool to be used in the chat completion request.
+/// </summary>
+internal class MistralTool
+{
+    /// <summary>
+    /// The type of the tool. Currently, only function is supported.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// The associated function.
+    /// </summary>
+    [JsonPropertyName("function")]
+    public MistralFunction Function { get; set; }
+
+    /// <summary>
+    /// Construct an instance of <see cref="MistralTool"/>.
+    /// </summary>
+    [JsonConstructorAttribute]
+    public MistralTool(string type, MistralFunction function)
+    {
+        this.Type = type;
+        this.Function = function;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralToolCall.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralToolCall.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+internal class MistralToolCall
+{
+    [JsonPropertyName("function")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public MistralFunction? Function { get; set; }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralToolCall.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralToolCall.cs
@@ -3,6 +3,10 @@
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+/// <summary>
+/// Tool call for chat completion.
+/// </summary>
 internal class MistralToolCall
 {
     [JsonPropertyName("function")]

--- a/dotnet/src/Connectors/Connectors.MistralAI/Connectors.MistralAI.csproj
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Connectors.MistralAI.csproj
@@ -5,7 +5,8 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.MistralAI</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionSuffix>preview</VersionSuffix>
+    <VersionSuffix>alpha</VersionSuffix>
+    <NoWarn>SKEXP0001,SKEXP0070</NoWarn>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->

--- a/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIPluginCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Extensions/MistralAIPluginCollectionExtensions.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI;
+
+/// <summary>
+/// Extension methods for <see cref="IReadOnlyKernelPluginCollection"/>.
+/// </summary>
+public static class MistralAIPluginCollectionExtensions
+{
+    /// <summary>
+    /// Given an <see cref="MistralFunction"/> object, tries to retrieve the corresponding <see cref="KernelFunction"/> and populate <see cref="KernelArguments"/> with its parameters.
+    /// </summary>
+    /// <param name="plugins">The plugins.</param>
+    /// <param name="kernel">The <see cref="Kernel"/> instance</param>
+    /// <param name="functionToolCall">The <see cref="MistralFunction"/> object.</param>
+    /// <param name="function">When this method returns, the function that was retrieved if one with the specified name was found; otherwise, <see langword="null"/></param>
+    /// <param name="arguments">When this method returns, the arguments for the function; otherwise, <see langword="null"/></param>
+    /// <returns><see langword="true"/> if the function was found; otherwise, <see langword="false"/>.</returns>
+    internal static bool TryGetFunctionAndArguments(
+        this IReadOnlyKernelPluginCollection plugins,
+        Kernel kernel,
+        MistralFunction functionToolCall,
+        [NotNullWhen(true)] out KernelFunction? function,
+        out KernelArguments? arguments)
+    {
+        if (plugins.TryGetFunction(functionToolCall.PluginName, functionToolCall.FunctionName, out function))
+        {
+            // Add parameters to arguments
+            arguments = null;
+            if (functionToolCall.Arguments is not null)
+            {
+                // TODO user serializer options from the Kernel
+                var functionArguments = JsonSerializer.Deserialize<Dictionary<string, object>>(functionToolCall.Arguments);
+                // TODO record error if deserialization fails
+
+                if (functionArguments is not null)
+                {
+                    arguments = new KernelArguments();
+
+                    foreach (var key in functionArguments.Keys)
+                    {
+                        arguments[key] = functionArguments[key];
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        // Function not found in collection
+        arguments = null;
+        return false;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MistralAI/MistralAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/MistralAIPromptExecutionSettings.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Text;
 
 namespace Microsoft.SemanticKernel.Connectors.MistralAI;
@@ -117,6 +118,43 @@ public sealed class MistralAIPromptExecutionSettings : PromptExecutionSettings
         }
     }
 
+    /// <summary>
+    /// Gets or sets the behavior for how tool calls are handled.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>To disable all tool calling, set the property to null (the default).</item>
+    /// <item>
+    /// To allow the model to request one of any number of functions, set the property to an
+    /// instance returned from <see cref="MistralAIToolCallBehavior.EnableFunctions"/>, called with
+    /// a list of the functions available.
+    /// </item>
+    /// <item>
+    /// To allow the model to request one of any of the functions in the supplied <see cref="Kernel"/>,
+    /// set the property to <see cref="MistralAIToolCallBehavior.EnableKernelFunctions"/> if the client should simply
+    /// send the information about the functions and not handle the response in any special manner, or
+    /// <see cref="MistralAIToolCallBehavior.AutoInvokeKernelFunctions"/> if the client should attempt to automatically
+    /// invoke the function and send the result back to the service.
+    /// </item>
+    /// </list>
+    /// For all options where an instance is provided, auto-invoke behavior may be selected. If the service
+    /// sends a request for a function call, if auto-invoke has been requested, the client will attempt to
+    /// resolve that function from the functions available in the <see cref="Kernel"/>, and if found, rather
+    /// than returning the response back to the caller, it will handle the request automatically, invoking
+    /// the function, and sending back the result. The intermediate messages will be retained in the
+    /// <see cref="ChatHistory"/> if an instance was provided.
+    /// </remarks>
+    public MistralAIToolCallBehavior? ToolCallBehavior
+    {
+        get => this._toolCallBehavior;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._toolCallBehavior = value;
+        }
+    }
+
     /// <inheritdoc/>
     public override void Freeze()
     {
@@ -141,6 +179,7 @@ public sealed class MistralAIPromptExecutionSettings : PromptExecutionSettings
             SafePrompt = this.SafePrompt,
             RandomSeed = this.RandomSeed,
             ApiVersion = this.ApiVersion,
+            ToolCallBehavior = this.ToolCallBehavior,
         };
     }
 
@@ -177,6 +216,7 @@ public sealed class MistralAIPromptExecutionSettings : PromptExecutionSettings
     private bool _safePrompt = false;
     private int? _randomSeed;
     private string _apiVersion = "v1";
+    private MistralAIToolCallBehavior? _toolCallBehavior;
 
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.MistralAI/MistralAIToolCallBehavior.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/MistralAIToolCallBehavior.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.SemanticKernel.Connectors.MistralAI.Client;
+
+namespace Microsoft.SemanticKernel.Connectors.MistralAI;
+
+/// <summary>Represents a behavior for Mistral tool calls.</summary>
+public abstract class MistralAIToolCallBehavior
+{
+    // NOTE: Right now, the only tools that are available are for function calling. In the future,
+    // this class can be extended to support additional kinds of tools, including composite ones:
+    // the MistralAIPromptExecutionSettings has a single ToolCallBehavior property, but we could
+    // expose a `public static ToolCallBehavior Composite(params ToolCallBehavior[] behaviors)`
+    // or the like to allow multiple distinct tools to be provided, should that be appropriate.
+    // We can also consider additional forms of tools, such as ones that dynamically examine
+    // the Kernel, KernelArguments, etc.
+
+    /// <summary>
+    /// The default maximum number of tool-call auto-invokes that can be made in a single request.
+    /// </summary>
+    /// <remarks>
+    /// After this number of iterations as part of a single user request is reached, auto-invocation
+    /// will be disabled (e.g. <see cref="AutoInvokeKernelFunctions"/> will behave like <see cref="EnableKernelFunctions"/>)).
+    /// This is a safeguard against possible runaway execution if the model routinely re-requests
+    /// the same function over and over. It is currently hardcoded, but in the future it could
+    /// be made configurable by the developer. Other configuration is also possible in the future,
+    /// such as a delegate on the instance that can be invoked upon function call failure (e.g. failure
+    /// to find the requested function, failure to invoke the function, etc.), with behaviors for
+    /// what to do in such a case, e.g. respond to the model telling it to try again. With parallel tool call
+    /// support, where the model can request multiple tools in a single response, it is significantly
+    /// less likely that this limit is reached, as most of the time only a single request is needed.
+    /// </remarks>
+    private const int DefaultMaximumAutoInvokeAttempts = 5;
+
+    /// <summary>
+    /// Gets an instance that will provide all of the <see cref="Kernel"/>'s plugins' function information.
+    /// Function call requests from the model will be propagated back to the caller.
+    /// </summary>
+    /// <remarks>
+    /// If no <see cref="Kernel"/> is available, no function information will be provided to the model.
+    /// </remarks>
+    public static MistralAIToolCallBehavior EnableKernelFunctions { get; } = new KernelFunctions(autoInvoke: false);
+
+    /// <summary>
+    /// Gets an instance that will both provide all of the <see cref="Kernel"/>'s plugins' function information
+    /// to the model and attempt to automatically handle any function call requests.
+    /// </summary>
+    /// <remarks>
+    /// When successful, tool call requests from the model become an implementation detail, with the service
+    /// handling invoking any requested functions and supplying the results back to the model.
+    /// If no <see cref="Kernel"/> is available, no function information will be provided to the model.
+    /// </remarks>
+    public static MistralAIToolCallBehavior AutoInvokeKernelFunctions { get; } = new KernelFunctions(autoInvoke: true);
+
+    /// <summary>Gets an instance that will provide the specified list of functions to the model.</summary>
+    /// <param name="functions">The functions that should be made available to the model.</param>
+    /// <param name="autoInvoke">true to attempt to automatically handle function call requests; otherwise, false.</param>
+    /// <returns>
+    /// The <see cref="MistralAIToolCallBehavior"/> that may be set into <see cref="MistralAIPromptExecutionSettings.ToolCallBehavior"/>
+    /// to indicate that the specified functions should be made available to the model.
+    /// </returns>
+    public static MistralAIToolCallBehavior EnableFunctions(IEnumerable<KernelFunction> functions, bool autoInvoke = false)
+    {
+        Verify.NotNull(functions);
+        return new EnabledFunctions(functions, autoInvoke);
+    }
+
+    /*
+    /// <summary>Gets an instance that will request the model to use the specified function.</summary>
+    /// <param name="function">The function the model should request to use.</param>
+    /// <param name="autoInvoke">true to attempt to automatically handle function call requests; otherwise, false.</param>
+    /// <returns>
+    /// The <see cref="MistralAIToolCallBehavior"/> that may be set into <see cref="MistralAIPromptExecutionSettings.ToolCallBehavior"/>
+    /// to indicate that the specified function should be requested by the model.
+    /// </returns>
+    public static MistralAIToolCallBehavior RequireFunction(KernelFunction function, bool autoInvoke = false)
+    {
+        Verify.NotNull(function);
+        return new RequiredFunction(function, autoInvoke);
+    }
+    */
+
+    /// <summary>Initializes the instance; prevents external instantiation.</summary>
+    private MistralAIToolCallBehavior(bool autoInvoke)
+    {
+        this.MaximumAutoInvokeAttempts = autoInvoke ? DefaultMaximumAutoInvokeAttempts : 0;
+    }
+
+    /// <summary>
+    /// Options to control tool call result serialization behavior.
+    /// </summary>
+    public virtual JsonSerializerOptions? ToolCallResultSerializerOptions { get; set; }
+
+    /// <summary>Gets how many requests are part of a single interaction should include this tool in the request.</summary>
+    /// <remarks>
+    /// This should be greater than or equal to <see cref="MaximumAutoInvokeAttempts"/>. It defaults to <see cref="int.MaxValue"/>.
+    /// Once this limit is reached, the tools will no longer be included in subsequent retries as part of the operation, e.g.
+    /// if this is 1, the first request will include the tools, but the subsequent response sending back the tool's result
+    /// will not include the tools for further use.
+    /// </remarks>
+    internal virtual int MaximumUseAttempts => int.MaxValue;
+
+    /// <summary>Gets how many tool call request/response roundtrips are supported with auto-invocation.</summary>
+    /// <remarks>
+    /// To disable auto invocation, this can be set to 0.
+    /// </remarks>
+    internal int MaximumAutoInvokeAttempts { get; }
+
+    /// <summary>
+    /// Gets whether validation against a specified list is required before allowing the model to request a function from the kernel.
+    /// </summary>
+    /// <value>true if it's ok to invoke any kernel function requested by the model if it's found; false if a request needs to be validated against an allow list.</value>
+    internal virtual bool AllowAnyRequestedKernelFunction => false;
+
+    /// <summary>Configures the <paramref name="request"/> with any tools this <see cref="MistralAIToolCallBehavior"/> provides.</summary>
+    /// <param name="kernel">The <see cref="Kernel"/> used for the operation. This can be queried to determine what tools to provide into the <paramref name="request"/>.</param>
+    /// <param name="request">The destination <see cref="ChatCompletionRequest"/> to configure.</param>
+    internal abstract void ConfigureRequest(Kernel? kernel, ChatCompletionRequest request);
+
+    /// <summary>
+    /// Represents a <see cref="MistralAIToolCallBehavior"/> that will provide to the model all available functions from a
+    /// <see cref="Kernel"/> provided by the client.
+    /// </summary>
+    internal sealed class KernelFunctions : MistralAIToolCallBehavior
+    {
+        internal KernelFunctions(bool autoInvoke) : base(autoInvoke) { }
+
+        public override string ToString() => $"{nameof(KernelFunctions)}(autoInvoke:{this.MaximumAutoInvokeAttempts != 0})";
+
+        internal IEnumerable<KernelFunctionMetadata>? GetFunctionsMetadata(Kernel? kernel)
+        {
+            // Provide all functions from the kernel.
+            return kernel?.Plugins?.GetFunctionsMetadata();
+        }
+
+        internal override void ConfigureRequest(Kernel? kernel, ChatCompletionRequest request)
+        {
+            var functionsMetadata = kernel?.Plugins?.GetFunctionsMetadata();
+
+            if (functionsMetadata is null)
+            {
+                return;
+            }
+
+            request.ToolChoice = "auto";
+
+            foreach (var functionMetadata in functionsMetadata)
+            {
+                request.AddTool(ToMistralTool(functionMetadata));
+            }
+        }
+
+        internal override bool AllowAnyRequestedKernelFunction => true;
+    }
+
+    /// <summary>
+    /// Represents a <see cref="MistralAIToolCallBehavior"/> that provides a specified list of functions to the model.
+    /// </summary>
+    internal sealed class EnabledFunctions : MistralAIToolCallBehavior
+    {
+        private readonly IEnumerable<KernelFunctionMetadata>? _kernelFunctionMetadata;
+        //private readonly ChatCompletionsFunctionToolDefinition[] _functions;
+
+        public EnabledFunctions(IEnumerable<KernelFunction> functions, bool autoInvoke) : base(autoInvoke)
+        {
+            this._kernelFunctionMetadata = functions.Select(f => f.Metadata);
+        }
+
+        public override string ToString() => $"{nameof(EnabledFunctions)}(autoInvoke:{this.MaximumAutoInvokeAttempts != 0}): {string.Join(", ", this._kernelFunctionMetadata.Select(f => f.Name))}";
+
+        internal override void ConfigureRequest(Kernel? kernel, ChatCompletionRequest request)
+        {
+            if (this._kernelFunctionMetadata is null)
+            {
+                return;
+            }
+
+            bool autoInvoke = base.MaximumAutoInvokeAttempts > 0;
+
+            // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
+            // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
+            // and then fail to do so, so we fail before we get to that point. This is an error
+            // on the consumers behalf: if they specify auto-invocation with any functions, they must
+            // specify the kernel and the kernel must contain those functions.
+            if (autoInvoke && kernel is null)
+            {
+                throw new KernelException($"Auto-invocation with {nameof(EnabledFunctions)} is not supported when no kernel is provided.");
+            }
+
+            foreach (var metadata in this._kernelFunctionMetadata)
+            {
+                // Make sure that if auto-invocation is specified, every enabled function can be found in the kernel.
+                if (autoInvoke)
+                {
+                    Debug.Assert(kernel is not null);
+                    if (!kernel!.Plugins.TryGetFunction(metadata.PluginName, metadata.Name, out _))
+                    {
+                        throw new KernelException($"The specified {nameof(EnabledFunctions)} function {metadata.PluginName}-{metadata.Name} is not available in the kernel.");
+                    }
+                }
+            }
+
+            foreach (var functionMetadata in this._kernelFunctionMetadata)
+            {
+                request.AddTool(ToMistralTool(functionMetadata));
+            }
+        }
+    }
+
+    // TODO : Implement Any Function
+
+    private static MistralTool ToMistralTool(KernelFunctionMetadata metadata)
+    {
+        return new MistralTool("function", new MistralFunction(metadata));
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Adds support for function calling for non-streaming chat completion requests only.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
