### PR TITLE
.Net: Fix milvus search metric type bug.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Milvus/MilvusMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Milvus/MilvusMemoryStore.cs
@@ -446,7 +446,7 @@ public class MilvusMemoryStore : IMemoryStore, IDisposable
         MilvusCollection collection = this.Client.GetCollection(collectionName);
 
         SearchResults results = await collection
-            .SearchAsync(EmbeddingFieldName, [embedding], SimilarityMetricType.Ip, limit, this._searchParameters, cancellationToken)
+            .SearchAsync(EmbeddingFieldName, [embedding], this._metricType, limit, this._searchParameters, cancellationToken)
             .ConfigureAwait(false);
 
         IReadOnlyList<string> ids = results.Ids.StringIds!;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Milvus/MilvusMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Milvus/MilvusMemoryStoreTests.cs
@@ -220,6 +220,47 @@ public class MilvusMemoryStoreTests(MilvusFixture milvusFixture) : IClassFixture
             });
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GetNearestMatchesWithMetricTypeAsync(bool withEmbeddings)
+    {
+        //Create collection with default, Ip metric
+        await this.Store.CreateCollectionAsync(CollectionName);
+        await this.InsertSampleDataAsync();
+        // There seems to be some race condition where the upserted data above isn't taken into account in the search below and zero results are returned...
+        await Task.Delay(1000);
+
+        //Search with Ip metric, run correctly
+        List<(MemoryRecord Record, double SimilarityScore)> ipResults =
+            this.Store.GetNearestMatchesAsync(CollectionName, new[] { 5f, 6f, 7f, 8f, 9f }, limit: 2, withEmbeddings: withEmbeddings).ToEnumerable().ToList();
+
+        Assert.All(ipResults, t => Assert.True(t.SimilarityScore > 0));
+
+        //Set the store to Cosine metric, without recreate collection
+        this.Store = new(this._milvusFixture.Host, vectorSize: 5, port: this._milvusFixture.Port, metricType: SimilarityMetricType.Cosine, consistencyLevel: ConsistencyLevel.Strong);
+
+        //An exception willl be thrown here, the exception message includes "metric type not match"
+        MilvusException milvusException = Assert.Throws<MilvusException>(() => this.Store.GetNearestMatchesAsync(CollectionName, new[] { 5f, 6f, 7f, 8f, 9f }, limit: 2, withEmbeddings: withEmbeddings).ToEnumerable().ToList());
+
+        Assert.NotNull(milvusException);
+
+        Assert.Contains("metric type not match", milvusException.Message);
+
+        //Recreate collection with Cosine metric
+        await this.Store.DeleteCollectionAsync(CollectionName);
+        await this.Store.CreateCollectionAsync(CollectionName);
+        await this.InsertSampleDataAsync();
+        // There seems to be some race condition where the upserted data above isn't taken into account in the search below and zero results are returned...
+        await Task.Delay(1000);
+
+        //Search with Ip metric, run correctly
+        List<(MemoryRecord Record, double SimilarityScore)> cosineResults =
+            this.Store.GetNearestMatchesAsync(CollectionName, new[] { 5f, 6f, 7f, 8f, 9f }, limit: 2, withEmbeddings: withEmbeddings).ToEnumerable().ToList();
+
+        Assert.All(cosineResults, t => Assert.True(t.SimilarityScore > 0));
+    }
+
     [Fact]
     public async Task GetNearestMatchesWithMinRelevanceScoreAsync()
     {

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Milvus/MilvusMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Milvus/MilvusMemoryStoreTests.cs
@@ -228,8 +228,7 @@ public class MilvusMemoryStoreTests(MilvusFixture milvusFixture) : IClassFixture
         //Create collection with default, Ip metric
         await this.Store.CreateCollectionAsync(CollectionName);
         await this.InsertSampleDataAsync();
-        // There seems to be some race condition where the upserted data above isn't taken into account in the search below and zero results are returned...
-        await Task.Delay(1000);
+        await this.Store.Client.FlushAsync([CollectionName]);
 
         //Search with Ip metric, run correctly
         List<(MemoryRecord Record, double SimilarityScore)> ipResults =
@@ -240,7 +239,7 @@ public class MilvusMemoryStoreTests(MilvusFixture milvusFixture) : IClassFixture
         //Set the store to Cosine metric, without recreate collection
         this.Store = new(this._milvusFixture.Host, vectorSize: 5, port: this._milvusFixture.Port, metricType: SimilarityMetricType.Cosine, consistencyLevel: ConsistencyLevel.Strong);
 
-        //An exception willl be thrown here, the exception message includes "metric type not match"
+        //An exception will be thrown here, the exception message includes "metric type not match"
         MilvusException milvusException = Assert.Throws<MilvusException>(() => this.Store.GetNearestMatchesAsync(CollectionName, new[] { 5f, 6f, 7f, 8f, 9f }, limit: 2, withEmbeddings: withEmbeddings).ToEnumerable().ToList());
 
         Assert.NotNull(milvusException);
@@ -251,8 +250,7 @@ public class MilvusMemoryStoreTests(MilvusFixture milvusFixture) : IClassFixture
         await this.Store.DeleteCollectionAsync(CollectionName);
         await this.Store.CreateCollectionAsync(CollectionName);
         await this.InsertSampleDataAsync();
-        // There seems to be some race condition where the upserted data above isn't taken into account in the search below and zero results are returned...
-        await Task.Delay(1000);
+        await this.Store.Client.FlushAsync([CollectionName]);
 
         //Search with Ip metric, run correctly
         List<(MemoryRecord Record, double SimilarityScore)> cosineResults =

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -733,13 +733,13 @@ numpy = "*"
 
 [[package]]
 name = "chromadb"
-version = "0.5.0"
+version = "0.5.3"
 description = "Chroma."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "chromadb-0.5.0-py3-none-any.whl", hash = "sha256:8193dc65c143b61d8faf87f02c44ecfa778d471febd70de517f51c5d88a06009"},
