### PR TITLE
Python: Updates to user agent. Add unit tests.

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/const.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/const.py
@@ -3,4 +3,3 @@
 from typing import Final
 
 DEFAULT_AZURE_API_VERSION: Final[str] = "2024-02-01"
-USER_AGENT: Final[str] = "User-Agent"

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_config_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_config_base.py
@@ -6,9 +6,10 @@ from collections.abc import Awaitable, Callable, Mapping
 from openai import AsyncAzureOpenAI
 from pydantic import ConfigDict, validate_call
 
-from semantic_kernel.connectors.ai.open_ai.const import DEFAULT_AZURE_API_VERSION, USER_AGENT
+from semantic_kernel.connectors.ai.open_ai.const import DEFAULT_AZURE_API_VERSION
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_handler import OpenAIHandler, OpenAIModelTypes
 from semantic_kernel.connectors.telemetry import APP_INFO, prepend_semantic_kernel_to_user_agent
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.exceptions import ServiceInitializationError
 from semantic_kernel.kernel_pydantic import HttpsUrl
 

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_config_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_config_base.py
@@ -6,10 +6,10 @@ from collections.abc import Mapping
 from openai import AsyncOpenAI
 from pydantic import ConfigDict, Field, validate_call
 
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_handler import OpenAIHandler
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_model_types import OpenAIModelTypes
 from semantic_kernel.connectors.telemetry import APP_INFO, prepend_semantic_kernel_to_user_agent
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.exceptions import ServiceInitializationError
 
 logger: logging.Logger = logging.getLogger(__name__)

--- a/python/semantic_kernel/connectors/memory/azure_cognitive_search/utils.py
+++ b/python/semantic_kernel/connectors/memory/azure_cognitive_search/utils.py
@@ -8,7 +8,7 @@ from azure.search.documents.indexes.aio import SearchIndexClient
 from azure.search.documents.indexes.models import SearchableField, SearchField, SearchFieldDataType, SimpleField
 from dotenv import load_dotenv
 
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.exceptions import ServiceInitializationError
 from semantic_kernel.memory.memory_record import MemoryRecord
 

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -10,7 +10,7 @@ TELEMETRY_DISABLED_ENV_VAR = "AZURE_TELEMETRY_DISABLED"
 
 IS_TELEMETRY_ENABLED = os.environ.get(TELEMETRY_DISABLED_ENV_VAR, "false").lower() not in ["true", "1"]
 
-HTTP_USER_AGENT = "semantic-kernel"
+HTTP_USER_AGENT = "semantic-kernel-python"
 
 try:
     version_info = version("semantic-kernel")

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -4,7 +4,7 @@ import os
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
+from semantic_kernel.const import USER_AGENT
 
 TELEMETRY_DISABLED_ENV_VAR = "AZURE_TELEMETRY_DISABLED"
 

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -10,7 +10,7 @@ TELEMETRY_DISABLED_ENV_VAR = "AZURE_TELEMETRY_DISABLED"
 
 IS_TELEMETRY_ENABLED = os.environ.get(TELEMETRY_DISABLED_ENV_VAR, "false").lower() not in ["true", "1"]
 
-HTTP_USER_AGENT = "Semantic-Kernel"
+HTTP_USER_AGENT = "semantic-kernel"
 
 try:
     version_info = version("semantic-kernel")
