### PR TITLE
.Net: Adding generic redis IVectorRecordStore implementation

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -140,9 +140,9 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         // Remove record.
         var searchClient = this.GetSearchClient(collectionName);
         return RunOperationAsync(
-            () => searchClient.DeleteDocumentsAsync(this._keyPropertyName, [key], new IndexDocumentsOptions(), cancellationToken),
             collectionName,
-            "DeleteDocuments");
+            "DeleteDocuments",
+            () => searchClient.DeleteDocumentsAsync(this._keyPropertyName, [key], new IndexDocumentsOptions(), cancellationToken));
     }
 
     /// <inheritdoc />
@@ -156,9 +156,9 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         // Remove records.
         var searchClient = this.GetSearchClient(collectionName);
         return RunOperationAsync(
-            () => searchClient.DeleteDocumentsAsync(this._keyPropertyName, keys, new IndexDocumentsOptions(), cancellationToken),
             collectionName,
-            "DeleteDocuments");
+            "DeleteDocuments",
+            () => searchClient.DeleteDocumentsAsync(this._keyPropertyName, keys, new IndexDocumentsOptions(), cancellationToken));
     }
 
     /// <inheritdoc />
@@ -214,21 +214,21 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         if (this._options.MapperType == AzureAISearchRecordMapperType.JsonObjectCustomMapper)
         {
             var jsonObject = await RunOperationAsync(
-                () => searchClient.GetDocumentAsync<JsonObject>(key, innerOptions, cancellationToken),
                 collectionName,
-                "GetDocument").ConfigureAwait(false);
+                "GetDocument",
+                () => searchClient.GetDocumentAsync<JsonObject>(key, innerOptions, cancellationToken)).ConfigureAwait(false);
 
             return RunModelConversion(
-                () => this._options.JsonObjectCustomMapper!.MapFromStorageToDataModel(jsonObject),
                 collectionName,
-                "GetDocument");
+                "GetDocument",
+                () => this._options.JsonObjectCustomMapper!.MapFromStorageToDataModel(jsonObject));
         }
 
         // Use the built in Azure AI Search mapper.
         return await RunOperationAsync(
-            () => searchClient.GetDocumentAsync<TRecord>(key, innerOptions, cancellationToken),
             collectionName,
-            "GetDocument").ConfigureAwait(false);
+            "GetDocument",
+            () => searchClient.GetDocumentAsync<TRecord>(key, innerOptions, cancellationToken)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -251,21 +251,21 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         if (this._options.MapperType == AzureAISearchRecordMapperType.JsonObjectCustomMapper)
         {
             var jsonObjects = RunModelConversion(
-                () => records.Select(this._options.JsonObjectCustomMapper!.MapFromDataToStorageModel),
                 collectionName,
-                "UploadDocuments");
+                "UploadDocuments",
+                () => records.Select(this._options.JsonObjectCustomMapper!.MapFromDataToStorageModel));
 
             return RunOperationAsync(
-                () => searchClient.UploadDocumentsAsync<JsonObject>(jsonObjects, innerOptions, cancellationToken),
                 collectionName,
-                "UploadDocuments");
+                "UploadDocuments",
+                () => searchClient.UploadDocumentsAsync<JsonObject>(jsonObjects, innerOptions, cancellationToken));
         }
 
         // Use the built in Azure AI Search mapper.
         return RunOperationAsync(
-            () => searchClient.UploadDocumentsAsync<TRecord>(records, innerOptions, cancellationToken),
             collectionName,
-            "UploadDocuments");
+            "UploadDocuments",
+            () => searchClient.UploadDocumentsAsync<TRecord>(records, innerOptions, cancellationToken));
     }
 
     /// <summary>
@@ -322,14 +322,14 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     }
 
     /// <summary>
-    /// Run the given operation and wrap any <see cref="RequestFailedException"/> with <see cref="HttpOperationException"/>."/>
+    /// Run the given operation and wrap any <see cref="RequestFailedException"/> with <see cref="VectorStoreOperationException"/>."/>
     /// </summary>
     /// <typeparam name="T">The response type of the operation.</typeparam>
-    /// <param name="operation">The operation to run.</param>
     /// <param name="collectionName">The name of the collection the operation is being run on.</param>
     /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
     /// <returns>The result of the operation.</returns>
