### PR TITLE
.Net: Adding In Memory (Volatile) vector record store implementation.

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStore.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Service for storing and retrieving vector records, that uses an in memory dictionary as the underlying storage.
+/// </summary>
+/// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+[Experimental("SKEXP0001")]
+public class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<string, TRecord>
+    where TRecord : class
+{
+    /// <summary>Internal storage for the record store.</summary>
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> _internalCollection;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly VolatileVectorRecordStoreOptions _options;
+
+    /// <summary>A set of types that a key on the provided model may have.</summary>
+    private static readonly HashSet<Type> s_supportedKeyTypes =
+    [
+        typeof(string)
+    ];
+
+    /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
+    private readonly PropertyInfo _keyPropertyInfo;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
+    /// </summary>
+    /// <param name="options">Optional configuration options for this class.</param>
+    public VolatileVectorRecordStore(VolatileVectorRecordStoreOptions? options = default)
+    {
+        // Assign.
+        this._internalCollection = new();
+        this._options = options ?? new VolatileVectorRecordStoreOptions();
+
+        // Enumerate public properties using configuration or attributes.
+        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;
+        if (this._options.VectorStoreRecordDefinition is not null)
+        {
+            properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), this._options.VectorStoreRecordDefinition, supportsMultipleVectors: true);
+        }
+        else
+        {
+            properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), supportsMultipleVectors: true);
+        }
+
+        // Validate property types and store for later use.
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
+        this._keyPropertyInfo = properties.keyProperty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
+    /// </summary>
+    /// <param name="internalCollection">Allows passing in the dictionary used for storage, for testing purposes.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    internal VolatileVectorRecordStore(ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> internalCollection, VolatileVectorRecordStoreOptions? options = default)
+        : this(options)
+    {
+        this._internalCollection = internalCollection;
+    }
+
+    /// <inheritdoc />
+    public Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+
+        if (collectionDictionary.TryGetValue(key, out var record))
+        {
+            return Task.FromResult<TRecord?>(record);
+        }
+
+        return Task.FromResult<TRecord?>(null);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<string> keys, GetRecordOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var key in keys)
+        {
+            var record = await this.GetAsync(key, options, cancellationToken).ConfigureAwait(false);
+
+            if (record is not null)
+            {
+                yield return record;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(string key, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+
+        collectionDictionary.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DeleteBatchAsync(IEnumerable<string> keys, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+
+        foreach (var key in keys)
+        {
+            collectionDictionary.TryRemove(key, out _);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<string> UpsertAsync(TRecord record, UpsertRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+
+        var key = this._keyPropertyInfo.GetValue(record) as string;
+        collectionDictionary.AddOrUpdate(key!, record, (key, currentValue) => record);
+
+        return Task.FromResult(key!);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var record in records)
+        {
+            yield return await this.UpsertAsync(record, options, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Get a collection dictionary from the internal storage, creating it if it does not exist.
+    /// Use the provided collection name if not null, and fall back to the default collection name otherwise.
+    /// </summary>
+    /// <param name="collectionName">The collection name passed to the operation.</param>
+    /// <returns>The retrieved collection dictionary.</returns>
+    private ConcurrentDictionary<string, TRecord> GetCollectionDictionary(string? collectionName)
+    {
+        string? chosenCollectionName = null;
+
+        if (collectionName is not null)
+        {
+            chosenCollectionName = collectionName;
+        }
+        else if (this._options.DefaultCollectionName is not null)
+        {
+            chosenCollectionName = this._options.DefaultCollectionName;
+        }
+        else
+        {
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+            throw new ArgumentException("Collection name must be provided in the operation options, since no default was provided at construction time.", "options");
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
+        }
+
+        return this._internalCollection.GetOrAdd(chosenCollectionName, _ => new());
+    }
+}

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStoreOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStoreOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Options when creating a <see cref="VolatileVectorRecordStore{TRecord}"/>.
+/// </summary>
+[Experimental("SKEXP0001")]
+public class VolatileVectorRecordStoreOptions
+{
+    /// <summary>
+    /// Gets or sets the default collection name to use.
+    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
+    /// </summary>
+    public string? DefaultCollectionName { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets an optional record definition that defines the schema of the record type.
+    /// </summary>
+    /// <remarks>
+    /// If not provided, the schema will be inferred from the record model class using reflection.
+    /// In this case, the record model properties must be annotated with the appropriate attributes to indicate their usage.
+    /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
+    /// </remarks>
+    public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorRecordStoreTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorRecordStoreTests.cs
@@ -1,0 +1,272 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Data;
+
+/// <summary>
+/// Contains tests for the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
+/// </summary>
+public class VolatileVectorRecordStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+    private const string TestRecordKey1 = "testid1";
+    private const string TestRecordKey2 = "testid2";
+
+    private readonly CancellationToken _testCancellationToken = new(false);
+
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SinglePropsModel>> _collectionStore;
+
+    public VolatileVectorRecordStoreTests()
+    {
+        this._collectionStore = new();
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var record = CreateModel(TestRecordKey1, withVectors: true);
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        collection.TryAdd(TestRecordKey1, record);
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var actual = await sut.GetAsync(
+            TestRecordKey1,
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        var expectedArgs = new object[] { TestRecordKey1 };
+
+        Assert.NotNull(actual);
+        Assert.Equal(TestRecordKey1, actual.Key);
+        Assert.Equal("data testid1", actual.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.Vector!.Value.ToArray());
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var record1 = CreateModel(TestRecordKey1, withVectors: true);
+        var record2 = CreateModel(TestRecordKey2, withVectors: true);
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        collection.TryAdd(TestRecordKey1, record1);
+        collection.TryAdd(TestRecordKey2, record2);
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var actual = await sut.GetBatchAsync(
+            [TestRecordKey1, TestRecordKey2],
+            new()
+            {
+                IncludeVectors = true,
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(TestRecordKey1, actual[0].Key);
+        Assert.Equal("data testid1", actual[0].Data);
+        Assert.Equal(TestRecordKey2, actual[1].Key);
+        Assert.Equal("data testid2", actual[1].Data);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var record1 = CreateModel(TestRecordKey1, withVectors: true);
+        var record2 = CreateModel(TestRecordKey2, withVectors: true);
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        collection.TryAdd(TestRecordKey1, record1);
+        collection.TryAdd(TestRecordKey2, record2);
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        await sut.DeleteAsync(
+            TestRecordKey1,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        Assert.False(collection.ContainsKey(TestRecordKey1));
+        Assert.True(collection.ContainsKey(TestRecordKey2));
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var record1 = CreateModel(TestRecordKey1, withVectors: true);
+        var record2 = CreateModel(TestRecordKey2, withVectors: true);
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        collection.TryAdd(TestRecordKey1, record1);
+        collection.TryAdd(TestRecordKey2, record2);
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        await sut.DeleteBatchAsync(
+            [TestRecordKey1, TestRecordKey2],
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        Assert.False(collection.ContainsKey(TestRecordKey1));
+        Assert.False(collection.ContainsKey(TestRecordKey2));
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var record1 = CreateModel(TestRecordKey1, withVectors: true);
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(
+            record1,
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken);
+
+        // Assert
+        Assert.Equal(TestRecordKey1, upsertResult);
+        Assert.True(collection.ContainsKey(TestRecordKey1));
+        Assert.Equal("data testid1", collection[TestRecordKey1].Data);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod)
+    {
+        // Arrange
+        var record1 = CreateModel(TestRecordKey1, withVectors: true);
+        var record2 = CreateModel(TestRecordKey2, withVectors: true);
+
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+
+        // Act
+        var actual = await sut.UpsertBatchAsync(
+            [record1, record2],
+            new()
+            {
+                CollectionName = passCollectionToMethod ? TestCollectionName : null
+            },
+            this._testCancellationToken).ToListAsync();
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count);
+        Assert.Equal(TestRecordKey1, actual[0]);
+        Assert.Equal(TestRecordKey2, actual[1]);
+
+        Assert.True(collection.ContainsKey(TestRecordKey1));
+        Assert.Equal("data testid1", collection[TestRecordKey1].Data);
+    }
+
+    private static SinglePropsModel CreateModel(string key, bool withVectors)
+    {
+        return new SinglePropsModel
+        {
+            Key = key,
+            Data = "data " + key,
+            Vector = withVectors ? new float[] { 1, 2, 3, 4 } : null,
+            NotAnnotated = null,
+        };
+    }
+
+    private VolatileVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition, bool passCollectionToMethod)
+    {
+        return new VolatileVectorRecordStore<SinglePropsModel>(
+            this._collectionStore,
+            new()
+            {
+                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
+                VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null
+            });
+    }
+
+    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    {
+        Properties =
+        [
+            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordDataProperty("Data"),
+            new VectorStoreRecordVectorProperty("Vector")
+        ]
+    };
+
+    public sealed class SinglePropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}


### PR DESCRIPTION
### Motivation and Context

We need an in memory implementation of new vector store design, so allow simple usage of the pattern without needing to have an external database.

### Description

This adds an In Memory VectorRecordStore implementation and unit tests.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
