### PR TITLE
.Net: Include streaming tool call information in model diagnostics

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -724,7 +724,7 @@ internal abstract class ClientCore
                     toolCalls = OpenAIFunctionToolCall.ConvertToolCallUpdatesToChatCompletionsFunctionToolCalls(
                         ref toolCallIdsByIndex, ref functionNamesByIndex, ref functionArgumentBuildersByIndex);
                     // Translate all entries into FunctionCallContent instances for diagnostics purposes.
-                    functionCallContents = activity is null ? null : toolCalls.Select(this.GetFunctionCallContent).ToArray();
+                    functionCallContents = ModelDiagnostics.IsSensitiveEventsEnabled() ? toolCalls.Select(this.GetFunctionCallContent).ToArray() : null;
                 }
                 finally
                 {

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -662,6 +662,8 @@ internal abstract class ClientCore
             string? streamedName = null;
             ChatRole? streamedRole = default;
             CompletionsFinishReason finishReason = default;
+            ChatCompletionsFunctionToolCall[]? toolCalls = null;
+            FunctionCallContent[]? functionCallContents = null;
 
             using (var activity = ModelDiagnostics.StartCompletionActivity(this.Endpoint, this.DeploymentOrModelName, ModelProvider, chat, chatExecutionSettings))
             {
@@ -717,10 +719,16 @@ internal abstract class ClientCore
                         streamedContents?.Add(openAIStreamingChatMessageContent);
                         yield return openAIStreamingChatMessageContent;
                     }
+
+                    // Translate all entries into ChatCompletionsFunctionToolCall instances.
+                    toolCalls = OpenAIFunctionToolCall.ConvertToolCallUpdatesToChatCompletionsFunctionToolCalls(
+                        ref toolCallIdsByIndex, ref functionNamesByIndex, ref functionArgumentBuildersByIndex);
+                    // Translate all entries into FunctionCallContent instances for diagnostics purposes.
+                    functionCallContents = activity is null ? null : toolCalls.Select(this.GetFunctionCallContent).ToArray();
                 }
                 finally
                 {
-                    activity?.EndStreaming(streamedContents);
+                    activity?.EndStreaming(streamedContents, functionCallContents);
                     await responseEnumerator.DisposeAsync();
                 }
             }
@@ -738,10 +746,6 @@ internal abstract class ClientCore
             // Get any response content that was streamed.
             string content = contentBuilder?.ToString() ?? string.Empty;
 
