### PR TITLE
Python: Refactoring. Use get_function and get_plugin.

### DIFF
--- a/python/samples/concepts/search/bing_plugin_examples.py
+++ b/python/samples/concepts/search/bing_plugin_examples.py
@@ -14,7 +14,7 @@ async def example1(kernel: Kernel, search_plugin_name: str):
     print("======== Bing and Google Search Plugins ========")
 
     question = "What's the largest building in the world?"
-    function = kernel.plugins[search_plugin_name]["search"]
+    function = kernel.get_function(search_plugin_name, "search")
     result = await kernel.invoke(function, query=question)
 
     print(question)

--- a/python/samples/concepts/search/bing_plugin_examples.py
+++ b/python/samples/concepts/search/bing_plugin_examples.py
@@ -14,7 +14,7 @@ async def example1(kernel: Kernel, search_plugin_name: str):
     print("======== Bing and Google Search Plugins ========")
 
     question = "What's the largest building in the world?"
-    function = kernel.get_function(search_plugin_name, "search")
+    function = kernel.get_function(plugin_name=search_plugin_name, function_name="search")
     result = await kernel.invoke(function, query=question)
 
     print(question)

--- a/python/samples/learn_resources/serializing_prompts.py
+++ b/python/samples/learn_resources/serializing_prompts.py
@@ -50,7 +50,7 @@ async def main():
         plugin_name="ConversationSummaryPlugin",
     )
 
-    summarize_function = kernel.plugins["ConversationSummaryPlugin"]["SummarizeConversation"]
+    summarize_function = kernel.get_function("ConversationSummaryPlugin", "SummarizeConversation")
 
     # Create the history
     history = ChatHistory()

--- a/python/samples/learn_resources/serializing_prompts.py
+++ b/python/samples/learn_resources/serializing_prompts.py
@@ -51,8 +51,7 @@ async def main():
     )
 
     summarize_function = kernel.get_function(
-        plugin_name="ConversationSummaryPlugin",
-        function_name="SummarizeConversation"
+        plugin_name="ConversationSummaryPlugin", function_name="SummarizeConversation"
     )
 
     # Create the history

--- a/python/samples/learn_resources/serializing_prompts.py
+++ b/python/samples/learn_resources/serializing_prompts.py
@@ -50,7 +50,10 @@ async def main():
         plugin_name="ConversationSummaryPlugin",
     )
 
-    summarize_function = kernel.get_function("ConversationSummaryPlugin", "SummarizeConversation")
+    summarize_function = kernel.get_function(
+        plugin_name="ConversationSummaryPlugin",
+        function_name="SummarizeConversation"
+    )
 
     # Create the history
     history = ChatHistory()

--- a/python/semantic_kernel/connectors/ai/open_ai/const.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/const.py
@@ -4,4 +4,3 @@ from typing import Final
 
 DEFAULT_AZURE_API_VERSION: Final[str] = "2024-02-01"
 USER_AGENT: Final[str] = "User-Agent"
-DEFAULT_CHAT_SYSTEM_PROMPT: Final[str] = "Assistant is a large language model."

--- a/python/tests/unit/core_plugins/test_http_plugin.py
+++ b/python/tests/unit/core_plugins/test_http_plugin.py
@@ -21,10 +21,10 @@ async def test_it_can_be_imported():
     kernel = Kernel()
     plugin = HttpPlugin()
     kernel.add_plugin(plugin, "http")
-    assert kernel.plugins["http"] is not None
-    assert kernel.plugins["http"].name == "http"
-    assert kernel.plugins["http"]["getAsync"] is not None
-    assert kernel.plugins["http"]["postAsync"] is not None
+    assert kernel.get_plugin("http") is not None
+    assert kernel.get_plugin("http").name == "http"
+    assert kernel.get_function("http", "getAsync") is not None
+    assert kernel.get_function("http", "postAsync") is not None
 
 
 @patch("aiohttp.ClientSession.get")

--- a/python/tests/unit/core_plugins/test_http_plugin.py
+++ b/python/tests/unit/core_plugins/test_http_plugin.py
@@ -21,10 +21,10 @@ async def test_it_can_be_imported():
     kernel = Kernel()
     plugin = HttpPlugin()
     kernel.add_plugin(plugin, "http")
