### PR TITLE
.Net - Convert message `AuthorName` whitespace or empty string assignment to `null`

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
@@ -20,7 +20,12 @@ public class ChatMessageContent : KernelContent
     /// </summary>
     [Experimental("SKEXP0001")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? AuthorName { get; set; }
+    public string? AuthorName
+    {
+        get => this._authorName;
+        set => this._authorName = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
 
     /// <summary>
     /// Role of the author of the message
@@ -171,4 +176,5 @@ public class ChatMessageContent : KernelContent
 
     private ChatMessageContentItemCollection? _items;
     private Encoding _encoding;
+    private string? _authorName;
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
@@ -26,7 +26,6 @@ public class ChatMessageContent : KernelContent
         set => this._authorName = string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
-
     /// <summary>
     /// Role of the author of the message
     /// </summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/StreamingChatMessageContent.cs
@@ -64,7 +64,11 @@ public class StreamingChatMessageContent : StreamingKernelContent
     /// </summary>
     [Experimental("SKEXP0001")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? AuthorName { get; set; }
+    public string? AuthorName
+    {
+        get => this._authorName;
+        set => this._authorName = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
 
     /// <summary>
     /// Role of the author of the message
@@ -126,4 +130,5 @@ public class StreamingChatMessageContent : StreamingKernelContent
 
     private StreamingKernelContentItemCollection? _items;
     private Encoding _encoding;
+    private string? _authorName;
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Contents/ChatMessageContentTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Contents/ChatMessageContentTests.cs
@@ -128,6 +128,25 @@ public class ChatMessageContentTests
         Assert.Equal("fake-content-1", sut.Content);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void ContentPropertySetterShouldConvertEmptyOrWhitespaceAuthorNameToNull(string? authorName)
+    {
+        // Arrange
+        var message = new ChatMessageContent(AuthorRole.User, content: null)
+        {
+            AuthorName = authorName
+        };
+
+        // Assert
+        Assert.Null(message.AuthorName);
+    }
+
     [Fact]
     public void ItShouldBePossibleToSetAndGetEncodingEvenIfThereAreNoItems()
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Contents/StreamingChatMessageContentTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Contents/StreamingChatMessageContentTests.cs
@@ -118,6 +118,25 @@ public class StreamingChatMessageContentTests
         Assert.Equal("fake-content-1", sut.Content);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void ContentPropertySetterShouldConvertEmptyOrWhitespaceAuthorNameToNull(string? authorName)
+    {
+        // Arrange
+        var message = new ChatMessageContent(AuthorRole.User, content: null)
+        {
+            AuthorName = authorName
+        };
+
+        // Assert
+        Assert.Null(message.AuthorName);
+    }
+
     [Fact]
     public void ItShouldBePossibleToSetAndGetEncodingEvenIfThereAreNoItems()
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Contents/StreamingChatMessageContentTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Contents/StreamingChatMessageContentTests.cs
@@ -128,7 +128,7 @@ public class StreamingChatMessageContentTests
     public void ContentPropertySetterShouldConvertEmptyOrWhitespaceAuthorNameToNull(string? authorName)
     {
         // Arrange
-        var message = new ChatMessageContent(AuthorRole.User, content: null)
+        var message = new StreamingChatMessageContent(AuthorRole.User, content: null)
         {
             AuthorName = authorName
         };


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Assist caller in avoiding an improper assignmemt of:

- `ChatMessageContent.AuthorRole`
- `StreamingChatMessageContent.AuthorRole`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Inadvertent assignment of an empty string (or whitespace) to `ChatMessageContant.AuthorName ` results in an `HttpOperationException` when using the message as input to `IChatCompletionService`.

While it may be ideal for caller to take care to _not_ assign such a value, intercepting this state at the earliest possible moment reduces debugging confusion. 

> Stronger validation may not be appropriate as it may be model specific.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
