### PR TITLE
.Net: Replaced text-davinci-003 with gpt-3.5-turbo-instruct

### DIFF
--- a/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/README.md
+++ b/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 1. **Azure OpenAI**: go to the [Azure OpenAI Quickstart](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart)
-   and deploy an instance of Azure OpenAI, deploy a model like "text-davinci-003" find your Endpoint and API key.
+   and deploy an instance of Azure OpenAI, deploy a model like "gpt-35-turbo-instruct" find your Endpoint and API key.
 2. **OpenAI**: go to [OpenAI](https://platform.openai.com) to register and procure your API key.
 3. **Azure Bing Web Search API**: go to [Bing Web Search API](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api)
    and select `Try Now` to get started.
@@ -25,13 +25,13 @@ To set your secrets with Secret Manager:
 cd dotnet/src/IntegrationTests
 
 dotnet user-secrets init
-dotnet user-secrets set "OpenAI:ServiceId" "text-davinci-003"
-dotnet user-secrets set "OpenAI:ModelId" "text-davinci-003"
+dotnet user-secrets set "OpenAI:ServiceId" "gpt-3.5-turbo-instruct"
+dotnet user-secrets set "OpenAI:ModelId" "gpt-3.5-turbo-instruct"
 dotnet user-secrets set "OpenAI:ChatModelId" "gpt-4"
 dotnet user-secrets set "OpenAI:ApiKey" "..."
 
-dotnet user-secrets set "AzureOpenAI:ServiceId" "azure-text-davinci-003"
-dotnet user-secrets set "AzureOpenAI:DeploymentName" "text-davinci-003"
+dotnet user-secrets set "AzureOpenAI:ServiceId" "azure-gpt-35-turbo-instruct"
+dotnet user-secrets set "AzureOpenAI:DeploymentName" "gpt-35-turbo-instruct"
 dotnet user-secrets set "AzureOpenAI:ChatDeploymentName" "gpt-4"
 dotnet user-secrets set "AzureOpenAI:Endpoint" "https://contoso.openai.azure.com/"
 dotnet user-secrets set "AzureOpenAI:ApiKey" "..."
@@ -56,14 +56,14 @@ For example:
 ```json
 {
   "OpenAI": {
-    "ServiceId": "text-davinci-003",
-    "ModelId": "text-davinci-003",
+    "ServiceId": "gpt-3.5-turbo-instruct",
+    "ModelId": "gpt-3.5-turbo-instruct",
     "ChatModelId": "gpt-4",
     "ApiKey": "sk-...."
   },
   "AzureOpenAI": {
-    "ServiceId": "azure-text-davinci-003",
-    "DeploymentName": "text-davinci-003",
+    "ServiceId": "gpt-35-turbo-instruct",
+    "DeploymentName": "gpt-35-turbo-instruct",
     "ChatDeploymentName": "gpt-4",
     "Endpoint": "https://contoso.openai.azure.com/",
     "ApiKey": "...."
@@ -95,7 +95,7 @@ When setting environment variables, use a double underscore (i.e. "\_\_") to del
   ```bash
   export OpenAI__ApiKey="sk-...."
   export AzureOpenAI__ApiKey="...."
-  export AzureOpenAI__DeploymentName="azure-text-davinci-003"
+  export AzureOpenAI__DeploymentName="gpt-35-turbo-instruct"
   export AzureOpenAI__ChatDeploymentName="gpt-4"
   export AzureOpenAIEmbeddings__DeploymentName="azure-text-embedding-ada-002"
   export AzureOpenAI__Endpoint="https://contoso.openai.azure.com/"
@@ -107,7 +107,7 @@ When setting environment variables, use a double underscore (i.e. "\_\_") to del
   ```ps
   $env:OpenAI__ApiKey = "sk-...."
   $env:AzureOpenAI__ApiKey = "...."
-  $env:AzureOpenAI__DeploymentName = "azure-text-davinci-003"
+  $env:AzureOpenAI__DeploymentName = "gpt-35-turbo-instruct"
   $env:AzureOpenAI__ChatDeploymentName = "gpt-4"
   $env:AzureOpenAIEmbeddings__DeploymentName = "azure-text-embedding-ada-002"
   $env:AzureOpenAI__Endpoint = "https://contoso.openai.azure.com/"

--- a/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/testsettings.json
+++ b/dotnet/src/Experimental/Orchestration.Flow.IntegrationTests/testsettings.json
@@ -1,12 +1,12 @@
 ﻿{
   "OpenAI": {
-    "ServiceId": "text-davinci-003",
-    "ModelId": "text-davinci-003",
+    "ServiceId": "gpt-3.5-turbo-instruct",
+    "ModelId": "gpt-3.5-turbo-instruct",
     "ApiKey": ""
   },
   "AzureOpenAI": {
-    "ServiceId": "azure-text-davinci-003",
-    "DeploymentName": "text-davinci-003",
+    "ServiceId": "azure-gpt-35-turbo-instruct",
+    "DeploymentName": "gpt-35-turbo-instruct",
     "ChatDeploymentName": "gpt-4",
     "Endpoint": "",
     "ApiKey": ""

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -434,7 +434,7 @@ public sealed class OpenAICompletionTests(ITestOutputHelper output) : IDisposabl
             {
                 "name": "FishMarket2",
                 "execution_settings": {
-                    "azure-text-davinci-003": {
+                    "azure-gpt-35-turbo-instruct": {
                         "max_tokens": 256
                     }
                 }

--- a/dotnet/src/IntegrationTests/README.md
+++ b/dotnet/src/IntegrationTests/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 1. **Azure OpenAI**: go to the [Azure OpenAI Quickstart](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart)
-   and deploy an instance of Azure OpenAI, deploy a model like "text-davinci-003" find your Endpoint and API key.
+   and deploy an instance of Azure OpenAI, deploy a model like "gpt-35-turbo-instruct" find your Endpoint and API key.
 2. **OpenAI**: go to [OpenAI](https://platform.openai.com) to register and procure your API key.
 3. **HuggingFace API key**: see https://huggingface.co/docs/huggingface_hub/guides/inference for details.
 4. **Azure Bing Web Search API**: go to [Bing Web Search API](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api)
@@ -30,8 +30,8 @@ cd dotnet/src/IntegrationTests
 
 dotnet user-secrets init
 
-dotnet user-secrets set "OpenAI:ServiceId" "text-davinci-003"
-dotnet user-secrets set "OpenAI:ModelId" "text-davinci-003"
+dotnet user-secrets set "OpenAI:ServiceId" "gpt-3.5-turbo-instruct"
+dotnet user-secrets set "OpenAI:ModelId" "gpt-3.5-turbo-instruct"
 dotnet user-secrets set "OpenAI:ChatModelId" "gpt-4"
 dotnet user-secrets set "OpenAI:ApiKey" "..."
 
@@ -39,8 +39,8 @@ dotnet user-secrets set "OpenAITextToImage:ServiceId" "dall-e-3"
 dotnet user-secrets set "OpenAITextToImage:ModelId" "dall-e-3"
 dotnet user-secrets set "OpenAITextToImage:ApiKey" "..."
 
-dotnet user-secrets set "AzureOpenAI:ServiceId" "azure-text-davinci-003"
-dotnet user-secrets set "AzureOpenAI:DeploymentName" "text-davinci-003"
+dotnet user-secrets set "AzureOpenAI:ServiceId" "azure-gpt-35-turbo-instruct"
+dotnet user-secrets set "AzureOpenAI:DeploymentName" "gpt-35-turbo-instruct"
 dotnet user-secrets set "AzureOpenAI:ChatDeploymentName" "gpt-4"
 dotnet user-secrets set "AzureOpenAI:Endpoint" "https://contoso.openai.azure.com/"
 dotnet user-secrets set "AzureOpenAI:ApiKey" "..."
@@ -94,14 +94,14 @@ For example:
 ```json
 {
   "OpenAI": {
-    "ServiceId": "text-davinci-003",
-    "ModelId": "text-davinci-003",
+    "ServiceId": "gpt-3.5-turbo-instruct",
+    "ModelId": "gpt-3.5-turbo-instruct",
     "ChatModelId": "gpt-4",
     "ApiKey": "sk-...."
   },
   "AzureOpenAI": {
-    "ServiceId": "azure-text-davinci-003",
-    "DeploymentName": "text-davinci-003",
+    "ServiceId": "azure-gpt-35-turbo-instruct",
+    "DeploymentName": "gpt-35-turbo-instruct",
     "ChatDeploymentName": "gpt-4",
     "Endpoint": "https://contoso.openai.azure.com/",
     "ApiKey": "...."
@@ -139,7 +139,7 @@ When setting environment variables, use a double underscore (i.e. "\_\_") to del
   ```bash
   export OpenAI__ApiKey="sk-...."
   export AzureOpenAI__ApiKey="...."
-  export AzureOpenAI__DeploymentName="azure-text-davinci-003"
+  export AzureOpenAI__DeploymentName="gpt-35-turbo-instruct"
   export AzureOpenAI__ChatDeploymentName="gpt-4"
   export AzureOpenAIEmbeddings__DeploymentName="azure-text-embedding-ada-002"
   export AzureOpenAI__Endpoint="https://contoso.openai.azure.com/"
@@ -153,7 +153,7 @@ When setting environment variables, use a double underscore (i.e. "\_\_") to del
   ```ps
   $env:OpenAI__ApiKey = "sk-...."
   $env:AzureOpenAI__ApiKey = "...."
-  $env:AzureOpenAI__DeploymentName = "azure-text-davinci-003"
+  $env:AzureOpenAI__DeploymentName = "gpt-35-turbo-instruct"
   $env:AzureOpenAI__ChatDeploymentName = "gpt-4"
   $env:AzureOpenAIEmbeddings__DeploymentName = "azure-text-embedding-ada-002"
   $env:AzureOpenAI__Endpoint = "https://contoso.openai.azure.com/"

--- a/dotnet/src/IntegrationTests/prompts/GenerateStory.yaml
+++ b/dotnet/src/IntegrationTests/prompts/GenerateStory.yaml
@@ -1,6 +1,6 @@
 ﻿name: GenerateStory
 template: |
-  Tell a story about {{$topic}} that is {{$length}} sentences long. Include '{{$topic}}' words in response.
+  Tell a story about {{$topic}} that is {{$length}} sentences long. Include {{$topic}} words in response.
 template_format: semantic-kernel
 description: A function that generates a story about a topic.
 input_variables:

--- a/dotnet/src/IntegrationTests/prompts/GenerateStory.yaml
+++ b/dotnet/src/IntegrationTests/prompts/GenerateStory.yaml
@@ -1,6 +1,6 @@
 ﻿name: GenerateStory
 template: |
-  Tell a story about {{$topic}} that is {{$length}} sentences long.
+  Tell a story about {{$topic}} that is {{$length}} sentences long. Include '{{$topic}}' words in response.
 template_format: semantic-kernel
 description: A function that generates a story about a topic.
 input_variables:

--- a/dotnet/src/IntegrationTests/prompts/GenerateStoryHandlebars.yaml
+++ b/dotnet/src/IntegrationTests/prompts/GenerateStoryHandlebars.yaml
@@ -1,6 +1,6 @@
 ﻿name: GenerateStory
 template: |
-  Tell a story about {{topic}} that is {{length}} sentences long.
+  Tell a story about {{topic}} that is {{length}} sentences long. Include '{{$topic}}' words in response.
 template_format: handlebars
 description: A function that generates a story about a topic.
 input_variables:

--- a/dotnet/src/IntegrationTests/prompts/GenerateStoryHandlebars.yaml
+++ b/dotnet/src/IntegrationTests/prompts/GenerateStoryHandlebars.yaml
@@ -1,6 +1,6 @@
 ﻿name: GenerateStory
 template: |
-  Tell a story about {{topic}} that is {{length}} sentences long. Include '{{$topic}}' words in response.
+  Tell a story about {{topic}} that is {{length}} sentences long. Include {{topic}} words in response.
 template_format: handlebars
 description: A function that generates a story about a topic.
 input_variables:

--- a/dotnet/src/IntegrationTests/testsettings.json
+++ b/dotnet/src/IntegrationTests/testsettings.json
@@ -1,12 +1,12 @@
 ﻿{
   "OpenAI": {
-    "ServiceId": "text-davinci-003",
-    "ModelId": "text-davinci-003",
+    "ServiceId": "gpt-3.5-turbo-instruct",
+    "ModelId": "gpt-3.5-turbo-instruct",
     "ApiKey": ""
   },
   "AzureOpenAI": {
-    "ServiceId": "azure-text-davinci-003",
-    "DeploymentName": "text-davinci-003",
+    "ServiceId": "azure-gpt-35-turbo-instruct",
+    "DeploymentName": "gpt-35-turbo-instruct",
     "ChatDeploymentName": "gpt-4",
     "Endpoint": "",
     "ApiKey": ""


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Azure OpenAI deprecated `text-davinci-003` model, which is used in our integration tests. This PR replaces `text-davinci-003` through the code with `gpt-3.5-turbo-instruct` and improves some prompts to be compatible with new model.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
