### PR TITLE
.Net: Migrate AzureOpenAITextToAudioService to Azure.AI.OpenAI SDK v2

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceCollectionExtensionsTests.cs
@@ -9,6 +9,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.TextGeneration;
+using Microsoft.SemanticKernel.TextToAudio;
 
 namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Extensions;
 
@@ -84,6 +85,25 @@ public sealed class AzureOpenAIServiceCollectionExtensionsTests
 
         Assert.NotNull(service);
         Assert.True(service is AzureOpenAITextEmbeddingGenerationService);
+    }
+
+    #endregion
+
+    #region Text to audio
+
+    [Fact]
+    public void ServiceCollectionAddAzureOpenAITextToAudioAddsValidService()
+    {
+        // Arrange
+        var sut = new ServiceCollection();
+
+        // Act
+        var service = sut.AddAzureOpenAITextToAudio("deployment-name", "https://endpoint", "api-key")
+            .BuildServiceProvider()
+            .GetRequiredService<ITextToAudioService>();
+
+        // Assert
+        Assert.IsType<AzureOpenAITextToAudioService>(service);
     }
 
     #endregion

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceKernelBuilderExtensionsTests.cs
@@ -9,6 +9,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.TextGeneration;
+using Microsoft.SemanticKernel.TextToAudio;
 
 namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Extensions;
 
@@ -84,6 +85,25 @@ public sealed class AzureOpenAIServiceKernelBuilderExtensionsTests
 
         Assert.NotNull(service);
         Assert.True(service is AzureOpenAITextEmbeddingGenerationService);
