### PR TITLE
Python: allow openapi runner to use a custom client

### DIFF
--- a/python/samples/concepts/plugins/openai_plugin_azure_key_vault.py
+++ b/python/samples/concepts/plugins/openai_plugin_azure_key_vault.py
@@ -17,7 +17,7 @@ from semantic_kernel.utils.settings import azure_key_vault_settings_from_dot_env
 async def add_secret_to_key_vault(kernel: Kernel, plugin: KernelPlugin):
     """Adds a secret to the Azure Key Vault."""
     result = await kernel.invoke(
-        functions=plugin["SetSecret"],
+        function=plugin["SetSecret"],
         path_params={"secret-name": "Foo"},
         query_params={"api-version": "7.0"},
         request_body={"value": "Bar", "enabled": True},
@@ -30,10 +30,11 @@ async def add_secret_to_key_vault(kernel: Kernel, plugin: KernelPlugin):
 async def get_secret_from_key_vault(kernel: Kernel, plugin: KernelPlugin):
     """Gets a secret from the Azure Key Vault."""
     result = await kernel.invoke(
-        functions=plugin["GetSecret"],
-        path_params={"secret-name ": "Foo"},
+        function=plugin["GetSecret"],
+        path_params={"secret-name": "Foo"},
         query_params={"api-version": "7.0"},
         headers={},
+        request_body={},
     )
 
     print(f"Secret retrieved from Key Vault: {result}")
@@ -136,12 +137,13 @@ async def main():
     kernel = Kernel()
 
     openai_spec_file = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "resources", "open_ai_plugins", "akv-openai.json"
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "resources", "open_ai_plugins", "akv-openai.json"
     )
     with open(openai_spec_file, "r") as file:
         openai_spec = file.read()
 
     http_client = httpx.AsyncClient()
+    http_client.headers["Test-X-ID"] = "1234"
 
     plugin = await kernel.add_plugin_from_openai(
         plugin_name="AzureKeyVaultPlugin",
@@ -155,6 +157,7 @@ async def main():
     )
 
     await add_secret_to_key_vault(kernel, plugin)
+    await get_secret_from_key_vault(kernel, plugin)
 
 
 if __name__ == "__main__":

--- a/python/samples/concepts/plugins/openai_plugin_azure_key_vault.py
+++ b/python/samples/concepts/plugins/openai_plugin_azure_key_vault.py
@@ -143,7 +143,6 @@ async def main():
         openai_spec = file.read()
 
     http_client = httpx.AsyncClient()
