### PR TITLE
Python: (Astra DB) Include caller identity as user-agent when issuing HTTP request to Astra DB's Data API

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -41,7 +41,8 @@ AZCOSMOS_API = "" // should be mongo-vcore for now, as CosmosDB only supports ve
 AZCOSMOS_CONNSTR = ""
 AZCOSMOS_DATABASE_NAME = ""
 AZCOSMOS_CONTAINER_NAME = ""
-ASTRADB_APP_TOKEN="" // Starts with AstraCS:
+# Starts with AstraCS:
+ASTRADB_APP_TOKEN=""
 ASTRADB_ID=""
 ASTRADB_REGION=""
 ASTRADB_KEYSPACE=""

--- a/python/semantic_kernel/connectors/memory/astradb/astra_client.py
+++ b/python/semantic_kernel/connectors/memory/astradb/astra_client.py
@@ -1,10 +1,19 @@
 import json
+from importlib.metadata import PackageNotFoundError, version
 from typing import Dict, List, Optional
 
 import aiohttp
 
 from semantic_kernel.connectors.memory.astradb.utils import AsyncSession
 from semantic_kernel.exceptions import ServiceResponseException
+
+SEMANTIC_KERNEL_VERSION: Optional[str]
+try:
+    SEMANTIC_KERNEL_VERSION = version("semantic_kernel")
+    ASTRA_CALLER_IDENTITY = f"semantic_kernel/{SEMANTIC_KERNEL_VERSION}"
+except PackageNotFoundError:
+    SEMANTIC_KERNEL_VERSION = None
+    ASTRA_CALLER_IDENTITY = "semantic_kernel"
 
 
 class AstraClient:
@@ -31,6 +40,7 @@ class AstraClient:
         self.request_header = {
             "x-cassandra-token": self.astra_application_token,
             "Content-Type": "application/json",
+            "User-Agent": ASTRA_CALLER_IDENTITY,
         }
         self._session = session
 

--- a/python/semantic_kernel/connectors/memory/astradb/astra_client.py
+++ b/python/semantic_kernel/connectors/memory/astradb/astra_client.py
@@ -1,18 +1,17 @@
 import json
-from importlib.metadata import PackageNotFoundError, version
 from typing import Dict, List, Optional
 
 import aiohttp
 
 from semantic_kernel.connectors.memory.astradb.utils import AsyncSession
+from semantic_kernel.connectors.telemetry import APP_INFO
 from semantic_kernel.exceptions import ServiceResponseException
 
-SEMANTIC_KERNEL_VERSION: Optional[str]
-try:
-    SEMANTIC_KERNEL_VERSION = version("semantic_kernel")
+ASTRA_CALLER_IDENTITY: str
+SEMANTIC_KERNEL_VERSION = APP_INFO.get("Semantic-Kernel-Version")
+if SEMANTIC_KERNEL_VERSION:
     ASTRA_CALLER_IDENTITY = f"semantic_kernel/{SEMANTIC_KERNEL_VERSION}"
-except PackageNotFoundError:
-    SEMANTIC_KERNEL_VERSION = None
+else:
     ASTRA_CALLER_IDENTITY = "semantic_kernel"
 
 

--- a/python/semantic_kernel/connectors/memory/astradb/astra_client.py
+++ b/python/semantic_kernel/connectors/memory/astradb/astra_client.py
@@ -10,9 +10,9 @@ from semantic_kernel.exceptions import ServiceResponseException
 ASTRA_CALLER_IDENTITY: str
 SEMANTIC_KERNEL_VERSION = APP_INFO.get("Semantic-Kernel-Version")
 if SEMANTIC_KERNEL_VERSION:
-    ASTRA_CALLER_IDENTITY = f"semantic_kernel/{SEMANTIC_KERNEL_VERSION}"
+    ASTRA_CALLER_IDENTITY = f"semantic-kernel/{SEMANTIC_KERNEL_VERSION}"
 else:
-    ASTRA_CALLER_IDENTITY = "semantic_kernel"
+    ASTRA_CALLER_IDENTITY = "semantic-kernel"
 
 
 class AstraClient:

--- a/python/tests/integration/connectors/memory/test_astradb.py
+++ b/python/tests/integration/connectors/memory/test_astradb.py
@@ -5,8 +5,8 @@ import time
 
 import pytest
 
-import semantic_kernel as sk
 from semantic_kernel.connectors.memory.astradb import AstraDBMemoryStore
+from semantic_kernel.utils.settings import astradb_settings_from_dot_env
 
 astradb_installed: bool
 try:
@@ -43,7 +43,7 @@ def get_astradb_config():
         keyspace = os.environ["ASTRADB_KEYSPACE"]
     else:
         # Load credentials from .env file
-        app_token, db_id, region, keyspace = sk.astradb_settings_from_dot_env()
+        app_token, db_id, region, keyspace = astradb_settings_from_dot_env()
 
     return app_token, db_id, region, keyspace
 


### PR DESCRIPTION
### Motivation and Context

This PR enriches the HTTP requests to the Astra DB Data API (occurring in the AstraClient) with a User-Agent header specifying the identity of the caller (specifically, "semantic_kernel"). While not mandatory, this is good practice with Astra DB and helps collecting aggregate usage data on the API side.

### Description

Using the `importlib.metadata` library the package version is extracted (in a fail-safe way) and used, if present, to enrich the caller information (variable `ASTRA_CALLER_IDENTITY`, later set as the user-agent header for all HTTP requests to the Data API).

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
