### PR TITLE
.Net: Refactor PromptyKernelExtensions.CreateFunctionFromPrompty

### DIFF
--- a/dotnet/samples/Concepts/Concepts.csproj
+++ b/dotnet/samples/Concepts/Concepts.csproj
@@ -62,9 +62,11 @@
     <ProjectReference Include="..\..\src\Experimental\Agents\Experimental.Agents.csproj" />
     <ProjectReference Include="..\..\src\Experimental\Orchestration.Flow\Experimental.Orchestration.Flow.csproj" />
     <ProjectReference Include="..\..\src\Extensions\PromptTemplates.Handlebars\PromptTemplates.Handlebars.csproj" />
+    <ProjectReference Include="..\..\src\Extensions\PromptTemplates.Liquid\PromptTemplates.Liquid.csproj" />
     <ProjectReference Include="..\..\src\Functions\Functions.Grpc\Functions.Grpc.csproj" />
     <ProjectReference Include="..\..\src\Functions\Functions.OpenApi.Extensions\Functions.OpenApi.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Functions\Functions.OpenApi\Functions.OpenApi.csproj" />
+    <ProjectReference Include="..\..\src\Functions\Functions.Prompty\Functions.Prompty.csproj" />
     <ProjectReference Include="..\..\src\Planners\Planners.Handlebars\Planners.Handlebars.csproj" />
     <ProjectReference Include="..\..\src\Planners\Planners.OpenAI\Planners.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Plugins\Plugins.Core\Plugins.Core.csproj" />

--- a/dotnet/samples/Concepts/Prompty/PromptyFunction.cs
+++ b/dotnet/samples/Concepts/Prompty/PromptyFunction.cs
@@ -15,22 +15,23 @@ public class PromptyFunction(ITestOutputHelper output) : BaseTest(output)
                 apiKey: TestConfiguration.OpenAI.ApiKey)
             .Build();
 
-        string promptTemplate = @"---
-name: Contoso_Chat_Prompt
-description: A sample prompt that responds with what Seattle is.
-authors:
-  - ????
-model:
-  api: chat
-  configuration:
-    type: openai
----
-system:
-You are a helpful assistant who knows all about cities in the USA
+        string promptTemplate = """
+            ---
+            name: Contoso_Chat_Prompt
+            description: A sample prompt that responds with what Seattle is.
+            authors:
+              - ????
+            model:
+              api: chat
+              configuration:
+                type: openai
+            ---
+            system:
+            You are a helpful assistant who knows all about cities in the USA
 
-user:
-What is Seattle?
-";
+            user:
+            What is Seattle?
+            """;
 
         var function = kernel.CreateFunctionFromPrompty(promptTemplate);
 

--- a/dotnet/samples/Concepts/Prompty/PromptyFunction.cs
+++ b/dotnet/samples/Concepts/Prompty/PromptyFunction.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel;
+
+namespace Prompty;
+
+public class PromptyFunction(ITestOutputHelper output) : BaseTest(output)
+{
+    [Fact]
+    public async Task InlineFunctionAsync()
+    {
+        Kernel kernel = Kernel.CreateBuilder()
+            .AddOpenAIChatCompletion(
+                modelId: TestConfiguration.OpenAI.ChatModelId,
+                apiKey: TestConfiguration.OpenAI.ApiKey)
+            .Build();
+
+        string promptTemplate = @"---
+name: Contoso_Chat_Prompt
+description: A sample prompt that responds with what Seattle is.
+authors:
+  - ????
+model:
+  api: chat
+  configuration:
+    type: openai
+---
+system:
+You are a helpful assistant who knows all about cities in the USA
+
+user:
+What is Seattle?
+";
+
+        var function = kernel.CreateFunctionFromPrompty(promptTemplate);
+
+        var result = await kernel.InvokeAsync(function);
+        Console.WriteLine(result);
+    }
+}

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/PromptyTest.cs
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/PromptyTest.cs
@@ -17,9 +17,10 @@ public sealed class PromptyTest
 
         var cwd = Directory.GetCurrentDirectory();
         var chatPromptyPath = Path.Combine(cwd, "TestData", "chat.prompty");
+        var promptyTemplate = File.ReadAllText(chatPromptyPath);
 
         // Act
-        var kernelFunction = kernel.CreateFunctionFromPrompty(chatPromptyPath);
+        var kernelFunction = kernel.CreateFunctionFromPrompty(promptyTemplate);
 
         // Assert
         Assert.Equal("Contoso_Chat_Prompt", kernelFunction.Name);