-    http_client.headers["Test-X-ID"] = "1234"
 
     plugin = await kernel.add_plugin_from_openai(
         plugin_name="AzureKeyVaultPlugin",

--- a/python/samples/concepts/plugins/openapi/openapi_client.py
+++ b/python/samples/concepts/plugins/openapi/openapi_client.py
@@ -8,9 +8,7 @@ async def main():
     """Client"""
     kernel = sk.Kernel()
 
-    openapi_plugin = kernel.import_plugin_from_openapi(
-        plugin_name="openApiPlugin", openapi_document_path="./openapi.yaml"
-    )
+    openapi_plugin = kernel.add_plugin_from_openapi(plugin_name="openApiPlugin", openapi_document_path="./openapi.yaml")
 
     arguments = {
         "request_body": '{"input": "hello world"}',

--- a/python/samples/concepts/resources/open_ai_plugins/akv-openai.json
+++ b/python/samples/concepts/resources/open_ai_plugins/akv-openai.json
@@ -12,7 +12,7 @@
     },
     "api": {
         "type": "openapi",
-        "url": "file:///./python/samples/kernel-syntax-examples/resources/open_ai_plugins/akv-openapi.yaml"
+        "url": "file:///./python/samples/concepts/resources/open_ai_plugins/akv-openapi.yaml"
     },
     "logo_url": "",
     "contact_email": "",

--- a/python/semantic_kernel/connectors/openapi_plugin/openapi_function_execution_parameters.py
+++ b/python/semantic_kernel/connectors/openapi_plugin/openapi_function_execution_parameters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Awaitable, Callable, List
 from urllib.parse import urlparse
 
+import httpx
 from pydantic import Field
 
 from semantic_kernel.kernel_pydantic import KernelBaseModel
@@ -15,7 +16,7 @@ AuthCallbackType = Callable[..., Awaitable[Any]]
 class OpenAPIFunctionExecutionParameters(KernelBaseModel):
     """OpenAPI function execution parameters."""
 
-    http_client: Any | None = None
+    http_client: httpx.AsyncClient | None = None
     auth_callback: AuthCallbackType | None = None
     server_url_override: str | None = None
     ignore_non_compliant_errors: bool = False

--- a/python/tests/unit/connectors/openapi/test_sk_openapi.py
+++ b/python/tests/unit/connectors/openapi/test_sk_openapi.py
@@ -323,7 +323,7 @@ def openapi_runner_with_auth_callback():
 
 
 @pytest.mark.asyncio
-@patch("aiohttp.ClientSession.request")
+@patch("httpx.AsyncClient.request")
 async def test_run_operation_with_auth_callback(mock_request, openapi_runner_with_auth_callback):
     runner, operations = openapi_runner_with_auth_callback
     operation = operations["addTodo"]
@@ -331,12 +331,13 @@ async def test_run_operation_with_auth_callback(mock_request, openapi_runner_wit
     request_body = {"title": "Buy milk", "completed": False}
 
     mock_response = AsyncMock()
-    mock_response.status = 200
-    mock_request.return_value.__aenter__.return_value = mock_response
+    mock_response.status_code = 200
+    mock_response.text = "response text"
+    mock_request.return_value = mock_response
 
     assert operation.server_url == "http://urloverride.com"
     response = await runner.run_operation(operation, headers=headers, request_body=request_body)
-    assert response is not None
+    assert response == "response text"
 
     _, kwargs = mock_request.call_args
 
@@ -344,29 +345,39 @@ async def test_run_operation_with_auth_callback(mock_request, openapi_runner_wit
     assert kwargs["headers"]["Authorization"] == "Bearer dummy-token"
 
 
-@patch("aiohttp.ClientSession.request")
 @pytest.mark.asyncio
+@patch("httpx.AsyncClient.request")
 async def test_run_operation_with_url_override(mock_request, openapi_runner_with_url_override):
     runner, operations = openapi_runner_with_url_override
     operation = operations["addTodo"]
     headers = {"Authorization": "Bearer abc123"}
     request_body = {"title": "Buy milk", "completed": False}
-    mock_request.return_value.__aenter__.return_value.text.return_value = 200
+
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.text = "response text"  # Simulate the text attribute directly
+    mock_request.return_value = mock_response
+
     assert operation.server_url == "http://urloverride.com"
     response = await runner.run_operation(operation, headers=headers, request_body=request_body)
-    assert response == 200
+    assert response == "response text"
 
 
-@patch("aiohttp.ClientSession.request")
 @pytest.mark.asyncio
+@patch("httpx.AsyncClient.request")
 async def test_run_operation_with_valid_request(mock_request, openapi_runner):
     runner, operations = openapi_runner
     operation = operations["addTodo"]
     headers = {"Authorization": "Bearer abc123"}
     request_body = {"title": "Buy milk", "completed": False}
-    mock_request.return_value.__aenter__.return_value.text.return_value = 200
+
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.text = "response text"
+    mock_request.return_value = mock_response
+
     response = await runner.run_operation(operation, headers=headers, request_body=request_body)
-    assert response == 200
+    assert response == "response text"
 
 
 @patch("aiohttp.ClientSession.request")

--- a/python/tests/unit/functions/test_kernel_plugins.py
+++ b/python/tests/unit/functions/test_kernel_plugins.py
@@ -511,7 +511,7 @@ async def test_from_openai_from_file(mock_parse_openai_manifest):
         plugin_name="TestOpenAIPlugin",
         plugin_str=openai_spec,
         execution_parameters=OpenAIFunctionExecutionParameters(
-            http_client=AsyncMock(),
+            http_client=AsyncMock(spec=httpx.AsyncClient),
             auth_callback=AsyncMock(),
             server_url_override="http://localhost",
             enable_dynamic_payload=True,

--- a/python/tests/unit/kernel/test_kernel.py
+++ b/python/tests/unit/kernel/test_kernel.py
@@ -5,6 +5,7 @@ import sys
 from typing import Union
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from semantic_kernel import Kernel
@@ -409,7 +410,7 @@ async def test_add_plugin_from_openai(mock_parse_openai_manifest, kernel: Kernel
         plugin_name="TestOpenAIPlugin",
         plugin_str=openai_spec,
         execution_parameters=OpenAIFunctionExecutionParameters(
-            http_client=AsyncMock(),
+            http_client=AsyncMock(spec=httpx.AsyncClient),
             auth_callback=AsyncMock(),
             server_url_override="http://localhost",
             enable_dynamic_payload=True,


### PR DESCRIPTION
### Motivation and Context

A custom client was used to get the openapi spec but it wasn't passed down into the openapi runner.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Pass the custom client into the open api runner if desired. Fix param parsing and samples.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
