### PR TITLE
Python: Handle streaming tool call attempts. Fix func calling concept example.

### DIFF
--- a/python/samples/concepts/auto_function_calling/chat_gpt_api_function_calling.py
+++ b/python/samples/concepts/auto_function_calling/chat_gpt_api_function_calling.py
@@ -111,7 +111,7 @@ async def handle_streaming(
     streamed_chunks: list[StreamingChatMessageContent] = []
     async for message in response:
         if not execution_settings.function_call_behavior.auto_invoke_kernel_functions and isinstance(
-            message[0], ChatMessageContent
+            message[0], StreamingChatMessageContent
         ):
             streamed_chunks.append(message[0])
         else:
@@ -150,9 +150,8 @@ async def chat() -> bool:
         # If tools are used, and auto invoke tool calls is False, the response will be of type
         # ChatMessageContent with information about the tool calls, which need to be sent
         # back to the model to get the final response.
-        if not execution_settings.function_call_behavior.auto_invoke_kernel_functions and isinstance(
-            result.value[0], FunctionCallContent
-        ):
+        function_calls = [item for item in result.value[-1].items if isinstance(item, FunctionCallContent)]
+        if not execution_settings.function_call_behavior.auto_invoke_kernel_functions and len(function_calls) > 0:
             print_tool_calls(result.value[0])
             return True
 

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -188,7 +188,10 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
         self._prepare_settings(settings, chat_history, stream_request=True, kernel=kernel)
 
         request_attempts = (
-            settings.function_call_behavior.max_auto_invoke_attempts if settings.function_call_behavior else 1
+            settings.function_call_behavior.max_auto_invoke_attempts 
+            if (settings.function_call_behavior and 
+                settings.function_call_behavior.auto_invoke_kernel_functions) 
+            else 1
         )
         # hold the messages, if there are more than one response, it will not be used, so we flatten
         for request_index in range(request_attempts):


### PR DESCRIPTION
### Motivation and Context

If auto_invoke was False and the function used streaming, the max func attempts were being set to 0 which Python's range function doesn't like. The chat gpt auto function calling example was also broken due to wrong checks on the returned result for FunctionCallResult objects.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fixing handling streaming tool calls when auto invoke is false and fixing the chat gpt auto function calling concept example.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
