### PR TITLE
.Net: Fix MistralAI logging

### DIFF
--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceMessageApiClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceMessageApiClient.cs
@@ -27,7 +27,7 @@ internal sealed class HuggingFaceMessageApiClient
 {
     private readonly HuggingFaceClient _clientCore;
 
-    private static readonly string s_namespace = typeof(HuggingFaceMessageApiClient).Namespace!;
+    private static readonly string s_namespace = typeof(HuggingFaceChatCompletionService).Namespace!;
 
     /// <summary>
     /// Instance of <see cref="Meter"/> for metrics.
@@ -179,20 +179,25 @@ internal sealed class HuggingFaceMessageApiClient
 
     private void LogChatCompletionUsage(HuggingFacePromptExecutionSettings executionSettings, ChatCompletionResponse chatCompletionResponse)
     {
-        if (this._clientCore.Logger.IsEnabled(LogLevel.Debug))
+        if (chatCompletionResponse.Usage is null)
         {
-            this._clientCore.Logger.Log(
-            LogLevel.Debug,
-            "HuggingFace chat completion usage - ModelId: {ModelId}, Prompt tokens: {PromptTokens}, Completion tokens: {CompletionTokens}, Total tokens: {TotalTokens}",
-            chatCompletionResponse.Model,
-            chatCompletionResponse.Usage!.PromptTokens,
-            chatCompletionResponse.Usage!.CompletionTokens,
-            chatCompletionResponse.Usage!.TotalTokens);
+            this._clientCore.Logger.LogDebug("Token usage information unavailable.");
+            return;
         }
 
-        s_promptTokensCounter.Add(chatCompletionResponse.Usage!.PromptTokens);
-        s_completionTokensCounter.Add(chatCompletionResponse.Usage!.CompletionTokens);
-        s_totalTokensCounter.Add(chatCompletionResponse.Usage!.TotalTokens);
+        if (this._clientCore.Logger.IsEnabled(LogLevel.Information))
+        {
+            this._clientCore.Logger.LogInformation(
+                "Prompt tokens: {PromptTokens}. Completion tokens: {CompletionTokens}. Total tokens: {TotalTokens}. ModelId: {ModelId}.",
+                chatCompletionResponse.Usage.PromptTokens,
+                chatCompletionResponse.Usage.CompletionTokens,
+                chatCompletionResponse.Usage.TotalTokens,
+                chatCompletionResponse.Model);
+        }
+
+        s_promptTokensCounter.Add(chatCompletionResponse.Usage.PromptTokens);
+        s_completionTokensCounter.Add(chatCompletionResponse.Usage.CompletionTokens);
+        s_totalTokensCounter.Add(chatCompletionResponse.Usage.TotalTokens);
     }
 
     private static List<ChatMessageContent> GetChatMessageContentsFromResponse(ChatCompletionResponse response, string modelId)

--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -26,8 +27,6 @@ namespace Microsoft.SemanticKernel.Connectors.MistralAI.Client;
 /// </summary>
 internal sealed class MistralClient
 {
-    private const string ModelProvider = "mistralai";
-
     internal MistralClient(
         string modelId,
         HttpClient httpClient,
@@ -67,6 +66,7 @@ internal sealed class MistralClient
                 {
                     using var httpRequestMessage = this.CreatePost(chatRequest, endpoint, this._apiKey, stream: false);
                     responseData = await this.SendRequestAsync<ChatCompletionResponse>(httpRequestMessage, cancellationToken).ConfigureAwait(false);
+                    this.LogUsage(responseData?.Usage);
                     if (responseData is null || responseData.Choices is null || responseData.Choices.Count == 0)
                     {
                         throw new KernelException("Chat completions not found");
@@ -572,6 +572,9 @@ internal sealed class MistralClient
     private readonly ILogger _logger;
     private readonly StreamJsonParser _streamJsonParser;
 
+    /// <summary>Provider name used for diagnostics.</summary>
+    private const string ModelProvider = "mistralai";
+
     /// <summary>
     /// The maximum number of auto-invokes that can be in-flight at any given time as part of the current
     /// asynchronous chain of execution.
@@ -592,6 +595,63 @@ internal sealed class MistralClient
 
     /// <summary>Tracking <see cref="AsyncLocal{Int32}"/> for <see cref="MaxInflightAutoInvokes"/>.</summary>
     private static readonly AsyncLocal<int> s_inflightAutoInvokes = new();
+
+    private static readonly string s_namespace = typeof(MistralAIChatCompletionService).Namespace!;
+
+    /// <summary>
+    /// Instance of <see cref="Meter"/> for metrics.
+    /// </summary>
+    private static readonly Meter s_meter = new(s_namespace);
+
+    /// <summary>
+    /// Instance of <see cref="Counter{T}"/> to keep track of the number of prompt tokens used.
+    /// </summary>
+    private static readonly Counter<int> s_promptTokensCounter =
+        s_meter.CreateCounter<int>(
+            name: $"{s_namespace}.tokens.prompt",
+            unit: "{token}",
+            description: "Number of prompt tokens used");
+
+    /// <summary>
+    /// Instance of <see cref="Counter{T}"/> to keep track of the number of completion tokens used.
+    /// </summary>
+    private static readonly Counter<int> s_completionTokensCounter =
+        s_meter.CreateCounter<int>(
+            name: $"{s_namespace}.tokens.completion",
+            unit: "{token}",
+            description: "Number of completion tokens used");
+
+    /// <summary>
+    /// Instance of <see cref="Counter{T}"/> to keep track of the total number of tokens used.
+    /// </summary>
+    private static readonly Counter<int> s_totalTokensCounter =
+        s_meter.CreateCounter<int>(
+            name: $"{s_namespace}.tokens.total",
+            unit: "{token}",
+            description: "Number of tokens used");
+
+    /// <summary>Log token usage to the logger and metrics.</summary>
+    private void LogUsage(MistralUsage? usage)
+    {
+        if (usage is null || usage.PromptTokens is null || usage.CompletionTokens is null || usage.TotalTokens is null)
+        {
+            this._logger.LogDebug("Usage information unavailable.");
+            return;
+        }
+
+        if (this._logger.IsEnabled(LogLevel.Information))
+        {
+            this._logger.LogInformation(
+                "Prompt tokens: {PromptTokens}. Completion tokens: {CompletionTokens}. Total tokens: {TotalTokens}.",
+                usage.PromptTokens,
+                usage.CompletionTokens,
+                usage.TotalTokens);
+        }
+
+        s_promptTokensCounter.Add(usage.PromptTokens.Value);
+        s_completionTokensCounter.Add(usage.CompletionTokens.Value);
+        s_totalTokensCounter.Add(usage.TotalTokens.Value);
+    }
 
     /// <summary>
     /// Messages are required and the first prompt role should be user or system.

--- a/dotnet/src/Connectors/Connectors.MistralAI/MistralAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/MistralAIKernelBuilderExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.MistralAI;
 using Microsoft.SemanticKernel.Embeddings;
@@ -38,7 +39,7 @@ public static class MistralAIKernelBuilderExtensions
         Verify.NotNullOrWhiteSpace(apiKey);
 
         builder.Services.AddKeyedSingleton<IChatCompletionService>(serviceId, (serviceProvider, _) =>
-            new MistralAIChatCompletionService(modelId, apiKey, endpoint, HttpClientProvider.GetHttpClient(httpClient, serviceProvider)));
+            new MistralAIChatCompletionService(modelId, apiKey, endpoint, HttpClientProvider.GetHttpClient(httpClient, serviceProvider), serviceProvider.GetService<ILoggerFactory>()));
 
         return builder;
     }
@@ -64,7 +65,7 @@ public static class MistralAIKernelBuilderExtensions
         Verify.NotNull(builder);
 
         builder.Services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
-            new MistralAITextEmbeddingGenerationService(modelId, apiKey, endpoint, HttpClientProvider.GetHttpClient(httpClient, serviceProvider)));
+            new MistralAITextEmbeddingGenerationService(modelId, apiKey, endpoint, HttpClientProvider.GetHttpClient(httpClient, serviceProvider), serviceProvider.GetService<ILoggerFactory>()));
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -166,7 +166,7 @@ internal abstract class ClientCore
             activity?.SetCompletionResponse(responseContent, responseData.Usage.PromptTokens, responseData.Usage.CompletionTokens);
         }
 
