### PR TITLE
.Net: VectorStore: Moving all vector store interfaces to data folder and namespace.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
@@ -12,7 +12,7 @@ using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Models;
 using Microsoft.SemanticKernel.Connectors.AzureAISearch;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Moq;
 using Xunit;
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -14,7 +14,7 @@ using Azure;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Models;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
@@ -3,7 +3,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Search.Documents.Indexes;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStore.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStoreOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapperOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapperOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStore.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using NRedisStack.Json.DataTypes;
 using NRedisStack.RedisStackCommands;
 using StackExchange.Redis;
@@ -76,7 +76,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         // Assign.
         this._database = database;
         this._options = options ?? new RedisVectorRecordStoreOptions<TRecord>();
-        this._jsonSerializerOptions = this._options.jsonSerializerOptions ?? JsonSerializerOptions.Default;
+        this._jsonSerializerOptions = this._options.JsonSerializerOptions ?? JsonSerializerOptions.Default;
 
         // Enumerate public properties using configuration or attributes.
         (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 
@@ -54,5 +54,5 @@ public sealed class RedisVectorRecordStoreOptions<TRecord>
     /// <summary>
     /// Gets or sets the JSON serializer options to use when converting between the data model and the Redis record.
     /// </summary>
-    public JsonSerializerOptions? jsonSerializerOptions { get; init; } = null;
+    public JsonSerializerOptions? JsonSerializerOptions { get; init; } = null;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordMapper.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Moq;
 using Qdrant.Client.Grpc;
 using Xunit;

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 using Xunit;
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Moq;
 using NRedisStack;
 using StackExchange.Redis;

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordMapperTests.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using System.Text.Json.Nodes;
 using Microsoft.SemanticKernel.Connectors.Redis;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Xunit;
 
 namespace SemanticKernel.Connectors.Redis.UnitTests;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Search.Documents.Indexes;
 using Microsoft.SemanticKernel.Connectors.AzureAISearch;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Xunit;
 using Xunit.Abstractions;
 using static SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch.AzureAISearchVectorStoreFixture;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -12,7 +12,7 @@ using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Configuration;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using SemanticKernel.IntegrationTests.TestSettings.Memory;
 using Xunit;
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 using Xunit;
 using Xunit.Abstractions;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using Grpc.Core;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 using Xunit;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Connectors.Redis;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Xunit;
 using Xunit.Abstractions;
 using static SemanticKernel.IntegrationTests.Connectors.Memory.Redis.RedisVectorStoreFixture;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Docker.DotNet;
 using Docker.DotNet.Models;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using NRedisStack.RedisStackCommands;
 using NRedisStack.Search;
 using StackExchange.Redis;

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreErrorHandler.cs
@@ -3,9 +3,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using Microsoft.SemanticKernel.Memory;
 
-namespace Microsoft.SemanticKernel;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Contains helpers for reading vector store model properties and their attributes.

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -8,9 +8,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.SemanticKernel.Memory;
 
-namespace Microsoft.SemanticKernel;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Contains helpers for reading vector store model properties and their attributes.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorRecordStore.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorRecordStore.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// An interface for adding, updating, deleting and retrieving records from a vector store.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordMapper.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordMapper.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.SemanticKernel.Memory;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Interface for mapping between a storage model, and the consumer record data model.
 /// </summary>
 /// <typeparam name="TRecordDataModel">The consumer record data model to map to or from.</typeparam>
 /// <typeparam name="TStorageModel">The storage model to map to or from.</typeparam>
+[Experimental("SKEXP0001")]
 public interface IVectorStoreRecordMapper<TRecordDataModel, TStorageModel>
     where TRecordDataModel : class
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Attribute to mark a property on a record class as data.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordKeyAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordKeyAttribute.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Attribute to mark a property on a record class as the key under which data is stored in a vector store.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordVectorAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordVectorAttribute.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Attribute to mark a property on a record class as the vector.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// A description of a data property on a record for storage in a vector store.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDefinition.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDefinition.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// A description of the properties of a record stored in a vector store, plus how the properties are used.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordKeyProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordKeyProperty.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// A description of a key property on a record for storage in a vector store.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// A description of a property on a record for storage in a vector store.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// A description of a vector property on a record for storage in a vector store.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/DeleteRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/DeleteRecordOptions.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.DeleteAsync"/>.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/GetRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/GetRecordOptions.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.GetAsync"/>.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/UpsertRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/UpsertRecordOptions.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.UpsertAsync"/>.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/StorageToDataModelMapperOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/StorageToDataModelMapperOptions.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.SemanticKernel.Memory;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Options to use with the <see cref="IVectorStoreRecordMapper{TRecordDataModel, TStorageModel}.MapFromStorageToDataModel"/> method.
 /// </summary>
+[Experimental("SKEXP0001")]
 public class StorageToDataModelMapperOptions
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreException.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Base exception type thrown for any type of failure when using vector stores.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreOperationException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreOperationException.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Exception thrown when a vector store command fails, such as upserting a record or deleting a collection.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreRecordMappingException.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreRecordMappingException.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.SemanticKernel.Memory;
+namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Exception thrown when a failure occurs while trying to convert models for storage or retrieval.

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -5,8 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Memory;
+using Microsoft.SemanticKernel.Data;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Data;


### PR DESCRIPTION
### Motivation and Context

We agreed to put all vector store core code in the Microsoft.SementicKernel.Data namespace, so moving all abstractions into this folder structure and namespace.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