@@ -19,7 +19,7 @@ except PackageNotFoundError:
 
 APP_INFO = (
     {
-        "Semantic-Kernel-Version": f"python-{version_info}",
+        "semantic-kernel-version": f"python/{version_info}",
     }
     if IS_TELEMETRY_ENABLED
     else None
@@ -27,14 +27,18 @@ APP_INFO = (
 
 
 def prepend_semantic_kernel_to_user_agent(headers: dict[str, Any]):
-    """Prepend "Semantic-Kernel" to the User-Agent in the headers.
+    """Prepend "semantic-kernel" to the User-Agent in the headers.
 
     Args:
         headers: The existing headers dictionary.
 
     Returns:
-        The modified headers dictionary with "Semantic-Kernel" prepended to the User-Agent.
+        The modified headers dictionary with "semantic-kernel" prepended to the User-Agent.
     """
-    headers[USER_AGENT] = f"{HTTP_USER_AGENT} {headers[USER_AGENT]}" if USER_AGENT in headers else f"{HTTP_USER_AGENT}"
+    headers[USER_AGENT] = (
+        f"{HTTP_USER_AGENT}/{version_info} {headers[USER_AGENT]}"
+        if USER_AGENT in headers
+        else f"{HTTP_USER_AGENT}/{version_info}"
+    )
 
     return headers

--- a/python/semantic_kernel/const.py
+++ b/python/semantic_kernel/const.py
@@ -4,3 +4,4 @@ from typing import Final
 
 METADATA_EXCEPTION_KEY: Final[str] = "exception"
 DEFAULT_SERVICE_NAME: Final[str] = "default"
+USER_AGENT: Final[str] = "User-Agent"

--- a/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
@@ -10,8 +10,8 @@ from typing import Annotated, Any
 import httpx
 from pydantic import ValidationError
 
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
 from semantic_kernel.connectors.telemetry import HTTP_USER_AGENT, version_info
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.core_plugins.sessions_python_tool.sessions_python_settings import (
     ACASessionsSettings,
     SessionsPythonSettings,
@@ -93,7 +93,7 @@ class SessionsPythonTool(KernelBaseModel):
         code = re.sub(r"^(\s|`)*(?i:python)?\s*", "", code)
         # Removes whitespace & ` from end
         return re.sub(r"(\s|`)*$", "", code)
-    
+
     def _construct_remote_file_path(self, remote_file_path: str) -> str:
         """Construct the remote file path.
 
@@ -109,8 +109,8 @@ class SessionsPythonTool(KernelBaseModel):
 
     def _build_url_with_version(self, base_url, endpoint, params):
         """Builds a URL with the provided base URL, endpoint, and query parameters."""
-        params['api-version'] = SESSIONS_API_VERSION
-        query_string = '&'.join([f"{key}={value}" for key, value in params.items()])
+        params["api-version"] = SESSIONS_API_VERSION
+        query_string = "&".join([f"{key}={value}" for key, value in params.items()])
         return f"{base_url}{endpoint}?{query_string}"
 
     @kernel_function(
@@ -178,7 +178,9 @@ class SessionsPythonTool(KernelBaseModel):
         self,
         *,
         local_file_path: Annotated[str, "The path to the local file on the machine"],
-        remote_file_path: Annotated[str | None, "The remote path to the file in the session. Defaults to /mnt/data"] = None,  # noqa: E501
+        remote_file_path: Annotated[
+            str | None, "The remote path to the file in the session. Defaults to /mnt/data"
+        ] = None,
     ) -> Annotated[SessionsRemoteFileMetadata, "The metadata of the uploaded file"]:
         """Upload a file to the session pool.
 
@@ -222,7 +224,7 @@ class SessionsPythonTool(KernelBaseModel):
             response.raise_for_status()
 
             response_json = response.json()
-            return SessionsRemoteFileMetadata.from_dict(response_json['$values'][0])
+            return SessionsRemoteFileMetadata.from_dict(response_json["$values"][0])
 
     @kernel_function(name="list_files", description="Lists all files in the provided Session ID")
     async def list_files(self) -> list[SessionsRemoteFileMetadata]:
@@ -242,7 +244,7 @@ class SessionsPythonTool(KernelBaseModel):
         url = self._build_url_with_version(
             base_url=self.pool_management_endpoint,
             endpoint="python/files",
-            params={"identifier": self.settings.session_id}
+            params={"identifier": self.settings.session_id},
         )
 
         response = await self.http_client.get(
@@ -275,10 +277,7 @@ class SessionsPythonTool(KernelBaseModel):
         url = self._build_url_with_version(
             base_url=self.pool_management_endpoint,
             endpoint="python/downloadFile",
-            params={
-                "identifier": self.settings.session_id,
-                "filename": remote_file_path
-            }
+            params={"identifier": self.settings.session_id, "filename": remote_file_path},
         )
 
         response = await self.http_client.get(

--- a/python/tests/unit/connectors/google_palm/services/test_palm_chat_completion.py
+++ b/python/tests/unit/connectors/google_palm/services/test_palm_chat_completion.py
@@ -29,6 +29,7 @@ def test_google_palm_chat_completion_init_with_empty_api_key(google_palm_unit_te
     with pytest.raises(ServiceInitializationError):
         GooglePalmChatCompletion(
             ai_model_id=ai_model_id,
+            env_file_path="test.env",
         )
 
 

--- a/python/tests/unit/connectors/google_palm/services/test_palm_text_completion.py
+++ b/python/tests/unit/connectors/google_palm/services/test_palm_text_completion.py
@@ -30,6 +30,7 @@ def test_google_palm_text_completion_init_with_empty_api_key(google_palm_unit_te
     with pytest.raises(ServiceInitializationError):
         GooglePalmTextCompletion(
             ai_model_id=ai_model_id,
+            env_file_path="test.env",
         )
 
 

--- a/python/tests/unit/connectors/google_palm/services/test_palm_text_embedding.py
+++ b/python/tests/unit/connectors/google_palm/services/test_palm_text_embedding.py
@@ -30,6 +30,7 @@ def test_google_palm_text_embedding_init_with_empty_api_key(google_palm_unit_tes
     with pytest.raises(ServiceInitializationError):
         GooglePalmTextEmbedding(
             ai_model_id=ai_model_id,
+            env_file_path="test.env",
         )
 
 

--- a/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
@@ -12,7 +12,6 @@ from openai.resources.chat.completions import AsyncCompletions as AsyncChatCompl
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
 from semantic_kernel.connectors.ai.function_call_behavior import FunctionCallBehavior
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
 from semantic_kernel.connectors.ai.open_ai.exceptions.content_filter_ai_exception import (
     ContentFilterAIException,
     ContentFilterResultSeverity,
@@ -22,6 +21,7 @@ from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.azure_chat_
     AzureChatPromptExecutionSettings,
     ExtraBody,
 )
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.exceptions import ServiceInitializationError, ServiceInvalidExecutionSettingsError
 from semantic_kernel.exceptions.service_exceptions import ServiceResponseException
@@ -450,9 +450,7 @@ async def test_azure_chat_completion_auto_invoke_false_no_kernel_provided_throws
     prompt = "some prompt that would trigger the content filtering"
     chat_history.add_user_message(prompt)
     complete_prompt_execution_settings = AzureChatPromptExecutionSettings(
-        function_call_behavior=FunctionCallBehavior.EnableFunctions(
-            auto_invoke=False, filters={}
-        )
+        function_call_behavior=FunctionCallBehavior.EnableFunctions(auto_invoke=False, filters={})
     )
 
     test_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")

--- a/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
@@ -58,19 +58,25 @@ def test_azure_chat_completion_init_base_url(azure_openai_unit_test_env) -> None
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]], indirect=True)
 def test_azure_chat_completion_init_with_empty_deployment_name(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureChatCompletion()
+        AzureChatCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
 def test_azure_chat_completion_init_with_empty_api_key(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureChatCompletion()
+        AzureChatCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_BASE_URL"]], indirect=True)
 def test_azure_chat_completion_init_with_empty_endpoint_and_base_url(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureChatCompletion()
+        AzureChatCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("override_env_param_dict", [{"AZURE_OPENAI_ENDPOINT": "http://test.com"}], indirect=True)

--- a/python/tests/unit/connectors/open_ai/services/test_azure_text_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_text_completion.py
@@ -46,19 +46,25 @@ def test_azure_text_completion_init_with_custom_header(azure_openai_unit_test_en
 def test_azure_text_completion_init_with_empty_deployment_name(monkeypatch, azure_openai_unit_test_env) -> None:
     monkeypatch.delenv("AZURE_OPENAI_TEXT_DEPLOYMENT_NAME", raising=False)
     with pytest.raises(ServiceInitializationError):
-        AzureTextCompletion()
+        AzureTextCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
 def test_azure_text_completion_init_with_empty_api_key(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureTextCompletion()
+        AzureTextCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_BASE_URL"]], indirect=True)
 def test_azure_text_completion_init_with_empty_endpoint_and_base_url(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureTextCompletion()
+        AzureTextCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("override_env_param_dict", [{"AZURE_OPENAI_ENDPOINT": "http://test.com"}], indirect=True)

--- a/python/tests/unit/connectors/open_ai/services/test_azure_text_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_text_completion.py
@@ -43,7 +43,8 @@ def test_azure_text_completion_init_with_custom_header(azure_openai_unit_test_en
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_TEXT_DEPLOYMENT_NAME"]], indirect=True)
-def test_azure_text_completion_init_with_empty_deployment_name(azure_openai_unit_test_env) -> None:
+def test_azure_text_completion_init_with_empty_deployment_name(monkeypatch, azure_openai_unit_test_env) -> None:
+    monkeypatch.delenv("AZURE_OPENAI_TEXT_DEPLOYMENT_NAME", raising=False)
     with pytest.raises(ServiceInitializationError):
         AzureTextCompletion()
 

--- a/python/tests/unit/connectors/open_ai/services/test_azure_text_embedding.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_text_embedding.py
@@ -24,19 +24,25 @@ def test_azure_text_embedding_init(azure_openai_unit_test_env) -> None:
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME"]], indirect=True)
 def test_azure_text_embedding_init_with_empty_deployment_name(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureTextEmbedding()
+        AzureTextEmbedding(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
 def test_azure_text_embedding_init_with_empty_api_key(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureTextEmbedding()
+        AzureTextEmbedding(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_BASE_URL"]], indirect=True)
 def test_azure_text_embedding_init_with_empty_endpoint_and_base_url(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        AzureTextEmbedding()
+        AzureTextEmbedding(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("override_env_param_dict", [{"AZURE_OPENAI_ENDPOINT": "http://test.com"}], indirect=True)

--- a/python/tests/unit/connectors/open_ai/services/test_openai_chat_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_openai_chat_completion.py
@@ -4,8 +4,8 @@
 import pytest
 
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion import OpenAIChatCompletion
+from semantic_kernel.const import USER_AGENT
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
 
 

--- a/python/tests/unit/connectors/open_ai/services/test_openai_chat_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_openai_chat_completion.py
@@ -46,7 +46,9 @@ def test_open_ai_chat_completion_init_with_default_header(openai_unit_test_env) 
 @pytest.mark.parametrize("exclude_list", [["OPENAI_API_KEY"]], indirect=True)
 def test_open_ai_chat_completion_init_with_empty_model_id(openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        OpenAIChatCompletion()
+        OpenAIChatCompletion(
+            env_file_path="test.env",
+        )
 
 
 @pytest.mark.parametrize("exclude_list", [["OPENAI_API_KEY"]], indirect=True)
@@ -56,6 +58,7 @@ def test_open_ai_chat_completion_init_with_empty_api_key(openai_unit_test_env) -
     with pytest.raises(ServiceInitializationError):
         OpenAIChatCompletion(
             ai_model_id=ai_model_id,
+            env_file_path="test.env",
         )
 
 

--- a/python/tests/unit/connectors/open_ai/services/test_openai_text_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_openai_text_completion.py
@@ -43,7 +43,9 @@ def test_open_ai_text_completion_init_with_default_header(openai_unit_test_env) 
 @pytest.mark.parametrize("exclude_list", [["OPENAI_API_KEY"]], indirect=True)
 def test_open_ai_text_completion_init_with_empty_api_key(openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):
-        OpenAITextCompletion()
+        OpenAITextCompletion(
+            env_file_path="test.env",
+        )
 
 
 def test_open_ai_text_completion_serialize(openai_unit_test_env) -> None:

--- a/python/tests/unit/core_plugins/test_sessions_python_plugin.py
+++ b/python/tests/unit/core_plugins/test_sessions_python_plugin.py
@@ -53,7 +53,10 @@ def test_validate_endpoint_no_final_slash(aca_python_sessions_unit_test_env):
 @pytest.mark.parametrize("exclude_list", [["ACA_POOL_MANAGEMENT_ENDPOINT"]], indirect=True)
 def test_validate_settings_fail(aca_python_sessions_unit_test_env):
     with pytest.raises(FunctionInitializationError):
-        SessionsPythonTool(auth_callback=auth_callback_test)
+        SessionsPythonTool(
+            auth_callback=auth_callback_test,
+            env_file_path="test.env",
+        )
 
 
 def test_it_can_be_imported(kernel: Kernel, aca_python_sessions_unit_test_env):
@@ -151,7 +154,10 @@ async def test_upload_file_with_local_path(mock_post, aca_python_sessions_unit_t
         )
         mock_post.return_value = await async_return(mock_response)
 
-        plugin = SessionsPythonTool(auth_callback=lambda: "sample_token")
+        plugin = SessionsPythonTool(
+            auth_callback=lambda: "sample_token",
+            env_file_path="test.env",
+        )
 
         result = await plugin.upload_file(local_file_path="test.txt", remote_file_path="uploaded_test.txt")
         assert result.filename == "test.txt"
@@ -194,7 +200,10 @@ async def test_upload_file_with_local_path_and_no_remote(mock_post, aca_python_s
         )
         mock_post.return_value = await async_return(mock_response)
 
-        plugin = SessionsPythonTool(auth_callback=lambda: "sample_token")
+        plugin = SessionsPythonTool(
+            auth_callback=lambda: "sample_token",
+            env_file_path="test.env",
+        )
 
         result = await plugin.upload_file(local_file_path="test.txt")
         assert result.filename == "test.txt"
@@ -338,7 +347,10 @@ async def test_download_file_to_local(mock_get, aca_python_sessions_unit_test_en
         mock_response = httpx.Response(status_code=200, content=b"file data", request=mock_request)
         mock_get.return_value = await async_return(mock_response)
 
-        plugin = SessionsPythonTool(auth_callback=mock_auth_callback)
+        plugin = SessionsPythonTool(
+            auth_callback=mock_auth_callback,
+            env_file_path="test.env",
+        )
 
         await plugin.download_file(remote_file_path="remote_test.txt", local_file_path="local_test.txt")
         mock_get.assert_awaited_once()

--- a/python/tests/unit/functions/test_kernel_plugins.py
+++ b/python/tests/unit/functions/test_kernel_plugins.py
@@ -13,6 +13,7 @@ from semantic_kernel.connectors.ai import PromptExecutionSettings
 from semantic_kernel.connectors.openai_plugin.openai_function_execution_parameters import (
     OpenAIFunctionExecutionParameters,
 )
+from semantic_kernel.connectors.telemetry import HTTP_USER_AGENT
 from semantic_kernel.exceptions.function_exceptions import PluginInitializationError
 from semantic_kernel.functions import kernel_function
 from semantic_kernel.functions.kernel_function import KernelFunction
@@ -558,7 +559,7 @@ async def test_from_openai_plugin_from_url(mock_parse_openai_manifest, mock_get)
     assert plugin.functions.get("GetSecret") is not None
     assert plugin.functions.get("SetSecret") is not None
 
-    mock_get.assert_awaited_once_with(fake_plugin_url, headers={"User-Agent": "Semantic-Kernel"})
+    mock_get.assert_awaited_once_with(fake_plugin_url, headers={"User-Agent": HTTP_USER_AGENT})
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/telemetry/test_user_agent.py
+++ b/python/tests/unit/telemetry/test_user_agent.py
@@ -2,12 +2,12 @@
 
 import importlib
 
-from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
 from semantic_kernel.connectors.telemetry import (
     HTTP_USER_AGENT,
     TELEMETRY_DISABLED_ENV_VAR,
     prepend_semantic_kernel_to_user_agent,
 )
+from semantic_kernel.const import USER_AGENT
 
 
 def test_append_to_existing_user_agent(monkeypatch):

--- a/python/tests/unit/telemetry/test_user_agent.py
+++ b/python/tests/unit/telemetry/test_user_agent.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import importlib
+
+from semantic_kernel.connectors.ai.open_ai.const import USER_AGENT
+from semantic_kernel.connectors.telemetry import (
+    HTTP_USER_AGENT,
+    TELEMETRY_DISABLED_ENV_VAR,
+    prepend_semantic_kernel_to_user_agent,
+)
+
+
+def test_append_to_existing_user_agent(monkeypatch):
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV_VAR, "false")
+    monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
+    monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
+
+    headers = {USER_AGENT: "existing-agent"}
+    expected = {USER_AGENT: f"{HTTP_USER_AGENT}/1.0.0 existing-agent"}
+    result = prepend_semantic_kernel_to_user_agent(headers)
+    assert result == expected
+
+
+def test_create_new_user_agent(monkeypatch):
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV_VAR, "false")
+    monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
+    monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
+
+    headers = {}
+    expected = {USER_AGENT: f"{HTTP_USER_AGENT}/1.0.0"}
+    result = prepend_semantic_kernel_to_user_agent(headers)
+    assert result == expected
+
+
+def test_telemetry_disabled(monkeypatch):
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV_VAR, "true")
+    monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
+    monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
+
+    headers = {}
+    result = prepend_semantic_kernel_to_user_agent(headers)
+    assert result == headers
+
+
+def test_app_info_when_telemetry_enabled(monkeypatch):
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV_VAR, "false")
+    monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
+    monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
+
+    # need to reload the module to get the updated APP_INFO
+    import semantic_kernel.connectors.telemetry
+
+    importlib.reload(semantic_kernel.connectors.telemetry)
+
+    expected = {"semantic-kernel-version": "python/1.0.0"}
+    assert expected == semantic_kernel.connectors.telemetry.APP_INFO
+
+
+def test_app_info_when_telemetry_disabled(monkeypatch):
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV_VAR, "true")
+    monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
+    monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
+
+    # need to reload the module to get the updated APP_INFO
+    import semantic_kernel.connectors.telemetry
+
+    importlib.reload(semantic_kernel.connectors.telemetry)
+
+    assert semantic_kernel.connectors.telemetry.APP_INFO is None


### PR DESCRIPTION
### Motivation and Context

Updates to the User-Agent are required so that we can align with all three SK languages. Examples:

User agent
- semantic-kernel-csharp/1.1.1 [existing user agent]
- semantic-kernel-java/1.1.1 [existing user agent]
- semantic-kernel-python/1.1.1 [existing user agent]

semantic-kernel-version header
- csharp/1.1.1 
- java/1.1.1
- python/1.1.1

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Updates to the user agent to reflect the desired changes/standardization across all SK languages. Adding unit tests.
- Closes #6827 
- Moves the `USER_AGENT` const from its previous home in the openai const file to a more generic const file.
- Updates unit tests to be able to run properly when a valid `.env` file exists in the current working directory. The unit tests patch the env vars and our current implementation of Pydantic Settings loads the `.env` file if not specified.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
