### PR TITLE
Python: updated decorator to allow no brackets

### DIFF
--- a/python/semantic_kernel/functions/kernel_function_decorator.py
+++ b/python/semantic_kernel/functions/kernel_function_decorator.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
-
+from __future__ import annotations
 
 import logging
 from functools import wraps
 from inspect import Parameter, Signature, isasyncgenfunction, isgeneratorfunction, signature
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 NoneType = type(None)
 logger = logging.getLogger(__name__)
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 def kernel_function(
     func: Callable[..., Any] | None = None,
-    name: Optional[str] = None,
-    description: Optional[str] = None,
+    name: str | None = None,
+    description: str | None = None,
 ) -> Callable[..., Any]:
     """
     Decorator for kernel functions.
@@ -69,7 +69,7 @@ def kernel_function(
     return decorator
 
 
-def _parse_parameter(param: Parameter) -> Dict[str, Any]:
+def _parse_parameter(param: Parameter) -> dict[str, Any]:
     logger.debug(f"Parsing param: {param}")
     ret = {}
     if param != Parameter.empty:
@@ -80,7 +80,7 @@ def _parse_parameter(param: Parameter) -> Dict[str, Any]:
     return ret
 
 
-def _parse_annotation(annotation: Parameter) -> Dict[str, Any]:
+def _parse_annotation(annotation: Parameter) -> dict[str, Any]:
     logger.debug(f"Parsing annotation: {annotation}")
     if annotation == Signature.empty:
         return {"type_": "Any", "is_required": True}
@@ -93,7 +93,7 @@ def _parse_annotation(annotation: Parameter) -> Dict[str, Any]:
     return ret
 
 
-def _parse_internal_annotation(annotation: Parameter, required: bool) -> Dict[str, Any]:
+def _parse_internal_annotation(annotation: Parameter, required: bool) -> dict[str, Any]:
     logger.debug(f"Internal {annotation=}")
     if hasattr(annotation, "__forward_arg__"):
         return {"type_": annotation.__forward_arg__, "is_required": required}

--- a/python/semantic_kernel/functions/kernel_function_decorator.py
+++ b/python/semantic_kernel/functions/kernel_function_decorator.py
@@ -2,6 +2,7 @@
 
 
 import logging
+from functools import wraps
 from inspect import Parameter, Signature, isasyncgenfunction, isgeneratorfunction, signature
 from typing import Any, Callable, Dict, Optional
 
@@ -10,10 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 def kernel_function(
-    *,
+    func: Callable[..., Any] | None = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
-):
+) -> Callable[..., Any]:
     """
     Decorator for kernel functions.
 
@@ -42,7 +43,8 @@ def kernel_function(
 
     """
 
-    def decorator(func: Callable):
+    @wraps(func)
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         func.__kernel_function__ = True
         func.__kernel_function_description__ = description or func.__doc__
         func.__kernel_function_name__ = name or func.__name__
@@ -62,6 +64,8 @@ def kernel_function(
         func.__kernel_function_return_required__ = return_param_dict.get("is_required", False)
         return func
 
+    if func:
+        return decorator(func)
     return decorator
 
 

--- a/python/tests/unit/functions/test_kernel_function_decorators.py
+++ b/python/tests/unit/functions/test_kernel_function_decorators.py
@@ -35,60 +35,60 @@ class MiscClass:
     def func_with_name(self, input):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_docstring_as_description(self, input):
         """description"""
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_annotated(self, input: Annotated[str, "input description"]):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_annotated_optional(self, input: Annotated[Optional[str], "input description"] = "test"):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_optional(self, input: Optional[str] = "test"):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_return_type(self, input: str) -> str:
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_return_type_optional(self, input: str) -> Optional[str]:
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_return_type_annotated(self, input: str) -> Annotated[str, "test return"]:
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_return_type_streaming(self, input: str) -> Annotated[AsyncIterable[str], "test return"]:
         yield input
 
-    @kernel_function()
+    @kernel_function
     def func_input_object(self, input: InputObject):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_object_optional(self, input: Optional[InputObject] = None):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_object_annotated(self, input: Annotated[InputObject, "input description"]):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_object_annotated_optional(self, input: Annotated[Optional[InputObject], "input description"] = None):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_input_object_union(self, input: Union[InputObject, str]):
         return input
 
-    @kernel_function()
+    @kernel_function
     def func_no_typing(self, input):
         return input
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Small change to allow a kernel function decorator without name and description, to be defined without brackets.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
