### PR TITLE
.Net: fixed extension data in Model diagnostics

### DIFF
--- a/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
@@ -48,7 +48,6 @@ public sealed class Program
             .AddSource("Microsoft.SemanticKernel*")
             .AddSource("Telemetry.Example")
             .AddAzureMonitorTraceExporter(options => options.ConnectionString = connectionString)
-            .AddOtlpExporter(options => options.Endpoint = new Uri("http://localhost:4317"))
             .Build();
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()

--- a/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
@@ -297,6 +297,9 @@ public sealed class Program
                         GoogleAIGeminiServiceKey => new GeminiPromptExecutionSettings()
                         {
                             Temperature = 0,
+                            // Not show casing the AutoInvokeKernelFunctions behavior for Gemini due the following issue:
+                            // https://github.com/microsoft/semantic-kernel/issues/6282
+                            // ToolCallBehavior = GeminiToolCallBehavior.AutoInvokeKernelFunctions
                         },
                         HuggingFaceServiceKey => new HuggingFacePromptExecutionSettings()
                         {

--- a/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
@@ -48,6 +48,7 @@ public sealed class Program
             .AddSource("Microsoft.SemanticKernel*")
             .AddSource("Telemetry.Example")
             .AddAzureMonitorTraceExporter(options => options.ConnectionString = connectionString)
+            .AddOtlpExporter(options => options.Endpoint = new Uri("http://localhost:4317"))
             .Build();
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
@@ -294,8 +295,14 @@ public sealed class Program
                             Temperature = 0,
                             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
                         },
-                        GoogleAIGeminiServiceKey => new GeminiPromptExecutionSettings(),
-                        HuggingFaceServiceKey => new HuggingFacePromptExecutionSettings(),
+                        GoogleAIGeminiServiceKey => new GeminiPromptExecutionSettings()
+                        {
+                            Temperature = 0,
+                        },
+                        HuggingFaceServiceKey => new HuggingFacePromptExecutionSettings()
+                        {
+                            Temperature = 0,
+                        },
                         _ => null,
                     };
 

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -166,7 +166,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
             GeminiResponse geminiResponse;
             List<GeminiChatMessageContent> chatResponses;
             using (var activity = ModelDiagnostics.StartCompletionActivity(
-                this._chatGenerationEndpoint, this._modelId, ModelProvider, chatHistory, executionSettings))
+                this._chatGenerationEndpoint, this._modelId, ModelProvider, chatHistory, state.ExecutionSettings))
             {
                 try
                 {
@@ -227,7 +227,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
         for (state.Iteration = 1; ; state.Iteration++)
         {
             using (var activity = ModelDiagnostics.StartCompletionActivity(
-                this._chatGenerationEndpoint, this._modelId, ModelProvider, chatHistory, executionSettings))
+                this._chatGenerationEndpoint, this._modelId, ModelProvider, chatHistory, state.ExecutionSettings))
             {
                 HttpResponseMessage? httpResponseMessage = null;
                 Stream? responseStream = null;

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceClient.cs
@@ -134,7 +134,8 @@ internal sealed class HuggingFaceClient
         var endpoint = this.GetTextGenerationEndpoint(modelId);
         var request = this.CreateTextRequest(prompt, executionSettings);
 
-        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this.ModelProvider, prompt, executionSettings);
+        var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this.ModelProvider, prompt, huggingFaceExecutionSettings);
         using var httpRequestMessage = this.CreatePost(request, endpoint, this.ApiKey);
 
         TextGenerationResponse response;
@@ -169,7 +170,8 @@ internal sealed class HuggingFaceClient
         var request = this.CreateTextRequest(prompt, executionSettings);
         request.Stream = true;
 
