### PR TITLE
Update Moq.Analyzers from 0.0.9 to 0.1.0

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -110,7 +110,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageVersion Include="Moq.Analyzers" Version="0.0.9" />
+    <PackageVersion Include="Moq.Analyzers" Version="0.1.0" />
     <PackageReference Include="Moq.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Motivation and Context

After a hiatus, there's a new version of Moq.Analyzers. As part of releasing the new version the maintainers (including me) are upgrading some popular OSS projects to use the new version and verify compatibility.

### Description

Updating Moq.Analyzers from 0.0.9 to 0.1.0. There were no issues found. I also manually created some incorrect mocks to verify the analyzer would fire correctly if there were issues.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
  - > NOTE: `dotnet format` isn't clean on `main`. So my change introduces no _new_ issues
- [X] All unit tests pass, and I have added new tests where possible
  - > NOTE: `.UnitTests` all pass, however some integration tests do not pass on `main`
- [X] I didn't break anyone :smile:
