### PR TITLE
.Net: VectorStore: Add strongly typed properties for vector store exception metadata.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -386,27 +386,21 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         }
         catch (AggregateException ex) when (ex.InnerException is RequestFailedException innerEx)
         {
-            var wrapperException = new VectorStoreOperationException("Call to vector store failed.", ex);
-
-            // Using Open Telemetry standard for naming of these entries.
-            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
-            wrapperException.Data.Add("db.system", DatabaseName);
-            wrapperException.Data.Add("db.collection.name", collectionName);
-            wrapperException.Data.Add("db.operation.name", operationName);
-
-            throw wrapperException;
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                DBSystem = DatabaseName,
+                DBCollectionName = collectionName,
+                DBOperationName = operationName
+            };
         }
         catch (RequestFailedException ex)
         {
-            var wrapperException = new VectorStoreOperationException("Call to vector store failed.", ex);
-
-            // Using Open Telemetry standard for naming of these entries.
-            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
-            wrapperException.Data.Add("db.system", DatabaseName);
-            wrapperException.Data.Add("db.collection.name", collectionName);
-            wrapperException.Data.Add("db.operation.name", operationName);
-
-            throw wrapperException;
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                DBSystem = DatabaseName,
+                DBCollectionName = collectionName,
+                DBOperationName = operationName
+            };
         }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -388,18 +388,18 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                DBSystem = DatabaseName,
-                DBCollectionName = collectionName,
-                DBOperationName = operationName
+                VectorStoreType = DatabaseName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
         catch (RequestFailedException ex)
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                DBSystem = DatabaseName,
-                DBCollectionName = collectionName,
-                DBOperationName = operationName
+                VectorStoreType = DatabaseName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -370,9 +370,9 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                DBSystem = DatabaseName,
-                DBCollectionName = collectionName,
-                DBOperationName = operationName
+                VectorStoreType = DatabaseName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -368,15 +368,12 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
         }
         catch (RpcException ex)
         {
-            var wrapperException = new VectorStoreOperationException("Call to vector store failed.", ex);
-
-            // Using Open Telemetry standard for naming of these entries.
-            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
-            wrapperException.Data.Add("db.system", DatabaseName);
-            wrapperException.Data.Add("db.collection.name", collectionName);
-            wrapperException.Data.Add("db.operation.name", operationName);
-
-            throw wrapperException;
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                DBSystem = DatabaseName,
+                DBCollectionName = collectionName,
+                DBOperationName = operationName
+            };
         }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -359,15 +359,12 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         }
         catch (RedisConnectionException ex)
         {
-            var wrapperException = new VectorStoreOperationException("Call to vector store failed.", ex);
-
-            // Using Open Telemetry standard for naming of these entries.
-            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
-            wrapperException.Data.Add("db.system", DatabaseName);
-            wrapperException.Data.Add("db.collection.name", collectionName);
-            wrapperException.Data.Add("db.operation.name", operationName);
-
-            throw wrapperException;
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                DBSystem = DatabaseName,
+                DBCollectionName = collectionName,
+                DBOperationName = operationName
+            };
         }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -361,9 +361,9 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
-                DBSystem = DatabaseName,
-                DBCollectionName = collectionName,
-                DBOperationName = operationName
+                VectorStoreType = DatabaseName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
     }

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
@@ -33,9 +33,9 @@ internal static class VectorStoreErrorHandler
         {
             throw new VectorStoreRecordMappingException("Failed to convert vector store record.", ex)
             {
-                DBSystem = databaseSystemName,
-                DBCollectionName = collectionName,
-                DBOperationName = operationName
+                VectorStoreType = databaseSystemName,
+                CollectionName = collectionName,
+                OperationName = operationName
             };
         }
     }

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
@@ -31,15 +31,12 @@ internal static class VectorStoreErrorHandler
         }
         catch (Exception ex)
         {
-            var wrapperException = new VectorStoreRecordMappingException("Failed to convert vector store record.", ex);
-
-            // Using Open Telemetry standard for naming of these entries.
-            // https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/
-            wrapperException.Data.Add("db.system", databaseSystemName);
-            wrapperException.Data.Add("db.collection.name", collectionName);
-            wrapperException.Data.Add("db.operation.name", operationName);
-
-            throw wrapperException;
+            throw new VectorStoreRecordMappingException("Failed to convert vector store record.", ex)
+            {
+                DBSystem = databaseSystemName,
+                DBCollectionName = collectionName,
+                DBOperationName = operationName
+            };
         }
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreException.cs
@@ -36,17 +36,17 @@ public abstract class VectorStoreException : KernelException
     }
 
     /// <summary>
-    /// Gets or sets the name of the database system that the failing operation was performed on.
+    /// Gets or sets the type of vector store that the failing operation was performed on.
     /// </summary>
-    public string? DBSystem { get; init; }
+    public string? VectorStoreType { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the database collection that the failing operation was performed on.
+    /// Gets or sets the name of the vector store collection that the failing operation was performed on.
     /// </summary>
-    public string? DBCollectionName { get; init; }
+    public string? CollectionName { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the database operation that failed.
+    /// Gets or sets the name of the vector store operation that failed.
     /// </summary>
-    public string? DBOperationName { get; init; }
+    public string? OperationName { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreException.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Memory;
+
+/// <summary>
+/// Base exception type thrown for any type of failure when using vector stores.
+/// </summary>
+[Experimental("SKEXP0001")]
+public abstract class VectorStoreException : KernelException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreException"/> class.
+    /// </summary>
+    protected VectorStoreException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    protected VectorStoreException(string? message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    protected VectorStoreException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the database system that the failing operation was performed on.
+    /// </summary>
+    public string? DBSystem { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the database collection that the failing operation was performed on.
+    /// </summary>
+    public string? DBCollectionName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the database operation that failed.
+    /// </summary>
+    public string? DBOperationName { get; init; }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreOperationException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreOperationException.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Memory;
 
 /// <summary>
 /// Exception thrown when a vector store command fails, such as upserting a record or deleting a collection.
 /// </summary>
-public class VectorStoreOperationException : KernelException
+[Experimental("SKEXP0001")]
+public class VectorStoreOperationException : VectorStoreException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="VectorStoreOperationException"/> class.

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreRecordMappingException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/VectorStoreRecordMappingException.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Memory;
 
 /// <summary>
 /// Exception thrown when a failure occurs while trying to convert models for storage or retrieval.
 /// </summary>
-public class VectorStoreRecordMappingException : KernelException
+[Experimental("SKEXP0001")]
+public class VectorStoreRecordMappingException : VectorStoreException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="VectorStoreRecordMappingException"/> class.


### PR DESCRIPTION
### Motivation and Context

As part of the new vector store implementation, we need to add additional metadata to exceptions to share information about the operation that failed.

### Description

Changing the way in which the metadata is stored to strongly typed properties.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
