### PR TITLE
.Net: Fix KernelFunctionFromMethod.ToString

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
@@ -381,6 +381,11 @@ public abstract class KernelFunction
     /// </remarks>
     public abstract KernelFunction Clone(string pluginName);
 
+    /// <inheritdoc/>
+    public override string ToString() => string.IsNullOrWhiteSpace(this.PluginName) ?
+        this.Name :
+        $"{this.PluginName}.{this.Name}";
+
     /// <summary>
     /// Invokes the <see cref="KernelFunction"/>.
     /// </summary>

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.SemanticKernel.Text;
 
 namespace Microsoft.SemanticKernel;
 
@@ -165,11 +164,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
             this.Metadata.ReturnParameter,
             this.Metadata.AdditionalProperties);
     }
-
-    /// <summary>
-    /// JSON serialized string representation of the function.
-    /// </summary>
-    public override string ToString() => JsonSerializer.Serialize(this, JsonOptionsCache.WriteIndented);
 
     /// <summary>Delegate used to invoke the underlying delegate.</summary>
     private delegate ValueTask<FunctionResult> ImplementationFunc(

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -232,11 +232,6 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
             this._logger);
     }
 
-    /// <summary>
-    /// JSON serialized string representation of the function.
-    /// </summary>
-    public override string ToString() => JsonSerializer.Serialize(this);
-
     private KernelFunctionFromPrompt(
         IPromptTemplate template,
         PromptTemplateConfig promptConfig,

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelPluginTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelPluginTests.cs
@@ -20,8 +20,12 @@ public class KernelPluginTests
         {
             KernelFunctionFactory.CreateFromMethod(() => { }, "Function1"),
             KernelFunctionFactory.CreateFromMethod(() => { }, "Function2"),
-            KernelFunctionFactory.CreateFromMethod(() => { }, "Function3"),
+            KernelFunctionFactory.CreateFromPrompt("some prompt", functionName: "Function3"),
         };
+
+        Assert.Equal("Function1", functions[0].ToString());
+        Assert.Equal("Function2", functions[1].ToString());
+        Assert.Equal("Function3", functions[2].ToString());
 
         plugin = KernelPluginFactory.CreateFromFunctions("name", null, null);
         Assert.Equal("name", plugin.Name);
@@ -34,6 +38,10 @@ public class KernelPluginTests
         Assert.Equal(3, plugin.FunctionCount);
         Assert.All(functions, f => Assert.True(plugin.Contains(f)));
 
+        Assert.Equal("name.Function1", plugin["Function1"].ToString());
+        Assert.Equal("name.Function2", plugin["Function2"].ToString());
+        Assert.Equal("name.Function3", plugin["Function3"].ToString());
+
         plugin = KernelPluginFactory.CreateFromFunctions("name", "description");
         Assert.Equal("name", plugin.Name);
         Assert.Equal("description", plugin.Description);
@@ -44,6 +52,10 @@ public class KernelPluginTests
         Assert.Equal("description", plugin.Description);
         Assert.Equal(3, plugin.FunctionCount);
         Assert.All(functions, f => Assert.True(plugin.Contains(f)));
+
+        Assert.Equal("name.Function1", plugin["Function1"].ToString());
+        Assert.Equal("name.Function2", plugin["Function2"].ToString());
+        Assert.Equal("name.Function3", plugin["Function3"].ToString());
     }
 
     [Fact]


### PR DESCRIPTION
It currently fails to call ToString (throws a JSON serialization exception). Change KernelFunction.ToString to just print out the name.