### PR TITLE
.Net: Bump Microsoft.Azure.Kusto.Data

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="5.4.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="11.3.5" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="12.2.2" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />

--- a/dotnet/src/Connectors/Connectors.Memory.Kusto/KustoMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Kusto/KustoMemoryStore.cs
@@ -358,7 +358,7 @@ public class KustoMemoryStore : IMemoryStore, IDisposable
     /// <param name="collectionName">Kusto table name.</param>
     /// <param name="normalized">Boolean flag that indicates if table name normalization is needed.</param>
     private static string GetTableName(string collectionName, bool normalized = true)
-        => normalized ? CslSyntaxGenerator.NormalizeTableName(collectionName) : collectionName;
+        => normalized ? CslSyntaxGenerator.NormalizeName(collectionName) : collectionName;
 
     /// <summary>
     /// Converts Kusto table name to collection name.

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Kusto/KustoMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Kusto/KustoMemoryStoreTests.cs
@@ -25,6 +25,7 @@ public class KustoMemoryStoreTests
     private const string DatabaseName = "FakeDb";
     private readonly Mock<ICslQueryProvider> _cslQueryProviderMock;
     private readonly Mock<ICslAdminProvider> _cslAdminProviderMock;
+    private readonly string _normalisedCollectionName = CslSyntaxGenerator.NormalizeName(CollectionName);
 
     public KustoMemoryStoreTests()
     {
@@ -145,7 +146,7 @@ public class KustoMemoryStoreTests
         // Assert
         this._cslAdminProviderMock.Verify(client => client.ExecuteControlCommandAsync(
             DatabaseName,
-            It.Is<string>(s => s.StartsWith($".ingest inline into table {CollectionName}", StringComparison.Ordinal) && s.Contains(actualMemoryRecordKey, StringComparison.Ordinal)),
+            It.Is<string>(s => s.StartsWith($".ingest inline into table {this._normalisedCollectionName}", StringComparison.Ordinal) && s.Contains(actualMemoryRecordKey, StringComparison.Ordinal)),
             It.IsAny<ClientRequestProperties>()), Times.Once());
         Assert.Equal(expectedMemoryRecord.Key, actualMemoryRecordKey);
     }
@@ -171,7 +172,7 @@ public class KustoMemoryStoreTests
             .Verify(client => client.ExecuteControlCommandAsync(
                 DatabaseName,
                 It.Is<string>(s =>
-                    s.StartsWith($".ingest inline into table {CollectionName}", StringComparison.Ordinal) &&
+                    s.StartsWith($".ingest inline into table {this._normalisedCollectionName}", StringComparison.Ordinal) &&
                     batchUpsertMemoryRecords.All(r => s.Contains(r.Key, StringComparison.Ordinal))),
                 It.IsAny<ClientRequestProperties>()
             ), Times.Once());
@@ -306,7 +307,7 @@ public class KustoMemoryStoreTests
         this._cslAdminProviderMock
             .Verify(client => client.ExecuteControlCommandAsync(
                 DatabaseName,
-                It.Is<string>(s => s.Replace("  ", " ").StartsWith($".delete table {CollectionName}") && s.Contains(MemoryRecordKey)), // Replace double spaces with single space to account for the fact that the query is formatted with double spaces and to be future proof
+                It.Is<string>(s => s.Replace("  ", " ").StartsWith($".delete table {this._normalisedCollectionName}") && s.Contains(MemoryRecordKey)), // Replace double spaces with single space to account for the fact that the query is formatted with double spaces and to be future proof
                 It.IsAny<ClientRequestProperties>()
             ), Times.Once());
     }
@@ -325,7 +326,7 @@ public class KustoMemoryStoreTests
         this._cslAdminProviderMock
             .Verify(client => client.ExecuteControlCommandAsync(
                 DatabaseName,
-                It.Is<string>(s => s.Replace("  ", " ").StartsWith($".delete table {CollectionName}") && memoryRecordKeys.All(r => s.Contains(r, StringComparison.OrdinalIgnoreCase))),
+                It.Is<string>(s => s.Replace("  ", " ").StartsWith($".delete table {this._normalisedCollectionName}") && memoryRecordKeys.All(r => s.Contains(r, StringComparison.OrdinalIgnoreCase))),
                 It.IsAny<ClientRequestProperties>()
             ), Times.Once());
     }


### PR DESCRIPTION
### Motivation and Context

This PR includes the following changes

1. Bump version of `Microsoft.Azure.Kusto.Data` to version 12.2.2
2. Switch from obsolete `NormalizeTableName` to recommended `NormalizeName`

Background on this second change:

- The default behavior of `NormalizeTableName` is to only add brackets if they seem needed, while `NormalizeName` always does. 
- Unless you rely on the exact kql generated it shouldn't matter, if you want to force the old behavior add `NormalizationMode.Classic`
- The normalization of plenty of identifier kinds has been unified, so you no longer need most of the specialized methods

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
- [ ] 