### PR TITLE
Python: Create an experimental class and function decorator.

### DIFF
--- a/python/samples/concepts/logging/setup_logging.py
+++ b/python/samples/concepts/logging/setup_logging.py
@@ -5,7 +5,7 @@ import os
 
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
-from semantic_kernel.utils.sk_logging import setup_logging
+from semantic_kernel.utils.logging import setup_logging
 
 
 async def main():

--- a/python/samples/concepts/logging/setup_logging.py
+++ b/python/samples/concepts/logging/setup_logging.py
@@ -5,7 +5,7 @@ import os
 
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
-from semantic_kernel.utils.logging import setup_logging
+from semantic_kernel.utils.sk_logging import setup_logging
 
 
 async def main():

--- a/python/semantic_kernel/utils/experimental_decorator.py
+++ b/python/semantic_kernel/utils/experimental_decorator.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import types
+from typing import Callable, Type
+
+
+def experimental_function(func: Callable) -> Callable:
+    if isinstance(func, types.FunctionType):
+        if func.__doc__:
+            func.__doc__ += "\n\nNote: This function is experimental and may change in the future."
+        else:
+            func.__doc__ = "Note: This function is experimental and may change in the future."
+
+        func.is_experimental = True
+
+    return func
+
+
+def experimental_class(cls: Type) -> Type:
+    if isinstance(cls, type):
+        if cls.__doc__:
+            cls.__doc__ += "\n\nNote: This class is experimental and may change in the future."
+        else:
+            cls.__doc__ = "Note: This class is experimental and may change in the future."
+
+        cls.is_experimental = True
+
+    return cls

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -95,6 +95,20 @@ def custom_plugin_class():
 
 
 @pytest.fixture(scope="session")
+def experimental_plugin_class():
+    from semantic_kernel.functions.kernel_function_decorator import kernel_function
+    from semantic_kernel.utils.experimental_decorator import experimental_class
+
+    @experimental_class
+    class ExperimentalPlugin:
+        @kernel_function(name="getLightStatus")
+        def decorated_native_function(self) -> str:
+            return "test"
+
+    return ExperimentalPlugin
+
+
+@pytest.fixture(scope="session")
 def create_mock_function() -> Callable:
     from semantic_kernel.contents.streaming_text_content import StreamingTextContent
     from semantic_kernel.functions.function_result import FunctionResult

--- a/python/tests/unit/functions/test_kernel_experimental_decorator.py
+++ b/python/tests/unit/functions/test_kernel_experimental_decorator.py
@@ -1,0 +1,31 @@
+# # Copyright (c) Microsoft. All rights reserved.
+
+from semantic_kernel.utils.experimental_decorator import (
+    experimental_function,
+)
+
+
+@experimental_function
+def my_function() -> None:
+    """This is a sample function docstring."""
+    pass
+
+
+@experimental_function
+def my_function_no_doc_string() -> None:
+    pass
+
+
+def test_function_experimental_decorator() -> None:
+    assert (
+        my_function.__doc__
+        == "This is a sample function docstring.\n\nNote: This function is experimental and may change in the future."
+    )  # noqa: E501
+    assert hasattr(my_function, "is_experimental")
+    assert my_function.is_experimental is True
+
+
+def test_function_experimental_decorator_with_no_doc_string() -> None:
+    assert my_function_no_doc_string.__doc__ == "Note: This function is experimental and may change in the future."
+    assert hasattr(my_function_no_doc_string, "is_experimental")
+    assert my_function_no_doc_string.is_experimental is True

--- a/python/tests/unit/functions/test_kernel_function_decorators.py
+++ b/python/tests/unit/functions/test_kernel_function_decorators.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft. All rights reserved.
+
 from typing import TYPE_CHECKING, Annotated, Any, AsyncGenerator, AsyncIterable, Optional, Union
 
 import pytest

--- a/python/tests/unit/kernel/test_kernel.py
+++ b/python/tests/unit/kernel/test_kernel.py
@@ -590,3 +590,13 @@ def test_instantiate_prompt_execution_settings_through_kernel(kernel_with_servic
 
 
 # endregion
+# experimental class decorator
+
+
+def test_experimental_class_has_decorator_and_flag(experimental_plugin_class):
+    assert hasattr(experimental_plugin_class, "is_experimental")
+    assert experimental_plugin_class.is_experimental
+    assert "This class is experimental and may change in the future." in experimental_plugin_class.__doc__
+
+
+# endregion


### PR DESCRIPTION
### Motivation and Context

There may be classes or functions inside of SK Python that should be deemed as experimental. Currently in Python there is no out-of-the-box way to get the decorator.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

As there is a name clash with using `experimental` as the decorator name, we are introducing two decorators: one `experimental_class` and one `experimental_function`. The note that "This {function | class} is experimental and may change in the future" is included in the docstring and a bool `is_experimental` on the class is added.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
