### PR TITLE
.Net: Add qdrant vector record store implementation

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -92,6 +92,7 @@
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="Testcontainers.Milvus" Version="3.8.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageVersion Include="Qdrant.Client" Version="1.9.0" />
     <!-- Symbols -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Toolset -->

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -335,7 +335,7 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     /// <summary>
     /// Get a document with the given key, and return null if it is not found.
     /// </summary>
-    /// <typeparam name="T">The type to deserialize the doucment to.</typeparam>
+    /// <typeparam name="T">The type to deserialize the document to.</typeparam>
     /// <param name="searchClient">The search client to use when fetching the document.</param>
     /// <param name="key">The key of the record to get.</param>
     /// <param name="innerOptions">The azure ai search sdk options for getting a document.</param>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Qdrant.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantRecordMapperType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantRecordMapperType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// The types of mapper supported by <see cref="QdrantVectorRecordStore{TRecord}"/>.
+/// </summary>
+public enum QdrantRecordMapperType
+{
+    /// <summary>
+    /// Use the default mapper that is provided by the semantic kernel SDK that uses json as an intermediary to allows automatic mapping to a wide variety of types.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Use a custom mapper between <see cref="PointStruct"/> and the data model.
+    /// </summary>
+    QdrantPointStructCustomMapper
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -68,21 +68,21 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
     }
 
     /// <inheritdoc />
-    public async Task<TRecord> GetAsync(ulong key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(ulong key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
         var retrievedPoints = await this.GetBatchAsync([key], options, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
-        return retrievedPoints[0];
+        return retrievedPoints.FirstOrDefault();
     }
 
     /// <inheritdoc />
-    public async Task<TRecord> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(key);
 
         var retrievedPoints = await this.GetBatchAsync([key], options, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
-        return retrievedPoints[0];
+        return retrievedPoints.FirstOrDefault();
     }
 
     /// <inheritdoc />
@@ -282,12 +282,6 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
             collectionName,
             "Retrieve",
             () => this._qdrantClient.RetrieveAsync(collectionName, pointsIds, true, options?.IncludeVectors ?? false, cancellationToken: cancellationToken)).ConfigureAwait(false);
-
-        // Check that we found the required number of values.
-        if (retrievedPoints.Count != pointsIds.Length)
-        {
-            throw new VectorStoreOperationException("Record not found");
-        }
 
         // Convert the retrieved points to the target data model.
         foreach (var retrievedPoint in retrievedPoints)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -1,0 +1,388 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.SemanticKernel.Memory;
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Service for storing and retrieving vector records, that uses Qdrant as the underlying storage.
+/// </summary>
+/// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong, TRecord>, IVectorRecordStore<Guid, TRecord>
+    where TRecord : class
+{
+    /// <summary>Qdrant client that can be used to manage the collections and points in a Qdrant store.</summary>
+    private readonly QdrantClient _qdrantClient;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly QdrantVectorRecordStoreOptions<TRecord> _options;
+
+    /// <summary>A mapper to use for converting between qdrant point and consumer models.</summary>
+    private readonly IVectorStoreRecordMapper<TRecord, PointStruct> _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+    /// </summary>
+    /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public QdrantVectorRecordStore(QdrantClient qdrantClient, QdrantVectorRecordStoreOptions<TRecord>? options = null)
+    {
+        // Verify.
+        Verify.NotNull(qdrantClient);
+
+        // Assign.
+        this._qdrantClient = qdrantClient;
+        this._options = options ?? new QdrantVectorRecordStoreOptions<TRecord>();
+
+        // Assign Mapper.
+        if (this._options.MapperType == QdrantRecordMapperType.QdrantPointStructCustomMapper)
+        {
+            // Custom Mapper.
+            if (this._options.PointStructCustomMapper is null)
+            {
+                throw new ArgumentException($"The {nameof(QdrantVectorRecordStoreOptions<TRecord>.PointStructCustomMapper)} option needs to be set if a {nameof(QdrantVectorRecordStoreOptions<TRecord>.MapperType)} of {nameof(QdrantRecordMapperType.QdrantPointStructCustomMapper)} has been chosen.", nameof(options));
+            }
+
+            this._mapper = this._options.PointStructCustomMapper;
+        }
+        else
+        {
+            // Default Mapper.
+            this._mapper = new QdrantVectorStoreRecordMapper<TRecord>(new QdrantVectorStoreRecordMapperOptions
+            {
+                HasNamedVectors = this._options.HasNamedVectors,
+                VectorStoreRecordDefinition = this._options.VectorStoreRecordDefinition
+            });
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<TRecord> GetAsync(ulong key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(key);
+
+        var retrievedPoints = await this.GetBatchAsync([key], options, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
+        return retrievedPoints[0];
+    }
+
+    /// <inheritdoc />
+    public async Task<TRecord> GetAsync(Guid key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(key);
+
+        var retrievedPoints = await this.GetBatchAsync([key], options, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
+        return retrievedPoints[0];
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<ulong> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        return this.GetBatchByPointIdAsync(keys, key => new PointId { Num = key }, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<Guid> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        return this.GetBatchByPointIdAsync(keys, key => new PointId { Uuid = key.ToString("D") }, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(ulong key, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(key);
+
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        return RunOperationAsync(
+            collectionName,
+            "Delete",
+            () => this._qdrantClient.DeleteAsync(
+                collectionName,
+                key,
+                wait: true,
+                cancellationToken: cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(Guid key, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(key);
+
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        return RunOperationAsync(
+            collectionName,
+            "Delete",
+            () => this._qdrantClient.DeleteAsync(
+                collectionName,
+                key,
+                wait: true,
+                cancellationToken: cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public Task DeleteBatchAsync(IEnumerable<ulong> keys, DeleteRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(keys);
+
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        return RunOperationAsync(
+            collectionName,
+            "Delete",
+            () => this._qdrantClient.DeleteAsync(
+                collectionName,
+                keys.ToList(),
+                wait: true,
+                cancellationToken: cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public Task DeleteBatchAsync(IEnumerable<Guid> keys, DeleteRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(keys);
+
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        return RunOperationAsync(
+            collectionName,
+            "Delete",
+            () => this._qdrantClient.DeleteAsync(
+                collectionName,
+                keys.ToList(),
+                wait: true,
+                cancellationToken: cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public async Task<ulong> UpsertAsync(TRecord record, UpsertRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(record);
+
+        // Create options.
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+
+        // Create point from record.
+        var pointStruct = RunModelConversion(
+            collectionName,
+            "Upsert",
+            () => this._mapper.MapFromDataToStorageModel(record));
+
+        // Upsert.
+        await RunOperationAsync(
+            collectionName,
+            "Upsert",
+            () => this._qdrantClient.UpsertAsync(collectionName, [pointStruct], true, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        return pointStruct.Id.Num;
+    }
+
+    /// <inheritdoc />
+    async Task<Guid> IVectorRecordStore<Guid, TRecord>.UpsertAsync(TRecord record, UpsertRecordOptions? options, CancellationToken cancellationToken)
+    {
+        Verify.NotNull(record);
+
+        // Create options.
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+
+        // Create point from record.
+        var pointStruct = RunModelConversion(
+            collectionName,
+            "Upsert",
+            () => this._mapper.MapFromDataToStorageModel(record));
+
+        // Upsert.
+        await RunOperationAsync(
+            collectionName,
+            "Upsert",
+            () => this._qdrantClient.UpsertAsync(collectionName, [pointStruct], true, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        return Guid.Parse(pointStruct.Id.Uuid);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ulong> UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(records);
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+
+        // Create points from records.
+        var pointStructs = RunModelConversion(
+            collectionName,
+            "Upsert",
+            () => records.Select(this._mapper.MapFromDataToStorageModel).ToList());
+
+        // Upsert.
+        await RunOperationAsync(
+            collectionName,
+            "Upsert",
+            () => this._qdrantClient.UpsertAsync(collectionName, pointStructs, true, cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        foreach (var pointStruct in pointStructs)
+        {
+            yield return pointStruct.Id.Num;
+        }
+    }
+
+    /// <inheritdoc />
+    async IAsyncEnumerable<Guid> IVectorRecordStore<Guid, TRecord>.UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        Verify.NotNull(records);
+
+        // Create Options
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+
+        // Create points from records.
+        var pointStructs = RunModelConversion(
+            collectionName,
+            "Upsert",
+            () => records.Select(this._mapper.MapFromDataToStorageModel).ToList());
+
+        // Upsert.
+        await RunOperationAsync(
+            collectionName,
+            "Upsert",
+            () => this._qdrantClient.UpsertAsync(collectionName, pointStructs, true, cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        foreach (var pointStruct in pointStructs)
+        {
+            yield return Guid.Parse(pointStruct.Id.Uuid);
+        }
+    }
+
+    /// <summary>
+    /// Get the requested records from the Qdrant store using the provided keys.
+    /// </summary>
+    /// <param name="keys">The keys of the points to retrieve.</param>
+    /// <param name="keyConverter">Function to convert the provided keys to point ids.</param>
+    /// <param name="options">The retrieval options.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The retrieved points.</returns>
+    private async IAsyncEnumerable<TRecord> GetBatchByPointIdAsync<TKey>(
+        IEnumerable<TKey> keys,
+        Func<TKey, PointId> keyConverter,
+        GetRecordOptions? options,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        Verify.NotNull(keys);
+
+        // Create options.
+        var collectionName = this.ChooseCollectionName(options?.CollectionName);
+        var pointsIds = keys.Select(key => keyConverter(key)).ToArray();
+
+        // Retrieve data points.
+        var retrievedPoints = await RunOperationAsync(
+            collectionName,
+            "Retrieve",
+            () => this._qdrantClient.RetrieveAsync(collectionName, pointsIds, true, options?.IncludeVectors ?? false, cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        // Check that we found the required number of values.
+        if (retrievedPoints.Count != pointsIds.Length)
+        {
+            throw new VectorStoreOperationException("Record not found");
+        }
+
+        // Convert the retrieved points to the target data model.
+        foreach (var retrievedPoint in retrievedPoints)
+        {
+            var pointStruct = new PointStruct
+            {
+                Id = retrievedPoint.Id,
+                Vectors = retrievedPoint.Vectors,
+                Payload = { }
+            };
+
+            foreach (KeyValuePair<string, Value> payloadEntry in retrievedPoint.Payload)
+            {
+                pointStruct.Payload.Add(payloadEntry.Key, payloadEntry.Value);
+            }
+
+            yield return RunModelConversion(
+                collectionName,
+                "Retrieve",
+                () => this._mapper.MapFromStorageToDataModel(pointStruct, options));
+        }
+    }
+
+    /// <summary>
+    /// Choose the right collection name to use for the operation by using the one provided
+    /// as part of the operation options, or the default one provided at construction time.
+    /// </summary>
+    /// <param name="operationCollectionName">The collection name provided on the operation options.</param>
+    /// <returns>The collection name to use.</returns>
+    private string ChooseCollectionName(string? operationCollectionName)
+    {
+        var collectionName = operationCollectionName ?? this._options.DefaultCollectionName;
+        if (collectionName is null)
+        {
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+            throw new ArgumentException("Collection name must be provided in the operation options, since no default was provided at construction time.", "options");
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
+        }
+
+        return collectionName;
+    }
+
+    /// <summary>
+    /// Run the given operation and wrap any <see cref="RpcException"/> with <see cref="VectorStoreOperationException"/>."/>
+    /// </summary>
+    /// <typeparam name="T">The response type of the operation.</typeparam>
+    /// <param name="collectionName">The name of the collection the operation is being run on.</param>
+    /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
+    /// <returns>The result of the operation.</returns>
+    private static async Task<T> RunOperationAsync<T>(string collectionName, string operationName, Func<Task<T>> operation)
+    {
+        try
+        {
+            return await operation.Invoke().ConfigureAwait(false);
+        }
+        catch (RpcException ex)
+        {
+            var wrapperException = new VectorStoreOperationException("Call to vector store failed.", ex);
+
+            // Using Open Telemetry standard for naming of these entries.
+            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
+            wrapperException.Data.Add("db.system", "Qdrant");
+            wrapperException.Data.Add("db.collection.name", collectionName);
+            wrapperException.Data.Add("db.operation.name", operationName);
+
+            throw wrapperException;
+        }
+    }
+
+    /// <summary>
+    /// Run the given model conversion and wrap any exceptions with <see cref="VectorStoreRecordMappingException"/>.
+    /// </summary>
+    /// <typeparam name="T">The response type of the operation.</typeparam>
+    /// <param name="collectionName">The name of the collection the operation is being run on.</param>
+    /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
+    /// <returns>The result of the operation.</returns>
+    private static T RunModelConversion<T>(string collectionName, string operationName, Func<T> operation)
+    {
+        try
+        {
+            return operation.Invoke();
+        }
+        catch (Exception ex) when (ex is not VectorStoreRecordMappingException)
+        {
+            var wrapperException = new VectorStoreRecordMappingException("Failed to convert vector store record.", ex);
+
+            // Using Open Telemetry standard for naming of these entries.
+            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
+            wrapperException.Data.Add("db.system", "Qdrant");
+            wrapperException.Data.Add("db.collection.name", collectionName);
+            wrapperException.Data.Add("db.operation.name", operationName);
+
+            throw wrapperException;
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStoreOptions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Memory;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Options when creating a <see cref="QdrantVectorRecordStore{TRecord}"/>.
+/// </summary>
+public sealed class QdrantVectorRecordStoreOptions<TRecord>
+    where TRecord : class
+{
+    /// <summary>
+    /// Gets or sets the default collection name to use.
+    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
+    /// </summary>
+    public string? DefaultCollectionName { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the vectors in the store are named and multiple vectors are supported, or whether there is just a single unnamed vector per qdrant point.
+    /// Defaults to single vector per point.
+    /// </summary>
+    public bool HasNamedVectors { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the choice of mapper to use when converting between the data model and the qdrant point.
+    /// </summary>
+    public QdrantRecordMapperType MapperType { get; init; } = QdrantRecordMapperType.Default;
+
+    /// <summary>
+    /// Gets or sets an optional custom mapper to use when converting between the data model and the qdrant point.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="MapperType"/> to <see cref="QdrantRecordMapperType.QdrantPointStructCustomMapper"/> to use this mapper."/>
+    /// </remarks>
+    public IVectorStoreRecordMapper<TRecord, PointStruct>? PointStructCustomMapper { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets an optional record definition that defines the schema of the record type.
+    /// </summary>
+    /// <remarks>
+    /// If not provided, the schema will be inferred from the record model class using reflection.
+    /// In this case, the record model properties must be annotated with the appropriate attributes to indicate their usage.
+    /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
+    /// </remarks>
+    public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -222,7 +222,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
     /// </summary>
     /// <param name="payloadValue">The value to convert to a native type.</param>
     /// <returns>The converted native value.</returns>
-    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is enountered.</exception>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
     private static JsonNode? ConvertFromGrpcFieldValueToJsonNode(Value payloadValue)
     {
         return payloadValue.KindCase switch
@@ -243,7 +243,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
     /// </summary>
     /// <param name="sourceValue">The object to convert.</param>
     /// <returns>The converted Qdrant value.</returns>
-    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is enountered.</exception>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
     private static Value ConvertToGrpcFieldValue(object? sourceValue)
     {
         var value = new Value();

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Memory;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Mapper between a Qdrant record and the consumer data model that uses json as an intermediary to allow supporting a wide range of models.
+/// </summary>
+/// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
+internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, PointStruct>
+    where TRecord : class
+{
+    /// <summary>A set of types that a key on the provided model may have.</summary>
+    private static readonly HashSet<Type> s_supportedKeyTypes =
+    [
+        typeof(ulong),
+        typeof(Guid)
+    ];
+
+    /// <summary>A set of types that data properties on the provided model may have.</summary>
+    private static readonly HashSet<Type> s_supportedDataTypes =
+    [
+        typeof(List<string>),
+        typeof(List<int>),
+        typeof(List<long>),
+        typeof(List<float>),
+        typeof(List<double>),
+        typeof(List<bool>),
+        typeof(string),
+        typeof(int),
+        typeof(long),
+        typeof(double),
+        typeof(float),
+        typeof(bool),
+        typeof(int?),
+        typeof(long?),
+        typeof(double?),
+        typeof(float?),
+        typeof(bool?)
+    ];
+
+    /// <summary>A set of types that vectors on the provided model may have.</summary>
+    /// <remarks>
+    /// While qdrant supports float32 and uint64, the api only supports float64, therefore
+    /// any float32 vectors will be converted to float64 before being sent to qdrant.
+    /// </remarks>
+    private static readonly HashSet<Type> s_supportedVectorTypes =
+    [
+        typeof(ReadOnlyMemory<float>),
+        typeof(ReadOnlyMemory<float>?),
+        typeof(ReadOnlyMemory<double>),
+        typeof(ReadOnlyMemory<double>?)
+    ];
+
+    /// <summary>A list of property info objects that point at the payload properties in the current model, and allows easy reading and writing of these properties.</summary>
+    private readonly List<PropertyInfo> _payloadPropertiesInfo = new();
+
+    /// <summary>A list of property info objects that point at the vector properties in the current model, and allows easy reading and writing of these properties.</summary>
+    private readonly List<PropertyInfo> _vectorPropertiesInfo = new();
+
+    /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
+    private readonly PropertyInfo _keyPropertyInfo;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly QdrantVectorStoreRecordMapperOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantVectorStoreRecordMapper{TDataModel}"/> class.
+    /// </summary>
+    /// <param name="options">Optional options to use when doing the model conversion.</param>
+    public QdrantVectorStoreRecordMapper(QdrantVectorStoreRecordMapperOptions? options)
+    {
+        this._options = options ?? new QdrantVectorStoreRecordMapperOptions();
+
+        // Enumerate public properties using configuration or attributes.
+        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;
+        if (this._options.VectorStoreRecordDefinition is not null)
+        {
+            properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), this._options.VectorStoreRecordDefinition, supportsMultipleVectors: this._options.HasNamedVectors);
+        }
+        else
+        {
+            properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), supportsMultipleVectors: this._options.HasNamedVectors);
+        }
+
+        // Validate property types and store for later use.
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, s_supportedDataTypes, "Data");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
+
+        this._keyPropertyInfo = properties.keyProperty;
+        this._payloadPropertiesInfo = properties.dataProperties;
+        this._vectorPropertiesInfo = properties.vectorProperties;
+    }
+
+    /// <inheritdoc />
+    public PointStruct MapFromDataToStorageModel(TRecord dataModel)
+    {
+        PointId pointId;
+        if (this._keyPropertyInfo.PropertyType == typeof(ulong))
+        {
+            var key = this._keyPropertyInfo.GetValue(dataModel) as ulong? ?? throw new VectorStoreRecordMappingException($"Missing key property {this._keyPropertyInfo.Name} on provided record of type {typeof(TRecord).FullName}.");
+            pointId = new PointId { Num = key };
+        }
+        else if (this._keyPropertyInfo.PropertyType == typeof(Guid))
+        {
+            var key = this._keyPropertyInfo.GetValue(dataModel) as Guid? ?? throw new VectorStoreRecordMappingException($"Missing key property {this._keyPropertyInfo.Name} on provided record of type {typeof(TRecord).FullName}.");
+            pointId = new PointId { Uuid = key.ToString("D") };
+        }
+        else
+        {
+            throw new VectorStoreRecordMappingException($"Unsupported key type {this._keyPropertyInfo.PropertyType.FullName} for key property {this._keyPropertyInfo.Name} on provided record of type {typeof(TRecord).FullName}.");
+        }
+
+        // Create point.
+        var pointStruct = new PointStruct
+        {
+            Id = pointId,
+            Vectors = new Vectors(),
+            Payload = { },
+        };
+
+        // Add point payload.
+        foreach (var payloadPropertyInfo in this._payloadPropertiesInfo)
+        {
+            var propertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(payloadPropertyInfo);
+            var propertyValue = payloadPropertyInfo.GetValue(dataModel);
+            pointStruct.Payload.Add(propertyName, ConvertToGrpcFieldValue(propertyValue));
+        }
+
+        // Add vectors.
+        if (this._options.HasNamedVectors)
+        {
+            var namedVectors = new NamedVectors();
+            foreach (var vectorPropertyInfo in this._vectorPropertiesInfo)
+            {
+                var propertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(vectorPropertyInfo);
+                var propertyValue = vectorPropertyInfo.GetValue(dataModel);
+                if (propertyValue is not null)
+                {
+                    var castPropertyValue = (ReadOnlyMemory<float>)propertyValue;
+                    namedVectors.Vectors.Add(propertyName, castPropertyValue.ToArray());
+                }
+            }
+
+            pointStruct.Vectors.Vectors_ = namedVectors;
+        }
+        else
+        {
+            var vectorPropertyInfo = this._vectorPropertiesInfo.First();
+            if (vectorPropertyInfo.GetValue(dataModel) is ReadOnlyMemory<float> floatROM)
+            {
+                pointStruct.Vectors.Vector = floatROM.ToArray();
+            }
+            else
+            {
+                throw new VectorStoreRecordMappingException($"Vector property {vectorPropertyInfo.Name} on provided record of type {typeof(TRecord).FullName} may not be null when not using named vectors.");
+            }
+        }
+
+        return pointStruct;
+    }
+
+    /// <inheritdoc />
+    public TRecord MapFromStorageToDataModel(PointStruct storageModel, GetRecordOptions? options = default)
+    {
+        // Get the key property name and value.
+        var keyPropertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(this._keyPropertyInfo);
+        var keyPropertyValue = storageModel.Id.HasNum ? storageModel.Id.Num as object : storageModel.Id.Uuid as object;
+
+        // Create a json object to represent the point.
+        var outputJsonObject = new JsonObject
+        {
+            { keyPropertyName, JsonValue.Create(keyPropertyValue) },
+        };
+
+        // Add each vector property if embeddings are included in the point.
+        if (options?.IncludeVectors is true)
+        {
+            foreach (var vectorProperty in this._vectorPropertiesInfo)
+            {
+                var propertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(vectorProperty);
+
+                if (this._options.HasNamedVectors)
+                {
+                    if (storageModel.Vectors.Vectors_.Vectors.TryGetValue(propertyName, out var vector))
+                    {
+                        outputJsonObject.Add(propertyName, new JsonArray(vector.Data.Select(x => JsonValue.Create(x)).ToArray()));
+                    }
+                }
+                else
+                {
+                    outputJsonObject.Add(propertyName, new JsonArray(storageModel.Vectors.Vector.Data.Select(x => JsonValue.Create(x)).ToArray()));
+                }
+            }
+        }
+
+        // Add each payload property.
+        foreach (var payloadProperty in this._payloadPropertiesInfo)
+        {
+            var propertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(payloadProperty);
+            if (storageModel.Payload.TryGetValue(propertyName, out var value))
+            {
+                outputJsonObject.Add(propertyName, ConvertFromGrpcFieldValueToJsonNode(value));
+            }
+        }
+
+        // Convert from json object to the target data model.
+        return JsonSerializer.Deserialize<TRecord>(outputJsonObject)!;
+    }
+
+    /// <summary>
+    /// Convert the given <paramref name="payloadValue"/> to the correct native type based on its properties.
+    /// </summary>
+    /// <param name="payloadValue">The value to convert to a native type.</param>
+    /// <returns>The converted native value.</returns>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is enountered.</exception>
+    private static JsonNode? ConvertFromGrpcFieldValueToJsonNode(Value payloadValue)
+    {
+        return payloadValue.KindCase switch
+        {
+            Value.KindOneofCase.NullValue => null,
+            Value.KindOneofCase.IntegerValue => JsonValue.Create(payloadValue.IntegerValue),
+            Value.KindOneofCase.StringValue => JsonValue.Create(payloadValue.StringValue),
+            Value.KindOneofCase.DoubleValue => JsonValue.Create(payloadValue.DoubleValue),
+            Value.KindOneofCase.BoolValue => JsonValue.Create(payloadValue.BoolValue),
+            Value.KindOneofCase.ListValue => new JsonArray(payloadValue.ListValue.Values.Select(x => ConvertFromGrpcFieldValueToJsonNode(x)).ToArray()),
+            Value.KindOneofCase.StructValue => new JsonObject(payloadValue.StructValue.Fields.ToDictionary(x => x.Key, x => ConvertFromGrpcFieldValueToJsonNode(x.Value))),
+            _ => throw new VectorStoreRecordMappingException($"Unsupported grpc value kind {payloadValue.KindCase}."),
+        };
+    }
+
+    /// <summary>
+    /// Convert the given <paramref name="sourceValue"/> to a <see cref="Value"/> object that can be stored in Qdrant.
+    /// </summary>
+    /// <param name="sourceValue">The object to convert.</param>
+    /// <returns>The converted Qdrant value.</returns>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is enountered.</exception>
+    private static Value ConvertToGrpcFieldValue(object? sourceValue)
+    {
+        var value = new Value();
+        if (sourceValue is null)
+        {
+            value.NullValue = NullValue.NullValue;
+        }
+        else if (sourceValue is int intValue)
+        {
+            value.IntegerValue = intValue;
+        }
+        else if (sourceValue is long longValue)
+        {
+            value.IntegerValue = longValue;
+        }
+        else if (sourceValue is string stringValue)
+        {
+            value.StringValue = stringValue;
+        }
+        else if (sourceValue is float floatValue)
+        {
+            value.DoubleValue = floatValue;
+        }
+        else if (sourceValue is double doubleValue)
+        {
+            value.DoubleValue = doubleValue;
+        }
+        else if (sourceValue is bool boolValue)
+        {
+            value.BoolValue = boolValue;
+        }
+        else if (sourceValue is IEnumerable<int> ||
+            sourceValue is IEnumerable<long> ||
+            sourceValue is IEnumerable<string> ||
+            sourceValue is IEnumerable<float> ||
+            sourceValue is IEnumerable<double> ||
+            sourceValue is IEnumerable<bool>)
+        {
+            var listValue = sourceValue as IEnumerable<object>;
+            value.ListValue = new ListValue();
+            foreach (var item in listValue!)
+            {
+                value.ListValue.Values.Add(ConvertToGrpcFieldValue(item));
+            }
+        }
+        else
+        {
+            throw new VectorStoreRecordMappingException($"Unsupported source value type {sourceValue?.GetType().FullName}.");
+        }
+
+        return value;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -69,16 +69,17 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
     /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
     private readonly PropertyInfo _keyPropertyInfo;
 
-    /// <summary>Optional configuration options for this class.</summary>
+    /// <summary>Configuration options for this class.</summary>
     private readonly QdrantVectorStoreRecordMapperOptions _options;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QdrantVectorStoreRecordMapper{TDataModel}"/> class.
     /// </summary>
-    /// <param name="options">Optional options to use when doing the model conversion.</param>
-    public QdrantVectorStoreRecordMapper(QdrantVectorStoreRecordMapperOptions? options)
+    /// <param name="options">Options to use when doing the model conversion.</param>
+    public QdrantVectorStoreRecordMapper(QdrantVectorStoreRecordMapperOptions options)
     {
-        this._options = options ?? new QdrantVectorStoreRecordMapperOptions();
+        Verify.NotNull(options);
+        this._options = options;
 
         // Enumerate public properties using configuration or attributes.
         (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;
@@ -155,6 +156,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
         }
         else
         {
+            // We already verified in the constructor via FindProperties that there is exactly one vector property when not using named vectors.
             var vectorPropertyInfo = this._vectorPropertiesInfo.First();
             if (vectorPropertyInfo.GetValue(dataModel) is ReadOnlyMemory<float> floatROM)
             {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapperOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapperOptions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Memory;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Options when creating a <see cref="QdrantVectorStoreRecordMapper{TRecord}"/>.
+/// </summary>
+internal sealed class QdrantVectorStoreRecordMapperOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the vectors in the store are named, or whether there is just a single vector per qdrant point.
+    /// Defaults to single vector per point.
+    /// </summary>
+    public bool HasNamedVectors { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets an optional record definition that defines the schema of the record type.
+    /// </summary>
+    /// <remarks>
+    /// If not provided, the schema will be inferred from the record model class using reflection.
+    /// In this case, the record model properties must be annotated with the appropriate attributes to indicate their usage.
+    /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
+    /// </remarks>
+    public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -111,7 +111,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
     }
 
     /// <inheritdoc />
-    public async Task<TRecord> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(key);
 
@@ -134,7 +134,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         // Check if the key was found before trying to parse the result.
         if (redisResult.IsNull || redisResult is null)
         {
-            throw new VectorStoreOperationException($"Could not find document with key '{key}'");
+            return null;
         }
 
         // Check if the value contained any json text before trying to parse the result.
@@ -183,7 +183,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
             // Check if the key was found before trying to parse the result.
             if (redisResult.IsNull || redisResult is null)
             {
-                throw new VectorStoreOperationException($"Could not find document with key '{key}'");
+                continue;
             }
 
             // Check if the value contained any json text before trying to parse the result.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
@@ -17,7 +17,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 /// Contains tests for the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
 /// </summary>
 /// <param name="output">Used for logging.</param>
-/// <param name="fixture">Redis setup and teardown.</param>
+/// <param name="fixture">Qdrant setup and teardown.</param>
 [Collection("QdrantVectorStoreCollection")]
 public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
 {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
@@ -1,0 +1,282 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.Qdrant;
+using Microsoft.SemanticKernel.Memory;
+using Qdrant.Client.Grpc;
+using Xunit;
+using Xunit.Abstractions;
+using static SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant.QdrantVectorStoreFixture;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
+
+/// <summary>
+/// Contains tests for the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+/// </summary>
+/// <param name="output">Used for logging.</param>
+/// <param name="fixture">Redis setup and teardown.</param>
+[Collection("QdrantVectorStoreCollection")]
+public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
+{
+    [Theory]
+    [InlineData(true, "singleVectorHotels", false)]
+    [InlineData(false, "singleVectorHotels", false)]
+    [InlineData(true, "namedVectorsHotels", true)]
+    [InlineData(false, "namedVectorsHotels", true)]
+    public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition, string collectionName, bool hasNamedVectors)
+    {
+        // Arrange.
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        {
+            HasNamedVectors = hasNamedVectors,
+            DefaultCollectionName = collectionName,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
+        };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+
+        var record = new HotelInfo
+        {
+            HotelId = 20,
+            HotelName = "My Hotel 20",
+            HotelCode = 20,
+            HotelRating = 4.3f,
+            ParkingIncluded = true,
+            Tags = { "t1", "t2" },
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+        };
+
+        // Act.
+        var upsertResult = await sut.UpsertAsync(record);
+
+        // Assert.
+        var getResult = await sut.GetAsync(20, new GetRecordOptions { IncludeVectors = true });
+        Assert.Equal(20ul, upsertResult);
+        Assert.Equal(record.HotelId, getResult?.HotelId);
+        Assert.Equal(record.HotelName, getResult?.HotelName);
+        Assert.Equal(record.HotelCode, getResult?.HotelCode);
+        Assert.Equal(record.HotelRating, getResult?.HotelRating);
+        Assert.Equal(record.ParkingIncluded, getResult?.ParkingIncluded);
+        Assert.Equal(record.Tags.ToArray(), getResult?.Tags.ToArray());
+        Assert.Equal(record.Description, getResult?.Description);
+
+        // TODO: figure out why original array is different from the one we get back.
+        //Assert.Equal(record.DescriptionEmbedding?.ToArray(), getResult?.DescriptionEmbedding?.ToArray());
+
+        // Output.
+        output.WriteLine(upsertResult.ToString(CultureInfo.InvariantCulture));
+        output.WriteLine(getResult?.ToString());
+    }
+
+    [Fact]
+    public async Task ItCanUpsertAndRemoveDocumentWithGuidIdToVectorStoreAsync()
+    {
+        // Arrange.
+        var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId> { HasNamedVectors = false, DefaultCollectionName = "singleVectorGuidIdHotels" };
+        IVectorRecordStore<Guid, HotelInfoWithGuidId> sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, options);
+
+        var record = new HotelInfoWithGuidId
+        {
+            HotelId = Guid.Parse("55555555-5555-5555-5555-555555555555"),
+            HotelName = "My Hotel 5",
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+        };
+
+        // Act.
+        var upsertResult = await sut.UpsertAsync(record);
+
+        // Assert.
+        var getResult = await sut.GetAsync(Guid.Parse("55555555-5555-5555-5555-555555555555"), new GetRecordOptions { IncludeVectors = true });
+        Assert.Equal(Guid.Parse("55555555-5555-5555-5555-555555555555"), upsertResult);
+        Assert.Equal(record.HotelId, getResult?.HotelId);
+        Assert.Equal(record.HotelName, getResult?.HotelName);
+        Assert.Equal(record.Description, getResult?.Description);
+
+        // Act.
+        await sut.DeleteAsync(Guid.Parse("55555555-5555-5555-5555-555555555555"));
+
+        // Assert.
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync(Guid.Parse("55555555-5555-5555-5555-555555555555")));
+
+        // Output.
+        output.WriteLine(upsertResult.ToString("D"));
+        output.WriteLine(getResult?.ToString());
+    }
+
+    [Theory]
+    [InlineData(true, true, "singleVectorHotels", false)]
+    [InlineData(true, false, "singleVectorHotels", false)]
+    [InlineData(false, true, "singleVectorHotels", false)]
+    [InlineData(false, false, "singleVectorHotels", false)]
+    [InlineData(true, true, "namedVectorsHotels", true)]
+    [InlineData(true, false, "namedVectorsHotels", true)]
+    [InlineData(false, true, "namedVectorsHotels", true)]
+    [InlineData(false, false, "namedVectorsHotels", true)]
+    public async Task ItCanGetDocumentFromVectorStoreAsync(bool useRecordDefinition, bool withEmbeddings, string collectionName, bool hasNamedVectors)
+    {
+        // Arrange.
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        {
+            HasNamedVectors = hasNamedVectors,
+            DefaultCollectionName = collectionName,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
+        };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+
+        // Act.
+        var getResult = await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = withEmbeddings });
+
+        // Assert.
+        Assert.Equal(11ul, getResult?.HotelId);
+        Assert.Equal("My Hotel 11", getResult?.HotelName);
+        Assert.Equal(11, getResult?.HotelCode);
+        Assert.True(getResult?.ParkingIncluded);
+        Assert.Equal(4.5f, getResult?.HotelRating);
+        Assert.Equal(2, getResult?.Tags.Count);
+        Assert.Equal("t1", getResult?.Tags[0]);
+        Assert.Equal("t2", getResult?.Tags[1]);
+        Assert.Equal("This is a great hotel.", getResult?.Description);
+        if (withEmbeddings)
+        {
+            Assert.NotNull(getResult?.DescriptionEmbedding);
+        }
+        else
+        {
+            Assert.Null(getResult?.DescriptionEmbedding);
+        }
+
+        // Output.
+        output.WriteLine(getResult?.ToString());
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task ItCanGetDocumentWithGuidIdFromVectorStoreAsync(bool useRecordDefinition, bool withEmbeddings)
+    {
+        // Arrange.
+        var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId>
+        {
+            HasNamedVectors = false,
+            DefaultCollectionName = "singleVectorGuidIdHotels",
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelWithGuidIdVectorStoreRecordDefinition : null
+        };
+        var sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, options);
+
+        // Act.
+        var getResult = await sut.GetAsync(Guid.Parse("11111111-1111-1111-1111-111111111111"), new GetRecordOptions { IncludeVectors = withEmbeddings });
+
+        // Assert.
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), getResult?.HotelId);
+        Assert.Equal("My Hotel 11", getResult?.HotelName);
+        Assert.Equal("This is a great hotel.", getResult?.Description);
+        if (withEmbeddings)
+        {
+            Assert.NotNull(getResult?.DescriptionEmbedding);
+        }
+        else
+        {
+            Assert.Null(getResult?.DescriptionEmbedding);
+        }
+
+        // Output.
+        output.WriteLine(getResult?.ToString());
+    }
+
+    [Fact]
+    public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
+    {
+        // Arrange
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = true, DefaultCollectionName = "namedVectorsHotels" };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+
+        // Act
+        var hotels = sut.GetBatchAsync([11, 12], new GetRecordOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.NotNull(hotels);
+        var hotelsList = await hotels.ToListAsync();
+        Assert.Equal(2, hotelsList.Count);
+
+        // Output
+        foreach (var hotel in hotelsList)
+        {
+            output.WriteLine(hotel?.ToString() ?? "Null");
+        }
+    }
+
+    [Fact]
+    public async Task ItThrowsForPartialBatchResultAsync()
+    {
+        // Arrange.
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = true, DefaultCollectionName = "namedVectorsHotels" };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+
+        // Act.
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetBatchAsync([1, 5, 2]).ToListAsync());
+    }
+
+    [Theory]
+    [InlineData(true, "singleVectorHotels", false)]
+    [InlineData(false, "singleVectorHotels", false)]
+    [InlineData(true, "namedVectorsHotels", true)]
+    [InlineData(false, "namedVectorsHotels", true)]
+    public async Task ItCanRemoveDocumentFromVectorStoreAsync(bool useRecordDefinition, string collectionName, bool hasNamedVectors)
+    {
+        // Arrange.
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        {
+            HasNamedVectors = hasNamedVectors,
+            DefaultCollectionName = collectionName,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
+        };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+
+        var record = new HotelInfo
+        {
+            HotelId = 20,
+            HotelName = "My Hotel 20",
+            HotelCode = 20,
+            ParkingIncluded = true,
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+        };
+        await sut.UpsertAsync(record);
+
+        // Act.
+        await sut.DeleteAsync(20);
+
+        // Assert.
+        await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync(20));
+    }
+
+    [Fact]
+    public async Task ItThrowsMappingExceptionForFailedMapperAsync()
+    {
+        // Arrange
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { DefaultCollectionName = "singleVectorHotels", MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper, PointStructCustomMapper = new FailingMapper() };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = true }));
+    }
+
+    private sealed class FailingMapper : IVectorStoreRecordMapper<HotelInfo, PointStruct>
+    {
+        public PointStruct MapFromDataToStorageModel(HotelInfo dataModel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public HotelInfo MapFromStorageToDataModel(PointStruct storageModel, GetRecordOptions? options = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreCollectionFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreCollectionFixture.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
+
+[CollectionDefinition("QdrantVectorStoreCollection")]
+public class QdrantVectorStoreCollectionFixture : ICollectionFixture<QdrantVectorStoreFixture>
+{
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
@@ -1,0 +1,325 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Grpc.Core;
+using Microsoft.SemanticKernel.Memory;
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
+
+public class QdrantVectorStoreFixture : IAsyncLifetime
+{
+    /// <summary>The docker client we are using to create a qdrant container with.</summary>
+    private readonly DockerClient _client;
+
+    /// <summary>The id of the qdrant container that we are testing with.</summary>
+    private string? _containerId = null;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantVectorStoreFixture"/> class.
+    /// </summary>
+    public QdrantVectorStoreFixture()
+    {
+        using var dockerClientConfiguration = new DockerClientConfiguration();
+        this._client = dockerClientConfiguration.CreateClient();
+        this.HotelVectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("HotelId"),
+                new VectorStoreRecordDataProperty("HotelName"),
+                new VectorStoreRecordDataProperty("HotelCode"),
+                new VectorStoreRecordDataProperty("ParkingIncluded"),
+                new VectorStoreRecordDataProperty("HotelRating"),
+                new VectorStoreRecordDataProperty("Tags"),
+                new VectorStoreRecordDataProperty("Description"),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding")
+            }
+        };
+        this.HotelWithGuidIdVectorStoreRecordDefinition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("HotelId"),
+                new VectorStoreRecordDataProperty("HotelName"),
+                new VectorStoreRecordDataProperty("Description"),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding")
+            }
+        };
+    }
+
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+    /// <summary>Gets the qdrant client connection to use for tests.</summary>
+    public QdrantClient QdrantClient { get; private set; }
+
+    /// <summary>Gets the manually created vector store record definition for our test model.</summary>
+    public VectorStoreRecordDefinition HotelVectorStoreRecordDefinition { get; private set; }
+
+    /// <summary>Gets the manually created vector store record definition for our test model.</summary>
+    public VectorStoreRecordDefinition HotelWithGuidIdVectorStoreRecordDefinition { get; private set; }
+
+    /// <summary>
+    /// Create / Recreate qdrant docker container and run it.
+    /// </summary>
+    /// <returns>An async task.</returns>
+    public async Task InitializeAsync()
+    {
+        this._containerId = await SetupQdrantContainerAsync(this._client);
+
+        // Connect to qdrant.
+        this.QdrantClient = new QdrantClient("localhost");
+
+        // Create schemas for the vector store.
+        var vectorParamsMap = new VectorParamsMap();
+        vectorParamsMap.Map.Add("DescriptionEmbedding", new VectorParams { Size = 4, Distance = Distance.Cosine });
+
+        // Wait for the qdrant container to be ready.
+        var retryCount = 0;
+        while (retryCount++ < 5)
+        {
+            try
+            {
+                await this.QdrantClient.ListCollectionsAsync();
+            }
+            catch (RpcException e)
+            {
+                if (e.StatusCode != Grpc.Core.StatusCode.Unavailable)
+                {
+                    throw;
+                }
+
+                await Task.Delay(1000);
+            }
+        }
+
+        await this.QdrantClient.CreateCollectionAsync(
+            "namedVectorsHotels",
+            vectorParamsMap);
+
+        await this.QdrantClient.CreateCollectionAsync(
+            "singleVectorHotels",
+            new VectorParams { Size = 4, Distance = Distance.Cosine });
+
+        await this.QdrantClient.CreateCollectionAsync(
+            "singleVectorGuidIdHotels",
+            new VectorParams { Size = 4, Distance = Distance.Cosine });
+
+        // Create test data common to both named and unnamed vectors.
+        var tags = new ListValue();
+        tags.Values.Add("t1");
+        tags.Values.Add("t2");
+        var tagsValue = new Value();
+        tagsValue.ListValue = tags;
+
+        // Create some test data using named vectors.
+        var embedding = new[] { 30f, 31f, 32f, 33f };
+
+        var namedVectors1 = new NamedVectors();
+        var namedVectors2 = new NamedVectors();
+        var namedVectors3 = new NamedVectors();
+
+        namedVectors1.Vectors.Add("DescriptionEmbedding", embedding);
+        namedVectors2.Vectors.Add("DescriptionEmbedding", embedding);
+        namedVectors3.Vectors.Add("DescriptionEmbedding", embedding);
+
+        List<PointStruct> namedVectorPoints =
+        [
+            new PointStruct
+            {
+                Id = 11,
+                Vectors = new Vectors { Vectors_ = namedVectors1 },
+                Payload = { ["HotelName"] = "My Hotel 11", ["HotelCode"] = 11, ["ParkingIncluded"] = true, ["Tags"] = tagsValue, ["HotelRating"] = 4.5f, ["Description"] = "This is a great hotel." }
+            },
+            new PointStruct
+            {
+                Id = 12,
+                Vectors = new Vectors { Vectors_ = namedVectors2 },
+                Payload = { ["HotelName"] = "My Hotel 12", ["HotelCode"] = 12, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+            },
+            new PointStruct
+            {
+                Id = 13,
+                Vectors = new Vectors { Vectors_ = namedVectors3 },
+                Payload = { ["HotelName"] = "My Hotel 13", ["HotelCode"] = 13, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+            },
+        ];
+
+        await this.QdrantClient.UpsertAsync("namedVectorsHotels", namedVectorPoints);
+
+        // Create some test data using a single unnamed vector.
+        List<PointStruct> unnamedVectorPoints =
+        [
+            new PointStruct
+            {
+                Id = 11,
+                Vectors = embedding,
+                Payload = { ["HotelName"] = "My Hotel 11", ["HotelCode"] = 11, ["ParkingIncluded"] = true, ["Tags"] = tagsValue, ["HotelRating"] = 4.5f, ["Description"] = "This is a great hotel." }
+            },
+            new PointStruct
+            {
+                Id = 12,
+                Vectors = embedding,
+                Payload = { ["HotelName"] = "My Hotel 12", ["HotelCode"] = 12, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+            },
+            new PointStruct
+            {
+                Id = 13,
+                Vectors = embedding,
+                Payload = { ["HotelName"] = "My Hotel 13", ["HotelCode"] = 13, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+            },
+        ];
+
+        await this.QdrantClient.UpsertAsync("singleVectorHotels", unnamedVectorPoints);
+
+        // Create some test data using a single unnamed vector and a guid id.
+        List<PointStruct> unnamedVectorGuidIdPoints =
+        [
+            new PointStruct
+            {
+                Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                Vectors = embedding,
+                Payload = { ["HotelName"] = "My Hotel 11", ["Description"] = "This is a great hotel." }
+            },
+            new PointStruct
+            {
+                Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                Vectors = embedding,
+                Payload = { ["HotelName"] = "My Hotel 12", ["Description"] = "This is a great hotel." }
+            },
+            new PointStruct
+            {
+                Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+                Vectors = embedding,
+                Payload = { ["HotelName"] = "My Hotel 13", ["Description"] = "This is a great hotel." }
+            },
+        ];
+
+        await this.QdrantClient.UpsertAsync("singleVectorGuidIdHotels", unnamedVectorGuidIdPoints);
+    }
+
+    /// <summary>
+    /// Delete the docker container after the test run.
+    /// </summary>
+    /// <returns>An async task.</returns>
+    public async Task DisposeAsync()
+    {
+        if (this._containerId != null)
+        {
+            await this._client.Containers.StopContainerAsync(this._containerId, new ContainerStopParameters());
+            await this._client.Containers.RemoveContainerAsync(this._containerId, new ContainerRemoveParameters());
+        }
+    }
+
+    /// <summary>
+    /// Setup the qdrant container by pulling the image and running it.
+    /// </summary>
+    /// <param name="client">The docker client to create the container with.</param>
+    /// <returns>The id of the container.</returns>
+    private static async Task<string> SetupQdrantContainerAsync(DockerClient client)
+    {
+        await client.Images.CreateImageAsync(
+            new ImagesCreateParameters
+            {
+                FromImage = "qdrant/qdrant",
+                Tag = "latest",
+            },
+            null,
+            new Progress<JSONMessage>());
+
+        var container = await client.Containers.CreateContainerAsync(new CreateContainerParameters()
+        {
+            Image = "qdrant/qdrant",
+            HostConfig = new HostConfig()
+            {
+                PortBindings = new Dictionary<string, IList<PortBinding>>
+                {
+                    {"6333", new List<PortBinding> {new() {HostPort = "6333" } }},
+                    {"6334", new List<PortBinding> {new() {HostPort = "6334" } }}
+                },
+                PublishAllPorts = true
+            },
+            ExposedPorts = new Dictionary<string, EmptyStruct>
+            {
+                { "6333", default },
+                { "6334", default }
+            },
+        });
+
+        await client.Containers.StartContainerAsync(
+            container.ID,
+            new ContainerStartParameters());
+
+        return container.ID;
+    }
+
+    /// <summary>
+    /// A test model for the qdrant vector store.
+    /// </summary>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    public record HotelInfo()
+    {
+        /// <summary>The key of the record.</summary>
+        [VectorStoreRecordKey]
+        public ulong HotelId { get; init; }
+
+        /// <summary>A string metadata field.</summary>
+        [VectorStoreRecordData]
+        public string? HotelName { get; set; }
+
+        /// <summary>An int metadata field.</summary>
+        [VectorStoreRecordData]
+        public int HotelCode { get; set; }
+
+        /// <summary>A  float metadata field.</summary>
+        [VectorStoreRecordData]
+        public float? HotelRating { get; set; }
+
+        /// <summary>A bool metadata field.</summary>
+        [VectorStoreRecordData]
+        public bool ParkingIncluded { get; set; }
+
+        [VectorStoreRecordData]
+        public List<string> Tags { get; set; } = new List<string>();
+
+        /// <summary>A data field.</summary>
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        public string Description { get; set; }
+
+        /// <summary>A vector field.</summary>
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
+    }
+
+    /// <summary>
+    /// A test model for the qdrant vector store.
+    /// </summary>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    public record HotelInfoWithGuidId()
+    {
+        /// <summary>The key of the record.</summary>
+        [VectorStoreRecordKey]
+        public Guid HotelId { get; init; }
+
+        /// <summary>A string metadata field.</summary>
+        [VectorStoreRecordData]
+        public string? HotelName { get; set; }
+
+        /// <summary>A data field.</summary>
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        public string Description { get; set; }
+
+        /// <summary>A vector field.</summary>
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
+    }
+}
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -64,6 +64,7 @@
     <ProjectReference Include="..\Agents\OpenAI\Agents.OpenAI.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Google\Connectors.Google.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Memory.Redis\Connectors.Memory.Redis.csproj" />
+    <ProjectReference Include="..\Connectors\Connectors.Memory.Qdrant\Connectors.Memory.Qdrant.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Onnx\Connectors.Onnx.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.HuggingFace\Connectors.HuggingFace.csproj" />

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.SemanticKernel.Memory;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Contains helpers for reading vector store model properties and their attributes.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class VectorStoreErrorHandler
+{
+    /// <summary>
+    /// Run the given model conversion and wrap any exceptions with <see cref="VectorStoreRecordMappingException"/>.
+    /// </summary>
+    /// <typeparam name="T">The response type of the operation.</typeparam>
+    /// <param name="databaseSystemName">The name of the database system the operation is being run on.</param>
+    /// <param name="collectionName">The name of the collection the operation is being run on.</param>
+    /// <param name="operationName">The type of database operation being run.</param>
+    /// <param name="operation">The operation to run.</param>
+    /// <returns>The result of the operation.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T RunModelConversion<T>(string databaseSystemName, string collectionName, string operationName, Func<T> operation)
+    {
+        try
+        {
+            return operation.Invoke();
+        }
+        catch (Exception ex)
+        {
+            var wrapperException = new VectorStoreRecordMappingException("Failed to convert vector store record.", ex);
+
+            // Using Open Telemetry standard for naming of these entries.
+            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
+            wrapperException.Data.Add("db.system", databaseSystemName);
+            wrapperException.Data.Add("db.collection.name", collectionName);
+            wrapperException.Data.Add("db.operation.name", operationName);
+
+            throw wrapperException;
+        }
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/IVectorRecordStore.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/IVectorRecordStore.cs
@@ -18,7 +18,7 @@ public interface IVectorRecordStore<TKey, TRecord>
 {
     /// <summary>
     /// Gets a record from the vector store. Does not guarantee that the collection exists.
-    /// Throws if the record is not found.
+    /// Returns null if the record is not found.
     /// </summary>
     /// <param name="key">The unique id associated with the record to get.</param>
     /// <param name="options">Optional options for retrieving the record.</param>
@@ -26,12 +26,13 @@ public interface IVectorRecordStore<TKey, TRecord>
     /// <returns>The record if found, otherwise null.</returns>
     /// <exception cref="VectorStoreOperationException">Throw when the command fails to execute for any reason.</exception>
     /// <exception cref="VectorStoreRecordMappingException">Throw when mapping between the storage model and record data model fails.</exception>
-    Task<TRecord> GetAsync(TKey key, GetRecordOptions? options = default, CancellationToken cancellationToken = default);
+    Task<TRecord?> GetAsync(TKey key, GetRecordOptions? options = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a batch of records from the vector store. Does not guarantee that the collection exists.
-    /// Throws if any of the records are not found.
     /// Gets will be made in a single request or in a single parallel batch depending on the available store functionality.
+    /// Only found records will be returned, so the resultset may be smaller than the requested keys.
+    /// Throws for any issues other than records not being found.
     /// </summary>
     /// <param name="keys">The unique ids associated with the record to get.</param>
     /// <param name="options">Optional options for retrieving the records.</param>

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -5,7 +5,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Memory;
 using Xunit;
 
-namespace SemanticKernel.UnitTests.Utilities;
+namespace SemanticKernel.UnitTests.Data;
 
 public class VectorStoreRecordPropertyReaderTests
 {
@@ -61,8 +61,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "Multiple vector properties configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported." :
-            "Multiple vector properties found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported.";
+            "Multiple vector properties configured for type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported." :
+            "Multiple vector properties found on type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+MultiPropsModel while only one is supported.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -78,8 +78,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "Multiple key properties configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiKeysModel." :
-            "Multiple key properties found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+MultiKeysModel.";
+            "Multiple key properties configured for type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+MultiKeysModel." :
+            "Multiple key properties found on type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+MultiKeysModel.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -95,8 +95,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "No key property configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoKeyModel." :
-            "No key property found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoKeyModel.";
+            "No key property configured for type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+NoKeyModel." :
+            "No key property found on type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+NoKeyModel.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -112,8 +112,8 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         var expectedMessage = useConfig ?
-            "No vector property configured for type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoVectorModel." :
-            "No vector property found on type SemanticKernel.UnitTests.Utilities.VectorStoreRecordPropertyReaderTests+NoVectorModel.";
+            "No vector property configured for type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+NoVectorModel." :
+            "No vector property found on type SemanticKernel.UnitTests.Data.VectorStoreRecordPropertyReaderTests+NoVectorModel.";
         Assert.Equal(expectedMessage, ex.Message);
     }
 
@@ -136,6 +136,33 @@ public class VectorStoreRecordPropertyReaderTests
         };
 
         Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.FindProperties(typeof(NoKeyModel), definition, false));
+    }
+
+    [Fact]
+    public void CreateVectorStoreRecordDefinitionFromTypeConvertsAllProps()
+    {
+        // Act.
+        var definition = VectorStoreRecordPropertyReader.CreateVectorStoreRecordDefinitionFromType(typeof(MultiPropsModel), true);
+
+        // Assert.
+        Assert.Equal(5, definition.Properties.Count);
+        Assert.Equal("Key", definition.Properties[0].PropertyName);
+        Assert.Equal("Data1", definition.Properties[1].PropertyName);
+        Assert.Equal("Data2", definition.Properties[2].PropertyName);
+        Assert.Equal("Vector1", definition.Properties[3].PropertyName);
+        Assert.Equal("Vector2", definition.Properties[4].PropertyName);
+
+        Assert.IsType<VectorStoreRecordKeyProperty>(definition.Properties[0]);
+        Assert.IsType<VectorStoreRecordDataProperty>(definition.Properties[1]);
+        Assert.IsType<VectorStoreRecordDataProperty>(definition.Properties[2]);
+        Assert.IsType<VectorStoreRecordVectorProperty>(definition.Properties[3]);
+        Assert.IsType<VectorStoreRecordVectorProperty>(definition.Properties[4]);
+
+        var data1 = (VectorStoreRecordDataProperty)definition.Properties[1];
+        var data2 = (VectorStoreRecordDataProperty)definition.Properties[2];
+
+        Assert.True(data1.HasEmbedding);
+        Assert.False(data2.HasEmbedding);
     }
 
     [Fact]
@@ -229,7 +256,7 @@ public class VectorStoreRecordPropertyReaderTests
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
 
-        [VectorStoreRecordData]
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
         public string Data1 { get; set; } = string.Empty;
 
         [VectorStoreRecordData]
@@ -249,7 +276,7 @@ public class VectorStoreRecordPropertyReaderTests
         Properties =
         [
             new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("Data1"),
+            new VectorStoreRecordDataProperty("Data1") { HasEmbedding = true, EmbeddingPropertyName = "Vector1" },
             new VectorStoreRecordDataProperty("Data2"),
             new VectorStoreRecordVectorProperty("Vector1"),
             new VectorStoreRecordVectorProperty("Vector2")


### PR DESCRIPTION
### Motivation and Context

As part of the evolution of memory connectors, we need to support custom data models and remove opinionated behaviors, so adding a new record store implementation for qdrant.

### Description

Adding an implementation for IVectorRecordStore for qdrant with support for:

Custom mappers
Generic data models
Annotating data models via attributes or via definition objects.
Also improving some styling in the AzureAISearch implementation.

See #6525

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
