### PR TITLE
Python: handle failing tool call gracefully

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -424,8 +424,13 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
         try:
             func_result = await kernel.invoke(**func.split_name_dict(), arguments=args_cloned)
         except Exception as exc:
-            logger.exception(f"Error occurred while invoking function {func.name}")
-            raise ServiceInvalidResponseError(f"Error occurred while invoking function {func.name}") from exc
+            logger.exception(f"Exception occurred while invoking function {func.name}, exception: {exc}")
+            frc = FunctionResultContent.from_function_call_content_and_result(
+                function_call_content=result,
+                result=f"Exception occurred while invoking function {func.name}, exception: {exc}",
+            )
+            chat_history.add_message(message=frc.to_chat_message_content())
+            return
         frc = FunctionResultContent.from_function_call_content_and_result(
             function_call_content=result, result=func_result
         )


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
When a function that was called using tool calling fails, it shouldn't drop the whole flow, this fixes that.

Fix #6260 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Creates a function result content item with the failing function and the error message, allowing the model to figure out if it wants to recall with different params.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
