### PR TITLE
.Net Fix - Include role definition for each StreamingChatMessageContent

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -699,7 +699,12 @@ internal abstract class ClientCore
                             role = new AuthorRole(streamedRole.Value.ToString());
                         }
 
-                        OpenAIStreamingChatMessageContent openAIStreamingChatMessageContent = new(update, update.ChoiceIndex ?? 0, this.DeploymentOrModelName, metadata) { AuthorName = streamedName, Role = role, };
+                        OpenAIStreamingChatMessageContent openAIStreamingChatMessageContent =
+                            new(update, update.ChoiceIndex ?? 0, this.DeploymentOrModelName, metadata)
+                            {
+                                AuthorName = streamedName,
+                                Role = role,
+                            };
 
                         if (update.ToolCallUpdate is StreamingFunctionToolCallUpdate functionCallUpdate)
                         {

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -693,15 +693,22 @@ internal abstract class ClientCore
                             OpenAIFunctionToolCall.TrackStreamingToolingUpdate(update.ToolCallUpdate, ref toolCallIdsByIndex, ref functionNamesByIndex, ref functionArgumentBuildersByIndex);
                         }
 
-                        var openAIStreamingChatMessageContent = new OpenAIStreamingChatMessageContent(update, update.ChoiceIndex ?? 0, this.DeploymentOrModelName, metadata) { AuthorName = streamedName };
+                        AuthorRole? role = null;
+                        if (streamedRole.HasValue)
+                        {
+                            role = new AuthorRole(streamedRole.Value.ToString());
+                        }
+
+                        OpenAIStreamingChatMessageContent openAIStreamingChatMessageContent = new(update, update.ChoiceIndex ?? 0, this.DeploymentOrModelName, metadata) { AuthorName = streamedName, Role = role, };
 
                         if (update.ToolCallUpdate is StreamingFunctionToolCallUpdate functionCallUpdate)
                         {
-                            openAIStreamingChatMessageContent.Items.Add(new StreamingFunctionCallUpdateContent(
-                                callId: functionCallUpdate.Id,
-                                name: functionCallUpdate.Name,
-                                arguments: functionCallUpdate.ArgumentsUpdate,
-                                functionCallIndex: functionCallUpdate.ToolCallIndex));
+                            openAIStreamingChatMessageContent.Items.Add(
+                                new StreamingFunctionCallUpdateContent(
+                                    callId: functionCallUpdate.Id,
+                                    name: functionCallUpdate.Name,
+                                    arguments: functionCallUpdate.ArgumentsUpdate,
+                                    functionCallIndex: functionCallUpdate.ToolCallIndex));
                         }
 
                         streamedContents?.Add(openAIStreamingChatMessageContent);

--- a/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/AzureSdk/ClientCore.cs
@@ -703,12 +703,11 @@ internal abstract class ClientCore
 
                         if (update.ToolCallUpdate is StreamingFunctionToolCallUpdate functionCallUpdate)
                         {
-                            openAIStreamingChatMessageContent.Items.Add(
-                                new StreamingFunctionCallUpdateContent(
-                                    callId: functionCallUpdate.Id,
-                                    name: functionCallUpdate.Name,
-                                    arguments: functionCallUpdate.ArgumentsUpdate,
-                                    functionCallIndex: functionCallUpdate.ToolCallIndex));
+                            openAIStreamingChatMessageContent.Items.Add(new StreamingFunctionCallUpdateContent(
+                                callId: functionCallUpdate.Id,
+                                name: functionCallUpdate.Name,
+                                arguments: functionCallUpdate.ArgumentsUpdate,
+                                functionCallIndex: functionCallUpdate.ToolCallIndex));
                         }
 
                         streamedContents?.Add(openAIStreamingChatMessageContent);

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAICompletionTests.cs
@@ -128,6 +128,11 @@ public sealed class OpenAICompletionTests(ITestOutputHelper output) : IDisposabl
         // Act
         await foreach (var content in target.InvokeStreamingAsync<StreamingKernelContent>(plugins["ChatPlugin"]["Chat"], new() { [InputParameterName] = prompt }))
         {
+            if (content is StreamingChatMessageContent messageContent)
+            {
+                Assert.NotNull(messageContent.Role);
+            }
+
             fullResult.Append(content);
         }
 


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

`StreamingChatMessageContent.AuthorRole` always `null`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Logic already exists to capture role, but it was not being passed to each and every instance of StreamingChatMessageContent.  Other properties, such as `ModelId` are included with each and every instance.

Updated integration test.

Issue: https://github.com/microsoft/semantic-kernel/issues/6952

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
