### PR TITLE
.Net - Enhance _OLD_ Agents Package for Function Calling Arguments

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example70_Agents.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example70_Agents.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;

--- a/dotnet/samples/KernelSyntaxExamples/Example70_Agents.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example70_Agents.cs
@@ -66,7 +66,7 @@ public class Example70_Agent(ITestOutputHelper output) : BaseTest(output)
         await ChatAsync(
             "Agents.ToolAgent.yaml", // Defined under ./Resources/Agents
             plugin,
-            arguments: new() { { MenuPlugin.CorrelationIdArgument, Guid.NewGuid() } },
+            arguments: new() { { MenuPlugin.CorrelationIdArgument, 3.141592653 } },
             "Hello",
             "What is the special soup?",
             "What is the special drink?",

--- a/dotnet/samples/KernelSyntaxExamples/Plugins/MenuPlugin.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Plugins/MenuPlugin.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.SemanticKernel;
 
@@ -7,20 +8,27 @@ namespace Plugins;
 
 public sealed class MenuPlugin
 {
+    public const string CorrelationIdArgument = "correlationId";
+
+    private readonly List<string> _correlationIds = [];
+
+    public IReadOnlyList<string> CorrelationIds => this._correlationIds;
+
     /// <summary>
     /// Returns a mock item menu.
     /// </summary>
     [KernelFunction, Description("Provides a list of specials from the menu.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Too smart")]
-    public string[] GetSpecials()
+    public string[] GetSpecials(KernelArguments? arguments)
     {
+        CaptureCorrelationId(arguments, nameof(GetSpecials));
+
         return
-            new[]
-            {
+            [
                 "Special Soup: Clam Chowder",
                 "Special Salad: Cobb Salad",
                 "Special Drink: Chai Tea",
-            };
+            ];
     }
 
     /// <summary>
@@ -29,8 +37,11 @@ public sealed class MenuPlugin
     [KernelFunction, Description("Provides the price of the requested menu item.")]
     public string GetItemPrice(
             [Description("The name of the menu item.")]
-            string menuItem)
+            string menuItem,
+            KernelArguments? arguments)
     {
+        CaptureCorrelationId(arguments, nameof(GetItemPrice));
+
         return "$9.99";
     }
 
@@ -42,8 +53,24 @@ public sealed class MenuPlugin
             [Description("The name of the menu item.")]
             string menuItem,
             [Description("The number of items requested.")]
-            int count)
+            int count,
+            KernelArguments? arguments)
     {
+        CaptureCorrelationId(arguments, nameof(IsItem86d));
+
         return count < 3;
+    }
+
+    private void CaptureCorrelationId(KernelArguments? arguments, string scope)
+    {
+        if (arguments?.TryGetValue(CorrelationIdArgument, out object? correlationId) ?? false)
+        {
+            string? correlationText = correlationId?.ToString();
+
+            if (!string.IsNullOrWhiteSpace(correlationText))
+            {
+                this._correlationIds.Add($"{scope}:{correlationText}");
+            }
+        }
     }
 }

--- a/dotnet/src/Experimental/Agents/IAgentThread.cs
+++ b/dotnet/src/Experimental/Agents/IAgentThread.cs
@@ -17,6 +17,12 @@ public interface IAgentThread
     string Id { get; }
 
     /// <summary>
+    /// Allow the <see cref="KernelArguments"/> provided to <see cref="IAgentThread.InvokeAsync(IAgent, KernelArguments?, CancellationToken)"/>
+    /// to be passed through to any function calling.
+    /// </summary>
+    bool EnableFunctionArgumentPassThrough { get; set; }
+
+    /// <summary>
     /// Add a textual user message to the thread.
     /// </summary>
     /// <param name="message">The user message</param>

--- a/dotnet/src/Experimental/Agents/Internal/ChatRun.cs
+++ b/dotnet/src/Experimental/Agents/Internal/ChatRun.cs
@@ -18,14 +18,25 @@ namespace Microsoft.SemanticKernel.Experimental.Agents.Internal;
 /// </summary>
 internal sealed class ChatRun
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// ID of this run.
+    /// </summary>
     public string Id => this._model.Id;
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// ID of the assistant used for execution of this run.
+    /// </summary>
     public string AgentId => this._model.AssistantId;
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// ID of the thread that was executed on as a part of this run.
+    /// </summary>
     public string ThreadId => this._model.ThreadId;
+
+    /// <summary>
+    /// Optional arguments for injection into function-calling.
+    /// </summary>
+    public KernelArguments? Arguments { get; init; }
 
     private const string ActionState = "requires_action";
     private const string CompletedState = "completed";
@@ -165,7 +176,7 @@ internal sealed class ChatRun
         {
             var function = this._kernel.GetAssistantTool(functionDetails.Name);
 
-            var functionArguments = new KernelArguments();
+            var functionArguments = new KernelArguments(this.Arguments ?? []);
             if (!string.IsNullOrWhiteSpace(functionDetails.Arguments))
             {
                 var arguments = JsonSerializer.Deserialize<Dictionary<string, object>>(functionDetails.Arguments)!;

--- a/dotnet/src/Experimental/Agents/Internal/ChatThread.cs
+++ b/dotnet/src/Experimental/Agents/Internal/ChatThread.cs
@@ -18,6 +18,9 @@ internal sealed class ChatThread : IAgentThread
     /// <inheritdoc/>
     public string Id { get; private set; }
 
+    /// <inheritdoc/>
+    public bool EnableFunctionArgumentPassThrough { get; set; }
+
     private readonly OpenAIRestContext _restContext;
     private bool _isDeleted;
 
@@ -88,7 +91,11 @@ internal sealed class ChatThread : IAgentThread
 
         // Create run using templated prompt
         var runModel = await this._restContext.CreateRunAsync(this.Id, agent.Id, instructions, agent.Tools, cancellationToken).ConfigureAwait(false);
-        var run = new ChatRun(runModel, agent.Kernel, this._restContext);
+        var run =
+            new ChatRun(runModel, agent.Kernel, this._restContext)
+            {
+                Arguments = this.EnableFunctionArgumentPassThrough ? arguments : null,
+            };
 
         await foreach (var messageId in run.GetResultAsync(cancellationToken).ConfigureAwait(false))
         {


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

A well justified customer request to allow `KernelArguments` to be injected into the assistant function calling.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Defined an _opt-in_ pattern that passes the already provided `KernelArguments` to the run (`ChatRun`).

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
