### PR TITLE
Python: Fix sample plugin path for Windows. Re-enable samples CI tests.

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -103,6 +103,7 @@ jobs:
 
           cd python
           poetry run pytest ./tests/integration -v
+          poetry run pytest ./tests/samples -v
 
   python-integration-tests:
     needs: paths-filter
@@ -169,6 +170,7 @@ jobs:
 
           cd python
           poetry run pytest ./tests/integration -v
+          poetry run pytest ./tests/samples -v
 
   # This final job is required to satisfy the merge queue. It must only run (or succeed) if no tests failed
   python-integration-tests-check:

--- a/python/samples/concepts/plugins/openai_plugin_azure_key_vault.py
+++ b/python/samples/concepts/plugins/openai_plugin_azure_key_vault.py
@@ -4,6 +4,8 @@ import json
 import os
 import platform
 from functools import reduce
+from urllib.parse import urljoin
+from urllib.request import pathname2url
 
 import httpx
 from aiohttp import ClientSession
@@ -25,16 +27,16 @@ from semantic_kernel.functions import KernelArguments, KernelFunction, KernelPlu
 def get_file_url(relative_path):
     absolute_path = os.path.abspath(relative_path)
     if platform.system() == "Windows":
-        return f"file:///{absolute_path.replace('\\', '/')}"
-    return f"file://{absolute_path}"
+        absolute_path = absolute_path.replace('\\', '/')
+    return urljoin('file:', pathname2url(absolute_path))
 
 
 def load_and_update_openai_spec():
     # Construct the path to the OpenAI spec file
     openai_spec_file = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 
-        "resources", 
-        "open_ai_plugins", 
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "resources",
+        "open_ai_plugins",
         "akv-openai.json"
     )
 
@@ -44,9 +46,9 @@ def load_and_update_openai_spec():
 
     # Adjust the OpenAI spec file to use the correct file URL based on platform
     openapi_yaml_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 
-        "resources", 
-        "open_ai_plugins", 
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "resources",
+        "open_ai_plugins",
         "akv-openapi.yaml"
     )
     openai_spec["api"]["url"] = get_file_url(openapi_yaml_path)

--- a/python/samples/concepts/prompt_templates/configuring_prompts.py
+++ b/python/samples/concepts/prompt_templates/configuring_prompts.py
@@ -8,61 +8,76 @@ from semantic_kernel.contents import ChatHistory
 from semantic_kernel.functions import KernelArguments
 from semantic_kernel.prompt_template import InputVariable, PromptTemplateConfig
 
+kernel = Kernel()
 
-async def main():
-    kernel = Kernel()
+useAzureOpenAI = False
+model = "gpt-35-turbo" if useAzureOpenAI else "gpt-3.5-turbo-1106"
+service_id = model
 
-    useAzureOpenAI = False
-    model = "gpt-35-turbo" if useAzureOpenAI else "gpt-3.5-turbo-1106"
-    service_id = model
+kernel.add_service(
+    OpenAIChatCompletion(service_id=service_id, ai_model_id=model),
+)
 
