### PR TITLE
Python: Allow args to pass to func calling stepwise planner

### DIFF
--- a/python/samples/kernel-syntax-examples/openai_function_calling_stepwise_planner.py
+++ b/python/samples/kernel-syntax-examples/openai_function_calling_stepwise_planner.py
@@ -4,9 +4,8 @@ import asyncio
 import os
 
 import semantic_kernel as sk
-from semantic_kernel.connectors.ai.open_ai import (
-    OpenAIChatCompletion,
-)
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.core_plugins.math_plugin import MathPlugin
 from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.planners.function_calling_stepwise_planner.function_calling_stepwise_planner import (
@@ -15,6 +14,58 @@ from semantic_kernel.planners.function_calling_stepwise_planner.function_calling
 from semantic_kernel.planners.function_calling_stepwise_planner.function_calling_stepwise_planner_options import (
     FunctionCallingStepwisePlannerOptions,
 )
+
+
+def get_initial_plan() -> str:
+    return """
+template_format: semantic-kernel
+template: |
+    <message role="system">
+    You are an expert at generating plans from a given GOAL. Think step by step and determine a plan to satisfy the specified GOAL using only the FUNCTIONS provided to you. You can also make use of your own knowledge while forming an answer but you must not use functions that are not provided. Once you have come to a final answer, use the UserInteraction{{$name_delimiter}}SendFinalAnswer function to communicate this back to the user.
+
+    [FUNCTIONS]
+
+    {{$available_functions}}
+
+    [END FUNCTIONS]
+
+    To create the plan, follow these steps:
+    0. Each step should be something that is capable of being done by the list of available functions.
+    1. Steps can use output from one or more previous steps as input, if appropriate.
+    2. The plan should be as short as possible.
+    3. Make use of other asks from the user.
+    </message>
+    <message role="user">{{$goal}}</message>
+    {{$chat_history}}
+description: Generate a step-by-step plan to satisfy a given goal
+name: GeneratePlan
+input_variables:
+  - name: available_functions
+    description: A list of functions that can be used to generate the plan
+  - name: goal
+    description: The goal to satisfy
+execution_settings:
+  default:
+    temperature: 0.0
+    top_p: 0.0
+    presence_penalty: 0.0
+    frequency_penalty: 0.0
+    max_tokens: 256
+    stop_sequences: []
+""".strip()  # noqa: E501
+
+
+def get_step_prompt() -> str:
+    return """
+{{$chat_history}}
+
+Original request: {{$goal}}
+
+You are in the process of helping the user fulfill this request using the following plan:
+{{$initial_plan}}
+
+The user will ask you for help with each step.
+""".strip()
 
 
 async def main():
@@ -45,12 +96,17 @@ async def main():
     options = FunctionCallingStepwisePlannerOptions(
         max_iterations=10,
         max_tokens=4000,
+        get_initial_plan=get_initial_plan,
+        get_step_prompt=get_step_prompt,
     )
+
+    chat_history = ChatHistory()
+    chat_history.add_user_message("You must respond to every ask like a parrot.")
 
     planner = FunctionCallingStepwisePlanner(service_id=service_id, options=options)
 
     for question in questions:
-        result = await planner.invoke(kernel, question)
+        result = await planner.invoke(kernel, question, chat_history=chat_history)
         print(f"Q: {question}\nA: {result.final_answer}\n")
 
         # Uncomment the following line to view the planner's process for completing the request

--- a/python/samples/kernel-syntax-examples/openai_function_calling_stepwise_planner.py
+++ b/python/samples/kernel-syntax-examples/openai_function_calling_stepwise_planner.py
@@ -5,7 +5,6 @@ import os
 
 import semantic_kernel as sk
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
-from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.core_plugins.math_plugin import MathPlugin
 from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.planners.function_calling_stepwise_planner.function_calling_stepwise_planner import (
@@ -14,58 +13,6 @@ from semantic_kernel.planners.function_calling_stepwise_planner.function_calling
 from semantic_kernel.planners.function_calling_stepwise_planner.function_calling_stepwise_planner_options import (
     FunctionCallingStepwisePlannerOptions,
 )
-
-
-def get_initial_plan() -> str:
-    return """
-template_format: semantic-kernel
-template: |
-    <message role="system">
-    You are an expert at generating plans from a given GOAL. Think step by step and determine a plan to satisfy the specified GOAL using only the FUNCTIONS provided to you. You can also make use of your own knowledge while forming an answer but you must not use functions that are not provided. Once you have come to a final answer, use the UserInteraction{{$name_delimiter}}SendFinalAnswer function to communicate this back to the user.
-
-    [FUNCTIONS]
-
-    {{$available_functions}}
-
-    [END FUNCTIONS]
-
-    To create the plan, follow these steps:
-    0. Each step should be something that is capable of being done by the list of available functions.
-    1. Steps can use output from one or more previous steps as input, if appropriate.
-    2. The plan should be as short as possible.
-    3. Make use of other asks from the user.
-    </message>
-    <message role="user">{{$goal}}</message>
-    {{$chat_history}}
-description: Generate a step-by-step plan to satisfy a given goal
-name: GeneratePlan
-input_variables:
-  - name: available_functions
-    description: A list of functions that can be used to generate the plan
-  - name: goal
-    description: The goal to satisfy
-execution_settings:
-  default:
-    temperature: 0.0
-    top_p: 0.0
-    presence_penalty: 0.0
-    frequency_penalty: 0.0
-    max_tokens: 256
-    stop_sequences: []
-""".strip()  # noqa: E501
-
-
-def get_step_prompt() -> str:
-    return """
-{{$chat_history}}
-
-Original request: {{$goal}}
-
-You are in the process of helping the user fulfill this request using the following plan:
-{{$initial_plan}}
-
-The user will ask you for help with each step.
-""".strip()
 
 
 async def main():
@@ -96,17 +43,12 @@ async def main():
     options = FunctionCallingStepwisePlannerOptions(
         max_iterations=10,
         max_tokens=4000,
-        get_initial_plan=get_initial_plan,
-        get_step_prompt=get_step_prompt,
     )
-
-    chat_history = ChatHistory()
-    chat_history.add_user_message("You must respond to every ask like a parrot.")
 
     planner = FunctionCallingStepwisePlanner(service_id=service_id, options=options)
 
     for question in questions:
-        result = await planner.invoke(kernel, question, chat_history=chat_history)
+        result = await planner.invoke(kernel, question)
         print(f"Q: {question}\nA: {result.final_answer}\n")
 
         # Uncomment the following line to view the planner's process for completing the request


### PR DESCRIPTION
### Motivation and Context

A recent feature was added to dotnet to allow for a chat_history object to be passed into invoke. This only allows the user to affect the `chatHistoryForSteps`, but doesn't account for generating a plan with provided context (via the chat history). 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR allows the user to pass in optional kernel arguments or kwargs (that get turned into kernel arguments). If the user then overrides the prompt template/step prompt.txt, they can utilize any new arguments that are supplied. 
- Closes #5824 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
