### PR TITLE
Python: revised to pass kwargs directly as argument to PromptExecutionSettings, not extension_data

### DIFF
--- a/python/semantic_kernel/planners/action_planner/action_planner.py
+++ b/python/semantic_kernel/planners/action_planner/action_planner.py
@@ -72,6 +72,7 @@ class ActionPlanner:
         execute_settings = PromptExecutionSettings(
             service_id=service_id,
             extension_data={"max_tokens": self.config.max_tokens, "stop_sequences": self._stop_sequence},
+            **kwargs
         )
 
         kernel.add_plugin(self, self.RESTRICTED_PLUGIN_NAME)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
