### PR TITLE
Java: Ensure xml is unescaped before sending to LLM

### DIFF
--- a/java/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/textcompletion/OpenAITextGenerationService.java
+++ b/java/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/textcompletion/OpenAITextGenerationService.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.commons.text.StringEscapeUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -106,6 +107,8 @@ public class OpenAITextGenerationService extends OpenAiService implements TextGe
     private CompletionsOptions getCompletionsOptions(
         String text,
         @Nullable PromptExecutionSettings requestSettings) {
+        text = StringEscapeUtils.unescapeXml(text);
+
         if (requestSettings == null) {
             return new CompletionsOptions(Collections.singletonList(text))
                 .setMaxTokens(PromptExecutionSettings.DEFAULT_MAX_TOKENS);

--- a/java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/RenderingTest.java
+++ b/java/api-test/integration-tests/src/test/java/com/microsoft/semantickernel/tests/RenderingTest.java
@@ -40,6 +40,28 @@ public class RenderingTest {
     }
 
     @Test
+    public void textSemanticKernelTemplateXml() {
+        buildTextKernel()
+            .invokeAsync(
+                KernelFunction
+                    .createFromPrompt("""
+                        Value: {{$value}}
+                        """)
+                    .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
+                    .build())
+            .withArguments(KernelFunctionArguments
+                .builder()
+                .withVariable("value", "<message role=\"user\">\"hello world\"</message>")
+                .build())
+            .block();
+
+        // The actual body will be escaped as its json
+        Assertions.assertTrue(
+            wm.getAllServeEvents().get(0).getRequest().getBodyAsString()
+                .contains("<message role=\\\"user\\\">\\\"hello world\\\"</message>"));
+    }
+
+    @Test
     public void textSemanticKernelTemplate() {
         buildTextKernel()
             .invokeAsync(
@@ -83,6 +105,28 @@ public class RenderingTest {
             wm.getAllServeEvents().get(0).getRequest().getBodyAsString().contains("dont show"));
         Assertions.assertTrue(
             wm.getAllServeEvents().get(0).getRequest().getBodyAsString().contains("{{ignore}}"));
+    }
+
+    @Test
+    public void chatSemanticKernelTemplateXml() {
+        buildChatKernel()
+            .invokeAsync(
+                KernelFunction
+                    .createFromPrompt("""
+                        Value: {{$value}}
+                        """)
+                    .withTemplateFormat(PromptTemplateConfig.SEMANTIC_KERNEL_TEMPLATE_FORMAT)
+                    .build())
+            .withArguments(KernelFunctionArguments
+                .builder()
+                .withVariable("value", "<message role=\"user\">\"hello world\"</message>")
+                .build())
+            .block();
+
+        // The actual body will be escaped as its json
+        Assertions.assertTrue(
+            wm.getAllServeEvents().get(0).getRequest().getBodyAsString()
+                .contains("<message role=\\\"user\\\">\\\"hello world\\\"</message>"));
     }
 
     @Test

--- a/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example17_ChatGPT.java
+++ b/java/samples/sample-code/src/main/java/com/microsoft/semantickernel/samples/syntaxexamples/Example17_ChatGPT.java
@@ -37,10 +37,6 @@ public class Example17_ChatGPT {
                 .buildAsyncClient();
         }
 
-        client = new OpenAIClientBuilder()
-            .endpoint("http://localhost:8123")
-            .buildAsyncClient();
-
         ChatCompletionService chatGPT = OpenAIChatCompletion.builder()
             .withModelId(MODEL_ID)
             .withOpenAIAsyncClient(client)

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/CodeBlock.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/implementation/templateengine/tokenizer/blocks/CodeBlock.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -98,8 +99,6 @@ public final class CodeBlock extends Block implements CodeRendering {
             context = InvocationContext.builder().build();
         }
 
-        // this.Log.LogTrace("Rendering code: `{0}`", this.Content);
-
         switch (this.tokens.get(0).getType()) {
             case VALUE:
             case VARIABLE:
@@ -115,9 +114,8 @@ public final class CodeBlock extends Block implements CodeRendering {
                         arguments,
                         context,
                         context.getContextVariableTypes().getVariableTypeForClass(String.class))
-                    .map(it -> {
-                        return it.getValue();
-                    });
+                    .map(ContextVariable::getValue)
+                    .map(StringEscapeUtils::escapeXml11);
 
             case UNDEFINED:
             case TEXT:

--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplate.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/templateengine/handlebars/HandlebarsPromptTemplate.java
@@ -4,6 +4,7 @@ package com.microsoft.semantickernel.templateengine.handlebars;
 import static com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments.MAIN_KEY;
 
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
@@ -34,6 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.text.StringEscapeUtils;
 import reactor.core.publisher.Mono;
 
 /**
@@ -180,7 +182,8 @@ public class HandlebarsPromptTemplate implements PromptTemplate {
             this.handlebars = new Handlebars();
             this.handlebars
                 .registerHelper("message", HandleBarsPromptTemplateHandler::handleMessage)
-                .registerHelper("each", handleEach(context));
+                .registerHelper("each", handleEach(context))
+                .with(EscapingStrategy.XML);
 
             addFunctionHelpers(kernel, this.handlebars, context);
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