-    kernel.add_service(
-        OpenAIChatCompletion(service_id=service_id, ai_model_id=model),
+template = """
+
+Previous information from chat:
+{{$chat_history}}
+
+User: {{$request}}
+Assistant:
+"""
+
+print("--- Rendered Prompt ---")
+prompt_template_config = PromptTemplateConfig(
+    template=template,
+    name="chat",
+    description="Chat with the assistant",
+    template_format="semantic-kernel",
+    input_variables=[
+        InputVariable(name="chat_history", description="The conversation history", is_required=False, default=""),
+        InputVariable(name="request", description="The user's request", is_required=True),
+    ],
+    execution_settings=OpenAIChatPromptExecutionSettings(service_id=service_id, max_tokens=4000, temperature=0.2),
+)
+
+chat_function = kernel.add_function(
+    function_name="chat",
+    plugin_name="ChatBot",
+    prompt_template_config=prompt_template_config,
+)
+
+chat_history = ChatHistory()
+
+
+async def chat() -> bool:
+    try:
+        user_input = input("User:> ")
+    except KeyboardInterrupt:
+        print("\n\nExiting chat...")
+        return False
+    except EOFError:
+        print("\n\nExiting chat...")
+        return False
+
+    if user_input == "exit":
+        print("\n\nExiting chat...")
+        return False
+
+    answer = await kernel.invoke(
+        function=chat_function, arguments=KernelArguments(
+            user_input=user_input, chat_history=chat_history,
+        ),
     )
+    chat_history.add_user_message(user_input)
+    chat_history.add_assistant_message(str(answer))
+    print(f"Mosscap:> {answer}")
+    return True
 
-    template = """
 
-    Previous information from chat:
-    {{$chat_history}}
-
-    User: {{$request}}
-    Assistant:
-    """
-
-    print("--- Rendered Prompt ---")
-    prompt_template_config = PromptTemplateConfig(
-        template=template,
-        name="chat",
-        description="Chat with the assistant",
-        template_format="semantic-kernel",
-        input_variables=[
-            InputVariable(name="chat_history", description="The conversation history", is_required=False, default=""),
-            InputVariable(name="request", description="The user's request", is_required=True),
-        ],
-        execution_settings=OpenAIChatPromptExecutionSettings(service_id=service_id, max_tokens=4000, temperature=0.2),
-    )
-
-    chat = kernel.add_function(
-        function_name="chat",
-        plugin_name="ChatBot",
-        prompt_template_config=prompt_template_config,
-    )
-
-    chat_history = ChatHistory()
-
-    print("User > ")
-    while (user_input := input()) != "exit":
-        result = await kernel.invoke(
-            chat,
-            KernelArguments(
-                request=user_input,
-                chat_history=chat_history,
-            ),
-        )
-        result = str(result)
-        print(result)
-        chat_history.add_user_message(user_input)
-        chat_history.add_assistant_message(result)
+async def main() -> None:
+    chatting = True
+    while chatting:
+        chatting = await chat()
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started/00-getting-started.ipynb
+++ b/python/samples/getting_started/00-getting-started.ipynb
@@ -16,6 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
    ]
   },
@@ -35,6 +36,25 @@
    "metadata": {},
    "source": [
     "### Configure the service you'd like to use via the `Service` Enum.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/01-basic-loading-the-kernel.ipynb
+++ b/python/samples/getting_started/01-basic-loading-the-kernel.ipynb
@@ -25,6 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
    ]
   },
@@ -93,6 +94,25 @@
     "The SDK currently supports OpenAI and Azure OpenAI, among other connectors.\n",
     "\n",
     "If you need an Azure OpenAI key, go [here](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart?pivots=rest-api).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/02-running-prompts-from-file.ipynb
+++ b/python/samples/getting_started/02-running-prompts-from-file.ipynb
@@ -105,7 +105,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81b3e727",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/03-prompt-function-inline.ipynb
+++ b/python/samples/getting_started/03-prompt-function-inline.ipynb
@@ -48,7 +48,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d6c00cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/04-kernel-arguments-chat.ipynb
+++ b/python/samples/getting_started/04-kernel-arguments-chat.ipynb
@@ -26,7 +26,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e796a816",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/05-using-the-planner.ipynb
+++ b/python/samples/getting_started/05-using-the-planner.ipynb
@@ -23,7 +23,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install -U semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5d9ed81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/06-memory-and-embeddings.ipynb
+++ b/python/samples/getting_started/06-memory-and-embeddings.ipynb
@@ -28,9 +28,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5\n",
     "!python -m pip install azure-core==1.30.1\n",
     "!python -m pip install azure-search-documents==11.4.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8a3db35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/07-hugging-face-for-plugins.ipynb
+++ b/python/samples/getting_started/07-hugging-face-for-plugins.ipynb
@@ -20,6 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel[hugging_face]==1.0.5"
    ]
   },

