### PR TITLE
.Net: Clean up some things in LiquidPromptTemplate and PromptyKernelExtensions

### DIFF
--- a/dotnet/src/Extensions/PromptTemplates.Liquid.UnitTests/LiquidTemplateFactoryTest.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Liquid.UnitTests/LiquidTemplateFactoryTest.cs
@@ -8,18 +8,22 @@ namespace SemanticKernel.Extensions.PromptTemplates.Liquid.UnitTests;
 
 public class LiquidTemplateFactoryTest
 {
-    [Fact]
-    public void ItThrowsExceptionForUnknownPromptTemplateFormat()
+    [Theory]
+    [InlineData("unknown-format")]
+    [InlineData(null)]
+    public void ItThrowsExceptionForUnknownPromptTemplateFormat(string? format)
     {
         // Arrange
         var promptConfig = new PromptTemplateConfig("UnknownFormat")
         {
-            TemplateFormat = "unknown-format",
+            TemplateFormat = format,
         };
 
         var target = new LiquidPromptTemplateFactory();
 
         // Act & Assert
+        Assert.False(target.TryCreate(promptConfig, out IPromptTemplate? result));
+        Assert.Null(result);
         Assert.Throws<KernelException>(() => target.Create(promptConfig));
     }
 
@@ -38,7 +42,6 @@ public class LiquidTemplateFactoryTest
         var result = target.Create(promptConfig);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.True(result is LiquidPromptTemplate);
+        Assert.IsType<LiquidPromptTemplate>(result);
     }
 }