+    }
+
+    #endregion
+
+    #region Text to audio
+
+    [Fact]
+    public void KernelBuilderAddAzureOpenAITextToAudioAddsValidService()
+    {
+        // Arrange
+        var sut = Kernel.CreateBuilder();
+
+        // Act
+        var service = sut.AddAzureOpenAITextToAudio("deployment-name", "https://endpoint", "api-key")
+            .Build()
+            .GetRequiredService<ITextToAudioService>();
+
+        // Assert
+        Assert.IsType<AzureOpenAITextToAudioService>(service);
     }
 
     #endregion

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToAudioServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToAudioServiceTests.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Moq;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AzureOpenAITextToAudioService"/> class.
+/// </summary>
+public sealed class AzureOpenAITextToAudioServiceTests : IDisposable
+{
+    private readonly HttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+    private readonly Mock<ILoggerFactory> _mockLoggerFactory;
+
+    public AzureOpenAITextToAudioServiceTests()
+    {
+        this._messageHandlerStub = new HttpMessageHandlerStub();
+        this._httpClient = new HttpClient(this._messageHandlerStub, false);
+        this._mockLoggerFactory = new Mock<ILoggerFactory>();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConstructorsAddRequiredMetadata(bool includeLoggerFactory)
+    {
+        // Arrange & Act
+        var service = includeLoggerFactory ?
+            new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", loggerFactory: this._mockLoggerFactory.Object) :
+            new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id");
+
+        // Assert
+        Assert.Equal("model-id", service.Attributes["ModelId"]);
+        Assert.Equal("deployment-name", service.Attributes["DeploymentName"]);
+    }
+
+    [Fact]
+    public void ItThrowsIfModelIdIsNotProvided()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AzureOpenAITextToAudioService(null!, "https://endpoint", "api-key"));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAITextToAudioService("", "https://endpoint", "api-key"));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAITextToAudioService(" ", "https://endpoint", "api-key"));
+    }
+
+    [Fact]
+    public async Task GetAudioContentWithInvalidSettingsThrowsExceptionAsync()
+    {
+        // Arrange
+        var settingsWithInvalidVoice = new AzureOpenAITextToAudioExecutionSettings("");
+
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+        await using var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0xFF, 0x7F });
+
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stream)
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(() => service.GetAudioContentsAsync("Some text", settingsWithInvalidVoice));
+    }
+
+    [Fact]
+    public async Task GetAudioContentByDefaultWorksCorrectlyAsync()
+    {
+        // Arrange
+        var expectedByteArray = new byte[] { 0x00, 0x00, 0xFF, 0x7F };
+
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+        await using var stream = new MemoryStream(expectedByteArray);
+
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stream)
+        };
+
+        // Act
+        var result = await service.GetAudioContentsAsync("Some text", new AzureOpenAITextToAudioExecutionSettings("Nova"));
+
+        // Assert
+        var audioData = result[0].Data!.Value;
+        Assert.False(audioData.IsEmpty);
+        Assert.True(audioData.Span.SequenceEqual(expectedByteArray));
+    }
+
+    [Theory]
+    [InlineData("echo", "wav")]
+    [InlineData("fable", "opus")]
+    [InlineData("onyx", "flac")]
+    [InlineData("nova", "aac")]
+    [InlineData("shimmer", "pcm")]
+    public async Task GetAudioContentVoicesWorksCorrectlyAsync(string voice, string format)
+    {
+        // Arrange
+        byte[] expectedByteArray = [0x00, 0x00, 0xFF, 0x7F];
+
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+        await using var stream = new MemoryStream(expectedByteArray);
+
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stream)
+        };
+
+        // Act
+        var result = await service.GetAudioContentsAsync("Some text", new AzureOpenAITextToAudioExecutionSettings(voice) { ResponseFormat = format });
+
+        // Assert
+        var requestBody = JsonSerializer.Deserialize<JsonObject>(this._messageHandlerStub.RequestContent!);
+        Assert.NotNull(requestBody);
+        Assert.Equal(voice, requestBody["voice"]?.ToString());
+        Assert.Equal(format, requestBody["response_format"]?.ToString());
+
+        var audioData = result[0].Data!.Value;
+        Assert.False(audioData.IsEmpty);
+        Assert.True(audioData.Span.SequenceEqual(expectedByteArray));
+    }
+
+    [Fact]
+    public async Task GetAudioContentThrowsWhenVoiceIsNotSupportedAsync()
+    {
+        // Arrange
+        byte[] expectedByteArray = [0x00, 0x00, 0xFF, 0x7F];
+
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await service.GetAudioContentsAsync("Some text", new AzureOpenAITextToAudioExecutionSettings("voice")));
+    }
+
+    [Fact]
+    public async Task GetAudioContentThrowsWhenFormatIsNotSupportedAsync()
+    {
+        // Arrange
+        byte[] expectedByteArray = [0x00, 0x00, 0xFF, 0x7F];
+
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await service.GetAudioContentsAsync("Some text", new AzureOpenAITextToAudioExecutionSettings() { ResponseFormat = "not supported" }));
+    }
+
+    [Theory]
+    [InlineData(true, "http://local-endpoint")]
+    [InlineData(false, "https://endpoint")]
+    public async Task GetAudioContentUsesValidBaseUrlAsync(bool useHttpClientBaseAddress, string expectedBaseAddress)
+    {
+        // Arrange
+        var expectedByteArray = new byte[] { 0x00, 0x00, 0xFF, 0x7F };
+
+        if (useHttpClientBaseAddress)
+        {
+            this._httpClient.BaseAddress = new Uri("http://local-endpoint");
+        }
+
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+        await using var stream = new MemoryStream(expectedByteArray);
+
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stream)
+        };
+
+        // Act
+        var result = await service.GetAudioContentsAsync("Some text", new AzureOpenAITextToAudioExecutionSettings("Nova"));
+
+        // Assert
+        Assert.StartsWith(expectedBaseAddress, this._messageHandlerStub.RequestUri!.AbsoluteUri, StringComparison.InvariantCulture);
+    }
+
+    [Theory]
+    [InlineData("model-1", "model-2", "deployment", "model-2")]
+    [InlineData("model-1", null, "deployment", "model-1")]
+    [InlineData(null, "model-2", "deployment", "model-2")]
+    [InlineData(null, null, "deployment", "deployment")]
+    public async Task GetAudioContentPrioritizesModelIdOverDeploymentNameAsync(string? modelInSettings, string? modelInConstructor, string deploymentName, string expectedModel)
+    {
+        // Arrange
+        var expectedByteArray = new byte[] { 0x00, 0x00, 0xFF, 0x7F };
+
+        var service = new AzureOpenAITextToAudioService(deploymentName, "https://endpoint", "api-key", modelInConstructor, this._httpClient);
+        await using var stream = new MemoryStream(expectedByteArray);
+
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stream)
+        };
+
+        // Act
+        var result = await service.GetAudioContentsAsync("Some text", new AzureOpenAITextToAudioExecutionSettings("Nova") { ModelId = modelInSettings });
+
+        // Assert
+        var requestBody = JsonSerializer.Deserialize<JsonObject>(this._messageHandlerStub.RequestContent!);
+        Assert.Equal(expectedModel, requestBody?["model"]?.ToString());
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToAudioServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToAudioServiceTests.cs
@@ -162,10 +162,10 @@ public sealed class AzureOpenAITextToAudioServiceTests : IDisposable
 
         if (useHttpClientBaseAddress)
         {
-            this._httpClient.BaseAddress = new Uri("http://local-endpoint");
+            this._httpClient.BaseAddress = new Uri("http://local-endpoint/path");
         }
 
-        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+        var service = new AzureOpenAITextToAudioService("deployment-name", "https://endpoint/path", "api-key", "model-id", this._httpClient);
         await using var stream = new MemoryStream(expectedByteArray);
 
         this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(HttpStatusCode.OK)

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
@@ -22,17 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Core\ClientCore.TextToAudio.cs" />
-    <Compile Remove="Services\AzureOpenAITextToAudioService.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="SemanticKernel.Connectors.AzureOpenAI.UnitTests" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Core\ClientCore.TextToAudio.cs" />
-    <None Include="Services\AzureOpenAITextToAudioService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
@@ -255,11 +255,11 @@ public static class AzureOpenAIKernelBuilderExtensions
     /// Adds the Azure OpenAI text-to-audio service to the list.
     /// </summary>
     /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
-    /// <param name="deploymentName">Azure OpenAI deployment name</param>
-    /// <param name="endpoint">Azure OpenAI deployment URL</param>
-    /// <param name="apiKey">Azure OpenAI API key</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="serviceId">A local identifier for the given AI service</param>
-    /// <param name="modelId">Model identifier</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
     [Experimental("SKEXP0001")]

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
@@ -252,7 +252,7 @@ public static class AzureOpenAIKernelBuilderExtensions
     #region Text-to-Audio
 
     /// <summary>
-    /// Adds the Azure OpenAI text-to-audio service to the list.
+    /// Adds the <see cref="AzureOpenAITextToAudioService"/> to the <see cref="IKernelBuilder.Services"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.TextGeneration;
+using Microsoft.SemanticKernel.TextToAudio;
 
 #pragma warning disable IDE0039 // Use local function
 
@@ -242,6 +243,47 @@ public static class AzureOpenAIKernelBuilderExtensions
                 modelId,
                 serviceProvider.GetService<ILoggerFactory>(),
                 dimensions));
+
+        return builder;
+    }
+
+    #endregion
+
+    #region Text-to-Audio
+
+    /// <summary>
+    /// Adds the Azure OpenAI text-to-audio service to the list.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL</param>
+    /// <param name="apiKey">Azure OpenAI API key</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0001")]
+    public static IKernelBuilder AddAzureOpenAITextToAudio(
+        this IKernelBuilder builder,
+        string deploymentName,
+        string endpoint,
+        string apiKey,
+        string? serviceId = null,
+        string? modelId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(endpoint);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        builder.Services.AddKeyedSingleton<ITextToAudioService>(serviceId, (serviceProvider, _) =>
+            new AzureOpenAITextToAudioService(
+                deploymentName,
+                endpoint,
+                apiKey,
+                modelId,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>()));
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -241,11 +241,11 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// Adds the Azure OpenAI text-to-audio service to the list.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
-    /// <param name="deploymentName">Azure OpenAI deployment name</param>
-    /// <param name="endpoint">Azure OpenAI deployment URL</param>
-    /// <param name="apiKey">Azure OpenAI API key</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="serviceId">A local identifier for the given AI service</param>
-    /// <param name="modelId">Model identifier</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0001")]

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -249,7 +249,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
-    [Experimental("SKEXP0001")]
+    [Experimental("SKEXP0010")]
     public static IServiceCollection AddAzureOpenAITextToAudio(
         this IServiceCollection services,
         string deploymentName,

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.TextGeneration;
+using Microsoft.SemanticKernel.TextToAudio;
 
 #pragma warning disable IDE0039 // Use local function
 
@@ -230,6 +231,46 @@ public static class AzureOpenAIServiceCollectionExtensions
                 modelId,
                 serviceProvider.GetService<ILoggerFactory>(),
                 dimensions));
