### PR TITLE
.Net: Moved Onnx tests to integration tests

### DIFF
--- a/dotnet/src/Connectors/Connectors.Onnx.UnitTests/BertOnnxOptionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Onnx.UnitTests/BertOnnxOptionsTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using Xunit;
+
+namespace SemanticKernel.Connectors.Onnx.UnitTests;
+
+public class BertOnnxTextEmbeddingGenerationServiceTests
+{
+    [Fact]
+    public void VerifyOptionsDefaults()
+    {
+        var options = new BertOnnxOptions();
+        Assert.False(options.CaseSensitive);
+        Assert.Equal(512, options.MaximumTokens);
+        Assert.Equal("[CLS]", options.ClsToken);
+        Assert.Equal("[UNK]", options.UnknownToken);
+        Assert.Equal("[SEP]", options.SepToken);
+        Assert.Equal("[PAD]", options.PadToken);
+        Assert.Equal(NormalizationForm.FormD, options.UnicodeNormalization);
+        Assert.Equal(EmbeddingPoolingMode.Mean, options.PoolingMode);
+        Assert.False(options.NormalizeEmbeddings);
+    }
+
+    [Fact]
+    public void RoundtripOptionsProperties()
+    {
+        var options = new BertOnnxOptions()
+        {
+            CaseSensitive = true,
+            MaximumTokens = 128,
+            ClsToken = "<A>",
+            UnknownToken = "<B>",
+            SepToken = "<C>",
+            PadToken = "<D>",
+            UnicodeNormalization = NormalizationForm.FormKC,
+            PoolingMode = EmbeddingPoolingMode.MeanSquareRootTokensLength,
+            NormalizeEmbeddings = true,
+        };
+
+        Assert.True(options.CaseSensitive);
+        Assert.Equal(128, options.MaximumTokens);
+        Assert.Equal("<A>", options.ClsToken);
+        Assert.Equal("<B>", options.UnknownToken);
+        Assert.Equal("<C>", options.SepToken);
+        Assert.Equal("<D>", options.PadToken);
+        Assert.Equal(NormalizationForm.FormKC, options.UnicodeNormalization);
+        Assert.Equal(EmbeddingPoolingMode.MeanSquareRootTokensLength, options.PoolingMode);
+        Assert.True(options.NormalizeEmbeddings);
+    }
+
+    [Fact]
+    public void ValidateInvalidOptionsPropertiesThrow()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BertOnnxOptions() { MaximumTokens = 0 });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BertOnnxOptions() { MaximumTokens = -1 });
+
+        Assert.Throws<ArgumentNullException>(() => new BertOnnxOptions() { ClsToken = null! });
+        Assert.Throws<ArgumentException>(() => new BertOnnxOptions() { ClsToken = "   " });
+
+        Assert.Throws<ArgumentNullException>(() => new BertOnnxOptions() { UnknownToken = null! });
+        Assert.Throws<ArgumentException>(() => new BertOnnxOptions() { UnknownToken = "   " });
+
+        Assert.Throws<ArgumentNullException>(() => new BertOnnxOptions() { SepToken = null! });
+        Assert.Throws<ArgumentException>(() => new BertOnnxOptions() { SepToken = "   " });
+
+        Assert.Throws<ArgumentNullException>(() => new BertOnnxOptions() { PadToken = null! });
+        Assert.Throws<ArgumentException>(() => new BertOnnxOptions() { PadToken = "   " });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BertOnnxOptions() { PoolingMode = (EmbeddingPoolingMode)4 });
+    }
+}

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Connectors\Connectors.Google\Connectors.Google.csproj" />
+    <ProjectReference Include="..\Connectors\Connectors.Onnx\Connectors.Onnx.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.HuggingFace\Connectors.HuggingFace.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Memory.Chroma\Connectors.Memory.Chroma.csproj" />


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

In one of my PRs I received HTTP 503 error during CI run in Onnx unit tests. It appeared that some of the tests perform actual requests to Hugging Face to download model files. It would be better to keep all unit tests isolated and lightweight, while keep the tests that require additional requests to perform as integration tests.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