-        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this.ModelProvider, prompt, executionSettings);
+        var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this.ModelProvider, prompt, huggingFaceExecutionSettings);
         HttpResponseMessage? httpResponseMessage = null;
         Stream? responseStream = null;
         try

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceClient.cs
@@ -132,9 +132,10 @@ internal sealed class HuggingFaceClient
     {
         string modelId = executionSettings?.ModelId ?? this.ModelId;
         var endpoint = this.GetTextGenerationEndpoint(modelId);
-        var request = this.CreateTextRequest(prompt, executionSettings);
 
         var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        var request = this.CreateTextRequest(prompt, huggingFaceExecutionSettings);
+
         using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this.ModelProvider, prompt, huggingFaceExecutionSettings);
         using var httpRequestMessage = this.CreatePost(request, endpoint, this.ApiKey);
 
@@ -155,7 +156,7 @@ internal sealed class HuggingFaceClient
         var textContents = GetTextContentsFromResponse(response, modelId);
 
         activity?.SetCompletionResponse(textContents);
-        this.LogTextGenerationUsage(executionSettings);
+        this.LogTextGenerationUsage(huggingFaceExecutionSettings);
 
         return textContents;
     }
@@ -167,10 +168,11 @@ internal sealed class HuggingFaceClient
     {
         string modelId = executionSettings?.ModelId ?? this.ModelId;
         var endpoint = this.GetTextGenerationEndpoint(modelId);
-        var request = this.CreateTextRequest(prompt, executionSettings);
-        request.Stream = true;
 
         var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        var request = this.CreateTextRequest(prompt, huggingFaceExecutionSettings);
+        request.Stream = true;
+
         using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this.ModelProvider, prompt, huggingFaceExecutionSettings);
         HttpResponseMessage? httpResponseMessage = null;
         Stream? responseStream = null;
@@ -241,9 +243,8 @@ internal sealed class HuggingFaceClient
 
     private TextGenerationRequest CreateTextRequest(
         string prompt,
-        PromptExecutionSettings? promptExecutionSettings)
+        HuggingFacePromptExecutionSettings huggingFaceExecutionSettings)
     {
-        var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(promptExecutionSettings);
         ValidateMaxNewTokens(huggingFaceExecutionSettings.MaxNewTokens);
         var request = TextGenerationRequest.FromPromptAndExecutionSettings(prompt, huggingFaceExecutionSettings);
         return request;
@@ -255,13 +256,13 @@ internal sealed class HuggingFaceClient
     private static List<TextContent> GetTextContentsFromResponse(ImageToTextGenerationResponse response, string modelId)
         => response.Select(r => new TextContent(r.GeneratedText, modelId, r, Encoding.UTF8)).ToList();
 
-    private void LogTextGenerationUsage(PromptExecutionSettings? executionSettings)
+    private void LogTextGenerationUsage(HuggingFacePromptExecutionSettings executionSettings)
     {
         if (this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger?.LogDebug(
+            this.Logger.LogDebug(
                 "HuggingFace text generation usage: ModelId: {ModelId}",
-                executionSettings?.ModelId ?? this.ModelId);
+                executionSettings.ModelId ?? this.ModelId);
         }
     }
     private Uri GetTextGenerationEndpoint(string modelId)

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceMessageApiClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceMessageApiClient.cs
@@ -82,10 +82,13 @@ internal sealed class HuggingFaceMessageApiClient
     {
         string modelId = executionSettings?.ModelId ?? this._clientCore.ModelId;
         var endpoint = this.GetChatGenerationEndpoint();
-        var request = this.CreateChatRequest(chatHistory, executionSettings);
-        request.Stream = true;
 
         var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        huggingFaceExecutionSettings.ModelId ??= this._clientCore.ModelId;
+
+        var request = this.CreateChatRequest(chatHistory, huggingFaceExecutionSettings);
+        request.Stream = true;
+
         using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this._clientCore.ModelProvider, chatHistory, huggingFaceExecutionSettings);
         HttpResponseMessage? httpResponseMessage = null;
         Stream? responseStream = null;
@@ -143,9 +146,11 @@ internal sealed class HuggingFaceMessageApiClient
     {
         string modelId = executionSettings?.ModelId ?? this._clientCore.ModelId;
         var endpoint = this.GetChatGenerationEndpoint();
-        var request = this.CreateChatRequest(chatHistory, executionSettings);
 
         var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        huggingFaceExecutionSettings.ModelId ??= this._clientCore.ModelId;
+        var request = this.CreateChatRequest(chatHistory, huggingFaceExecutionSettings);
+
         using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this._clientCore.ModelProvider, chatHistory, huggingFaceExecutionSettings);
         using var httpRequestMessage = this._clientCore.CreatePost(request, endpoint, this._clientCore.ApiKey);
 
@@ -166,12 +171,12 @@ internal sealed class HuggingFaceMessageApiClient
         var chatContents = GetChatMessageContentsFromResponse(response, modelId);
 
         activity?.SetCompletionResponse(chatContents, response.Usage?.PromptTokens, response.Usage?.CompletionTokens);
-        this.LogChatCompletionUsage(executionSettings, response);
+        this.LogChatCompletionUsage(huggingFaceExecutionSettings, response);
 
         return chatContents;
     }
 
