### PR TITLE
.Net: instead running two queries now a single query can do the same thing

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -88,21 +88,6 @@ internal sealed class Database
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task InsertOrIgnoreAsync(SqliteConnection conn,
-        string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancellationToken = default)
-    {
-        using SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
-             INSERT OR IGNORE INTO {TableName}(collection, key, metadata, embedding, timestamp)
-             VALUES(@collection, @key, @metadata, @embedding, @timestamp); ";
-        cmd.Parameters.AddWithValue("@collection", collection);
-        cmd.Parameters.AddWithValue("@key", key);
-        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
-        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
-        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
-        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
     public async Task<bool> DoesCollectionExistsAsync(SqliteConnection conn,
         string collectionName,
         CancellationToken cancellationToken = default)

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -73,6 +73,21 @@ internal sealed class Database
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task UpsertAsync(SqliteConnection conn,
+        string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancellationToken = default)
+    {
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
+        INSERT OR REPLACE INTO {TableName}(collection, key, metadata, embedding, timestamp)
+        VALUES(@collection, @key, @metadata, @embedding, @timestamp);";
+        cmd.Parameters.AddWithValue("@collection", collection);
+        cmd.Parameters.AddWithValue("@key", key);
+        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
+        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
+        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task InsertOrIgnoreAsync(SqliteConnection conn,
         string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancellationToken = default)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -56,23 +56,6 @@ internal sealed class Database
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task UpdateAsync(SqliteConnection conn,
-        string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancellationToken = default)
-    {
-        using SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = $@"
-             UPDATE {TableName}
-             SET metadata=@metadata, embedding=@embedding, timestamp=@timestamp
-             WHERE collection=@collection
-                AND key=@key ";
-        cmd.Parameters.AddWithValue("@collection", collection);
-        cmd.Parameters.AddWithValue("@key", key);
-        cmd.Parameters.AddWithValue("@metadata", metadata ?? string.Empty);
-        cmd.Parameters.AddWithValue("@embedding", embedding ?? string.Empty);
-        cmd.Parameters.AddWithValue("@timestamp", timestamp ?? string.Empty);
-        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
     public async Task UpsertAsync(SqliteConnection conn,
         string collection, string key, string? metadata, string? embedding, string? timestamp, CancellationToken cancellationToken = default)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
@@ -246,18 +246,8 @@ public class SqliteMemoryStore : IMemoryStore, IDisposable
     {
         record.Key = record.Metadata.Id;
 
-        // Update
-        await this._dbConnector.UpdateAsync(
-            conn: connection,
-            collection: collectionName,
-            key: record.Key,
-            metadata: record.GetSerializedMetadata(),
-            embedding: JsonSerializer.Serialize(record.Embedding, JsonOptionsCache.Default),
-            timestamp: ToTimestampString(record.Timestamp),
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-
-        // Insert if entry does not exists
-        await this._dbConnector.InsertOrIgnoreAsync(
+        // Insert or replace
+        await this._dbConnector.UpsertAsync(
             conn: connection,
             collection: collectionName,
             key: record.Key,


### PR DESCRIPTION
### Motivation and Context
1. Instead of executing two SQL queries, a single query can do the same thing.
2. Performance improvement

### Description
Previously the **InternalUpsertAsync** method was executing two sql query by calling two individual methods - First **UpdateAsync** and then second **InsertOrIgnoreAsync**.

The new method uses the INSERT OR REPLACE statement to either update an existing row or insert a new one based on the unique collection and key combination

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, same unit test can detect the bug
- [ ] I didn't break anyone :smile:
