### PR TITLE
.Net: VectorStore: Add custom serialization options / naming support.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,12 +95,13 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         }
 
         // Validate property types and store for later use.
+        var jsonSerializerOptions = this._options.jsonSerializerOptions ?? JsonSerializerOptions.Default;
         VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
-        this._keyPropertyName = properties.keyProperty.Name;
+        this._keyPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(jsonSerializerOptions, properties.keyProperty);
 
         // Build the list of property names from the current model that are either key or data fields.
-        this._nonVectorPropertyNames = properties.dataProperties.Concat([properties.keyProperty]).Select(x => x.Name).ToList();
+        this._nonVectorPropertyNames = properties.dataProperties.Concat([properties.keyProperty]).Select(x => VectorStoreRecordPropertyReader.GetJsonPropertyName(jsonSerializerOptions, x)).ToList();
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -95,7 +95,7 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         }
 
         // Validate property types and store for later use.
-        var jsonSerializerOptions = this._options.jsonSerializerOptions ?? JsonSerializerOptions.Default;
+        var jsonSerializerOptions = this._options.JsonSerializerOptions ?? JsonSerializerOptions.Default;
         VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
         this._keyPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(jsonSerializerOptions, properties.keyProperty);
@@ -214,7 +214,7 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     /// <param name="collectionName">The name of the collection to retrieve the record from.</param>
     /// <param name="key">The key of the record to get.</param>
     /// <param name="includeVectors">A value indicating whether to include vectors in the result or not.</param>
-    /// <param name="innerOptions">The azure ai search sdk options for getting a document.</param>
+    /// <param name="innerOptions">The Azure AI Search sdk options for getting a document.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The retrieved document, mapped to the consumer data model.</returns>
     private async Task<TRecord?> GetDocumentAndMapToDataModelAsync(
@@ -260,7 +260,7 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     /// <param name="searchClient">The search client to use when uploading the document.</param>
     /// <param name="collectionName">The name of the collection to upsert the records to.</param>
     /// <param name="records">The records to upload.</param>
-    /// <param name="innerOptions">The azure ai search sdk options for uploading a document.</param>
+    /// <param name="innerOptions">The Azure AI Search sdk options for uploading a document.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The document upload result.</returns>
     private Task<Response<IndexDocumentsResult>> MapToStorageModelAndUploadDocumentAsync(
@@ -332,10 +332,10 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     }
 
     /// <summary>
-    /// Convert the public <see cref="GetRecordOptions"/> options model to the azure ai search <see cref="GetDocumentOptions"/> options model.
+    /// Convert the public <see cref="GetRecordOptions"/> options model to the Azure AI Search <see cref="GetDocumentOptions"/> options model.
     /// </summary>
     /// <param name="options">The public options model.</param>
-    /// <returns>The azure ai search options model.</returns>
+    /// <returns>The Azure AI Search options model.</returns>
     private GetDocumentOptions ConvertGetDocumentOptions(GetRecordOptions? options)
     {
         var innerOptions = new GetDocumentOptions();
@@ -353,7 +353,7 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     /// <typeparam name="T">The type to deserialize the document to.</typeparam>
     /// <param name="searchClient">The search client to use when fetching the document.</param>
     /// <param name="key">The key of the record to get.</param>
-    /// <param name="innerOptions">The azure ai search sdk options for getting a document.</param>
+    /// <param name="innerOptions">The Azure AI Search sdk options for getting a document.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The retrieved document, mapped to the consumer data model, or null if not found.</returns>
     private static async Task<T?> GetDocumentWithNotFoundHandlingAsync<T>(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using Azure.Search.Documents.Indexes;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
@@ -39,4 +41,10 @@ public sealed class AzureAISearchVectorRecordStoreOptions<TRecord>
     /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
     /// </remarks>
     public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets the json serializer options to use when converting between the data model and the azure ai search record.
+    /// Note that when using the default mapper, you will need to provide the same set of <see cref="JsonSerializerOptions"/> both here and when constructing the <see cref="SearchIndexClient"/>.
+    /// </summary>
+    public JsonSerializerOptions? jsonSerializerOptions { get; init; } = null;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
@@ -20,12 +20,12 @@ public sealed class AzureAISearchVectorRecordStoreOptions<TRecord>
     public string? DefaultCollectionName { get; init; } = null;
 
     /// <summary>
-    /// Gets or sets the choice of mapper to use when converting between the data model and the azure ai search record.
+    /// Gets or sets the choice of mapper to use when converting between the data model and the Azure AI Search record.
     /// </summary>
     public AzureAISearchRecordMapperType MapperType { get; init; } = AzureAISearchRecordMapperType.Default;
 
     /// <summary>
-    /// Gets or sets an optional custom mapper to use when converting between the data model and the azure ai search record.
+    /// Gets or sets an optional custom mapper to use when converting between the data model and the Azure AI Search record.
     /// </summary>
     /// <remarks>
     /// Set <see cref="MapperType"/> to <see cref="AzureAISearchRecordMapperType.JsonObjectCustomMapper"/> to use this mapper."/>
@@ -43,8 +43,8 @@ public sealed class AzureAISearchVectorRecordStoreOptions<TRecord>
     public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
 
     /// <summary>
-    /// Gets or sets the json serializer options to use when converting between the data model and the azure ai search record.
-    /// Note that when using the default mapper, you will need to provide the same set of <see cref="JsonSerializerOptions"/> both here and when constructing the <see cref="SearchIndexClient"/>.
+    /// Gets or sets the JSON serializer options to use when converting between the data model and the Azure AI Search record.
+    /// Note that when using the default mapper, you will need to provide the same set of <see cref="System.Text.Json.JsonSerializerOptions"/> both here and when constructing the <see cref="SearchIndexClient"/>.
     /// </summary>
-    public JsonSerializerOptions? jsonSerializerOptions { get; init; } = null;
+    public JsonSerializerOptions? JsonSerializerOptions { get; init; } = null;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -41,7 +41,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         typeof(ReadOnlyMemory<double>?)
     ];
 
-    /// <summary>The redis database to read/write records from.</summary>
+    /// <summary>The Redis database to read/write records from.</summary>
     private readonly IDatabase _database;
 
     /// <summary>Optional configuration options for this class.</summary>
@@ -50,22 +50,22 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
     /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
     private readonly PropertyInfo _keyPropertyInfo;
 
-    /// <summary>The name of the temporary json property that the key property will be serialized / parsed from.</summary>
+    /// <summary>The name of the temporary JSON property that the key property will be serialized / parsed from.</summary>
     private readonly string _keyJsonPropertyName;
 
-    /// <summary>An array of the names of all the data properties that are part of the redis payload, i.e. all properties except the key and vector properties.</summary>
+    /// <summary>An array of the names of all the data properties that are part of the Redis payload, i.e. all properties except the key and vector properties.</summary>
     private readonly string[] _dataPropertyNames;
 
-    /// <summary>The mapper to use when mapping between the consumer data model and the redis record.</summary>
+    /// <summary>The mapper to use when mapping between the consumer data model and the Redis record.</summary>
     private readonly IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)> _mapper;
 
-    /// <summary>The json serializer options to use when converting between the data model and the redis record.</summary>
+    /// <summary>The JSON serializer options to use when converting between the data model and the Redis record.</summary>
     private readonly JsonSerializerOptions _jsonSerializerOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RedisVectorRecordStore{TRecord}"/> class.
     /// </summary>
-    /// <param name="database">The redis database to read/write records from.</param>
+    /// <param name="database">The Redis database to read/write records from.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     /// <exception cref="ArgumentNullException">Throw when parameters are invalid.</exception>
     public RedisVectorRecordStore(IDatabase database, RedisVectorRecordStoreOptions<TRecord>? options = null)
@@ -127,7 +127,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         var maybePrefixedKey = this.PrefixKeyIfNeeded(key, collectionName);
         var includeVectors = options?.IncludeVectors ?? false;
 
-        // Get the redis value.
+        // Get the Redis value.
         var redisResult = await RunOperationAsync(
             collectionName,
             "GET",
@@ -145,7 +145,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
             return null;
         }
 
-        // Check if the value contained any json text before trying to parse the result.
+        // Check if the value contained any JSON text before trying to parse the result.
         var redisResultString = redisResult.ToString();
         if (redisResultString is null)
         {
@@ -176,7 +176,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         var redisKeys = maybePrefixedKeys.Select(x => new RedisKey(x)).ToArray();
         var includeVectors = options?.IncludeVectors ?? false;
 
-        // Get the list of redis results.
+        // Get the list of Redis results.
         var redisResults = await RunOperationAsync(
             collectionName,
             "MGET",
@@ -196,7 +196,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
                 continue;
             }
 
-            // Check if the value contained any json text before trying to parse the result.
+            // Check if the value contained any JSON text before trying to parse the result.
             var redisResultString = redisResult.ToString();
             if (redisResultString is null)
             {
@@ -358,7 +358,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
     }
 
     /// <summary>
-    /// Run the given operation and wrap any redis exceptions with <see cref="VectorStoreOperationException"/>."/>
+    /// Run the given operation and wrap any Redis exceptions with <see cref="VectorStoreOperationException"/>."/>
     /// </summary>
     /// <typeparam name="T">The response type of the operation.</typeparam>
     /// <param name="collectionName">The name of the collection the operation is being run on.</param>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
@@ -20,21 +20,21 @@ public sealed class RedisVectorRecordStoreOptions<TRecord>
 
     /// <summary>
     /// Gets or sets a value indicating whether the collection name should be prefixed to the
-    /// key names before reading or writing to the redis store. Default is false.
+    /// key names before reading or writing to the Redis store. Default is false.
     /// </summary>
     /// <remarks>
-    /// For a record to be indexed by a specific redis index, the key name must be prefixed with the matching prefix configured on the redis index.
+    /// For a record to be indexed by a specific Redis index, the key name must be prefixed with the matching prefix configured on the Redis index.
     /// You can either pass in keys that are already prefixed, or set this option to true to have the collection name prefixed to the key names automatically.
     /// </remarks>
     public bool PrefixCollectionNameToKeyNames { get; init; } = false;
 
     /// <summary>
-    /// Gets or sets the choice of mapper to use when converting between the data model and the redis record.
+    /// Gets or sets the choice of mapper to use when converting between the data model and the Redis record.
     /// </summary>
     public RedisRecordMapperType MapperType { get; init; } = RedisRecordMapperType.Default;
 
     /// <summary>
-    /// Gets or sets an optional custom mapper to use when converting between the data model and the redis record.
+    /// Gets or sets an optional custom mapper to use when converting between the data model and the Redis record.
     /// </summary>
     /// <remarks>
     /// Set <see cref="MapperType"/> to <see cref="RedisRecordMapperType.JsonNodeCustomMapper"/> to use this mapper."/>
@@ -52,7 +52,7 @@ public sealed class RedisVectorRecordStoreOptions<TRecord>
     public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
 
     /// <summary>
-    /// Gets or sets the json serializer options to use when converting between the data model and the redis record.
+    /// Gets or sets the JSON serializer options to use when converting between the data model and the Redis record.
     /// </summary>
     public JsonSerializerOptions? jsonSerializerOptions { get; init; } = null;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.SemanticKernel.Memory;
 
@@ -49,4 +50,9 @@ public sealed class RedisVectorRecordStoreOptions<TRecord>
     /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
     /// </remarks>
     public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets the json serializer options to use when converting between the data model and the redis record.
+    /// </summary>
+    public JsonSerializerOptions? jsonSerializerOptions { get; init; } = null;
 }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure;
@@ -248,6 +249,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         public string[] Tags { get; set; }
 #pragma warning restore CA1819 // Properties should not return arrays
 
+        [JsonPropertyName("parking_is_included")]
         [SimpleField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
         [VectorStoreRecordData]
         public bool? ParkingIncluded { get; set; }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
@@ -37,7 +37,7 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
                 new VectorStoreRecordKeyProperty("HotelId"),
                 new VectorStoreRecordDataProperty("HotelName"),
                 new VectorStoreRecordDataProperty("HotelCode"),
-                new VectorStoreRecordDataProperty("ParkingIncluded"),
+                new VectorStoreRecordDataProperty("ParkingIncluded") { StoragePropertyName = "parking_is_included" },
                 new VectorStoreRecordDataProperty("HotelRating"),
                 new VectorStoreRecordDataProperty("Tags"),
                 new VectorStoreRecordDataProperty("Description"),
@@ -137,19 +137,19 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
             {
                 Id = 11,
                 Vectors = new Vectors { Vectors_ = namedVectors1 },
-                Payload = { ["HotelName"] = "My Hotel 11", ["HotelCode"] = 11, ["ParkingIncluded"] = true, ["Tags"] = tagsValue, ["HotelRating"] = 4.5f, ["Description"] = "This is a great hotel." }
+                Payload = { ["HotelName"] = "My Hotel 11", ["HotelCode"] = 11, ["parking_is_included"] = true, ["Tags"] = tagsValue, ["HotelRating"] = 4.5f, ["Description"] = "This is a great hotel." }
             },
             new PointStruct
             {
                 Id = 12,
                 Vectors = new Vectors { Vectors_ = namedVectors2 },
-                Payload = { ["HotelName"] = "My Hotel 12", ["HotelCode"] = 12, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+                Payload = { ["HotelName"] = "My Hotel 12", ["HotelCode"] = 12, ["parking_is_included"] = false, ["Description"] = "This is a great hotel." }
             },
             new PointStruct
             {
                 Id = 13,
                 Vectors = new Vectors { Vectors_ = namedVectors3 },
-                Payload = { ["HotelName"] = "My Hotel 13", ["HotelCode"] = 13, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+                Payload = { ["HotelName"] = "My Hotel 13", ["HotelCode"] = 13, ["parking_is_included"] = false, ["Description"] = "This is a great hotel." }
             },
         ];
 
@@ -162,19 +162,19 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
             {
                 Id = 11,
                 Vectors = embedding,
-                Payload = { ["HotelName"] = "My Hotel 11", ["HotelCode"] = 11, ["ParkingIncluded"] = true, ["Tags"] = tagsValue, ["HotelRating"] = 4.5f, ["Description"] = "This is a great hotel." }
+                Payload = { ["HotelName"] = "My Hotel 11", ["HotelCode"] = 11, ["parking_is_included"] = true, ["Tags"] = tagsValue, ["HotelRating"] = 4.5f, ["Description"] = "This is a great hotel." }
             },
             new PointStruct
             {
                 Id = 12,
                 Vectors = embedding,
-                Payload = { ["HotelName"] = "My Hotel 12", ["HotelCode"] = 12, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+                Payload = { ["HotelName"] = "My Hotel 12", ["HotelCode"] = 12, ["parking_is_included"] = false, ["Description"] = "This is a great hotel." }
             },
             new PointStruct
             {
                 Id = 13,
                 Vectors = embedding,
-                Payload = { ["HotelName"] = "My Hotel 13", ["HotelCode"] = 13, ["ParkingIncluded"] = false, ["Description"] = "This is a great hotel." }
+                Payload = { ["HotelName"] = "My Hotel 13", ["HotelCode"] = 13, ["parking_is_included"] = false, ["Description"] = "This is a great hotel." }
             },
         ];
 
@@ -284,7 +284,7 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
         public float? HotelRating { get; set; }
 
         /// <summary>A bool metadata field.</summary>
-        [VectorStoreRecordData]
+        [VectorStoreRecordData(StoragePropertyName = "parking_is_included")]
         public bool ParkingIncluded { get; set; }
 
         [VectorStoreRecordData]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Docker.DotNet;
 using Docker.DotNet.Models;
@@ -94,14 +95,14 @@ public class RedisVectorStoreFixture : IAsyncLifetime
             Description = "This is a great hotel.",
             DescriptionEmbedding = embedding,
             Tags = new[] { "pool", "air conditioning", "concierge" },
-            ParkingIncluded = true,
+            parking_is_included = true,
             LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
             Rating = 3.6,
             Address = address
         });
-        await this.Database.JSON().SetAsync("hotels:BaseSet-2", "$", new { HotelName = "My Hotel 2", HotelCode = 2, Description = "This is a great hotel.", DescriptionEmbedding = embedding, ParkingIncluded = false });
-        await this.Database.JSON().SetAsync("hotels:BaseSet-3", "$", new { HotelName = "My Hotel 3", HotelCode = 3, Description = "This is a great hotel.", DescriptionEmbedding = embedding, ParkingIncluded = false });
-        await this.Database.JSON().SetAsync("hotels:BaseSet-4-Invalid", "$", new { HotelId = "AnotherId", HotelName = "My Invalid Hotel", HotelCode = 4, Description = "This is an invalid hotel.", DescriptionEmbedding = embedding, ParkingIncluded = false });
+        await this.Database.JSON().SetAsync("hotels:BaseSet-2", "$", new { HotelName = "My Hotel 2", HotelCode = 2, Description = "This is a great hotel.", DescriptionEmbedding = embedding, parking_is_included = false });
+        await this.Database.JSON().SetAsync("hotels:BaseSet-3", "$", new { HotelName = "My Hotel 3", HotelCode = 3, Description = "This is a great hotel.", DescriptionEmbedding = embedding, parking_is_included = false });
+        await this.Database.JSON().SetAsync("hotels:BaseSet-4-Invalid", "$", new { HotelId = "AnotherId", HotelName = "My Invalid Hotel", HotelCode = 4, Description = "This is an invalid hotel.", DescriptionEmbedding = embedding, parking_is_included = false });
     }
 
     /// <summary>
@@ -182,6 +183,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         public string[] Tags { get; init; }
 #pragma warning restore CA1819 // Properties should not return arrays
 
+        [JsonPropertyName("parking_is_included")]
         [VectorStoreRecordData]
         public bool ParkingIncluded { get; init; }
 

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -260,12 +260,12 @@ internal static class VectorStoreRecordPropertyReader
     }
 
     /// <summary>
-    /// Get the json property name of a property by using the <see cref="JsonPropertyNameAttribute"/> if available, otherwise
+    /// Get the JSON property name of a property by using the <see cref="JsonPropertyNameAttribute"/> if available, otherwise
     /// using the <see cref="JsonNamingPolicy"/> if available, otherwise falling back to the property name.
     /// </summary>
-    /// <param name="options">The options used for json serialization.</param>
+    /// <param name="options">The options used for JSON serialization.</param>
     /// <param name="property">The property to retrieve a storage name for.</param>
-    /// <returns>The json storage property name.</returns>
+    /// <returns>The JSON storage property name.</returns>
     public static string GetJsonPropertyName(JsonSerializerOptions options, PropertyInfo property)
     {
         var jsonPropertyNameAttribute = property.GetCustomAttribute<JsonPropertyNameAttribute>();

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/RecordAttributes/VectorStoreRecordDataAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/RecordAttributes/VectorStoreRecordDataAttribute.cs
@@ -22,4 +22,10 @@ public sealed class VectorStoreRecordDataAttribute : Attribute
     /// Gets or sets the name of the property that contains the embedding for this data field.
     /// </summary>
     public string? EmbeddingPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional name to use for the property in storage, if different from the property name.
+    /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
+    /// </summary>
+    public string? StoragePropertyName { get; set; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/RecordAttributes/VectorStoreRecordKeyAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/RecordAttributes/VectorStoreRecordKeyAttribute.cs
@@ -12,4 +12,9 @@ namespace Microsoft.SemanticKernel.Memory;
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class VectorStoreRecordKeyAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an optional name to use for the property in storage, if different from the property name.
+    /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
+    /// </summary>
+    public string? StoragePropertyName { get; set; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/RecordAttributes/VectorStoreRecordVectorAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/RecordAttributes/VectorStoreRecordVectorAttribute.cs
@@ -12,4 +12,9 @@ namespace Microsoft.SemanticKernel.Memory;
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class VectorStoreRecordVectorAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an optional name to use for the property in storage, if different from the property name.
+    /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
+    /// </summary>
+    public string? StoragePropertyName { get; set; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/RecordDefinition/VectorStoreRecordProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/RecordDefinition/VectorStoreRecordProperty.cs
@@ -23,4 +23,10 @@ public abstract class VectorStoreRecordProperty
     /// Gets or sets the name of the property.
     /// </summary>
     public string PropertyName { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional name to use for the property in storage, if different from the property name.
+    /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
+    /// </summary>
+    public string? StoragePropertyName { get; set; }
 }


### PR DESCRIPTION
### Motivation and Context

As part of the new vector store implementation, we need to allow developers to provide their own names or json serialization options for storage properties.

### Description

Adding support for this to AzureAISearch, Redis and Qdrant implementations in the following way:
AzureAISearch: via JsonPropertyName attributes or JsonSerializerOptions.
Redis: via JsonPropertyName attributes or JsonSerializerOptions.
Qdrant: via StoragePropertyName on VectorRecord definitions.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
