### PR TITLE
.Net: Fix PlatformNotSupportedException from HttpClientProvider

### DIFF
--- a/dotnet/src/InternalUtilities/src/Http/HttpClientProvider.cs
+++ b/dotnet/src/InternalUtilities/src/Http/HttpClientProvider.cs
@@ -91,11 +91,13 @@ internal static class HttpClientProvider
 #else
         private static HttpClientHandler CreateHandler()
         {
-            return new HttpClientHandler()
+            var handler = new HttpClientHandler();
+            try
             {
-                // Check cert revocation
-                CheckCertificateRevocationList = true,
-            };
+                handler.CheckCertificateRevocationList = true;
+            }
+            catch (PlatformNotSupportedException) { } // not supported on older frameworks
+            return handler;
         }
 #endif
     }


### PR DESCRIPTION
On older .NET Frameworks, CheckCertificateRevocationList may not be supported.
https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler.checkcertificaterevocationlist?view=net-8.0#exceptions