@@ -40,7 +41,7 @@ public sealed class PromptyTest
         var chatPromptyPath = Path.Combine(cwd, "TestData", "chat.prompty");
 
         // Act
-        var kernelFunction = kernel.CreateFunctionFromPrompty(chatPromptyPath);
+        var kernelFunction = kernel.CreateFunctionFromPromptyFile(chatPromptyPath);
 
         // Assert
         // kernel function created from chat.prompty should have a single execution setting
@@ -75,7 +76,7 @@ public sealed class PromptyTest
         var promptyPath = Path.Combine(cwd, "TestData", "chatNoExecutionSettings.prompty");
 
         // Act
-        var kernelFunction = kernel.CreateFunctionFromPrompty(promptyPath);
+        var kernelFunction = kernel.CreateFunctionFromPromptyFile(promptyPath);
 
         // Assert
         Assert.NotNull(kernelFunction);

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -20,21 +20,39 @@ public static class PromptyKernelExtensions
     /// Create a <see cref="KernelFunction"/> from a prompty file.
     /// </summary>
     /// <param name="kernel">kernel</param>
-    /// <param name="promptyPath">path to prompty file.</param>
+    /// <param name="promptyFilePath">Prompty template.</param>
+    /// <param name="promptTemplateFactory">prompty template factory, if not provided, a <see cref="LiquidPromptTemplateFactory"/> will be used.</param>
+    /// <param name="loggerFactory">logger factory</param>
+    /// <returns><see cref="KernelFunction"/></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="NotSupportedException"></exception>
+    public static KernelFunction CreateFunctionFromPromptyFile(
+        this Kernel kernel,
+        string promptyFilePath,
+        IPromptTemplateFactory? promptTemplateFactory = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var promptyTemplate = File.ReadAllText(promptyFilePath);
+        return kernel.CreateFunctionFromPrompty(promptyTemplate, promptTemplateFactory, loggerFactory);
+    }
+
+    /// <summary>
+    /// Create a <see cref="KernelFunction"/> from a prompty file.
+    /// </summary>
+    /// <param name="kernel">kernel</param>
+    /// <param name="promptyTemplate">Prompty template.</param>
     /// <param name="promptTemplateFactory">prompty template factory, if not provided, a <see cref="LiquidPromptTemplateFactory"/> will be used.</param>
     /// <param name="loggerFactory">logger factory</param>
     /// <returns><see cref="KernelFunction"/></returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="NotSupportedException"></exception>
     public static KernelFunction CreateFunctionFromPrompty(
-        this Kernel kernel,
-        string promptyPath,
-        IPromptTemplateFactory? promptTemplateFactory = null,
-        ILoggerFactory? loggerFactory = null)
+    this Kernel kernel,
+    string promptyTemplate,
+    IPromptTemplateFactory? promptTemplateFactory = null,
+    ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(kernel);
-
-        var text = File.ReadAllText(promptyPath);
 
         promptTemplateFactory ??= new AggregatorPromptTemplateFactory(new HandlebarsPromptTemplateFactory(), new LiquidPromptTemplateFactory());
 
@@ -70,7 +88,7 @@ public static class PromptyKernelExtensions
         // ---
         // ... (rest of the prompty content)
 
-        var splits = text.Split(["---"], StringSplitOptions.RemoveEmptyEntries);
+        var splits = promptyTemplate.Split(["---"], StringSplitOptions.RemoveEmptyEntries);
         var yaml = splits[0];
         var content = splits[1];
 

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -53,6 +53,7 @@ public static class PromptyKernelExtensions
     ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(kernel);
