### PR TITLE
.Net: cleanup build warnings/errors in the memory service branch

### DIFF
--- a/docs/decisions/0046-kernel-content-graduation.md
+++ b/docs/decisions/0046-kernel-content-graduation.md
@@ -85,7 +85,7 @@ Pros:
 - With no deferred content we have simpler API and a single responsibility for contents.
 - Can be written and read in both `Data` or `DataUri` formats.
 - Can have a `Uri` reference property, which is common for specialized contexts.
-- Fully serializeable.
+- Fully serializable.
 - Data Uri parameters support (serialization included).
 - Data Uri and Base64 validation checks
 - Data Uri and Data can be dynamically generated
@@ -197,7 +197,7 @@ Pros:
 - Can be used as a `BinaryContent` type
 - Can be written and read in both `Data` or `DataUri` formats.
 - Can have a `Uri` dedicated for referenced location.
-- Fully serializeable.
+- Fully serializable.
 - Data Uri parameters support (serialization included).
 - Data Uri and Base64 validation checks
 - Can be retrieved
@@ -254,7 +254,7 @@ Pros:
 - Can be used as a `BinaryContent` type
 - Can be written and read in both `Data` or `DataUri` formats.
 - Can have a `Uri` dedicated for referenced location.
-- Fully serializeable.
+- Fully serializable.
 - Data Uri parameters support (serialization included).
 - Data Uri and Base64 validation checks
 - Can be retrieved

--- a/dotnet/src/InternalUtilities/src/Schema/JsonSchemaMapper.ReflectionHelpers.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/JsonSchemaMapper.ReflectionHelpers.cs
@@ -170,16 +170,16 @@ static partial class JsonSchemaMapper
     {
         public ParameterLookupKey(string name, Type type)
         {
-            Name = name;
-            Type = type;
+            this.Name = name;
+            this.Type = type;
         }
 
         public string Name { get; }
         public Type Type { get; }
 
-        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
-        public bool Equals(ParameterLookupKey other) => Type == other.Type && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
-        public override bool Equals(object? obj) => obj is ParameterLookupKey key && Equals(key);
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(this.Name);
+        public bool Equals(ParameterLookupKey other) => this.Type == other.Type && string.Equals(this.Name, other.Name, StringComparison.OrdinalIgnoreCase);
+        public override bool Equals(object? obj) => obj is ParameterLookupKey key && this.Equals(key);
     }
 
     // Resolves the deserialization constructor for a type using logic copied from

--- a/dotnet/src/InternalUtilities/src/Schema/JsonSchemaMapper.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/JsonSchemaMapper.cs
@@ -578,42 +578,42 @@ ConstructSchemaDocument:
 
         public GenerationState(JsonSchemaMapperConfiguration configuration)
         {
-            _configuration = configuration;
-            _nullabilityInfoContext = configuration.ReferenceTypeNullability is ReferenceTypeNullability.Annotated ? new() : null;
-            _generatedTypePaths = configuration.AllowSchemaReferences ? new() : null;
-            _currentPath = configuration.AllowSchemaReferences ? new() : null;
-            _currentDepth = 0;
+            this._configuration = configuration;
+            this._nullabilityInfoContext = configuration.ReferenceTypeNullability is ReferenceTypeNullability.Annotated ? new() : null;
+            this._generatedTypePaths = configuration.AllowSchemaReferences ? new() : null;
+            this._currentPath = configuration.AllowSchemaReferences ? new() : null;
+            this._currentDepth = 0;
         }
 
-        public readonly JsonSchemaMapperConfiguration Configuration => _configuration;
-        public readonly NullabilityInfoContext? NullabilityInfoContext => _nullabilityInfoContext;
-        public readonly int CurrentDepth => _currentDepth;
+        public readonly JsonSchemaMapperConfiguration Configuration => this._configuration;
+        public readonly NullabilityInfoContext? NullabilityInfoContext => this._nullabilityInfoContext;
+        public readonly int CurrentDepth => this._currentDepth;
 
         public void Push(string nodeId)
         {
-            if (_currentDepth == Configuration.MaxDepth)
+            if (this._currentDepth == this.Configuration.MaxDepth)
             {
                 ThrowHelpers.ThrowInvalidOperationException_MaxDepthReached();
             }
 
-            _currentDepth++;
+            this._currentDepth++;
 
-            if (Configuration.AllowSchemaReferences)
+            if (this.Configuration.AllowSchemaReferences)
             {
-                Debug.Assert(_currentPath is not null);
-                _currentPath!.Add(nodeId);
+                Debug.Assert(this._currentPath is not null);
+                this._currentPath!.Add(nodeId);
             }
         }
 
         public void Pop()
         {
-            Debug.Assert(_currentDepth > 0);
-            _currentDepth--;
+            Debug.Assert(this._currentDepth > 0);
+            this._currentDepth--;
 
-            if (Configuration.AllowSchemaReferences)
+            if (this.Configuration.AllowSchemaReferences)
             {
-                Debug.Assert(_currentPath is not null);
-                _currentPath!.RemoveAt(_currentPath.Count - 1);
+                Debug.Assert(this._currentPath is not null);
+                this._currentPath!.RemoveAt(this._currentPath.Count - 1);
             }
         }
 
@@ -622,13 +622,13 @@ ConstructSchemaDocument:
         /// </summary>
         public readonly void RegisterTypePath(Type type, Type? parentNullableOfT, JsonConverter? customConverter, bool isNullableReferenceType, JsonNumberHandling? customNumberHandling)
         {
-            if (Configuration.AllowSchemaReferences)
+            if (this.Configuration.AllowSchemaReferences)
             {
-                Debug.Assert(_currentPath is not null);
-                Debug.Assert(_generatedTypePaths is not null);
+                Debug.Assert(this._currentPath is not null);
+                Debug.Assert(this._generatedTypePaths is not null);
 
-                string pointer = _currentDepth == 0 ? "#" : "#/" + string.Join("/", _currentPath);
-                _generatedTypePaths!.Add((parentNullableOfT ?? type, customConverter, isNullableReferenceType, customNumberHandling), pointer);
+                string pointer = this._currentDepth == 0 ? "#" : "#/" + string.Join("/", this._currentPath);
+                this._generatedTypePaths!.Add((parentNullableOfT ?? type, customConverter, isNullableReferenceType, customNumberHandling), pointer);
             }
         }
 
@@ -637,10 +637,10 @@ ConstructSchemaDocument:
         /// </summary>
         public readonly bool TryGetGeneratedSchemaPath(Type type, Type? parentNullableOfT, JsonConverter? customConverter, bool isNullableReferenceType, JsonNumberHandling? customNumberHandling, [NotNullWhen(true)] out string? value)
         {
-            if (Configuration.AllowSchemaReferences)
+            if (this.Configuration.AllowSchemaReferences)
             {
-                Debug.Assert(_generatedTypePaths is not null);
-                return _generatedTypePaths!.TryGetValue((parentNullableOfT ?? type, customConverter, isNullableReferenceType, customNumberHandling), out value);
+                Debug.Assert(this._generatedTypePaths is not null);
+                return this._generatedTypePaths!.TryGetValue((parentNullableOfT ?? type, customConverter, isNullableReferenceType, customNumberHandling), out value);
             }
 
             value = null;
@@ -810,9 +810,9 @@ ConstructSchemaDocument:
     {
         public SimpleTypeJsonSchema(JsonSchemaType schemaType, string? format = null, string? pattern = null)
         {
-            SchemaType = schemaType;
-            Format = format;
-            Pattern = pattern;
+            this.SchemaType = schemaType;
+            this.Format = format;
+            this.Pattern = pattern;
         }
 
         public JsonSchemaType SchemaType { get; }

--- a/dotnet/src/InternalUtilities/src/Schema/JsonSchemaMapperConfiguration.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/JsonSchemaMapperConfiguration.cs
@@ -78,7 +78,7 @@ class JsonSchemaMapperConfiguration
     /// </remarks>
     public int MaxDepth
     {
-        get => _maxDepth;
+        get => this._maxDepth;
         init
         {
             if (value < 0)
@@ -87,7 +87,7 @@ class JsonSchemaMapperConfiguration
                 static void Throw() => throw new ArgumentOutOfRangeException(nameof(value));
             }
 
-            _maxDepth = value;
+            this._maxDepth = value;
         }
     }
 }

