### PR TITLE
.Net: Handle empty response with no content type in RestApiOperationRunner

### DIFF
--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
@@ -226,7 +226,7 @@ internal static class KernelFunctionHelpers
             // Deserialize any JSON content or return the content as a string
             if (restApiOperationResponse.ContentType?.IndexOf("application/json", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                var parsedJson = JsonValue.Parse(restApiOperationResponse.Content.ToString() ?? string.Empty);
+                var parsedJson = JsonValue.Parse(restApiOperationResponse.Content?.ToString() ?? string.Empty);
                 return KernelHelpersUtils.DeserializeJsonNode(parsedJson);
             }
 

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationResponseExtensions.cs
@@ -33,7 +33,7 @@ public static class RestApiOperationResponseExtensions
             return true;
         }
 
-        return response.ContentType switch
+        return response.ContentType! switch
         {
             var ct when ct.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) => ValidateJson(response),
             var ct when ct.StartsWith("application/xml", StringComparison.OrdinalIgnoreCase) => ValidateXml(response),
@@ -47,7 +47,7 @@ public static class RestApiOperationResponseExtensions
         try
         {
             var jsonSchema = JsonSchema.FromText(JsonSerializer.Serialize(response.ExpectedSchema));
-            using var contentDoc = JsonDocument.Parse(response.Content.ToString() ?? "");
+            using var contentDoc = JsonDocument.Parse(response.Content?.ToString() ?? string.Empty);
             var result = jsonSchema.Evaluate(contentDoc);
             return result.IsValid;
         }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1103,6 +1103,54 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         Assert.Equal("{\"name\":\"fake-name-value\",\"attributes\":{\"enabled\":true}}", ((JsonObject)result.RequestPayload).ToJsonString());
     }
 
+    [Fact]
+    public async Task ItShouldHandleNoContentAsync()
+    {
+        // Arrange
+        this._httpMessageHandlerStub!.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.NoContent);
+
+        List<RestApiOperationPayloadProperty> payloadProperties =
+        [
+            new("name", "string", true, []),
+            new("attributes", "object", false,
+            [
+                new("enabled", "boolean", false, []),
+            ])
+        ];
+
+        var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
+
+        var operation = new RestApiOperation(
+            "fake-id",
+            new Uri("https://fake-random-test-host"),
+            "fake-path",
+            HttpMethod.Post,
+            "fake-description",
+            [],
+            payload
+        );
+
+        var arguments = new KernelArguments
+        {
+            { "name", "fake-name-value" },
+            { "enabled", true }
+        };
+
+        var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object, enableDynamicPayload: true);
+
+        // Act
+        var result = await sut.RunAsync(operation, arguments);
+
+        // Assert
+        Assert.NotNull(result.RequestMethod);
+        Assert.Equal(HttpMethod.Post.Method, result.RequestMethod);
+        Assert.NotNull(result.RequestUri);
+        Assert.Equal("https://fake-random-test-host/fake-path", result.RequestUri.AbsoluteUri);
+        Assert.NotNull(result.RequestPayload);
+        Assert.IsType<JsonObject>(result.RequestPayload);
+        Assert.Equal("{\"name\":\"fake-name-value\",\"attributes\":{\"enabled\":true}}", ((JsonObject)result.RequestPayload).ToJsonString());
+    }
+
     public class SchemaTestData : IEnumerable<object[]>
     {
         public IEnumerator<object[]> GetEnumerator()

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
@@ -14,12 +14,12 @@ public sealed class RestApiOperationResponse
     /// <summary>
     /// Gets the content of the response.
     /// </summary>
-    public object Content { get; }
+    public object? Content { get; }
 
     /// <summary>
     /// Gets the content type of the response.
     /// </summary>
-    public string ContentType { get; }
+    public string? ContentType { get; }
 
     /// <summary>
     /// The expected schema of the response as advertised in the OpenAPI operation.
@@ -47,7 +47,7 @@ public sealed class RestApiOperationResponse
     /// <param name="content">The content of the response.</param>
     /// <param name="contentType">The content type of the response.</param>
     /// <param name="expectedSchema">The schema against which the response body should be validated.</param>
-    public RestApiOperationResponse(object content, string contentType, KernelJsonSchema? expectedSchema = null)
+    public RestApiOperationResponse(object? content, string? contentType, KernelJsonSchema? expectedSchema = null)
     {
         this.Content = content;
         this.ContentType = contentType;


### PR DESCRIPTION
### Motivation and Context

Closes #6427 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