-    assert kernel.get_plugin("http") is not None
-    assert kernel.get_plugin("http").name == "http"
-    assert kernel.get_function("http", "getAsync") is not None
-    assert kernel.get_function("http", "postAsync") is not None
+    assert kernel.get_plugin(plugin_name="http") is not None
+    assert kernel.get_plugin(plugin_name="http").name == "http"
+    assert kernel.get_function(plugin_name="http", function_name="getAsync") is not None
+    assert kernel.get_function(plugin_name="http", function_name="postAsync") is not None
 
 
 @patch("aiohttp.ClientSession.get")

--- a/python/tests/unit/core_plugins/test_math_plugin.py
+++ b/python/tests/unit/core_plugins/test_math_plugin.py
@@ -15,10 +15,10 @@ def test_can_be_instantiated():
 def test_can_be_imported():
     kernel = Kernel()
     kernel.add_plugin(MathPlugin(), "math")
-    assert kernel.get_plugin("math") is not None
-    assert kernel.get_plugin("math").name == "math"
-    assert kernel.get_function("math", "Add") is not None
-    assert kernel.get_function("math", "Subtract") is not None
+    assert kernel.get_plugin(plugin_name="math") is not None
+    assert kernel.get_plugin(plugin_name="math").name == "math"
+    assert kernel.get_function(plugin_name="math", function_name="Add") is not None
+    assert kernel.get_function(plugin_name="math", function_name="Subtract") is not None
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/core_plugins/test_math_plugin.py
+++ b/python/tests/unit/core_plugins/test_math_plugin.py
@@ -15,10 +15,10 @@ def test_can_be_instantiated():
 def test_can_be_imported():
     kernel = Kernel()
     kernel.add_plugin(MathPlugin(), "math")
-    assert kernel.plugins["math"] is not None
-    assert kernel.plugins["math"].name == "math"
-    assert kernel.plugins["math"]["Add"] is not None
-    assert kernel.plugins["math"]["Subtract"] is not None
+    assert kernel.get_plugin("math") is not None
+    assert kernel.get_plugin("math").name == "math"
+    assert kernel.get_function("math", "Add") is not None
+    assert kernel.get_function("math", "Subtract") is not None
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/core_plugins/test_sessions_python_plugin.py
+++ b/python/tests/unit/core_plugins/test_sessions_python_plugin.py
@@ -30,8 +30,8 @@ def test_validate_endpoint(aca_python_sessions_unit_test_env):
 def test_it_can_be_imported(kernel: Kernel, aca_python_sessions_unit_test_env):
     plugin = SessionsPythonTool(auth_callback=test_auth_callback)
     assert kernel.add_plugin(plugin=plugin, plugin_name="PythonCodeInterpreter")
-    assert kernel.get_plugin("PythonCodeInterpreter") is not None
-    assert kernel.get_plugin("PythonCodeInterpreter").name == "PythonCodeInterpreter"
+    assert kernel.get_plugin(plugin_name="PythonCodeInterpreter") is not None
+    assert kernel.get_plugin(plugin_name="PythonCodeInterpreter").name == "PythonCodeInterpreter"
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/core_plugins/test_sessions_python_plugin.py
+++ b/python/tests/unit/core_plugins/test_sessions_python_plugin.py
@@ -30,8 +30,8 @@ def test_validate_endpoint(aca_python_sessions_unit_test_env):
 def test_it_can_be_imported(kernel: Kernel, aca_python_sessions_unit_test_env):
     plugin = SessionsPythonTool(auth_callback=test_auth_callback)
     assert kernel.add_plugin(plugin=plugin, plugin_name="PythonCodeInterpreter")
-    assert kernel.plugins["PythonCodeInterpreter"] is not None
-    assert kernel.plugins["PythonCodeInterpreter"].name == "PythonCodeInterpreter"
+    assert kernel.get_plugin("PythonCodeInterpreter") is not None
+    assert kernel.get_plugin("PythonCodeInterpreter").name == "PythonCodeInterpreter"
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/core_plugins/test_text_memory_plugin.py
+++ b/python/tests/unit/core_plugins/test_text_memory_plugin.py
@@ -36,7 +36,7 @@ def test_can_be_instantiated(memory: SemanticTextMemory):
 
 def test_can_be_imported(kernel: Kernel, memory: SemanticTextMemory):
     kernel.add_plugin(TextMemoryPlugin(memory), "memory_plugin")
-    assert not kernel.plugins["memory_plugin"]["recall"].is_prompt
+    assert not kernel.get_function("memory_plugin", "recall").is_prompt
 
 
 @mark.asyncio