--- a/dotnet/src/InternalUtilities/src/Schema/Polyfills/NullabilityInfo.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/Polyfills/NullabilityInfo.cs
@@ -3,70 +3,69 @@
 #if !NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 
-namespace System.Reflection
+namespace System.Reflection;
+
+/// <summary>
+/// A class that represents nullability info.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class NullabilityInfo
+{
+    internal NullabilityInfo(Type type, NullabilityState readState, NullabilityState writeState,
+        NullabilityInfo? elementType, NullabilityInfo[] typeArguments)
+    {
+        this.Type = type;
+        this.ReadState = readState;
+        this.WriteState = writeState;
+        this.ElementType = elementType;
+        this.GenericTypeArguments = typeArguments;
+    }
+
+    /// <summary>
+    /// The <see cref="System.Type" /> of the member or generic parameter
+    /// to which this NullabilityInfo belongs.
+    /// </summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// The nullability read state of the member.
+    /// </summary>
+    public NullabilityState ReadState { get; internal set; }
+
+    /// <summary>
+    /// The nullability write state of the member.
+    /// </summary>
+    public NullabilityState WriteState { get; internal set; }
+
+    /// <summary>
+    /// If the member type is an array, gives the <see cref="NullabilityInfo" /> of the elements of the array, null otherwise.
+    /// </summary>
+    public NullabilityInfo? ElementType { get; }
+
+    /// <summary>
+    /// If the member type is a generic type, gives the array of <see cref="NullabilityInfo" /> for each type parameter.
+    /// </summary>
+    public NullabilityInfo[] GenericTypeArguments { get; }
+}
+
+/// <summary>
+/// An enum that represents nullability state.
+/// </summary>
+internal enum NullabilityState
 {
     /// <summary>
-    /// A class that represents nullability info.
+    /// Nullability context not enabled (oblivious)
     /// </summary>
-    [ExcludeFromCodeCoverage]
-    internal sealed class NullabilityInfo
-    {
-        internal NullabilityInfo(Type type, NullabilityState readState, NullabilityState writeState,
-            NullabilityInfo? elementType, NullabilityInfo[] typeArguments)
-        {
-            Type = type;
-            ReadState = readState;
-            WriteState = writeState;
-            ElementType = elementType;
-            GenericTypeArguments = typeArguments;
-        }
-
-        /// <summary>
-        /// The <see cref="System.Type" /> of the member or generic parameter
-        /// to which this NullabilityInfo belongs.
-        /// </summary>
-        public Type Type { get; }
-
-        /// <summary>
-        /// The nullability read state of the member.
-        /// </summary>
-        public NullabilityState ReadState { get; internal set; }
-
-        /// <summary>
-        /// The nullability write state of the member.
-        /// </summary>
-        public NullabilityState WriteState { get; internal set; }
-
-        /// <summary>
-        /// If the member type is an array, gives the <see cref="NullabilityInfo" /> of the elements of the array, null otherwise.
-        /// </summary>
-        public NullabilityInfo? ElementType { get; }
-
-        /// <summary>
-        /// If the member type is a generic type, gives the array of <see cref="NullabilityInfo" /> for each type parameter.
-        /// </summary>
-        public NullabilityInfo[] GenericTypeArguments { get; }
-    }
+    Unknown,
 
     /// <summary>
-    /// An enum that represents nullability state.
+    /// Non nullable value or reference type
     /// </summary>
-    internal enum NullabilityState
-    {
-        /// <summary>
-        /// Nullability context not enabled (oblivious)
-        /// </summary>
-        Unknown,
+    NotNull,
 
-        /// <summary>
-        /// Non nullable value or reference type
-        /// </summary>
-        NotNull,
-
-        /// <summary>
-        /// Nullable value or reference type
-        /// </summary>
-        Nullable,
-    }
+    /// <summary>
+    /// Nullable value or reference type
+    /// </summary>
+    Nullable,
 }
 #endif

