### PR TITLE
Python: slight improvements in kernel and function result content, sample of local function calling with Nexus Raven

### DIFF
--- a/python/samples/concepts/auto_function_calling/nexus_raven.py
+++ b/python/samples/concepts/auto_function_calling/nexus_raven.py
@@ -1,25 +1,77 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import ast
 import asyncio
-import json
 import math
+from collections.abc import AsyncGenerator
+from html import escape
 from typing import Annotated, Any
 
 from huggingface_hub import AsyncInferenceClient
 from pydantic import HttpUrl
 
 from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.open_ai import (
+    OpenAIChatCompletion,
+)
+from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_prompt_execution_settings import (
+    OpenAIChatPromptExecutionSettings,
+)
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
-from semantic_kernel.contents.function_call_content import FunctionCallContent
-from semantic_kernel.contents.text_content import TextContent
+from semantic_kernel.contents import (
+    ChatHistory,
+    ChatMessageContent,
+    FunctionCallContent,
+    StreamingChatMessageContent,
+    TextContent,
+)
+from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.core_plugins.math_plugin import MathPlugin
-from semantic_kernel.core_plugins.time_plugin import TimePlugin
-from semantic_kernel.functions import kernel_function
-from semantic_kernel.functions.kernel_arguments import KernelArguments
+from semantic_kernel.functions import KernelArguments, KernelFunction, kernel_function
+from semantic_kernel.kernel_types import AI_SERVICE_CLIENT_TYPE
+from semantic_kernel.services import AIServiceSelector
+from semantic_kernel.services.ai_service_client_base import AIServiceClientBase
 
 
-class HuggingFaceHubPromptExecutionSettings(PromptExecutionSettings):
+async def execute_function_call(kernel: Kernel, function_call: FunctionCallContent) -> ChatMessageContent:
+    """Execute a function call."""
+    function = kernel.get_function_from_fully_qualified_function_name(function_call.name)
+    args = function_call.to_kernel_arguments()
+    func_result = await function.invoke(kernel=kernel, arguments=args)
+    return ChatMessageContent(
+        role="tool",
+        name=function_call.id,
+        items=[FunctionResultContent.from_function_call_content_and_result(function_call, func_result)],
+    )
+
+
+class ServiceSelector(AIServiceSelector):
+    def select_ai_service(
+        self,
+        kernel: "Kernel",
+        function: "KernelFunction",
+        arguments: "KernelArguments",
+        type_: type[AI_SERVICE_CLIENT_TYPE] | tuple[type[AI_SERVICE_CLIENT_TYPE], ...] | None = None,
+    ) -> tuple["AIServiceClientBase", "PromptExecutionSettings"]:
+        settings = function.prompt_execution_settings
+        if "chat_history" not in arguments:
+            return super().select_ai_service(kernel, function, arguments, type_=type_)
+        chat_history = arguments["chat_history"]
+        if chat_history.messages:
+            last_message = chat_history.messages[-1]
+            if last_message.role == "tool":
+                service = kernel.get_service("openai", type=type_)
+                if service is not None:
+                    service_settings = service.get_prompt_execution_settings_from_settings(settings["openai"])
+                    return service, service_settings
+        service = kernel.get_service("nexus", type=type_)
+        service_settings = service.get_prompt_execution_settings_from_settings(settings["nexus"])
+        return service, service_settings
+
+
+class NexusRavenPromptExecutionSettings(PromptExecutionSettings):
     do_sample: bool = True
     max_new_tokens: int | None = None
     stop_sequences: Any = None
@@ -36,7 +88,7 @@ class HuggingFaceHubPromptExecutionSettings(PromptExecutionSettings):
         )
 
 
-class HuggingFaceEndpoint(TextCompletionClientBase):
+class NexusRavenCompletion(TextCompletionClientBase, ChatCompletionClientBase):
     """To use this class, you should have installed the ``huggingface_hub`` package, and
     the environment variable ``HUGGINGFACEHUB_API_TOKEN`` set with your API token,
     or given as a named parameter to the constructor."""
@@ -55,17 +107,108 @@ class HuggingFaceEndpoint(TextCompletionClientBase):
             client = AsyncInferenceClient(model=endpoint_url, token=api_token)
         super().__init__(service_id=service_id, ai_model_id=ai_model_id, client=client)
 
