### PR TITLE
Python: Remove assert on non-required api_key

### DIFF
--- a/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_cognitive_search_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_cognitive_search_memory_store.py
@@ -81,7 +81,6 @@ class AzureCognitiveSearchMemoryStore(MemoryStoreBase):
             if acs_memory_settings and acs_memory_settings.api_key
             else None
         )
-        assert admin_key, "The ACS admin_key is required to connect to Azure Cognitive Search."
         search_endpoint = search_endpoint or (
             acs_memory_settings.endpoint if acs_memory_settings and acs_memory_settings.endpoint else None
         )


### PR DESCRIPTION
### Motivation and Context

The ACS admin key isn't required as the user can pass in either azure credentials or token credentials. Right now there is an assert on the api_key not being null that is blocking. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Remove the assert on the api_key. Closes #6369

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