--- a/dotnet/src/InternalUtilities/src/Schema/Polyfills/NullabilityInfoContext.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/Polyfills/NullabilityInfoContext.cs
@@ -7,664 +7,663 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace System.Reflection
+namespace System.Reflection;
+
+/// <summary>
+/// Provides APIs for populating nullability information/context from reflection members:
+/// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class NullabilityInfoContext
 {
-    /// <summary>
-    /// Provides APIs for populating nullability information/context from reflection members:
-    /// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.
-    /// </summary>
-    [ExcludeFromCodeCoverage]
-    internal sealed class NullabilityInfoContext
+    private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
+    private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = [];
+    private readonly Dictionary<MemberInfo, NullabilityState> _context = [];
+
+    internal static bool IsSupported { get; } =
+        AppContext.TryGetSwitch("System.Reflection.NullabilityInfoContext.IsSupported", out bool isSupported) ? isSupported : true;
+
+    [Flags]
+    private enum NotAnnotatedStatus
     {
-        private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
-        private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = [];
-        private readonly Dictionary<MemberInfo, NullabilityState> _context = [];
+        None = 0x0,    // no restriction, all members annotated
+        Private = 0x1, // private members not annotated
+        Internal = 0x2, // internal members not annotated
+    }
 
-        internal static bool IsSupported { get; } =
-            AppContext.TryGetSwitch("System.Reflection.NullabilityInfoContext.IsSupported", out bool isSupported) ? isSupported : true;
-
-        [Flags]
-        private enum NotAnnotatedStatus
+    private NullabilityState? GetNullableContext(MemberInfo? memberInfo)
+    {
+        while (memberInfo is not null)
         {
-            None = 0x0,    // no restriction, all members annotated
-            Private = 0x1, // private members not annotated
-            Internal = 0x2, // internal members not annotated
-        }
-
-        private NullabilityState? GetNullableContext(MemberInfo? memberInfo)
-        {
-            while (memberInfo is not null)
+            if (this._context.TryGetValue(memberInfo, out NullabilityState state))
             {
-                if (_context.TryGetValue(memberInfo, out NullabilityState state))
-                {
-                    return state;
-                }
-
-                foreach (CustomAttributeData attribute in memberInfo.GetCustomAttributesData())
-                {
-                    if (attribute.AttributeType.Name == "NullableContextAttribute" &&
-                        attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
-                        attribute.ConstructorArguments.Count == 1)
-                    {
-                        state = TranslateByte(attribute.ConstructorArguments[0].Value);
-                        _context.Add(memberInfo, state);
-                        return state;
-                    }
-                }
-
-                memberInfo = memberInfo.DeclaringType;
+                return state;
             }
 
-            return null;
-        }
-
-        /// <summary>
-        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="ParameterInfo" />.
-        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
-        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
-        /// </summary>
-        /// <param name="parameterInfo">The parameter which nullability info gets populated.</param>
-        /// <exception cref="ArgumentNullException">If the parameterInfo parameter is null.</exception>
-        /// <returns><see cref="NullabilityInfo" />.</returns>
-        public NullabilityInfo Create(ParameterInfo parameterInfo)
-        {
-            EnsureIsSupported();
-
-            IList<CustomAttributeData> attributes = parameterInfo.GetCustomAttributesData();
-            NullableAttributeStateParser parser = parameterInfo.Member is MethodBase method && IsPrivateOrInternalMethodAndAnnotationDisabled(method)
-                ? NullableAttributeStateParser.Unknown
-                : CreateParser(attributes);
-            NullabilityInfo nullability = GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, parser);
-
-            if (nullability.ReadState != NullabilityState.Unknown)
+            foreach (CustomAttributeData attribute in memberInfo.GetCustomAttributesData())
             {
-                CheckParameterMetadataType(parameterInfo, nullability);
-            }
-
-            CheckNullabilityAttributes(nullability, attributes);
-            return nullability;
-        }
-
-        private void CheckParameterMetadataType(ParameterInfo parameter, NullabilityInfo nullability)
-        {
-            ParameterInfo? metaParameter;
-            MemberInfo metaMember;
-
-            switch (parameter.Member)
-            {
-                case ConstructorInfo ctor:
-                    var metaCtor = (ConstructorInfo)GetMemberMetadataDefinition(ctor);
-                    metaMember = metaCtor;
-                    metaParameter = GetMetaParameter(metaCtor, parameter);
-                    break;
-
-                case MethodInfo method:
-                    MethodInfo metaMethod = GetMethodMetadataDefinition(method);
-                    metaMember = metaMethod;
-                    metaParameter = string.IsNullOrEmpty(parameter.Name) ? metaMethod.ReturnParameter : GetMetaParameter(metaMethod, parameter);
-                    break;
-
-                default:
-                    return;
-            }
-
-            if (metaParameter is not null)
-            {
-                CheckGenericParameters(nullability, metaMember, metaParameter.ParameterType, parameter.Member.ReflectedType);
-            }
-        }
-
-        private static ParameterInfo? GetMetaParameter(MethodBase metaMethod, ParameterInfo parameter)
-        {
-            var parameters = metaMethod.GetParameters();
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                if (parameter.Position == i &&
-                    parameter.Name == parameters[i].Name)
-                {
-                    return parameters[i];
-                }
-            }
-
-            return null;
-        }
-
-        private static MethodInfo GetMethodMetadataDefinition(MethodInfo method)
-        {
-            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
-            {
-                method = method.GetGenericMethodDefinition();
-            }
-
-            return (MethodInfo)GetMemberMetadataDefinition(method);
-        }
-
-        private static void CheckNullabilityAttributes(NullabilityInfo nullability, IList<CustomAttributeData> attributes)
-        {
-            var codeAnalysisReadState = NullabilityState.Unknown;
-            var codeAnalysisWriteState = NullabilityState.Unknown;
-
-            foreach (CustomAttributeData attribute in attributes)
-            {
-                if (attribute.AttributeType.Namespace == "System.Diagnostics.CodeAnalysis")
-                {
-                    if (attribute.AttributeType.Name == "NotNullAttribute")
-                    {
-                        codeAnalysisReadState = NullabilityState.NotNull;
-                    }
-                    else if ((attribute.AttributeType.Name == "MaybeNullAttribute" ||
-                            attribute.AttributeType.Name == "MaybeNullWhenAttribute") &&
-                            codeAnalysisReadState == NullabilityState.Unknown &&
-                            !IsValueTypeOrValueTypeByRef(nullability.Type))
-                    {
-                        codeAnalysisReadState = NullabilityState.Nullable;
-                    }
-                    else if (attribute.AttributeType.Name == "DisallowNullAttribute")
-                    {
-                        codeAnalysisWriteState = NullabilityState.NotNull;
-                    }
-                    else if (attribute.AttributeType.Name == "AllowNullAttribute" &&
-                        codeAnalysisWriteState == NullabilityState.Unknown &&
-                        !IsValueTypeOrValueTypeByRef(nullability.Type))
-                    {
-                        codeAnalysisWriteState = NullabilityState.Nullable;
-                    }
-                }
-            }
-
-            if (codeAnalysisReadState != NullabilityState.Unknown)
-            {
-                nullability.ReadState = codeAnalysisReadState;
-            }
-
-            if (codeAnalysisWriteState != NullabilityState.Unknown)
-            {
-                nullability.WriteState = codeAnalysisWriteState;
-            }
-        }
-
-        /// <summary>
-        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="PropertyInfo" />.
-        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
-        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
-        /// </summary>
-        /// <param name="propertyInfo">The parameter which nullability info gets populated.</param>
-        /// <exception cref="ArgumentNullException">If the propertyInfo parameter is null.</exception>
-        /// <returns><see cref="NullabilityInfo" />.</returns>
-        public NullabilityInfo Create(PropertyInfo propertyInfo)
-        {
-            EnsureIsSupported();
-
-            MethodInfo? getter = propertyInfo.GetGetMethod(true);
-            MethodInfo? setter = propertyInfo.GetSetMethod(true);
-            bool annotationsDisabled = (getter is null || IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
-                && (setter is null || IsPrivateOrInternalMethodAndAnnotationDisabled(setter));
-            NullableAttributeStateParser parser = annotationsDisabled ? NullableAttributeStateParser.Unknown : CreateParser(propertyInfo.GetCustomAttributesData());
-            NullabilityInfo nullability = GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, parser);
-
-            if (getter is not null)
-            {
-                CheckNullabilityAttributes(nullability, getter.ReturnParameter.GetCustomAttributesData());
-            }
-            else
-            {
-                nullability.ReadState = NullabilityState.Unknown;
-            }
-
-            if (setter is not null)
-            {
-                CheckNullabilityAttributes(nullability, setter.GetParameters().Last().GetCustomAttributesData());
-            }
-            else
-            {
-                nullability.WriteState = NullabilityState.Unknown;
-            }
-
-            return nullability;
-        }
-
-        private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodBase method)
-        {
-            if ((method.IsPrivate || method.IsFamilyAndAssembly || method.IsAssembly) &&
-               IsPublicOnly(method.IsPrivate, method.IsFamilyAndAssembly, method.IsAssembly, method.Module))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="EventInfo" />.
-        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
-        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
-        /// </summary>
-        /// <param name="eventInfo">The parameter which nullability info gets populated.</param>
-        /// <exception cref="ArgumentNullException">If the eventInfo parameter is null.</exception>
-        /// <returns><see cref="NullabilityInfo" />.</returns>
-        public NullabilityInfo Create(EventInfo eventInfo)
-        {
-            EnsureIsSupported();
-
-            return GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, CreateParser(eventInfo.GetCustomAttributesData()));
-        }
-
-        /// <summary>
-        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="FieldInfo" />
-        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
-        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
-        /// </summary>
-        /// <param name="fieldInfo">The parameter which nullability info gets populated.</param>
-        /// <exception cref="ArgumentNullException">If the fieldInfo parameter is null.</exception>
-        /// <returns><see cref="NullabilityInfo" />.</returns>
-        public NullabilityInfo Create(FieldInfo fieldInfo)
-        {
-            EnsureIsSupported();
-
-            IList<CustomAttributeData> attributes = fieldInfo.GetCustomAttributesData();
-            NullableAttributeStateParser parser = IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo) ? NullableAttributeStateParser.Unknown : CreateParser(attributes);
-            NullabilityInfo nullability = GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, parser);
-            CheckNullabilityAttributes(nullability, attributes);
-            return nullability;
-        }
-
-        private static void EnsureIsSupported()
-        {
-            if (!IsSupported)
-            {
-                throw new InvalidOperationException("NullabilityInfoContext is not supported");
-            }
-        }
-
-        private bool IsPrivateOrInternalFieldAndAnnotationDisabled(FieldInfo fieldInfo)
-        {
-            if ((fieldInfo.IsPrivate || fieldInfo.IsFamilyAndAssembly || fieldInfo.IsAssembly) &&
-                IsPublicOnly(fieldInfo.IsPrivate, fieldInfo.IsFamilyAndAssembly, fieldInfo.IsAssembly, fieldInfo.Module))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool IsPublicOnly(bool isPrivate, bool isFamilyAndAssembly, bool isAssembly, Module module)
-        {
-            if (!_publicOnlyModules.TryGetValue(module, out NotAnnotatedStatus value))
-            {
-                value = PopulateAnnotationInfo(module.GetCustomAttributesData());
-                _publicOnlyModules.Add(module, value);
-            }
-
-            if (value == NotAnnotatedStatus.None)
-            {
-                return false;
-            }
-
-            if (((isPrivate || isFamilyAndAssembly) && value.HasFlag(NotAnnotatedStatus.Private)) ||
-                 (isAssembly && value.HasFlag(NotAnnotatedStatus.Internal)))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static NotAnnotatedStatus PopulateAnnotationInfo(IList<CustomAttributeData> customAttributes)
-        {
-            foreach (CustomAttributeData attribute in customAttributes)
-            {
-                if (attribute.AttributeType.Name == "NullablePublicOnlyAttribute" &&
+                if (attribute.AttributeType.Name == "NullableContextAttribute" &&
                     attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
                     attribute.ConstructorArguments.Count == 1)
                 {
-                    if (attribute.ConstructorArguments[0].Value is bool boolValue && boolValue)
-                    {
-                        return NotAnnotatedStatus.Internal | NotAnnotatedStatus.Private;
-                    }
-                    else
-                    {
-                        return NotAnnotatedStatus.Private;
-                    }
+                    state = TranslateByte(attribute.ConstructorArguments[0].Value);
+                    this._context.Add(memberInfo, state);
+                    return state;
                 }
             }
 
-            return NotAnnotatedStatus.None;
+            memberInfo = memberInfo.DeclaringType;
         }
 
-        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser)
+        return null;
+    }
+
+    /// <summary>
+    /// Populates <see cref="NullabilityInfo" /> for the given <see cref="ParameterInfo" />.
+    /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+    /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+    /// </summary>
+    /// <param name="parameterInfo">The parameter which nullability info gets populated.</param>
+    /// <exception cref="ArgumentNullException">If the parameterInfo parameter is null.</exception>
+    /// <returns><see cref="NullabilityInfo" />.</returns>
+    public NullabilityInfo Create(ParameterInfo parameterInfo)
+    {
+        EnsureIsSupported();
+
+        IList<CustomAttributeData> attributes = parameterInfo.GetCustomAttributesData();
+        NullableAttributeStateParser parser = parameterInfo.Member is MethodBase method && this.IsPrivateOrInternalMethodAndAnnotationDisabled(method)
+            ? NullableAttributeStateParser.Unknown
+            : CreateParser(attributes);
+        NullabilityInfo nullability = this.GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, parser);
+
+        if (nullability.ReadState != NullabilityState.Unknown)
         {
-            int index = 0;
-            NullabilityInfo nullability = GetNullabilityInfo(memberInfo, type, parser, ref index);
-
-            if (nullability.ReadState != NullabilityState.Unknown)
-            {
-                TryLoadGenericMetaTypeNullability(memberInfo, nullability);
-            }
-
-            return nullability;
+            this.CheckParameterMetadataType(parameterInfo, nullability);
         }
 
-        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, ref int index)
+        CheckNullabilityAttributes(nullability, attributes);
+        return nullability;
+    }
+
+    private void CheckParameterMetadataType(ParameterInfo parameter, NullabilityInfo nullability)
+    {
+        ParameterInfo? metaParameter;
+        MemberInfo metaMember;
+
+        switch (parameter.Member)
         {
-            NullabilityState state = NullabilityState.Unknown;
-            NullabilityInfo? elementState = null;
-            NullabilityInfo[] genericArgumentsState = [];
-            Type underlyingType = type;
+            case ConstructorInfo ctor:
+                var metaCtor = (ConstructorInfo)GetMemberMetadataDefinition(ctor);
+                metaMember = metaCtor;
+                metaParameter = GetMetaParameter(metaCtor, parameter);
+                break;
 
-            if (underlyingType.IsByRef || underlyingType.IsPointer)
+            case MethodInfo method:
+                MethodInfo metaMethod = GetMethodMetadataDefinition(method);
+                metaMember = metaMethod;
+                metaParameter = string.IsNullOrEmpty(parameter.Name) ? metaMethod.ReturnParameter : GetMetaParameter(metaMethod, parameter);
+                break;
+
+            default:
+                return;
+        }
+
+        if (metaParameter is not null)
+        {
+            this.CheckGenericParameters(nullability, metaMember, metaParameter.ParameterType, parameter.Member.ReflectedType);
+        }
+    }
+
+    private static ParameterInfo? GetMetaParameter(MethodBase metaMethod, ParameterInfo parameter)
+    {
+        var parameters = metaMethod.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (parameter.Position == i &&
+                parameter.Name == parameters[i].Name)
             {
-                underlyingType = underlyingType.GetElementType()!;
+                return parameters[i];
             }
+        }
 
