### PR TITLE
.Net: Migrate AzureOpenAITextToImageService to Azure.AI.OpenAI v2

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Connectors.AzureOpenAI.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Connectors.AzureOpenAI.UnitTests.csproj
@@ -31,14 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="Services\AzureOpenAITextToImageServiceTests.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Services\AzureOpenAITextToImageServiceTests.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToImageServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToImageServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class AzureOpenAITextToImageServiceTests : IDisposable
         Assert.Equal("model", sut.Attributes[AIServiceExtensions.ModelIdKey]);
 
         // Case #3
-        sut = new AzureOpenAITextToImageService("deployment", new AzureOpenAIClient(), "model");
+        sut = new AzureOpenAITextToImageService("deployment", new AzureOpenAIClient(new Uri("https://api-host/"), "api-key"), "model");
         Assert.Equal("deployment", sut.Attributes[ClientCore.DeploymentNameKey]);
         Assert.Equal("model", sut.Attributes[AIServiceExtensions.ModelIdKey]);
     }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/TestData/text-to-image-response.txt
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/TestData/text-to-image-response.txt
@@ -1,0 +1,9 @@
+{
+    "created": 1702575371,
+    "data": [
+        {
+            "revised_prompt": "A photo capturing the diversity of the Earth's landscapes.",
+            "url": "https://image-url/"
+        }
+    ]
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
@@ -22,17 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Core\ClientCore.TextToImage.cs" />
-    <Compile Remove="Services\AzureOpenAITextToImageService.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="SemanticKernel.Connectors.AzureOpenAI.UnitTests" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Core\ClientCore.TextToImage.cs" />
-    <None Include="Services\AzureOpenAITextToImageService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.ChatCompletion.cs
@@ -23,7 +23,7 @@ using OpenAIChatCompletion = OpenAI.Chat.ChatCompletion;
 namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 /// <summary>
-/// Base class for AI clients that provides common functionality for interacting with OpenAI services.
+/// Base class for AI clients that provides common functionality for interacting with Azure OpenAI services.
 /// </summary>
 internal partial class ClientCore
 {

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.Embeddings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.Embeddings.cs
@@ -9,7 +9,7 @@ using OpenAI.Embeddings;
 namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 /// <summary>
-/// Base class for AI clients that provides common functionality for interacting with OpenAI services.
+/// Base class for AI clients that provides common functionality for interacting with Azure OpenAI services.
 /// </summary>
 internal partial class ClientCore
 {

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.TextToImage.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.TextToImage.cs
@@ -8,7 +8,7 @@ using OpenAI.Images;
 namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 /// <summary>
-/// Base class for AI clients that provides common functionality for interacting with OpenAI services.
+/// Base class for AI clients that provides common functionality for interacting with Azure OpenAI services.
 /// </summary>
 internal partial class ClientCore
 {
@@ -36,9 +36,8 @@ internal partial class ClientCore
             ResponseFormat = GeneratedImageFormat.Uri
         };
 
-        ClientResult<GeneratedImage> response = await RunRequestAsync(() => this.Client.GetImageClient(this.ModelId).GenerateImageAsync(prompt, imageOptions, cancellationToken)).ConfigureAwait(false);
-        var generatedImage = response.Value;
+        ClientResult<GeneratedImage> response = await RunRequestAsync(() => this.Client.GetImageClient(this.DeploymentOrModelName).GenerateImageAsync(prompt, imageOptions, cancellationToken)).ConfigureAwait(false);
 
-        return generatedImage.ImageUri?.ToString() ?? throw new KernelException("The generated image is not in url format");
+        return response.Value.ImageUri?.ToString() ?? throw new KernelException("The generated image is not in url format");
     }
 }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.cs
@@ -17,7 +17,7 @@ using OpenAI;
 namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 /// <summary>
-/// Base class for AI clients that provides common functionality for interacting with OpenAI services.
+/// Base class for AI clients that provides common functionality for interacting with Azure OpenAI services.
 /// </summary>
 internal partial class ClientCore
 {
@@ -135,13 +135,13 @@ internal partial class ClientCore
 
     /// <summary>Gets options to use for an OpenAIClient</summary>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <param name="serviceVersion">Optional API version.</param>
     /// <returns>An instance of <see cref="OpenAIClientOptions"/>.</returns>
-    internal static AzureOpenAIClientOptions GetAzureOpenAIClientOptions(HttpClient? httpClient)
+    internal static AzureOpenAIClientOptions GetAzureOpenAIClientOptions(HttpClient? httpClient, AzureOpenAIClientOptions.ServiceVersion? serviceVersion = null)
     {
-        AzureOpenAIClientOptions options = new()
-        {
-            ApplicationId = HttpHeaderConstant.Values.UserAgent,
-        };
+        AzureOpenAIClientOptions options = serviceVersion is not null
+            ? new(serviceVersion.Value) { ApplicationId = HttpHeaderConstant.Values.UserAgent }
+            : new() { ApplicationId = HttpHeaderConstant.Values.UserAgent };
 
         options.AddPolicy(CreateRequestHeaderPolicy(HttpHeaderConstant.Names.SemanticKernelVersion, HttpHeaderConstant.Values.GetAssemblyVersion(typeof(ClientCore))), PipelinePosition.PerCall);
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextEmbeddingGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextEmbeddingGenerationService.cs
@@ -79,18 +79,18 @@ public sealed class AzureOpenAITextEmbeddingGenerationService : ITextEmbeddingGe
     /// Creates a new <see cref="AzureOpenAITextEmbeddingGenerationService"/> client.
     /// </summary>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
-    /// <param name="openAIClient">Custom <see cref="AzureOpenAIClient"/> for HTTP requests.</param>
+    /// <param name="azureOpenAIClient">Custom <see cref="AzureOpenAIClient"/> for HTTP requests.</param>
     /// <param name="modelId">Azure OpenAI model id, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     public AzureOpenAITextEmbeddingGenerationService(
         string deploymentName,
-        AzureOpenAIClient openAIClient,
+        AzureOpenAIClient azureOpenAIClient,
         string? modelId = null,
         ILoggerFactory? loggerFactory = null,
         int? dimensions = null)
     {
-        this._core = new(deploymentName, openAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
+        this._core = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextEmbeddingGenerationService)));
 
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToImageService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToImageService.cs
@@ -52,11 +52,9 @@ public class AzureOpenAITextToImageService : ITextToImageService
             throw new ArgumentException($"The {nameof(httpClient)}.{nameof(HttpClient.BaseAddress)} and {nameof(endpoint)} are both null or empty. Please ensure at least one is provided.");
         }
 
