### PR TITLE
Add API to create a PromptTemplateConfig from a Prompty template

### DIFF
--- a/dotnet/samples/Concepts/Prompty/PromptyFunction.cs
+++ b/dotnet/samples/Concepts/Prompty/PromptyFunction.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.PromptTemplates.Liquid;
 
 namespace Prompty;
 
@@ -99,6 +101,38 @@ public class PromptyFunction(ITestOutputHelper output) : BaseTest(output)
         var function = kernel.CreateFunctionFromPrompty(promptyTemplate);
 
         var result = await kernel.InvokeAsync(function, arguments);
+        Console.WriteLine(result);
+    }
+
+    [Fact]
+    public async Task RenderPromptAsync()
+    {
+        Kernel kernel = Kernel.CreateBuilder()
+            .AddOpenAIChatCompletion(
+                modelId: TestConfiguration.OpenAI.ChatModelId,
+                apiKey: TestConfiguration.OpenAI.ApiKey)
+            .Build();
+
+        string promptyTemplate = """
+            ---
+            name: Contoso_Prompt
+            description: A sample prompt that responds with what Seattle is.
+            authors:
+              - ????
+            model:
+              api: chat
+            ---
+            What is Seattle?
+            """;
+
+        var promptConfig = PromptyKernelExtensions.ToPromptTemplateConfig(promptyTemplate);
+        var promptTemplateFactory = new LiquidPromptTemplateFactory();
+        var promptTemplate = promptTemplateFactory.Create(promptConfig);
+        var prompt = await promptTemplate.RenderAsync(kernel);
+
+        var chatService = kernel.GetRequiredService<IChatCompletionService>();
+        var result = await chatService.GetChatMessageContentAsync(prompt);
+
         Console.WriteLine(result);
     }
 }

--- a/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Extensions/PromptyKernelExtensions.cs
@@ -83,6 +83,25 @@ public static partial class PromptyKernelExtensions
         Verify.NotNull(kernel);
         Verify.NotNullOrWhiteSpace(promptyTemplate);
 
+        var promptTemplateConfig = ToPromptTemplateConfig(promptyTemplate);
+
+        return KernelFunctionFactory.CreateFromPrompt(
+            promptTemplateConfig,
+            promptTemplateFactory ?? s_defaultTemplateFactory,
+            kernel.LoggerFactory);
+    }
+
+    /// <summary>
+    /// Create a <see cref="PromptTemplateConfig"/> from a prompty template.
+    /// </summary>
+    /// <param name="promptyTemplate">Prompty representation of a prompt-based <see cref="KernelFunction"/>.</param>
+    /// <returns>The created <see cref="PromptTemplateConfig"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="promptyTemplate"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="promptyTemplate"/> is empty or composed entirely of whitespace.</exception>
+    public static PromptTemplateConfig ToPromptTemplateConfig(string promptyTemplate)
+    {
+        Verify.NotNullOrWhiteSpace(promptyTemplate);
+
         // Step 1:
         // Create PromptTemplateConfig from text.
         // Retrieve the header, which is in yaml format and put between ---
@@ -224,9 +243,6 @@ public static partial class PromptyKernelExtensions
         // Update template format. If not provided, use Liquid as default.
         promptTemplateConfig.TemplateFormat = prompty.Template ?? LiquidPromptTemplateFactory.LiquidTemplateFormat;
 
-        return KernelFunctionFactory.CreateFromPrompt(
-            promptTemplateConfig,
-            promptTemplateFactory ?? s_defaultTemplateFactory,
-            kernel.LoggerFactory);
+        return promptTemplateConfig;
     }
 }


### PR DESCRIPTION
### Motivation and Context

This change enables the following flow:

```csharp
      Kernel kernel = Kernel.CreateBuilder()
          .AddOpenAIChatCompletion(
              modelId: TestConfiguration.OpenAI.ChatModelId,
              apiKey: TestConfiguration.OpenAI.ApiKey)
          .Build();

      string promptyTemplate = """
          ---
          name: Contoso_Prompt
          description: A sample prompt that responds with what Seattle is.
          authors:
            - ????
          model:
            api: chat
          ---
          What is Seattle?
          """;

      var promptConfig = PromptyKernelExtensions.ToPromptTemplateConfig(promptyTemplate);
      var promptTemplateFactory = new LiquidPromptTemplateFactory();
      var promptTemplate = promptTemplateFactory.Create(promptConfig);
      var prompt = await promptTemplate.RenderAsync(kernel);

      var chatService = kernel.GetRequiredService<IChatCompletionService>();
      var result = await chatService.GetChatMessageContentAsync(prompt);
```

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
