### PR TITLE
.Net: Enable unit tests to build and pass on .NET Framework

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <!-- Tokenizers -->

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/Connectors.AzureAISearch.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/Connectors.AzureAISearch.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.AzureAISearch.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.AzureAISearch.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Connectors.Google.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Connectors.Google.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.GoogleVertexAI.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.GoogleVertexAI.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/AuthorRoleConverterTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/AuthorRoleConverterTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers;
+using System.IO;
 using System.Text.Json;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Google.Core;
@@ -94,14 +95,15 @@ public sealed class AuthorRoleConverterTests
     {
         // Arrange
         var converter = new AuthorRoleConverter();
-        var bufferWriter = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(bufferWriter);
+        var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
 
         // Act
         converter.Write(writer, AuthorRole.User, JsonSerializerOptions.Default);
+        writer.Flush();
 
         // Assert
-        Assert.Equal("\"user\""u8, bufferWriter.GetSpan().Trim((byte)'\0'));
+        Assert.Equal("\"user\""u8.ToArray(), stream.ToArray());
     }
 
     [Fact]
@@ -109,14 +111,15 @@ public sealed class AuthorRoleConverterTests
     {
         // Arrange
         var converter = new AuthorRoleConverter();
-        var bufferWriter = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(bufferWriter);
+        var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
 
         // Act
         converter.Write(writer, AuthorRole.Assistant, JsonSerializerOptions.Default);
+        writer.Flush();
 
         // Assert
-        Assert.Equal("\"model\""u8, bufferWriter.GetSpan().Trim((byte)'\0'));
+        Assert.Equal("\"model\""u8.ToArray(), stream.ToArray());
     }
 
     [Fact]
@@ -124,14 +127,15 @@ public sealed class AuthorRoleConverterTests
     {
         // Arrange
         var converter = new AuthorRoleConverter();
-        var bufferWriter = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(bufferWriter);
+        var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
 
         // Act
         converter.Write(writer, AuthorRole.Tool, JsonSerializerOptions.Default);
+        writer.Flush();
 
         // Assert
-        Assert.Equal("\"function\""u8, bufferWriter.GetSpan().Trim((byte)'\0'));
+        Assert.Equal("\"function\""u8.ToArray(), stream.ToArray());
     }
 
     [Fact]
@@ -139,14 +143,15 @@ public sealed class AuthorRoleConverterTests
     {
         // Arrange
         var converter = new AuthorRoleConverter();
-        var bufferWriter = new ArrayBufferWriter<byte>();
-        using var writer = new Utf8JsonWriter(bufferWriter);
+        var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
 
         // Act
         converter.Write(writer, null, JsonSerializerOptions.Default);
+        writer.Flush();
 
         // Assert
-        Assert.Equal("null"u8, bufferWriter.GetSpan().Trim((byte)'\0'));
+        Assert.Equal("null"u8.ToArray(), stream.ToArray());
     }
 
     [Fact]
@@ -154,7 +159,8 @@ public sealed class AuthorRoleConverterTests
     {
         // Arrange
         var converter = new AuthorRoleConverter();
-        using var writer = new Utf8JsonWriter(new ArrayBufferWriter<byte>());
+        var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
 
         // Act
         void Act()

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationFunctionCallingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationFunctionCallingTests.cs
@@ -32,7 +32,7 @@ public sealed class GeminiChatGenerationFunctionCallingTests : IDisposable
     {
         this._responseContent = File.ReadAllText(ChatTestDataFilePath);
         this._responseContentWithFunction = File.ReadAllText(ChatTestDataWithFunctionFilePath)
-            .Replace("%nameSeparator%", GeminiFunction.NameSeparator, StringComparison.Ordinal);
+            .Replace("%nameSeparator%", GeminiFunction.NameSeparator);
         this._messageHandlerStub = new HttpMessageHandlerStub();
         this._messageHandlerStub.ResponseToReturn.Content = new StringContent(
             this._responseContent);

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
@@ -71,7 +71,7 @@ public sealed class GeminiChatGenerationTests : IDisposable
     {
         // Arrange
         this._messageHandlerStub.ResponseToReturn.Content = new StringContent(
-            await File.ReadAllTextAsync(ChatTestDataFilePath));
+            File.ReadAllText(ChatTestDataFilePath));
         var client = this.CreateChatCompletionClient();
         var chatHistory = CreateSampleChatHistory();
 
@@ -115,7 +115,7 @@ public sealed class GeminiChatGenerationTests : IDisposable
 
         // Assert
         GeminiResponse testDataResponse = JsonSerializer.Deserialize<GeminiResponse>(
-            await File.ReadAllTextAsync(ChatTestDataFilePath))!;
+            File.ReadAllText(ChatTestDataFilePath))!;
         var testDataCandidate = testDataResponse.Candidates![0];
         var textContent = chatMessageContents.SingleOrDefault();
         Assert.NotNull(textContent);
@@ -160,7 +160,7 @@ public sealed class GeminiChatGenerationTests : IDisposable
 
         // Assert
         GeminiResponse testDataResponse = JsonSerializer.Deserialize<GeminiResponse>(
-            await File.ReadAllTextAsync(ChatTestDataFilePath))!;
+            File.ReadAllText(ChatTestDataFilePath))!;
         var testDataCandidate = testDataResponse.Candidates![0];
         var textContent = chatMessageContents.SingleOrDefault();
         Assert.NotNull(textContent);

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatStreamingFunctionCallingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatStreamingFunctionCallingTests.cs
@@ -32,7 +32,7 @@ public sealed class GeminiChatStreamingFunctionCallingTests : IDisposable
     {
         this._responseContent = File.ReadAllText(ChatTestDataFilePath);
         this._responseContentWithFunction = File.ReadAllText(ChatTestDataWithFunctionFilePath)
-            .Replace("%nameSeparator%", GeminiFunction.NameSeparator, StringComparison.Ordinal);
+            .Replace("%nameSeparator%", GeminiFunction.NameSeparator);
         this._messageHandlerStub = new HttpMessageHandlerStub();
         this._messageHandlerStub.ResponseToReturn.Content = new StringContent(
             this._responseContent);

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatStreamingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatStreamingTests.cs
@@ -100,7 +100,7 @@ public sealed class GeminiChatStreamingTests : IDisposable
 
         // Assert
         List<GeminiResponse> testDataResponse = JsonSerializer.Deserialize<List<GeminiResponse>>(
-            await File.ReadAllTextAsync(StreamTestDataFilePath))!;
+            File.ReadAllText(StreamTestDataFilePath))!;
 
         Assert.NotEmpty(chatMessageContents);
         Assert.Equal(testDataResponse.Count, chatMessageContents.Count);
@@ -128,7 +128,7 @@ public sealed class GeminiChatStreamingTests : IDisposable
 
         // Assert
         GeminiResponse testDataResponse = JsonSerializer.Deserialize<List<GeminiResponse>>(
-            await File.ReadAllTextAsync(StreamTestDataFilePath))![0];
+            File.ReadAllText(StreamTestDataFilePath))![0];
         var testDataCandidate = testDataResponse.Candidates![0];
         var textContent = chatMessageContents.FirstOrDefault();
         Assert.NotNull(textContent);