-        var options = ClientCore.GetAzureOpenAIClientOptions(httpClient, apiVersion switch
-        {
-            // DALL-E 3 is supported in the latest API releases - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#image-generation
-            _ => AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview
-        });
+        var options = ClientCore.GetAzureOpenAIClientOptions(
+            httpClient,
+            AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview); // DALL-E 3 is supported in the latest API releases - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#image-generation
 
         var azureOpenAIClient = new AzureOpenAIClient(new Uri(connectorEndpoint), apiKey, options);
 
@@ -95,11 +93,9 @@ public class AzureOpenAITextToImageService : ITextToImageService
             throw new ArgumentException($"The {nameof(httpClient)}.{nameof(HttpClient.BaseAddress)} and {nameof(endpoint)} are both null or empty. Please ensure at least one is provided.");
         }
 
-        var options = ClientCore.GetAzureOpenAIClientOptions(httpClient, apiVersion switch
-        {
-            // DALL-E 3 is supported in the latest API releases - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#image-generation
-            _ => AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview
-        });
+        var options = ClientCore.GetAzureOpenAIClientOptions(
+            httpClient,
+            AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview); // DALL-E 3 is supported in the latest API releases - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#image-generation
 
         var azureOpenAIClient = new AzureOpenAIClient(new Uri(connectorEndpoint), credential, options);
 


### PR DESCRIPTION
### Motivation, Context, and Description  
This PR migrates `AzureOpenAITextToImageService` to Azure.AI.OpenAI v2:  
1. It updates the previously added `AzureOpenAITextToImageService` to use `AzureOpenAIClient`.  
2. It replaces all constructors in the `AzureOpenAITextToImageService` with the relevant ones from the original `AzureOpenAITextToImageService`.  
3. It adds the `serviceVersion` parameter to the `ClientCore.GetAzureOpenAIClientOptions` methods, allowing the specification of the service API version.  
4. It updates XML documentation comments in a few classes to indicate their relevance to Azure OpenAI services.  
5. It adds unit tests for the `AzureOpenAITextToImageService` class.