-        this.CaptureUsageDetails(responseData.Usage);
+        this.LogUsage(responseData.Usage);
 
         return responseContent;
     }
@@ -396,7 +396,7 @@ internal abstract class ClientCore
                 try
                 {
                     responseData = (await RunRequestAsync(() => this.Client.GetChatCompletionsAsync(chatOptions, cancellationToken)).ConfigureAwait(false)).Value;
-                    this.CaptureUsageDetails(responseData.Usage);
+                    this.LogUsage(responseData.Usage);
                     if (responseData.Choices.Count == 0)
                     {
                         throw new KernelException("Chat completions not found");
@@ -1435,11 +1435,11 @@ internal abstract class ClientCore
     /// Captures usage details, including token information.
     /// </summary>
     /// <param name="usage">Instance of <see cref="CompletionsUsage"/> with usage details.</param>
-    private void CaptureUsageDetails(CompletionsUsage usage)
+    private void LogUsage(CompletionsUsage usage)
     {
         if (usage is null)
         {
-            this.Logger.LogDebug("Usage information is not available.");
+            this.Logger.LogDebug("Token usage information unavailable.");
             return;
         }
 


### PR DESCRIPTION
- The logger factory wasn't being forwarded to the chat completion service instance
- The class wasn't logging tokens like the other connectors

Also made the others consistent in verbiage, metrics namespace, etc.