-            if (underlyingType.IsValueType)
+        return null;
+    }
+
+    private static MethodInfo GetMethodMetadataDefinition(MethodInfo method)
+    {
+        if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+        {
+            method = method.GetGenericMethodDefinition();
+        }
+
+        return (MethodInfo)GetMemberMetadataDefinition(method);
+    }
+
+    private static void CheckNullabilityAttributes(NullabilityInfo nullability, IList<CustomAttributeData> attributes)
+    {
+        var codeAnalysisReadState = NullabilityState.Unknown;
+        var codeAnalysisWriteState = NullabilityState.Unknown;
+
+        foreach (CustomAttributeData attribute in attributes)
+        {
+            if (attribute.AttributeType.Namespace == "System.Diagnostics.CodeAnalysis")
             {
-                if (Nullable.GetUnderlyingType(underlyingType) is { } nullableUnderlyingType)
+                if (attribute.AttributeType.Name == "NotNullAttribute")
                 {
-                    underlyingType = nullableUnderlyingType;
-                    state = NullabilityState.Nullable;
+                    codeAnalysisReadState = NullabilityState.NotNull;
+                }
+                else if ((attribute.AttributeType.Name == "MaybeNullAttribute" ||
+                        attribute.AttributeType.Name == "MaybeNullWhenAttribute") &&
+                        codeAnalysisReadState == NullabilityState.Unknown &&
+                        !IsValueTypeOrValueTypeByRef(nullability.Type))
+                {
+                    codeAnalysisReadState = NullabilityState.Nullable;
+                }
+                else if (attribute.AttributeType.Name == "DisallowNullAttribute")
+                {
+                    codeAnalysisWriteState = NullabilityState.NotNull;
+                }
+                else if (attribute.AttributeType.Name == "AllowNullAttribute" &&
+                    codeAnalysisWriteState == NullabilityState.Unknown &&
+                    !IsValueTypeOrValueTypeByRef(nullability.Type))
+                {
+                    codeAnalysisWriteState = NullabilityState.Nullable;
+                }
+            }
+        }
+
+        if (codeAnalysisReadState != NullabilityState.Unknown)
+        {
+            nullability.ReadState = codeAnalysisReadState;
+        }
+
+        if (codeAnalysisWriteState != NullabilityState.Unknown)
+        {
+            nullability.WriteState = codeAnalysisWriteState;
+        }
+    }
+
+    /// <summary>
+    /// Populates <see cref="NullabilityInfo" /> for the given <see cref="PropertyInfo" />.
+    /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+    /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+    /// </summary>
+    /// <param name="propertyInfo">The parameter which nullability info gets populated.</param>
+    /// <exception cref="ArgumentNullException">If the propertyInfo parameter is null.</exception>
+    /// <returns><see cref="NullabilityInfo" />.</returns>
+    public NullabilityInfo Create(PropertyInfo propertyInfo)
+    {
+        EnsureIsSupported();
+
+        MethodInfo? getter = propertyInfo.GetGetMethod(true);
+        MethodInfo? setter = propertyInfo.GetSetMethod(true);
+        bool annotationsDisabled = (getter is null || this.IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
+            && (setter is null || this.IsPrivateOrInternalMethodAndAnnotationDisabled(setter));
+        NullableAttributeStateParser parser = annotationsDisabled ? NullableAttributeStateParser.Unknown : CreateParser(propertyInfo.GetCustomAttributesData());
+        NullabilityInfo nullability = this.GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, parser);
+
+        if (getter is not null)
+        {
+            CheckNullabilityAttributes(nullability, getter.ReturnParameter.GetCustomAttributesData());
+        }
+        else
+        {
+            nullability.ReadState = NullabilityState.Unknown;
+        }
+
+        if (setter is not null)
+        {
+            CheckNullabilityAttributes(nullability, setter.GetParameters().Last().GetCustomAttributesData());
+        }
+        else
+        {
+            nullability.WriteState = NullabilityState.Unknown;
+        }
+
+        return nullability;
+    }
+
+    private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodBase method)
+    {
+        if ((method.IsPrivate || method.IsFamilyAndAssembly || method.IsAssembly) &&
+           this.IsPublicOnly(method.IsPrivate, method.IsFamilyAndAssembly, method.IsAssembly, method.Module))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Populates <see cref="NullabilityInfo" /> for the given <see cref="EventInfo" />.
+    /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+    /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+    /// </summary>
+    /// <param name="eventInfo">The parameter which nullability info gets populated.</param>
+    /// <exception cref="ArgumentNullException">If the eventInfo parameter is null.</exception>
+    /// <returns><see cref="NullabilityInfo" />.</returns>
+    public NullabilityInfo Create(EventInfo eventInfo)
+    {
+        EnsureIsSupported();
+
+        return this.GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, CreateParser(eventInfo.GetCustomAttributesData()));
+    }
+
+    /// <summary>
+    /// Populates <see cref="NullabilityInfo" /> for the given <see cref="FieldInfo" />
+    /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+    /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+    /// </summary>
+    /// <param name="fieldInfo">The parameter which nullability info gets populated.</param>
+    /// <exception cref="ArgumentNullException">If the fieldInfo parameter is null.</exception>
+    /// <returns><see cref="NullabilityInfo" />.</returns>
+    public NullabilityInfo Create(FieldInfo fieldInfo)
+    {
+        EnsureIsSupported();
+
+        IList<CustomAttributeData> attributes = fieldInfo.GetCustomAttributesData();
+        NullableAttributeStateParser parser = this.IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo) ? NullableAttributeStateParser.Unknown : CreateParser(attributes);
+        NullabilityInfo nullability = this.GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, parser);
+        CheckNullabilityAttributes(nullability, attributes);
+        return nullability;
+    }
+
+    private static void EnsureIsSupported()
+    {
+        if (!IsSupported)
+        {
+            throw new InvalidOperationException("NullabilityInfoContext is not supported");
+        }
+    }
+
+    private bool IsPrivateOrInternalFieldAndAnnotationDisabled(FieldInfo fieldInfo)
+    {
+        if ((fieldInfo.IsPrivate || fieldInfo.IsFamilyAndAssembly || fieldInfo.IsAssembly) &&
+            this.IsPublicOnly(fieldInfo.IsPrivate, fieldInfo.IsFamilyAndAssembly, fieldInfo.IsAssembly, fieldInfo.Module))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsPublicOnly(bool isPrivate, bool isFamilyAndAssembly, bool isAssembly, Module module)
+    {
+        if (!this._publicOnlyModules.TryGetValue(module, out NotAnnotatedStatus value))
+        {
+            value = PopulateAnnotationInfo(module.GetCustomAttributesData());
+            this._publicOnlyModules.Add(module, value);
+        }
+
+        if (value == NotAnnotatedStatus.None)
+        {
+            return false;
+        }
+
+        if (((isPrivate || isFamilyAndAssembly) && value.HasFlag(NotAnnotatedStatus.Private)) ||
+             (isAssembly && value.HasFlag(NotAnnotatedStatus.Internal)))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static NotAnnotatedStatus PopulateAnnotationInfo(IList<CustomAttributeData> customAttributes)
+    {
+        foreach (CustomAttributeData attribute in customAttributes)
+        {
+            if (attribute.AttributeType.Name == "NullablePublicOnlyAttribute" &&
+                attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                attribute.ConstructorArguments.Count == 1)
+            {
+                if (attribute.ConstructorArguments[0].Value is bool boolValue && boolValue)
+                {
+                    return NotAnnotatedStatus.Internal | NotAnnotatedStatus.Private;
                 }
                 else
                 {
-                    state = NullabilityState.NotNull;
+                    return NotAnnotatedStatus.Private;
                 }
+            }
+        }
 
-                if (underlyingType.IsGenericType)
-                {
-                    ++index;
-                }
+        return NotAnnotatedStatus.None;
+    }
+
+    private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser)
+    {
+        int index = 0;
+        NullabilityInfo nullability = this.GetNullabilityInfo(memberInfo, type, parser, ref index);
+
+        if (nullability.ReadState != NullabilityState.Unknown)
+        {
+            this.TryLoadGenericMetaTypeNullability(memberInfo, nullability);
+        }
+
+        return nullability;
+    }
+
+    private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, ref int index)
+    {
+        NullabilityState state = NullabilityState.Unknown;
+        NullabilityInfo? elementState = null;
+        NullabilityInfo[] genericArgumentsState = [];
+        Type underlyingType = type;
+
+        if (underlyingType.IsByRef || underlyingType.IsPointer)
+        {
+            underlyingType = underlyingType.GetElementType()!;
+        }
+
+        if (underlyingType.IsValueType)
+        {
+            if (Nullable.GetUnderlyingType(underlyingType) is { } nullableUnderlyingType)
+            {
+                underlyingType = nullableUnderlyingType;
+                state = NullabilityState.Nullable;
             }
             else
             {
-                if (!parser.ParseNullableState(index++, ref state)
-                    && GetNullableContext(memberInfo) is { } contextState)
-                {
-                    state = contextState;
-                }
-
-                if (underlyingType.IsArray)
-                {
-                    elementState = GetNullabilityInfo(memberInfo, underlyingType.GetElementType()!, parser, ref index);
-                }
+                state = NullabilityState.NotNull;
             }
 
             if (underlyingType.IsGenericType)
             {
-                Type[] genericArguments = underlyingType.GetGenericArguments();
-                genericArgumentsState = new NullabilityInfo[genericArguments.Length];
+                ++index;
+            }
+        }
+        else
+        {
+            if (!parser.ParseNullableState(index++, ref state)
+                && this.GetNullableContext(memberInfo) is { } contextState)
+            {
+                state = contextState;
+            }
+
+            if (underlyingType.IsArray)
+            {
+                elementState = this.GetNullabilityInfo(memberInfo, underlyingType.GetElementType()!, parser, ref index);
+            }
+        }
+
+        if (underlyingType.IsGenericType)
+        {
+            Type[] genericArguments = underlyingType.GetGenericArguments();
+            genericArgumentsState = new NullabilityInfo[genericArguments.Length];
+
+            for (int i = 0; i < genericArguments.Length; i++)
+            {
+                genericArgumentsState[i] = this.GetNullabilityInfo(memberInfo, genericArguments[i], parser, ref index);
+            }
+        }
+
+        return new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
+    }
+
+    private static NullableAttributeStateParser CreateParser(IList<CustomAttributeData> customAttributes)
+    {
+        foreach (CustomAttributeData attribute in customAttributes)
+        {
+            if (attribute.AttributeType.Name == "NullableAttribute" &&
+                attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                attribute.ConstructorArguments.Count == 1)
+            {
+                return new NullableAttributeStateParser(attribute.ConstructorArguments[0].Value);
+            }
+        }
+
+        return new NullableAttributeStateParser(null);
+    }
+
+    private void TryLoadGenericMetaTypeNullability(MemberInfo memberInfo, NullabilityInfo nullability)
+    {
+        MemberInfo? metaMember = GetMemberMetadataDefinition(memberInfo);
+        Type? metaType = null;
+        if (metaMember is FieldInfo field)
+        {
+            metaType = field.FieldType;
+        }
+        else if (metaMember is PropertyInfo property)
+        {
+            metaType = GetPropertyMetaType(property);
+        }
+
+        if (metaType is not null)
+        {
+            this.CheckGenericParameters(nullability, metaMember!, metaType, memberInfo.ReflectedType);
+        }
+    }
+
+    private static MemberInfo GetMemberMetadataDefinition(MemberInfo member)
+    {
+        Type? type = member.DeclaringType;
+        if ((type is not null) && type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            return NullabilityInfoHelpers.GetMemberWithSameMetadataDefinitionAs(type.GetGenericTypeDefinition(), member);
+        }
+
+        return member;
+    }
+
+    private static Type GetPropertyMetaType(PropertyInfo property)
+    {
+        if (property.GetGetMethod(true) is MethodInfo method)
+        {
+            return method.ReturnType;
+        }
+
+        return property.GetSetMethod(true)!.GetParameters()[0].ParameterType;
+    }
+
+    private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType, Type? reflectedType)
+    {
+        if (metaType.IsGenericParameter)
+        {
+            if (nullability.ReadState == NullabilityState.NotNull)
+            {
+                this.TryUpdateGenericParameterNullability(nullability, metaType, reflectedType);
+            }
+        }
+        else if (metaType.ContainsGenericParameters)
+        {
+            if (nullability.GenericTypeArguments.Length > 0)
+            {
+                Type[] genericArguments = metaType.GetGenericArguments();
 
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
-                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], parser, ref index);
+                    this.CheckGenericParameters(nullability.GenericTypeArguments[i], metaMember, genericArguments[i], reflectedType);
                 }
             }
