### PR TITLE
.Net: Add unit tests for AzureAISearch and Redis Vector Record Stores.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
@@ -1,0 +1,461 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Models;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Microsoft.SemanticKernel.Memory;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="AzureAISearchVectorRecordStore{TRecord}"/> class.
+/// </summary>
+public class AzureAISearchVectorRecordStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+    private const string TestRecordKey1 = "testid1";
+    private const string TestRecordKey2 = "testid2";
+
+    private readonly Mock<SearchIndexClient> _searchIndexClientMock;
+    private readonly Mock<SearchClient> _searchClientMock;
+
+    private readonly CancellationToken _testCancellationToken = new(false);
+
+    public AzureAISearchVectorRecordStoreTests()
+    {
+        this._searchClientMock = new Mock<SearchClient>(MockBehavior.Strict);
+        this._searchIndexClientMock = new Mock<SearchIndexClient>(MockBehavior.Strict);
+        this._searchIndexClientMock.Setup(x => x.GetSearchClient(TestCollectionName)).Returns(this._searchClientMock.Object);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange.
+        this._searchClientMock.Setup(
+            x => x.GetDocumentAsync<SinglePropsModel>(
+                TestRecordKey1,
+                It.Is<GetDocumentOptions>(x => !x.SelectedFields.Any()),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act.
+        var actual = await sut.GetAsync(
+            TestRecordKey1,
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetRecordWithoutVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange.
+        var storageObject = JsonSerializer.SerializeToNode(CreateModel(TestRecordKey1, false))!.AsObject();
+
+        this._searchClientMock.Setup(
+            x => x.GetDocumentAsync<SinglePropsModel>(
+                TestRecordKey1,
+                It.Is<GetDocumentOptions>(x => x.SelectedFields.Contains("Key") && x.SelectedFields.Contains("Data")),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act.
+        var actual = await sut.GetAsync(
+            TestRecordKey1,
+            new()
+            {
+                IncludeVectors = false,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange.
+        this._searchClientMock.Setup(
+            x => x.GetDocumentAsync<SinglePropsModel>(
+                It.IsAny<string>(),
+                It.IsAny<GetDocumentOptions>(),
+                this._testCancellationToken))
+            .ReturnsAsync((string id, GetDocumentOptions options, CancellationToken cancellationToken) =>
+            {
+                return Response.FromValue(CreateModel(id, true), Mock.Of<Response>());
+            });
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act.
+        var actual = await sut.GetBatchAsync(
+            [TestRecordKey1, TestRecordKey2],
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(TestRecordKey1, actual[0].Key);
+        Assert.Equal(TestRecordKey2, actual[1].Key);
+    }
+
+    [Fact]
+    public async Task CanGetRecordWithCustomMapperAsync()
+    {
+        // Arrange.
+        var storageObject = JsonSerializer.SerializeToNode(CreateModel(TestRecordKey1, false))!.AsObject();
+
+        // Arrange GetDocumentAsync mock returning JsonObject.
+        this._searchClientMock.Setup(
+            x => x.GetDocumentAsync<JsonObject>(
+                TestRecordKey1,
+                It.Is<GetDocumentOptions>(x => !x.SelectedFields.Any()),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(storageObject, Mock.Of<Response>()));
+
+        // Arrange mapper mock from JsonObject to data model.
+        var mapperMock = new Mock<IVectorStoreRecordMapper<SinglePropsModel, JsonObject>>(MockBehavior.Strict);
+        mapperMock.Setup(
+            x => x.MapFromStorageToDataModel(
+                storageObject,
+                It.Is<StorageToDataModelMapperOptions>(x => x.IncludeVectors)))
+            .Returns(CreateModel(TestRecordKey1, true));
+
+        // Arrange target with custom mapper.
+        var sut = new AzureAISearchVectorRecordStore<SinglePropsModel>(
+            this._searchIndexClientMock.Object,
+            new()
+            {
+                DefaultCollectionName = TestCollectionName,
+                MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper,
+                JsonObjectCustomMapper = mapperMock.Object
+            });
+
+        // Act.
+        var actual = await sut.GetAsync(TestRecordKey1, new() { IncludeVectors = true }, this._testCancellationToken);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange.
+#pragma warning disable Moq1002 // Moq: No matching constructor
+        var indexDocumentsResultMock = new Mock<IndexDocumentsResult>(MockBehavior.Strict, new List<IndexingResult>());
+#pragma warning restore Moq1002 // Moq: No matching constructor
+
+        this._searchClientMock.Setup(
+            x => x.DeleteDocumentsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act.
+        await sut.DeleteAsync(
+            TestRecordKey1,
+            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
+            this._testCancellationToken);
+
+        // Assert.
+        this._searchClientMock.Verify(
+            x => x.DeleteDocumentsAsync(
+                "Key",
+                It.Is<IEnumerable<string>>(x => x.Count() == 1 && x.Contains(TestRecordKey1)),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange.
+#pragma warning disable Moq1002 // Moq: No matching constructor
+        var indexDocumentsResultMock = new Mock<IndexDocumentsResult>(MockBehavior.Strict, new List<IndexingResult>());
+#pragma warning restore Moq1002 // Moq: No matching constructor
+
+        this._searchClientMock.Setup(
+            x => x.DeleteDocumentsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act.
+        await sut.DeleteBatchAsync(
+            [TestRecordKey1, TestRecordKey2],
+            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
+            this._testCancellationToken);
+
+        // Assert.
+        this._searchClientMock.Verify(
+            x => x.DeleteDocumentsAsync(
+                "Key",
+                It.Is<IEnumerable<string>>(x => x.Count() == 2 && x.Contains(TestRecordKey1) && x.Contains(TestRecordKey2)),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange upload result object.
+#pragma warning disable Moq1002 // Moq: No matching constructor
+        var indexingResult = new Mock<IndexingResult>(MockBehavior.Strict, TestRecordKey1, true, 200);
+        var indexingResults = new List<IndexingResult>();
+        indexingResults.Add(indexingResult.Object);
+        var indexDocumentsResultMock = new Mock<IndexDocumentsResult>(MockBehavior.Strict, indexingResults);
+#pragma warning restore Moq1002 // Moq: No matching constructor
+
+        // Arrange upload.
+        this._searchClientMock.Setup(
+            x => x.UploadDocumentsAsync(
+                It.IsAny<IEnumerable<SinglePropsModel>>(),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
+
+        // Arrange sut.
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        var model = CreateModel(TestRecordKey1, true);
+
+        // Act.
+        var actual = await sut.UpsertAsync(
+            model,
+            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
+            this._testCancellationToken);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual);
+        this._searchClientMock.Verify(
+            x => x.UploadDocumentsAsync(
+                It.Is<IEnumerable<SinglePropsModel>>(x => x.Count() == 1 && x.First().Key == TestRecordKey1),
+                It.Is<IndexDocumentsOptions>(x => x.ThrowOnAnyError == true),
+                this._testCancellationToken),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange upload result object.
+#pragma warning disable Moq1002 // Moq: No matching constructor
+        var indexingResult1 = new Mock<IndexingResult>(MockBehavior.Strict, TestRecordKey1, true, 200);
+        var indexingResult2 = new Mock<IndexingResult>(MockBehavior.Strict, TestRecordKey2, true, 200);
+
+        var indexingResults = new List<IndexingResult>();
+        indexingResults.Add(indexingResult1.Object);
+        indexingResults.Add(indexingResult2.Object);
+        var indexDocumentsResultMock = new Mock<IndexDocumentsResult>(MockBehavior.Strict, indexingResults);
+#pragma warning restore Moq1002 // Moq: No matching constructor
+
+        // Arrange upload.
+        this._searchClientMock.Setup(
+            x => x.UploadDocumentsAsync(
+                It.IsAny<IEnumerable<SinglePropsModel>>(),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
+
+        // Arrange sut.
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        var model1 = CreateModel(TestRecordKey1, true);
+        var model2 = CreateModel(TestRecordKey2, true);
+
+        // Act.
+        var actual = await sut.UpsertBatchAsync(
+            [model1, model2],
+            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(TestRecordKey1, actual[0]);
+        Assert.Equal(TestRecordKey2, actual[1]);
+
+        this._searchClientMock.Verify(
+            x => x.UploadDocumentsAsync(
+                It.Is<IEnumerable<SinglePropsModel>>(x => x.Count() == 2 && x.First().Key == TestRecordKey1 && x.ElementAt(1).Key == TestRecordKey2),
+                It.Is<IndexDocumentsOptions>(x => x.ThrowOnAnyError == true),
+                this._testCancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CanUpsertRecordWithCustomMapperAsync()
+    {
+        // Arrange.
+#pragma warning disable Moq1002 // Moq: No matching constructor
+        var indexingResult = new Mock<IndexingResult>(MockBehavior.Strict, TestRecordKey1, true, 200);
+        var indexingResults = new List<IndexingResult>();
+        indexingResults.Add(indexingResult.Object);
+        var indexDocumentsResultMock = new Mock<IndexDocumentsResult>(MockBehavior.Strict, indexingResults);
+#pragma warning restore Moq1002 // Moq: No matching constructor
+
+        var model = CreateModel(TestRecordKey1, true);
+        var storageObject = JsonSerializer.SerializeToNode(model)!.AsObject();
+
+        // Arrange UploadDocumentsAsync mock returning upsert result.
+        this._searchClientMock.Setup(
+            x => x.UploadDocumentsAsync(
+                It.IsAny<IEnumerable<JsonObject>>(),
+                It.IsAny<IndexDocumentsOptions>(),
+                this._testCancellationToken))
+            .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
+
+        // Arrange mapper mock from data model to JsonObject.
+        var mapperMock = new Mock<IVectorStoreRecordMapper<SinglePropsModel, JsonObject>>(MockBehavior.Strict);
+        mapperMock.Setup(
+            x => x.MapFromDataToStorageModel(
+                model))
+            .Returns(storageObject);
+
+        // Arrange target with custom mapper.
+        var sut = new AzureAISearchVectorRecordStore<SinglePropsModel>(
+            this._searchIndexClientMock.Object,
+            new()
+            {
+                DefaultCollectionName = TestCollectionName,
+                MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper,
+                JsonObjectCustomMapper = mapperMock.Object
+            });
+
+        // Act.
+        await sut.UpsertAsync(
+            model,
+            null,
+            this._testCancellationToken);
+
+        // Assert.
+        this._searchClientMock.Verify(
+            x => x.UploadDocumentsAsync(
+                It.Is<IEnumerable<JsonObject>>(x => x.Count() == 1 && x.First() == storageObject),
+                It.Is<IndexDocumentsOptions>(x => x.ThrowOnAnyError == true),
+                this._testCancellationToken),
+            Times.Once);
+    }
+
+    private AzureAISearchVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition, bool passCollectionToMethod)
+    {
+        return new AzureAISearchVectorRecordStore<SinglePropsModel>(
+            this._searchIndexClientMock.Object,
+            new()
+            {
+                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
+                VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null
+            });
+    }
+
+    private static SinglePropsModel CreateModel(string key, bool withVectors)
+    {
+        return new SinglePropsModel
+        {
+            Key = key,
+            Data = "data 1",
+            Vector = withVectors ? new float[] { 1, 2, 3, 4 } : null,
+            NotAnnotated = null,
+        };
+    }
+
+    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordDataProperty("Data"),
+            new VectorStoreRecordVectorProperty("Vector")
+        ]
+    };
+
+    public sealed class SinglePropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
@@ -1,0 +1,434 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Memory;
+using Moq;
+using NRedisStack;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorRecordStore{TRecord}"/> class.
+/// </summary>
+public class RedisVectorRecordStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+    private const string TestRecordKey1 = "testid1";
+    private const string TestRecordKey2 = "testid2";
+
+    private readonly Mock<IDatabase> _redisDatabaseMock;
+
+    private readonly CancellationToken _testCancellationToken = new(false);
+
+    public RedisVectorRecordStoreTests()
+    {
+        this._redisDatabaseMock = new Mock<IDatabase>(MockBehavior.Strict);
+
+        var batchMock = new Mock<IBatch>();
+        this._redisDatabaseMock.Setup(x => x.CreateBatch(It.IsAny<object>())).Returns(batchMock.Object);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var redisResultString = """{ "Data": "data 1", "Vector": [1, 2, 3, 4] }""";
+        SetupExecuteMock(this._redisDatabaseMock, redisResultString);
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var actual = await sut.GetAsync(
+            TestRecordKey1,
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        var expectedArgs = new object[] { TestRecordKey1 };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.GET",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetRecordWithoutVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var redisResultString = """{ "Data": "data 1" }""";
+        SetupExecuteMock(this._redisDatabaseMock, redisResultString);
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var actual = await sut.GetAsync(
+            TestRecordKey1,
+            new()
+            {
+                IncludeVectors = false,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        var expectedArgs = new object[] { TestRecordKey1, "Data" };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.GET",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.False(actual.Vector.HasValue);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var redisResultString1 = """{ "Data": "data 1", "Vector": [1, 2, 3, 4] }""";
+        var redisResultString2 = """{ "Data": "data 2", "Vector": [5, 6, 7, 8] }""";
+        SetupExecuteMock(this._redisDatabaseMock, [redisResultString1, redisResultString2]);
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var actual = await sut.GetBatchAsync(
+            [TestRecordKey1, TestRecordKey2],
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert
+        var expectedArgs = new object[] { TestRecordKey1, TestRecordKey2, "$" };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.MGET",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(TestRecordKey1, actual[0].Key);
+        Assert.Equal("data 1", actual[0].Data);
+        Assert.Equal(TestRecordKey2, actual[1].Key);
+        Assert.Equal("data 2", actual[1].Data);
+    }
+
+    [Fact]
+    public async Task CanGetRecordWithCustomMapperAsync()
+    {
+        // Arrange.
+        var redisResultString = """{ "Data": "data 1", "Vector": [1, 2, 3, 4] }""";
+        var redisResultJsonNode = JsonNode.Parse(redisResultString);
+        SetupExecuteMock(this._redisDatabaseMock, redisResultString);
+
+        // Arrange mapper mock from JsonNode to data model.
+        var mapperMock = new Mock<IVectorStoreRecordMapper<SinglePropsModel, (string key, JsonNode node)>>(MockBehavior.Strict);
+        mapperMock.Setup(
+            x => x.MapFromStorageToDataModel(
+                It.Is<(string key, JsonNode node)>(x => x.node == redisResultJsonNode && x.key == TestRecordKey1),
+                It.Is<StorageToDataModelMapperOptions>(x => x.IncludeVectors)))
+            .Returns(CreateModel(TestRecordKey1, true));
+
+        // Arrange target with custom mapper.
+        var sut = new RedisVectorRecordStore<SinglePropsModel>(
+            this._redisDatabaseMock.Object,
+            new()
+            {
+                DefaultCollectionName = TestCollectionName,
+                JsonNodeCustomMapper = mapperMock.Object
+            });
+
+        // Act
+        var actual = await sut.GetAsync(
+            TestRecordKey1,
+            new() { IncludeVectors = false },
+            this._testCancellationToken);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        SetupExecuteMock(this._redisDatabaseMock, "200");
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        await sut.DeleteAsync(
+            TestRecordKey1,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        var expectedArgs = new object[] { TestRecordKey1 };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.DEL",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        SetupExecuteMock(this._redisDatabaseMock, "200");
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        await sut.DeleteBatchAsync(
+            [TestRecordKey1, TestRecordKey2],
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        var expectedArgs1 = new object[] { TestRecordKey1 };
+        var expectedArgs2 = new object[] { TestRecordKey2 };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.DEL",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs1))),
+                Times.Once);
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.DEL",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs2))),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        SetupExecuteMock(this._redisDatabaseMock, "OK");
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var model = CreateModel(TestRecordKey1, true);
+
+        // Act
+        await sut.UpsertAsync(
+            model,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        // TODO: Fix issue where NotAnnotated is being included in the JSON.
+        var expectedArgs = new object[] { TestRecordKey1, "$", """{"Data":"data 1","Vector":[1,2,3,4],"NotAnnotated":null}""" };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.SET",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        SetupExecuteMock(this._redisDatabaseMock, "OK");
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        var model1 = CreateModel(TestRecordKey1, true);
+        var model2 = CreateModel(TestRecordKey2, true);
+
+        // Act
+        var actual = await sut.UpsertBatchAsync(
+            [model1, model2],
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(TestRecordKey1, actual[0]);
+        Assert.Equal(TestRecordKey2, actual[1]);
+
+        // TODO: Fix issue where NotAnnotated is being included in the JSON.
+        var expectedArgs = new object[] { TestRecordKey1, "$", """{"Data":"data 1","Vector":[1,2,3,4],"NotAnnotated":null}""", TestRecordKey2, "$", """{"Data":"data 1","Vector":[1,2,3,4],"NotAnnotated":null}""" };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.MSET",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task CanUpsertRecordWithCustomMapperAsync()
+    {
+        // Arrange.
+        SetupExecuteMock(this._redisDatabaseMock, "OK");
+
+        // Arrange mapper mock from data model to JsonNode.
+        var mapperMock = new Mock<IVectorStoreRecordMapper<SinglePropsModel, (string key, JsonNode node)>>(MockBehavior.Strict);
+        var jsonNode = """{"Data":"data 1","Vector":[1,2,3,4],"NotAnnotated":null}""";
+        mapperMock
+            .Setup(x => x.MapFromDataToStorageModel(It.Is<SinglePropsModel>(x => x.Key == TestRecordKey1)))
+            .Returns((TestRecordKey1, JsonNode.Parse(jsonNode)!));
+
+        // Arrange target with custom mapper.
+        var sut = new RedisVectorRecordStore<SinglePropsModel>(
+            this._redisDatabaseMock.Object,
+            new()
+            {
+                DefaultCollectionName = TestCollectionName,
+                JsonNodeCustomMapper = mapperMock.Object
+            });
+
+        // Act
+        await sut.UpsertAsync(
+            CreateModel(TestRecordKey1, true),
+            new() { CollectionName = TestCollectionName },
+            this._testCancellationToken);
+
+        // Assert
+        var expectedArgs = new object[] { TestRecordKey1, "$", jsonNode };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "JSON.SET",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+    }
+
+    private RedisVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition, bool passCollectionToMethod)
+    {
+        return new RedisVectorRecordStore<SinglePropsModel>(
+            this._redisDatabaseMock.Object,
+            new()
+            {
+                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
+                VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null
+            });
+    }
+
+    private static void SetupExecuteMock(Mock<IDatabase> redisDatabaseMock, IEnumerable<string> redisResultStrings)
+    {
+        var results = redisResultStrings
+            .Select(x => RedisResult.Create(new RedisValue(x)))
+            .ToArray();
+        redisDatabaseMock
+            .Setup(
+                x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<object[]>()))
+            .ReturnsAsync(RedisResult.Create(results));
+    }
+
+    private static void SetupExecuteMock(Mock<IDatabase> redisDatabaseMock, string redisResultString)
+    {
+        redisDatabaseMock
+            .Setup(
+                x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<object[]>()))
+            .ReturnsAsync(RedisResult.Create(new RedisValue(redisResultString)));
+    }
+
+    private static SinglePropsModel CreateModel(string key, bool withVectors)
+    {
+        return new SinglePropsModel
+        {
+            Key = key,
+            Data = "data 1",
+            Vector = withVectors ? new float[] { 1, 2, 3, 4 } : null,
+            NotAnnotated = null,
+        };
+    }
+
+    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordDataProperty("Data"),
+            new VectorStoreRecordVectorProperty("Vector")
+        ]
+    };
+
+    public sealed class SinglePropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -17,10 +18,10 @@ namespace Microsoft.SemanticKernel;
 internal static class VectorStoreRecordPropertyReader
 {
     /// <summary>Cache of property enumerations so that we don't incur reflection costs with each invocation.</summary>
-    private static readonly Dictionary<Type, (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties)> s_singleVectorPropertiesCache = new();
+    private static readonly ConcurrentDictionary<Type, (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties)> s_singleVectorPropertiesCache = new();
 
     /// <summary>Cache of property enumerations so that we don't incur reflection costs with each invocation.</summary>
-    private static readonly Dictionary<Type, (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties)> s_multipleVectorsPropertiesCache = new();
+    private static readonly ConcurrentDictionary<Type, (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties)> s_multipleVectorsPropertiesCache = new();
 
     /// <summary>
     /// Find the properties with <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/> attributes


### PR DESCRIPTION
### Motivation and Context

As part of updating the design of the memory connectors to allow custom schemas, adding unit tests
for AzureAISearch and Redis Vector Record Stores.

### Description

Add unit tests for AzureAISearch and Redis Vector Record Stores.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