--- a/python/samples/getting_started/08-native-function-inline.ipynb
+++ b/python/samples/getting_started/08-native-function-inline.ipynb
@@ -46,7 +46,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecfe74be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/09-groundedness-checking.ipynb
+++ b/python/samples/getting_started/09-groundedness-checking.ipynb
@@ -82,7 +82,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d46739e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/10-multiple-results-per-prompt.ipynb
+++ b/python/samples/getting_started/10-multiple-results-per-prompt.ipynb
@@ -25,7 +25,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cff141d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/samples/getting_started/11-streaming-completions.ipynb
+++ b/python/samples/getting_started/11-streaming-completions.ipynb
@@ -18,7 +18,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: if using a Poetry virtual environment, do not run this cell\n",
     "!python -m pip install semantic-kernel==1.0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7547e59b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure paths are correct for the imports\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "notebook_dir = os.path.abspath('')\n",
+    "parent_dir = os.path.dirname(notebook_dir)\n",
+    "grandparent_dir = os.path.dirname(parent_dir)\n",
+    "\n",
+    "\n",
+    "sys.path.append(grandparent_dir)"
    ]
   },
   {

--- a/python/tests/samples/test_concepts.py
+++ b/python/tests/samples/test_concepts.py
@@ -39,6 +39,7 @@ from samples.concepts.prompt_templates.load_yaml_prompt import main as load_yaml
 from samples.concepts.prompt_templates.template_language import main as template_language
 from samples.concepts.rag.rag_with_text_memory_plugin import main as rag_with_text_memory_plugin
 from samples.concepts.search.bing_search_plugin import main as bing_search_plugin
+from tests.samples.test_samples_utils import retry
 
 
 @mark.asyncio
@@ -109,4 +110,4 @@ from samples.concepts.search.bing_search_plugin import main as bing_search_plugi
 )
 async def test_concepts(func, responses, monkeypatch):
     monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
-    await func()
+    await retry(lambda: func())

--- a/python/tests/samples/test_learn_resources.py
+++ b/python/tests/samples/test_learn_resources.py
@@ -12,6 +12,7 @@ from samples.learn_resources.serializing_prompts import main as serializing_prom
 from samples.learn_resources.templates import main as templates
 from samples.learn_resources.using_the_kernel import main as using_the_kernel
 from samples.learn_resources.your_first_prompt import main as your_first_prompt
+from tests.samples.test_samples_utils import retry
 
 
 @mark.asyncio
@@ -45,6 +46,6 @@ from samples.learn_resources.your_first_prompt import main as your_first_prompt
 async def test_learn_resources(func, responses, monkeypatch):
     monkeypatch.setattr("builtins.input", lambda _: responses.pop(0))
     if func.__module__ == "samples.learn_resources.your_first_prompt":
-        await func(delay=10)
+        await retry(lambda: func(delay=10))
         return
-    await func()
+    await retry(lambda: func())

--- a/python/tests/samples/test_samples_utils.py
+++ b/python/tests/samples/test_samples_utils.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+
+async def retry(func, max_retries=3):
+    """Retry a function a number of times before raising an exception."""
+    attempt = 0
+    while attempt < max_retries:
+        try:
+            await func()
+            break
+        except Exception as e:
+            attempt += 1
+            logger.error(f"Attempt {attempt} for {func.__name__} failed: {e}")
+            if attempt == max_retries:
+                logger.error(f"All {max_retries} attempts for {func.__name__} failed")
+                raise e
+            await asyncio.sleep(1)


### PR DESCRIPTION
### Motivation and Context

Fix sample plugin path for Windows. Re-enable samples CI tests.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix sample plugin path for Windows. Re-enable samples CI tests.
- Tests passing locally on both MacOS and Windows.
- Adds logic to each notebook to properly set up the correct path to find imports. Notebooks should now run out of the box to close #6588
- Added retry logic for the samples tests to retry 3 times in the event of a failure.

The GH Action code quality check was failing for this same code in #6675, so this is superseding it.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile: