### PR TITLE
.Net: Update obsolete links

### DIFF
--- a/docs/decisions/0010-dotnet-project-structure.md
+++ b/docs/decisions/0010-dotnet-project-structure.md
@@ -1,7 +1,7 @@
 ---
 # These are optional elements. Feel free to remove any of them
 
-status: accepted
+status: superseded by [ADR-0042](0042-samples-restructure.md)
 contact: markwallace-microsoft
 date: 2023-09-29
 deciders: SergeyMenshykh, dmytrostruk, RogerBarreto
@@ -250,11 +250,9 @@ Below are some different examples of Assembly and root namespace naming that are
 ```text
 dotnet/
 ├── samples/
-│   └── Concepts/
-│   └── Demos/
-│   └── GettingStarted/
-│   └── GettingStartedWithAgents/
-│   └── LearnResources/
+│   ├── ApplicationInsightsExample/
+│   ├── KernelSyntaxExamples/
+│   └── NCalcSkills/
 └── src/
     ├── Connectors/
     │   ├── Connectors.AI.OpenAI*

--- a/docs/decisions/0010-dotnet-project-structure.md
+++ b/docs/decisions/0010-dotnet-project-structure.md
@@ -250,9 +250,11 @@ Below are some different examples of Assembly and root namespace naming that are
 ```text
 dotnet/
 ├── samples/
-│   ├── ApplicationInsightsExample/
-│   ├── KernelSyntaxExamples/
-│   └── NCalcSkills/
+│   └── Concepts/
+│   └── Demos/
+│   └── GettingStarted/
+│   └── GettingStartedWithAgents/
+│   └── LearnResources/
 └── src/
     ├── Connectors/
     │   ├── Connectors.AI.OpenAI*

--- a/dotnet/samples/Demos/BookingRestaurant/README.md
+++ b/dotnet/samples/Demos/BookingRestaurant/README.md
@@ -7,7 +7,7 @@ This sample provides a practical demonstration of how to leverage features from 
 - [Plugin](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel.Abstractions/Functions/KernelPlugin.cs) - Creating a Plugin from a native C# Booking class to be used by the Kernel to interact with Bookings API.
 - [Chat Completion Service](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatCompletionService.cs) - Using the Chat Completion Service [OpenAI Connector implementation](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Connectors/Connectors.OpenAI/ChatCompletion/OpenAIChatCompletionService.cs) to generate responses from the LLM.
 - [Chat History](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatHistory.cs) Using the Chat History abstraction to create, update and retrieve chat history from Chat Completion Models.
-- [Auto Function Calling](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs) Enables the LLM to have knowledge of current importedUsing the Function Calling feature automatically call the Booking Plugin from the LLM.
+- [Auto Function Calling](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/AutoFunctionCalling/OpenAI_FunctionCalling.cs) Enables the LLM to have knowledge of current importedUsing the Function Calling feature automatically call the Booking Plugin from the LLM.
 
 ## Prerequisites
 

--- a/dotnet/samples/Demos/TimePlugin/README.md
+++ b/dotnet/samples/Demos/TimePlugin/README.md
@@ -10,7 +10,7 @@ Here we have a simple Time Plugin created in C# that can be called from the AI M
 - [Plugin](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel.Abstractions/Functions/KernelPlugin.cs) - Creating a Plugin from a native C# Booking class to be used by the Kernel to interact with Bookings API.
 - [Chat Completion Service](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatCompletionService.cs) - Using the Chat Completion Service [OpenAI Connector implementation](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Connectors/Connectors.OpenAI/ChatCompletion/OpenAIChatCompletionService.cs) to generate responses from the LLM.
 - [Chat History](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatHistory.cs) Using the Chat History abstraction to create, update and retrieve chat history from Chat Completion Models.
-- [Auto Function Calling](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs) Enables the LLM to have knowledge of current importedUsing the Function Calling feature automatically call the Booking Plugin from the LLM.
+- [Auto Function Calling](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/AutoFunctionCalling/OpenAI_FunctionCalling.cs) Enables the LLM to have knowledge of current importedUsing the Function Calling feature automatically call the Booking Plugin from the LLM.
 
 ## Prerequisites
 


### PR DESCRIPTION
### Motivation and Context

1. This change is required to ensure all documentation links are up-to-date.
2. It solves the problem of users encountering broken or outdated links.
3. It contributes to the scenario of maintaining accurate and helpful documentation for users.
4. N/A


<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Updated several obsolete links in the documentation to point to the current and correct URLs. This ensures users have access to the most recent and relevant information.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
