### PR TITLE
Python: Verify that plugin names are unique. #6383

### DIFF
--- a/python/tests/unit/kernel/test_kernel.py
+++ b/python/tests/unit/kernel/test_kernel.py
@@ -18,6 +18,7 @@ from semantic_kernel.const import METADATA_EXCEPTION_KEY
 from semantic_kernel.exceptions import (
     KernelFunctionAlreadyExistsError,
     KernelServiceNotFoundError,
+    PluginInvalidNameError,
     ServiceInvalidTypeError,
 )
 from semantic_kernel.exceptions.kernel_exceptions import KernelFunctionNotFoundError, KernelPluginNotFoundError
@@ -185,7 +186,7 @@ def test_plugin_no_plugin(kernel: Kernel):
 
 
 def test_plugin_name_error(kernel: Kernel):
-    with pytest.raises(ValueError):
+    with pytest.raises(PluginInvalidNameError, match="plugin_name must be provided if a plugin is not supplied."):
         kernel.add_plugin(" ", None)
 
 
@@ -195,6 +196,13 @@ def test_plugins_add_plugins(kernel: Kernel):
 
     kernel.add_plugins([plugin1, plugin2])
     assert len(kernel.plugins) == 2
+
+
+def test_plugins_name_unique(kernel: Kernel):
+    with pytest.raises(PluginInvalidNameError, match="A plugin with the name TestPlugin already exists."):
+        plugin1 = KernelPlugin(name="TestPlugin")
+        plugin2 = KernelPlugin(name="TestPlugin")
+        kernel.add_plugins([plugin1, plugin2])
 
 
 def test_add_function_from_prompt(kernel: Kernel):


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

It should not be possible to add two or more plugins with the same name. The .Net version validates that plugin names are unique. I'm adding a similar check in Python.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

All the methods to register plugins, such as `add_plugins` and `add_plugin_from_openapi` end up in `add_plugin` so that's where I added the validation.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
