### PR TITLE
.Net: Return result of the function executed before termination for streaming API

### DIFF
--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
@@ -447,7 +447,7 @@ internal sealed class MistralClient
 
                 this.AddResponseMessage(chatRequest, chatHistory, toolCall, result: stringResult, errorMessage: null);
 
-                // If filter requested termination, breaking request iteration loop.
+                // If filter requested termination, returning latest function result and breaking request iteration loop.
                 if (invocationContext.Terminate)
                 {
                     if (this._logger.IsEnabled(LogLevel.Debug))
@@ -455,6 +455,9 @@ internal sealed class MistralClient
                         this._logger.LogDebug("Filter requested termination of automatic function invocation.");
                     }
 
+                    var lastChatMessage = chatHistory.Last();
+
+                    yield return new StreamingChatMessageContent(lastChatMessage.Role, lastChatMessage.Content);
                     yield break;
                 }
             }

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -859,7 +859,7 @@ internal abstract class ClientCore
 
                 AddResponseMessage(chatOptions, chat, streamedRole, toolCall, metadata, stringResult, errorMessage: null, this.Logger);
 
-                // If filter requested termination, breaking request iteration loop.
+                // If filter requested termination, returning latest function result and breaking request iteration loop.
                 if (invocationContext.Terminate)
                 {
                     if (this.Logger.IsEnabled(LogLevel.Debug))
@@ -867,6 +867,9 @@ internal abstract class ClientCore
                         this.Logger.LogDebug("Filter requested termination of automatic function invocation.");
                     }
 
+                    var lastChatMessage = chat.Last();
+
+                    yield return new OpenAIStreamingChatMessageContent(lastChatMessage.Role, lastChatMessage.Content);
                     yield break;
                 }
 


### PR DESCRIPTION
### Motivation, Context and Description
Fixes: https://github.com/microsoft/semantic-kernel/issues/6404

Today, the SK chat completion streaming API does not return the result of a function executed before termination, whereas the non-streaming version does return the result. This PR resolves this issue by returning the result of a function executed before termination was requested.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
