### PR TITLE
.Net: Fixing ConversationSummaryPlugin's ActionItems response by improving underlying prompt

### DIFF
--- a/dotnet/src/Plugins/Plugins.Core/PromptFunctionConstants.cs
+++ b/dotnet/src/Plugins/Plugins.Core/PromptFunctionConstants.cs
@@ -19,9 +19,13 @@ BEGIN SUMMARY:
 
     internal const string GetConversationActionItemsDefinition =
         """
-        You are an action item extractor. You will be given chat history and need to make note of action items mentioned in the chat.
+        You are an action item extractor. You will be given chat history or content and need to make note of action items mentioned.
         Extract action items from the content if there are any. If there are no action, return nothing. If a single field is missing, use an empty string.
         Return the action items in json.
+
+        Guidelines:
+        Action items are specific tasks or requests that someone needs to complete.
+        Routine statements or general comments about habits or preferences should not be considered action items.
 
         Possible statuses for action items are: Open, Closed, In Progress.
 
@@ -40,6 +44,23 @@ BEGIN SUMMARY:
                     "status": "Open",
                     "notes": ""
                 }
+            ]
+        }
+
+        EXAMPLE INPUT WITH IMPLIED ACTION ITEMS:
+
+        I need a list of vegan breakfast recipes. Can you get that for me?
+
+        EXAMPLE OUTPUT:
+        {
+            "actionItems": [
+              {
+                  "owner": "",
+                  "actionItem": "Give a list of breakfast recipes that are vegan friendly",
+                  "dueDate": "",
+                  "status": "Open",
+                  "notes": ""
+              }
             ]
         }
 


### PR DESCRIPTION
Fixing ConversationSummaryPlugin's ActionItems response by improving underlying prompt

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
1. Why is this change required?
This change is required in order to fix reported [issue: 4843](https://github.com/microsoft/semantic-kernel/issues/4843)
The change improves the prompt behind the "GetConversationActionItems" function of "ConversationSummaryPlugin", in order to get expected/correct results.  

2. What problem does it solve?
The "GetConversationActionItems" doesn't return expected result. It even did not return as expected by the MS Learning path samples. Upon checking the issues, I found [Issue 4843](https://github.com/microsoft/semantic-kernel/issues/4843) already opened against it, so I tried to find the root cause of this behavior and fix it.

### Description

The change improves the prompt behind the "GetConversationActionItems" function of "ConversationSummaryPlugin", in order to get expected/correct results.  

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
