### PR TITLE
.Net: Update DuckDB.NET.Data and DuckDB.NET.Data.Full package versions to 1.0.0

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -71,8 +71,8 @@
     <!-- Plugins -->
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.2" />
-    <PackageVersion Include="DuckDB.NET.Data.Full" Version="0.10.1.2" />
-    <PackageVersion Include="DuckDB.NET.Data" Version="0.10.2" />
+    <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.0.0" />
+    <PackageVersion Include="DuckDB.NET.Data" Version="1.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
     <PackageVersion Include="Microsoft.Graph" Version="[4.51.0, 5)" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="[2.28.0, )" />


### PR DESCRIPTION
This pull request updates the package versions of DuckDB.NET.Data and DuckDB.NET.Data.Full from 0.10.x to 1.0.0 
