### PR TITLE
.Net: Copy OpenAITextToImageService related code to AzureOpenAI project

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Connectors.AzureOpenAI.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Connectors.AzureOpenAI.UnitTests.csproj
@@ -31,6 +31,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="Services\AzureOpenAITextToImageServiceTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Services\AzureOpenAITextToImageServiceTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToImageServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToImageServiceTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Services;
+using Moq;
+using OpenAI;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AzureOpenAITextToImageServiceTests"/> class.
+/// </summary>
+public sealed class AzureOpenAITextToImageServiceTests : IDisposable
+{
+    private readonly HttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+    private readonly Mock<ILoggerFactory> _mockLoggerFactory;
+
+    public AzureOpenAITextToImageServiceTests()
+    {
+        this._messageHandlerStub = new()
+        {
+            ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(File.ReadAllText("./TestData/text-to-image-response.txt"))
+            }
+        };
+        this._httpClient = new HttpClient(this._messageHandlerStub, false);
+        this._mockLoggerFactory = new Mock<ILoggerFactory>();
+    }
+
+    [Fact]
+    public void ConstructorWorksCorrectly()
+    {
+        // Arrange & Act
+        var sut = new AzureOpenAITextToImageServiceTests("model", "api-key", "organization");
+
+        // Assert
+        Assert.NotNull(sut);
+        Assert.Equal("organization", sut.Attributes[ClientCore.OrganizationKey]);
+        Assert.Equal("model", sut.Attributes[AIServiceExtensions.ModelIdKey]);
+    }
+
+    [Fact]
+    public void OpenAIClientConstructorWorksCorrectly()
+    {
+        // Arrange
+        var sut = new AzureOpenAITextToImageServiceTests("model", new OpenAIClient("apikey"));
+
+        // Assert
+        Assert.NotNull(sut);
+        Assert.Equal("model", sut.Attributes[AIServiceExtensions.ModelIdKey]);
+    }
+
+    [Theory]
+    [InlineData(256, 256, "dall-e-2")]
+    [InlineData(512, 512, "dall-e-2")]
+    [InlineData(1024, 1024, "dall-e-2")]
+    [InlineData(1024, 1024, "dall-e-3")]
+    [InlineData(1024, 1792, "dall-e-3")]
+    [InlineData(1792, 1024, "dall-e-3")]
+    [InlineData(123, 321, "custom-model-1")]
+    [InlineData(179, 124, "custom-model-2")]
+    public async Task GenerateImageWorksCorrectlyAsync(int width, int height, string modelId)
+    {
+        // Arrange
+        var sut = new AzureOpenAITextToImageServiceTests(modelId, "api-key", httpClient: this._httpClient);
+        Assert.Equal(modelId, sut.Attributes["ModelId"]);
+
+        // Act 
+        var result = await sut.GenerateImageAsync("description", width, height);
+
+        // Assert
+        Assert.Equal("https://image-url/", result);
+    }
+
+    [Fact]
+    public async Task GenerateImageDoesLogActionAsync()
+    {
+        // Assert
+        var modelId = "dall-e-2";
+        var logger = new Mock<ILogger<AzureOpenAITextToImageServiceTests>>();
+        logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+        this._mockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+        // Arrange
+        var sut = new AzureOpenAITextToImageServiceTests(modelId, "apiKey", httpClient: this._httpClient, loggerFactory: this._mockLoggerFactory.Object);
+
+        // Act
+        await sut.GenerateImageAsync("description", 256, 256);
+
+        // Assert
+        logger.VerifyLog(LogLevel.Information, $"Action: {nameof(AzureOpenAITextToImageServiceTests.GenerateImageAsync)}. OpenAI Model ID: {modelId}.", Times.Once());
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
@@ -22,7 +22,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Core\ClientCore.TextToImage.cs" />
+    <Compile Remove="Services\AzureOpenAITextToImageService.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="SemanticKernel.Connectors.AzureOpenAI.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Core\ClientCore.TextToImage.cs" />
+    <None Include="Services\AzureOpenAITextToImageService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.TextToImage.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.TextToImage.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ClientModel;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenAI.Images;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+/// <summary>
+/// Base class for AI clients that provides common functionality for interacting with OpenAI services.
+/// </summary>
+internal partial class ClientCore
+{
+    /// <summary>
+    /// Generates an image with the provided configuration.
+    /// </summary>
+    /// <param name="prompt">Prompt to generate the image</param>
+    /// <param name="width">Width of the image</param>
+    /// <param name="height">Height of the image</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Url of the generated image</returns>
+    internal async Task<string> GenerateImageAsync(
+        string prompt,
+        int width,
+        int height,
+        CancellationToken cancellationToken)
+    {
+        Verify.NotNullOrWhiteSpace(prompt);
+
+        var size = new GeneratedImageSize(width, height);
+
+        var imageOptions = new ImageGenerationOptions()
+        {
+            Size = size,
+            ResponseFormat = GeneratedImageFormat.Uri
+        };
+
+        ClientResult<GeneratedImage> response = await RunRequestAsync(() => this.Client.GetImageClient(this.ModelId).GenerateImageAsync(prompt, imageOptions, cancellationToken)).ConfigureAwait(false);
+        var generatedImage = response.Value;
+
+        return generatedImage.ImageUri?.ToString() ?? throw new KernelException("The generated image is not in url format");
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToImageService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToImageService.cs
@@ -10,23 +10,13 @@ using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.TextToImage;
 using OpenAI;
 
-/* Phase 02
-- Breaking the current constructor parameter order to follow the same order as the other services.
-- Added custom endpoint support, and removed ApiKey validation, as it is performed by the ClientCore when the Endpoint is not provided.
-- Added custom OpenAIClient support.
-- Updated "organization" parameter to "organizationId".
-- "modelId" parameter is now required in the constructor.
-
-- Added OpenAIClient breaking glass constructor.
-*/
-
-namespace Microsoft.SemanticKernel.Connectors.OpenAI;
+namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 /// <summary>
 /// OpenAI text to image service.
 /// </summary>
 [Experimental("SKEXP0010")]
-public class OpenAITextToImageService : ITextToImageService
+public class AzureOpenAITextToImageService : ITextToImageService
 {
     private readonly ClientCore _client;
 
@@ -34,7 +24,7 @@ public class OpenAITextToImageService : ITextToImageService
     public IReadOnlyDictionary<string, object?> Attributes => this._client.Attributes;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OpenAITextToImageService"/> class.
+    /// Initializes a new instance of the <see cref="AzureOpenAITextToImageService"/> class.
     /// </summary>
     /// <param name="modelId">The model to use for image generation.</param>
     /// <param name="apiKey">OpenAI API key, see https://platform.openai.com/account/api-keys</param>
@@ -42,7 +32,7 @@ public class OpenAITextToImageService : ITextToImageService
     /// <param name="endpoint">Non-default endpoint for the OpenAI API.</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public OpenAITextToImageService(
+    public AzureOpenAITextToImageService(
         string modelId,
         string? apiKey = null,
         string? organizationId = null,
@@ -54,17 +44,17 @@ public class OpenAITextToImageService : ITextToImageService
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OpenAITextToImageService"/> class.
+    /// Initializes a new instance of the <see cref="AzureOpenAITextToImageService"/> class.
     /// </summary>
     /// <param name="modelId">Model name</param>
     /// <param name="openAIClient">Custom <see cref="OpenAIClient"/> for HTTP requests.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
-    public OpenAITextToImageService(
+    public AzureOpenAITextToImageService(
         string modelId,
         OpenAIClient openAIClient,
         ILoggerFactory? loggerFactory = null)
     {
-        this._client = new(modelId, openAIClient, loggerFactory?.CreateLogger(typeof(OpenAITextToImageService)));
+        this._client = new(modelId, openAIClient, loggerFactory?.CreateLogger(typeof(OpenAITextEmbeddingGenerationService)));
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Connectors/Connectors.OpenAIV2/Services/OpenAIAudioToTextService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2/Services/OpenAIAudioToTextService.cs
@@ -33,7 +33,7 @@ public sealed class OpenAIAudioToTextService : IAudioToTextService
     public IReadOnlyDictionary<string, object?> Attributes => this._client.Attributes;
 
     /// <summary>
-    /// Creates an instance of the <see cref="OpenAITextToAudioService"/> with API key auth.
+    /// Creates an instance of the <see cref="OpenAIAudioToTextService"/> with API key auth.
     /// </summary>
     /// <param name="modelId">Model name</param>
     /// <param name="apiKey">OpenAI API Key</param>
@@ -49,11 +49,11 @@ public sealed class OpenAIAudioToTextService : IAudioToTextService
         HttpClient? httpClient = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._client = new(modelId, apiKey, organization, endpoint, httpClient, loggerFactory?.CreateLogger(typeof(OpenAITextToAudioService)));
+        this._client = new(modelId, apiKey, organization, endpoint, httpClient, loggerFactory?.CreateLogger(typeof(OpenAIAudioToTextService)));
     }
 
     /// <summary>
-    /// Creates an instance of the <see cref="OpenAITextToAudioService"/> with API key auth.
+    /// Creates an instance of the <see cref="OpenAIAudioToTextService"/> with API key auth.
     /// </summary>
     /// <param name="modelId">Model name</param>
     /// <param name="openAIClient">Custom <see cref="OpenAIClient"/> for HTTP requests.</param>


### PR DESCRIPTION
### Motivation, Context and Description
This PR copies the `OpenAITextToImageService` class and related code, including unit tests, from the `Connectors.OpenAIV2` project to the `Connectors.AzureOpenAI` project. The copied classes have no functional changes; they have only been renamed to have the `Azure` prefix and placed into the corresponding `Microsoft.SemanticKernel.Connectors.AzureOpenAI` namespace. All the classes are temporarily excluded from the compilation process. This is done to simplify the code review of follow-up PR(s) that will include functional changes.

A few small fixes, unrelated to the main purpose of the PR, were made to the XML documentation comments and logging in the `OpenAIAudioToTextService` and `OpenAITextToImageService` classes.