### PR TITLE
.Net: VectorStore: Adding unit tests for the Qdrant vector record store.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Connectors.Memory.Qdrant.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.SemanticKernel.Connectors.Qdrant.UnitTests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Decorator class for <see cref="QdrantClient"/> that exposes the required methods as virtual allowing for mocking in unit tests.
+/// </summary>
+internal class MockableQdrantClient
+{
+    /// <summary>Qdrant client that can be used to manage the collections and points in a Qdrant store.</summary>
+    private readonly QdrantClient _qdrantClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MockableQdrantClient"/> class.
+    /// </summary>
+    /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
+    public MockableQdrantClient(QdrantClient qdrantClient)
+    {
+        Verify.NotNull(qdrantClient);
+        this._qdrantClient = qdrantClient;
+    }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    /// <summary>
+    /// Constructor for mocking purposes only.
+    /// </summary>
+    internal MockableQdrantClient()
+    {
+    }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+    /// <summary>
+    /// Delete a point.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="id">The ID to delete.</param>
+    /// <param name="wait">Whether to wait until the changes have been applied. Defaults to <c>true</c>.</param>
+	/// <param name="ordering">Write ordering guarantees. Defaults to <c>Weak</c>.</param>
+	/// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<UpdateResult> DeleteAsync(
+        string collectionName,
+        ulong id,
+        bool wait = true,
+        WriteOrderingType? ordering = null,
+        ShardKeySelector? shardKeySelector = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.DeleteAsync(collectionName, id, wait, ordering, shardKeySelector, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Delete a point.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="id">The ID to delete.</param>
+    /// <param name="wait">Whether to wait until the changes have been applied. Defaults to <c>true</c>.</param>
+	/// <param name="ordering">Write ordering guarantees. Defaults to <c>Weak</c>.</param>
+	/// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<UpdateResult> DeleteAsync(
+        string collectionName,
+        Guid id,
+        bool wait = true,
+        WriteOrderingType? ordering = null,
+        ShardKeySelector? shardKeySelector = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.DeleteAsync(collectionName, id, wait, ordering, shardKeySelector, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Delete a point.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="ids">The IDs to delete.</param>
+    /// <param name="wait">Whether to wait until the changes have been applied. Defaults to <c>true</c>.</param>
+	/// <param name="ordering">Write ordering guarantees. Defaults to <c>Weak</c>.</param>
+	/// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<UpdateResult> DeleteAsync(
+        string collectionName,
+        IReadOnlyList<ulong> ids,
+        bool wait = true,
+        WriteOrderingType? ordering = null,
+        ShardKeySelector? shardKeySelector = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.DeleteAsync(collectionName, ids, wait, ordering, shardKeySelector, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Delete a point.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="ids">The IDs to delete.</param>
+    /// <param name="wait">Whether to wait until the changes have been applied. Defaults to <c>true</c>.</param>
+	/// <param name="ordering">Write ordering guarantees. Defaults to <c>Weak</c>.</param>
+	/// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<UpdateResult> DeleteAsync(
+        string collectionName,
+        IReadOnlyList<Guid> ids,
+        bool wait = true,
+        WriteOrderingType? ordering = null,
+        ShardKeySelector? shardKeySelector = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.DeleteAsync(collectionName, ids, wait, ordering, shardKeySelector, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Perform insert and updates on points. If a point with a given ID already exists, it will be overwritten.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="points">The points to be upserted.</param>
+    /// <param name="wait">Whether to wait until the changes have been applied. Defaults to <c>true</c>.</param>
+    /// <param name="ordering">Write ordering guarantees.</param>
+    /// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<UpdateResult> UpsertAsync(
+        string collectionName,
+        IReadOnlyList<PointStruct> points,
+        bool wait = true,
+        WriteOrderingType? ordering = null,
+        ShardKeySelector? shardKeySelector = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.UpsertAsync(collectionName, points, wait, ordering, shardKeySelector, cancellationToken);
+
+    /// <summary>
+    /// Retrieve points.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="ids">List of points to retrieve.</param>
+    /// <param name="withPayload">Whether to include the payload or not.</param>
+    /// <param name="withVectors">Whether to include the vectors or not.</param>
+    /// <param name="readConsistency">Options for specifying read consistency guarantees.</param>
+    /// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<IReadOnlyList<RetrievedPoint>> RetrieveAsync(
+        string collectionName,
+        IReadOnlyList<PointId> ids,
+        bool withPayload = true,
+        bool withVectors = false,
+        ReadConsistency? readConsistency = null,
+        ShardKeySelector? shardKeySelector = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.RetrieveAsync(collectionName, ids, withPayload, withVectors, readConsistency, shardKeySelector, cancellationToken);
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -30,7 +30,7 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
     private const string DeleteName = "Delete";
 
     /// <summary>Qdrant client that can be used to manage the collections and points in a Qdrant store.</summary>
-    private readonly QdrantClient _qdrantClient;
+    private readonly MockableQdrantClient _qdrantClient;
 
     /// <summary>Optional configuration options for this class.</summary>
     private readonly QdrantVectorRecordStoreOptions<TRecord> _options;
@@ -43,9 +43,21 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
     /// </summary>
     /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="qdrantClient"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown for any misconfigured options.</exception>
     public QdrantVectorRecordStore(QdrantClient qdrantClient, QdrantVectorRecordStoreOptions<TRecord>? options = null)
+        : this(new MockableQdrantClient(qdrantClient), options)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+    /// </summary>
+    /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    /// <exception cref="ArgumentNullException">Thrown if the <paramref name="qdrantClient"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown for any misconfigured options.</exception>
+    internal QdrantVectorRecordStore(MockableQdrantClient qdrantClient, QdrantVectorRecordStoreOptions<TRecord>? options = null)
     {
         // Verify.
         Verify.NotNull(qdrantClient);

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -65,7 +65,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
     /// <param name="database">The redis database to read/write records from.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     /// <exception cref="ArgumentNullException">Throw when parameters are invalid.</exception>
-    public RedisVectorRecordStore(IDatabase database, RedisVectorRecordStoreOptions<TRecord>? options)
+    public RedisVectorRecordStore(IDatabase database, RedisVectorRecordStoreOptions<TRecord>? options = null)
     {
         // Verify.
         Verify.NotNull(database);

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
@@ -34,23 +34,7 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(TestOptions))]
-    public Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
-    {
-        if (keyType == typeof(ulong))
-        {
-            return this.CanGetRecordWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
-        }
-
-        if (keyType == typeof(Guid))
-        {
-            return this.CanGetRecordWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
-        }
-
-        Assert.Fail("No valid key type provided.");
-        return Task.CompletedTask;
-    }
-
-    private async Task CanGetRecordWithVectorsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    public async Task CanGetRecordWithVectorsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
     {
         var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
 
@@ -89,23 +73,7 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(TestOptions))]
-    public Task CanGetRecordWithoutVectorsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
-    {
-        if (keyType == typeof(ulong))
-        {
-            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
-        }
-
-        if (keyType == typeof(Guid))
-        {
-            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
-        }
-
-        Assert.Fail("No valid key type provided.");
-        return Task.CompletedTask;
-    }
-
-    private async Task CanGetRecordWithoutVectorsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    public async Task CanGetRecordWithoutVectorsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
     {
         // Arrange.
         var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
@@ -142,24 +110,8 @@ public class QdrantVectorRecordStoreTests
     }
 
     [Theory]
-    [MemberData(nameof(TestOptions))]
-    public Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
-    {
-        if (keyType == typeof(ulong))
-        {
-            return this.CanGetManyRecordsWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, [UlongTestRecordKey1, UlongTestRecordKey2]);
-        }
-
-        if (keyType == typeof(Guid))
-        {
-            return this.CanGetManyRecordsWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, [s_guidTestRecordKey1, s_guidTestRecordKey2]);
-        }
-
-        Assert.Fail("No valid key type provided.");
-        return Task.CompletedTask;
-    }
-
-    private async Task CanGetManyRecordsWithVectorsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
+    [MemberData(nameof(MultiRecordTestOptions))]
+    public async Task CanGetManyRecordsWithVectorsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
     {
         // Arrange.
         var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
@@ -395,23 +347,7 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(TestOptions))]
-    public Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
-    {
-        if (keyType == typeof(ulong))
-        {
-            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
-        }
-
-        if (keyType == typeof(Guid))
-        {
-            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
-        }
-
-        Assert.Fail("No valid key type provided.");
-        return Task.CompletedTask;
-    }
-
-    private async Task CanUpsertRecordInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    public async Task CanUpsertRecordAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
     {
         // Arrange
         var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
@@ -440,24 +376,8 @@ public class QdrantVectorRecordStoreTests
     }
 
     [Theory]
-    [MemberData(nameof(TestOptions))]
-    public Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
-    {
-        if (keyType == typeof(ulong))
-        {
-            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
-        }
-
-        if (keyType == typeof(Guid))
-        {
-            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
-        }
-
-        Assert.Fail("No valid key type provided.");
-        return Task.CompletedTask;
-    }
-
-    private async Task CanUpsertManyRecordsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
+    [MemberData(nameof(MultiRecordTestOptions))]
+    public async Task CanUpsertManyRecordsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
     {
         // Arrange
         var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
@@ -697,8 +617,16 @@ public class QdrantVectorRecordStoreTests
                 new object[] { true, false },
                 new object[] { true, false },
                 new object[] { true, false },
-                new object[] { typeof(ulong), typeof(Guid) }
+                new object[] { UlongTestRecordKey1, s_guidTestRecordKey1 }
         });
