### PR TITLE
Python: Add missing await to openapi client

### DIFF
--- a/python/samples/kernel-syntax-examples/openapi_example/openapi_client.py
+++ b/python/samples/kernel-syntax-examples/openapi_example/openapi_client.py
@@ -21,7 +21,7 @@ async def main():
 
     kernel_arguments = KernelArguments(**arguments)
 
-    result = kernel.invoke(openapi_plugin["helloWorld"], arguments=kernel_arguments)
+    result = await kernel.invoke(openapi_plugin["helloWorld"], arguments=kernel_arguments)
 
     print(result)
 


### PR DESCRIPTION
### Motivation and Context

Add missing await to openapi client

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Add missing await to openapi client

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
