### PR TITLE
Python: Separate set and __setitem__ strings

### DIFF
--- a/python/semantic_kernel/functions/kernel_plugin.py
+++ b/python/semantic_kernel/functions/kernel_plugin.py
@@ -56,7 +56,8 @@ class KernelPlugin(KernelBaseModel):
             indexed by their name.
 
     Methods:
-        set, __setitem__ (key: str, value: KernelFunction): Set a function in the plugin.
+        set (key: str, value: KernelFunction): Set a function in the plugin.
+        __setitem__ (key: str, value: KernelFunction): Set a function in the plugin.
         get (key: str, default: KernelFunction | None = None): Get a function from the plugin.
         __getitem__ (key: str): Get a function from the plugin.
         __contains__ (key: str): Check if a function is in the plugin.


### PR DESCRIPTION
### Motivation and Context

Separate set and __setitem__ doc strings

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Separate set and __setitem__ doc strings

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
