### PR TITLE
.Net: Flaky integration test disabled.

### DIFF
--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIToolsTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIToolsTests.cs
@@ -260,7 +260,7 @@ public sealed class OpenAIToolsTests : BaseIntegrationTest
         Assert.Contains("rain", messageContent.Content, StringComparison.InvariantCultureIgnoreCase);
     }
 
-    [Fact]
+    [Fact(Skip = "The test is temporarily disabled until a more stable solution is found.")]
     public async Task ConnectorAgnosticFunctionCallingModelClassesCanPassFunctionExceptionToConnectorAsync()
     {
         // Arrange


### PR DESCRIPTION
The ConnectorAgnosticFunctionCallingModelClassesCanPassFunctionExceptionToConnectorAsync integration test has been disabled because it continues to fail, even though it was configured with system instructions on how to handle errors.