### PR TITLE
Python: added kwargs to embedding and text memory

### DIFF
--- a/python/semantic_kernel/connectors/ai/embeddings/embedding_generator_base.py
+++ b/python/semantic_kernel/connectors/ai/embeddings/embedding_generator_base.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
 from semantic_kernel.services.ai_service_client_base import AIServiceClientBase
 
@@ -11,5 +11,5 @@ if TYPE_CHECKING:
 
 class EmbeddingGeneratorBase(AIServiceClientBase, ABC):
     @abstractmethod
-    async def generate_embeddings(self, texts: List[str], **kwargs) -> "ndarray":
+    async def generate_embeddings(self, texts: List[str], **kwargs: Any) -> "ndarray":
         pass

--- a/python/semantic_kernel/connectors/ai/embeddings/embedding_generator_base.py
+++ b/python/semantic_kernel/connectors/ai/embeddings/embedding_generator_base.py
@@ -11,5 +11,5 @@ if TYPE_CHECKING:
 
 class EmbeddingGeneratorBase(AIServiceClientBase, ABC):
     @abstractmethod
-    async def generate_embeddings(self, texts: List[str]) -> "ndarray":
+    async def generate_embeddings(self, texts: List[str], **kwargs) -> "ndarray":
         pass

--- a/python/semantic_kernel/connectors/ai/google_palm/services/gp_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/google_palm/services/gp_text_embedding.py
@@ -2,7 +2,7 @@
 
 
 import sys
-from typing import List
+from typing import Any, List
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -13,9 +13,7 @@ import google.generativeai as palm
 from numpy import array, ndarray
 from pydantic import StringConstraints
 
-from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import (
-    EmbeddingGeneratorBase,
-)
+from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import EmbeddingGeneratorBase
 from semantic_kernel.exceptions import ServiceInvalidAuthError, ServiceResponseException
 
 
@@ -34,7 +32,7 @@ class GooglePalmTextEmbedding(EmbeddingGeneratorBase):
         """
         super().__init__(ai_model_id=ai_model_id, api_key=api_key)
 
-    async def generate_embeddings(self, texts: List[str]) -> ndarray:
+    async def generate_embeddings(self, texts: List[str], **kwargs: Any) -> ndarray:
         """
         Generates embeddings for a list of texts.
 
@@ -54,10 +52,7 @@ class GooglePalmTextEmbedding(EmbeddingGeneratorBase):
         embeddings = []
         for text in texts:
             try:
-                response = palm.generate_embeddings(
-                    model=self.ai_model_id,
-                    text=text,
-                )
+                response = palm.generate_embeddings(model=self.ai_model_id, text=text, **kwargs)
                 embeddings.append(array(response["embedding"]))
             except Exception as ex:
                 raise ServiceResponseException(

--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_embedding.py
@@ -42,7 +42,7 @@ class HuggingFaceTextEmbedding(EmbeddingGeneratorBase):
             generator=sentence_transformers.SentenceTransformer(model_name_or_path=ai_model_id, device=resolved_device),
         )
 
-    async def generate_embeddings(self, texts: List[str]) -> ndarray:
+    async def generate_embeddings(self, texts: List[str], **kwargs: Any) -> ndarray:
         """
         Generates embeddings for a list of texts.
 
@@ -54,7 +54,7 @@ class HuggingFaceTextEmbedding(EmbeddingGeneratorBase):
         """
         try:
             logger.info(f"Generating embeddings for {len(texts)} texts")
-            embeddings = self.generator.encode(texts)
+            embeddings = self.generator.encode(texts, **kwargs)
             return array(embeddings)
         except Exception as e:
             raise ServiceResponseException("Hugging Face embeddings failed", e) from e

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_embedding.py
@@ -1,15 +1,13 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import aiohttp
 from numpy import array, ndarray
 from pydantic import HttpUrl
 
-from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import (
-    EmbeddingGeneratorBase,
-)
+from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import EmbeddingGeneratorBase
 from semantic_kernel.connectors.ai.ollama.utils import AsyncSession
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -29,7 +27,7 @@ class OllamaTextEmbedding(EmbeddingGeneratorBase):
     url: HttpUrl = "http://localhost:11434/api/embeddings"
     session: Optional[aiohttp.ClientSession] = None
 
