### PR TITLE
Replace 'import_plugin_from_object' with 'add_plugin'

### DIFF
--- a/python/semantic_kernel/core_plugins/http_plugin.py
+++ b/python/semantic_kernel/core_plugins/http_plugin.py
@@ -21,7 +21,7 @@ class HttpPlugin(KernelBaseModel):
     A plugin that provides HTTP functionality.
 
     Usage:
-        kernel.import_plugin_from_object(HttpPlugin(), "http")
+        kernel.add_plugin(HttpPlugin(), "http")
 
     Examples:
 

--- a/python/semantic_kernel/core_plugins/math_plugin.py
+++ b/python/semantic_kernel/core_plugins/math_plugin.py
@@ -14,7 +14,7 @@ class MathPlugin:
     Description: MathPlugin provides a set of functions to make Math calculations.
 
     Usage:
-        kernel.import_plugin_from_object(MathPlugin(), plugin_name="math")
+        kernel.add_plugin(MathPlugin(), plugin_name="math")
 
     Examples:
         {{math.Add}} => Returns the sum of input and amount (provided in the KernelArguments)

--- a/python/semantic_kernel/core_plugins/text_plugin.py
+++ b/python/semantic_kernel/core_plugins/text_plugin.py
@@ -9,7 +9,7 @@ class TextPlugin(KernelBaseModel):
     TextPlugin provides a set of functions to manipulate strings.
 
     Usage:
-        kernel.import_plugin_from_object(TextPlugin(), plugin_name="text")
+        kernel.add_plugin(TextPlugin(), plugin_name="text")
 
     Examples:
         KernelArguments["input"] = "  hello world  "

--- a/python/semantic_kernel/core_plugins/time_plugin.py
+++ b/python/semantic_kernel/core_plugins/time_plugin.py
@@ -13,7 +13,7 @@ class TimePlugin(KernelBaseModel):
                  to get the current time and date.
 
     Usage:
-        kernel.import_plugin_from_object(TimePlugin(), plugin_name="time")
+        kernel.add_plugin(TimePlugin(), plugin_name="time")
 
     Examples:
         {{time.date}}            => Sunday, 12 January, 2031

--- a/python/semantic_kernel/core_plugins/wait_plugin.py
+++ b/python/semantic_kernel/core_plugins/wait_plugin.py
@@ -20,7 +20,7 @@ class WaitPlugin(KernelBaseModel):
     WaitPlugin provides a set of functions to wait for a certain amount of time.
 
     Usage:
-        kernel.import_plugin_from_object(WaitPlugin(), plugin_name="wait")
+        kernel.add_plugin(WaitPlugin(), plugin_name="wait")
 
     Examples:
         {{wait.wait 5}} => Wait for 5 seconds

--- a/python/semantic_kernel/core_plugins/web_search_engine_plugin.py
+++ b/python/semantic_kernel/core_plugins/web_search_engine_plugin.py
@@ -18,7 +18,7 @@ class WebSearchEnginePlugin:
 
     Usage:
         connector = BingConnector(bing_search_api_key)
-        kernel.import_plugin_from_object(WebSearchEnginePlugin(connector), plugin_name="WebSearch")
+        kernel.add_plugin(WebSearchEnginePlugin(connector), plugin_name="WebSearch")
 
     Examples:
         {{WebSearch.search "What is semantic kernel?"}}


### PR DESCRIPTION
'import_plugin_from_object' is removed from Kernel. Replace it's usage with add_plugin in function docstring

### Motivation and Context

Fix docstrings of core_plugins to replace  'import_plugin_from_object' with 'add_plugin'.  

### Description

'import_plugin_from_object' is removed from Kernel. Replace it's usage with 'add_plugin' in docstring


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
