### PR TITLE
.Net: Deprecated unused filter context classes

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionFilterContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionFilterContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// Base class with data related to function invocation.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("This class is deprecated in favor of FunctionInvocationContext class, which is used in IFunctionInvocationFilter interface.")]
 public abstract class FunctionFilterContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvokedContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvokedContext.cs
@@ -9,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Class with data related to function after invocation.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("This class is deprecated in favor of FunctionInvocationContext class, which is used in IFunctionInvocationFilter interface.")]
 public sealed class FunctionInvokedContext : FunctionFilterContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvokingContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvokingContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Class with data related to function before invocation.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("This class is deprecated in favor of FunctionInvocationContext class, which is used in IFunctionInvocationFilter interface.")]
 public sealed class FunctionInvokingContext : FunctionFilterContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptFilterContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptFilterContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// Base class with data related to prompt rendering.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("This class is deprecated in favor of PromptRenderContext class, which is used in IPromptRenderFilter interface.")]
 public abstract class PromptFilterContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderedContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderedContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Class with data related to prompt after rendering.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("This class is deprecated in favor of PromptRenderContext class, which is used in IPromptRenderFilter interface.")]
 public sealed class PromptRenderedContext : PromptFilterContext
 {
     private string _renderedPrompt;

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderingContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderingContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Class with data related to prompt before rendering.
 /// </summary>
 [Experimental("SKEXP0001")]
+[Obsolete("This class is deprecated in favor of PromptRenderContext class, which is used in IPromptRenderFilter interface.")]
 public sealed class PromptRenderingContext : PromptFilterContext
 {
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Marked unused filter context classes as `Obsolete`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