-
-            return new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
-        }
-
-        private static NullableAttributeStateParser CreateParser(IList<CustomAttributeData> customAttributes)
-        {
-            foreach (CustomAttributeData attribute in customAttributes)
+            else if (nullability.ElementType is { } elementNullability && metaType.IsArray)
             {
-                if (attribute.AttributeType.Name == "NullableAttribute" &&
-                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
-                    attribute.ConstructorArguments.Count == 1)
-                {
-                    return new NullableAttributeStateParser(attribute.ConstructorArguments[0].Value);
-                }
+                this.CheckGenericParameters(elementNullability, metaMember, metaType.GetElementType()!, reflectedType);
             }
 
-            return new NullableAttributeStateParser(null);
-        }
-
-        private void TryLoadGenericMetaTypeNullability(MemberInfo memberInfo, NullabilityInfo nullability)
-        {
-            MemberInfo? metaMember = GetMemberMetadataDefinition(memberInfo);
-            Type? metaType = null;
-            if (metaMember is FieldInfo field)
+            // We could also follow this branch for metaType.IsPointer, but since pointers must be unmanaged this
+            // will be a no-op regardless
+            else if (metaType.IsByRef)
             {
-                metaType = field.FieldType;
-            }
-            else if (metaMember is PropertyInfo property)
-            {
-                metaType = GetPropertyMetaType(property);
-            }
-
-            if (metaType is not null)
-            {
-                CheckGenericParameters(nullability, metaMember!, metaType, memberInfo.ReflectedType);
+                this.CheckGenericParameters(nullability, metaMember, metaType.GetElementType()!, reflectedType);
             }
         }
