### PR TITLE
.Net: VectorStore: Add unit tests for mappers and adding dedicated options for mapper.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -290,12 +290,13 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
         // Create options.
         var collectionName = this.ChooseCollectionName(options?.CollectionName);
         var pointsIds = keys.Select(key => keyConverter(key)).ToArray();
+        var includeVectors = options?.IncludeVectors ?? false;
 
         // Retrieve data points.
         var retrievedPoints = await RunOperationAsync(
             collectionName,
             OperationName,
-            () => this._qdrantClient.RetrieveAsync(collectionName, pointsIds, true, options?.IncludeVectors ?? false, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            () => this._qdrantClient.RetrieveAsync(collectionName, pointsIds, true, includeVectors, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
         // Convert the retrieved points to the target data model.
         foreach (var retrievedPoint in retrievedPoints)
@@ -316,7 +317,7 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
                 DatabaseName,
                 collectionName,
                 OperationName,
-                () => this._mapper.MapFromStorageToDataModel(pointStruct, options));
+                () => this._mapper.MapFromStorageToDataModel(pointStruct, new() { IncludeVectors = includeVectors }));
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -172,7 +173,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
     }
 
     /// <inheritdoc />
-    public TRecord MapFromStorageToDataModel(PointStruct storageModel, GetRecordOptions? options = default)
+    public TRecord MapFromStorageToDataModel(PointStruct storageModel, StorageToDataModelMapperOptions options)
     {
         // Get the key property name and value.
         var keyPropertyName = VectorStoreRecordPropertyReader.GetSerializedPropertyName(this._keyPropertyInfo);
@@ -284,7 +285,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
             sourceValue is IEnumerable<double> ||
             sourceValue is IEnumerable<bool>)
         {
-            var listValue = sourceValue as IEnumerable<object>;
+            var listValue = sourceValue as IEnumerable;
             value.ListValue = new ListValue();
             foreach (var item in listValue!)
             {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -121,6 +121,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         // Create Options
         var collectionName = this.ChooseCollectionName(options?.CollectionName);
         var maybePrefixedKey = this.PrefixKeyIfNeeded(key, collectionName);
+        var includeVectors = options?.IncludeVectors ?? false;
 
         // Get the redis value.
         var redisResult = await RunOperationAsync(
@@ -155,7 +156,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
             () =>
             {
                 var node = JsonSerializer.Deserialize<JsonNode>(redisResultString)!;
-                return this._mapper.MapFromStorageToDataModel((key, node));
+                return this._mapper.MapFromStorageToDataModel((key, node), new() { IncludeVectors = includeVectors });
             });
     }
 
@@ -169,6 +170,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         var collectionName = this.ChooseCollectionName(options?.CollectionName);
         var maybePrefixedKeys = keysList.Select(key => this.PrefixKeyIfNeeded(key, collectionName));
         var redisKeys = maybePrefixedKeys.Select(x => new RedisKey(x)).ToArray();
+        var includeVectors = options?.IncludeVectors ?? false;
 
         // Get the list of redis results.
         var redisResults = await RunOperationAsync(
@@ -205,7 +207,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
                 () =>
                 {
                     var node = JsonSerializer.Deserialize<JsonNode>(redisResultString)!;
-                    return this._mapper.MapFromStorageToDataModel((key, node));
+                    return this._mapper.MapFromStorageToDataModel((key, node), new() { IncludeVectors = includeVectors });
                 });
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordMapper.cs
@@ -46,7 +46,7 @@ internal sealed class RedisVectorStoreRecordMapper<TConsumerDataModel> : IVector
     }
 
     /// <inheritdoc />