-            // Translate all entries into ChatCompletionsFunctionToolCall instances.
-            ChatCompletionsFunctionToolCall[] toolCalls = OpenAIFunctionToolCall.ConvertToolCallUpdatesToChatCompletionsFunctionToolCalls(
-                ref toolCallIdsByIndex, ref functionNamesByIndex, ref functionArgumentBuildersByIndex);
-
             // Log the requests
             if (this.Logger.IsEnabled(LogLevel.Trace))
             {
@@ -755,7 +759,17 @@ internal abstract class ClientCore
             // Add the original assistant message to the chatOptions; this is required for the service
             // to understand the tool call responses.
             chatOptions.Messages.Add(GetRequestMessage(streamedRole ?? default, content, streamedName, toolCalls));
-            chat.Add(new OpenAIChatMessageContent(streamedRole ?? default, content, this.DeploymentOrModelName, toolCalls, metadata) { AuthorName = streamedName });
+            // Add the result message to the caller's chat history
+            var newChatMessageContent = new OpenAIChatMessageContent(streamedRole ?? default, content, this.DeploymentOrModelName, toolCalls, metadata)
+            {
+                AuthorName = streamedName
+            };
+            // Add the tool call messages to the new chat message content for diagnostics purposes.
+            foreach (var functionCall in functionCallContents ?? [])
+            {
+                newChatMessageContent.Items.Add(functionCall);
+            }
+            chat.Add(newChatMessageContent);
 
             // Respond to each tooling request.
             for (int toolCallIndex = 0; toolCallIndex < toolCalls.Length; toolCallIndex++)
@@ -1350,48 +1364,52 @@ internal abstract class ClientCore
             // This allows consumers to work with functions in an LLM-agnostic way.
             if (toolCall is ChatCompletionsFunctionToolCall functionToolCall)
             {
-                Exception? exception = null;
-                KernelArguments? arguments = null;
-                try
-                {
-                    arguments = JsonSerializer.Deserialize<KernelArguments>(functionToolCall.Arguments);
-                    if (arguments is not null)
-                    {
-                        // Iterate over copy of the names to avoid mutating the dictionary while enumerating it
-                        var names = arguments.Names.ToArray();
-                        foreach (var name in names)
-                        {
-                            arguments[name] = arguments[name]?.ToString();
-                        }
-                    }
-                }
-                catch (JsonException ex)
-                {
-                    exception = new KernelException("Error: Function call arguments were invalid JSON.", ex);
-
-                    if (this.Logger.IsEnabled(LogLevel.Debug))
-                    {
-                        this.Logger.LogDebug(ex, "Failed to deserialize function arguments ({FunctionName}/{FunctionId}).", functionToolCall.Name, functionToolCall.Id);
-                    }
-                }
-
-                var functionName = FunctionName.Parse(functionToolCall.Name, OpenAIFunction.NameSeparator);
-
-                var functionCallContent = new FunctionCallContent(
-                    functionName: functionName.Name,
-                    pluginName: functionName.PluginName,
-                    id: functionToolCall.Id,
-                    arguments: arguments)
-                {
-                    InnerContent = functionToolCall,
-                    Exception = exception
-                };
-
+                var functionCallContent = this.GetFunctionCallContent(functionToolCall);
                 message.Items.Add(functionCallContent);
             }
         }
 
         return message;
+    }
+
+    private FunctionCallContent GetFunctionCallContent(ChatCompletionsFunctionToolCall toolCall)
+    {
+        KernelArguments? arguments = null;
+        Exception? exception = null;
+        try
+        {
+            arguments = JsonSerializer.Deserialize<KernelArguments>(toolCall.Arguments);
+            if (arguments is not null)
+            {
+                // Iterate over copy of the names to avoid mutating the dictionary while enumerating it
+                var names = arguments.Names.ToArray();
+                foreach (var name in names)
+                {
+                    arguments[name] = arguments[name]?.ToString();
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            exception = new KernelException("Error: Function call arguments were invalid JSON.", ex);
+
+            if (this.Logger.IsEnabled(LogLevel.Debug))
+            {
+                this.Logger.LogDebug(ex, "Failed to deserialize function arguments ({FunctionName}/{FunctionId}).", toolCall.Name, toolCall.Id);
+            }
+        }
+
+        var functionName = FunctionName.Parse(toolCall.Name, OpenAIFunction.NameSeparator);
+
+        return new FunctionCallContent(
+            functionName: functionName.Name,
+            pluginName: functionName.PluginName,
+            id: toolCall.Id,
+            arguments: arguments)
+        {
+            InnerContent = toolCall,
+            Exception = exception
+        };
     }
 
     private static void ValidateMaxTokens(int? maxTokens)

--- a/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
@@ -125,6 +125,12 @@ internal static class ModelDiagnostics
         return (s_enableDiagnostics || s_enableSensitiveEvents) && s_activitySource.HasListeners();
     }
 
+    /// <summary>
+    /// Check if sensitive events are enabled.
+    /// Sensitive events are enabled if EnableSensitiveEvents is set to true and there are listeners.
+    /// </summary>
+    public static bool IsSensitiveEventsEnabled() => s_enableSensitiveEvents && s_activitySource.HasListeners();
+
     #region Private
     private static void AddOptionalTags<TPromptExecutionSettings>(Activity? activity, TPromptExecutionSettings? executionSettings)
         where TPromptExecutionSettings : PromptExecutionSettings


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Tool call information is currently not included in the model diagnostics when using the streaming APIs.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Record OpenAI tool call information in model diagnostics for the streaming API.
2. If there is no tool call information, do not record an empty entry.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