+
+    public static IEnumerable<object[]> MultiRecordTestOptions
+    => GenerateAllCombinations(new object[][] {
+                new object[] { true, false },
+                new object[] { true, false },
+                new object[] { true, false },
+                new object[] { new ulong[] { UlongTestRecordKey1, UlongTestRecordKey2 }, new Guid[] { s_guidTestRecordKey1, s_guidTestRecordKey2 } }
+    });
 
     private static object[][] GenerateAllCombinations(object[][] input)
     {

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
@@ -1,0 +1,731 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Memory;
+using Moq;
+using Qdrant.Client.Grpc;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+/// </summary>
+public class QdrantVectorRecordStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+    private const ulong UlongTestRecordKey1 = 1;
+    private const ulong UlongTestRecordKey2 = 2;
+    private static readonly Guid s_guidTestRecordKey1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid s_guidTestRecordKey2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly Mock<MockableQdrantClient> _qdrantClientMock;
+
+    private readonly CancellationToken _testCancellationToken = new(false);
+
+    public QdrantVectorRecordStoreTests()
+    {
+        this._qdrantClientMock = new Mock<MockableQdrantClient>(MockBehavior.Strict);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestOptions))]
+    public Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
+    {
+        if (keyType == typeof(ulong))
+        {
+            return this.CanGetRecordWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
+        }
+
+        if (keyType == typeof(Guid))
+        {
+            return this.CanGetRecordWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
+        }
+
+        Assert.Fail("No valid key type provided.");
+        return Task.CompletedTask;
+    }
+
+    private async Task CanGetRecordWithVectorsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    {
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+
+        // Arrange.
+        var retrievedPoint = CreateRetrievedPoint(hasNamedVectors, testRecordKey);
+        this.SetupRetrieveMock([retrievedPoint]);
+
+        // Act.
+        var actual = await sut.GetAsync(
+            testRecordKey,
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert.
+        this._qdrantClientMock
+            .Verify(
+                x => x.RetrieveAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<PointId>>(x => x.Count == 1 && (testRecordKey!.GetType() == typeof(ulong) && x[0].Num == (testRecordKey as ulong?) || testRecordKey!.GetType() == typeof(Guid) && x[0].Uuid == (testRecordKey as Guid?).ToString())),
+                    true,
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+
+        Assert.NotNull(actual);
+        Assert.Equal(testRecordKey, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+    }
+
+    [Theory]
+    [MemberData(nameof(TestOptions))]
+    public Task CanGetRecordWithoutVectorsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
+    {
+        if (keyType == typeof(ulong))
+        {
+            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
+        }
+
+        if (keyType == typeof(Guid))
+        {
+            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
+        }
+
+        Assert.Fail("No valid key type provided.");
+        return Task.CompletedTask;
+    }
+
+    private async Task CanGetRecordWithoutVectorsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    {
+        // Arrange.
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var retrievedPoint = CreateRetrievedPoint(hasNamedVectors, testRecordKey);
+        this.SetupRetrieveMock([retrievedPoint]);
+
+        // Act.
+        var actual = await sut.GetAsync(
+            testRecordKey,
+            new()
+            {
+                IncludeVectors = false,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert.
+        this._qdrantClientMock
+            .Verify(
+                x => x.RetrieveAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<PointId>>(x => x.Count == 1 && (testRecordKey!.GetType() == typeof(ulong) && x[0].Num == (testRecordKey as ulong?) || testRecordKey!.GetType() == typeof(Guid) && x[0].Uuid == (testRecordKey as Guid?).ToString())),
+                    true,
+                    false,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+
+        Assert.NotNull(actual);
+        Assert.Equal(testRecordKey, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.Null(actual.Vector);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestOptions))]
+    public Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
+    {
+        if (keyType == typeof(ulong))
+        {
+            return this.CanGetManyRecordsWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, [UlongTestRecordKey1, UlongTestRecordKey2]);
+        }
+
+        if (keyType == typeof(Guid))
+        {
+            return this.CanGetManyRecordsWithVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, [s_guidTestRecordKey1, s_guidTestRecordKey2]);
+        }
+
+        Assert.Fail("No valid key type provided.");
+        return Task.CompletedTask;
+    }
+
+    private async Task CanGetManyRecordsWithVectorsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
+    {
+        // Arrange.
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var retrievedPoint1 = CreateRetrievedPoint(hasNamedVectors, UlongTestRecordKey1);
+        var retrievedPoint2 = CreateRetrievedPoint(hasNamedVectors, UlongTestRecordKey2);
+        this.SetupRetrieveMock(testRecordKeys.Select(x => CreateRetrievedPoint(hasNamedVectors, x)).ToList());
+
+        // Act.
+        var actual = await sut.GetBatchAsync(
+            testRecordKeys,
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert.
+        this._qdrantClientMock
+            .Verify(
+                x => x.RetrieveAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<PointId>>(x =>
+                        x.Count == 2 &&
+                        (testRecordKeys[0]!.GetType() == typeof(ulong) && x[0].Num == (testRecordKeys[0] as ulong?) || testRecordKeys[0]!.GetType() == typeof(Guid) && x[0].Uuid == (testRecordKeys[0] as Guid?).ToString()) &&
+                        (testRecordKeys[1]!.GetType() == typeof(ulong) && x[1].Num == (testRecordKeys[1] as ulong?) || testRecordKeys[1]!.GetType() == typeof(Guid) && x[1].Uuid == (testRecordKeys[1] as Guid?).ToString())),
+                    true,
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(testRecordKeys[0], actual[0].Key);
+        Assert.Equal(testRecordKeys[1], actual[1].Key);
+    }
+
+    [Fact]
+    public async Task CanGetRecordWithCustomMapperAsync()
+    {
+        // Arrange.
+        var retrievedPoint = CreateRetrievedPoint(true, UlongTestRecordKey1);
+        this.SetupRetrieveMock([retrievedPoint]);
+
+        // Arrange mapper mock from PointStruct to data model.
+        var mapperMock = new Mock<IVectorStoreRecordMapper<SinglePropsModel<ulong>, PointStruct>>(MockBehavior.Strict);
+        mapperMock.Setup(
+            x => x.MapFromStorageToDataModel(
+                It.IsAny<PointStruct>(),
+                It.IsAny<StorageToDataModelMapperOptions>()))
+            .Returns(CreateModel(UlongTestRecordKey1, true));
+
+        // Arrange target with custom mapper.
+        var sut = new QdrantVectorRecordStore<SinglePropsModel<ulong>>(
+            this._qdrantClientMock.Object,
+            new()
+            {
+                DefaultCollectionName = TestCollectionName,
+                HasNamedVectors = true,
+                MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper,
+                PointStructCustomMapper = mapperMock.Object
+            });
+
+        // Act
+        var actual = await sut.GetAsync(
+            UlongTestRecordKey1,
+            new() { IncludeVectors = true },
+            this._testCancellationToken);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(UlongTestRecordKey1, actual.Key);
+        Assert.Equal("data 1", actual.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+
+        mapperMock
+            .Verify(
+                x => x.MapFromStorageToDataModel(
+                    It.Is<PointStruct>(x => x.Id.Num == UlongTestRecordKey1),
+                    It.Is<StorageToDataModelMapperOptions>(x => x.IncludeVectors)),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, false, false)]
+    public async Task CanDeleteUlongRecordAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    {
+        // Arrange
+        var sut = this.CreateVectorRecordStore<ulong>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        this.SetupDeleteMocks();
+
+        // Act
+        await sut.DeleteAsync(
+            UlongTestRecordKey1,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        this._qdrantClientMock
+            .Verify(
+                x => x.DeleteAsync(
+                    TestCollectionName,
+                    It.Is<ulong>(x => x == UlongTestRecordKey1),
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, false, false)]
+    public async Task CanDeleteGuidRecordAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    {
+        // Arrange
+        var sut = this.CreateVectorRecordStore<Guid>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        this.SetupDeleteMocks();
+
+        // Act
+        await sut.DeleteAsync(
+            s_guidTestRecordKey1,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        this._qdrantClientMock
+            .Verify(
+                x => x.DeleteAsync(
+                    TestCollectionName,
+                    It.Is<Guid>(x => x == s_guidTestRecordKey1),
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, false, false)]
+    public async Task CanDeleteManyUlongRecordsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    {
+        // Arrange
+        var sut = this.CreateVectorRecordStore<ulong>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        this.SetupDeleteMocks();
+
+        // Act
+        await sut.DeleteBatchAsync(
+            [UlongTestRecordKey1, UlongTestRecordKey2],
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        this._qdrantClientMock
+            .Verify(
+                x => x.DeleteAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<ulong>>(x => x.Count == 2 && x.Contains(UlongTestRecordKey1) && x.Contains(UlongTestRecordKey2)),
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, false, false)]
+    public async Task CanDeleteManyGuidRecordsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    {
+        // Arrange
+        var sut = this.CreateVectorRecordStore<Guid>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        this.SetupDeleteMocks();
+
+        // Act
+        await sut.DeleteBatchAsync(
+            [s_guidTestRecordKey1, s_guidTestRecordKey2],
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        this._qdrantClientMock
+            .Verify(
+                x => x.DeleteAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<Guid>>(x => x.Count == 2 && x.Contains(s_guidTestRecordKey1) && x.Contains(s_guidTestRecordKey2)),
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestOptions))]
+    public Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
+    {
+        if (keyType == typeof(ulong))
+        {
+            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
+        }
+
+        if (keyType == typeof(Guid))
+        {
+            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
+        }
+
+        Assert.Fail("No valid key type provided.");
+        return Task.CompletedTask;
+    }
+
+    private async Task CanUpsertRecordInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    {
+        // Arrange
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        this.SetupUpsertMock();
+
+        // Act
+        await sut.UpsertAsync(
+            CreateModel(testRecordKey, true),
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        this._qdrantClientMock
+            .Verify(
+                x => x.UpsertAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<PointStruct>>(x => x.Count == 1 && (testRecordKey!.GetType() == typeof(ulong) && x[0].Id.Num == (testRecordKey as ulong?) || testRecordKey!.GetType() == typeof(Guid) && x[0].Id.Uuid == (testRecordKey as Guid?).ToString())),
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestOptions))]
+    public Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, Type keyType)
+    {
+        if (keyType == typeof(ulong))
+        {
+            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, UlongTestRecordKey1);
+        }
+
+        if (keyType == typeof(Guid))
+        {
+            return this.CanGetRecordWithoutVectorsInternalAsync(useDefinition, passCollectionToMethod, hasNamedVectors, s_guidTestRecordKey1);
+        }
+
+        Assert.Fail("No valid key type provided.");
+        return Task.CompletedTask;
+    }
+
+    private async Task CanUpsertManyRecordsInternalAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
+    {
+        // Arrange
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        this.SetupUpsertMock();
+
+        var models = testRecordKeys.Select(x => CreateModel(x, true));
+
+        // Act
+        var actual = await sut.UpsertBatchAsync(
+            models,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(testRecordKeys[0], actual[0]);
+        Assert.Equal(testRecordKeys[1], actual[1]);
+
+        this._qdrantClientMock
+            .Verify(
+                x => x.UpsertAsync(
+                    TestCollectionName,
+                    It.Is<IReadOnlyList<PointStruct>>(x =>
+                        x.Count == 2 &&
+                        (testRecordKeys[0]!.GetType() == typeof(ulong) && x[0].Id.Num == (testRecordKeys[0] as ulong?) || testRecordKeys[0]!.GetType() == typeof(Guid) && x[0].Id.Uuid == (testRecordKeys[0] as Guid?).ToString()) &&
+                        (testRecordKeys[1]!.GetType() == typeof(ulong) && x[1].Id.Num == (testRecordKeys[1] as ulong?) || testRecordKeys[1]!.GetType() == typeof(Guid) && x[1].Id.Uuid == (testRecordKeys[1] as Guid?).ToString())),
+                    true,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+    }
+
+    [Fact]
+    public async Task CanUpsertRecordWithCustomMapperAsync()
+    {
+        // Arrange.
+        this.SetupUpsertMock();
+        var pointStruct = new PointStruct
+        {
+            Id = new() { Num = UlongTestRecordKey1 },
+            Payload = { ["Data"] = "data 1" },
+            Vectors = new[] { 1f, 2f, 3f, 4f }
+        };
+
+        // Arrange mapper mock from data model to PointStruct.
+        var mapperMock = new Mock<IVectorStoreRecordMapper<SinglePropsModel<ulong>, PointStruct>>(MockBehavior.Strict);
+        mapperMock
+            .Setup(x => x.MapFromDataToStorageModel(It.IsAny<SinglePropsModel<ulong>>()))
+            .Returns(pointStruct);
+
+        // Arrange target with custom mapper.
+        var sut = new QdrantVectorRecordStore<SinglePropsModel<ulong>>(
+            this._qdrantClientMock.Object,
+            new()
+            {
+                DefaultCollectionName = TestCollectionName,
+                HasNamedVectors = false,
+                MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper,
+                PointStructCustomMapper = mapperMock.Object
+            });
+
+        var model = CreateModel(UlongTestRecordKey1, true);
+
+        // Act
+        await sut.UpsertAsync(
+            model,
+            null,
+            this._testCancellationToken);
+
+        // Assert
+        mapperMock
+            .Verify(
+                x => x.MapFromDataToStorageModel(It.Is<SinglePropsModel<ulong>>(x => x == model)),
+                Times.Once);
+    }
+
+    private void SetupRetrieveMock(List<RetrievedPoint> retrievedPoints)
+    {
+        this._qdrantClientMock
+            .Setup(x => x.RetrieveAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<PointId>>(),
+                It.IsAny<bool>(), // With Payload
+                It.IsAny<bool>(), // With Vectors
+                It.IsAny<ReadConsistency>(),
+                It.IsAny<ShardKeySelector>(),
+                this._testCancellationToken))
+            .ReturnsAsync(retrievedPoints);
+    }
+
+    private void SetupDeleteMocks()
+    {
+        this._qdrantClientMock
+            .Setup(x => x.DeleteAsync(
+                It.IsAny<string>(),
+                It.IsAny<ulong>(),
+                It.IsAny<bool>(), // wait
+                It.IsAny<WriteOrderingType?>(),
+                It.IsAny<ShardKeySelector?>(),
+                this._testCancellationToken))
+            .ReturnsAsync(new UpdateResult());
+
+        this._qdrantClientMock
+            .Setup(x => x.DeleteAsync(
+                It.IsAny<string>(),
+                It.IsAny<Guid>(),
+                It.IsAny<bool>(), // wait
+                It.IsAny<WriteOrderingType?>(),
+                It.IsAny<ShardKeySelector?>(),
+                this._testCancellationToken))
+            .ReturnsAsync(new UpdateResult());
+
+        this._qdrantClientMock
+            .Setup(x => x.DeleteAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<ulong>>(),
+                It.IsAny<bool>(), // wait
+                It.IsAny<WriteOrderingType?>(),
+                It.IsAny<ShardKeySelector?>(),
+                this._testCancellationToken))
+            .ReturnsAsync(new UpdateResult());
+
+        this._qdrantClientMock
+            .Setup(x => x.DeleteAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<Guid>>(),
+                It.IsAny<bool>(), // wait
+                It.IsAny<WriteOrderingType?>(),
+                It.IsAny<ShardKeySelector?>(),
+                this._testCancellationToken))
+            .ReturnsAsync(new UpdateResult());
+    }
+
+    private void SetupUpsertMock()
+    {
+        this._qdrantClientMock
+            .Setup(x => x.UpsertAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<PointStruct>>(),
+                It.IsAny<bool>(), // wait
+                It.IsAny<WriteOrderingType?>(),
+                It.IsAny<ShardKeySelector?>(),
+                this._testCancellationToken))
+            .ReturnsAsync(new UpdateResult());
+    }
+
+    private static RetrievedPoint CreateRetrievedPoint<TKey>(bool hasNamedVectors, TKey recordKey)
+    {
+        RetrievedPoint point;
+        if (hasNamedVectors)
+        {
+            var namedVectors = new NamedVectors();
+            namedVectors.Vectors.Add("Vector", new[] { 1f, 2f, 3f, 4f });
+            point = new RetrievedPoint()
+            {
+                Payload = { ["Data"] = "data 1" },
+                Vectors = new Vectors { Vectors_ = namedVectors }
+            };
+        }
+        else
+        {
+            point = new RetrievedPoint()
+            {
+                Payload = { ["Data"] = "data 1" },
+                Vectors = new[] { 1f, 2f, 3f, 4f }
+            };
+        }
+
+        if (recordKey is ulong ulongKey)
+        {
+            point.Id = ulongKey;
+        }
+
+        if (recordKey is Guid guidKey)
+        {
+            point.Id = guidKey;
+        }
+
+        return point;
+    }
+
+    private IVectorRecordStore<T, SinglePropsModel<T>> CreateVectorRecordStore<T>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    {
+        var store = new QdrantVectorRecordStore<SinglePropsModel<T>>(
+            this._qdrantClientMock.Object,
+            new()
+            {
+                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
+                VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null,
+                HasNamedVectors = hasNamedVectors
+            }) as IVectorRecordStore<T, SinglePropsModel<T>>;
+        return store!;
+    }
+
+    private static SinglePropsModel<T> CreateModel<T>(T key, bool withVectors)
+    {
+        return new SinglePropsModel<T>
+        {
+            Key = key,
+            Data = "data 1",
+            Vector = withVectors ? new float[] { 1, 2, 3, 4 } : null,
+            NotAnnotated = null,
+        };
+    }
+
+    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordDataProperty("Data"),
+            new VectorStoreRecordVectorProperty("Vector")
+        ]
+    };
+
+    public sealed class SinglePropsModel<T>
+    {
+        [VectorStoreRecordKey]
+        public required T Key { get; set; }
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+
+    public static IEnumerable<object[]> TestOptions
+        => GenerateAllCombinations(new object[][] {
+                new object[] { true, false },
+                new object[] { true, false },
+                new object[] { true, false },
+                new object[] { typeof(ulong), typeof(Guid) }
+        });
+
+    private static object[][] GenerateAllCombinations(object[][] input)
+    {
+        var counterArray = Enumerable.Range(0, input.Length).Select(x => 0).ToArray();
+
+        // Add each item from the first option set as a separate row.
+        object[][] currentCombinations = input[0].Select(x => new object[1] { x }).ToArray();
+
+        // Loop through each additional option set.
+        for (int currentOptionSetIndex = 1; currentOptionSetIndex < input.Length; currentOptionSetIndex++)
+        {
+            var iterationCombinations = new List<object[]>();
+            var currentOptionSet = input[currentOptionSetIndex];
+
+            // Loop through each row we have already.
+            foreach (var currentCombination in currentCombinations)
+            {
+                // Add each of the values from the new options set to the current row to genereate a new row.
+                for (var currentColumnRow = 0; currentColumnRow < currentOptionSet.Length; currentColumnRow++)
+                {
+                    iterationCombinations.Add(currentCombination.Append(currentOptionSet[currentColumnRow]).ToArray());
+                }
+            }
+
+            currentCombinations = iterationCombinations.ToArray();
+        }
+
+        return currentCombinations;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
@@ -716,7 +716,7 @@ public class QdrantVectorRecordStoreTests
             // Loop through each row we have already.
             foreach (var currentCombination in currentCombinations)
             {
-                // Add each of the values from the new options set to the current row to genereate a new row.
+                // Add each of the values from the new options set to the current row to generate a new row.
                 for (var currentColumnRow = 0; currentColumnRow < currentOptionSet.Length; currentColumnRow++)
                 {
                     iterationCombinations.Add(currentCombination.Append(currentOptionSet[currentColumnRow]).ToArray());


### PR DESCRIPTION
### Motivation and Context

As part of updating the design of the memory connectors to allow custom schemas, adding unit tests
for Qdrant Vector Record Store.

### Description

Add unit tests for Qdrant Vector Record Store.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
