### PR TITLE
Python: fix: Preserve class type in `experimental_class` decorator to avoid type inference issues

### DIFF
--- a/python/semantic_kernel/utils/experimental_decorator.py
+++ b/python/semantic_kernel/utils/experimental_decorator.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T", bound=type)
 
 
 def experimental_function(func: Callable) -> Callable:
@@ -16,7 +19,7 @@ def experimental_function(func: Callable) -> Callable:
     return func
 
 
-def experimental_class(cls: type) -> type:
+def experimental_class(cls: T) -> T:
     """Decorator to mark a class as experimental."""
     if isinstance(cls, type):
         if cls.__doc__:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Closes https://github.com/microsoft/semantic-kernel/issues/6707 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Introduce `TypeVar` `T` bounded to `type` to ensure the decorator maintains the class type.
- Modify the `experimental_class` decorator to use the bounded `TypeVar` for accurate type hinting.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
