### PR TITLE
.Net: Upgrade projects from net6.0 to net8.0 and adjust LangVersion to 12

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -163,11 +163,13 @@ dotnet_diagnostic.CA1510.severity = none
 dotnet_diagnostic.CA1805.severity = none # Member is explicitly initialized to its default value
 dotnet_diagnostic.CA1822.severity = none # Member does not access instance data and can be marked as static
 dotnet_diagnostic.CA1848.severity = none # For improved performance, use the LoggerMessage delegates
+dotnet_diagnostic.CA1849.severity = none # Use async equivalent; analyzer is currently noisy
 dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
 dotnet_diagnostic.CA2225.severity = none # Operator overloads have named alternates
 dotnet_diagnostic.CA2227.severity = none # Change to be read-only by removing the property setter
 dotnet_diagnostic.CA2253.severity = none # Named placeholders in the logging message template should not be comprised of only numeric characters
 
+dotnet_diagnostic.VSTHRD103.severity = none # Use async equivalent; analyzer is currently noisy
 dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
 dotnet_diagnostic.VSTHRD200.severity = none # Use Async suffix for async methods
 dotnet_diagnostic.xUnit1004.severity = none # Test methods should not be skipped. Remove the Skip property to start running the test again.

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -6,7 +6,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -86,12 +86,6 @@
     <!-- Symbols -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Toolset -->
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/dotnet/samples/CreateChatGptPlugin/MathPlugin/azure-function/Directory.Build.props
+++ b/dotnet/samples/CreateChatGptPlugin/MathPlugin/azure-function/Directory.Build.props
@@ -6,7 +6,6 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <NoWarn>CS1591,CA1852,CA1050</NoWarn> 

--- a/dotnet/samples/CreateChatGptPlugin/MathPlugin/azure-function/shared/PluginShared.csproj
+++ b/dotnet/samples/CreateChatGptPlugin/MathPlugin/azure-function/shared/PluginShared.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>skchatgptazurefunction.PluginShared</RootNamespace>
   </PropertyGroup>

--- a/dotnet/samples/CreateChatGptPlugin/MathPlugin/azure-function/sk-chatgpt-azure-function.csproj
+++ b/dotnet/samples/CreateChatGptPlugin/MathPlugin/azure-function/sk-chatgpt-azure-function.csproj
@@ -6,12 +6,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>skchatgptazurefunction</RootNamespace>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <OutputType>Exe</OutputType>
-    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/dotnet/samples/CreateChatGptPlugin/MathPlugin/kernel-functions-generator/kernel-functions-generator.csproj
+++ b/dotnet/samples/CreateChatGptPlugin/MathPlugin/kernel-functions-generator/kernel-functions-generator.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>RS1035,CS0612,CS1591,CS8601,CS8602,CS860218</NoWarn>

--- a/dotnet/samples/CreateChatGptPlugin/Solution/CreateChatGptPlugin.csproj
+++ b/dotnet/samples/CreateChatGptPlugin/Solution/CreateChatGptPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/dotnet/samples/CreateChatGptPlugin/Solution/Program.cs
+++ b/dotnet/samples/CreateChatGptPlugin/Solution/Program.cs
@@ -46,7 +46,7 @@ while (true)
     // Stream the results
     string fullMessage = "";
     var first = true;