+    }
 
-        private static MemberInfo GetMemberMetadataDefinition(MemberInfo member)
+    private bool TryUpdateGenericParameterNullability(NullabilityInfo nullability, Type genericParameter, Type? reflectedType)
+    {
+        Debug.Assert(genericParameter.IsGenericParameter);
+
+        if (reflectedType is not null
+            && !genericParameter.IsGenericMethodParameter()
+            && this.TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, reflectedType, reflectedType))
         {
-            Type? type = member.DeclaringType;
-            if ((type is not null) && type.IsGenericType && !type.IsGenericTypeDefinition)
-            {
-                return NullabilityInfoHelpers.GetMemberWithSameMetadataDefinitionAs(type.GetGenericTypeDefinition(), member);
-            }
-
-            return member;
-        }
-
-        private static Type GetPropertyMetaType(PropertyInfo property)
-        {
-            if (property.GetGetMethod(true) is MethodInfo method)
-            {
-                return method.ReturnType;
-            }
-
-            return property.GetSetMethod(true)!.GetParameters()[0].ParameterType;
-        }
-
-        private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType, Type? reflectedType)
-        {
-            if (metaType.IsGenericParameter)
-            {
-                if (nullability.ReadState == NullabilityState.NotNull)
-                {
-                    TryUpdateGenericParameterNullability(nullability, metaType, reflectedType);
-                }
-            }
-            else if (metaType.ContainsGenericParameters)
-            {
-                if (nullability.GenericTypeArguments.Length > 0)
-                {
-                    Type[] genericArguments = metaType.GetGenericArguments();
-
-                    for (int i = 0; i < genericArguments.Length; i++)
-                    {
-                        CheckGenericParameters(nullability.GenericTypeArguments[i], metaMember, genericArguments[i], reflectedType);
-                    }
-                }
-                else if (nullability.ElementType is { } elementNullability && metaType.IsArray)
-                {
-                    CheckGenericParameters(elementNullability, metaMember, metaType.GetElementType()!, reflectedType);
-                }
-
-                // We could also follow this branch for metaType.IsPointer, but since pointers must be unmanaged this
-                // will be a no-op regardless
-                else if (metaType.IsByRef)
-                {
-                    CheckGenericParameters(nullability, metaMember, metaType.GetElementType()!, reflectedType);
-                }
-            }
-        }
-
-        private bool TryUpdateGenericParameterNullability(NullabilityInfo nullability, Type genericParameter, Type? reflectedType)
-        {
-            Debug.Assert(genericParameter.IsGenericParameter);
-
-            if (reflectedType is not null
-                && !genericParameter.IsGenericMethodParameter()
-                && TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, reflectedType, reflectedType))
-            {
-                return true;
-            }
-
-            if (IsValueTypeOrValueTypeByRef(nullability.Type))
-            {
-                return true;
-            }
-
-            var state = NullabilityState.Unknown;
-            if (CreateParser(genericParameter.GetCustomAttributesData()).ParseNullableState(0, ref state))
-            {
-                nullability.ReadState = state;
-                nullability.WriteState = state;
-                return true;
-            }
-
-            if (GetNullableContext(genericParameter) is { } contextState)
-            {
-                nullability.ReadState = contextState;
-                nullability.WriteState = contextState;
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TryUpdateGenericTypeParameterNullabilityFromReflectedType(NullabilityInfo nullability, Type genericParameter, Type context, Type reflectedType)
-        {
-            Debug.Assert(genericParameter.IsGenericParameter && !genericParameter.IsGenericMethodParameter());
-
-            Type contextTypeDefinition = context.IsGenericType && !context.IsGenericTypeDefinition ? context.GetGenericTypeDefinition() : context;
-            if (genericParameter.DeclaringType == contextTypeDefinition)
-            {
-                return false;
-            }
-
-            Type? baseType = contextTypeDefinition.BaseType;
-            if (baseType is null)
-            {
-                return false;
-            }
-
-            if (!baseType.IsGenericType
-                || (baseType.IsGenericTypeDefinition ? baseType : baseType.GetGenericTypeDefinition()) != genericParameter.DeclaringType)
-            {
-                return TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, baseType, reflectedType);
-            }
-
-            Type[] genericArguments = baseType.GetGenericArguments();
-            Type genericArgument = genericArguments[genericParameter.GenericParameterPosition];
-            if (genericArgument.IsGenericParameter)
-            {
-                return TryUpdateGenericParameterNullability(nullability, genericArgument, reflectedType);
-            }
-
-            NullableAttributeStateParser parser = CreateParser(contextTypeDefinition.GetCustomAttributesData());
-            int nullabilityStateIndex = 1; // start at 1 since index 0 is the type itself
-            for (int i = 0; i < genericParameter.GenericParameterPosition; i++)
-            {
-                nullabilityStateIndex += CountNullabilityStates(genericArguments[i]);
-            }
-
-            return TryPopulateNullabilityInfo(nullability, parser, ref nullabilityStateIndex);
-
-            static int CountNullabilityStates(Type type)
-            {
-                Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
-                if (underlyingType.IsGenericType)
-                {
-                    int count = 1;
-                    foreach (Type genericArgument in underlyingType.GetGenericArguments())
-                    {
-                        count += CountNullabilityStates(genericArgument);
-                    }
-
-                    return count;
-                }
-
-                if (underlyingType.HasElementType)
-                {
-                    return (underlyingType.IsArray ? 1 : 0) + CountNullabilityStates(underlyingType.GetElementType()!);
-                }
-
-                return type.IsValueType ? 0 : 1;
-            }
-        }
-
-#pragma warning disable SA1204 // Static elements should appear before instance elements
-        private static bool TryPopulateNullabilityInfo(NullabilityInfo nullability, NullableAttributeStateParser parser, ref int index)
-#pragma warning restore SA1204 // Static elements should appear before instance elements
-        {
-            bool isValueType = IsValueTypeOrValueTypeByRef(nullability.Type);
-            if (!isValueType)
-            {
-                var state = NullabilityState.Unknown;
-                if (!parser.ParseNullableState(index, ref state))
-                {
-                    return false;
-                }
-
-                nullability.ReadState = state;
-                nullability.WriteState = state;
-            }
-
-            if (!isValueType || (Nullable.GetUnderlyingType(nullability.Type) ?? nullability.Type).IsGenericType)
-            {
-                index++;
-            }
-
-            if (nullability.GenericTypeArguments.Length > 0)
-            {
-                foreach (NullabilityInfo genericTypeArgumentNullability in nullability.GenericTypeArguments)
-                {
-                    TryPopulateNullabilityInfo(genericTypeArgumentNullability, parser, ref index);
-                }
-            }
-            else if (nullability.ElementType is { } elementTypeNullability)
-            {
-                TryPopulateNullabilityInfo(elementTypeNullability, parser, ref index);
-            }
-
             return true;
         }
 