-    public TConsumerDataModel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, GetRecordOptions? options = null)
+    public TConsumerDataModel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, StorageToDataModelMapperOptions options)
     {
         JsonObject jsonObject;
 

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
@@ -1,0 +1,382 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Connectors.Qdrant;
+using Microsoft.SemanticKernel.Memory;
+using Qdrant.Client.Grpc;
+using Xunit;
+
+namespace SemanticKernel.Connectors.Qdrant.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="QdrantVectorStoreRecordMapper{TConsumerDataModel}"/> class.
+/// </summary>
+public class QdrantVectorStoreRecordMapperTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapsSinglePropsFromDataToStorageModelWithUlong(bool hasNamedVectors)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<ulong>>(new() { HasNamedVectors = hasNamedVectors });
+
+        // Act.
+        var actual = sut.MapFromDataToStorageModel(CreateSinglePropsModel<ulong>(5ul));
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(5ul, actual.Id.Num);
+        Assert.Single(actual.Payload);
+        Assert.Equal("data", actual.Payload["Data"].StringValue);
+
+        if (hasNamedVectors)
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vectors.Vectors_.Vectors["Vector"].Data.ToArray());
+        }
+        else
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vectors.Vector.Data.ToArray());
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapsSinglePropsFromDataToStorageModelWithGuid(bool hasNamedVectors)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<Guid>>(new() { HasNamedVectors = hasNamedVectors });
+
+        // Act.
+        var actual = sut.MapFromDataToStorageModel(CreateSinglePropsModel<Guid>(Guid.Parse("11111111-1111-1111-1111-111111111111")));
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), Guid.Parse(actual.Id.Uuid));
+        Assert.Single(actual.Payload);
+        Assert.Equal("data", actual.Payload["Data"].StringValue);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void MapsSinglePropsFromStorageToDataModelWithUlong(bool hasNamedVectors, bool includeVectors)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<ulong>>(new() { HasNamedVectors = hasNamedVectors });
+
+        // Act.
+        var actual = sut.MapFromStorageToDataModel(CreateSinglePropsPointStruct(5, hasNamedVectors), new() { IncludeVectors = includeVectors });
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(5ul, actual.Key);
+        Assert.Equal("data", actual.Data);
+
+        if (includeVectors)
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+        }
+        else
+        {
+            Assert.Null(actual.Vector);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void MapsSinglePropsFromStorageToDataModelWithGuid(bool hasNamedVectors, bool includeVectors)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<Guid>>(new() { HasNamedVectors = hasNamedVectors });
+
+        // Act.
+        var actual = sut.MapFromStorageToDataModel(CreateSinglePropsPointStruct(Guid.Parse("11111111-1111-1111-1111-111111111111"), hasNamedVectors), new() { IncludeVectors = includeVectors });
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), actual.Key);
+        Assert.Equal("data", actual.Data);
+
+        if (includeVectors)
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+        }
+        else
+        {
+            Assert.Null(actual.Vector);
+        }
+    }
+
+    [Fact]
+    public void MapsMultiPropsFromDataToStorageModelWithUlong()
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<ulong>>(new() { HasNamedVectors = true });
+
+        // Act.
+        var actual = sut.MapFromDataToStorageModel(CreateMultiPropsModel<ulong>(5ul));
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(5ul, actual.Id.Num);
+        Assert.Equal(7, actual.Payload.Count);
+        Assert.Equal("data 1", actual.Payload["DataString"].StringValue);
+        Assert.Equal(5, actual.Payload["DataInt"].IntegerValue);
+        Assert.Equal(5, actual.Payload["DataLong"].IntegerValue);
+        Assert.Equal(5.5f, actual.Payload["DataFloat"].DoubleValue);
+        Assert.Equal(5.5d, actual.Payload["DataDouble"].DoubleValue);
+        Assert.True(actual.Payload["DataBool"].BoolValue);
+        Assert.Equal(new int[] { 1, 2, 3, 4 }, actual.Payload["DataArrayInt"].ListValue.Values.Select(x => (int)x.IntegerValue).ToArray());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vectors.Vectors_.Vectors["Vector1"].Data.ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, actual.Vectors.Vectors_.Vectors["Vector2"].Data.ToArray());
+    }
+
+    [Fact]
+    public void MapsMultiPropsFromDataToStorageModelWithGuid()
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<Guid>>(new() { HasNamedVectors = true });
+
+        // Act.
+        var actual = sut.MapFromDataToStorageModel(CreateMultiPropsModel<Guid>(Guid.Parse("11111111-1111-1111-1111-111111111111")));
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), Guid.Parse(actual.Id.Uuid));
+        Assert.Equal(7, actual.Payload.Count);
+        Assert.Equal("data 1", actual.Payload["DataString"].StringValue);
+        Assert.Equal(5, actual.Payload["DataInt"].IntegerValue);
+        Assert.Equal(5, actual.Payload["DataLong"].IntegerValue);
+        Assert.Equal(5.5f, actual.Payload["DataFloat"].DoubleValue);
+        Assert.Equal(5.5d, actual.Payload["DataDouble"].DoubleValue);
+        Assert.True(actual.Payload["DataBool"].BoolValue);
+        Assert.Equal(new int[] { 1, 2, 3, 4 }, actual.Payload["DataArrayInt"].ListValue.Values.Select(x => (int)x.IntegerValue).ToArray());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vectors.Vectors_.Vectors["Vector1"].Data.ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, actual.Vectors.Vectors_.Vectors["Vector2"].Data.ToArray());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapsMultiPropsFromStorageToDataModelWithUlong(bool includeVectors)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<ulong>>(new() { HasNamedVectors = true });
+
+        // Act.
+        var actual = sut.MapFromStorageToDataModel(CreateMultiPropsPointStruct(5), new() { IncludeVectors = includeVectors });
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(5ul, actual.Key);
+        Assert.Equal("data 1", actual.DataString);
+        Assert.Equal(5, actual.DataInt);
+        Assert.Equal(5L, actual.DataLong);
+        Assert.Equal(5.5f, actual.DataFloat);
+        Assert.Equal(5.5d, actual.DataDouble);
+        Assert.True(actual.DataBool);
+        Assert.Equal(new int[] { 1, 2, 3, 4 }, actual.DataArrayInt);
+
+        if (includeVectors)
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector1!.Value.ToArray());
+            Assert.Equal(new float[] { 5, 6, 7, 8 }, actual.Vector2!.Value.ToArray());
+        }
+        else
+        {
+            Assert.Null(actual.Vector1);
+            Assert.Null(actual.Vector2);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapsMultiPropsFromStorageToDataModelWithGuid(bool includeVectors)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<Guid>>(new() { HasNamedVectors = true });
+
+        // Act.
+        var actual = sut.MapFromStorageToDataModel(CreateMultiPropsPointStruct(Guid.Parse("11111111-1111-1111-1111-111111111111")), new() { IncludeVectors = includeVectors });
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(Guid.Parse("11111111-1111-1111-1111-111111111111"), actual.Key);
+        Assert.Equal("data 1", actual.DataString);
+        Assert.Equal(5, actual.DataInt);
+        Assert.Equal(5L, actual.DataLong);
+        Assert.Equal(5.5f, actual.DataFloat);
+        Assert.Equal(5.5d, actual.DataDouble);
+        Assert.True(actual.DataBool);
+        Assert.Equal(new int[] { 1, 2, 3, 4 }, actual.DataArrayInt);
+
+        if (includeVectors)
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector1!.Value.ToArray());
+            Assert.Equal(new float[] { 5, 6, 7, 8 }, actual.Vector2!.Value.ToArray());
+        }
+        else
+        {
+            Assert.Null(actual.Vector1);
+            Assert.Null(actual.Vector2);
+        }
+    }
+
+    private static SinglePropsModel<TKey> CreateSinglePropsModel<TKey>(TKey key)
+    {
+        return new SinglePropsModel<TKey>
+        {
+            Key = key,
+            Data = "data",
+            Vector = new float[] { 1, 2, 3, 4 },
+            NotAnnotated = "notAnnotated",
+        };
+    }
+
+    private static MultiPropsModel<TKey> CreateMultiPropsModel<TKey>(TKey key)
+    {
+        return new MultiPropsModel<TKey>
+        {
+            Key = key,
+            DataString = "data 1",
+            DataInt = 5,
+            DataLong = 5L,
+            DataFloat = 5.5f,
+            DataDouble = 5.5d,
+            DataBool = true,
+            DataArrayInt = new List<int> { 1, 2, 3, 4 },
+            Vector1 = new float[] { 1, 2, 3, 4 },
+            Vector2 = new float[] { 5, 6, 7, 8 },
+            NotAnnotated = "notAnnotated",
+        };
+    }
+
+    private static PointStruct CreateSinglePropsPointStruct(ulong id, bool hasNamedVectors)
+    {
+        var pointStruct = new PointStruct();
+        pointStruct.Id = new PointId() { Num = id };
+        AddDataToSinglePropsPointStruct(pointStruct, hasNamedVectors);
+        return pointStruct;
+    }
+
+    private static PointStruct CreateSinglePropsPointStruct(Guid id, bool hasNamedVectors)
+    {
+        var pointStruct = new PointStruct();
+        pointStruct.Id = new PointId() { Uuid = id.ToString() };
+        AddDataToSinglePropsPointStruct(pointStruct, hasNamedVectors);
+        return pointStruct;
+    }
+
+    private static void AddDataToSinglePropsPointStruct(PointStruct pointStruct, bool hasNamedVectors)
+    {
+        pointStruct.Payload.Add("Data", "data");
+
+        if (hasNamedVectors)
+        {
+            var namedVectors = new NamedVectors();
+            namedVectors.Vectors.Add("Vector", new[] { 1f, 2f, 3f, 4f });
+            pointStruct.Vectors = new Vectors() { Vectors_ = namedVectors };
+        }
+        else
+        {
+            pointStruct.Vectors = new[] { 1f, 2f, 3f, 4f };
+        }
+    }
+
+    private static PointStruct CreateMultiPropsPointStruct(ulong id)
+    {
+        var pointStruct = new PointStruct();
+        pointStruct.Id = new PointId() { Num = id };
+        AddDataToMultiPropsPointStruct(pointStruct);
+        return pointStruct;
+    }
+
+    private static PointStruct CreateMultiPropsPointStruct(Guid id)
+    {
+        var pointStruct = new PointStruct();
+        pointStruct.Id = new PointId() { Uuid = id.ToString() };
+        AddDataToMultiPropsPointStruct(pointStruct);
+        return pointStruct;
+    }
+
+    private static void AddDataToMultiPropsPointStruct(PointStruct pointStruct)
+    {
+        pointStruct.Payload.Add("DataString", "data 1");
+        pointStruct.Payload.Add("DataInt", 5);
+        pointStruct.Payload.Add("DataLong", 5L);
+        pointStruct.Payload.Add("DataFloat", 5.5f);
+        pointStruct.Payload.Add("DataDouble", 5.5d);
+        pointStruct.Payload.Add("DataBool", true);
+
+        var dataIntArray = new ListValue();
+        dataIntArray.Values.Add(1);
+        dataIntArray.Values.Add(2);
+        dataIntArray.Values.Add(3);
+        dataIntArray.Values.Add(4);
+        pointStruct.Payload.Add("DataArrayInt", new Value { ListValue = dataIntArray });
+
+        var namedVectors = new NamedVectors();
+        namedVectors.Vectors.Add("Vector1", new[] { 1f, 2f, 3f, 4f });
+        namedVectors.Vectors.Add("Vector2", new[] { 5f, 6f, 7f, 8f });
+        pointStruct.Vectors = new Vectors() { Vectors_ = namedVectors };
+    }
+
+    private sealed class SinglePropsModel<TKey>
+    {
+        [VectorStoreRecordKey]
+        public TKey? Key { get; set; } = default;
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string NotAnnotated { get; set; } = string.Empty;
+    }
+
+    private sealed class MultiPropsModel<TKey>
+    {
+        [VectorStoreRecordKey]
+        public TKey? Key { get; set; } = default;
+
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
+        public string DataString { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public int DataInt { get; set; } = 0;
+
+        [VectorStoreRecordData]
+        public long DataLong { get; set; } = 0;
+
+        [VectorStoreRecordData]
+        public float DataFloat { get; set; } = 0;
+
+        [VectorStoreRecordData]
+        public double DataDouble { get; set; } = 0;
+
+        [VectorStoreRecordData]
+        public bool DataBool { get; set; } = false;
+
+        [VectorStoreRecordData]
+        public List<int>? DataArrayInt { get; set; }
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector1 { get; set; }
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector2 { get; set; }
+
+        public string NotAnnotated { get; set; } = string.Empty;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordMapperTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Connectors.Redis;
+using Microsoft.SemanticKernel.Memory;
+using Xunit;
+
+namespace SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorStoreRecordMapper{TConsumerDataModel}"/> class.
+/// </summary>
+public sealed class RedisVectorStoreRecordMapperTests
+{
+    [Fact]
+    public void MapsAllFieldsFromDataToStorageModel()
+    {
+        // Arrange.
+        var sut = new RedisVectorStoreRecordMapper<MultiPropsModel>("Key");
+
+        // Act.
+        var actual = sut.MapFromDataToStorageModel(CreateModel("test key"));
+
+        // Assert.
+        Assert.NotNull(actual.Node);
+        Assert.Equal("test key", actual.Key);
+        var jsonObject = actual.Node.AsObject();
+        Assert.Equal("data 1", jsonObject?["Data1"]?.ToString());
+        Assert.Equal("data 2", jsonObject?["Data2"]?.ToString());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, jsonObject?["Vector1"]?.AsArray().GetValues<float>().ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, jsonObject?["Vector2"]?.AsArray().GetValues<float>().ToArray());
+    }
+
+    [Fact]
+    public void MapsAllFieldsFromStorageToDataModel()
+    {
+        // Arrange.
+        var sut = new RedisVectorStoreRecordMapper<MultiPropsModel>("Key");
+
+        // Act.
+        var actual = sut.MapFromStorageToDataModel(("test key", CreateJsonNode()), new());
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal("test key", actual.Key);
+        Assert.Equal("data 1", actual.Data1);
+        Assert.Equal("data 2", actual.Data2);
+
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector1!.Value.ToArray());
+        Assert.Equal(new float[] { 5, 6, 7, 8 }, actual.Vector2!.Value.ToArray());
+    }
+
+    private static MultiPropsModel CreateModel(string key)
+    {
+        return new MultiPropsModel
+        {
+            Key = key,
+            Data1 = "data 1",
+            Data2 = "data 2",
+            Vector1 = new float[] { 1, 2, 3, 4 },
+            Vector2 = new float[] { 5, 6, 7, 8 },
+            NotAnnotated = "notAnnotated",
+        };
+    }
+
+    private static JsonObject CreateJsonNode()
+    {
+        var jsonObject = new JsonObject();
+        jsonObject.Add("Data1", "data 1");
+        jsonObject.Add("Data2", "data 2");
+        jsonObject.Add("Vector1", new JsonArray(new[] { 1, 2, 3, 4 }.Select(x => JsonValue.Create(x)).ToArray()));
+        jsonObject.Add("Vector2", new JsonArray(new[] { 5, 6, 7, 8 }.Select(x => JsonValue.Create(x)).ToArray()));
+        return jsonObject;
+    }
+
+    private sealed class MultiPropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
+        public string Data1 { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data2 { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector1 { get; set; }
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector2 { get; set; }
+
+        public string NotAnnotated { get; set; } = string.Empty;
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
@@ -278,7 +278,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
             throw new NotImplementedException();
         }
 
-        public Hotel MapFromStorageToDataModel(JsonObject storageModel, GetRecordOptions? options = null)
+        public Hotel MapFromStorageToDataModel(JsonObject storageModel, StorageToDataModelMapperOptions options)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
@@ -299,7 +299,7 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
             throw new NotImplementedException();
         }
 
-        public HotelInfo MapFromStorageToDataModel(PointStruct storageModel, GetRecordOptions? options = null)
+        public HotelInfo MapFromStorageToDataModel(PointStruct storageModel, StorageToDataModelMapperOptions options)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
@@ -280,7 +280,7 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
             throw new NotImplementedException();
         }
 
-        public Hotel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, GetRecordOptions? options = null)
+        public Hotel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, StorageToDataModelMapperOptions options)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/IVectorStoreRecordMapper.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/IVectorStoreRecordMapper.cs
@@ -21,7 +21,7 @@ public interface IVectorStoreRecordMapper<TRecordDataModel, TStorageModel>
     /// Map from the storage model to the consumer record data model.
     /// </summary>
     /// <param name="storageModel">The storage data model record to map.</param>
-    /// <param name="options">The <see cref="GetRecordOptions"/> of the operation that this mapping is needed for.</param>
+    /// <param name="options">Options to control the mapping behavior.</param>
     /// <returns>The mapped result.</returns>
-    TRecordDataModel MapFromStorageToDataModel(TStorageModel storageModel, GetRecordOptions? options = default);
+    TRecordDataModel MapFromStorageToDataModel(TStorageModel storageModel, StorageToDataModelMapperOptions options);
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/StorageToDataModelMapperOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/StorageToDataModelMapperOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Memory;
+
+/// <summary>
+/// Options to use with the <see cref="IVectorStoreRecordMapper{TRecordDataModel, TStorageModel}.MapFromStorageToDataModel"/> method.
+/// </summary>
+public class StorageToDataModelMapperOptions
+{
+    /// <summary>
+    /// Get or sets a value indicating whether to include vectors in the retrieval result.
+    /// </summary>
+    public bool IncludeVectors { get; init; } = false;
+}


### PR DESCRIPTION
### Motivation and Context

As part of adding new vector stores for redis and qdrant, these include mappers from data models to storage models and back, that require unit testing.
The mapper interface also uses an options parameter which was reused from the IVectorRecordStore.GetAsync method, but really should have been a dedicated options object from the start.

### Description

- Added unit tests for the redis and qdrant data model mappers.
- Added a dedicated options model for the mapper.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