-    async def get_text_contents(
-        self, prompt: str, settings: HuggingFaceHubPromptExecutionSettings
-    ) -> list[TextContent]:
-        result = await self.client.text_generation(prompt, **settings.prepare_settings_dict(), stream=False)
-        return [TextContent(text=result, ai_model_id=self.ai_model_id)]
+    async def get_chat_message_contents(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+        **kwargs: Any,
+    ) -> list["ChatMessageContent"]:
+        """Creates a chat message content with a function call content within.
 
-    async def get_streaming_text_contents(self, prompt: str, settings: HuggingFaceHubPromptExecutionSettings):
+        Uses the text content and and parses it into a function call content."""
+        kernel = kwargs.get("kernel")
+        result = await self.get_text_contents(
+            prompt=chat_history.messages[-1].content,
+            settings=settings,
+        )
+        fcc = await self._create_function_call_stack(result[0], kernel)
+        if fcc:
+            return fcc
+        return [ChatMessageContent(role="assistant", items=result, metadata={"ai_model_id": self.ai_model_id})]
+
+    async def _create_function_call_stack(self, result: TextContent, kernel: Kernel) -> list[ChatMessageContent] | None:
+        function_call = result.text.strip().split("\n")[0].strip("Call:").strip()
+        if not function_call:
+            return None
+        parsed_fc = ast.parse(function_call, mode="eval")
+        if not isinstance(parsed_fc.body, ast.Call):
+            return None
+        idx = 0
+        call_stack = {}
+        queue = []
+        current = parsed_fc.body
+        # call_stack.append(parsed_fc)
+        queue.append((idx, parsed_fc.body))
+        idx += 1
+        while queue:
+            current_idx, current = queue.pop(0)
+            dependent_on = []
+            args = {}
+            for keyword in current.keywords:
+                if isinstance(keyword.value, ast.Call):
+                    queue.append((idx, keyword.value))
+                    dependent_on.append(idx)
+                    args[keyword.arg] = (idx, keyword.value)
+                    idx += 1
+                else:
+                    args[keyword.arg] = keyword.value.value
+            call = {
+                "idx": current_idx,
+                "func": current.func.id.replace("_", "-", 1),
+                "args": args,
+                "dependent_on": dependent_on,
+                "result": None,
+            }
+            call_stack[current_idx] = call
+        while any(call["result"] is None for call in call_stack.values()):
+            await asyncio.gather(
+                *[
+                    self._execute_function_call(call, kernel)
+                    for call in call_stack.values()
+                    if not any(isinstance(arg, tuple) for arg in call["args"].values())
+                ]
+            )
+            for call in call_stack.values():
+                if call["result"] is None:
+                    for arg in call["args"].values():
+                        if isinstance(arg, tuple) and call_stack[arg[0]]["result"] is not None:
+                            arg[0] = str(call_stack[arg[0]]["result"])
+        print(call_stack)
+
+    async def _execute_function_call(self, call_def: dict[str, Any], kernel: Kernel) -> FunctionResultContent:
+        """Execute a function call."""
+        fcc = FunctionCallContent(name=call_def["func"], arguments=call_def["args"], id=call_def["idx"])
+        kernel_function = kernel.get_function_from_fully_qualified_function_name(fcc.name)
+        kernel_arguments = fcc.get_kernel_arguments()
+        call_def["result"] = await kernel_function.invoke(kernel=kernel, arguments=kernel_arguments)
+
+    def _function_call_from_text(self, function_call: str) -> tuple[str, dict[str, str]]:
+        function_name, args = function_call.split("(")
+        function_name = function_name.replace("_", "-", 1)
+        args = args.strip(")").split(",")
+        arguments = {}
+        for arg in args:
+            key, value = arg.split("=", maxsplit=1)
+            arguments[key.strip()] = value.strip()
+        return function_name, arguments
+
+    async def get_text_contents(self, prompt: str, settings: NexusRavenPromptExecutionSettings) -> list[TextContent]:
+        result = await self.client.text_generation(prompt, **settings.prepare_settings_dict(), stream=False)
+        return [TextContent(text=result.strip(), ai_model_id=self.ai_model_id)]
+
+    async def get_streaming_text_contents(self, prompt: str, settings: NexusRavenPromptExecutionSettings):
+        raise NotImplementedError("Streaming text contents not implemented.")
+
+    def get_streaming_chat_message_contents(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+        **kwargs: Any,
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
         raise NotImplementedError("Streaming chat message contents not implemented.")
 
     def get_prompt_execution_settings_class(self) -> type[PromptExecutionSettings]:
-        return HuggingFaceHubPromptExecutionSettings
+        return NexusRavenPromptExecutionSettings
 
 
 ##########################################################
@@ -86,9 +229,11 @@ def cylinder_volume(
 
 
 kernel = Kernel()
-kernel.add_plugin(MathPlugin(), "math")
-kernel.add_plugin(TimePlugin(), "time")
-kernel.add_function("math", cylinder_volume)
+# ai_service_selector=ServiceSelector())
+kernel.add_service(
+    NexusRavenCompletion(service_id="nexus", ai_model_id="raven", endpoint_url="http://nexusraven.nexusflow.ai")
+)
+kernel.add_service(OpenAIChatCompletion(service_id="openai"))
 
 #############################################################
 # Step 2: Let's define some utils for building the prompt ###
@@ -97,7 +242,7 @@ kernel.add_function("math", cylinder_volume)
 
 @kernel_function
 def format_functions_for_prompt():
-    filters = {"exclude_plugins": ["kernel"]}
+    filters = {"excluded_plugins": ["kernel"]}
     functions = kernel.get_list_of_function_metadata(filters)
     formatted_functions = []
     for func in functions:
@@ -109,89 +254,97 @@ def format_functions_for_prompt():
             args_strings.append(arg_string)
         func_string = f"{func.fully_qualified_name.replace('-', '_')}({', '.join(args_strings)})"
         formatted_functions.append(
-            f"OPTION:\n<func_start>{func_string}<func_end>\n<docstring_start>\n{func.description}\n<docstring_end>"
+            escape(
+                f"OPTION:\n<func_start>{func_string}<func_end>\n<docstring_start>\n{func.description}\n<docstring_end>"
+            )
         )
     return formatted_functions
 
 
+function_call_prompt = """{{chat_history}}&lt;human&gt;:
+{{kernel-format_functions_for_prompt}}
+\n\nUser Query: Question: {{user_query}}
+Please pick a function from the above options that best answers the user query and fill in the appropriate arguments.&lt;human_end&gt;"""  # noqa: E501
+chat_prompt = """You are a chatbot that get's fed questions and basic answers, you write out the response to the question based on the answer, but you do not supply underlying math formulas, just a nice sentence that repeats the question and gives the answer. {{chat_history}}"""  # noqa: E501
+
+kernel.add_plugin(MathPlugin(), "math")
+kernel.add_function("math", cylinder_volume)
 kernel.add_function("kernel", format_functions_for_prompt)
+kernel.add_function(
+    "kernel",
+    function_name="function_call",
+    prompt=function_call_prompt,
+    template_format="handlebars",
+    prompt_execution_settings=NexusRavenPromptExecutionSettings(
+        service_id="nexus",
+        temperature=0.001,
+        max_new_tokens=500,
+        do_sample=False,
+        stop_sequences=["\nReflection:", "\nThought:"],
+    ),
+)
+kernel.add_function(
+    "kernel",
+    function_name="chat",
+    prompt=chat_prompt,
+    template_format="handlebars",
+    prompt_execution_settings=OpenAIChatPromptExecutionSettings(
+        service_id="openai",
+        temperature=0.0,
+        max_tokens=1000,
+    ),
+)
 
 ##############################
 # Step 3: Construct Prompt ###
 ##############################
 
 
-def function_call_string_to_function_call_content(function_call: str) -> FunctionCallContent:
-    """Convert a function call string to a FunctionCallContent object."""
-    function_call = function_call.strip()
-    function_name, args = function_call.split("(")
-    function_name = function_name.replace("_", "-")
-    args = args.strip(")").split(",")
-    arguments = {}
-    for arg in args:
-        key, value = arg.split("=")
-        arguments[key.strip()] = value.strip()
-
-    return FunctionCallContent(id="manual", name=function_name, arguments=json.dumps(arguments))
-
-
-async def execute_function_call(kernel: Kernel, function_call: FunctionCallContent):
-    """Execute a function call."""
-    function = kernel.get_function_from_fully_qualified_function_name(function_call.name)
-    args = function_call.to_kernel_arguments()
-    return await function.invoke(kernel=kernel, arguments=args)
+async def run_question(user_input: str, chat_history: ChatHistory):
+    arguments = KernelArguments(
+        user_query=user_input,
+        chat_history=chat_history,
+        kernel=kernel,
+    )
+    result = await kernel.invoke(plugin_name="kernel", function_name="function_call", arguments=arguments)
+    chat_history.add_user_message(user_input)
+    chat_history.add_message(result.value[0])
+    # chat_history.add_message(await execute_function_call(kernel, chat_history.messages[-1].items[0]))
+    final_result = await kernel.invoke(plugin_name="kernel", function_name="chat", arguments=arguments)
+    chat_history.add_message(final_result.value[0])
 
 
 async def main():
-    # Build the model
-    nexus = HuggingFaceEndpoint(service_id="nexus", ai_model_id="raven", endpoint_url="http://nexusraven.nexusflow.ai")
-
-    kernel.add_service(nexus)
-    prompt = """<human>:
-    {{kernel-format_functions_for_prompt}}
-    \n\nUser Query: Question: {{user_query}}
-    Please pick a function from the above options that best answers the user query and fill in the appropriate arguments.<human_end>
-    """
-    func = kernel.add_function(
-        function_name="function_call",
-        plugin_name="kernel",
-        prompt=prompt,
-        template_format="handlebars",
+    chat_history = ChatHistory()
+    # user_input = "What is 1+10?"
+    # user_input_example = (
+    #     "I have a cake that is about 3 centimenters high and 200 centimeters in radius. How much cake do I have?"
+    # )
+    user_input_example = (
+        "my cake is 3 centimers high and 20 centimers in radius, can you subtract 200 from that number?"
     )
-    arguments = KernelArguments(
-        settings={
-            "nexus": HuggingFaceHubPromptExecutionSettings(
-                temperature=0.001, max_new_tokens=400, do_sample=False, stop_sequences=["\nReflection:", "\nThought:"]
-            )
-        },
-        user_query="What is 1+10?",
+    print("Welcome to the chatbot!")
+    print(
+        "This chatbot uses local function calling with Nexus Raven, and OpenAI for the final answer, "
+        "it has some math skills so feel free to ask anything about that."
     )
+    print(f"for example: {user_input_example}")
+    while True:
+        try:
+            user_input = input("What is your question: ")
+        except Exception:
+            break
+        if user_input == "exit":
+            break
+        if not user_input:
+            user_input = user_input_example
 
-    result = await func.invoke(kernel=kernel, arguments=arguments)
-    function_call = result.value[0].text.strip().split("\n")[0].strip("Call: ")
-    print("Function Call:", function_call)
-    fcc = function_call_string_to_function_call_content(function_call)
-    print(fcc)
-    result = await execute_function_call(kernel, fcc)
-
-    print("Model Output:", function_call)
-    print("Execution Result:", result)
-
-    prompt = construct_prompt(
-        "I have a cake that is about 3 centimenters high and 200 centimeters in diameter. How much cake do I have?"
-    )
-    model_output = text_gen(
-        prompt,
-        do_sample=False,
-        max_new_tokens=400,
-        return_full_text=False,
-        stop=["\nReflection:"],
-    )
-    result = execute_function_call(model_output)
-
-    print("Model Output:", model_output)
-    print("Execution Result:", result)
+        await run_question(user_input, chat_history)
+        print(chat_history.messages[-1].content)
+    print("thanks for chatting with me!")
 
 
 if __name__ == "__main__":
     asyncio.run(main())
+
+# 'Call: math_Subtract(input=math_cylinder_volume(radius=20, height=3), amount=200) \nThought:'

--- a/python/samples/concepts/auto_function_calling/nexus_raven.py
+++ b/python/samples/concepts/auto_function_calling/nexus_raven.py
@@ -1,0 +1,197 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+import json
+import math
+from typing import Annotated, Any
+
+from huggingface_hub import AsyncInferenceClient
+from pydantic import HttpUrl
+
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
+from semantic_kernel.contents.function_call_content import FunctionCallContent
+from semantic_kernel.contents.text_content import TextContent
+from semantic_kernel.core_plugins.math_plugin import MathPlugin
+from semantic_kernel.core_plugins.time_plugin import TimePlugin
+from semantic_kernel.functions import kernel_function
+from semantic_kernel.functions.kernel_arguments import KernelArguments
+
+
+class HuggingFaceHubPromptExecutionSettings(PromptExecutionSettings):
+    do_sample: bool = True
+    max_new_tokens: int | None = None
+    stop_sequences: Any = None
+    temperature: float | None = None
+    top_p: float | None = None
+
+    def prepare_settings_dict(self, **kwargs) -> dict[str, Any]:
+        """Prepare the settings dictionary."""
+        return self.model_dump(
+            include={"max_new_tokens", "temperature", "top_p", "do_sample", "stop_sequences"},
+            exclude_unset=False,
+            exclude_none=True,
+            by_alias=True,
+        )
+
+
+class HuggingFaceEndpoint(TextCompletionClientBase):
+    """To use this class, you should have installed the ``huggingface_hub`` package, and
+    the environment variable ``HUGGINGFACEHUB_API_TOKEN`` set with your API token,
+    or given as a named parameter to the constructor."""
+
+    client: AsyncInferenceClient
+
+    def __init__(
+        self,
+        service_id: str,
+        ai_model_id: str,
+        endpoint_url: HttpUrl,
+        api_token: str | None = None,
+        client: AsyncInferenceClient | None = None,
+    ):
+        if not client:
+            client = AsyncInferenceClient(model=endpoint_url, token=api_token)
+        super().__init__(service_id=service_id, ai_model_id=ai_model_id, client=client)
+
+    async def get_text_contents(
+        self, prompt: str, settings: HuggingFaceHubPromptExecutionSettings
+    ) -> list[TextContent]:
+        result = await self.client.text_generation(prompt, **settings.prepare_settings_dict(), stream=False)
+        return [TextContent(text=result, ai_model_id=self.ai_model_id)]
+
+    async def get_streaming_text_contents(self, prompt: str, settings: HuggingFaceHubPromptExecutionSettings):
+        raise NotImplementedError("Streaming chat message contents not implemented.")
+
+    def get_prompt_execution_settings_class(self) -> type[PromptExecutionSettings]:
+        return HuggingFaceHubPromptExecutionSettings
+
+
+##########################################################
+# Step 1: Define the functions you want to articulate. ###
+##########################################################
+
+
+@kernel_function
+def cylinder_volume(
+    radius: Annotated[float, "The radius of the base of the cylinder."],
+    height: Annotated[float, "The height of the cylinder."],
+):
+    """Calculate the volume of a cylinder."""
+    if radius < 0 or height < 0:
+        raise ValueError("Radius and height must be non-negative.")
+
+    return math.pi * (radius**2) * height
+
+
+kernel = Kernel()
+kernel.add_plugin(MathPlugin(), "math")
+kernel.add_plugin(TimePlugin(), "time")
+kernel.add_function("math", cylinder_volume)
+
+#############################################################
+# Step 2: Let's define some utils for building the prompt ###
+#############################################################
+
+
+@kernel_function
+def format_functions_for_prompt():
+    filters = {"exclude_plugins": ["kernel"]}
+    functions = kernel.get_list_of_function_metadata(filters)
+    formatted_functions = []
+    for func in functions:
+        args_strings = []
+        for arg in func.parameters:
+            arg_string = f"{arg.name}: {arg.type_}"
+            if arg.default_value:
+                arg_string += f" = {arg.default_value}"
+            args_strings.append(arg_string)
+        func_string = f"{func.fully_qualified_name.replace('-', '_')}({', '.join(args_strings)})"
+        formatted_functions.append(
+            f"OPTION:\n<func_start>{func_string}<func_end>\n<docstring_start>\n{func.description}\n<docstring_end>"
+        )
+    return formatted_functions
+
+
+kernel.add_function("kernel", format_functions_for_prompt)
+
+##############################
+# Step 3: Construct Prompt ###
+##############################
+
+
+def function_call_string_to_function_call_content(function_call: str) -> FunctionCallContent:
+    """Convert a function call string to a FunctionCallContent object."""
+    function_call = function_call.strip()
+    function_name, args = function_call.split("(")
+    function_name = function_name.replace("_", "-")
+    args = args.strip(")").split(",")
+    arguments = {}
+    for arg in args:
+        key, value = arg.split("=")
+        arguments[key.strip()] = value.strip()
+
+    return FunctionCallContent(id="manual", name=function_name, arguments=json.dumps(arguments))
+
+
+async def execute_function_call(kernel: Kernel, function_call: FunctionCallContent):
+    """Execute a function call."""
+    function = kernel.get_function_from_fully_qualified_function_name(function_call.name)
+    args = function_call.to_kernel_arguments()
+    return await function.invoke(kernel=kernel, arguments=args)
+
+
+async def main():
+    # Build the model
+    nexus = HuggingFaceEndpoint(service_id="nexus", ai_model_id="raven", endpoint_url="http://nexusraven.nexusflow.ai")
+
+    kernel.add_service(nexus)
+    prompt = """<human>:
+    {{kernel-format_functions_for_prompt}}
+    \n\nUser Query: Question: {{user_query}}
+    Please pick a function from the above options that best answers the user query and fill in the appropriate arguments.<human_end>
+    """
+    func = kernel.add_function(
+        function_name="function_call",
+        plugin_name="kernel",
+        prompt=prompt,
+        template_format="handlebars",
+    )
+    arguments = KernelArguments(
+        settings={
+            "nexus": HuggingFaceHubPromptExecutionSettings(
+                temperature=0.001, max_new_tokens=400, do_sample=False, stop_sequences=["\nReflection:", "\nThought:"]
+            )
+        },
+        user_query="What is 1+10?",
+    )
+
+    result = await func.invoke(kernel=kernel, arguments=arguments)
+    function_call = result.value[0].text.strip().split("\n")[0].strip("Call: ")
+    print("Function Call:", function_call)
+    fcc = function_call_string_to_function_call_content(function_call)
+    print(fcc)
+    result = await execute_function_call(kernel, fcc)
+
+    print("Model Output:", function_call)
+    print("Execution Result:", result)
+
+    prompt = construct_prompt(
+        "I have a cake that is about 3 centimenters high and 200 centimeters in diameter. How much cake do I have?"
+    )
+    model_output = text_gen(
+        prompt,
+        do_sample=False,
+        max_new_tokens=400,
+        return_full_text=False,
+        stop=["\nReflection:"],
+    )
+    result = execute_function_call(model_output)
+
+    print("Model Output:", model_output)
+    print("Execution Result:", result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/concepts/auto_function_calling/nexus_raven.py
+++ b/python/samples/concepts/auto_function_calling/nexus_raven.py
@@ -88,11 +88,13 @@ class NexusRavenCompletion(TextCompletionClientBase, ChatCompletionClientBase):
             prompt=chat_history.messages[-1].content,
             settings=settings,
         )
-        fcc, frc = await self._execute_function_calls(result[0], **kwargs)
-        if fcc:
+        function_call, function_result = await self._execute_function_calls(result[0], **kwargs)
+        if function_call:
             return [
-                ChatMessageContent(role="assistant", items=[fcc], metadata={"ai_model_id": self.ai_model_id}),
-                ChatMessageContent(role="tool", items=[frc], name="nexus", metadata={"ai_model_id": self.ai_model_id}),
+                ChatMessageContent(role="assistant", items=[function_call], metadata={"ai_model_id": self.ai_model_id}),
+                ChatMessageContent(
+                    role="tool", items=[function_result], name="nexus", metadata={"ai_model_id": self.ai_model_id}
+                ),
             ]
         return [ChatMessageContent(role="assistant", items=result, metadata={"ai_model_id": self.ai_model_id})]
 

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -263,8 +263,8 @@ class ChatHistory(KernelBaseModel):
         prompt = rendered_prompt.strip()
         try:
             xml_prompt = XML(text=f"<{prompt_tag}>{prompt}</{prompt_tag}>")
-        except ParseError:
-            logger.info(f"Could not parse prompt {prompt} as xml, treating as text")
+        except ParseError as exc:
+            logger.info(f"Could not parse prompt {prompt} as xml, treating as text, error was: {exc}")
             return cls(messages=[ChatMessageContent(role=AuthorRole.USER, content=unescape(prompt))])
         if xml_prompt.text and xml_prompt.text.strip():
             messages.append(ChatMessageContent(role=AuthorRole.SYSTEM, content=unescape(xml_prompt.text.strip())))

--- a/python/semantic_kernel/contents/chat_message_content.py
+++ b/python/semantic_kernel/contents/chat_message_content.py
@@ -296,5 +296,5 @@ class ChatMessageContent(KernelContent):
         if len(self.items) == 1 and isinstance(self.items[0], TextContent):
             return self.items[0].text
         if len(self.items) == 1 and isinstance(self.items[0], FunctionResultContent):
-            return self.items[0].result
+            return str(self.items[0].result)
         return [item.to_dict() for item in self.items]

--- a/python/semantic_kernel/core_plugins/math_plugin.py
+++ b/python/semantic_kernel/core_plugins/math_plugin.py
@@ -29,21 +29,13 @@ class MathPlugin:
             amount = int(amount)
         return MathPlugin.add_or_subtract(input, amount, add=True)
 
-    @kernel_function(
-        description="Subtracts value to a value",
-        name="Subtract",
-    )
+    @kernel_function(name="Subtract")
     def subtract(
         self,
         input: Annotated[int, "the first number"],
         amount: Annotated[int, "the number to subtract"],
     ) -> int:
-        """Returns the difference of numbers provided.
-
-        :param initial_value_text: Initial value as string to subtract the specified amount
-        :param context: Contains the context to get the numbers from
-        :return: The resulting subtraction as a string
-        """
+        """Returns the difference of numbers provided."""
         if isinstance(input, str):
             input = int(input)
         if isinstance(amount, str):
@@ -52,11 +44,5 @@ class MathPlugin:
 
     @staticmethod
     def add_or_subtract(input: int, amount: int, add: bool) -> int:
-        """Helper function to perform addition or subtraction based on the add flag.
-
-        :param initial_value_text: Initial value as string to add or subtract the specified amount
-        :param context: Contains the context to get the numbers from
-        :param add: If True, performs addition, otherwise performs subtraction
-        :return: The resulting sum or subtraction as a string
-        """
+        """Helper function to perform addition or subtraction based on the add flag."""
         return input + amount if add else input - amount

--- a/python/semantic_kernel/functions/kernel_function_from_prompt.py
+++ b/python/semantic_kernel/functions/kernel_function_from_prompt.py
@@ -170,8 +170,8 @@ through prompt_template_config or in the prompt_template."
 
             # pass the kernel in for auto function calling
             kwargs: dict[str, Any] = {}
-            if hasattr(prompt_render_result.execution_settings, "function_choice_behavior"):
-                kwargs["kernel"] = context.kernel
+            kwargs["kernel"] = context.kernel
+            if hasattr(prompt_render_result.execution_settings, "function_call_behavior"):
                 kwargs["arguments"] = context.arguments
 
             try:

--- a/python/semantic_kernel/functions/kernel_function_from_prompt.py
+++ b/python/semantic_kernel/functions/kernel_function_from_prompt.py
@@ -167,18 +167,11 @@ through prompt_template_config or in the prompt_template."
 
         if isinstance(prompt_render_result.ai_service, ChatCompletionClientBase):
             chat_history = ChatHistory.from_rendered_prompt(prompt_render_result.rendered_prompt)
-
-            # pass the kernel in for auto function calling
-            kwargs: dict[str, Any] = {}
-            kwargs["kernel"] = context.kernel
-            if hasattr(prompt_render_result.execution_settings, "function_call_behavior"):
-                kwargs["arguments"] = context.arguments
-
             try:
                 chat_message_contents = await prompt_render_result.ai_service.get_chat_message_contents(
                     chat_history=chat_history,
                     settings=prompt_render_result.execution_settings,
-                    **kwargs,
+                    **{"kernel": context.kernel, "arguments": context.arguments},
                 )
             except Exception as exc:
                 raise FunctionExecutionException(f"Error occurred while invoking function {self.name}: {exc}") from exc
@@ -211,18 +204,11 @@ through prompt_template_config or in the prompt_template."
         prompt_render_result = await self._render_prompt(context)
 
         if isinstance(prompt_render_result.ai_service, ChatCompletionClientBase):
-            # pass the kernel in for auto function calling
-            kwargs: dict[str, Any] = {}
-            if hasattr(prompt_render_result.execution_settings, "function_choice_behavior"):
-                kwargs["kernel"] = context.kernel
-                kwargs["arguments"] = context.arguments
-
             chat_history = ChatHistory.from_rendered_prompt(prompt_render_result.rendered_prompt)
-
             value: AsyncGenerator = prompt_render_result.ai_service.get_streaming_chat_message_contents(
                 chat_history=chat_history,
                 settings=prompt_render_result.execution_settings,
-                **kwargs,
+                **{"kernel": context.kernel, "arguments": context.arguments},
             )
         elif isinstance(prompt_render_result.ai_service, TextCompletionClientBase):
             value = prompt_render_result.ai_service.get_streaming_text_contents(

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -6,10 +6,7 @@ from copy import copy
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from semantic_kernel.const import METADATA_EXCEPTION_KEY
-<< << << < HEAD
 from semantic_kernel.contents.chat_history import ChatHistory
-== == == =
->> >> >> > 2c21c804f(cleanup)
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.contents.streaming_content_mixin import StreamingContentMixin
@@ -320,13 +317,13 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         self,
         function_call: FunctionCallContent,
         chat_history: ChatHistory,
-        arguments: "KernelArguments",
+        arguments: "KernelArguments | None" = None,
         function_call_count: int | None = None,
         request_index: int | None = None,
         function_behavior: "FunctionChoiceBehavior" = None,  # type: ignore
     ) -> "AutoFunctionInvocationContext | None":
         """Processes the provided FunctionCallContent and updates the chat history."""
-        args_cloned = copy(arguments)
+        args_cloned = copy(arguments) if arguments else KernelArguments()
         try:
             parsed_args = function_call.to_kernel_arguments()
             if parsed_args:
@@ -389,8 +386,8 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
             arguments=args_cloned,
             chat_history=chat_history,
             function_result=FunctionResult(function=function_to_call.metadata, value=None),
-            function_count=function_call_count,
-            request_sequence_index=request_index,
+            function_count=function_call_count or 0,
+            request_sequence_index=request_index or 0,
         )
         if function_call.index is not None:
             invocation_context.function_sequence_index = function_call.index

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -6,7 +6,10 @@ from copy import copy
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from semantic_kernel.const import METADATA_EXCEPTION_KEY
+<< << << < HEAD
 from semantic_kernel.contents.chat_history import ChatHistory
+== == == =
+>> >> >> > 2c21c804f(cleanup)
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.contents.streaming_content_mixin import StreamingContentMixin
@@ -36,6 +39,7 @@ from semantic_kernel.prompt_template.const import KERNEL_TEMPLATE_FORMAT_NAME
 from semantic_kernel.reliability.kernel_reliability_extension import KernelReliabilityExtension
 from semantic_kernel.services.ai_service_selector import AIServiceSelector
 from semantic_kernel.services.kernel_services_extension import KernelServicesExtension
+from semantic_kernel.utils.naming import generate_random_ascii_name
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.function_choice_behavior import (
@@ -128,6 +132,8 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         """
         if arguments is None:
             arguments = KernelArguments(**kwargs)
+        else:
+            arguments.update(kwargs)
         if not function:
             if not function_name or not plugin_name:
                 raise KernelFunctionNotFoundError("No function(s) or function- and plugin-name provided")
@@ -207,9 +213,9 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
 
     async def invoke_prompt(
         self,
-        function_name: str,
-        plugin_name: str,
         prompt: str,
+        function_name: str | None = None,
+        plugin_name: str | None = None,
         arguments: KernelArguments | None = None,
         template_format: Literal[
             "semantic-kernel",
@@ -221,9 +227,9 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         """Invoke a function from the provided prompt.
 
         Args:
-            function_name (str): The name of the function
-            plugin_name (str): The name of the plugin
             prompt (str): The prompt to use
+            function_name (str): The name of the function, optional
+            plugin_name (str): The name of the plugin, optional
             arguments (KernelArguments | None): The arguments to pass to the function(s), optional
             template_format (str | None): The format of the prompt template
             kwargs (dict[str, Any]): arguments that can be used instead of supplying KernelArguments
@@ -237,7 +243,7 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
             raise TemplateSyntaxError("The prompt is either null or empty.")
 
         function = KernelFunctionFromPrompt(
-            function_name=function_name,
+            function_name=function_name or generate_random_ascii_name(),
             plugin_name=plugin_name,
             prompt=prompt,
             template_format=template_format,
@@ -246,9 +252,9 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
 
     async def invoke_prompt_stream(
         self,
-        function_name: str,
-        plugin_name: str,
         prompt: str,
+        function_name: str | None = None,
+        plugin_name: str | None = None,
         arguments: KernelArguments | None = None,
         template_format: Literal[
             "semantic-kernel",
@@ -261,9 +267,9 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         """Invoke a function from the provided prompt and stream the results.
 
         Args:
-            function_name (str): The name of the function
-            plugin_name (str): The name of the plugin
             prompt (str): The prompt to use
+            function_name (str): The name of the function, optional
+            plugin_name (str): The name of the plugin, optional
             arguments (KernelArguments | None): The arguments to pass to the function(s), optional
             template_format (str | None): The format of the prompt template
             return_function_results (bool): If True, the function results are yielded as a list[FunctionResult]
@@ -280,7 +286,7 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         from semantic_kernel.functions.kernel_function_from_prompt import KernelFunctionFromPrompt
 
         function = KernelFunctionFromPrompt(
-            function_name=function_name,
+            function_name=function_name or generate_random_ascii_name(),
             plugin_name=plugin_name,
             prompt=prompt,
             template_format=template_format,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This introduces a sample that uses function calling with a local model, Nexus Raven V2, in this case using the API, but the same model can be loaded using the Hugging Face Connection, the class here is highly adapted and specific to Nexus including parsing the returned function call value, into FunctionCallContent and then running that.
It then returns one or more ChatMessageContents with the function call content and function result content which can then be shared with a OpenAI call.

Error handling improvements:

* [`python/semantic_kernel/contents/chat_history.py`](diffhunk://#diff-b57a30f97fec1a91bbf6f7d15584473a8f0cf409797bdcd90d8c80bedc670892L266-R267): Improved error logging when parsing prompts as XML fails.
* [`python/semantic_kernel/contents/function_result_content.py`](diffhunk://#diff-3b69e6aedf4c29038cdff0ac99602b70583ab6c85f7bd777b08ad96b7fa48d87L7-R10): Removed field validator for `result` and allow result to be any value, instead of casting everything to string. [[1]](diffhunk://#diff-3b69e6aedf4c29038cdff0ac99602b70583ab6c85f7bd777b08ad96b7fa48d87L7-R10) [[2]](diffhunk://#diff-3b69e6aedf4c29038cdff0ac99602b70583ab6c85f7bd777b08ad96b7fa48d87L50-R51) [[3]](diffhunk://#diff-3b69e6aedf4c29038cdff0ac99602b70583ab6c85f7bd777b08ad96b7fa48d87L63-L69) [[4]](diffhunk://#diff-3b69e6aedf4c29038cdff0ac99602b70583ab6c85f7bd777b08ad96b7fa48d87R92-R115)

Minor changes:

* [`python/semantic_kernel/core_plugins/math_plugin.py`](diffhunk://#diff-632444474bd3ea991b4409dfd0ab194e0789c73617bef4a3dcae4db5c4b0b6c0L32-R38): Removed some docstrings for clarity. [[1]](diffhunk://#diff-632444474bd3ea991b4409dfd0ab194e0789c73617bef4a3dcae4db5c4b0b6c0L32-R38) [[2]](diffhunk://#diff-632444474bd3ea991b4409dfd0ab194e0789c73617bef4a3dcae4db5c4b0b6c0L55-R47)
* [`python/semantic_kernel/functions/kernel_function_from_prompt.py`](diffhunk://#diff-eabd53da2ec241cce6f92de85283065e7b478d62cefb52817c5b29ff07e28189L173-R174): Changed the order of condition checks for better readability.
* [`python/semantic_kernel/kernel.py`](diffhunk://#diff-3db6fe98818eda0b824788901c718d35eac8b13d0ff428d3dfd417866d922d3aR9-R10): Added functionality to update kernel arguments in `invoke_stream` method and made `function_name` and `plugin_name` optional in `invoke_prompt` method. [[1]](diffhunk://#diff-3db6fe98818eda0b824788901c718d35eac8b13d0ff428d3dfd417866d922d3aR9-R10) [[2]](diffhunk://#diff-3db6fe98818eda0b824788901c718d35eac8b13d0ff428d3dfd417866d922d3aR29) [[3]](diffhunk://#diff-3db6fe98818eda0b824788901c718d35eac8b13d0ff428d3dfd417866d922d3aR119-R120) [[4]](diffhunk://#diff-3db6fe98818eda0b824788901c718d35eac8b13d0ff428d3dfd417866d922d3aL195-R202) [[5]](diffhunk://#diff-3db6fe98818eda0b824788901c718d35eac8b13d0ff428d3dfd417866d922d3aL209-R216)

Closes #6804
Closes #6944

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