-        private static NullabilityState TranslateByte(object? value)
+        if (IsValueTypeOrValueTypeByRef(nullability.Type))
         {
-            return value is byte b ? TranslateByte(b) : NullabilityState.Unknown;
+            return true;
         }
 
-        private static NullabilityState TranslateByte(byte b) =>
-            b switch
-            {
-                1 => NullabilityState.NotNull,
-                2 => NullabilityState.Nullable,
-                _ => NullabilityState.Unknown
-            };
-
-        private static bool IsValueTypeOrValueTypeByRef(Type type) =>
-            type.IsValueType || ((type.IsByRef || type.IsPointer) && type.GetElementType()!.IsValueType);
-
-        private readonly struct NullableAttributeStateParser
+        var state = NullabilityState.Unknown;
+        if (CreateParser(genericParameter.GetCustomAttributesData()).ParseNullableState(0, ref state))
         {
-            private static readonly object UnknownByte = (byte)0;
+            nullability.ReadState = state;
+            nullability.WriteState = state;
+            return true;
+        }
 
-            private readonly object? _nullableAttributeArgument;
+        if (this.GetNullableContext(genericParameter) is { } contextState)
+        {
+            nullability.ReadState = contextState;
+            nullability.WriteState = contextState;
+            return true;
+        }
 