+        Verify.NotNullOrWhitespace(promptyTemplate);
 
         promptTemplateFactory ??= new AggregatorPromptTemplateFactory(new HandlebarsPromptTemplateFactory(), new LiquidPromptTemplateFactory());
 

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -12,17 +12,20 @@ using YamlDotNet.Serialization;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Extension methods for <see cref="Kernel"/> to create a <see cref="KernelFunction"/> from a prompty file.
+/// Extension methods for <see cref="Kernel"/> to create a <see cref="KernelFunction"/> from a Prompty file.
 /// </summary>
 public static class PromptyKernelExtensions
 {
     /// <summary>
     /// Create a <see cref="KernelFunction"/> from a prompty file.
     /// </summary>
-    /// <param name="kernel">kernel</param>
-    /// <param name="promptyFilePath">Path to the file containing the prompty template.</param>
-    /// <param name="promptTemplateFactory">prompty template factory, if not provided, a <see cref="LiquidPromptTemplateFactory"/> will be used.</param>
-    /// <param name="loggerFactory">logger factory</param>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="promptyFilePath">Path to the file containing the Prompty representation of a prompt based <see cref="KernelFunction"/>.</param>
+    /// <param name="promptTemplateFactory">
+    /// The <see cref="IPromptTemplateFactory"/> to use when interpreting the prompt template configuration into a <see cref="IPromptTemplate"/>.
+    /// If null, a <see cref="AggregatorPromptTemplateFactory"/> will be used with support for Liquid and Handlebars prompt templates.
+    /// </param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
     /// <returns><see cref="KernelFunction"/></returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="NotSupportedException"></exception>
@@ -32,6 +35,9 @@ public static class PromptyKernelExtensions
         IPromptTemplateFactory? promptTemplateFactory = null,
         ILoggerFactory? loggerFactory = null)
     {
+        Verify.NotNull(kernel);
+        Verify.NotNullOrWhiteSpace(promptyFilePath);
+
         var promptyTemplate = File.ReadAllText(promptyFilePath);
         return kernel.CreateFunctionFromPrompty(promptyTemplate, promptTemplateFactory, loggerFactory);
     }
@@ -39,10 +45,13 @@ public static class PromptyKernelExtensions
     /// <summary>
     /// Create a <see cref="KernelFunction"/> from a prompty file.
     /// </summary>
-    /// <param name="kernel">kernel</param>
-    /// <param name="promptyTemplate">Prompty template.</param>
-    /// <param name="promptTemplateFactory">prompty template factory, if not provided, a <see cref="LiquidPromptTemplateFactory"/> will be used.</param>
-    /// <param name="loggerFactory">logger factory</param>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="promptyTemplate">Prompty representation of a prompt based <see cref="KernelFunction"/>.</param>
+    /// <param name="promptTemplateFactory">
+    /// The <see cref="IPromptTemplateFactory"/> to use when interpreting the prompt template configuration into a <see cref="IPromptTemplate"/>.
+    /// If null, a <see cref="AggregatorPromptTemplateFactory"/> will be used with support for Liquid and Handlebars prompt templates.
+    /// </param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
     /// <returns><see cref="KernelFunction"/></returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="NotSupportedException"></exception>
@@ -53,7 +62,7 @@ public static class PromptyKernelExtensions
         ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(kernel);
-        Verify.NotNullOrWhitespace(promptyTemplate);
+        Verify.NotNullOrWhiteSpace(promptyTemplate);
 
         promptTemplateFactory ??= new AggregatorPromptTemplateFactory(new HandlebarsPromptTemplateFactory(), new LiquidPromptTemplateFactory());
 

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -20,7 +20,7 @@ public static class PromptyKernelExtensions
     /// Create a <see cref="KernelFunction"/> from a prompty file.
     /// </summary>
     /// <param name="kernel">kernel</param>
-    /// <param name="promptyFilePath">Prompty template.</param>
+    /// <param name="promptyFilePath">Path to the file containing the prompty template.</param>
     /// <param name="promptTemplateFactory">prompty template factory, if not provided, a <see cref="LiquidPromptTemplateFactory"/> will be used.</param>
     /// <param name="loggerFactory">logger factory</param>
     /// <returns><see cref="KernelFunction"/></returns>

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -47,10 +47,10 @@ public static class PromptyKernelExtensions
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="NotSupportedException"></exception>
     public static KernelFunction CreateFunctionFromPrompty(
-    this Kernel kernel,
-    string promptyTemplate,
-    IPromptTemplateFactory? promptTemplateFactory = null,
-    ILoggerFactory? loggerFactory = null)
+        this Kernel kernel,
+        string promptyTemplate,
+        IPromptTemplateFactory? promptTemplateFactory = null,
+        ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(kernel);
         Verify.NotNullOrWhitespace(promptyTemplate);


### PR DESCRIPTION
### Motivation and Context

`PromptyKernelExtensions.CreateFunctionFromPrompty`

The second parameter is a file path to a prompty file. This should be changed to the prompty text. Doing this will allow developers to be responsible for loading the prompty file e.g. could be a file or an embedded resource or a database record...

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
