### PR TITLE
.Net: Fixed ImageContent usage in OpenAI connector

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.15" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
     <PackageVersion Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.3" />
     <PackageVersion Include="Azure.Identity" Version="1.11.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionWithVision.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionWithVision.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Resources;
 
 namespace ChatCompletion;
 
@@ -9,7 +10,7 @@ namespace ChatCompletion;
 public class OpenAI_ChatCompletionWithVision(ITestOutputHelper output) : BaseTest(output)
 {
     [Fact]
-    public async Task RunAsync()
+    public async Task RemoteImageAsync()
     {
         const string ImageUri = "https://upload.wikimedia.org/wikipedia/commons/d/d5/Half-timbered_mansion%2C_Zirkel%2C_East_view.jpg";
 
@@ -25,6 +26,30 @@ public class OpenAI_ChatCompletionWithVision(ITestOutputHelper output) : BaseTes
         [
             new TextContent("What’s in this image?"),
             new ImageContent(new Uri(ImageUri))
+        ]);
+
+        var reply = await chatCompletionService.GetChatMessageContentAsync(chatHistory);
+
+        Console.WriteLine(reply.Content);
+    }
+
+    [Fact]
+    public async Task LocalImageAsync()
+    {
+        var imageBytes = await EmbeddedResource.ReadAllAsync("sample_image.jpg");
+
+        var kernel = Kernel.CreateBuilder()
+            .AddOpenAIChatCompletion("gpt-4-vision-preview", TestConfiguration.OpenAI.ApiKey)
+            .Build();
+
+        var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+
+        var chatHistory = new ChatHistory("You are a friendly assistant.");
+
+        chatHistory.AddUserMessage(
+        [
+            new TextContent("What’s in this image?"),
+            new ImageContent(imageBytes) { MimeType = "image/jpg" }
         ]);
 
         var reply = await chatCompletionService.GetChatMessageContentAsync(chatHistory);

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -1267,7 +1267,7 @@ internal abstract class ClientCore
             return [new ChatRequestUserMessage(message.Items.Select(static (KernelContent item) => (ChatMessageContentItem)(item switch
             {
                 TextContent textContent => new ChatMessageTextContentItem(textContent.Text),
-                ImageContent imageContent => new ChatMessageImageContentItem(imageContent.Uri),
+                ImageContent imageContent => GetImageContentItem(imageContent),
                 _ => throw new NotSupportedException($"Unsupported chat message content type '{item.GetType()}'.")
             })))
             { Name = message.AuthorName }];
@@ -1335,6 +1335,21 @@ internal abstract class ClientCore
         }
 
         throw new NotSupportedException($"Role {message.Role} is not supported.");
+    }
+
+    private static ChatMessageImageContentItem GetImageContentItem(ImageContent imageContent)
+    {
+        if (imageContent.Data is { IsEmpty: false } data)
+        {
+            return new ChatMessageImageContentItem(BinaryData.FromBytes(data), imageContent.MimeType);
+        }
+
+        if (imageContent.Uri is not null)
+        {
+            return new ChatMessageImageContentItem(imageContent.Uri);
+        }
+
+        throw new ArgumentException($"{nameof(ImageContent)} must have either Data or a Uri.");
     }
 
     private static ChatRequestMessage GetRequestMessage(ChatResponseMessage message)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Fixes: https://github.com/microsoft/semantic-kernel/issues/6443

This is temporary fix before new updates to `ImageContent` class will be in place: https://github.com/microsoft/semantic-kernel/pull/6319

cc: @RogerBarreto

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