-            public NullableAttributeStateParser(object? nullableAttributeArgument)
+        return false;
+    }
+
+    private bool TryUpdateGenericTypeParameterNullabilityFromReflectedType(NullabilityInfo nullability, Type genericParameter, Type context, Type reflectedType)
+    {
+        Debug.Assert(genericParameter.IsGenericParameter && !genericParameter.IsGenericMethodParameter());
+
+        Type contextTypeDefinition = context.IsGenericType && !context.IsGenericTypeDefinition ? context.GetGenericTypeDefinition() : context;
+        if (genericParameter.DeclaringType == contextTypeDefinition)
+        {
+            return false;
+        }
+
+        Type? baseType = contextTypeDefinition.BaseType;
+        if (baseType is null)
+        {
+            return false;
+        }
+
+        if (!baseType.IsGenericType
+            || (baseType.IsGenericTypeDefinition ? baseType : baseType.GetGenericTypeDefinition()) != genericParameter.DeclaringType)
+        {
+            return this.TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, baseType, reflectedType);
+        }
+
+        Type[] genericArguments = baseType.GetGenericArguments();
+        Type genericArgument = genericArguments[genericParameter.GenericParameterPosition];
+        if (genericArgument.IsGenericParameter)
+        {
+            return this.TryUpdateGenericParameterNullability(nullability, genericArgument, reflectedType);
+        }
+
+        NullableAttributeStateParser parser = CreateParser(contextTypeDefinition.GetCustomAttributesData());
+        int nullabilityStateIndex = 1; // start at 1 since index 0 is the type itself
+        for (int i = 0; i < genericParameter.GenericParameterPosition; i++)
+        {
+            nullabilityStateIndex += CountNullabilityStates(genericArguments[i]);
+        }
+
+        return TryPopulateNullabilityInfo(nullability, parser, ref nullabilityStateIndex);
+
+        static int CountNullabilityStates(Type type)
+        {
+            Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            if (underlyingType.IsGenericType)
             {
-                this._nullableAttributeArgument = nullableAttributeArgument;
+                int count = 1;
+                foreach (Type genericArgument in underlyingType.GetGenericArguments())
+                {
+                    count += CountNullabilityStates(genericArgument);
+                }
+
+                return count;
             }
 
-            public static NullableAttributeStateParser Unknown => new(UnknownByte);
-
-            public bool ParseNullableState(int index, ref NullabilityState state)
+            if (underlyingType.HasElementType)
             {
-                switch (this._nullableAttributeArgument)
-                {
-                    case byte b:
-                        state = TranslateByte(b);
-                        return true;
-                    case ReadOnlyCollection<CustomAttributeTypedArgument> args
-                        when index < args.Count && args[index].Value is byte elementB:
-                        state = TranslateByte(elementB);
-                        return true;
-                    default:
-                        return false;
-                }
+                return (underlyingType.IsArray ? 1 : 0) + CountNullabilityStates(underlyingType.GetElementType()!);
+            }
+
+            return type.IsValueType ? 0 : 1;
+        }
+    }
+
+#pragma warning disable SA1204 // Static elements should appear before instance elements
+    private static bool TryPopulateNullabilityInfo(NullabilityInfo nullability, NullableAttributeStateParser parser, ref int index)
+#pragma warning restore SA1204 // Static elements should appear before instance elements
+    {
+        bool isValueType = IsValueTypeOrValueTypeByRef(nullability.Type);
+        if (!isValueType)
+        {
+            var state = NullabilityState.Unknown;
+            if (!parser.ParseNullableState(index, ref state))
+            {
+                return false;
+            }
+
+            nullability.ReadState = state;
+            nullability.WriteState = state;
+        }
+
+        if (!isValueType || (Nullable.GetUnderlyingType(nullability.Type) ?? nullability.Type).IsGenericType)
+        {
+            index++;
+        }
+
+        if (nullability.GenericTypeArguments.Length > 0)
+        {
+            foreach (NullabilityInfo genericTypeArgumentNullability in nullability.GenericTypeArguments)
+            {
+                TryPopulateNullabilityInfo(genericTypeArgumentNullability, parser, ref index);
+            }
+        }
+        else if (nullability.ElementType is { } elementTypeNullability)
+        {
+            TryPopulateNullabilityInfo(elementTypeNullability, parser, ref index);
+        }
+
+        return true;
+    }
+
+    private static NullabilityState TranslateByte(object? value)
+    {
+        return value is byte b ? TranslateByte(b) : NullabilityState.Unknown;
+    }
+
+    private static NullabilityState TranslateByte(byte b) =>
+        b switch
+        {
+            1 => NullabilityState.NotNull,
+            2 => NullabilityState.Nullable,
+            _ => NullabilityState.Unknown
+        };
+
+    private static bool IsValueTypeOrValueTypeByRef(Type type) =>
+        type.IsValueType || ((type.IsByRef || type.IsPointer) && type.GetElementType()!.IsValueType);
+
+    private readonly struct NullableAttributeStateParser
+    {
+        private static readonly object UnknownByte = (byte)0;
+
+        private readonly object? _nullableAttributeArgument;
+
+        public NullableAttributeStateParser(object? nullableAttributeArgument)
+        {
+            this._nullableAttributeArgument = nullableAttributeArgument;
+        }
+
+        public static NullableAttributeStateParser Unknown => new(UnknownByte);
+
+        public bool ParseNullableState(int index, ref NullabilityState state)
+        {
+            switch (this._nullableAttributeArgument)
+            {
+                case byte b:
+                    state = TranslateByte(b);
+                    return true;
+                case ReadOnlyCollection<CustomAttributeTypedArgument> args
+                    when index < args.Count && args[index].Value is byte elementB:
+                    state = TranslateByte(elementB);
+                    return true;
+                default:
+                    return false;
             }
         }
     }

--- a/dotnet/src/InternalUtilities/src/Schema/Polyfills/NullabilityInfoHelpers.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/Polyfills/NullabilityInfoHelpers.cs
@@ -3,41 +3,40 @@
 #if !NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 
-namespace System.Reflection
+namespace System.Reflection;
+
+/// <summary>
+/// Polyfills for System.Private.CoreLib internals.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class NullabilityInfoHelpers
 {
-    /// <summary>
-    /// Polyfills for System.Private.CoreLib internals.
-    /// </summary>
-    [ExcludeFromCodeCoverage]
-    internal static class NullabilityInfoHelpers
+    public static MemberInfo GetMemberWithSameMetadataDefinitionAs(Type type, MemberInfo member)
     {
-        public static MemberInfo GetMemberWithSameMetadataDefinitionAs(Type type, MemberInfo member)
+        const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+        foreach (var info in type.GetMembers(all))
         {
-            const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
-            foreach (var info in type.GetMembers(all))
+            if (info.HasSameMetadataDefinitionAs(member))
             {
-                if (info.HasSameMetadataDefinitionAs(member))
-                {
-                    return info;
-                }
+                return info;
             }
-
-            throw new MissingMemberException(type.FullName, member.Name);
         }
 
-        // https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs
-        public static bool HasSameMetadataDefinitionAs(this MemberInfo target, MemberInfo other)
-        {
-            return target.MetadataToken == other.MetadataToken &&
-                   target.Module.Equals(other.Module);
-        }
+        throw new MissingMemberException(type.FullName, member.Name);
+    }
 
-        // https://github.com/dotnet/runtime/issues/23493
-        public static bool IsGenericMethodParameter(this Type target)
-        {
-            return target.IsGenericParameter &&
-                   target.DeclaringMethod is not null;
-        }
+    // https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs
+    public static bool HasSameMetadataDefinitionAs(this MemberInfo target, MemberInfo other)
+    {
+        return target.MetadataToken == other.MetadataToken &&
+               target.Module.Equals(other.Module);
+    }
+
+    // https://github.com/dotnet/runtime/issues/23493
+    public static bool IsGenericMethodParameter(this Type target)
+    {
+        return target.IsGenericParameter &&
+               target.DeclaringMethod is not null;
     }
 }
 #endif


### PR DESCRIPTION
### Motivation and Context

Currently the memory service branch has some code formatting and spelling issues that prevents new PRs from clearing the PR checks.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting
script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: