### PR TITLE
Python: Adjust the learn file imports based on a previous refactor.

### DIFF
--- a/python/samples/__init__.py
+++ b/python/samples/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from .service_settings import ServiceSettings
+from .sk_service_configurator import add_service
+
+__all__ = ["add_service", "ServiceSettings"]

--- a/python/samples/learn_resources/__init__.py
+++ b/python/samples/learn_resources/__init__.py
@@ -1,6 +1,0 @@
-# Copyright (c) Microsoft. All rights reserved.
-
-from ..service_settings import ServiceSettings
-from ..sk_service_configurator import add_service
-
-__all__ = ["add_service", "ServiceSettings"]

--- a/python/samples/learn_resources/configuring_prompts.py
+++ b/python/samples/learn_resources/configuring_prompts.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from samples.learn_resources.sk_service_configurator import add_service
+from samples.sk_service_configurator import add_service
 from semantic_kernel.connectors.ai import PromptExecutionSettings
 from semantic_kernel.contents import ChatHistory
 from semantic_kernel.core_plugins import ConversationSummaryPlugin

--- a/python/samples/learn_resources/creating_functions.py
+++ b/python/samples/learn_resources/creating_functions.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 
-from samples.learn_resources.sk_service_configurator import add_service
+from samples.sk_service_configurator import add_service
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.function_call_behavior import FunctionCallBehavior
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatPromptExecutionSettings

--- a/python/samples/learn_resources/plugin.py
+++ b/python/samples/learn_resources/plugin.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Annotated
 
-from samples.learn_resources.sk_service_configurator import add_service
+from samples.sk_service_configurator import add_service
 from semantic_kernel import Kernel
 from semantic_kernel.functions import kernel_function
 

--- a/python/samples/learn_resources/templates.py
+++ b/python/samples/learn_resources/templates.py
@@ -3,7 +3,7 @@
 import asyncio
 from functools import reduce
 
-from samples.learn_resources.sk_service_configurator import add_service
+from samples.sk_service_configurator import add_service
 from semantic_kernel import Kernel
 from semantic_kernel.contents import ChatHistory
 from semantic_kernel.contents.author_role import AuthorRole

--- a/python/samples/learn_resources/using_the_kernel.py
+++ b/python/samples/learn_resources/using_the_kernel.py
@@ -4,7 +4,7 @@
 import asyncio
 import os
 
-from samples.learn_resources import add_service
+from samples.sk_service_configurator import add_service
 from semantic_kernel import Kernel
 
 # </NecessaryPackages>

--- a/python/tests/integration/completions/test_azure_oai_text_service.py
+++ b/python/tests/integration/completions/test_azure_oai_text_service.py
@@ -52,7 +52,7 @@ async def test_azure_e2e_text_completion_with_plugin_with_provided_client(setup_
 
     azure_openai_settings = AzureOpenAISettings.create()
     endpoint = azure_openai_settings.endpoint
-    deployment_name = azure_openai_settings.chat_deployment_name
+    deployment_name = azure_openai_settings.text_deployment_name
     api_key = azure_openai_settings.api_key.get_secret_value()
     api_version = azure_openai_settings.api_version
 


### PR DESCRIPTION
### Motivation and Context

Several of the imports in the learn files were showing as unable to resolve after the service configuration was moved to a different directory.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Creating the `__init__.py` in the directory where the importable files live. Adjusting code to reflect this. Imports now resolve.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