-    {file = "chromadb-0.5.0.tar.gz", hash = "sha256:7954af614a9ff7b2902ddbd0a162f33f7ec0669e2429903905c4f7876d1f766f"},
+    {file = "chromadb-0.5.3-py3-none-any.whl", hash = "sha256:b3874f08356e291c68c6d2e177db472cd51f22f3af7b9746215b748fd1e29982"},
+    {file = "chromadb-0.5.3.tar.gz", hash = "sha256:05d887f56a46b2e0fc6ac5ab979503a27b9ee50d5ca9e455f83b2fb9840cd026"},
 ]
 
 [package.dependencies]
@@ -748,10 +748,11 @@ build = ">=1.0.3"
 chroma-hnswlib = "0.7.3"
 fastapi = ">=0.95.2"
 grpcio = ">=1.58.0"
+httpx = ">=0.27.0"
 importlib-resources = "*"
 kubernetes = ">=28.1.0"
 mmh3 = ">=4.0.1"
-numpy = ">=1.22.5"
+numpy = ">=1.22.5,<2.0.0"
 onnxruntime = ">=1.14.1"
 opentelemetry-api = ">=1.2.0"
 opentelemetry-exporter-otlp-proto-grpc = ">=1.2.0"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The `metricType` parameter in the `SearchAsync` method of the Milvus connector is incorrect.

It will always use the `SimilarityMetricType.Ip` for searching.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

The current code hard-codes the milvus search metric type to `SimilarityMetricType.Ip`, which causes the issue where even if the Metric type is specified as `SimilarityMetricType.Cosine` when creating the `MilvusMemoryStore`, `SimilarityMetricType.IP` is still used during the search.

Issue:  [#7062](https://github.com/microsoft/semantic-kernel/issues/7062)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