@@ -174,7 +174,7 @@ public sealed class GeminiChatStreamingTests : IDisposable
 
         // Assert
         GeminiResponse testDataResponse = JsonSerializer.Deserialize<List<GeminiResponse>>(
-            await File.ReadAllTextAsync(StreamTestDataFilePath))![0];
+            File.ReadAllText(StreamTestDataFilePath))![0];
         var testDataCandidate = testDataResponse.Candidates![0];
         var textContent = chatMessageContents.FirstOrDefault();
         Assert.NotNull(textContent);

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
@@ -215,7 +215,7 @@ public sealed class GeminiRequestTests
     {
         // Arrange
         ChatHistory chatHistory = [];
-        var kvp = KeyValuePair.Create("sampleKey", "sampleValue");
+        var kvp = new KeyValuePair<string, string>("sampleKey", "sampleValue");
         var expectedArgs = new JsonObject { [kvp.Key] = kvp.Value };
         var kernelFunction = KernelFunctionFactory.CreateFromMethod(() => "");
         var toolCall = new GeminiFunctionToolCall(new GeminiPart.FunctionCallPart { FunctionName = "function-name" });
@@ -242,7 +242,7 @@ public sealed class GeminiRequestTests
     {
         // Arrange
         ChatHistory chatHistory = [];
-        var kvp = KeyValuePair.Create("sampleKey", "sampleValue");
+        var kvp = new KeyValuePair<string, string>("sampleKey", "sampleValue");
         var expectedArgs = new JsonObject { [kvp.Key] = kvp.Value };
         var toolCallPart = new GeminiPart.FunctionCallPart
         { FunctionName = "function-name", Arguments = expectedArgs };

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiStreamResponseTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiStreamResponseTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.Google.Core;
@@ -27,7 +28,7 @@ public sealed class GeminiStreamResponseTests
         // Arrange
         var parser = new StreamJsonParser();
         var stream = new MemoryStream();
-        var streamExample = await File.ReadAllTextAsync(StreamTestDataFilePath);
+        var streamExample = File.ReadAllText(StreamTestDataFilePath);
         var sampleResponses = JsonSerializer.Deserialize<List<GeminiResponse>>(streamExample)!;
 
         WriteToStream(stream, streamExample);
@@ -43,7 +44,7 @@ public sealed class GeminiStreamResponseTests
 
     private static void WriteToStream(Stream stream, string input)
     {
-        using var writer = new StreamWriter(stream, leaveOpen: true);
+        using var writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 0x1000, leaveOpen: true);
         writer.Write(input);
         writer.Flush();
         stream.Position = 0;

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/GoogleAI/GoogleAIClientEmbeddingsGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/GoogleAI/GoogleAIClientEmbeddingsGenerationTests.cs
@@ -87,12 +87,11 @@ public sealed class GoogleAIClientEmbeddingsGenerationTests : IDisposable
         var embeddings = await client.GenerateEmbeddingsAsync(dataToEmbed);
 
         // Assert
-        GoogleAIEmbeddingResponse testDataResponse = JsonSerializer.Deserialize<GoogleAIEmbeddingResponse>(
-            await File.ReadAllTextAsync(TestDataFilePath))!;
+        GoogleAIEmbeddingResponse testDataResponse = JsonSerializer.Deserialize<GoogleAIEmbeddingResponse>(File.ReadAllText(TestDataFilePath))!;
         Assert.NotNull(embeddings);
         Assert.Collection(embeddings,
-            values => Assert.Equal(testDataResponse.Embeddings[0].Values, values),
-            values => Assert.Equal(testDataResponse.Embeddings[1].Values, values));
+            values => Assert.Equal(testDataResponse.Embeddings[0].Values.ToArray(), values.ToArray()),
+            values => Assert.Equal(testDataResponse.Embeddings[1].Values.ToArray(), values.ToArray()));
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/VertexAI/VertexAIClientEmbeddingsGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/VertexAI/VertexAIClientEmbeddingsGenerationTests.cs
@@ -64,12 +64,11 @@ public sealed class VertexAIClientEmbeddingsGenerationTests : IDisposable
         var embeddings = await client.GenerateEmbeddingsAsync(dataToEmbed);
 
         // Assert
-        VertexAIEmbeddingResponse testDataResponse = JsonSerializer.Deserialize<VertexAIEmbeddingResponse>(
-            await File.ReadAllTextAsync(TestDataFilePath))!;
+        VertexAIEmbeddingResponse testDataResponse = JsonSerializer.Deserialize<VertexAIEmbeddingResponse>(File.ReadAllText(TestDataFilePath))!;
         Assert.NotNull(embeddings);
         Assert.Collection(embeddings,
-            values => Assert.Equal(testDataResponse.Predictions[0].Embeddings.Values, values),
-            values => Assert.Equal(testDataResponse.Predictions[1].Embeddings.Values, values));
+            values => Assert.Equal(testDataResponse.Predictions[0].Embeddings.Values.ToArray(), values.ToArray()),
+            values => Assert.Equal(testDataResponse.Predictions[1].Embeddings.Values.ToArray(), values.ToArray()));
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Connectors.HuggingFace.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Connectors.HuggingFace.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.HuggingFace.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.HuggingFace.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/MultipleHttpMessageHandlerStub.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/MultipleHttpMessageHandlerStub.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace SemanticKernel.Connectors.HuggingFace.UnitTests;
 
