### PR TITLE
.Net: Utbose/open api/fix/default value for params

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
@@ -172,7 +172,7 @@ public sealed class RestApiOperation
                     throw new KernelException($"No argument or value is provided for the '{parameter.Name}' required parameter of the operation - '{this.Id}'.");
                 }
 
-                // Skipping not required parameter if no argument provided for it.
+                // Skipping not required parameter if no argument provided for it unless it has a default value.
                 continue;
             }
 

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
@@ -164,7 +164,7 @@ public sealed class RestApiOperation
 
         foreach (var parameter in parameters)
         {
-            if (!arguments.TryGetValue(parameter.Name, out object? argument) || argument is null)
+            if (!arguments.TryGetValue(parameter.Name, out object? argument) && parameter.DefaultValue == null)
             {
                 // Throw an exception if the parameter is a required one but no value is provided.
                 if (parameter.IsRequired)
@@ -174,6 +174,11 @@ public sealed class RestApiOperation
 
                 // Skipping not required parameter if no argument provided for it unless it has a default value.
                 continue;
+            }
+
+            if (argument == null)
+            {
+                argument = parameter.DefaultValue;
             }
 
             var parameterStyle = parameter.Style ?? RestApiOperationParameterStyle.Form;

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationTests.cs
@@ -552,4 +552,128 @@ public class RestApiOperationTests
         Assert.NotNull(provider.GetService<KernelPluginCollection>());
         Assert.NotNull(provider.GetService<Kernel>());
     }
+
+    [Fact]
+    public void ItShouldBuildQueryStringFromArguments()
+    {
+        // Arrange
+        var parameters = new List<RestApiOperationParameter> {
+            new(
+                name: "param1",
+                type: "string",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.Form,
+                defaultValue: "dv1"),
+            new(
+                name: "param2",
+                type: "string",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.Form,
+                defaultValue: "dv2")
+        };
+
+        var sut = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "{fake-path}/", HttpMethod.Get, "fake_description", parameters);
+        var arguments = new Dictionary<string, object?> { { "param1", "p1" }, { "param2", "p2" } };
+
+        // Act
+        var queryString = sut.BuildQueryString(arguments);
+
+        // Assert
+        Assert.Equal("param1=p1&param2=p2", queryString);
+    }
+
+    [Fact]
+    public void ItShouldBuildQueryStringFromArgumentsAndDefaultValue()
+    {
+        // Arrange
+        var parameters = new List<RestApiOperationParameter> {
+        new(
+            name: "param1",
+            type: "string",
+            isRequired: false,
+            expand: false,
+            location: RestApiOperationParameterLocation.Query,
+            style: RestApiOperationParameterStyle.Form,
+            defaultValue: "dv1"),
+        new(
+            name: "param2",
+            type: "string",
+            isRequired: false,
+            expand: false,
+            location: RestApiOperationParameterLocation.Query,
+            style: RestApiOperationParameterStyle.Form,
+            defaultValue: "dv2")
+        };
+
+        var sut = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "{fake-path}/", HttpMethod.Get, "fake_description", parameters);
+        var arguments = new Dictionary<string, object?> { { "param1", "p1" } };
+
+        // Act
+        var queryString = sut.BuildQueryString(arguments);
+
+        // Assert
+        Assert.Equal("param1=p1&param2=dv2", queryString);
+    }
+
+    [Fact]
+    public void ItShouldBuildQueryStringFromDefaultValueWhenArgumentsAreAbsent()
+    {
+        // Arrange
+        var parameters = new List<RestApiOperationParameter> {
+            new(
+                name: "param1",
+                type: "string",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.Form,
+                defaultValue: "dv1"),
+            new(
+                name: "param2",
+                type: "string",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.Form,
+                defaultValue: "dv2")
+        };
+
+        var sut = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "{fake-path}/", HttpMethod.Get, "fake_description", parameters);
+        var arguments = new Dictionary<string, object?> { };
+
+        // Act
+        var queryString = sut.BuildQueryString(arguments);
+
+        // Assert
+        Assert.Equal("param1=dv1&param2=dv2", queryString);
+    }
+
+    [Fact]
+    public void ItShouldBuildQueryStringFromDefaultValueWhenArgumentsHaveNullEntry()
+    {
+        // Arrange
+        var parameters = new List<RestApiOperationParameter> {
+            new(
+                name: "param1",
+                type: "string",
+                isRequired: false,
+                expand: false,
+                location: RestApiOperationParameterLocation.Query,
+                style: RestApiOperationParameterStyle.Form,
+                defaultValue: "p0")
+        };
+
+        var sut = new RestApiOperation("fake_id", new Uri("https://fake-random-test-host"), "{fake-path}/", HttpMethod.Get, "fake_description", parameters);
+        var arguments = new Dictionary<string, object?> { { "param1", null } };
+
+        // Act
+        var queryString = sut.BuildQueryString(arguments);
+
+        // Assert
+        Assert.Equal("param1=p0", queryString);
+    }
 }


### PR DESCRIPTION
### Motivation and Context

  1. Why is this change required?
  This change will help assign default values that is specified in openAPI schema to parameter objects if no arguments are provided from the caller. Without this change we wont be able to support urls which has default query parameters.
  2. What problem does it solve?
Currently if the caller does not set any arguments for the query parameters, the RestApiOperation.BuildQueryString() does not assign any value to the query parameter objects even though they have default value specified in the openAPI spec.
  4. What scenario does it contribute to?
  Executing REST API using openAPI spec.
  5. If it fixes an open issue, please link to the issue here.

### Description

Making changes in code to ensure if the query parameters cannot be populated from the caller provided arguments, then just use default values (if specified in openAPI spec) to populate them instead of dropping of the query parameter all together.

Created a new issue: https://github.com/microsoft/semantic-kernel/issues/5864

### Contribution Checklist

- [*] The code builds clean without any errors or warnings
- [*] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [*] All unit tests pass, and I have added new tests where possible
- [*] I didn't break anyone :smile:
