### PR TITLE
.Net: Create a classifiable Kernel Function logger

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
@@ -156,7 +156,7 @@ public abstract class KernelFunction
         Verify.NotNull(kernel);
 
         using var activity = s_activitySource.StartActivity(this.Name);
-        ILogger logger = kernel.LoggerFactory.CreateLogger(this.Name) ?? NullLogger.Instance;
+        ILogger logger = kernel.LoggerFactory.CreateLogger($"Microsoft.SemanticKernel.KernelFunction.{this.Name}") ?? NullLogger.Instance;
 
         // Ensure arguments are initialized.
         arguments ??= [];
@@ -282,7 +282,7 @@ public abstract class KernelFunction
         Verify.NotNull(kernel);
 
         using var activity = s_activitySource.StartActivity(this.Name);
-        ILogger logger = kernel.LoggerFactory.CreateLogger(this.Name) ?? NullLogger.Instance;
+        ILogger logger = kernel.LoggerFactory.CreateLogger($"Microsoft.SemanticKernel.KernelFunction.{this.Name}") ?? NullLogger.Instance;
 
         arguments ??= [];
         logger.LogFunctionStreamingInvoking(this.Name);


### PR DESCRIPTION
fix #5989 