-#pragma warning disable CA1812
+#pragma warning disable CA1812, CA2016
 
 internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
 {
@@ -36,7 +36,7 @@ internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
         this.RequestHeaders.Add(request.Headers);
         this.ContentHeaders.Add(request.Content?.Headers);
 
-        var content = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+        var content = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
 
         this.RequestContents.Add(content);
 

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Services/HuggingFaceImageToTextTests.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/Services/HuggingFaceImageToTextTests.cs
@@ -163,7 +163,7 @@ public sealed class HuggingFaceImageToTextTests : IDisposable
         var requestPayload = this._messageHandlerStub.RequestContent;
 
         Assert.NotNull(requestPayload);
-        Assert.Equal(this._imageContentInput.Data!.Value.Span, requestPayload);
+        Assert.Equal(this._imageContentInput.Data!.Value.ToArray(), requestPayload);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/TextGeneration/TextGenerationStreamResponseTests.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace.UnitTests/TextGeneration/TextGenerationStreamResponseTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.HuggingFace.Core;
@@ -75,7 +76,7 @@ public class TextGenerationStreamResponseTests
 
     private static void WriteToStream(Stream stream, string input)
     {
-        using var writer = new StreamWriter(stream, leaveOpen: true);
+        using var writer = new StreamWriter(stream, Encoding.UTF8, 0x1000, leaveOpen: true);
         writer.Write(input);
         writer.Flush();
         stream.Position = 0;

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Client/MistralClientTests.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Client/MistralClientTests.cs
@@ -477,7 +477,7 @@ public sealed class MistralClientTests : MistralTestBase
         [Description("Creates a new widget of the specified type and colors")]
         public string CreateWidget([Description("The colors of the widget to be created")] WidgetColor[] widgetColors)
         {
-            var colors = string.Join('-', widgetColors.Select(c => c.GetDisplayName()).ToArray());
+            var colors = string.Join("-", widgetColors.Select(c => c.GetDisplayName()).ToArray());
             return $"Widget created with colors: {colors}";
         }
     }

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Connectors.MistralAI.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Connectors.MistralAI.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.MistralAI.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.MistralAI.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <RollForward>LatestMajor</RollForward>
     <IsTestProject>true</IsTestProject>

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/MistralTestBase.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/MistralTestBase.cs
@@ -11,6 +11,9 @@ using Microsoft.SemanticKernel.Http;
 using Xunit;
 
 namespace SemanticKernel.Connectors.MistralAI.UnitTests;
+
+#pragma warning disable CA2016
+
 public abstract class MistralTestBase : IDisposable
 {
     protected AssertingDelegatingHandler? DelegatingHandler { get; set; }
@@ -94,7 +97,7 @@ public abstract class MistralTestBase : IDisposable
             Assert.Equal(this.Method, request.Method);
             Assert.Equal(this.RequestHeaders, request.Headers);
 
-            this.RequestContent = await request.Content!.ReadAsStringAsync(cancellationToken);
+            this.RequestContent = await request.Content!.ReadAsStringAsync();
 
             if (this._responseStringArray is not null)
             {

--- a/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.Onnx.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.Onnx.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Connectors.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Connectors.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/DuckDB/DuckDBMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/DuckDB/DuckDBMemoryStoreTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO: Tests fail with "Unable to load DLL 'duckdb': The specified module could not be found." on .NET Framework
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -38,7 +39,7 @@ public class DuckDBMemoryStoreTests
                 text: "text" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 1, 1 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         for (int i = numRecords / 2; i < numRecords; i++)
@@ -48,7 +49,7 @@ public class DuckDBMemoryStoreTests
                 sourceName: "sourceName" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 2, 3 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         return records;
@@ -650,3 +651,4 @@ public class DuckDBMemoryStoreTests
         await db.DeleteCollectionAsync(collection);
     }
 }
+#endif

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryBuilderExtensionsTests.cs
@@ -31,7 +31,7 @@ public sealed class PineconeMemoryBuilderExtensionsTests : IDisposable
     {
         // Arrange
         var embeddingGenerationMock = Mock.Of<ITextEmbeddingGenerationService>();
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""["fake-index1"]""", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""["fake-index1"]""", Encoding.UTF8, "application/json");
 
         var builder = new MemoryBuilder();
         builder.WithPineconeMemoryStore("fake-environment", "fake-api-key", this._httpClient);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Qdrant/QdrantMemoryBuilderExtensionsTests.cs
@@ -32,7 +32,7 @@ public sealed class QdrantMemoryBuilderExtensionsTests : IDisposable
         var embeddingGenerationMock = Mock.Of<ITextEmbeddingGenerationService>();
 
         this._httpClient.BaseAddress = new Uri("https://fake-random-qdrant-host");
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""{"result":{"collections":[]}}""", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent("""{"result":{"collections":[]}}""", Encoding.UTF8, "application/json");
 
         var builder = new MemoryBuilder();
         builder.WithQdrantMemoryStore(this._httpClient, 123);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Redis/RedisMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Redis/RedisMemoryStoreTests.cs
@@ -771,7 +771,10 @@ public class RedisMemoryStoreTests
             .ReturnsAsync(RedisResult.Create("OK", ResultType.SimpleString))
             .Callback(() =>
             {
-                this._collections.TryAdd(collection, []);
+                if (!this._collections.ContainsKey(collection))
+                {
+                    this._collections.Add(collection, []);
+                }
 
                 this._mockDatabase
                     .Setup<Task<RedisResult>>(x => x.ExecuteAsync(
@@ -972,7 +975,7 @@ public class RedisMemoryStoreTests
                 text: "text" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 1, 1 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         for (int i = numRecords / 2; i < numRecords; i++)
@@ -982,7 +985,7 @@ public class RedisMemoryStoreTests
                 sourceName: "sourceName" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 2, 3 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         return records;

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Sqlite/SqliteMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Sqlite/SqliteMemoryStoreTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO: Tests fail with "Library e_sqlite3 not found" on .NET Framework
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -56,7 +57,7 @@ public sealed class SqliteMemoryStoreTests : IDisposable
                 text: "text" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 1, 1 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         for (int i = numRecords / 2; i < numRecords; i++)
@@ -66,7 +67,7 @@ public sealed class SqliteMemoryStoreTests : IDisposable
                 sourceName: "sourceName" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 2, 3 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         return records;
@@ -678,3 +679,4 @@ public sealed class SqliteMemoryStoreTests : IDisposable
         await db.DeleteCollectionAsync(collection);
     }
 }
+#endif

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryBuilderExtensionsTests.cs
@@ -46,7 +46,7 @@ public sealed class WeaviateMemoryBuilderExtensionsTests : IDisposable
             }
         };
 
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent(JsonSerializer.Serialize(getResponse, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }), Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent(JsonSerializer.Serialize(getResponse, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }), Encoding.UTF8, "application/json");
 
         var builder = new MemoryBuilder();
         builder.WithWeaviateMemoryStore(this._httpClient, "https://fake-random-test-weaviate-host", "fake-api-key", apiVersion);

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Weaviate/WeaviateMemoryStoreTests.cs
@@ -35,7 +35,7 @@ public sealed class WeaviateMemoryStoreTests : IDisposable
             }
         };
 
-        this._messageHandlerStub.ResponseToReturn.Content = new StringContent(JsonSerializer.Serialize(getResponse, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }), Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._messageHandlerStub.ResponseToReturn.Content = new StringContent(JsonSerializer.Serialize(getResponse, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }), Encoding.UTF8, "application/json");
 
         this._httpClient = new HttpClient(this._messageHandlerStub, false);
     }

--- a/dotnet/src/Connectors/Connectors.UnitTests/MultipleHttpMessageHandlerStub.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/MultipleHttpMessageHandlerStub.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 
 namespace SemanticKernel.Connectors.UnitTests;
 
+#pragma warning disable CA2016
+
 internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
 {
     private int _callIteration = 0;
@@ -44,7 +46,7 @@ internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
         this.RequestHeaders.Add(request.Headers);
         this.ContentHeaders.Add(request.Content?.Headers);
 
-        var content = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+        var content = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
 
         this.RequestContents.Add(content);
 

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AzureSdk/OpenAIChatMessageContentTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/AzureSdk/OpenAIChatMessageContentTests.cs
@@ -2,7 +2,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Azure.AI.OpenAI;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
@@ -119,7 +118,7 @@ public sealed class OpenAIChatMessageContentTests
         public int Count => dictionary.Count;
         public bool ContainsKey(TKey key) => dictionary.ContainsKey(key);
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => dictionary.GetEnumerator();
-        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => dictionary.TryGetValue(key, out value);
+        public bool TryGetValue(TKey key, out TValue value) => dictionary.TryGetValue(key, out value!);
         IEnumerator IEnumerable.GetEnumerator() => dictionary.GetEnumerator();
     }
 }

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/AzureOpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/ChatCompletion/AzureOpenAIChatCompletionServiceTests.cs
@@ -210,10 +210,10 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         Assert.Equal("Assistant Message", assistantMessage.GetProperty("content").GetString());
 
         Assert.Equal(123, content.GetProperty("max_tokens").GetInt32());
-        Assert.Equal(0.6, content.GetProperty("temperature").GetDouble());
-        Assert.Equal(0.5, content.GetProperty("top_p").GetDouble());
-        Assert.Equal(1.6, content.GetProperty("frequency_penalty").GetDouble());
-        Assert.Equal(1.2, content.GetProperty("presence_penalty").GetDouble());
+        Assert.Equal(0.6, content.GetProperty("temperature").GetDouble(), 0.0001);
+        Assert.Equal(0.5, content.GetProperty("top_p").GetDouble(), 0.0001);
+        Assert.Equal(1.6, content.GetProperty("frequency_penalty").GetDouble(), 0.0001);
+        Assert.Equal(1.2, content.GetProperty("presence_penalty").GetDouble(), 0.0001);
         Assert.Equal(5, content.GetProperty("n").GetInt32());
         Assert.Equal(567, content.GetProperty("seed").GetInt32());
         Assert.Equal(3, content.GetProperty("logit_bias").GetProperty("2").GetInt32());

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/Files/OpenAIFileServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/Files/OpenAIFileServiceTests.cs
@@ -227,8 +227,8 @@ public sealed class OpenAIFileServiceTests : IDisposable
 
         var settings = new OpenAIFileUploadExecutionSettings("test.txt", OpenAIFilePurpose.Assistants);
 
-        await using var stream = new MemoryStream();
-        await using (var writer = new StreamWriter(stream, leaveOpen: true))
+        using var stream = new MemoryStream();
+        using (var writer = new StreamWriter(stream, Encoding.UTF8, 0x1000, leaveOpen: true))
         {
             await writer.WriteLineAsync("test");
             await writer.FlushAsync();

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/AutoFunctionInvocationFilterTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/FunctionCalling/AutoFunctionInvocationFilterTests.cs
@@ -316,8 +316,8 @@ public sealed class AutoFunctionInvocationFilterTests : IDisposable
         // Act
         var result = await chatCompletion.GetChatMessageContentsAsync(chatHistory, executionSettings, kernel);
 
-        var firstFunctionResult = chatHistory[^2].Content;
-        var secondFunctionResult = chatHistory[^1].Content;
+        var firstFunctionResult = chatHistory[chatHistory.Count - 2].Content;
+        var secondFunctionResult = chatHistory[chatHistory.Count - 1].Content;
 
         // Assert
         Assert.Equal("Result from filter", firstFunctionResult);
@@ -354,8 +354,8 @@ public sealed class AutoFunctionInvocationFilterTests : IDisposable
         await foreach (var item in chatCompletion.GetStreamingChatMessageContentsAsync(chatHistory, executionSettings, kernel))
         { }
 
-        var firstFunctionResult = chatHistory[^2].Content;
-        var secondFunctionResult = chatHistory[^1].Content;
+        var firstFunctionResult = chatHistory[chatHistory.Count - 2].Content;
+        var secondFunctionResult = chatHistory[chatHistory.Count - 1].Content;
 
         // Assert
         Assert.Equal("Result from filter", firstFunctionResult);

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextGeneration/AzureOpenAITextGenerationServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextGeneration/AzureOpenAITextGenerationServiceTests.cs
@@ -146,10 +146,10 @@ public sealed class AzureOpenAITextGenerationServiceTests : IDisposable
 
         Assert.Equal("Prompt", content.GetProperty("prompt")[0].GetString());
         Assert.Equal(123, content.GetProperty("max_tokens").GetInt32());
-        Assert.Equal(0.6, content.GetProperty("temperature").GetDouble());
-        Assert.Equal(0.5, content.GetProperty("top_p").GetDouble());
-        Assert.Equal(1.6, content.GetProperty("frequency_penalty").GetDouble());
-        Assert.Equal(1.2, content.GetProperty("presence_penalty").GetDouble());
+        Assert.Equal(0.6, content.GetProperty("temperature").GetDouble(), 0.0001);
+        Assert.Equal(0.5, content.GetProperty("top_p").GetDouble(), 0.0001);
+        Assert.Equal(1.6, content.GetProperty("frequency_penalty").GetDouble(), 0.0001);
+        Assert.Equal(1.2, content.GetProperty("presence_penalty").GetDouble(), 0.0001);
         Assert.Equal(5, content.GetProperty("n").GetInt32());
         Assert.Equal(5, content.GetProperty("best_of").GetInt32());
         Assert.Equal(3, content.GetProperty("logit_bias").GetProperty("2").GetInt32());

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/AzureOpenAITextToAudioServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/AzureOpenAITextToAudioServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class AzureOpenAITextToAudioServiceTests : IDisposable
     {
         // Arrange
         var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
-        await using var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0xFF, 0x7F });
+        using var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0xFF, 0x7F });
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -73,7 +73,7 @@ public sealed class AzureOpenAITextToAudioServiceTests : IDisposable
         var expectedByteArray = new byte[] { 0x00, 0x00, 0xFF, 0x7F };
 
         var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
-        await using var stream = new MemoryStream(expectedByteArray);
+        using var stream = new MemoryStream(expectedByteArray);
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -102,7 +102,7 @@ public sealed class AzureOpenAITextToAudioServiceTests : IDisposable
         }
 
         var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
-        await using var stream = new MemoryStream(expectedByteArray);
+        using var stream = new MemoryStream(expectedByteArray);
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {

--- a/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/OpenAITextToAudioServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/OpenAI/TextToAudio/OpenAITextToAudioServiceTests.cs
@@ -50,7 +50,7 @@ public sealed class OpenAITextToAudioServiceTests : IDisposable
     {
         // Arrange
         var service = new OpenAITextToAudioService("model-id", "api-key", "organization", this._httpClient);
-        await using var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0xFF, 0x7F });
+        using var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0xFF, 0x7F });
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -72,7 +72,7 @@ public sealed class OpenAITextToAudioServiceTests : IDisposable
         var expectedByteArray = new byte[] { 0x00, 0x00, 0xFF, 0x7F };
 
         var service = new OpenAITextToAudioService("model-id", "api-key", "organization", this._httpClient);
-        await using var stream = new MemoryStream(expectedByteArray);
+        using var stream = new MemoryStream(expectedByteArray);
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -101,7 +101,7 @@ public sealed class OpenAITextToAudioServiceTests : IDisposable
         }
 
         var service = new OpenAITextToAudioService("model-id", "api-key", "organization", this._httpClient);
-        await using var stream = new MemoryStream(expectedByteArray);
+        using var stream = new MemoryStream(expectedByteArray);
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {

--- a/dotnet/src/Experimental/Agents.UnitTests/Experimental.Agents.UnitTests.csproj
+++ b/dotnet/src/Experimental/Agents.UnitTests/Experimental.Agents.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Experimental.Agents.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Experimental.Agents.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Experimental/Agents.UnitTests/Integration/AgentHarness.cs
+++ b/dotnet/src/Experimental/Agents.UnitTests/Integration/AgentHarness.cs
@@ -113,7 +113,7 @@ public sealed class AgentHarness(ITestOutputHelper output)
         var agents = await context.ListAssistantModelsAsync().ConfigureAwait(true);
         foreach (var agent in agents)
         {
-            if (!string.IsNullOrWhiteSpace(agent.Name) && names.Contains(agent.Name))
+            if (!string.IsNullOrWhiteSpace(agent.Name) && names.Contains(agent.Name!))
             {
                 this._output.WriteLine($"Removing: {agent.Name} - {agent.Id}");
                 await context.DeleteAssistantModelAsync(agent.Id).ConfigureAwait(true);

--- a/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/Experimental.Orchestration.Flow.IntegrationTests.csproj
+++ b/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/Experimental.Orchestration.Flow.IntegrationTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Experimental.Orchestration.Flow.IntegrationTests</AssemblyName>
     <RootNamespace>SemanticKernel.Experimental.Orchestration.Flow.IntegrationTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA2007,VSTHRD111,SKEXP0101,SKEXP0050</NoWarn>

--- a/dotnet/src/Experimental/Orchestration.Flow.UnitTests/Experimental.Orchestration.Flow.UnitTests.csproj
+++ b/dotnet/src/Experimental/Orchestration.Flow.UnitTests/Experimental.Orchestration.Flow.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Experimental.Orchestration.Flow.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Experimental.Orchestration.Flow.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Extensions/Extensions.UnitTests/Extensions.UnitTests.csproj
+++ b/dotnet/src/Extensions/Extensions.UnitTests/Extensions.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Extensions.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Extensions.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelSystemHelpersTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelSystemHelpersTests.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using System.Web;
+using System.Net;
 using HandlebarsDotNet;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.PromptTemplates.Handlebars;
@@ -64,7 +64,7 @@ public sealed class KernelSystemHelpersTests
         var result = await this.RenderPromptTemplateAsync(template, arguments);
 
         // Assert
-        Assert.Equal("""{"name":"Alice","age":25}""", HttpUtility.HtmlDecode(result));
+        Assert.Equal("""{"name":"Alice","age":25}""", WebUtility.HtmlDecode(result));
     }
 
     [Fact]

--- a/dotnet/src/Extensions/PromptTemplates.Liquid.UnitTests/LiquidTemplateTest.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Liquid.UnitTests/LiquidTemplateTest.cs
@@ -719,7 +719,7 @@ public class LiquidTemplateTest
     {
         var chatObject = chatHistory.Select(chat => new { Role = chat.Role.ToString(), Content = chat.Content });
 
-        return JsonSerializer.Serialize(chatObject, this._jsonSerializerOptions).Replace(Environment.NewLine, "\n", StringComparison.InvariantCulture);
+        return JsonSerializer.Serialize(chatObject, this._jsonSerializerOptions).Replace(Environment.NewLine, "\n");
     }
     #endregion Private
 }

--- a/dotnet/src/Extensions/PromptTemplates.Liquid.UnitTests/PromptTemplates.Liquid.UnitTests.csproj
+++ b/dotnet/src/Extensions/PromptTemplates.Liquid.UnitTests/PromptTemplates.Liquid.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Extensions.PromptTemplates.Liquid.UnitTests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/Functions.Prompty.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/Functions.Prompty.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Functions.Prompty.UnitTests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Functions.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Functions.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/dotnet/src/Functions/Functions.UnitTests/Grpc/GrpcRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Grpc/GrpcRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO: gRPC unavailable by default on .NET Framework
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -203,3 +204,4 @@ public sealed class GrpcRunnerTests : IDisposable
         }
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -191,7 +191,7 @@ public sealed class OpenApiKernelExtensionsTests : IDisposable
     {
         // Arrange
         using var messageHandlerStub = new HttpMessageHandlerStub();
-        messageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        messageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         using var httpClient = new HttpClient(messageHandlerStub, false);
 
@@ -339,3 +339,4 @@ public sealed class OpenApiKernelExtensionsTests : IDisposable
 
     #endregion
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/HttpMessageHandlerStub.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/HttpMessageHandlerStub.cs
@@ -4,12 +4,13 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace SemanticKernel.Functions.UnitTests.OpenApi;
+
+#pragma warning disable CA1812, CA2016
 
 internal sealed class HttpMessageHandlerStub : DelegatingHandler
 {
@@ -29,7 +30,7 @@ internal sealed class HttpMessageHandlerStub : DelegatingHandler
     {
         this.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json)
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
         };
     }
 
@@ -45,7 +46,7 @@ internal sealed class HttpMessageHandlerStub : DelegatingHandler
     {
         this.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json)
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
         };
     }
 
@@ -54,7 +55,7 @@ internal sealed class HttpMessageHandlerStub : DelegatingHandler
         this.Method = request.Method;
         this.RequestUri = request.RequestUri;
         this.RequestHeaders = request.Headers;
-        this.RequestContent = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+        this.RequestContent = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
         this.ContentHeaders = request.Content?.Headers;
 
         return await Task.FromResult(this.ResponseToReturn);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenAI/KernelOpenAIPluginExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenAI/KernelOpenAIPluginExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.IO;
 using System.Net.Http;
@@ -92,3 +93,4 @@ public sealed class KernelOpenAIPluginExtensionsTests : IDisposable
         this._openApiDocument.Dispose();
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.Globalization;
 using System.Linq;
@@ -78,3 +79,4 @@ public class OpenApiDocumentParserExtensionsTests
         Assert.Equal("{\"key1\":\"value1\",\"key2\":\"value2\"}", objectValue);
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -374,3 +375,4 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         this._openApiDocument.Dispose();
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -462,3 +463,4 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         this._openApiDocument.Dispose();
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -443,3 +444,4 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         this._openApiDocument.Dispose();
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+#if NET // TODO https://github.com/microsoft/OpenAPI.NET/issues/1635: Enable for .NET Framework when issues is addressed
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -21,6 +22,8 @@ using SemanticKernel.Functions.UnitTests.OpenApi.TestResponses;
 using Xunit;
 
 namespace SemanticKernel.Functions.UnitTests.OpenApi;
+
+#pragma warning disable CA2016
 
 public sealed class RestApiOperationRunnerTests : IDisposable
 {
@@ -60,7 +63,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItCanRunCreateAndUpdateOperationsWithJsonPayloadSuccessfullyAsync(string method)
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         var httpMethod = new HttpMethod(method);
 
@@ -305,7 +308,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldBuildJsonPayloadDynamicallyAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         List<RestApiOperationPayloadProperty> payloadProperties =
         [
@@ -316,7 +319,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             ])
         ];
 
-        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+        var payload = new RestApiOperationPayload("application/json", payloadProperties);
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -365,7 +368,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldBuildJsonPayloadDynamicallyUsingPayloadMetadataDataTypesAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         List<RestApiOperationPayloadProperty> payloadProperties =
         [
@@ -380,7 +383,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             ])
         ];
 
-        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+        var payload = new RestApiOperationPayload("application/json", payloadProperties);
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -450,7 +453,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldBuildJsonPayloadDynamicallyResolvingArgumentsByFullNamesAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         List<RestApiOperationPayloadProperty> payloadProperties =
         [
@@ -469,7 +472,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             ])
         ];
 
-        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+        var payload = new RestApiOperationPayload("application/json", payloadProperties);
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -632,12 +635,12 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     }
 
     [Theory]
-    [InlineData(MediaTypeNames.Text.Plain)]
-    [InlineData(MediaTypeNames.Application.Json)]
+    [InlineData("text/plain")]
+    [InlineData("application/json")]
     public async Task ItShouldUsePayloadAndContentTypeArgumentsIfDynamicPayloadBuildingIsNotRequiredAsync(string contentType)
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Text.Plain);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "text/plain");
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -676,14 +679,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldBuildJsonPayloadDynamicallyExcludingOptionalParametersIfTheirArgumentsNotProvidedAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         List<RestApiOperationPayloadProperty> payloadProperties =
         [
             new("upn", "string", false, []),
         ];
 
-        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+        var payload = new RestApiOperationPayload("application/json", payloadProperties);
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -722,14 +725,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldBuildJsonPayloadDynamicallyIncludingOptionalParametersIfTheirArgumentsProvidedAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         List<RestApiOperationPayloadProperty> payloadProperties =
         [
             new("upn", "string", false, []),
         ];
 
-        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+        var payload = new RestApiOperationPayload("application/json", payloadProperties);
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -768,7 +771,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldAddRequiredQueryStringParametersIfTheirArgumentsProvidedAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         var firstParameter = new RestApiOperationParameter(
             "p1",
@@ -816,7 +819,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldAddNotRequiredQueryStringParametersIfTheirArgumentsProvidedAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         var firstParameter = new RestApiOperationParameter(
             "p1",
@@ -864,7 +867,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldSkipNotRequiredQueryStringParametersIfNoArgumentsProvidedAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         var firstParameter = new RestApiOperationParameter(
             "p1",
@@ -911,7 +914,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldThrowExceptionIfNoArgumentProvidedForRequiredQueryStringParameterAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         var parameter = new RestApiOperationParameter(
             "p1",
@@ -940,8 +943,8 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     }
 
     [Theory]
-    [InlineData(MediaTypeNames.Application.Json)]
-    [InlineData(MediaTypeNames.Application.Xml)]
+    [InlineData("application/json")]
+    [InlineData("application/xml")]
     [InlineData(MediaTypeNames.Text.Plain)]
     [InlineData(MediaTypeNames.Text.Html)]
     [InlineData(MediaTypeNames.Text.Xml)]
@@ -1055,7 +1058,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldReturnRequestUriAndContentAsync()
     {
         // Arrange
-        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "application/json");
 
         List<RestApiOperationPayloadProperty> payloadProperties =
         [
@@ -1066,7 +1069,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             ])
         ];
 
-        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+        var payload = new RestApiOperationPayload("application/json", payloadProperties);
 
         var operation = new RestApiOperation(
             "fake-id",
@@ -1197,7 +1200,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         {
             this.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
             {
-                Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json)
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
             };
         }
 
@@ -1206,10 +1209,11 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             this.Method = request.Method;
             this.RequestUri = request.RequestUri;
             this.RequestHeaders = request.Headers;
-            this.RequestContent = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            this.RequestContent = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
             this.ContentHeaders = request.Content?.Headers;
 
             return await Task.FromResult(this.ResponseToReturn);
         }
     }
 }
+#endif

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/OpenApiTypeConverterTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/OpenApiTypeConverterTests.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
-using Microsoft.VisualBasic;
 using Xunit;
 
 namespace SemanticKernel.Functions.UnitTests.OpenApi.Serialization;
@@ -108,7 +108,7 @@ public class OpenApiTypeConverterTests
 
         Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new List<int> { 1, 2, 3 }).ToJsonString());
 
-        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new Collection() { 1, 2, 3 }).ToJsonString());
+        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new Collection<int>() { 1, 2, 3 }).ToJsonString());
 
         Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", "[1, 2, 3]").ToJsonString());
     }

--- a/dotnet/src/IntegrationTests/BaseIntegrationTest.cs
+++ b/dotnet/src/IntegrationTests/BaseIntegrationTest.cs
@@ -19,7 +19,7 @@ public class BaseIntegrationTest
             c.AddStandardResilienceHandler().Configure(o =>
             {
                 o.Retry.ShouldRetryAfterHeader = true;
-                o.Retry.ShouldHandle = args => ValueTask.FromResult(args.Outcome.Result?.StatusCode is HttpStatusCode.TooManyRequests);
+                o.Retry.ShouldHandle = args => new ValueTask<bool>(args.Outcome.Result?.StatusCode is (HttpStatusCode)429 /*TooManyRequests*/);
                 o.CircuitBreaker = new HttpCircuitBreakerStrategyOptions
                 {
                     SamplingDuration = TimeSpan.FromSeconds(40.0), // The duration should be least double of an attempt timeout

--- a/dotnet/src/IntegrationTests/Connectors/Google/Gemini/GeminiChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Google/Gemini/GeminiChatCompletionTests.cs
@@ -70,7 +70,7 @@ public sealed class GeminiChatCompletionTests(ITestOutputHelper output) : TestsB
     public async Task ChatGenerationVisionBinaryDataAsync(ServiceType serviceType)
     {
         // Arrange
-        Memory<byte> image = await File.ReadAllBytesAsync("./TestData/test_image_001.jpg");
+        Memory<byte> image = File.ReadAllBytes("./TestData/test_image_001.jpg");
         var chatHistory = new ChatHistory();
         var messageContent = new ChatMessageContent(AuthorRole.User, items:
         [
@@ -96,7 +96,7 @@ public sealed class GeminiChatCompletionTests(ITestOutputHelper output) : TestsB
     public async Task ChatStreamingVisionBinaryDataAsync(ServiceType serviceType)
     {
         // Arrange
-        Memory<byte> image = await File.ReadAllBytesAsync("./TestData/test_image_001.jpg");
+        Memory<byte> image = File.ReadAllBytes("./TestData/test_image_001.jpg");
         var chatHistory = new ChatHistory();
         var messageContent = new ChatMessageContent(AuthorRole.User, items:
         [
@@ -191,9 +191,9 @@ public sealed class GeminiChatCompletionTests(ITestOutputHelper output) : TestsB
         // Assert
         var geminiMetadata = response.Metadata as GeminiMetadata;
         Assert.NotNull(geminiMetadata);
-        foreach ((string? key, object? value) in geminiMetadata)
+        foreach (var entry in geminiMetadata)
         {
-            this.Output.WriteLine($"{key}: {JsonSerializer.Serialize(value)}");
+            this.Output.WriteLine($"{entry.Key}: {JsonSerializer.Serialize(entry.Value)}");
         }
 
         Assert.True(geminiMetadata.TotalTokenCount > 0);

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStoreTestsFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStoreTestsFixture.cs
@@ -60,6 +60,6 @@ public class AzureCosmosDBMongoDBMemoryStoreTestsFixture : IAsyncLifetime
             throw new ArgumentNullException($"{settingValue} string is not configured");
         }
 
-        return settingValue;
+        return settingValue!;
     }
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBMemoryStoreTestsFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBMemoryStoreTestsFixture.cs
@@ -91,7 +91,7 @@ public class MongoDBMemoryStoreTestsFixture : IAsyncLifetime
             throw new ArgumentNullException($"{settingValue} string is not configured");
         }
 
-        return settingValue;
+        return settingValue!;
     }
 
     private static string GetRandomName() => $"test_{Guid.NewGuid():N}";

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresMemoryStoreTests.cs
@@ -38,7 +38,7 @@ public class PostgresMemoryStoreTests : IAsyncLifetime
             throw new ArgumentNullException("Postgres memory connection string is not configured");
         }
 
-        this._connectionString = connectionString;
+        this._connectionString = connectionString!;
         this._databaseName = $"sk_it_{Guid.NewGuid():N}";
 
         NpgsqlConnectionStringBuilder connectionStringBuilder = new(this._connectionString)
@@ -636,13 +636,13 @@ public class PostgresMemoryStoreTests : IAsyncLifetime
         using NpgsqlDataSource dataSource = NpgsqlDataSource.Create(this._connectionString);
         await using (NpgsqlConnection conn = await dataSource.OpenConnectionAsync())
         {
-            await using NpgsqlCommand command = new($"CREATE DATABASE \"{this._databaseName}\"", conn);
+            using NpgsqlCommand command = new($"CREATE DATABASE \"{this._databaseName}\"", conn);
             await command.ExecuteNonQueryAsync();
         }
 
         await using (NpgsqlConnection conn = await this._dataSource.OpenConnectionAsync())
         {
-            await using (NpgsqlCommand command = new("CREATE EXTENSION vector", conn))
+            using (NpgsqlCommand command = new("CREATE EXTENSION vector", conn))
             {
                 await command.ExecuteNonQueryAsync();
             }
@@ -655,7 +655,7 @@ public class PostgresMemoryStoreTests : IAsyncLifetime
     {
         using NpgsqlDataSource dataSource = NpgsqlDataSource.Create(this._connectionString);
         await using NpgsqlConnection conn = await dataSource.OpenConnectionAsync();
-        await using NpgsqlCommand command = new($"DROP DATABASE IF EXISTS \"{this._databaseName}\"", conn);
+        using NpgsqlCommand command = new($"DROP DATABASE IF EXISTS \"{this._databaseName}\"", conn);
         await command.ExecuteNonQueryAsync();
     }
 
@@ -677,7 +677,7 @@ public class PostgresMemoryStoreTests : IAsyncLifetime
                 text: "text" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 1, 1 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         for (int i = numRecords / 2; i < numRecords; i++)
@@ -687,7 +687,7 @@ public class PostgresMemoryStoreTests : IAsyncLifetime
                 sourceName: "sourceName" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 2, 3 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         return records;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/SqlServer/SqlServerMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/SqlServer/SqlServerMemoryStoreTests.cs
@@ -42,12 +42,12 @@ public class SqlServerMemoryStoreTests : IAsyncLifetime
             throw new ArgumentException("SqlServer memory connection string is not configured.");
         }
 
-        this._connectionString = connectionString;
+        this._connectionString = connectionString!;
 
         await this.CleanupDatabaseAsync();
         await this.InitializeDatabaseAsync();
 
-        this.Store = new SqlServerMemoryStore(this._connectionString, SchemaName);
+        this.Store = new SqlServerMemoryStore(this._connectionString!, SchemaName);
     }
 
     public async Task DisposeAsync()
@@ -323,18 +323,18 @@ public class SqlServerMemoryStoreTests : IAsyncLifetime
 
     private async Task InitializeDatabaseAsync()
     {
-        await using var connection = new SqlConnection(this._connectionString);
+        using var connection = new SqlConnection(this._connectionString);
         await connection.OpenAsync();
-        await using var cmd = connection.CreateCommand();
+        using var cmd = connection.CreateCommand();
         cmd.CommandText = $"CREATE SCHEMA {SchemaName}";
         await cmd.ExecuteNonQueryAsync();
     }
 
     private async Task CleanupDatabaseAsync()
     {
-        await using var connection = new SqlConnection(this._connectionString);
+        using var connection = new SqlConnection(this._connectionString);
         await connection.OpenAsync();
-        await using var cmd = connection.CreateCommand();
+        using var cmd = connection.CreateCommand();
         cmd.CommandText = $"""
             DECLARE tables_cursor CURSOR FOR
             SELECT table_name 

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIAudioToTextTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIAudioToTextTests.cs
@@ -36,7 +36,7 @@ public sealed class OpenAIAudioToTextTests()
 
         var service = kernel.GetRequiredService<IAudioToTextService>();
 
-        await using Stream audio = File.OpenRead($"./TestData/{Filename}");
+        using Stream audio = File.OpenRead($"./TestData/{Filename}");
         var audioData = await BinaryData.FromStreamAsync(audio);
 
         // Act
@@ -64,7 +64,7 @@ public sealed class OpenAIAudioToTextTests()
 
         var service = kernel.GetRequiredService<IAudioToTextService>();
 
-        await using Stream audio = File.OpenRead($"./TestData/{Filename}");
+        using Stream audio = File.OpenRead($"./TestData/{Filename}");
         var audioData = await BinaryData.FromStreamAsync(audio);
 
         // Act

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -182,7 +182,7 @@ public sealed class OpenAICompletionTests(ITestOutputHelper output) : IDisposabl
             // Use a standard resiliency policy, augmented to retry on 401 Unauthorized for this example
             c.AddStandardResilienceHandler().Configure(o =>
             {
-                o.Retry.ShouldHandle = args => ValueTask.FromResult(args.Outcome.Result?.StatusCode is HttpStatusCode.Unauthorized);
+                o.Retry.ShouldHandle = args => new ValueTask<bool>(args.Outcome.Result?.StatusCode is HttpStatusCode.Unauthorized);
             });
         });
         Kernel target = this._kernelBuilder.Build();