+    }
+
+    #endregion
+
+    #region Text-to-Audio
+
+    /// <summary>
+    /// Adds the Azure OpenAI text-to-audio service to the list.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL</param>
+    /// <param name="apiKey">Azure OpenAI API key</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="services"/>.</returns>
+    [Experimental("SKEXP0001")]
+    public static IServiceCollection AddAzureOpenAITextToAudio(
+        this IServiceCollection services,
+        string deploymentName,
+        string endpoint,
+        string apiKey,
+        string? serviceId = null,
+        string? modelId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(services);
+        Verify.NotNullOrWhiteSpace(deploymentName);
+        Verify.NotNullOrWhiteSpace(endpoint);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        return services.AddKeyedSingleton<ITextToAudioService>(serviceId, (serviceProvider, _) =>
+            new AzureOpenAITextToAudioService(
+                deploymentName,
+                endpoint,
+                apiKey,
+                modelId,
+                HttpClientProvider.GetHttpClient(serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>()));
     }
 
     #endregion

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -238,7 +238,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     #region Text-to-Audio
 
     /// <summary>
-    /// Adds the Azure OpenAI text-to-audio service to the list.
+    /// Adds the <see cref="AzureOpenAITextToAudioService"/> to the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> instance to augment.</param>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToAudioService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToAudioService.cs
@@ -38,7 +38,7 @@ public sealed class AzureOpenAITextToAudioService : ITextToAudioService
     public static string DeploymentNameKey => "DeploymentName";
 
     /// <summary>
-    /// Creates an instance of the <see cref="AzureOpenAITextToAudioService"/> connector with API key auth.
+    /// Initializes a new instance of the <see cref="AzureOpenAITextToAudioService"/> class.
     /// </summary>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAITextToAudioExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAITextToAudioExecutionSettings.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 /// <summary>
 /// Execution settings for Azure OpenAI text-to-audio request.
 /// </summary>
-[Experimental("SKEXP0001")]
+[Experimental("SKEXP0010")]
 public sealed class AzureOpenAITextToAudioExecutionSettings : PromptExecutionSettings
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAITextToAudioExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAITextToAudioExecutionSettings.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.SemanticKernel.Text;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+/// <summary>
+/// Execution settings for Azure OpenAI text-to-audio request.
+/// </summary>
+[Experimental("SKEXP0001")]
+public sealed class AzureOpenAITextToAudioExecutionSettings : PromptExecutionSettings
+{
+    /// <summary>
+    /// The voice to use when generating the audio. Supported voices are alloy, echo, fable, onyx, nova, and shimmer.
+    /// </summary>
+    [JsonPropertyName("voice")]
+    public string Voice
+    {
+        get => this._voice;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._voice = value;
+        }
+    }
+
+    /// <summary>
+    /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
+    /// </summary>
+    [JsonPropertyName("response_format")]
+    public string ResponseFormat
+    {
+        get => this._responseFormat;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._responseFormat = value;
+        }
+    }
+
+    /// <summary>
+    /// The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.
+    /// </summary>
+    [JsonPropertyName("speed")]
+    public float Speed
+    {
+        get => this._speed;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._speed = value;
+        }
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="AzureOpenAITextToAudioExecutionSettings"/> class with default voice - "alloy".
+    /// </summary>
+    public AzureOpenAITextToAudioExecutionSettings()
+        : this(DefaultVoice)
+    {
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="AzureOpenAITextToAudioExecutionSettings"/> class.
+    /// </summary>
+    /// <param name="voice">The voice to use when generating the audio. Supported voices are alloy, echo, fable, onyx, nova, and shimmer.</param>
+    public AzureOpenAITextToAudioExecutionSettings(string voice)
+    {
+        this._voice = voice;
+    }
+
+    /// <inheritdoc/>
+    public override PromptExecutionSettings Clone()
+    {
+        return new AzureOpenAITextToAudioExecutionSettings(this.Voice)
+        {
+            ModelId = this.ModelId,
+            ExtensionData = this.ExtensionData is not null ? new Dictionary<string, object>(this.ExtensionData) : null,
+            Speed = this.Speed,
+            ResponseFormat = this.ResponseFormat
+        };
+    }
+
+    /// <summary>
+    /// Converts <see cref="PromptExecutionSettings"/> to derived <see cref="AzureOpenAITextToAudioExecutionSettings"/> type.
+    /// </summary>
+    /// <param name="executionSettings">Instance of <see cref="PromptExecutionSettings"/>.</param>
+    /// <returns>Instance of <see cref="AzureOpenAITextToAudioExecutionSettings"/>.</returns>
+    public static AzureOpenAITextToAudioExecutionSettings FromExecutionSettings(PromptExecutionSettings? executionSettings)
+    {
+        if (executionSettings is null)
+        {
+            return new AzureOpenAITextToAudioExecutionSettings();
+        }
+
+        if (executionSettings is AzureOpenAITextToAudioExecutionSettings settings)
+        {
+            return settings;
+        }
+
+        var json = JsonSerializer.Serialize(executionSettings);
+
+        var azureOpenAIExecutionSettings = JsonSerializer.Deserialize<AzureOpenAITextToAudioExecutionSettings>(json, JsonOptionsCache.ReadPermissive);
+
+        if (azureOpenAIExecutionSettings is not null)
+        {
+            return azureOpenAIExecutionSettings;
+        }
+
+        throw new ArgumentException($"Invalid execution settings, cannot convert to {nameof(AzureOpenAITextToAudioExecutionSettings)}", nameof(executionSettings));
+    }
+
+    #region private ================================================================================
+
+    private const string DefaultVoice = "alloy";
+
+    private float _speed = 1.0f;
+    private string _responseFormat = "mp3";
+    private string _voice;
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTestsV2/Connectors/AzureOpenAI/AzureOpenAITextToAudioTests.cs
+++ b/dotnet/src/IntegrationTestsV2/Connectors/AzureOpenAI/AzureOpenAITextToAudioTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.TextToAudio;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTestsV2.Connectors.AzureOpenAI;
+
+public sealed class AzureOpenAITextToAudioTests
+{
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+        .AddJsonFile(path: "testsettings.json", optional: true, reloadOnChange: true)
+        .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+        .AddEnvironmentVariables()
+        .AddUserSecrets<AzureOpenAITextToAudioTests>()
+        .Build();
+
+    [Fact]
+    public async Task AzureOpenAITextToAudioTestAsync()
+    {
+        // Arrange
+        AzureOpenAIConfiguration? azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAITextToAudio").Get<AzureOpenAIConfiguration>();
+        Assert.NotNull(azureOpenAIConfiguration);
+
+        var kernel = Kernel.CreateBuilder()
+            .AddAzureOpenAITextToAudio(
+                azureOpenAIConfiguration.DeploymentName,
+                azureOpenAIConfiguration.Endpoint,
+                azureOpenAIConfiguration.ApiKey)
+            .Build();
+
+        var service = kernel.GetRequiredService<ITextToAudioService>();
+
+        // Act
+        var result = await service.GetAudioContentAsync("The sun rises in the east and sets in the west.");
+
+        // Assert
+        var audioData = result.Data!.Value;
+        Assert.False(audioData.IsEmpty);
+    }
+}


### PR DESCRIPTION
### Motivation and Context
This PR migrates AzureOpenAITextToAudioService to Azure.AI.OpenAI SDK v2.

### Description
1. The new `AzureOpenAITextToAudioExecutionSettings` class is added to represent prompt execution settings for `AzureOpenAITextToAudioService`. Both `AzureOpenAITextToAudioService` classes that SK has today use the same prompt execution settings class - [OpenAITextToAudioExecutionSettings](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Connectors/Connectors.OpenAI/TextToAudio/OpenAITextToAudioExecutionSettings.cs). This is a breaking change that is tracked in the issue - https://github.com/microsoft/semantic-kernel/issues/7053, and it will be decided later whether to proceed with the change or roll it back.
2. The `ClientCore.TextToAudio.cs` class is refactored to use the new `AzureOpenAITextToAudioExecutionSettings` class.  
3. The `ClientCore.TextToAudio.cs` class is refactored to decide which model id to use - the one from the prompt execution setting, the one supplied when registering the connector, or to use the deployment name if no model id is provided. This is done for backward compatibility with the existing `AzureOpenAITextToAudioService`. https://github.com/microsoft/semantic-kernel/issues/7104
4. Service collection and kernel builder extension methods are added to register the service in the DI container.  
5. Unit and integration tests are added as well.