### PR TITLE
Python: Try to fix a doc building issue.

### DIFF
--- a/python/semantic_kernel/functions/kernel_plugin.py
+++ b/python/semantic_kernel/functions/kernel_plugin.py
@@ -131,7 +131,7 @@ class KernelPlugin(KernelBaseModel):
     # region Dict-like methods
 
     def __setitem__(self, key: str, value: KERNEL_FUNCTION_TYPE) -> None:
-        """Set a function in the plugin.
+        """Sets a function in the plugin.
 
         This function uses plugin[function_name] = function syntax.
 


### PR DESCRIPTION
### Motivation and Context

The docs tool is breaking because two methods share the same signatures and the beginnings of the docstring. 
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Try to differentiate the docstrings by a char to see if it fixes the docs generation.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
