### PR TITLE
Python: Fix doc string for allow_dangerously_set_content

### DIFF
--- a/python/semantic_kernel/prompt_template/input_variable.py
+++ b/python/semantic_kernel/prompt_template/input_variable.py
@@ -14,8 +14,9 @@ class InputVariable(KernelBaseModel):
         default: The default value of the input variable.
         is_required: Whether the input variable is required.
         json_schema: The JSON schema for the input variable.
-        allow_dangerously_set_content (default: false): Allow content without encoding, this controls
-            if this variable is encoded before use.
+        allow_dangerously_set_content (bool = False): Allow content without encoding throughout, this overrides
+            the same settings in the prompt template config and input variables.
+            This reverts the behavior to unencoded input.
     """
 
     name: str

--- a/python/semantic_kernel/prompt_template/prompt_template_config.py
+++ b/python/semantic_kernel/prompt_template/prompt_template_config.py
@@ -24,8 +24,9 @@ class PromptTemplateConfig(KernelBaseModel):
         template: The template for the prompt.
         template_format: The format of the template, should be 'semantic-kernel', 'jinja2' or 'handlebars'.
         input_variables: The input variables for the prompt.
-        allow_dangerously_set_content (default: false): Allow content without encoding, this controls
-            if the output of functions called in the template is encoded before use.
+        allow_dangerously_set_content (bool = False): Allow content without encoding throughout, this overrides
+            the same settings in the prompt template config and input variables.
+            This reverts the behavior to unencoded input.
         execution_settings: The execution settings for the prompt.
 
     """


### PR DESCRIPTION
### Motivation and Context

Fix doc string for allow_dangerously_set_content

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix doc string for allow_dangerously_set_content

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