-    private static async Task<T> RunOperationAsync<T>(Func<Task<T>> operation, string collectionName, string operationName)
+    private static async Task<T> RunOperationAsync<T>(string collectionName, string operationName, Func<Task<T>> operation)
     {
         try
         {
@@ -365,11 +365,11 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     /// Run the given model conversion and wrap any exceptions with <see cref="VectorStoreRecordMappingException"/>.
     /// </summary>
     /// <typeparam name="T">The response type of the operation.</typeparam>
-    /// <param name="operation">The operation to run.</param>
     /// <param name="collectionName">The name of the collection the operation is being run on.</param>
     /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
     /// <returns>The result of the operation.</returns>
-    private static T RunModelConversion<T>(Func<T> operation, string collectionName, string operationName)
+    private static T RunModelConversion<T>(string collectionName, string operationName, Func<T> operation)
     {
         try
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisRecordMapperType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisRecordMapperType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// The types of mapper supported by <see cref="RedisVectorRecordStore{TRecord}"/>.
+/// </summary>
+public enum RedisRecordMapperType
+{
+    /// <summary>
+    /// Use the default semantic kernel mapper that uses property attributes to determine how to map fields.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Use a custom mapper between <see cref="JsonNode"/> and the data model.
+    /// </summary>
+    JsonNodeCustomMapper
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -1,0 +1,385 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Memory;
+using NRedisStack.Json.DataTypes;
+using NRedisStack.RedisStackCommands;
+using StackExchange.Redis;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Service for storing and retrieving records, that uses Redis as the underlying storage.
+/// </summary>
+/// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string, TRecord>
+    where TRecord : class
+{
+    /// <summary>A set of types that a key on the provided model may have.</summary>
+    private static readonly HashSet<Type> s_supportedKeyTypes =
+    [
+        typeof(string)
+    ];
+
+    /// <summary>A set of types that vectors on the provided model may have.</summary>
+    private static readonly HashSet<Type> s_supportedVectorTypes =
+    [
+        typeof(ReadOnlyMemory<float>),
+        typeof(ReadOnlyMemory<double>),
+        typeof(ReadOnlyMemory<float>?),
+        typeof(ReadOnlyMemory<double>?)
+    ];
+
+    /// <summary>The redis database to read/write records from.</summary>
+    private readonly IDatabase _database;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly RedisVectorRecordStoreOptions<TRecord> _options;
+
+    /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
+    private readonly PropertyInfo _keyPropertyInfo;
+
+    /// <summary>The name of the temporary json property that the key property will be serialized / parsed from.</summary>
+    private readonly string _keyJsonPropertyName;
+
+    /// <summary>An array of the names of all the data properties that are part of the redis payload, i.e. all properties except the key and vector properties.</summary>
+    private readonly string[] _dataPropertyNames;
+
+    /// <summary>An array of the names of all the data and vector properties that are part of the redis payload.</summary>
+    private readonly string[] _dataAndVectorPropertyNames;
+
+    /// <summary>The mapper to use when mapping between the consumer data model and the redis record.</summary>
+    private readonly IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)> _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisVectorRecordStore{TRecord}"/> class.
+    /// </summary>
+    /// <param name="database">The redis database to read/write records from.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    /// <exception cref="ArgumentNullException">Throw when parameters are invalid.</exception>
+    public RedisVectorRecordStore(IDatabase database, RedisVectorRecordStoreOptions<TRecord>? options)
+    {
+        // Verify.
+        Verify.NotNull(database);
+
+        // Assign.
+        this._database = database;
+        this._options = options ?? new RedisVectorRecordStoreOptions<TRecord>();
+
+        // Enumerate public properties using configuration or attributes.
+        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;
+        if (this._options.VectorStoreRecordDefinition is not null)
+        {
+            properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), this._options.VectorStoreRecordDefinition, supportsMultipleVectors: true);
+        }
+        else
+        {
+            properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), supportsMultipleVectors: true);
+        }
+
+        // Validate property types and store for later use.
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
+
+        this._keyPropertyInfo = properties.keyProperty;
+        this._keyJsonPropertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(this._keyPropertyInfo);
+
+        this._dataPropertyNames = properties
+            .dataProperties
+            .Select(VectorStoreRecordPropertyReader.GetSerializedPropertyName)
+            .ToArray();
+
+        this._dataAndVectorPropertyNames = this._dataPropertyNames
+            .Concat(properties.vectorProperties.Select(VectorStoreRecordPropertyReader.GetSerializedPropertyName))
+            .ToArray();
+
+        // Assign Mapper.
+        if (this._options.MapperType == RedisRecordMapperType.JsonNodeCustomMapper)
+        {
+            if (this._options.JsonNodeCustomMapper is null)
+            {
+                throw new ArgumentException($"The {nameof(RedisVectorRecordStoreOptions<TRecord>.JsonNodeCustomMapper)} option needs to be set if a {nameof(RedisVectorRecordStoreOptions<TRecord>.MapperType)} of {nameof(RedisRecordMapperType.JsonNodeCustomMapper)} has been chosen.", nameof(options));
+            }
+
+            this._mapper = this._options.JsonNodeCustomMapper;
+        }
+        else
+        {
+            this._mapper = new RedisVectorStoreRecordMapper<TRecord>(this._keyJsonPropertyName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<TRecord> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(key);
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        var maybePrefixedKey = this.PrefixKeyIfNeeded(key, collectionName);
+
+        // Get the redis value.
+        var redisResult = await RunOperationAsync(
+            collectionName,
+            "GET",
+            () => options?.IncludeVectors is true ?
+                this._database
+                    .JSON()
+                    .GetAsync(maybePrefixedKey) :
+                this._database
+                    .JSON()
+                    .GetAsync(maybePrefixedKey, this._dataPropertyNames)).ConfigureAwait(false);
+
+        // Check if the key was found before trying to serialize the result.
+        if (redisResult.IsNull)
+        {
+            throw new VectorStoreOperationException($"Could not find document with key '{key}'");
+        }
+
+        // Convert to the caller's data model.
+        return RunModelConversion(
+            collectionName,
+            "GET",
+            () =>
+            {
+                var node = JsonSerializer.Deserialize<JsonNode>(redisResult.ToString())!;
+                return this._mapper.MapFromStorageToDataModel((key, node));
+            });
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<string> keys, GetRecordOptions? options = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(keys);
+        var keysList = keys.ToList();
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        var maybePrefixedKeys = keysList.Select(key => this.PrefixKeyIfNeeded(key, collectionName));
+        var redisKeys = maybePrefixedKeys.Select(x => new RedisKey(x)).ToArray();
+
+        // Get the list of redis results.
+        var redisResults = await RunOperationAsync(
+            collectionName,
+            "MGET",
+            () => this._database
+                .JSON()
+                .MGetAsync(redisKeys, "$")).ConfigureAwait(false);
+
+        // Loop through each key and result and convert to the caller's data model.
+        for (int i = 0; i < keysList.Count; i++)
+        {
+            var key = keysList[i];
+            var redisResult = redisResults[i];
+
+            // Check if the key was found before trying to serialize the result.
+            if (redisResult.IsNull)
+            {
+                throw new VectorStoreOperationException($"Could not find document with key '{key}'");
+            }
+
+            // Convert to the caller's data model.
+            yield return RunModelConversion(
+                collectionName,
+                "MGET",
+                () =>
+                {
+                    var node = JsonSerializer.Deserialize<JsonNode>(redisResult.ToString())!;
+                    return this._mapper.MapFromStorageToDataModel((key, node));
+                });
+        }
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(string key, DeleteRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(key);
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        var maybePrefixedKey = this.PrefixKeyIfNeeded(key, collectionName);
+
+        // Remove.
+        return RunOperationAsync(
+            collectionName,
+            "DEL",
+            () => this._database
+                .JSON()
+                .DelAsync(maybePrefixedKey));
+    }
+
+    /// <inheritdoc />
+    public Task DeleteBatchAsync(IEnumerable<string> keys, DeleteRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(keys);
+
+        // Remove records in parallel.
+        var tasks = keys.Select(key => this.DeleteAsync(key, options, cancellationToken));
+        return Task.WhenAll(tasks);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> UpsertAsync(TRecord record, UpsertRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(record);
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+
+        // Map.
+        var redisJsonRecord = RunModelConversion(
+            collectionName,
+            "SET",
+            () => this._mapper.MapFromDataToStorageModel(record));
+
+        // Upsert.
+        var maybePrefixedKey = this.PrefixKeyIfNeeded(redisJsonRecord.Key, collectionName);
+        await RunOperationAsync(
+            collectionName,
+            "SET",
+            () => this._database
+                .JSON()
+                .SetAsync(
+                    maybePrefixedKey,
+                    "$",
+                    redisJsonRecord.Node)).ConfigureAwait(false);
+
+        return redisJsonRecord.Key;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(records);
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+
+        // Map.
+        var redisRecords = new List<(string maybePrefixedKey, string originalKey, JsonNode jsonNode)>();
+        foreach (var record in records)
+        {
+            var redisJsonRecord = RunModelConversion(
+                collectionName,
+                "MSET",
+                () => this._mapper.MapFromDataToStorageModel(record));
+
+            var maybePrefixedKey = this.PrefixKeyIfNeeded(redisJsonRecord.Key, collectionName);
+            redisRecords.Add((maybePrefixedKey, redisJsonRecord.Key, redisJsonRecord.Node));
+        }
+
+        // Upsert.
+        var keyPathValues = redisRecords.Select(x => new KeyPathValue(x.maybePrefixedKey, "$", x.jsonNode)).ToArray();
+        await RunOperationAsync(
+            collectionName,
+            "MSET",
+            () => this._database
+                .JSON()
+                .MSetAsync(keyPathValues)).ConfigureAwait(false);
+
+        // Return keys of upserted records.
+        foreach (var record in redisRecords)
+        {
+            yield return record.originalKey;
+        }
+    }
+
+    /// <summary>
+    /// Prefix the key with the collection name if the option is set.
+    /// </summary>
+    /// <param name="key">The key to prefix.</param>
+    /// <param name="collectionName">The collection name that was provided as part of an operation to override the default or the default if not.</param>
+    /// <returns>The updated key if updating is required, otherwise the input key.</returns>
+    private string PrefixKeyIfNeeded(string key, string? collectionName)
+    {
+        if (this._options.PrefixCollectionNameToKeyNames)
+        {
+            return $"{collectionName}:{key}";
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Choose the right collection name to use for the operation by using the one provided
+    /// as part of the operation options, or the default one provided at construction time.
+    /// </summary>
+    /// <param name="operationCollectionName">The collection name provided on the operation options.</param>
+    /// <returns>The collection name to use.</returns>
+    private string ChooseCollectionName(string? operationCollectionName)
+    {
+        var collectionName = operationCollectionName ?? this._options.DefaultCollectionName;
+        if (collectionName is null)
+        {
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+            throw new ArgumentException("Collection name must be provided in the operation options, since no default was provided at construction time.", "options");
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
+        }
+
+        return collectionName;
+    }
+
+    /// <summary>
+    /// Run the given operation and wrap any redis exceptions with <see cref="VectorStoreOperationException"/>."/>
+    /// </summary>
+    /// <typeparam name="T">The response type of the operation.</typeparam>
+    /// <param name="collectionName">The name of the collection the operation is being run on.</param>
+    /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
+    /// <returns>The result of the operation.</returns>
+    private static async Task<T> RunOperationAsync<T>(string collectionName, string operationName, Func<Task<T>> operation)
+    {
+        try
+        {
+            return await operation.Invoke().ConfigureAwait(false);
+        }
+        catch (RedisConnectionException ex)
+        {
+            var wrapperException = new VectorStoreOperationException("Call to vector store failed.", ex);
+
+            // Using Open Telemetry standard for naming of these entries.
+            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
+            wrapperException.Data.Add("db.system", "Redis");
+            wrapperException.Data.Add("db.collection.name", collectionName);
+            wrapperException.Data.Add("db.operation.name", operationName);
+
+            throw wrapperException;
+        }
+    }
+
+    /// <summary>
+    /// Run the given model conversion and wrap any exceptions with <see cref="VectorStoreRecordMappingException"/>.
+    /// </summary>
+    /// <typeparam name="T">The response type of the operation.</typeparam>
+    /// <param name="collectionName">The name of the collection the operation is being run on.</param>
+    /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
+    /// <returns>The result of the operation.</returns>
+    private static T RunModelConversion<T>(string collectionName, string operationName, Func<T> operation)
+    {
+        try
+        {
+            return operation.Invoke();
+        }
+        catch (Exception ex)
+        {
+            var wrapperException = new VectorStoreRecordMappingException("Failed to convert vector store record.", ex);
+
+            // Using Open Telemetry standard for naming of these entries.
+            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
+            wrapperException.Data.Add("db.system", "AzureAISearch");
+            wrapperException.Data.Add("db.collection.name", collectionName);
+            wrapperException.Data.Add("db.operation.name", operationName);
+
+            throw wrapperException;
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Memory;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Options when creating a <see cref="RedisVectorRecordStore{TRecord}"/>.
+/// </summary>
+public sealed class RedisVectorRecordStoreOptions<TRecord>
+    where TRecord : class
+{
+    /// <summary>
+    /// Gets or sets the default collection name to use.
+    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
+    /// </summary>
+    public string? DefaultCollectionName { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the collection name should be prefixed to the
+    /// key names before reading or writing to the redis store. Default is false.
+    /// </summary>
+    /// <remarks>
+    /// For a record to be indexed by a specific redis index, the key name must be prefixed with the index name.
+    /// You can either pass in keys that are already prefixed, or set this option to true to have the collection name prefixed to the key names automatically.
+    /// </remarks>
+    public bool PrefixCollectionNameToKeyNames { get; init; } = false;
+
+    /// <summary>
+    /// Gets or sets the choice of mapper to use when converting between the data model and the redis record.
+    /// </summary>
+    public RedisRecordMapperType MapperType { get; init; } = RedisRecordMapperType.Default;
+
+    /// <summary>
+    /// Gets or sets an optional custom mapper to use when converting between the data model and the redis record.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="MapperType"/> to <see cref="RedisRecordMapperType.JsonNodeCustomMapper"/> to use this mapper."/>
+    /// </remarks>
+    public IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)>? JsonNodeCustomMapper { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets an optional record definition that defines the schema of the record type.
+    /// </summary>
+    /// <remarks>
+    /// If not provided, the schema will be inferred from the record model class using reflection.
+    /// In this case, the record model properties must be annotated with the appropriate attributes to indicate their usage.
+    /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
+    /// </remarks>
+    public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordMapper.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Memory;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Class for mapping between a json node stored in redis, and the consumer data model.
+/// </summary>
+/// <typeparam name="TConsumerDataModel">The consumer data model to map to or from.</typeparam>
+internal sealed class RedisVectorStoreRecordMapper<TConsumerDataModel> : IVectorStoreRecordMapper<TConsumerDataModel, (string Key, JsonNode Node)>
+    where TConsumerDataModel : class
+{
+    /// <summary>The name of the temporary json property that the key field will be serialized / parsed from.</summary>
+    private readonly string _keyFieldJsonPropertyName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisVectorStoreRecordMapper{TConsumerDataModel}"/> class.
+    /// </summary>
+    /// <param name="keyFieldJsonPropertyName">The name of the key field on the model when serialized to json.</param>
+    public RedisVectorStoreRecordMapper(string keyFieldJsonPropertyName)
+    {
+        Verify.NotNullOrWhiteSpace(keyFieldJsonPropertyName);
+        this._keyFieldJsonPropertyName = keyFieldJsonPropertyName;
+    }
+
+    /// <inheritdoc />
+    public (string Key, JsonNode Node) MapFromDataToStorageModel(TConsumerDataModel dataModel)
+    {
+        // Convert the provided record into a JsonNode object and try to get the key field for it.
+        // Since we aleady checked that the key field is a string in the constructor, and that it exists on the model,
+        // the only edge case we have to be concerned about is if the key field is null.
+        var jsonNode = JsonSerializer.SerializeToNode(dataModel);
+        if (jsonNode!.AsObject().TryGetPropertyValue(this._keyFieldJsonPropertyName, out var keyField) && keyField is JsonValue jsonValue)
+        {
+            // Remove the key field from the JSON object since we don't want to store it in the redis payload.
+            var keyValue = jsonValue.ToString();
+            jsonNode.AsObject().Remove(this._keyFieldJsonPropertyName);
+
+            return (keyValue, jsonNode);
+        }
+
+        throw new VectorStoreRecordMappingException($"Missing key field {this._keyFieldJsonPropertyName} on provided record of type {typeof(TConsumerDataModel).FullName}.");
+    }
+
+    /// <inheritdoc />
+    public TConsumerDataModel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, GetRecordOptions? options = null)
+    {
+        JsonObject jsonObject;
+
+        // The redis result can be either a single object or an array with a single object in the case where we are doing an MGET.
+        if (storageModel.Node is JsonObject topLevelJsonObject)
+        {
+            jsonObject = topLevelJsonObject;
+        }
+        else if (storageModel.Node is JsonArray jsonArray && jsonArray.Count == 1 && jsonArray[0] is JsonObject arrayEntryJsonObject)
+        {
+            jsonObject = arrayEntryJsonObject;
+        }
+        else
+        {
+            throw new VectorStoreRecordMappingException($"Invalid data format for document with key '{storageModel.Key}'");
+        }
+
+        // Check that the key field is not already present in the redis value.
+        if (jsonObject.ContainsKey(this._keyFieldJsonPropertyName))
+        {
+            throw new VectorStoreRecordMappingException($"Invalid data format for document with key '{storageModel.Key}'. Key property '{this._keyFieldJsonPropertyName}' is already present on retrieved object.");
+        }
+
+        // Since the key is not stored in the redis value, add it back in before deserializing into the data model.
+        jsonObject.Add(this._keyFieldJsonPropertyName, storageModel.Key);
+
+        return JsonSerializer.Deserialize<TConsumerDataModel>(jsonObject)!;
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
@@ -38,22 +38,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
 
         // Act
-        var hotel = new Hotel()
-        {
-            HotelId = "Upsert-1",
-            HotelName = "MyHotel1",
-            Description = "My Hotel is great.",
-            DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
-            Tags = new[] { "pool", "air conditioning", "concierge" },
-            ParkingIncluded = true,
-            LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
-            Rating = 3.6,
-            Address = new Address()
-            {
-                City = "New York",
-                Country = "USA"
-            }
-        };
+        var hotel = CreateTestHotel("Upsert-1");
         var upsertResult = await sut.UpsertAsync(hotel);
         var getResult = await sut.GetAsync("Upsert-1");
 
@@ -65,7 +50,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         Assert.Equal(hotel.HotelName, getResult.HotelName);
         Assert.Equal(hotel.Description, getResult.Description);
         Assert.NotNull(getResult.DescriptionEmbedding);
-        Assert.Equal(hotel.DescriptionEmbedding.Value, getResult.DescriptionEmbedding.Value);
+        Assert.Equal(hotel.DescriptionEmbedding?.ToArray(), getResult.DescriptionEmbedding?.ToArray());
         Assert.Equal(hotel.Tags, getResult.Tags);
         Assert.Equal(hotel.ParkingIncluded, getResult.ParkingIncluded);
         Assert.Equal(hotel.LastRenovationDate, getResult.LastRenovationDate);
@@ -234,7 +219,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     }
 
     [Fact(Skip = SkipReason)]
-    public async Task ItThrowsCommandExecutionExceptionForFailedConnectionAsync()
+    public async Task ItThrowsOperationExceptionForFailedConnectionAsync()
     {
         // Arrange
         var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { DefaultCollectionName = fixture.TestIndexName };
@@ -246,7 +231,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     }
 
     [Fact(Skip = SkipReason)]
-    public async Task ItThrowsCommandExecutionExceptionForFailedAuthenticationAsync()
+    public async Task ItThrowsOperationExceptionForFailedAuthenticationAsync()
     {
         // Arrange
         var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { DefaultCollectionName = fixture.TestIndexName };
@@ -274,7 +259,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         HotelName = $"MyHotel {hotelId}",
         Description = "My Hotel is great.",
         DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
-        Tags = new[] { "pool", "air conditioning", "concierge" },
+        Tags = ["pool", "air conditioning", "concierge"],
         ParkingIncluded = true,
         LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
         Rating = 3.6,

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
@@ -1,0 +1,284 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.Redis;
+using Microsoft.SemanticKernel.Memory;
+using Xunit;
+using Xunit.Abstractions;
+using static SemanticKernel.IntegrationTests.Connectors.Memory.Redis.RedisVectorStoreFixture;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorRecordStore{TRecord}"/> class.
+/// </summary>
+/// <param name="output">Used for logging.</param>
+/// <param name="fixture">Redis setup and teardown.</param>
+[Collection("RedisVectorStoreCollection")]
+public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisVectorStoreFixture fixture)
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition)
+    {
+        // Arrange.
+        var options = new RedisVectorRecordStoreOptions<Hotel>
+        {
+            DefaultCollectionName = "hotels",
+            PrefixCollectionNameToKeyNames = true,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
+        };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        Hotel record = CreateTestHotel("Upsert-1", 1);
+
+        // Act.
+        var upsertResult = await sut.UpsertAsync(record);
+
+        // Assert.
+        var getResult = await sut.GetAsync("Upsert-1", new GetRecordOptions { IncludeVectors = true });
+        Assert.Equal("Upsert-1", upsertResult);
+        Assert.Equal(record.HotelId, getResult?.HotelId);
+        Assert.Equal(record.HotelName, getResult?.HotelName);
+        Assert.Equal(record.HotelCode, getResult?.HotelCode);
+        Assert.Equal(record.Tags, getResult?.Tags);
+        Assert.Equal(record.ParkingIncluded, getResult?.ParkingIncluded);
+        Assert.Equal(record.LastRenovationDate, getResult?.LastRenovationDate);
+        Assert.Equal(record.Rating, getResult?.Rating);
+        Assert.Equal(record.Address.Country, getResult?.Address.Country);
+        Assert.Equal(record.Address.City, getResult?.Address.City);
+        Assert.Equal(record.Description, getResult?.Description);
+        Assert.Equal(record.DescriptionEmbedding?.ToArray(), getResult?.DescriptionEmbedding?.ToArray());
+
+        // Output.
+        output.WriteLine(upsertResult);
+        output.WriteLine(getResult?.ToString());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItCanUpsertManyDocumentsToVectorStoreAsync(bool useRecordDefinition)
+    {
+        // Arrange.
+        var options = new RedisVectorRecordStoreOptions<Hotel>
+        {
+            DefaultCollectionName = "hotels",
+            PrefixCollectionNameToKeyNames = true,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
+        };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+
+        // Act.
+        var results = sut.UpsertBatchAsync(
+            [
+                CreateTestHotel("UpsertMany-1", 1),
+                CreateTestHotel("UpsertMany-2", 2),
+                CreateTestHotel("UpsertMany-3", 3),
+            ]);
+
+        // Assert.
+        Assert.NotNull(results);
+        var resultsList = await results.ToListAsync();
+
+        Assert.Equal(3, resultsList.Count);
+        Assert.Contains("UpsertMany-1", resultsList);
+        Assert.Contains("UpsertMany-2", resultsList);
+        Assert.Contains("UpsertMany-3", resultsList);
+
+        // Output
+        foreach (var result in resultsList)
+        {
+            output.WriteLine(result);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task ItCanGetDocumentFromVectorStoreAsync(bool includeVectors, bool useRecordDefinition)
+    {
+        // Arrange.
+        var options = new RedisVectorRecordStoreOptions<Hotel>
+        {
+            DefaultCollectionName = "hotels",
+            PrefixCollectionNameToKeyNames = true,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
+        };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+
+        // Act.
+        var getResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
+
+        // Assert.
+        Assert.Equal("BaseSet-1", getResult?.HotelId);
+        Assert.Equal("My Hotel 1", getResult?.HotelName);
+        Assert.Equal(1, getResult?.HotelCode);
+        Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, getResult?.Tags);
+        Assert.True(getResult?.ParkingIncluded);
+        Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), getResult?.LastRenovationDate);
+        Assert.Equal(3.6, getResult?.Rating);
+        Assert.Equal("Seattle", getResult?.Address.City);
+        Assert.Equal("This is a great hotel.", getResult?.Description);
+        if (includeVectors)
+        {
+            Assert.Equal(new[] { 30f, 31f, 32f, 33f }, getResult?.DescriptionEmbedding?.ToArray());
+        }
+        else
+        {
+            Assert.Null(getResult?.DescriptionEmbedding);
+        }
+
+        // Output.
+        output.WriteLine(getResult?.ToString());
+    }
+
+    [Fact]
+    public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
+    {
+        // Arrange
+        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+
+        // Act
+        var hotels = sut.GetBatchAsync(["BaseSet-1", "BaseSet-2"], new GetRecordOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.NotNull(hotels);
+        var hotelsList = await hotels.ToListAsync();
+        Assert.Equal(2, hotelsList.Count);
+
+        // Output
+        foreach (var hotel in hotelsList)
+        {
+            output.WriteLine(hotel?.ToString() ?? "Null");
+        }
+    }
+
+    [Fact]
+    public async Task ItFailsToGetDocumentsWithInvalidSchemaAsync()
+    {
+        // Arrange.
+        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+
+        // Act & Assert.
+        await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-4-Invalid", new GetRecordOptions { IncludeVectors = true }));
+    }
+
+    [Fact]
+    public async Task ItThrowsForPartialGetBatchResultAsync()
+    {
+        // Arrange.
+        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+
+        // Act & Assert.
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetBatchAsync(["BaseSet-1", "nonexistant", "BaseSet-2"], new GetRecordOptions { IncludeVectors = true }).ToListAsync());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItCanRemoveDocumentFromVectorStoreAsync(bool useRecordDefinition)
+    {
+        // Arrange.
+        var options = new RedisVectorRecordStoreOptions<Hotel>
+        {
+            DefaultCollectionName = "hotels",
+            PrefixCollectionNameToKeyNames = true,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
+        };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var address = new HotelAddress { City = "Seattle", Country = "USA" };
+        var record = new Hotel
+        {
+            HotelId = "Remove-1",
+            HotelName = "Remove Test Hotel",
+            HotelCode = 20,
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f }
+        };
+
+        await sut.UpsertAsync(record);
+
+        // Act.
+        await sut.DeleteAsync("Remove-1");
+
+        // Assert.
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("Remove-1"));
+    }
+
+    [Fact]
+    public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
+    {
+        // Arrange
+        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        await sut.UpsertAsync(CreateTestHotel("RemoveMany-1", 1));
+        await sut.UpsertAsync(CreateTestHotel("RemoveMany-2", 2));
+        await sut.UpsertAsync(CreateTestHotel("RemoveMany-3", 3));
+
+        // Act
+        await sut.DeleteBatchAsync(["RemoveMany-1", "RemoveMany-2", "RemoveMany-3"]);
+
+        // Assert
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("RemoveMany-1", new GetRecordOptions { IncludeVectors = true }));
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("RemoveMany-2", new GetRecordOptions { IncludeVectors = true }));
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("RemoveMany-3", new GetRecordOptions { IncludeVectors = true }));
+    }
+
+    [Fact]
+    public async Task ItThrowsMappingExceptionForFailedMapperAsync()
+    {
+        // Arrange
+        var options = new RedisVectorRecordStoreOptions<Hotel>
+        {
+            DefaultCollectionName = "hotels",
+            PrefixCollectionNameToKeyNames = true,
+            MapperType = RedisRecordMapperType.JsonNodeCustomMapper,
+            JsonNodeCustomMapper = new FailingMapper()
+        };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
+    }
+
+    private static Hotel CreateTestHotel(string hotelId, int hotelCode)
+    {
+        var address = new HotelAddress { City = "Seattle", Country = "USA" };
+        var record = new Hotel
+        {
+            HotelId = hotelId,
+            HotelName = $"My Hotel {hotelCode}",
+            HotelCode = 1,
+            Tags = ["pool", "air conditioning", "concierge"],
+            ParkingIncluded = true,
+            LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
+            Rating = 3.6,
+            Address = address,
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f }
+        };
+        return record;
+    }
+
+    private sealed class FailingMapper : IVectorStoreRecordMapper<Hotel, (string Key, JsonNode Node)>
+    {
+        public (string Key, JsonNode Node) MapFromDataToStorageModel(Hotel dataModel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Hotel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, GetRecordOptions? options = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreCollectionFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreCollectionFixture.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
+
+[CollectionDefinition("RedisVectorStoreCollection")]
+public class RedisVectorStoreCollectionFixture : ICollectionFixture<RedisVectorStoreFixture>
+{
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.SemanticKernel.Memory;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using StackExchange.Redis;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+/// <summary>
+/// Does setup and teardown of redis docker container and associated test data.
+/// </summary>
+public class RedisVectorStoreFixture : IAsyncLifetime
+{
+    /// <summary>The docker client we are using to create a redis container with.</summary>
+    private readonly DockerClient _client;
+
+    /// <summary>The id of the redis container that we are testing with.</summary>
+    private string? _containerId = null;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisVectorStoreFixture"/> class.
+    /// </summary>
+    public RedisVectorStoreFixture()
+    {
+        using var dockerClientConfiguration = new DockerClientConfiguration();
+        this._client = dockerClientConfiguration.CreateClient();
+        this.VectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("HotelId"),
+                new VectorStoreRecordDataProperty("HotelName"),
+                new VectorStoreRecordDataProperty("HotelCode"),
+                new VectorStoreRecordDataProperty("Description"),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding"),
+                new VectorStoreRecordDataProperty("Tags"),
+                new VectorStoreRecordDataProperty("ParkingIncluded"),
+                new VectorStoreRecordDataProperty("LastRenovationDate"),
+                new VectorStoreRecordDataProperty("Rating"),
+                new VectorStoreRecordDataProperty("Address")
+            }
+        };
+    }
+
+    /// <summary>Gets the redis database connection to use for tests.</summary>
+    public IDatabase Database { get; private set; }
+
+    /// <summary>Gets the manually created vector store record definition for our test model.</summary>
+    public VectorStoreRecordDefinition VectorStoreRecordDefinition { get; private set; }
+
+    /// <summary>
+    /// Create / Recreate redis docker container, create an index and add test data.
+    /// </summary>
+    /// <returns>An async task.</returns>
+    public async Task InitializeAsync()
+    {
+        this._containerId = await SetupRedisContainerAsync(this._client);
+
+        // Connect to redis.
+        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379");
+        this.Database = redis.GetDatabase();
+
+        // Create a schema for the vector store.
+        var schema = new Schema();
+        schema.AddTextField("HotelName");
+        schema.AddNumericField("hotelCode");
+        schema.AddTextField("Description");
+        schema.AddVectorField("DescriptionEmbedding", Schema.VectorField.VectorAlgo.HNSW, new Dictionary<string, object>()
+        {
+            ["TYPE"] = "FLOAT32",
+            ["DIM"] = "4",
+            ["DISTANCE_METRIC"] = "L2"
+        });
+        var createParams = new FTCreateParams();
+        createParams.AddPrefix("hotels");
+        await this.Database.FT().CreateAsync("hotels", createParams, schema);
+
+        // Create some test data.
+        var address = new HotelAddress { City = "Seattle", Country = "USA" };
+        var embedding = new[] { 30f, 31f, 32f, 33f };
+
+        await this.Database.JSON().SetAsync("hotels:BaseSet-1", "$", new
+        {
+            HotelName = "My Hotel 1",
+            HotelCode = 1,
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = embedding,
+            Tags = new[] { "pool", "air conditioning", "concierge" },
+            ParkingIncluded = true,
+            LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
+            Rating = 3.6,
+            Address = address
+        });
+        await this.Database.JSON().SetAsync("hotels:BaseSet-2", "$", new { HotelName = "My Hotel 2", HotelCode = 2, Description = "This is a great hotel.", DescriptionEmbedding = embedding, ParkingIncluded = false });
+        await this.Database.JSON().SetAsync("hotels:BaseSet-3", "$", new { HotelName = "My Hotel 3", HotelCode = 3, Description = "This is a great hotel.", DescriptionEmbedding = embedding, ParkingIncluded = false });
+        await this.Database.JSON().SetAsync("hotels:BaseSet-4-Invalid", "$", new { HotelId = "AnotherId", HotelName = "My Invalid Hotel", HotelCode = 4, Description = "This is an invalid hotel.", DescriptionEmbedding = embedding, ParkingIncluded = false });
+    }
+
+    /// <summary>
+    /// Delete the docker container after the test run.
+    /// </summary>
+    /// <returns>An async task.</returns>
+    public async Task DisposeAsync()
+    {
+        if (this._containerId != null)
+        {
+            await this._client.Containers.StopContainerAsync(this._containerId, new ContainerStopParameters());
+            await this._client.Containers.RemoveContainerAsync(this._containerId, new ContainerRemoveParameters());
+        }
+    }
+
+    /// <summary>
+    /// Setup the redis container by pulling the image and running it.
+    /// </summary>
+    /// <param name="client">The docker client to create the container with.</param>
+    /// <returns>The id of the container.</returns>
+    private static async Task<string> SetupRedisContainerAsync(DockerClient client)
+    {
+        await client.Images.CreateImageAsync(
+            new ImagesCreateParameters
+            {
+                FromImage = "redis/redis-stack",
+                Tag = "latest",
+            },
+            null,
+            new Progress<JSONMessage>());
+
+        var container = await client.Containers.CreateContainerAsync(new CreateContainerParameters()
+        {
+            Image = "redis/redis-stack",
+            HostConfig = new HostConfig()
+            {
+                PortBindings = new Dictionary<string, IList<PortBinding>>
+                {
+                    {"6379", new List<PortBinding> {new() {HostPort = "6379"}}}
+                },
+                PublishAllPorts = true
+            },
+            ExposedPorts = new Dictionary<string, EmptyStruct>
+            {
+                { "6379", default }
+            },
+        });
+
+        await client.Containers.StartContainerAsync(
+            container.ID,
+            new ContainerStartParameters());
+
+        return container.ID;
+    }
+
+    /// <summary>
+    /// A test model for the vector store.
+    /// </summary>
+    public class Hotel
+    {
+        [VectorStoreRecordKey]
+        public string HotelId { get; init; }
+
+        [VectorStoreRecordData]
+        public string HotelName { get; init; }
+
+        [VectorStoreRecordData]
+        public int HotelCode { get; init; }
+
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        public string Description { get; init; }
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? DescriptionEmbedding { get; init; }
+
+#pragma warning disable CA1819 // Properties should not return arrays
+        [VectorStoreRecordData]
+        public string[] Tags { get; init; }
+#pragma warning restore CA1819 // Properties should not return arrays
+
+        [VectorStoreRecordData]
+        public bool ParkingIncluded { get; init; }
+
+        [VectorStoreRecordData]
+        public DateTimeOffset LastRenovationDate { get; init; }
+
+        [VectorStoreRecordData]
+        public double Rating { get; init; }
+
+        [VectorStoreRecordData]
+        public HotelAddress Address { get; init; }
+    }
+
+    /// <summary>
+    /// A test model for the vector store to simulate a complex type.
+    /// </summary>
+    public class HotelAddress
+    {
+        public string City { get; init; }
+        public string Country { get; init; }
+    }
+}
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -63,6 +63,7 @@
     <ProjectReference Include="..\Agents\Core\Agents.Core.csproj" />
     <ProjectReference Include="..\Agents\OpenAI\Agents.OpenAI.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Google\Connectors.Google.csproj" />
+    <ProjectReference Include="..\Connectors\Connectors.Memory.Redis\Connectors.Memory.Redis.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Onnx\Connectors.Onnx.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.HuggingFace\Connectors.HuggingFace.csproj" />


### PR DESCRIPTION
### Motivation and Context

As part of the evolution of memory connectors, we need to support custom data models and remove opinionated behaviors, so adding a new record store implementation for redis.

### Description

Adding an implementation for IVectorRecordStore for redis with support for:

Custom mappers
Generic data models
Annotating data models via attributes or via definition objects.
Also improving some styling in the AzureAISearch implementation.

See #6525

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