-    async def generate_embeddings(self, texts: List[str], **kwargs) -> ndarray:
+    async def generate_embeddings(self, texts: List[str], **kwargs: Any) -> ndarray:
         """
         Generates embeddings for a list of texts.
 

--- a/python/semantic_kernel/core_plugins/text_memory_plugin.py
+++ b/python/semantic_kernel/core_plugins/text_memory_plugin.py
@@ -2,7 +2,9 @@
 import json
 import logging
 import sys
-from typing import Any, Dict, Final, Optional
+from typing import Any, Dict, Final
+
+from pydantic import Field
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -24,9 +26,9 @@ DEFAULT_LIMIT: Final[int] = 1
 
 class TextMemoryPlugin(KernelBaseModel):
     memory: SemanticTextMemoryBase
-    embeddings_kwargs: Optional[Dict[str, Any]] = None
+    embeddings_kwargs: Dict[str, Any] = Field(default_factory=dict)
 
-    def __init__(self, memory: SemanticTextMemoryBase, embeddings_kwargs: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, memory: SemanticTextMemoryBase, embeddings_kwargs: Dict[str, Any] = {}) -> None:
         """
         Initialize a new instance of the TextMemoryPlugin
 

--- a/python/semantic_kernel/core_plugins/text_memory_plugin.py
+++ b/python/semantic_kernel/core_plugins/text_memory_plugin.py
@@ -2,36 +2,39 @@
 import json
 import logging
 import sys
-from typing import ClassVar, Optional
+from typing import Any, Dict, Final, Optional
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
     from typing_extensions import Annotated
+
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 from semantic_kernel.memory.semantic_text_memory_base import SemanticTextMemoryBase
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+DEFAULT_COLLECTION: Final[str] = "generic"
+COLLECTION_PARAM: Final[str] = "collection"
+DEFAULT_RELEVANCE: Final[float] = 0.75
+RELEVANCE_PARAM: Final[str] = "relevance"
+DEFAULT_LIMIT: Final[int] = 1
+
 
 class TextMemoryPlugin(KernelBaseModel):
-    DEFAULT_COLLECTION: ClassVar[str] = "generic"
-    COLLECTION_PARAM: ClassVar[str] = "collection"
-    DEFAULT_RELEVANCE: ClassVar[float] = 0.75
-    RELEVANCE_PARAM: ClassVar[str] = "relevance"
-    DEFAULT_LIMIT: ClassVar[int] = 1
-
     memory: SemanticTextMemoryBase
+    embeddings_kwargs: Optional[Dict[str, Any]] = None
 
-    def __init__(self, memory: SemanticTextMemoryBase) -> None:
+    def __init__(self, memory: SemanticTextMemoryBase, embeddings_kwargs: Optional[Dict[str, Any]] = None) -> None:
         """
         Initialize a new instance of the TextMemoryPlugin
 
         Args:
             memory (SemanticTextMemoryBase) - the underlying Semantic Text Memory to use
+            embeddings_kwargs (Optional[Dict[str, Any]]) - the keyword arguments to pass to the embedding generator
         """