-    await foreach (var content in result)
+    await foreach (var content in result.ConfigureAwait(false))
     {
         if (content.Role.HasValue && first)
         {

--- a/dotnet/samples/DocumentationExamples/DocumentationExamples.csproj
+++ b/dotnet/samples/DocumentationExamples/DocumentationExamples.csproj
@@ -5,14 +5,12 @@
   <PropertyGroup>
     <AssemblyName>DocumentationExamples</AssemblyName>
     <RootNamespace></RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <!-- Suppress: "Declare types in namespaces", "Require ConfigureAwait", "Experimental" -->
     <NoWarn>CS8618,IDE0009,CA1051,CA1050,CA1707,CA2007,VSTHRD111,CS1591,RCS1110,CA5394,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0040,SKEXP0050,SKEXP0060,SKEXP0101</NoWarn>
     <OutputType>Library</OutputType>
-    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Plugins\Prompts\chat\skprompt.txt" />
@@ -58,11 +56,6 @@
     <ProjectReference Include="..\..\src\Functions\Functions.OpenApi\Functions.OpenApi.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel.Core\SemanticKernel.Core.csproj" />
     <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Use newest available compiler to handle newer source-generating libraries used in the examples. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\getIntent.prompt.yaml">

--- a/dotnet/samples/HomeAutomation/HomeAutomation.csproj
+++ b/dotnet/samples/HomeAutomation/HomeAutomation.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>

--- a/dotnet/samples/HuggingFaceImageTextExample/FormMain.cs
+++ b/dotnet/samples/HuggingFaceImageTextExample/FormMain.cs
@@ -156,7 +156,7 @@ public partial class FormMain : Form
     private static ReadOnlyMemory<byte> ConvertImageToReadOnlyMemory(PictureBox pictureBox)
     {
         var image = pictureBox.Image;
-        var fileName = pictureBox.Tag.ToString()!;
+        var fileName = pictureBox.Tag!.ToString()!;
 
         using var memoryStream = new MemoryStream();
 

--- a/dotnet/samples/HuggingFaceImageTextExample/HuggingFaceImageTextExample.csproj
+++ b/dotnet/samples/HuggingFaceImageTextExample/HuggingFaceImageTextExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>

--- a/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
+++ b/dotnet/samples/KernelSyntaxExamples/KernelSyntaxExamples.csproj
@@ -5,8 +5,7 @@
   <PropertyGroup>
     <AssemblyName>KernelSyntaxExamples</AssemblyName>
     <RootNamespace></RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <!-- Suppress: "Declare types in namespaces", "Require ConfigureAwait", "Experimental" -->
@@ -69,11 +68,6 @@
     <ProjectReference Include="..\..\src\Plugins\Plugins.Web\Plugins.Web.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel.Core\SemanticKernel.Core.csproj" />
     <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Use newest available compiler to handle newer source-generating libraries used in the examples. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="RepoUtils\PlanExtensions.cs" />

--- a/dotnet/samples/TelemetryExample/TelemetryExample.csproj
+++ b/dotnet/samples/TelemetryExample/TelemetryExample.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/Connectors.AzureAISearch.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/Connectors.AzureAISearch.UnitTests.csproj
@@ -3,21 +3,13 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.AzureAISearch.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.AzureAISearch.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>12</LangVersion>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <NoWarn>SKEXP0001,SKEXP0020</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to permit LangVersion 12. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Connectors.Google.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Connectors.Google.UnitTests.csproj
@@ -3,21 +3,13 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.GoogleVertexAI.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.GoogleVertexAI.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>12</LangVersion>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,CA1806,CA1869,CA1861,IDE0300,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050,SKEXP0070</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to permit LangVersion 12. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -204,7 +204,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
             using var responseStream = await response.Content.ReadAsStreamAndTranslateExceptionAsync()
                 .ConfigureAwait(false);
 
-            await foreach (var messageContent in this.GetStreamingChatMessageContentsOrPopulateStateForToolCallingAsync(state, responseStream, cancellationToken))
+            await foreach (var messageContent in this.GetStreamingChatMessageContentsOrPopulateStateForToolCallingAsync(state, responseStream, cancellationToken).ConfigureAwait(false))
             {
                 yield return messageContent;
             }
@@ -489,7 +489,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         Stream responseStream,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        await foreach (var response in this.ParseResponseStreamAsync(responseStream, ct: ct))
+        await foreach (var response in this.ParseResponseStreamAsync(responseStream, ct: ct).ConfigureAwait(false))
         {
             foreach (var messageContent in this.ProcessChatResponse(response))
             {
@@ -502,7 +502,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         Stream responseStream,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        await foreach (var json in this._streamJsonParser.ParseAsync(responseStream, cancellationToken: ct))
+        await foreach (var json in this._streamJsonParser.ParseAsync(responseStream, cancellationToken: ct).ConfigureAwait(false))
         {
             yield return DeserializeResponse<GeminiResponse>(json);
         }
@@ -531,7 +531,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         }
     }
 
-    private void LogUsage(IReadOnlyList<GeminiChatMessageContent> chatMessageContents)
+    private void LogUsage(List<GeminiChatMessageContent> chatMessageContents)
         => this.LogUsageMetadata(chatMessageContents[0].Metadata!);
 
     private List<GeminiChatMessageContent> GetChatMessageContentsFromResponse(GeminiResponse geminiResponse)

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Connectors.HuggingFace.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Connectors.HuggingFace.UnitTests.csproj
@@ -3,21 +3,13 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.HuggingFace.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.HuggingFace.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>12</LangVersion>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,CA1806,CA1869,CA1861,IDE0300,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0070,SKEXP0050</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to permit LangVersion 12. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Client/HuggingFaceClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Client/HuggingFaceClient.cs
@@ -179,7 +179,7 @@ internal sealed class HuggingFaceClient
 
     private async IAsyncEnumerable<TextGenerationStreamResponse> ParseTextResponseStreamAsync(Stream responseStream, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var json in this._streamJsonParser.ParseAsync(responseStream, cancellationToken: cancellationToken))
+        await foreach (var json in this._streamJsonParser.ParseAsync(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             yield return DeserializeResponse<TextGenerationStreamResponse>(json);
         }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryStore.cs
@@ -214,7 +214,7 @@ public class AzureAISearchMemoryStore : IMemoryStore
         if (searchResult == null) { yield break; }
 
         var minAzureSearchScore = CosineSimilarityToScore(minRelevanceScore);
-        await foreach (SearchResult<AzureAISearchMemoryRecord>? doc in searchResult.Value.GetResultsAsync())
+        await foreach (SearchResult<AzureAISearchMemoryRecord>? doc in searchResult.Value.GetResultsAsync().ConfigureAwait(false))
         {
             if (doc == null || doc.Score < minAzureSearchScore) { continue; }
 
@@ -332,7 +332,7 @@ public class AzureAISearchMemoryStore : IMemoryStore
 
     private async Task<List<string>> UpsertBatchAsync(
         string indexName,
-        IList<AzureAISearchMemoryRecord> records,
+        List<AzureAISearchMemoryRecord> records,
         CancellationToken cancellationToken = default)
     {
         var keys = new List<string>();

--- a/dotnet/src/Connectors/Connectors.Memory.DuckDB/DuckDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.DuckDB/DuckDBMemoryStore.cs
@@ -69,7 +69,7 @@ public sealed class DuckDBMemoryStore : IMemoryStore, IDisposable
     /// <inheritdoc/>
     public async IAsyncEnumerable<string> GetCollectionsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await foreach (var collection in this._dbConnector.GetCollectionsAsync(this._dbConnection, cancellationToken))
+        await foreach (var collection in this._dbConnector.GetCollectionsAsync(this._dbConnection, cancellationToken).ConfigureAwait(false))
         {
             yield return collection;
         }
@@ -149,7 +149,7 @@ public sealed class DuckDBMemoryStore : IMemoryStore, IDisposable
 
         List<(MemoryRecord Record, double Score)> embeddings = new();
 
-        await foreach (var dbEntry in this._dbConnector.GetNearestMatchesAsync(this._dbConnection, collectionName, embedding.ToArray(), limit, minRelevanceScore, cancellationToken))
+        await foreach (var dbEntry in this._dbConnector.GetNearestMatchesAsync(this._dbConnection, collectionName, embedding.ToArray(), limit, minRelevanceScore, cancellationToken).ConfigureAwait(false))
         {
             var entry = MemoryRecord.FromJsonMetadata(
                 json: dbEntry.MetadataString,

--- a/dotnet/src/Connectors/Connectors.Memory.Milvus/MilvusMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Milvus/MilvusMemoryStore.cs
@@ -341,7 +341,7 @@ public class MilvusMemoryStore : IMemoryStore, IDisposable
         bool withEmbedding = false,
         CancellationToken cancellationToken = default)
     {
-        await foreach (MemoryRecord record in this.GetBatchAsync(collectionName, new[] { key }, withEmbedding, cancellationToken))
+        await foreach (MemoryRecord record in this.GetBatchAsync(collectionName, new[] { key }, withEmbedding, cancellationToken).ConfigureAwait(false))
         {
             return record;
         }
@@ -426,7 +426,7 @@ public class MilvusMemoryStore : IMemoryStore, IDisposable
         bool withEmbedding = false,
         CancellationToken cancellationToken = default)
     {
-        await foreach ((MemoryRecord, double) result in this.GetNearestMatchesAsync(collectionName, embedding, limit: 1, minRelevanceScore, withEmbedding, cancellationToken))
+        await foreach ((MemoryRecord, double) result in this.GetNearestMatchesAsync(collectionName, embedding, limit: 1, minRelevanceScore, withEmbedding, cancellationToken).ConfigureAwait(false))
         {
             return result;
         }

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryStore.cs
@@ -60,7 +60,7 @@ public class MongoDBMemoryStore : IMemoryStore, IDisposable
     /// <inheritdoc/>
     public async Task<bool> DoesCollectionExistAsync(string collectionName, CancellationToken cancellationToken = default)
     {
-        await foreach (var existingCollectionName in this.GetCollectionsAsync(cancellationToken))
+        await foreach (var existingCollectionName in this.GetCollectionsAsync(cancellationToken).ConfigureAwait(false))
         {
             if (existingCollectionName == collectionName)
             {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
@@ -166,7 +166,7 @@ public sealed class PineconeClient : IPineconeClient
             includeValues,
             includeMetadata, cancellationToken);
 
-        await foreach (PineconeDocument? match in matches.WithCancellation(cancellationToken))
+        await foreach (PineconeDocument? match in matches.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             if (match == null)
             {
@@ -209,7 +209,7 @@ public sealed class PineconeClient : IPineconeClient
         string basePath = await this.GetVectorOperationsApiBasePathAsync(indexName).ConfigureAwait(false);
         IAsyncEnumerable<PineconeDocument> validVectors = PineconeUtils.EnsureValidMetadataAsync(vectors.ToAsyncEnumerable());
 
-        await foreach (UpsertRequest? batch in PineconeUtils.GetUpsertBatchesAsync(validVectors, MaxBatchSize).WithCancellation(cancellationToken))
+        await foreach (UpsertRequest? batch in PineconeUtils.GetUpsertBatchesAsync(validVectors, MaxBatchSize).WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             totalBatches++;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocumentExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocumentExtensions.cs
@@ -58,16 +58,7 @@ public static class PineconeDocumentExtensions
     /// </summary>
     /// <param name="pineconeDocument">Instance of <see cref="PineconeDocument"/>.</param>
     /// <returns>Instance of <see cref="MemoryRecord"/>.</returns>
-    public static MemoryRecord ToMemoryRecord(this PineconeDocument pineconeDocument) =>
-        ToMemoryRecord(pineconeDocument, transferVectorOwnership: false);
-
-    /// <summary>
-    /// Maps <see cref="PineconeDocument"/> instance to <see cref="MemoryRecord"/>.
-    /// </summary>
-    /// <param name="pineconeDocument">Instance of <see cref="PineconeDocument"/>.</param>
-    /// <param name="transferVectorOwnership">Whether to allow the created embedding to store a reference to this instance.</param>
-    /// <returns>Instance of <see cref="MemoryRecord"/>.</returns>
-    internal static MemoryRecord ToMemoryRecord(this PineconeDocument pineconeDocument, bool transferVectorOwnership)
+    public static MemoryRecord ToMemoryRecord(this PineconeDocument pineconeDocument)
     {
         ReadOnlyMemory<float> embedding = pineconeDocument.Values;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
@@ -246,9 +246,9 @@ public class PineconeMemoryStore : IPineconeMemoryStore
                                new[] { key },
                                indexNamespace,
                                withEmbedding,
-                               cancellationToken))
+                               cancellationToken).ConfigureAwait(false))
             {
-                return record?.ToMemoryRecord(transferVectorOwnership: true);
+                return record?.ToMemoryRecord();
             }
         }
         catch (HttpOperationException ex)
@@ -341,7 +341,7 @@ public class PineconeMemoryStore : IPineconeMemoryStore
                  in documentIds.Select(
                      documentId => this.GetWithDocumentIdAsync(indexName, documentId, limit, indexNamespace, withEmbeddings, cancellationToken)))
         {
-            await foreach (MemoryRecord? record in records.WithCancellation(cancellationToken))
+            await foreach (MemoryRecord? record in records.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
                 yield return record;
             }
@@ -379,7 +379,7 @@ public class PineconeMemoryStore : IPineconeMemoryStore
 
         foreach (PineconeDocument? record in vectorDataList)
         {
-            yield return record?.ToMemoryRecord(transferVectorOwnership: true);
+            yield return record?.ToMemoryRecord();
         }
     }
 
@@ -550,9 +550,9 @@ public class PineconeMemoryStore : IPineconeMemoryStore
             default,
             cancellationToken);
 
-        await foreach ((PineconeDocument, double) result in results.WithCancellation(cancellationToken))
+        await foreach ((PineconeDocument, double) result in results.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            yield return (result.Item1.ToMemoryRecord(transferVectorOwnership: true), result.Item2);
+            yield return (result.Item1.ToMemoryRecord(), result.Item2);
         }
     }
 
@@ -623,9 +623,9 @@ public class PineconeMemoryStore : IPineconeMemoryStore
             filter,
             cancellationToken);
 
-        await foreach ((PineconeDocument, double) result in results.WithCancellation(cancellationToken))
+        await foreach ((PineconeDocument, double) result in results.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            yield return (result.Item1.ToMemoryRecord(transferVectorOwnership: true), result.Item2);
+            yield return (result.Item1.ToMemoryRecord(), result.Item2);
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeUtils.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeUtils.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
@@ -71,7 +72,7 @@ public static class PineconeUtils
     public static async IAsyncEnumerable<PineconeDocument> EnsureValidMetadataAsync(
         IAsyncEnumerable<PineconeDocument> documents)
     {
-        await foreach (PineconeDocument document in documents)
+        await foreach (PineconeDocument document in documents.ConfigureAwait(false))
         {
             if (document.Metadata == null || GetMetadataSize(document.Metadata) <= MaxMetadataSize)
             {
@@ -138,7 +139,7 @@ public static class PineconeUtils
         List<PineconeDocument> currentBatch = new(batchSize);
         int batchCounter = 0;
 
-        await foreach (PineconeDocument record in data)
+        await foreach (PineconeDocument record in data.ConfigureAwait(false))
         {
             currentBatch.Add(record);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -226,7 +226,7 @@ public class QdrantMemoryStore : IMemoryStore
         var vectorDataList = this._qdrantClient
             .GetVectorsByIdAsync(collectionName, pointIds, withEmbeddings, cancellationToken);
 
-        await foreach (var vectorData in vectorDataList)
+        await foreach (var vectorData in vectorDataList.ConfigureAwait(false))
         {
             yield return MemoryRecord.FromJsonMetadata(
                 json: vectorData.GetSerializedPayload(),

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
@@ -52,7 +52,7 @@ public class SqliteMemoryStore : IMemoryStore, IDisposable
     /// <inheritdoc/>
     public async IAsyncEnumerable<string> GetCollectionsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await foreach (var collection in this._dbConnector.GetCollectionsAsync(this._dbConnection, cancellationToken))
+        await foreach (var collection in this._dbConnector.GetCollectionsAsync(this._dbConnection, cancellationToken).ConfigureAwait(false))
         {
             yield return collection;
         }
@@ -133,7 +133,7 @@ public class SqliteMemoryStore : IMemoryStore, IDisposable
         var collectionMemories = new List<MemoryRecord>();
         List<(MemoryRecord Record, double Score)> embeddings = new();
 
-        await foreach (var record in this.GetAllAsync(collectionName, cancellationToken))
+        await foreach (var record in this.GetAllAsync(collectionName, cancellationToken).ConfigureAwait(false))
         {
             if (record != null)
             {
@@ -232,7 +232,7 @@ public class SqliteMemoryStore : IMemoryStore, IDisposable
         // delete empty entry in the database if it exists (see CreateCollection)
         await this._dbConnector.DeleteEmptyAsync(this._dbConnection, collectionName, cancellationToken).ConfigureAwait(false);
 
-        await foreach (DatabaseEntry dbEntry in this._dbConnector.ReadAllAsync(this._dbConnection, collectionName, cancellationToken))
+        await foreach (DatabaseEntry dbEntry in this._dbConnector.ReadAllAsync(this._dbConnection, collectionName, cancellationToken).ConfigureAwait(false))
         {
             ReadOnlyMemory<float> vector = JsonSerializer.Deserialize<ReadOnlyMemory<float>>(dbEntry.EmbeddingString, JsonOptionsCache.Default);
 

--- a/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
@@ -7,7 +7,7 @@
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);SKEXP0001;SKEXP0070;CS1591;IDE1006;RCS1261;CA1031;CA1308;CA1849;CA1861;CA2007;CA2234;VSTHRD111</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001;SKEXP0070;CS1591;IDE1006;RCS1261;CA1031;CA1308;CA1861;CA2007;CA2234;VSTHRD111</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
@@ -3,20 +3,12 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.Onnx.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.Onnx.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>12</LangVersion>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SKEXP0001;SKEXP0070;CS1591;IDE1006;RCS1261;CA1031;CA1308;CA1849;CA1861;CA2007;CA2234;VSTHRD111</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to permit LangVersion 12. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/dotnet/src/Connectors/Connectors.Onnx/BertOnnxTextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx/BertOnnxTextEmbeddingGenerationService.cs
@@ -16,7 +16,6 @@ using Microsoft.SemanticKernel.Embeddings;
 
 namespace Microsoft.SemanticKernel.Connectors.Onnx;
 
-#pragma warning disable CA1849, VSTHRD103 // Call async methods when in an async method
 #pragma warning disable CA2000 // Dispose objects before losing scope
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -157,7 +157,7 @@ internal abstract class ClientCore
 
         StreamingResponse<Completions>? response = await RunRequestAsync(() => this.Client.GetCompletionsStreamingAsync(options, cancellationToken)).ConfigureAwait(false);
 
-        await foreach (Completions completions in response)
+        await foreach (Completions completions in response.ConfigureAwait(false))
         {
             foreach (Choice choice in completions.Choices)
             {
@@ -725,7 +725,7 @@ internal abstract class ClientCore
         OpenAIPromptExecutionSettings chatSettings = OpenAIPromptExecutionSettings.FromExecutionSettings(executionSettings);
         ChatHistory chat = CreateNewChat(prompt, chatSettings);
 
-        await foreach (var chatUpdate in this.GetStreamingChatMessageContentsAsync(chat, executionSettings, kernel, cancellationToken))
+        await foreach (var chatUpdate in this.GetStreamingChatMessageContentsAsync(chat, executionSettings, kernel, cancellationToken).ConfigureAwait(false))
         {
             yield return new StreamingTextContent(chatUpdate.Content, chatUpdate.ChoiceIndex, chatUpdate.ModelId, chatUpdate, Encoding.UTF8, chatUpdate.Metadata);
         }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
@@ -3,21 +3,13 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>12</LangVersion>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,CA1806,CA1869,CA1861,IDE0300,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to permit LangVersion 12. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset"/>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>

--- a/dotnet/src/Experimental/Agents.UnitTests/Experimental.Agents.UnitTests.csproj
+++ b/dotnet/src/Experimental/Agents.UnitTests/Experimental.Agents.UnitTests.csproj
@@ -1,9 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Experimental.Agents.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Experimental.Agents.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Experimental/Agents/Experimental.Agents.csproj
+++ b/dotnet/src/Experimental/Agents/Experimental.Agents.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>Microsoft.SemanticKernel.Experimental.Agents</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
     <VersionSuffix>alpha</VersionSuffix>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />

--- a/dotnet/src/Experimental/Agents/IAgentExtensions.cs
+++ b/dotnet/src/Experimental/Agents/IAgentExtensions.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Experimental.Agents;
 
@@ -30,7 +31,7 @@ public static class IAgentExtensions
         IAgentThread thread = await agent.NewThreadAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await foreach (var message in thread.InvokeAsync(agent, input, arguments, fileIds, cancellationToken))
+            await foreach (var message in thread.InvokeAsync(agent, input, arguments, fileIds, cancellationToken).ConfigureAwait(false))
             {
                 yield return message;
             }

--- a/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/Experimental.Orchestration.Flow.IntegrationTests.csproj
+++ b/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/Experimental.Orchestration.Flow.IntegrationTests.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Experimental.Orchestration.Flow.IntegrationTests</AssemblyName>
     <RootNamespace>SemanticKernel.Experimental.Orchestration.Flow.IntegrationTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,VSTHRD111,SKEXP0101,SKEXP0050</NoWarn>

--- a/dotnet/src/Experimental/Orchestration.Flow.UnitTests/Experimental.Orchestration.Flow.UnitTests.csproj
+++ b/dotnet/src/Experimental/Orchestration.Flow.UnitTests/Experimental.Orchestration.Flow.UnitTests.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Experimental.Orchestration.Flow.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Experimental.Orchestration.Flow.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Experimental/Orchestration.Flow/Experimental.Orchestration.Flow.csproj
+++ b/dotnet/src/Experimental/Orchestration.Flow/Experimental.Orchestration.Flow.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>Microsoft.SemanticKernel.Experimental.Orchestration</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
     <VersionSuffix>alpha</VersionSuffix>
-    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />

--- a/dotnet/src/Extensions/Extensions.UnitTests/Extensions.UnitTests.csproj
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Extensions.UnitTests.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Extensions.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Extensions.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Functions.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Functions.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <AssemblyName>IntegrationTests</AssemblyName>
     <RootNamespace>SemanticKernel.IntegrationTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <NoWarn>CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0040,SKEXP0050,SKEXP0060,SKEXP0070</NoWarn>
@@ -65,12 +64,6 @@
     <ProjectReference Include="..\Functions\Functions.OpenApi\Functions.OpenApi.csproj" />
     <ProjectReference Include="..\Plugins\Plugins.Web\Plugins.Web.csproj" />
     <ProjectReference Include="..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to handle newer source-generating libraries used in the examples. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
   </ItemGroup>
   
   <ItemGroup>

--- a/dotnet/src/InternalUtilities/planning/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
+++ b/dotnet/src/InternalUtilities/planning/Extensions/ReadOnlyFunctionCollectionPlannerExtensions.cs
@@ -169,7 +169,7 @@ internal static class ReadOnlyPluginCollectionPlannerExtensions
         CancellationToken cancellationToken = default)
     {
         var relevantFunctions = new List<KernelFunctionMetadata>();
-        await foreach (var memoryEntry in memories.WithCancellation(cancellationToken))
+        await foreach (var memoryEntry in memories.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             var function = availableFunctions.FirstOrDefault(x => x.ToFullyQualifiedName() == memoryEntry.Metadata.Id);
             if (function != null)

--- a/dotnet/src/Planners/Planners.Core.UnitTests/Planners.Core.UnitTests.csproj
+++ b/dotnet/src/Planners/Planners.Core.UnitTests/Planners.Core.UnitTests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.SemanticKernel.Planners.Core.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Planners.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/dotnet/src/Planners/Planners.Handlebars.UnitTests/Planners.Handlebars.UnitTests.csproj
+++ b/dotnet/src/Planners/Planners.Handlebars.UnitTests/Planners.Handlebars.UnitTests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.SemanticKernel.Planners.Handlebars.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Planners.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Plugins.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Plugins.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextGeneration/TextGenerationExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextGeneration/TextGenerationExtensions.cs
@@ -84,7 +84,7 @@ public static class TextGenerationExtensions
         if (textGenerationService is IChatCompletionService chatCompletion
             && ChatPromptParser.TryParse(prompt, out var chatHistory))
         {
-            await foreach (var chatMessage in chatCompletion.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken))
+            await foreach (var chatMessage in chatCompletion.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel, cancellationToken).ConfigureAwait(false))
             {
                 yield return new StreamingTextContent(chatMessage.Content, chatMessage.ChoiceIndex, chatMessage.ModelId, chatMessage, chatMessage.Encoding, chatMessage.Metadata);
             }
@@ -93,7 +93,7 @@ public static class TextGenerationExtensions
         }
 
         // When using against text generations, the prompt will be used as is.
-        await foreach (var textChunk in textGenerationService.GetStreamingTextContentsAsync(prompt, executionSettings, kernel, cancellationToken))
+        await foreach (var textChunk in textGenerationService.GetStreamingTextContentsAsync(prompt, executionSettings, kernel, cancellationToken).ConfigureAwait(false))
         {
             yield return textChunk;
         }

--- a/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel.Core/Memory/SemanticTextMemory.cs
@@ -124,7 +124,7 @@ public sealed class SemanticTextMemory : ISemanticTextMemory
             withEmbeddings: withEmbeddings,
             cancellationToken: cancellationToken);
 
-        await foreach ((MemoryRecord, double) result in results.WithCancellation(cancellationToken))
+        await foreach ((MemoryRecord, double) result in results.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             yield return MemoryQueryResult.FromMemoryRecord(result.Item1, result.Item2);
         }

--- a/dotnet/src/SemanticKernel.UnitTests/.editorconfig
+++ b/dotnet/src/SemanticKernel.UnitTests/.editorconfig
@@ -1,6 +1,6 @@
 # Suppressing errors for Test projects under dotnet folder
 [*.cs]
 dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
-dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
 dotnet_diagnostic.IDE1006.severity = warning # Naming rule violations
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelPluginCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelPluginCollectionTests.cs
@@ -151,7 +151,7 @@ public class KernelPluginCollectionTests
             })
         };
 
-        IList<KernelFunctionMetadata> metadata = c.GetFunctionsMetadata().OrderBy(f => f.Name).ToList();
+        List<KernelFunctionMetadata> metadata = c.GetFunctionsMetadata().OrderBy(f => f.Name).ToList();
 
         Assert.Equal("plugin1", metadata[0].PluginName);
         Assert.Equal("Function1", metadata[0].Name);

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -3,20 +3,11 @@
   <PropertyGroup>
     <RootNamespace>SemanticKernel.UnitTests</RootNamespace>
     <AssemblyName>SemanticKernel.UnitTests</AssemblyName>
-    <TargetFrameworks>net6.0</TargetFrameworks>    <!-- ;net48 -->
-    <RollForward>LatestMajor</RollForward>
+    <TargetFrameworks>net8.0</TargetFrameworks>    <!-- ;net48 -->
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <LangVersion>12</LangVersion>
     <NoWarn>CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0050</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Use newest available compiler to handle newer source-generating libraries used in the examples. -->
-    <!-- This can be removed once we no longer target the .NET 6 SDK in CI. -->
-    <PackageReference Include="Microsoft.ML.Tokenizers" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -31,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.ML.Tokenizers" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />


### PR DESCRIPTION
- Test projects targeting net6.0 are updated to net8.0
- LangVersion is consolidated to be 12 and set only in the top-level Directory.Build.props
- RollForward was used to enable test projects targeting net6.0 to execute in CI when there was only a net8.0 runtime present. These can all be deleted.
- Microsoft.Net.Compilers.Toolset was used in a bunch of places to allow for LangVersion 12 when on older toolsets. Now that the .NET 8 SDK is used, this can all be deleted.
- Microsoft.CodeAnalysis.NetAnalyzers was pinned to the 8.0 version. That can now be deleted.
- Allowing the analyzers to use a newer build by default flagged a bunch of CA2007 violations to be addressed. These have all been fixed.