### PR TITLE
.Net: Fixing minor defects: Disposing cursor too early also wrong sequence on constructor

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
@@ -73,10 +73,10 @@ internal struct AzureCosmosDBMongoDBMemoryRecordMetadata
     public MemoryRecordMetadata ToMemoryRecordMetadata() =>
         new(
             this.IsReference,
-            this.ExternalSourceName,
             this.Id,
-            this.Description,
             this.Text,
+            this.Description,
+            this.ExternalSourceName,
             this.AdditionalMetadata
         );
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
@@ -408,7 +408,7 @@ public class AzureCosmosDBMongoDBMemoryStore : IMemoryStore, IDisposable
                 break;
         }
 
-        using var cursor = await this.GetCollection(collectionName)
+        var cursor = await this.GetCollection(collectionName)
             .AggregateAsync<BsonDocument>(pipeline, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
         return cursor;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?  -  Fixing some defects
  3. What problem does it solve? - SearchAsync will return error when enumerating the Bson Document.
  4. What scenario does it contribute to? 
  5. If it fixes an open issue, please link to the issue here.
-->

### Description

1. Fixing the wrong sequence in the constructor of `MemoryRecordMetadata`
2. The cursor is disposed to early, resulting the `SearchAsync` failed.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x ] The code builds clean without any errors or warnings
- [ x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x ] All unit tests pass, and I have added new tests where possible
- [ x] I didn't break anyone :smile:
