### PR TITLE
.Net: Adding unit tests for property enumerator and excluding from code coverage since it's in InternalUtilities.

### DIFF
--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/VectorStoreRecordPropertyReaderTests.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Memory;
+using Xunit;
+
+namespace SemanticKernel.Connectors.UnitTests.Memory;
+
+public class VectorStoreRecordPropertyReaderTests
+{
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void FindPropertiesCanFindAllPropertiesOnSinglePropsModel(bool supportsMultipleVectors, bool useConfig)
+    {
+        // Act.
+        var properties = useConfig ?
+            VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), this._singlePropsDefinition, supportsMultipleVectors) :
+            VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), supportsMultipleVectors);
+
+        // Assert.
+        Assert.Equal("Key", properties.keyProperty.Name);
+        Assert.Single(properties.dataProperties);
+        Assert.Single(properties.vectorProperties);
+        Assert.Equal("Data", properties.dataProperties[0].Name);
+        Assert.Equal("Vector", properties.vectorProperties[0].Name);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindPropertiesCanFindAllPropertiesOnMultiPropsModel(bool useConfig)
+    {
+        // Act.
+        var properties = useConfig ?
+            VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), this._multiPropsDefinition, true) :
+            VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), true);
+
+        // Assert.
+        Assert.Equal("Key", properties.keyProperty.Name);
+        Assert.Equal(2, properties.dataProperties.Count);
+        Assert.Equal(2, properties.vectorProperties.Count);
+        Assert.Equal("Data1", properties.dataProperties[0].Name);
+        Assert.Equal("Data2", properties.dataProperties[1].Name);
+        Assert.Equal("Vector1", properties.vectorProperties[0].Name);
+        Assert.Equal("Vector2", properties.vectorProperties[1].Name);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindPropertiesThrowsForMultipleVectorsWithSingleVectorSupport(bool useConfig)
+    {
+        // Act.
+        var ex = useConfig ?
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), this._multiPropsDefinition, false)) :
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), false));
+
+        // Assert.
+        var expectedMessage = useConfig ?
+            "Multiple vector properties configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported." :
+            "Multiple vector properties found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported.";
+        Assert.Equal(expectedMessage, ex.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindPropertiesThrowsOnMultipleKeyProperties(bool useConfig)
+    {
+        // Act.
+        var ex = useConfig ?
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(MultiKeysModel), this._multiKeysDefinition, true)) :
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(MultiKeysModel), true));
+
+        // Assert.
+        var expectedMessage = useConfig ?
+            "Multiple key properties configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiKeysModel." :
+            "Multiple key properties found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiKeysModel.";
+        Assert.Equal(expectedMessage, ex.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindPropertiesThrowsOnNoKeyProperty(bool useConfig)
+    {
+        // Act.
+        var ex = useConfig ?
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(NoKeyModel), this._noKeyDefinition, true)) :
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(NoKeyModel), true));
+
+        // Assert.
+        var expectedMessage = useConfig ?
+            "No key property configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoKeyModel." :
+            "No key property found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoKeyModel.";
+        Assert.Equal(expectedMessage, ex.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindPropertiesThrowsOnNoVectorPropertyWithSingleVectorSupport(bool useConfig)
+    {
+        // Act.
+        var ex = useConfig ?
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(NoVectorModel), this._noVectorDefinition, false)) :
+            Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(NoVectorModel), false));
+
+        // Assert.
+        var expectedMessage = useConfig ?
+            "No vector property configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoVectorModel." :
+            "No vector property found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoVectorModel.";
+        Assert.Equal(expectedMessage, ex.Message);
+    }
+
+    [Theory]
+    [InlineData("Key", "MissingKey")]
+    [InlineData("Data", "MissingData")]
+    [InlineData("Vector", "MissingVector")]
+    public void FindPropertiesUsingConfigThrowsForNotFoundProperties(string propertyType, string propertyName)
+    {
+        var missingKeyDefinition = new VectorStoreRecordDefinition { Properties = [new VectorStoreRecordKeyProperty(propertyName)] };
+        var missingDataDefinition = new VectorStoreRecordDefinition { Properties = [new VectorStoreRecordDataProperty(propertyName)] };
+        var missingVectorDefinition = new VectorStoreRecordDefinition { Properties = [new VectorStoreRecordVectorProperty(propertyName)] };
+
+        var definition = propertyType switch
+        {
+            "Key" => missingKeyDefinition,
+            "Data" => missingDataDefinition,
+            "Vector" => missingVectorDefinition,
+            _ => throw new ArgumentException("Invalid property type.")
+        };
+
+        Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(NoKeyModel), definition, false));
+    }
+
+    [Fact]
+    public void VerifyPropertyTypesPassForAllowedTypes()
+    {
+        // Arrange.
+        var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), true);
+
+        // Act.
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, [typeof(string)], "Data");
+    }
+
+    [Fact]
+    public void VerifyPropertyTypesFailsForDisallowedTypes()
+    {
+        // Arrange.
+        var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), true);
+
+        // Act.
+        var ex = Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, [typeof(int), typeof(float)], "Data"));
+
+        // Assert.
+        Assert.Equal("Data properties must be one of the supported types: System.Int32, System.Single. Type of Data is System.String.", ex.Message);
+    }
+
+    private class NoKeyModel
+    {
+    }
+
+    private readonly VectorStoreRecordDefinition _noKeyDefinition = new();
+
+    private class NoVectorModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+    }
+
+    private readonly VectorStoreRecordDefinition _noVectorDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key")
+        ]
+    };
+
+    private class MultiKeysModel
+    {
+        [VectorStoreRecordKey]
+        public string Key1 { get; set; } = string.Empty;
+
+        [VectorStoreRecordKey]
+        public string Key2 { get; set; } = string.Empty;
+    }
+
+    private readonly VectorStoreRecordDefinition _multiKeysDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key1"),
+            new VectorStoreRecordKeyProperty("Key2")
+        ]
+    };
+
+    private class SinglePropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float> Vector { get; set; }
+
+        public string NotAnnotated { get; set; } = string.Empty;
+    }
+
+    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordDataProperty("Data"),
+            new VectorStoreRecordVectorProperty("Vector")
+        ]
+    };
+
+    private class MultiPropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data1 { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data2 { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float> Vector1 { get; set; }
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float> Vector2 { get; set; }
+
+        public string NotAnnotated { get; set; } = string.Empty;
+    }
+
+    private readonly VectorStoreRecordDefinition _multiPropsDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordDataProperty("Data1"),
+            new VectorStoreRecordDataProperty("Data2"),
+            new VectorStoreRecordVectorProperty("Vector1"),
+            new VectorStoreRecordVectorProperty("Vector2")
+        ]
+    };
+}

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/VectorStoreRecordPropertyReaderTests.cs
@@ -161,13 +161,14 @@ public class VectorStoreRecordPropertyReaderTests
         Assert.Equal("Data properties must be one of the supported types: System.Int32, System.Single. Type of Data is System.String.", ex.Message);
     }
 
