### PR TITLE
.Net: Avoid null ref in ModelDiagnostics.SetCompletionResponse

### DIFF
--- a/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
@@ -325,13 +325,13 @@ internal static class ModelDiagnostics
         int? promptTokens,
         int? completionTokens)
     {
-        if (!IsModelDiagnosticsEnabled())
+        if (!IsModelDiagnosticsEnabled() || choices.Count == 0)
         {
             return;
         }
 
         // Assuming all metadata is in the last chunk of the choice
-        switch (choices.FirstOrDefault().Value.FirstOrDefault())
+        switch (choices.FirstOrDefault().Value?.FirstOrDefault())
         {
             case StreamingTextContent:
                 var textCompletions = choices.Select(choiceContents =>


### PR DESCRIPTION
cc: @lemillermicrosoft 