@@ -219,7 +219,7 @@ public sealed class OpenAICompletionTests(ITestOutputHelper output) : IDisposabl
             // Use a standard resiliency policy, augmented to retry on 401 Unauthorized for this example
             c.AddStandardResilienceHandler().Configure(o =>
             {
-                o.Retry.ShouldHandle = args => ValueTask.FromResult(args.Outcome.Result?.StatusCode is HttpStatusCode.Unauthorized);
+                o.Retry.ShouldHandle = args => new ValueTask<bool>(args.Outcome.Result?.StatusCode is HttpStatusCode.Unauthorized);
             });
         });
 
@@ -348,7 +348,7 @@ public sealed class OpenAICompletionTests(ITestOutputHelper output) : IDisposabl
 
         // Act
         // Assert
-        await Assert.ThrowsAsync<HttpOperationException>(() => plugins["SummarizePlugin"]["Summarize"].InvokeAsync(target, new() { [InputParameterName] = string.Join('.', Enumerable.Range(1, 40000)) }));
+        await Assert.ThrowsAsync<HttpOperationException>(() => plugins["SummarizePlugin"]["Summarize"].InvokeAsync(target, new() { [InputParameterName] = string.Join(".", Enumerable.Range(1, 40000)) }));
     }
 
     [Theory(Skip = "This test is for manual verification.")]

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIToolsTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIToolsTests.cs
@@ -547,7 +547,10 @@ public sealed class OpenAIToolsTests : BaseIntegrationTest
         }
     }
 
-    public record WeatherParameters(City City);
+    public class WeatherParameters(City city)
+    {
+        public City City { get; } = city;
+    }
 
     public class City
     {

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -2,11 +2,12 @@
   <PropertyGroup>
     <AssemblyName>IntegrationTests</AssemblyName>
     <RootNamespace>SemanticKernel.IntegrationTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0040,SKEXP0050,SKEXP0060,SKEXP0070,SKEXP0110</NoWarn>
     <UserSecretsId>b7762d10-e29b-4bb1-8b74-b6d69a667dd4</UserSecretsId>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Planners\SequentialPlanner\**" />

--- a/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlanTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlanTests.cs
@@ -50,7 +50,7 @@ public sealed class HandlebarsPlanTests
     public async Task InvokePlanWithHallucinatedFunctionAsync()
     {
         // Arrange
-        var planWithInvalidHelper = PlanTemplate1.Replace("Foo-Combine", "Foo-HallucinatedHelper", StringComparison.CurrentCulture);
+        var planWithInvalidHelper = PlanTemplate1.Replace("Foo-Combine", "Foo-HallucinatedHelper");
 
         // Act & Assert  
         var exception = await Assert.ThrowsAsync<KernelException>(async () => await this.InvokePlanAsync(planWithInvalidHelper));

--- a/dotnet/src/InternalUtilities/samples/InternalUtilities/BaseTest.cs
+++ b/dotnet/src/InternalUtilities/samples/InternalUtilities/BaseTest.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
+
+#pragma warning disable CA2016
 
 public abstract class BaseTest
 {
@@ -106,7 +109,7 @@ public abstract class BaseTest
             // Log the request details
             if (request.Content is not null)
             {
-                var content = await request.Content.ReadAsStringAsync(cancellationToken);
+                var content = await request.Content.ReadAsStringAsync();
                 this._output.WriteLine(content);
             }
 
@@ -116,7 +119,7 @@ public abstract class BaseTest
             if (response.Content is not null)
             {
                 // Log the response details
-                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                var responseContent = await response.Content.ReadAsStringAsync();
                 this._output.WriteLine(responseContent);
             }
 

--- a/dotnet/src/InternalUtilities/test/HttpMessageHandlerStub.cs
+++ b/dotnet/src/InternalUtilities/test/HttpMessageHandlerStub.cs
@@ -5,12 +5,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-#pragma warning disable CA1812 // Internal class that is apparently never instantiated; this class is compiled in tests projects
+#pragma warning disable CA1812, CA2016
+
 internal sealed class HttpMessageHandlerStub : DelegatingHandler
 #pragma warning restore CA1812 // Internal class that is apparently never instantiated
 {
@@ -33,7 +33,7 @@ internal sealed class HttpMessageHandlerStub : DelegatingHandler
     {
         this.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent("{}", Encoding.UTF8, MediaTypeNames.Application.Json),
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
         };
     }
 
@@ -42,11 +42,11 @@ internal sealed class HttpMessageHandlerStub : DelegatingHandler
         this.Method = request.Method;
         this.RequestUri = request.RequestUri;
         this.RequestHeaders = request.Headers;
-        this.RequestContent = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+        this.RequestContent = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
 
         if (request.Content is MultipartContent multipartContent)
         {
-            this.FirstMultipartContent = await multipartContent.First().ReadAsByteArrayAsync(cancellationToken);
+            this.FirstMultipartContent = await multipartContent.First().ReadAsByteArrayAsync();
         }
 
         this.ContentHeaders = request.Content?.Headers;

--- a/dotnet/src/InternalUtilities/test/MultipleHttpMessageHandlerStub.cs
+++ b/dotnet/src/InternalUtilities/test/MultipleHttpMessageHandlerStub.cs
@@ -4,12 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-#pragma warning disable CA1812
+#pragma warning disable CA1812, CA2016
 
 internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
 {
@@ -33,7 +32,7 @@ internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
     {
         this.ResponsesToReturn.Add(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json)
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
         });
     }
 
@@ -46,7 +45,7 @@ internal sealed class MultipleHttpMessageHandlerStub : DelegatingHandler
         this.RequestHeaders.Add(request.Headers);
         this.ContentHeaders.Add(request.Content?.Headers);
 
-        var content = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+        var content = request.Content is null ? null : await request.Content.ReadAsByteArrayAsync();
 
         this.RequestContents.Add(content);
 

--- a/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/HandlebarsPlannerTests.cs
+++ b/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/HandlebarsPlannerTests.cs
@@ -71,8 +71,8 @@ public sealed class HandlebarsPlannerTests
         // Act & Assert
         var exception = await Assert.ThrowsAsync<PlanCreationException>(async () => await planner.CreatePlanAsync(kernel, "goal"));
 
-        Assert.True(exception?.Message?.Contains("CreatePlan failed. See inner exception for details.", StringComparison.InvariantCulture));
-        Assert.True(exception?.InnerException?.Message?.Contains("Could not find the plan in the results", StringComparison.InvariantCulture));
+        Assert.True(exception?.Message?.Contains("CreatePlan failed. See inner exception for details."));
+        Assert.True(exception?.InnerException?.Message?.Contains("Could not find the plan in the results"));
         Assert.Equal(exception?.ModelResults?.Content, invalidPlan);
         Assert.NotNull(exception?.CreatePlanPrompt);
     }
@@ -86,8 +86,7 @@ public sealed class HandlebarsPlannerTests
 
         var promptName = "CreatePlan";
         var actualPartialsNamespace = $"{planner.GetType().Namespace}.{promptName}PromptPartials";
-        var resourceNames = assemply.GetManifestResourceNames()
-            .Where(name => name.Contains($"{promptName}PromptPartials", StringComparison.CurrentCulture));
+        var resourceNames = assemply.GetManifestResourceNames().Where(name => name.Contains($"{promptName}PromptPartials"));
 
         // Act  
         var actualContent = planner.ReadAllPromptPartials(promptName);
@@ -227,7 +226,7 @@ public sealed class HandlebarsPlannerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<PlanCreationException>(async () => await planner.CreatePlanAsync(kernel, "goal"));
-        Assert.True(exception?.InnerException?.Message?.Contains("Identified multiple Handlebars templates in model response", StringComparison.InvariantCulture));
+        Assert.True(exception?.InnerException?.Message?.Contains("Identified multiple Handlebars templates in model response"));
     }
 
     private Kernel CreateKernelWithMockCompletionResult(string testPlanString, KernelPluginCollection? plugins = null)

