### PR TITLE
Python: Azure AI Search api key should not be required.

### DIFF
--- a/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_ai_search_settings.py
+++ b/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_ai_search_settings.py
@@ -20,7 +20,7 @@ class AzureAISearchSettings(KernelBaseSettings):
 
     env_prefix: ClassVar[str] = "AZURE_AI_SEARCH_"
 
-    api_key: SecretStr
+    api_key: SecretStr | None = None
     endpoint: HttpsUrl
     index_name: str | None = None
 

--- a/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_cognitive_search_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/azure_cognitive_search/azure_cognitive_search_memory_store.py
@@ -89,7 +89,7 @@ class AzureCognitiveSearchMemoryStore(MemoryStoreBase):
         self._vector_size = vector_size
         self._search_index_client = get_search_index_async_client(
             search_endpoint=str(acs_memory_settings.endpoint),
-            admin_key=acs_memory_settings.api_key.get_secret_value(),
+            admin_key=acs_memory_settings.api_key.get_secret_value() if acs_memory_settings.api_key else None,
             azure_credential=azure_credentials,
             token_credential=token_credentials,
         )


### PR DESCRIPTION
### Motivation and Context

We have a regression that makes the AI Search Setting's API key required.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Make the AI Search setting a non-required attribute. Fixes #6697

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
