### PR TITLE
Python: Check for other services registered before throwing service not found.

### DIFF
--- a/python/semantic_kernel/services/ai_service_selector.py
+++ b/python/semantic_kernel/services/ai_service_selector.py
@@ -41,7 +41,10 @@ class AIServiceSelector:
         if not execution_settings_dict:
             execution_settings_dict = {"default": PromptExecutionSettings()}
         for service_id, settings in execution_settings_dict.items():
-            service = kernel.get_service(service_id, type=(TextCompletionClientBase, ChatCompletionClientBase))
+            try:
+                service = kernel.get_service(service_id, type=(TextCompletionClientBase, ChatCompletionClientBase))
+            except KernelServiceNotFoundError:
+                continue
             if service:
                 service_settings = service.get_prompt_execution_settings_from_settings(settings)
                 return service, service_settings

--- a/python/tests/unit/functions/test_kernel_function_from_prompt.py
+++ b/python/tests/unit/functions/test_kernel_function_from_prompt.py
@@ -290,6 +290,29 @@ def test_create_with_multiple_settings():
     )
 
 
+@pytest.mark.asyncio
+async def test_create_with_multiple_settings_one_service_registered():
+    kernel = Kernel()
+    kernel.add_service(OpenAIChatCompletion(service_id="test2", ai_model_id="test", api_key="test"))
+    function = KernelFunctionFromPrompt(
+        function_name="test",
+        plugin_name="test",
+        prompt_template_config=PromptTemplateConfig(
+            template="test",
+            execution_settings=[
+                PromptExecutionSettings(service_id="test", temperature=0.0),
+                PromptExecutionSettings(service_id="test2", temperature=1.0),
+            ],
+        ),
+    )
+    with patch(
+        "semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion.OpenAIChatCompletion.complete_chat"
+    ) as mock:
+        mock.return_value = [ChatMessageContent(role="assistant", content="test", metadata={})]
+        result = await function.invoke(kernel=kernel)
+        assert str(result) == "test"
+
+
 def test_from_yaml_fail():
     with pytest.raises(FunctionInitializationError):
         KernelFunctionFromPrompt.from_yaml("template_format: something_else")


### PR DESCRIPTION
### Motivation and Context

The `ai_service_selector` was not properly grabbing a registered service if it didn't match the first registered `service_id`. It's possible that there may be multiple prompt execution settings registered as part of a kernel function; however, only one Chat/Text completion service could be registered, and it may not be the first service id present in the dictionary. If it isn't, we shouldn't be throwing a service not found exception.
 
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR fixes the behavior, and allows us to try to find other registered services based on the present service IDs. 
- Closes #5977 
- Adds a unit test to cover this behavior.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