-    private void LogChatCompletionUsage(PromptExecutionSettings? executionSettings, ChatCompletionResponse chatCompletionResponse)
+    private void LogChatCompletionUsage(HuggingFacePromptExecutionSettings executionSettings, ChatCompletionResponse chatCompletionResponse)
     {
         if (this._clientCore.Logger.IsEnabled(LogLevel.Debug))
         {
@@ -265,11 +270,8 @@ internal sealed class HuggingFaceMessageApiClient
 
     private ChatCompletionRequest CreateChatRequest(
         ChatHistory chatHistory,
-        PromptExecutionSettings? promptExecutionSettings)
+        HuggingFacePromptExecutionSettings huggingFaceExecutionSettings)
     {
-        var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(promptExecutionSettings);
-        huggingFaceExecutionSettings.ModelId ??= this._clientCore.ModelId;
-
         HuggingFaceClient.ValidateMaxTokens(huggingFaceExecutionSettings.MaxTokens);
         var request = ChatCompletionRequest.FromChatHistoryAndExecutionSettings(chatHistory, huggingFaceExecutionSettings);
         return request;

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceMessageApiClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceMessageApiClient.cs
@@ -85,7 +85,8 @@ internal sealed class HuggingFaceMessageApiClient
         var request = this.CreateChatRequest(chatHistory, executionSettings);
         request.Stream = true;
 
-        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this._clientCore.ModelProvider, chatHistory, executionSettings);
+        var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this._clientCore.ModelProvider, chatHistory, huggingFaceExecutionSettings);
         HttpResponseMessage? httpResponseMessage = null;
         Stream? responseStream = null;
         try
@@ -144,7 +145,8 @@ internal sealed class HuggingFaceMessageApiClient
         var endpoint = this.GetChatGenerationEndpoint();
         var request = this.CreateChatRequest(chatHistory, executionSettings);
 
-        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this._clientCore.ModelProvider, chatHistory, executionSettings);
+        var huggingFaceExecutionSettings = HuggingFacePromptExecutionSettings.FromExecutionSettings(executionSettings);
+        using var activity = ModelDiagnostics.StartCompletionActivity(endpoint, modelId, this._clientCore.ModelProvider, chatHistory, huggingFaceExecutionSettings);
         using var httpRequestMessage = this._clientCore.CreatePost(request, endpoint, this._clientCore.ApiKey);
 
         ChatCompletionResponse response;

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -138,7 +138,7 @@ internal abstract class ClientCore
 
         Completions? responseData = null;
         List<TextContent> responseContent;
-        using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, prompt, executionSettings))
+        using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, prompt, textExecutionSettings))
         {
             try
             {
@@ -183,7 +183,7 @@ internal abstract class ClientCore
 
         var options = CreateCompletionsOptions(prompt, textExecutionSettings, this.DeploymentOrModelName);
 
-        using var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, prompt, executionSettings);
+        using var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, prompt, textExecutionSettings);
 
         StreamingResponse<Completions> response;
         try
@@ -391,7 +391,7 @@ internal abstract class ClientCore
             // Make the request.
             ChatCompletions? responseData = null;
             List<OpenAIChatMessageContent> responseContent;