--- a/dotnet/src/Extensions/PromptTemplates.Liquid/LiquidPromptTemplateFactory.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Liquid/LiquidPromptTemplateFactory.cs
@@ -18,7 +18,9 @@ public sealed class LiquidPromptTemplateFactory : IPromptTemplateFactory
     /// <inheritdoc/>
     public bool TryCreate(PromptTemplateConfig templateConfig, [NotNullWhen(true)] out IPromptTemplate? result)
     {
-        if (templateConfig.TemplateFormat.Equals(LiquidTemplateFormat, StringComparison.Ordinal))
+        Verify.NotNull(templateConfig);
+
+        if (LiquidTemplateFormat.Equals(templateConfig.TemplateFormat, StringComparison.Ordinal))
         {
             result = new LiquidPromptTemplate(templateConfig);
             return true;

--- a/dotnet/src/Functions/Functions.Prompty/Core/PromptyModelParameters.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Core/PromptyModelParameters.cs
@@ -5,36 +5,46 @@ using YamlDotNet.Serialization;
 
 namespace Microsoft.SemanticKernel.Prompty.Core;
 
+/// <summary>Parameters to be sent to the model.</summary>
 internal sealed class PromptyModelParameters
 {
-    // Parameters to be sent to the model
+    /// <summary>Specify the format for model output (e.g., JSON mode).</summary>
     [YamlMember(Alias = "response_format")]
-    public string? ResponseFormat { get; set; } // Specify the format for model output (e.g., JSON mode)
+    public string? ResponseFormat { get; set; }
 
+    /// <summary>Seed for deterministic sampling (Beta feature).</summary>
     [YamlMember(Alias = "seed")]
-    public int? Seed { get; set; } // Seed for deterministic sampling (Beta feature)
+    public int? Seed { get; set; }
 
+    /// <summary>Maximum number of tokens in chat completion.</summary>
     [YamlMember(Alias = "max_tokens")]
-    public int? MaxTokens { get; set; } // Maximum number of tokens in chat completion
+    public int? MaxTokens { get; set; }
 
+    /// <summary>Sampling temperature (0 means deterministic).</summary>
     [YamlMember(Alias = "temperature")]
-    public double? Temperature { get; set; } // Sampling temperature (0 means deterministic)
+    public double? Temperature { get; set; }
 
+    /// <summary>Controls which function the model calls (e.g., "none" or "auto").</summary>
     [YamlMember(Alias = "tools_choice")]
-    public string? ToolsChoice { get; set; } // Controls which function the model calls (e.g., "none" or "auto")
+    public string? ToolsChoice { get; set; }
 
+    /// <summary>Array of tools (if applicable).</summary>
     [YamlMember(Alias = "tools")]
-    public List<PromptyTool>? Tools { get; set; } // Array of tools (if applicable)
+    public List<PromptyTool>? Tools { get; set; }
 
+    /// <summary>Frequency penalty for sampling.</summary>
     [YamlMember(Alias = "frequency_penalty")]
-    public double? FrequencyPenalty { get; set; } // Frequency penalty for sampling
+    public double? FrequencyPenalty { get; set; }
 
+    /// <summary>Presence penalty for sampling.</summary>
     [YamlMember(Alias = "presence_penalty")]
-    public double? PresencePenalty { get; set; } // Presence penalty for sampling
+    public double? PresencePenalty { get; set; }
 
+    /// <summary>Sequences where model stops generating tokens.</summary>
     [YamlMember(Alias = "stop")]
-    public List<string>? Stop { get; set; } // Sequences where model stops generating tokens
+    public List<string>? Stop { get; set; }
 
+    /// <summary>Nucleus sampling probability (0 means no tokens generated).</summary>
     [YamlMember(Alias = "top_p")]
-    public double? TopP { get; set; } // Nucleus sampling probability (0 means no tokens generated)
+    public double? TopP { get; set; }
 }

--- a/dotnet/src/Functions/Functions.Prompty/Core/PromptyYaml.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Core/PromptyYaml.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Prompty.Core;
 /// <summary>
 /// Schema: https://github.com/Azure/azureml_run_specification/blob/master/schemas/Prompty.yaml
 /// </summary>
-internal sealed class PromptyYaml()
+internal sealed class PromptyYaml
 {
     [YamlMember(Alias = "name")]
     public string? Name { get; set; }

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -3,7 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.SemanticKernel.PromptTemplates.Handlebars;
 using Microsoft.SemanticKernel.PromptTemplates.Liquid;
 using Microsoft.SemanticKernel.Prompty.Core;
@@ -12,12 +13,25 @@ using YamlDotNet.Serialization;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Extension methods for <see cref="Kernel"/> to create a <see cref="KernelFunction"/> from a Prompty file.
+/// Provides extension methods for creating <see cref="KernelFunction"/>s from the Prompty template format.
 /// </summary>
 public static class PromptyKernelExtensions
 {
+    /// <summary>Default template factory to use when none is provided.</summary>
+    private static readonly AggregatorPromptTemplateFactory s_defaultTemplateFactory =
+        new(new LiquidPromptTemplateFactory(), new HandlebarsPromptTemplateFactory());
+
+    /// <summary>Regex for parsing the YAML frontmatter and content from the prompty template.</summary>
+    private static readonly Regex s_promptyRegex = new("""
+        ^---\s*$\n      # Start of YAML front matter, a line beginning with "---" followed by optional whitespace
+        (?<header>.*?)  # Capture the YAML front matter, everything up to the next "---" line
+        ^---\s*$\n      # End of YAML front matter, a line beginning with "---" followed by optional whitespace
+        (?<content>.*)  # Capture the content after the YAML front matter
+        """,
+        RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
+
     /// <summary>
-    /// Create a <see cref="KernelFunction"/> from a prompty file.
+    /// Create a <see cref="KernelFunction"/> from a prompty template file.
     /// </summary>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="promptyFilePath">Path to the file containing the Prompty representation of a prompt based <see cref="KernelFunction"/>.</param>
@@ -25,51 +39,46 @@ public static class PromptyKernelExtensions
     /// The <see cref="IPromptTemplateFactory"/> to use when interpreting the prompt template configuration into a <see cref="IPromptTemplate"/>.
     /// If null, a <see cref="AggregatorPromptTemplateFactory"/> will be used with support for Liquid and Handlebars prompt templates.
     /// </param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
-    /// <returns><see cref="KernelFunction"/></returns>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <exception cref="NotSupportedException"></exception>
+    /// <returns>The created <see cref="KernelFunction"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="kernel"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="promptyFilePath"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="promptyFilePath"/> is empty or composed entirely of whitespace.</exception>
     public static KernelFunction CreateFunctionFromPromptyFile(
         this Kernel kernel,
         string promptyFilePath,
-        IPromptTemplateFactory? promptTemplateFactory = null,
-        ILoggerFactory? loggerFactory = null)
+        IPromptTemplateFactory? promptTemplateFactory = null)
     {
         Verify.NotNull(kernel);
         Verify.NotNullOrWhiteSpace(promptyFilePath);
 
         var promptyTemplate = File.ReadAllText(promptyFilePath);
-        return kernel.CreateFunctionFromPrompty(promptyTemplate, promptTemplateFactory, loggerFactory);
+        return kernel.CreateFunctionFromPrompty(promptyTemplate, promptTemplateFactory);
     }
 
     /// <summary>
-    /// Create a <see cref="KernelFunction"/> from a prompty file.
+    /// Create a <see cref="KernelFunction"/> from a prompty template.
     /// </summary>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
-    /// <param name="promptyTemplate">Prompty representation of a prompt based <see cref="KernelFunction"/>.</param>
+    /// <param name="promptyTemplate">Prompty representation of a prompt-based <see cref="KernelFunction"/>.</param>
     /// <param name="promptTemplateFactory">
     /// The <see cref="IPromptTemplateFactory"/> to use when interpreting the prompt template configuration into a <see cref="IPromptTemplate"/>.
     /// If null, a <see cref="AggregatorPromptTemplateFactory"/> will be used with support for Liquid and Handlebars prompt templates.
     /// </param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
-    /// <returns><see cref="KernelFunction"/></returns>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <exception cref="NotSupportedException"></exception>
+    /// <returns>The created <see cref="KernelFunction"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="kernel"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="promptyTemplate"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="promptyTemplate"/> is empty or composed entirely of whitespace.</exception>
     public static KernelFunction CreateFunctionFromPrompty(
         this Kernel kernel,
         string promptyTemplate,
-        IPromptTemplateFactory? promptTemplateFactory = null,
-        ILoggerFactory? loggerFactory = null)
+        IPromptTemplateFactory? promptTemplateFactory = null)
     {
         Verify.NotNull(kernel);
         Verify.NotNullOrWhiteSpace(promptyTemplate);
 
-        promptTemplateFactory ??= new AggregatorPromptTemplateFactory(new HandlebarsPromptTemplateFactory(), new LiquidPromptTemplateFactory());
-
-        // create PromptTemplateConfig from text
-        // step 1
-        // retrieve the header, which is in yaml format and put between ---
-        //
+        // Step 1:
+        // Create PromptTemplateConfig from text.
+        // Retrieve the header, which is in yaml format and put between ---
         // e.g
         // file: chat.prompty
         // ---
@@ -81,8 +90,8 @@ public static class PromptyKernelExtensions
         //   api: chat
         //   configuration:
         //     type: azure_openai
-        //     azure_deployment: gpt - 35 - turbo
-        //     api_version: 2023 - 07 - 01 - preview
+        //     azure_deployment: gpt-35-turbo
+        //     api_version: 2023-07-01-preview
         //   parameters:
         //     tools_choice: auto
         //     tools:
@@ -98,15 +107,20 @@ public static class PromptyKernelExtensions
         // ---
         // ... (rest of the prompty content)
 
-        var splits = promptyTemplate.Split(["---"], StringSplitOptions.RemoveEmptyEntries);
-        var yaml = splits[0];
-        var content = splits[1];
+        // Parse the YAML frontmatter and content from the prompty template
+        Match m = s_promptyRegex.Match(promptyTemplate);
+        if (!m.Success)
+        {
+            throw new ArgumentException("Invalid prompty template. Header and content could not be parsed.");
+        }
 
-        var deserializer = new DeserializerBuilder().Build();
-        var prompty = deserializer.Deserialize<PromptyYaml>(yaml);
+        var header = m.Groups["header"].Value;
+        var content = m.Groups["content"].Value;
 
-        // step 2
-        // create a prompt template config from the prompty object
+        var prompty = new DeserializerBuilder().Build().Deserialize<PromptyYaml>(header);
+
+        // Step 2:
+        // Create a prompt template config from the prompty data.
         var promptTemplateConfig = new PromptTemplateConfig
         {
             Name = prompty.Name, // TODO: sanitize name
@@ -115,16 +129,27 @@ public static class PromptyKernelExtensions
         };
 
         PromptExecutionSettings? defaultExecutionSetting = null;
-        if (prompty.Model?.ModelConfiguration?.ModelType is ModelType.azure_openai || prompty.Model?.ModelConfiguration?.ModelType is ModelType.openai)
+        if (prompty.Model?.ModelConfiguration?.ModelType is ModelType.azure_openai or ModelType.openai)
         {
             defaultExecutionSetting = new PromptExecutionSettings
             {
-                ModelId = prompty.Model?.ModelConfiguration?.AzureDeployment,
+                ModelId = prompty.Model.ModelConfiguration.ModelType is ModelType.azure_openai ?
+                    prompty.Model.ModelConfiguration.AzureDeployment :
+                    prompty.Model.ModelConfiguration.Name
             };
 
             var extensionData = new Dictionary<string, object>();
-            extensionData.Add("temperature", prompty.Model?.Parameters?.Temperature ?? 1.0);
-            extensionData.Add("top_p", prompty.Model?.Parameters?.TopP ?? 1.0);
+
+            if (prompty.Model?.Parameters?.Temperature is double temperature)
+            {
+                extensionData.Add("temperature", temperature);
+            }
+
+            if (prompty.Model?.Parameters?.TopP is double topP)
+            {
+                extensionData.Add("top_p", topP);
+            }
+
             if (prompty.Model?.Parameters?.MaxTokens is int maxTokens)
             {
                 extensionData.Add("max_tokens", maxTokens);
@@ -159,28 +184,41 @@ public static class PromptyKernelExtensions
             promptTemplateConfig.AddExecutionSettings(defaultExecutionSetting);
         }
 
-        // step 3. add input variables
-        if (prompty.Inputs != null)
+        // Step 3:
+        // Add input and output variables.
+        if (prompty.Inputs is not null)
         {
             foreach (var input in prompty.Inputs)
             {
                 if (input.Value is string description)
                 {
-                    var inputVariable = new InputVariable()
+                    promptTemplateConfig.InputVariables.Add(new()
                     {
                         Name = input.Key,
                         Description = description,
-                    };
-
-                    promptTemplateConfig.InputVariables.Add(inputVariable);
+                    });
                 }
             }
         }
 
-        // step 4. update template format, if not provided, use Liquid as default
-        var templateFormat = prompty.Template ?? LiquidPromptTemplateFactory.LiquidTemplateFormat;
-        promptTemplateConfig.TemplateFormat = templateFormat;
+        if (prompty.Outputs is not null)
+        {
+            // PromptTemplateConfig supports only a single output variable. If the prompty template
+            // contains one and only one, use it. Otherwise, ignore any outputs.
+            if (prompty.Outputs.Count == 1 &&
+                prompty.Outputs.First().Value is string description)
+            {
+                promptTemplateConfig.OutputVariable = new() { Description = description };
+            }
+        }
 
-        return KernelFunctionFactory.CreateFromPrompt(promptTemplateConfig, promptTemplateFactory, loggerFactory);
+        // Step 4:
+        // Update template format. If not provided, use Liquid as default.
+        promptTemplateConfig.TemplateFormat = prompty.Template ?? LiquidPromptTemplateFactory.LiquidTemplateFormat;
+
+        return KernelFunctionFactory.CreateFromPrompt(
+            promptTemplateConfig,
+            promptTemplateFactory ?? s_defaultTemplateFactory,
+            kernel.LoggerFactory);
     }
 }


### PR DESCRIPTION
- Liquid template parsing should happen during construction, not on each render
- Liquid prompt template construction should fail for invalid templates
- Default inputs should be evaluated once at Liquid template construction time
- RenderAsync should capture any exceptions into returned Task
- Role regex used in parsing rendered messages should be Compiled
- LiquidPromptTemplateFactory should do arg validation and accomodate a PromptTemplateConfig whose TemplateFormat is null
- Use XML comments instead of normal comments to describe properties in internal DOM
- Remove unnecessary empty primary constructor
- Use a regex to parse the components of a prompty template in order to a) more strictly validate contents but more importantly b) avoid losing part of the template when the separator appears in the contents itself
- Clean up some XML comments
- Set ModelId appropriately for openai
- Avoid storing temperature/top_p in execution settings if they weren't specified
- Add an OutputVariable if the prompty specifies one
- Cache the default template factory rather than creating a new one on each construction

cc: @LittleLittleCloud