-        super().__init__(memory=memory)
+        super().__init__(memory=memory, embeddings_kwargs=embeddings_kwargs)
 
     @kernel_function(
         description="Recall a fact from the long term memory",
@@ -40,11 +43,11 @@ class TextMemoryPlugin(KernelBaseModel):
     async def recall(
         self,
         ask: Annotated[str, "The information to retrieve"],
-        collection: Annotated[Optional[str], "The collection to search for information."] = DEFAULT_COLLECTION,
+        collection: Annotated[str, "The collection to search for information."] = DEFAULT_COLLECTION,
         relevance: Annotated[
-            Optional[float], "The relevance score, from 0.0 to 1.0; 1.0 means perfect match"
+            float, "The relevance score, from 0.0 to 1.0; 1.0 means perfect match"
         ] = DEFAULT_RELEVANCE,
-        limit: Annotated[Optional[int], "The maximum number of relevant memories to recall."] = DEFAULT_LIMIT,
+        limit: Annotated[int, "The maximum number of relevant memories to recall."] = DEFAULT_LIMIT,
     ) -> str:
         """
         Recall a fact from the long term memory.
@@ -81,7 +84,7 @@ class TextMemoryPlugin(KernelBaseModel):
         self,
         text: Annotated[str, "The information to save."],
         key: Annotated[str, "The unique key to associate with the information."],
-        collection: Annotated[Optional[str], "The collection to save the information."] = DEFAULT_COLLECTION,
+        collection: Annotated[str, "The collection to save the information."] = DEFAULT_COLLECTION,
     ) -> None:
         """
         Save a fact to the long term memory.
@@ -94,4 +97,6 @@ class TextMemoryPlugin(KernelBaseModel):
 
         """
 
-        await self.memory.save_information(collection, text=text, id=key)
+        await self.memory.save_information(
+            collection=collection, text=text, id=key, embeddings_kwargs=self.embeddings_kwargs
+        )

--- a/python/semantic_kernel/memory/semantic_text_memory.py
+++ b/python/semantic_kernel/memory/semantic_text_memory.py
@@ -38,7 +38,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         id: str,
         description: Optional[str] = None,
         additional_metadata: Optional[str] = None,
-        embeddings_kwargs: Optional[Dict[str, Any]] = None,
+        embeddings_kwargs: Optional[Dict[str, Any]] = {},
     ) -> None:
         """Save information to the memory (calls the memory store's upsert method).
 
@@ -74,6 +74,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         external_source_name: str,
         description: Optional[str] = None,
         additional_metadata: Optional[str] = None,
+        embeddings_kwargs: Optional[Dict[str, Any]] = {},
     ) -> None:
         """Save a reference to the memory (calls the memory store's upsert method).
 
@@ -91,7 +92,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         if not await self._storage.does_collection_exist(collection_name=collection):
             await self._storage.create_collection(collection_name=collection)
 
-        embedding = (await self._embeddings_generator.generate_embeddings([text]))[0]
+        embedding = (await self._embeddings_generator.generate_embeddings([text], **embeddings_kwargs))[0]
         data = MemoryRecord.reference_record(
             external_id=external_id,
             source_name=external_source_name,
@@ -126,6 +127,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         limit: int = 1,
         min_relevance_score: float = 0.0,
         with_embeddings: bool = False,
+        embeddings_kwargs: Optional[Dict[str, Any]] = {},
     ) -> List[MemoryQueryResult]:
         """Search the memory (calls the memory store's get_nearest_matches method).
 
@@ -139,7 +141,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         Returns:
             List[MemoryQueryResult] -- The list of MemoryQueryResult found.
         """
-        query_embedding = (await self._embeddings_generator.generate_embeddings([query]))[0]
+        query_embedding = (await self._embeddings_generator.generate_embeddings([query], **embeddings_kwargs))[0]
         results = await self._storage.get_nearest_matches(
             collection_name=collection,
             embedding=query_embedding,

--- a/python/semantic_kernel/memory/semantic_text_memory.py
+++ b/python/semantic_kernel/memory/semantic_text_memory.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import PrivateAttr
 
@@ -38,6 +38,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         id: str,
         description: Optional[str] = None,
         additional_metadata: Optional[str] = None,
+        embeddings_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Save information to the memory (calls the memory store's upsert method).
 
@@ -54,7 +55,7 @@ class SemanticTextMemory(SemanticTextMemoryBase):
         if not await self._storage.does_collection_exist(collection_name=collection):
             await self._storage.create_collection(collection_name=collection)
 
-        embedding = (await self._embeddings_generator.generate_embeddings([text]))[0]
+        embedding = (await self._embeddings_generator.generate_embeddings([text], **embeddings_kwargs))[0]
         data = MemoryRecord.local_record(
             id=id,
             text=text,

--- a/python/semantic_kernel/memory/semantic_text_memory_base.py
+++ b/python/semantic_kernel/memory/semantic_text_memory_base.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from abc import abstractmethod
-from typing import List, Optional, TypeVar
+from typing import Any, Dict, List, Optional, TypeVar
 
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 from semantic_kernel.memory.memory_query_result import MemoryQueryResult
@@ -18,6 +18,7 @@ class SemanticTextMemoryBase(KernelBaseModel):
         id: str,
         description: Optional[str] = None,
         additional_metadata: Optional[str] = None,
+        embeddings_kwargs: Optional[Dict[str, Any]] = None,
         # TODO: ctoken?
     ) -> None:
         """Save information to the memory (calls the memory store's upsert method).


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Added kwargs handling throughout embeddings connectors and as a additional field for the TextMemoryPlugin.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