--- a/python/tests/unit/core_plugins/test_text_memory_plugin.py
+++ b/python/tests/unit/core_plugins/test_text_memory_plugin.py
@@ -36,7 +36,7 @@ def test_can_be_instantiated(memory: SemanticTextMemory):
 
 def test_can_be_imported(kernel: Kernel, memory: SemanticTextMemory):
     kernel.add_plugin(TextMemoryPlugin(memory), "memory_plugin")
-    assert not kernel.get_function("memory_plugin", "recall").is_prompt
+    assert not kernel.get_function(plugin_name="memory_plugin", function_name="recall").is_prompt
 
 
 @mark.asyncio

--- a/python/tests/unit/core_plugins/test_text_plugin.py
+++ b/python/tests/unit/core_plugins/test_text_plugin.py
@@ -10,12 +10,12 @@ def test_can_be_instantiated():
 
 def test_can_be_imported(kernel: Kernel):
     kernel.add_plugin(TextPlugin(), "text_plugin")
-    assert not kernel.plugins["text_plugin"]["trim"].is_prompt
+    assert not kernel.get_function("text_plugin", "trim").is_prompt
 
 
 def test_can_be_imported_with_name(kernel: Kernel):
     kernel.add_plugin(TextPlugin(), "text")
-    assert not kernel.plugins["text"]["trim"].is_prompt
+    assert not kernel.get_function("text", "trim").is_prompt
 
 
 def test_can_trim():

--- a/python/tests/unit/core_plugins/test_text_plugin.py
+++ b/python/tests/unit/core_plugins/test_text_plugin.py
@@ -10,12 +10,12 @@ def test_can_be_instantiated():
 
 def test_can_be_imported(kernel: Kernel):
     kernel.add_plugin(TextPlugin(), "text_plugin")
-    assert not kernel.get_function("text_plugin", "trim").is_prompt
+    assert not kernel.get_function(plugin_name="text_plugin", function_name="trim").is_prompt
 
 
 def test_can_be_imported_with_name(kernel: Kernel):
     kernel.add_plugin(TextPlugin(), "text")
-    assert not kernel.get_function("text", "trim").is_prompt
+    assert not kernel.get_function(plugin_name="text", function_name="trim").is_prompt
 
 
 def test_can_trim():

--- a/python/tests/unit/core_plugins/test_time_plugin.py
+++ b/python/tests/unit/core_plugins/test_time_plugin.py
@@ -15,9 +15,9 @@ def test_can_be_instantiated():
 def test_can_be_imported():
     kernel = sk.Kernel()
     kernel.add_plugin(TimePlugin(), "time")
-    assert kernel.plugins["time"] is not None
-    assert kernel.plugins["time"].name == "time"
-    assert kernel.plugins["time"]["now"] is not None
+    assert kernel.get_plugin("time") is not None
+    assert kernel.get_plugin("time").name == "time"
+    assert kernel.get_function("time", "now") is not None
 
 
 def test_date():

--- a/python/tests/unit/core_plugins/test_time_plugin.py
+++ b/python/tests/unit/core_plugins/test_time_plugin.py
@@ -15,9 +15,9 @@ def test_can_be_instantiated():
 def test_can_be_imported():
     kernel = sk.Kernel()
     kernel.add_plugin(TimePlugin(), "time")
-    assert kernel.get_plugin("time") is not None
-    assert kernel.get_plugin("time").name == "time"
-    assert kernel.get_function("time", "now") is not None
+    assert kernel.get_plugin(plugin_name="time") is not None
+    assert kernel.get_plugin(plugin_name="time").name == "time"
+    assert kernel.get_function(plugin_name="time", function_name="now") is not None
 
 
 def test_date():

--- a/python/tests/unit/kernel/test_kernel.py
+++ b/python/tests/unit/kernel/test_kernel.py
@@ -279,7 +279,7 @@ async def test_add_plugin_from_openai(mock_parse_openai_manifest, kernel: Kernel
             enable_dynamic_payload=True,
         ),
     )
-    plugin = kernel.plugins["TestOpenAIPlugin"]
+    plugin = kernel.get_plugin("TestOpenAIPlugin")
     assert plugin is not None
     assert plugin.name == "TestOpenAIPlugin"
     assert plugin.functions.get("GetSecret") is not None
