### PR TITLE
Fix hugging face embedding

### DIFF
--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceClient.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/HuggingFaceClient.cs
@@ -293,11 +293,29 @@ internal sealed class HuggingFaceClient
 
         string body = await this.SendRequestAndGetStringBodyAsync(httpRequestMessage, cancellationToken)
             .ConfigureAwait(false);
+        try
+        {
+            // Attempt to deserialize as TextEmbeddingResponseType1
+            var response = DeserializeResponse<TextEmbeddingResponseType1>(body);
+            return response.ToList();
+        }
+        catch (KernelException ex1)
+        {
+            try
+            {
+                // If it fails, attempt to deserialize as TextEmbeddingResponseType2
+                var response = DeserializeResponse<TextEmbeddingResponseType2>(body);
+                
+                // Currently, only one embedding per data is supported
+                return response[0][0].ToList();
+            }
+            catch (KernelException ex2)
+            {
+                // If both fail, throw the second exception
+                throw ex2;
+            }
+        }
 
-        var response = DeserializeResponse<TextEmbeddingResponse>(body);
-
-        // Currently only one embedding per data is supported
-        return response[0][0].ToList()!;
     }
 
     private Uri GetEmbeddingGenerationEndpoint(string modelId)

--- a/dotnet/src/Connectors/Connectors.HuggingFace/Core/Models/TextEmbeddingResponse.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/Core/Models/TextEmbeddingResponse.cs
@@ -8,4 +8,12 @@ namespace Microsoft.SemanticKernel.Connectors.HuggingFace.Core;
 /// <summary>
 /// Represents the response from the Hugging Face text embedding API.
 /// </summary>
-internal sealed class TextEmbeddingResponse : List<List<List<ReadOnlyMemory<float>>>>;
+/// <returns> List&lt;ReadOnlyMemory&lt;float&gt;&gt;</returns>
+internal sealed class TextEmbeddingResponseType1 : List<ReadOnlyMemory<float>>;
+
+/// <summary>
+/// Represents the response from the Hugging Face text embedding API.
+/// </summary>
+/// <returns>List&lt;List&lt;List&lt;ReadOnlyMemory&lt;float&gt;&gt;&gt;&gt;</returns>
+internal sealed class TextEmbeddingResponseType2 : List<List<List<ReadOnlyMemory<float>>>>;
+


### PR DESCRIPTION
### Motivation and Context
Fix the Bug #6635 HuggingFace Embedding: Unable to Deserialization for certain models

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
As mentioned in the issue, the HuggingFace Embedding API interface returns responses typically in the form of `List<ReadOnlyMemory<float>>` and occasionally as `List<List<List<ReadOnlyMemory<float>>>>`. Currently, only the latter format is handled correctly, leading to deserialization issues.

To address this, I propose the following solution:
```
try {
    // Attempt to parse data as List<ReadOnlyMemory<float>> and return the parsed data
}
catch (KernelException ex1) {
    try {
        // If the first attempt fails, attempt to parse data as List<List<List<ReadOnlyMemory<float>>>>` and return the parsed data
    }
    catch (KernelException ex2) {
        // If both attempts fail, handle the exception (e.g., the model doesn't exist ,the model has still been loading, or an HTTP exception occurred) and rethrow the error
    }
}

```
### Contribution Checklist 

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
