### PR TITLE
Java: Add example of a multi turnaround chat with tool calls. Fixes bug with serializing tool call arguments

### DIFF
--- a/java/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
+++ b/java/aiservices/openai/src/main/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAIChatCompletion.java
@@ -885,7 +885,7 @@ public class OpenAIChatCompletion extends OpenAiService implements ChatCompletio
 
                 if (id == null) {
                     throw new SKException(
-                        "Require to create a tool call message, but not tool call id is available");
+                        "Require to create a tool call message, but no tool call id is available");
                 }
                 return new ChatRequestToolMessage(content, id);
             default:
@@ -918,7 +918,7 @@ public class OpenAIChatCompletion extends OpenAiService implements ChatCompletio
                                     StringEscapeUtils.escapeJson(entry.getKey()),
                                     StringEscapeUtils.escapeJson(
                                         entry.getValue().toPromptString())))
-                                .collect(Collectors.joining("{", "}", ","))
+                                .collect(Collectors.joining(",", "{", "}"))
                             : "{}";
 
                         String prefix = "";

--- a/java/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAiChatCompletionTest.java
+++ b/java/aiservices/openai/src/test/java/com/microsoft/semantickernel/aiservices/openai/chatcompletion/OpenAiChatCompletionTest.java
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft. All rights reserved.
+package com.microsoft.semantickernel.aiservices.openai.chatcompletion;
+
+import com.azure.ai.openai.OpenAIAsyncClient;
+import com.azure.ai.openai.models.ChatCompletions;
+import com.azure.ai.openai.models.ChatCompletionsFunctionToolCall;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.azure.ai.openai.models.ChatRequestAssistantMessage;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.semantickernel.implementation.EmbeddedResourceLoader;
+import com.microsoft.semantickernel.orchestration.FunctionResultMetadata;
+import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.services.chatcompletion.AuthorRole;
+import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+public class OpenAiChatCompletionTest {
+
+    @Test
+    public void serializesToolCallsCorrectly() {
+        OpenAIAsyncClient client = Mockito.mock(OpenAIAsyncClient.class);
+        OpenAIChatCompletion chatCompletion = mockClient(client);
+
+        ChatHistory chatHistory = new ChatHistory();
+
+        chatHistory.addUserMessage(
+            "What is the name of the pet with id ca2fc6bc-1307-4da6-a009-d7bf88dec37b?");
+
+        chatHistory.addMessage(new OpenAIChatMessageContent(
+            AuthorRole.ASSISTANT,
+            "",
+            "test",
+            null,
+            Charset.defaultCharset(),
+            null,
+            Arrays.asList(
+                new OpenAIFunctionToolCall(
+                    "a-tool-id",
+                    "pluginName",
+                    "funcName",
+                    KernelFunctionArguments.builder()
+                        .withVariable("id", "ca2fc6bc-1307-4da6-a009-d7bf88dec37b")
+                        .build()))));
+        chatHistory.addMessage(new OpenAIChatMessageContent(
+            AuthorRole.TOOL,
+            "Snuggles",
+            "test",
+            null,
+            Charset.defaultCharset(),
+            FunctionResultMetadata.build("a-tool-id"),
+            null));
+
+        chatCompletion
+            .getChatMessageContentsAsync(chatHistory, null, null).block();
+
+        Mockito.verify(client, Mockito.times(1))
+            .getChatCompletionsWithResponse(
+                Mockito.any(),
+                Mockito.<ChatCompletionsOptions>argThat(options -> {
+                    ChatRequestAssistantMessage message = ((ChatRequestAssistantMessage) options
+                        .getMessages()
+                        .get(1));
+                    ChatCompletionsFunctionToolCall toolcall = ((ChatCompletionsFunctionToolCall) message
+                        .getToolCalls()
+                        .get(0));
+                    return toolcall
+                        .getFunction()
+                        .getArguments()
+                        .equals("{\"id\": \"ca2fc6bc-1307-4da6-a009-d7bf88dec37b\"}");
+                }),
+                Mockito.any());
+    }
+
+    private static OpenAIChatCompletion mockClient(OpenAIAsyncClient client) {
+        Mockito.when(client.getChatCompletionsWithResponse(Mockito.any(),
+            Mockito.<ChatCompletionsOptions>any(), Mockito.any()))
+            .thenReturn(Mono.just(
+                new Response<ChatCompletions>() {
+                    @Override
+                    public int getStatusCode() {
+                        return 200;
+                    }
+
+                    @Override
+                    public HttpHeaders getHeaders() {
+                        return new HttpHeaders();
+                    }
+
+                    @Override
+                    public HttpRequest getRequest() {
+                        return null;
+                    }
+
+                    @Override
+                    public ChatCompletions getValue() {
+                        try {
+                            String message = EmbeddedResourceLoader.readFile("chatCompletion.txt",
+                                OpenAiChatCompletionTest.class);
+
+                            return new ObjectMapper()
+                                .readValue(String.format(message, "Snuggles"),
+                                    ChatCompletions.class);
+
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }));
+        return new OpenAIChatCompletion(
+            client,
+            "test",
+            "test",
+            "test");
+    }
+
+}

--- a/java/aiservices/openai/src/test/resources/com/microsoft/semantickernel/aiservices/openai/chatcompletion/chatCompletion.txt
+++ b/java/aiservices/openai/src/test/resources/com/microsoft/semantickernel/aiservices/openai/chatcompletion/chatCompletion.txt
@@ -1,0 +1,60 @@
+{
+   "choices" : [
+      {
+         "content_filter_results" : {
+            "hate" : {
+               "filtered" : false,
+               "severity" : "safe"
+            },
+            "self_harm" : {
+               "filtered" : false,
+               "severity" : "safe"
+            },
+            "sexual" : {
+               "filtered" : false,
+               "severity" : "safe"
+            },
+            "violence" : {
+               "filtered" : false,
+               "severity" : "safe"
+            }
+         },
+         "finish_reason" : "stop",
+         "index" : 0,
+         "message" : {
+            "content" : "%s",
+            "role" : "assistant"
+         }
+      }
+   ],
+   "created" : 1707253039,
+   "id" : "chatcmpl-xxx",
+   "prompt_filter_results" : [
+      {
+         "content_filter_results" : {
+            "hate" : {
+               "filtered" : false,
+               "severity" : "safe"
+            },
+            "self_harm" : {
+               "filtered" : false,
+               "severity" : "safe"
+            },
+            "sexual" : {
+               "filtered" : false,
+               "severity" : "safe"
+            },
+            "violence" : {
+               "filtered" : false,
+               "severity" : "safe"
+            }
+         },
+         "prompt_index" : 0
+      }
+   ],
+   "usage" : {
+      "completion_tokens" : 131,
+      "prompt_tokens" : 26,
+      "total_tokens" : 157
+   }
+}


### PR DESCRIPTION


### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