--- a/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/KernelParameterMetadataExtensionsTests.cs
+++ b/dotnet/src/Planners/Planners.Handlebars.UnitTests/Handlebars/KernelParameterMetadataExtensionsTests.cs
@@ -249,7 +249,7 @@ public class KernelParameterMetadataExtensionsTests
         var result = jsonProperties.ToJsonString();
 
         // Ensure that the line endings are consistent across different dotnet versions
-        result = result.Replace("\r\n", "\n", StringComparison.InvariantCulture);
+        result = result.Replace("\r\n", "\n");
 
         // Assert
         var expected = "{\n  \"name\": \"Alice\",\n  \"age\": 25\n}";

--- a/dotnet/src/Planners/Planners.Handlebars.UnitTests/Planners.Handlebars.UnitTests.csproj
+++ b/dotnet/src/Planners/Planners.Handlebars.UnitTests/Planners.Handlebars.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.SemanticKernel.Planners.Handlebars.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel.Planners.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/FileIOPluginTests.cs
@@ -31,7 +31,7 @@ public class FileIOPluginTests
         // Arrange
         var plugin = new FileIOPlugin();
         var path = Path.GetTempFileName();
-        await File.WriteAllTextAsync(path, "hello world");
+        File.WriteAllText(path, "hello world");
 
         // Act
         var result = await plugin.ReadAsync(path);