-            using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, chat, executionSettings))
+            using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, chat, chatExecutionSettings))
             {
                 try
                 {
@@ -663,7 +663,7 @@ internal abstract class ClientCore
             ChatRole? streamedRole = default;
             CompletionsFinishReason finishReason = default;
 
-            using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, chat, executionSettings))
+            using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, chat, chatExecutionSettings))
             {
                 // Make the request.
                 StreamingResponse<StreamingChatCompletionsUpdate> response;

--- a/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
@@ -39,25 +39,27 @@ internal static class ModelDiagnostics
     /// Start a text completion activity for a given model.
     /// The activity will be tagged with the a set of attributes specified by the semantic conventions.
     /// </summary>
-    public static Activity? StartCompletionActivity<T>(
+    public static Activity? StartCompletionActivity<TPromptExecutionSettings>(
         Uri? endpoint,
         string modelName,
         string modelProvider,
         string prompt,
-        T? executionSettings
-    ) where T : PromptExecutionSettings => StartCompletionActivity(endpoint, modelName, modelProvider, prompt, executionSettings, prompt => prompt);
+        TPromptExecutionSettings? executionSettings
+    ) where TPromptExecutionSettings : PromptExecutionSettings
+        => StartCompletionActivity(endpoint, modelName, modelProvider, prompt, executionSettings, prompt => prompt);
 
     /// <summary>
     /// Start a chat completion activity for a given model.
     /// The activity will be tagged with the a set of attributes specified by the semantic conventions.
     /// </summary>
-    public static Activity? StartCompletionActivity<T>(
+    public static Activity? StartCompletionActivity<TPromptExecutionSettings>(
         Uri? endpoint,
         string modelName,
         string modelProvider,
         ChatHistory chatHistory,
-        T? executionSettings
-    ) where T : PromptExecutionSettings => StartCompletionActivity(endpoint, modelName, modelProvider, chatHistory, executionSettings, ToOpenAIFormat);
+        TPromptExecutionSettings? executionSettings
+    ) where TPromptExecutionSettings : PromptExecutionSettings
+        => StartCompletionActivity(endpoint, modelName, modelProvider, chatHistory, executionSettings, ToOpenAIFormat);
 
     /// <summary>
     /// Set the text completion response for a given activity.
@@ -119,7 +121,8 @@ internal static class ModelDiagnostics
     }
 
     #region Private
-    private static void AddOptionalTags<T>(Activity? activity, T? executionSettings) where T : PromptExecutionSettings
+    private static void AddOptionalTags<TPromptExecutionSettings>(Activity? activity, TPromptExecutionSettings? executionSettings)
+        where TPromptExecutionSettings : PromptExecutionSettings
     {
         if (activity is null || executionSettings is null)
         {
@@ -211,13 +214,13 @@ internal static class ModelDiagnostics
     /// Start a completion activity and return the activity.
     /// The `formatPrompt` delegate won't be invoked if events are disabled.
     /// </summary>
-    private static Activity? StartCompletionActivity<T1, T2>(
+    private static Activity? StartCompletionActivity<TPrompt, TPromptExecutionSettings>(
         Uri? endpoint,
         string modelName,
         string modelProvider,
-        T1 prompt,
-        T2? executionSettings,
-        Func<T1, string> formatPrompt) where T2 : PromptExecutionSettings
+        TPrompt prompt,
+        TPromptExecutionSettings? executionSettings,
+        Func<TPrompt, string> formatPrompt) where TPromptExecutionSettings : PromptExecutionSettings
     {
         if (!IsModelDiagnosticsEnabled())
         {


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Previously when an AI client starts a model diagnostics activity, it passes in an execution setting that is not parsed to a setting that is specific to the client. This creates an issue where the some of the settings cannot be read by the diagnostics module.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Pass in the parsed setting to the diagnostics module. The diagnostics module will the serialize the object and deserialize it to `PromptExecutionSettings` to get the extension data.

![image](https://github.com/microsoft/semantic-kernel/assets/12570346/e64d5e70-94d2-4cad-ae34-aeb249f62f58)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