-    private class NoKeyModel
+#pragma warning disable CA1812 // Invalid unused classes error, since I am using these for testing purposes above.
+    private sealed class NoKeyModel
     {
     }
 
     private readonly VectorStoreRecordDefinition _noKeyDefinition = new();
 
-    private class NoVectorModel
+    private sealed class NoVectorModel
     {
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
@@ -181,7 +182,7 @@ public class VectorStoreRecordPropertyReaderTests
         ]
     };
 
-    private class MultiKeysModel
+    private sealed class MultiKeysModel
     {
         [VectorStoreRecordKey]
         public string Key1 { get; set; } = string.Empty;
@@ -199,7 +200,7 @@ public class VectorStoreRecordPropertyReaderTests
         ]
     };
 
-    private class SinglePropsModel
+    private sealed class SinglePropsModel
     {
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
@@ -223,7 +224,7 @@ public class VectorStoreRecordPropertyReaderTests
         ]
     };
 
-    private class MultiPropsModel
+    private sealed class MultiPropsModel
     {
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
@@ -254,4 +255,5 @@ public class VectorStoreRecordPropertyReaderTests
             new VectorStoreRecordVectorProperty("Vector2")
         ]
     };
+#pragma warning restore CA1812 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 }

--- a/dotnet/src/InternalUtilities/src/Schema/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/VectorStoreRecordPropertyReader.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -16,6 +17,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Contains helpers for reading vector store model properties and their attributes.
 /// </summary>
+[ExcludeFromCodeCoverage]
 internal static class VectorStoreRecordPropertyReader
 {
     /// <summary>Cache of property enumerations so that we don't incur reflection costs with each invocation.</summary>

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/VectorStoreRecordPropertyReaderTests.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
 using Xunit;
 
-namespace SemanticKernel.Connectors.UnitTests.Memory;
+namespace SemanticKernel.UnitTests.Utilities;
 
 public class VectorStoreRecordPropertyReaderTests
 {
@@ -61,8 +61,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "Multiple vector properties configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported." :
-            "Multiple vector properties found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported.";
+            "Multiple vector properties configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported." :
+            "Multiple vector properties found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -78,8 +78,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "Multiple key properties configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiKeysModel." :
-            "Multiple key properties found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+MultiKeysModel.";
+            "Multiple key properties configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiKeysModel." :
+            "Multiple key properties found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiKeysModel.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -95,8 +95,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "No key property configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoKeyModel." :
-            "No key property found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoKeyModel.";
+            "No key property configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoKeyModel." :
+            "No key property found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoKeyModel.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -112,8 +112,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "No vector property configured for type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoVectorModel." :
-            "No vector property found on type SemanticKernel.Connectors.UnitTests.Memory.VectorStoreRecordPropertyReaderTests+NoVectorModel.";
+            "No vector property configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoVectorModel." :
+            "No vector property found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoVectorModel.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 


### PR DESCRIPTION
### Motivation and Context

The property enumerator helps to read property information from a model used with any of the vector stores.
This property information is used to map from the storage model to the user data model.
Adding unit tests for this property enumerator, and marking it with the exclude from code coverage attribute, since
the file is located in the Internal Utilities folder and therefore is included in all projects, but it will not be unit tested in each, just in the one centralized location.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