@@ -69,7 +69,7 @@ public class FileIOPluginTests
         await plugin.WriteAsync(path, "hello world");
 
         // Assert
-        Assert.Equal("hello world", await File.ReadAllTextAsync(path));
+        Assert.Equal("hello world", File.ReadAllText(path));
     }
 
     [Fact]

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/SessionsPythonPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/SessionsPythonPluginTests.cs
@@ -207,8 +207,8 @@ public sealed class SessionsPythonPluginTests : IDisposable
     public async Task ItShouldUploadFileAsync()
     {
         // Arrange
-        var responseContent = await File.ReadAllTextAsync(UpdaloadFileTestDataFilePath);
-        var requestPayload = await File.ReadAllBytesAsync(FileTestDataFilePath);
+        var responseContent = File.ReadAllText(UpdaloadFileTestDataFilePath);
+        var requestPayload = File.ReadAllBytes(FileTestDataFilePath);
 
         var expectedResponse = new SessionsRemoteFileMetadata("test.txt", 680)
         {
@@ -236,7 +236,7 @@ public sealed class SessionsPythonPluginTests : IDisposable
     public async Task ItShouldDownloadFileWithoutSavingInDiskAsync()
     {
         // Arrange
-        var responseContent = await File.ReadAllBytesAsync(FileTestDataFilePath);
+        var responseContent = File.ReadAllBytes(FileTestDataFilePath);
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new ByteArrayContent(responseContent),
@@ -255,8 +255,8 @@ public sealed class SessionsPythonPluginTests : IDisposable
     public async Task ItShouldDownloadFileSavingInDiskAsync()
     {
         // Arrange
-        var responseContent = await File.ReadAllBytesAsync(FileTestDataFilePath);
-        var downloadDiskPath = FileTestDataFilePath.Replace(".txt", "_download.txt", StringComparison.InvariantCultureIgnoreCase);
+        var responseContent = File.ReadAllBytes(FileTestDataFilePath);
+        var downloadDiskPath = FileTestDataFilePath.Replace(".txt", "_download.txt");
         if (File.Exists(downloadDiskPath))
         {
             File.Delete(downloadDiskPath);
@@ -275,7 +275,7 @@ public sealed class SessionsPythonPluginTests : IDisposable
         // Assert
         Assert.Equal(responseContent, result);
         Assert.True(File.Exists(downloadDiskPath));
-        Assert.Equal(responseContent, await File.ReadAllBytesAsync(downloadDiskPath));
+        Assert.Equal(responseContent, File.ReadAllBytes(downloadDiskPath));
     }
 
     public void Dispose()

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/TextPluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/TextPluginTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Globalization;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Plugins.Core;
 using Xunit;

--- a/dotnet/src/Plugins/Plugins.UnitTests/Core/TimePluginTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Core/TimePluginTests.cs
@@ -85,7 +85,7 @@ public class TimePluginTests
 
     public static IEnumerable<object[]> DayOfWeekEnumerator()
     {
-        foreach (var day in Enum.GetValues<DayOfWeek>())
+        foreach (var day in Enum.GetValues(typeof(DayOfWeek)))
         {
             yield return new object[] { day };
         }

--- a/dotnet/src/Plugins/Plugins.UnitTests/Memory/VolatileMemoryStoreTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Memory/VolatileMemoryStoreTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -35,7 +34,7 @@ public class VolatileMemoryStoreTests
                 text: "text" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 1, 1 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         for (int i = numRecords / 2; i < numRecords; i++)
@@ -45,7 +44,7 @@ public class VolatileMemoryStoreTests
                 sourceName: "sourceName" + i,
                 description: "description" + i,
                 embedding: new float[] { 1, 2, 3 });
-            records = records.Append(testRecord);
+            records = records.Concat([testRecord]);
         }
 
         return records;
@@ -476,7 +475,7 @@ public class VolatileMemoryStoreTests
 
         // Act
         var topNResults = this._db.GetNearestMatchesAsync(collection, compareEmbedding, limit: topN, minRelevanceScore: 0.75).ToEnumerable().ToArray();
-        IEnumerable<string> topNKeys = topNResults.Select(x => x.Item1.Key).ToImmutableSortedSet();
+        IEnumerable<string> topNKeys = new SortedSet<string>(topNResults.Select(x => x.Item1.Key));
 
         // Assert
         Assert.Equal(topN, topNResults.Length);

--- a/dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Plugins.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SemanticKernel.Plugins.UnitTests</AssemblyName>
     <RootNamespace>SemanticKernel.Plugins.UnitTests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>


### PR DESCRIPTION
@dmytrostruk, in conjunction with https://github.com/microsoft/semantic-kernel/pull/6323 and https://github.com/microsoft/semantic-kernel/pull/6324, this enables all of the tests projects for .NET Framework, gets all of them building, and gets the unit tests passing for me locally.

Contributes to https://github.com/microsoft/semantic-kernel/issues/6063