### PR TITLE
Update 04-kernel-arguments-chat.ipynb

### DIFF
--- a/python/notebooks/04-kernel-arguments-chat.ipynb
+++ b/python/notebooks/04-kernel-arguments-chat.ipynb
@@ -140,7 +140,7 @@
                 "    name=\"chat\",\n",
                 "    template_format=\"semantic-kernel\",\n",
                 "    input_variables=[\n",
-                "        InputVariable(name=\"input\", description=\"The user input\", is_required=True),\n",
+                "        InputVariable(name=\"user_input\", description=\"The user input\", is_required=True),\n",
                 "        InputVariable(name=\"history\", description=\"The conversation history\", is_required=True),\n",
                 "    ],\n",
                 "    execution_settings=execution_settings,\n",
@@ -245,7 +245,6 @@
                 "async def chat(input_text: str) -> None:\n",
                 "    # Save new message in the context variables\n",
                 "    print(f\"User: {input_text}\")\n",
-                "    chat_history.add_user_message(input_text)\n",
                 "\n",
                 "    # Process the user message and get an answer\n",
                 "    answer = await kernel.invoke(chat_function, KernelArguments(user_input=input_text, history=chat_history))\n",
@@ -253,6 +252,7 @@
                 "    # Show the response\n",
                 "    print(f\"ChatBot: {answer}\")\n",
                 "\n",
+                "    chat_history.add_user_message(input_text)\n",
                 "    chat_history.add_assistant_message(str(answer))"
             ]
         },


### PR DESCRIPTION
InputVariable name should be changed from "input" to "user_input". But in my test, Both works well.

chat_history.add_user_message(input_text) command should be after kernel.invoke() function. Otherwise chat_history will include the current new input_text in the prompt. It is not  necessary.

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