@@ -295,7 +295,7 @@ def test_import_plugin_from_openapi(kernel: Kernel):
         plugin_name="TestOpenAPIPlugin",
         openapi_document_path=openapi_spec_file,
     )
-    plugin = kernel.plugins["TestOpenAPIPlugin"]
+    plugin = kernel.get_plugin("TestOpenAPIPlugin")
     assert plugin is not None
     assert plugin.name == "TestOpenAPIPlugin"
     assert plugin.functions.get("GetSecret") is not None

--- a/python/tests/unit/kernel/test_kernel.py
+++ b/python/tests/unit/kernel/test_kernel.py
@@ -279,7 +279,7 @@ async def test_add_plugin_from_openai(mock_parse_openai_manifest, kernel: Kernel
             enable_dynamic_payload=True,
         ),
     )
-    plugin = kernel.get_plugin("TestOpenAIPlugin")
+    plugin = kernel.get_plugin(plugin_name="TestOpenAIPlugin")
     assert plugin is not None
     assert plugin.name == "TestOpenAIPlugin"
     assert plugin.functions.get("GetSecret") is not None
@@ -295,7 +295,7 @@ def test_import_plugin_from_openapi(kernel: Kernel):
         plugin_name="TestOpenAPIPlugin",
         openapi_document_path=openapi_spec_file,
     )
-    plugin = kernel.get_plugin("TestOpenAPIPlugin")
+    plugin = kernel.get_plugin(plugin_name="TestOpenAPIPlugin")
     assert plugin is not None
     assert plugin.name == "TestOpenAPIPlugin"
     assert plugin.functions.get("GetSecret") is not None

--- a/python/tests/unit/kernel/test_register_functions.py
+++ b/python/tests/unit/kernel/test_register_functions.py
@@ -18,7 +18,7 @@ async def test_register_valid_native_function(kernel: Kernel, decorated_native_f
     registered_func = kernel.get_function(plugin_name="TestPlugin", function_name="getLightStatus")
 
     assert isinstance(registered_func, KernelFunction)
-    assert kernel.get_function(plugin_name="TestPlugin",function_name= "getLightStatus") == registered_func
+    assert kernel.get_function(plugin_name="TestPlugin", function_name="getLightStatus") == registered_func
     func_result = await registered_func.invoke(kernel, KernelArguments(arg1="testtest"))
     assert str(func_result) == "test"
 

--- a/python/tests/unit/kernel/test_register_functions.py
+++ b/python/tests/unit/kernel/test_register_functions.py
@@ -18,7 +18,7 @@ async def test_register_valid_native_function(kernel: Kernel, decorated_native_f
     registered_func = kernel.get_function("TestPlugin", "getLightStatus")
 
     assert isinstance(registered_func, KernelFunction)
-    assert kernel.plugins["TestPlugin"]["getLightStatus"] == registered_func
+    assert kernel.get_function("TestPlugin", "getLightStatus") == registered_func
     func_result = await registered_func.invoke(kernel, KernelArguments(arg1="testtest"))
     assert str(func_result) == "test"
 

--- a/python/tests/unit/kernel/test_register_functions.py
+++ b/python/tests/unit/kernel/test_register_functions.py
@@ -14,11 +14,11 @@ from semantic_kernel.functions.kernel_function import KernelFunction
 
 @pytest.mark.asyncio
 async def test_register_valid_native_function(kernel: Kernel, decorated_native_function: Callable):
-    kernel.add_function("TestPlugin", function=decorated_native_function)
-    registered_func = kernel.get_function("TestPlugin", "getLightStatus")
+    kernel.add_function(plugin_name="TestPlugin", function=decorated_native_function)
+    registered_func = kernel.get_function(plugin_name="TestPlugin", function_name="getLightStatus")
 
     assert isinstance(registered_func, KernelFunction)
-    assert kernel.get_function("TestPlugin", "getLightStatus") == registered_func
+    assert kernel.get_function(plugin_name="TestPlugin",function_name= "getLightStatus") == registered_func
     func_result = await registered_func.invoke(kernel, KernelArguments(arg1="testtest"))
     assert str(func_result) == "test"
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Refactoring some of the code following [this advice](https://github.com/microsoft/semantic-kernel/pull/6371#discussion_r1611138252) from the maintainers.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Look up kernel functions and plugins with the `get_function` and `get_plugin` method. Removed the unused `DEFAULT_CHAT_SYSTEM_PROMPT`

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
