### PR TITLE
.Net: Align the behavior of the ChatMessageContent.Content property setter with streaming counterpart

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
@@ -41,18 +41,12 @@ public class ChatMessageContent : KernelContent
         }
         set
         {
-            if (value is null)
-            {
-                return;
-            }
-
             var textContent = this.Items.OfType<TextContent>().FirstOrDefault();
             if (textContent is not null)
             {
                 textContent.Text = value;
-                textContent.Encoding = this.Encoding;
             }
-            else
+            else if (value is not null)
             {
                 this.Items.Add(new TextContent(
                     text: value,

--- a/dotnet/src/SemanticKernel.UnitTests/Contents/ChatMessageContentTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Contents/ChatMessageContentTests.cs
@@ -55,8 +55,10 @@ public class ChatMessageContentTests
         Assert.Contains(sut.Items, item => item is TextContent textContent && textContent.Text == "fake-content");
     }
 
-    [Fact]
-    public void ContentPropertySetterShouldUpdateContentOfFirstTextContentItem()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("fake-content-1-update")]
+    public void ContentPropertySetterShouldUpdateContentOfFirstTextContentItem(string? content)
     {
         // Arrange
         var items = new ChatMessageContentItemCollection
@@ -68,10 +70,23 @@ public class ChatMessageContentTests
 
         var sut = new ChatMessageContent(AuthorRole.User, items: items)
         {
-            Content = "fake-content-1-update"
+            Content = content
         };
 
-        Assert.Equal("fake-content-1-update", ((TextContent)sut.Items[1]).Text);
+        Assert.Equal(content, ((TextContent)sut.Items[1]).Text);
+    }
+
+    [Fact]
+    public void ContentPropertySetterShouldNotAddTextContentToItemsCollection()
+    {
+        // Arrange
+        var sut = new ChatMessageContent(AuthorRole.User, content: null)
+        {
+            Content = null
+        };
+
+        // Assert
+        Assert.Empty(sut.Items);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation and Context
This is a follow-up fix for the `ChatMessageContent.Content` property setter, similar to the one that was done to the `StreamingChatMessageContent.Content` property when addressing the PR comment: https://github.com/microsoft/semantic-kernel/pull/6449#discussion_r1633235050.

### Description
This change updates the text of the first text item regardless of the value being set. This helps avoid inconsistency that occurs when text content already exists in the items collection, null is set via the Content property, and the setter does nothing, while the getter returns the text message content:
```csharp
var items = new ChatMessageContentItemCollection
{
    new TextContent("Hi AI."),
};

var chatMessage = new ChatMessageContent(AuthorRole.User, items: items);
chatMessage.Content = null; // The property setter does nothing if the value is null.

// Fails
Assert.Null(chatMessage.Content); // The property getter returns the "Hi AI." text.
```