### PR TITLE
.Net - Agents IReadonlyList instead of IEnumerable (Step #ANY)

### DIFF
--- a/dotnet/src/Agents/Abstractions/AgentChannel.cs
+++ b/dotnet/src/Agents/Abstractions/AgentChannel.cs
@@ -16,7 +16,7 @@ public abstract class AgentChannel
     /// </summary>
     /// <param name="history">The chat history at the point the channel is created.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    protected internal abstract Task ReceiveAsync(IEnumerable<ChatMessageContent> history, CancellationToken cancellationToken = default);
+    protected internal abstract Task ReceiveAsync(IReadOnlyList<ChatMessageContent> history, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Perform a discrete incremental interaction between a single <see cref="Agent"/> and <see cref="AgentChat"/>.

--- a/dotnet/src/Agents/Abstractions/ChatHistoryChannel.cs
+++ b/dotnet/src/Agents/Abstractions/ChatHistoryChannel.cs
@@ -34,7 +34,7 @@ public class ChatHistoryChannel : AgentChannel
     }
 
     /// <inheritdoc/>
-    protected internal sealed override Task ReceiveAsync(IEnumerable<ChatMessageContent> history, CancellationToken cancellationToken)
+    protected internal sealed override Task ReceiveAsync(IReadOnlyList<ChatMessageContent> history, CancellationToken cancellationToken)
     {
         this._history.AddRange(history);
 

--- a/dotnet/src/Agents/Abstractions/Internal/BroadcastQueue.cs
+++ b/dotnet/src/Agents/Abstractions/Internal/BroadcastQueue.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Agents.Internal;
 /// <summary>
 /// Utility class used by <see cref="AgentChat"/> to manage the broadcast of
 /// conversation messages via the <see cref="AgentChannel"/>.
-/// (<see cref="AgentChannel.ReceiveAsync(IEnumerable{ChatMessageContent}, System.Threading.CancellationToken)"/>.)
+/// (<see cref="AgentChannel.ReceiveAsync"/>.)
 /// </summary>
 /// <remarks>
 /// Maintains a set of channel specific queues, each with individual locks, in addition to a global state lock.

--- a/dotnet/src/Agents/UnitTests/AgentChannelTests.cs
+++ b/dotnet/src/Agents/UnitTests/AgentChannelTests.cs
@@ -57,7 +57,7 @@ public class AgentChannelTests
             throw new NotImplementedException();
         }
 
-        protected internal override Task ReceiveAsync(IEnumerable<ChatMessageContent> history, CancellationToken cancellationToken = default)
+        protected internal override Task ReceiveAsync(IReadOnlyList<ChatMessageContent> history, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/src/Agents/UnitTests/Internal/BroadcastQueueTests.cs
+++ b/dotnet/src/Agents/UnitTests/Internal/BroadcastQueueTests.cs
@@ -141,7 +141,7 @@ public class BroadcastQueueTests
             throw new NotImplementedException();
         }
 
-        protected internal override async Task ReceiveAsync(IEnumerable<ChatMessageContent> history, CancellationToken cancellationToken = default)
+        protected internal override async Task ReceiveAsync(IReadOnlyList<ChatMessageContent> history, CancellationToken cancellationToken = default)
         {
             this.ReceivedMessages.AddRange(history);
             this.ReceiveCount += 1;
@@ -164,7 +164,7 @@ public class BroadcastQueueTests
             throw new NotImplementedException();
         }
 
-        protected internal override async Task ReceiveAsync(IEnumerable<ChatMessageContent> history, CancellationToken cancellationToken = default)
+        protected internal override async Task ReceiveAsync(IReadOnlyList<ChatMessageContent> history, CancellationToken cancellationToken = default)
         {
             await Task.Delay(this.ReceiveDuration, cancellationToken);
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

`IEnumerable` can be cumbersome if not required.  Identified a usage that is improved by `IReadOnlyList` (as the usage of `IEnumerable` was extraneous.)

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Been on the look-out for tuning these signatures...this one slipped through.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
