### PR TITLE
Python: Small docstring fix

### DIFF
--- a/python/semantic_kernel/events/function_invoked_event_args.py
+++ b/python/semantic_kernel/events/function_invoked_event_args.py
@@ -24,7 +24,7 @@ class FunctionInvokedEventArgs(KernelEventArgs):
         kernel_function_metadata (KernelFunctionMetadata): The function that is being executed.
         arguments (KernelArguments): The arguments that are being passed to the function.
         function_result (FunctionResult): The result of the function execution.
-        exception (Optional: Exception): The exception that was raised during the function execution.
+        exception (Exception, optional): The exception that was raised during the function execution.
 
     Flags:
         updated_arguments (bool): Whether the arguments were updated, default False.


### PR DESCRIPTION
### Motivation and Context

This is a single-line fix to a Python docstring to get it to conform to Sphinx standards and convention used [elsewhere](https://github.com/microsoft/semantic-kernel/blob/290f44d593daa21f5a4f88eb5bb4e49468ebb608/python/semantic_kernel/planners/plan.py#L137) in the project.

(My team owns the reference docs generation process for this and other libraries. We forced a build the other day from our side for test purposes and noticed it stumbled over this line. Feel free to ping me if any questions.)

### Description

See changes, it's a one-liner :grin:

### Contribution Checklist

I ashamedly admit I have done *none* of the below; hopefully this is a gimme, apologies if it creates noise.

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
