### PR TITLE
.Net: Tidying up AzureOpenAIChatCompletionService

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Core/AzureOpenAIChatMessageContentTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Core/AzureOpenAIChatMessageContentTests.cs
@@ -41,8 +41,8 @@ public sealed class AzureOpenAIChatMessageContentTests
         var content2 = new AzureOpenAIChatMessageContent(AuthorRole.User, "content", "model-id", []);
 
         // Act
-        var actualToolCalls1 = content1.GetOpenAIFunctionToolCalls();
-        var actualToolCalls2 = content2.GetOpenAIFunctionToolCalls();
+        var actualToolCalls1 = content1.GetFunctionToolCalls();
+        var actualToolCalls2 = content2.GetFunctionToolCalls();
 
         // Assert
         Assert.Equal(2, actualToolCalls1.Count);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureOpenAIChatMessageContent.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureOpenAIChatMessageContent.cs
@@ -75,15 +75,15 @@ public sealed class AzureOpenAIChatMessageContent : ChatMessageContent
     /// Retrieve the resulting function from the chat result.
     /// </summary>
     /// <returns>The <see cref="AzureOpenAIFunctionToolCall"/>, or null if no function was returned by the model.</returns>
-    public IReadOnlyList<AzureOpenAIFunctionToolCall> GetOpenAIFunctionToolCalls()
+    public IReadOnlyList<AzureOpenAIFunctionToolCall> GetFunctionToolCalls()
     {
         List<AzureOpenAIFunctionToolCall>? functionToolCallList = null;
 
         foreach (var toolCall in this.ToolCalls)
         {
-            if (toolCall is ChatToolCall functionToolCall)
+            if (toolCall.Kind == ChatToolCallKind.Function)
             {
-                (functionToolCallList ??= []).Add(new AzureOpenAIFunctionToolCall(functionToolCall));
+                (functionToolCallList ??= []).Add(new AzureOpenAIFunctionToolCall(toolCall));
             }
         }
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAIChatCompletionService.cs
@@ -69,16 +69,16 @@ public sealed class AzureOpenAIChatCompletionService : IChatCompletionService, I
     /// Creates a new <see cref="AzureOpenAIChatCompletionService"/> client instance using the specified <see cref="OpenAIClient"/>.
     /// </summary>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
-    /// <param name="openAIClient">Custom <see cref="OpenAIClient"/>.</param>
+    /// <param name="azureOpenAIClient">Custom <see cref="AzureOpenAIClient"/>.</param>
     /// <param name="modelId">Azure OpenAI model id, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     public AzureOpenAIChatCompletionService(
         string deploymentName,
-        AzureOpenAIClient openAIClient,
+        AzureOpenAIClient azureOpenAIClient,
         string? modelId = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, openAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
+        this._core = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIChatCompletionService)));
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
 


### PR DESCRIPTION
### Motivation, Context and Description
This PR fixes a small issue that would occur if the LLM started calling tools that are not functions. Additionally, it renames the `openAIClient` parameter of the `AzureOpenAIChatCompletionService` class constructor to `azureOpenAIClient` to keep the name consistent with its type. It also renames the `AzureOpenAIChatMessageContent.GetOpenAIFunctionToolCalls` method to `GetFunctionToolCalls` because the old one is not relevant anymore. The last two changes are breaking changes and it will be decided in the scope of the https://github.com/microsoft/semantic-kernel/issues/7053 issue whether to keep them or roll them back.
