### PR TITLE
.Net: Focus CI on .NET 8 SDK

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -52,16 +52,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { dotnet: "6.0-jammy", os: "ubuntu", configuration: Debug }
-          - { dotnet: "7.0-jammy", os: "ubuntu", configuration: Release }
           - { dotnet: "8.0-jammy", os: "ubuntu", configuration: Release }
-          - { dotnet: "6.0", os: "windows", configuration: Release }
-          - {
-              dotnet: "7.0",
-              os: "windows",
-              configuration: Debug,
-              integration-tests: true,
-            }
+          - { dotnet: "8.0", os: "windows", configuration: Debug, integration-tests: true, }
           - { dotnet: "8.0", os: "windows", configuration: Release }
 
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -19,9 +19,7 @@ jobs:
         fail-fast: false
         matrix:
           include:
-          - { os: ubuntu-latest, dotnet: '6.0', configuration: Debug }
-          - { os: ubuntu-latest, dotnet: '6.0', configuration: Release }
-          - { os: ubuntu-latest, dotnet: '7.0', configuration: Release }
+          - { os: ubuntu-latest, dotnet: '8.0', configuration: Debug }
           - { os: ubuntu-latest, dotnet: '8.0', configuration: Release }
 
     runs-on: ${{ matrix.os }}
@@ -68,7 +66,7 @@ jobs:
         matrix:
           os: [windows-latest]
           configuration: [Release, Debug]
-          dotnet-version: ['7.0.x']
+          dotnet-version: ['8.0.x']
     runs-on: ${{ matrix.os }}
     env:
       NUGET_CERT_REVOCATION_MODE: offline

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,8 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        #- { dotnet: '6.0', configuration: Release, os: ubuntu-latest }
-        #- { dotnet: '7.0', configuration: Release, os: ubuntu-latest }
         - { dotnet: '8.0', configuration: Release, os: ubuntu-latest }
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         if: ${{ github.event_name != 'pull_request' }}
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Find projects
         shell: bash

--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SemanticKernel;
 /// </remarks>
 public sealed class Kernel
 {
-    /// <summary>Key used by KernelBuilder to store type information into the service provider.</summary>
+    /// <summary>Key used by <see cref="IKernelBuilder"/> to store type information into the service provider.</summary>
     internal const string KernelServiceTypeToKeyMappings = nameof(KernelServiceTypeToKeyMappings);
 
     /// <summary>Dictionary containing ambient data stored in the kernel, lazily-initialized on first access.</summary>


### PR DESCRIPTION
This is about which SDK is used, not which target framework is used. .NET 7 is EOL in May. .NET 6 is EOL in Nov.