### PR TITLE
.Net: Migrate AzureOpenAIAudioToTextService to Azure.AI.OpenAI SDK v2

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceCollectionExtensionsTests.cs
@@ -5,6 +5,7 @@ using Azure.AI.OpenAI;
 using Azure.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AudioToText;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
@@ -139,6 +140,40 @@ public sealed class AzureOpenAIServiceCollectionExtensionsTests
         var service = builder.Build().GetRequiredService<ITextToImageService>();
 
         Assert.True(service is AzureOpenAITextToImageService);
+    }
+
+    #endregion
+
+    #region Audio to text
+
+    [Theory]
+    [InlineData(InitializationType.ApiKey)]
+    [InlineData(InitializationType.TokenCredential)]
+    [InlineData(InitializationType.ClientInline)]
+    [InlineData(InitializationType.ClientInServiceProvider)]
+    public void ServiceCollectionAddAzureOpenAIAudioToTextAddsValidService(InitializationType type)
+    {
+        // Arrange
+        var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
+        var client = new AzureOpenAIClient(new Uri("https://endpoint"), "key");
+        var builder = Kernel.CreateBuilder();
+
+        builder.Services.AddSingleton<AzureOpenAIClient>(client);
+
+        // Act
+        IServiceCollection collection = type switch
+        {
+            InitializationType.ApiKey => builder.Services.AddAzureOpenAIAudioToText("deployment-name", "https://endpoint", "api-key"),
+            InitializationType.TokenCredential => builder.Services.AddAzureOpenAIAudioToText("deployment-name", "https://endpoint", credentials),
+            InitializationType.ClientInline => builder.Services.AddAzureOpenAIAudioToText("deployment-name", client),
+            InitializationType.ClientInServiceProvider => builder.Services.AddAzureOpenAIAudioToText("deployment-name"),
+            _ => builder.Services
+        };
+
+        // Assert
+        var service = builder.Build().GetRequiredService<IAudioToTextService>();
+
+        Assert.True(service is AzureOpenAIAudioToTextService);
     }
 
     #endregion

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIAudioToTextServiceTests.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Services;
+using Moq;
+using static Microsoft.SemanticKernel.Connectors.AzureOpenAI.AzureOpenAIAudioToTextExecutionSettings;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AzureOpenAIAudioToTextService"/> class.
+/// </summary>
+public sealed class AzureOpenAIAudioToTextServiceTests : IDisposable
+{
+    private readonly HttpMessageHandlerStub _messageHandlerStub;
+    private readonly HttpClient _httpClient;
+    private readonly Mock<ILoggerFactory> _mockLoggerFactory;
+
+    public AzureOpenAIAudioToTextServiceTests()
+    {
+        this._messageHandlerStub = new HttpMessageHandlerStub();
+        this._httpClient = new HttpClient(this._messageHandlerStub, false);
+        this._mockLoggerFactory = new Mock<ILoggerFactory>();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConstructorWithApiKeyWorksCorrectly(bool includeLoggerFactory)
+    {
+        // Arrange & Act
+        var service = includeLoggerFactory ?
+            new AzureOpenAIAudioToTextService("deployment", "https://endpoint", "api-key", "model-id", loggerFactory: this._mockLoggerFactory.Object) :
+            new AzureOpenAIAudioToTextService("deployment", "https://endpoint", "api-key", "model-id");
+
+        // Assert
+        Assert.Equal("model-id", service.Attributes[AIServiceExtensions.ModelIdKey]);
+        Assert.Equal("deployment", service.Attributes[ClientCore.DeploymentNameKey]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConstructorWithTokenCredentialWorksCorrectly(bool includeLoggerFactory)
+    {
+        // Arrange & Act
+        var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
+        var service = includeLoggerFactory ?
+            new AzureOpenAIAudioToTextService("deployment", "https://endpoint", credentials, "model-id", loggerFactory: this._mockLoggerFactory.Object) :
+            new AzureOpenAIAudioToTextService("deployment", "https://endpoint", credentials, "model-id");
+
+        // Assert
+        Assert.Equal("model-id", service.Attributes[AIServiceExtensions.ModelIdKey]);
+        Assert.Equal("deployment", service.Attributes[ClientCore.DeploymentNameKey]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConstructorWithOpenAIClientWorksCorrectly(bool includeLoggerFactory)
+    {
+        // Arrange & Act
+        var client = new AzureOpenAIClient(new Uri("http://host"), "key");
+        var service = includeLoggerFactory ?
+            new AzureOpenAIAudioToTextService("deployment", client, "model-id", loggerFactory: this._mockLoggerFactory.Object) :
+            new AzureOpenAIAudioToTextService("deployment", client, "model-id");
+
+        // Assert
+        Assert.Equal("model-id", service.Attributes[AIServiceExtensions.ModelIdKey]);
+        Assert.Equal("deployment", service.Attributes[ClientCore.DeploymentNameKey]);
+    }
+
+    [Fact]
+    public void ItThrowsIfDeploymentNameIsNotProvided()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService(" ", "http://host", "apikey"));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService(" ", azureOpenAIClient: new(new Uri("http://host"), "apikey")));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService("", "http://host", "apikey"));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService("", azureOpenAIClient: new(new Uri("http://host"), "apikey")));
+        Assert.Throws<ArgumentNullException>(() => new AzureOpenAIAudioToTextService(null!, "http://host", "apikey"));
+        Assert.Throws<ArgumentNullException>(() => new AzureOpenAIAudioToTextService(null!, azureOpenAIClient: new(new Uri("http://host"), "apikey")));
+    }
+
+    [Theory]
+    [MemberData(nameof(ExecutionSettings))]
+    public async Task GetTextContentWithInvalidSettingsThrowsExceptionAsync(AzureOpenAIAudioToTextExecutionSettings? settings, Type expectedExceptionType)
+    {
+        // Arrange
+        var service = new AzureOpenAIAudioToTextService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("Test audio-to-text response")
+        };
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => service.GetTextContentsAsync(new AudioContent(new BinaryData("data"), mimeType: null), settings));
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType(expectedExceptionType, exception);
+    }
+
+    [Theory]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default }, "0")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word }, "word")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment }, "segment")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment, TimeStampGranularities.Word }, "word", "segment")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word, TimeStampGranularities.Segment }, "word", "segment")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default, TimeStampGranularities.Word }, "word", "0")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word, TimeStampGranularities.Default }, "word", "0")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default, TimeStampGranularities.Segment }, "segment", "0")]
+    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment, TimeStampGranularities.Default }, "segment", "0")]
+    public async Task GetTextContentGranularitiesWorksAsync(TimeStampGranularities[] granularities, params string[] expectedGranularities)
+    {
+        // Arrange
+        var service = new AzureOpenAIAudioToTextService("deployment", "https://endpoint", "api-key", httpClient: this._httpClient);
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("Test audio-to-text response")
+        };
+
+        // Act
+        var settings = new AzureOpenAIAudioToTextExecutionSettings("file.mp3") { Granularities = granularities };
+        var result = await service.GetTextContentsAsync(new AudioContent(new BinaryData("data"), mimeType: null), settings);
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(result);
+
+        var multiPartData = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContent!);
+        var multiPartBreak = multiPartData.Substring(0, multiPartData.IndexOf("\r\n", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var granularity in expectedGranularities)
+        {
+            var expectedMultipart = $"{granularity}\r\n{multiPartBreak}";
+            Assert.Contains(expectedMultipart, multiPartData);
+        }
+    }
+
+    [Theory]
+    [InlineData(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Verbose, "verbose_json")]
+    [InlineData(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple, "json")]
+    [InlineData(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Vtt, "vtt")]
+    [InlineData(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Srt, "srt")]
+    public async Task ItRespectResultFormatExecutionSettingAsync(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat responseFormat, string expectedFormat)
+    {
+        // Arrange
+        var service = new AzureOpenAIAudioToTextService("deployment", "https://endpoint", "api-key", httpClient: this._httpClient);
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("Test audio-to-text response")
+        };
+
+        // Act
+        var settings = new AzureOpenAIAudioToTextExecutionSettings("file.mp3") { ResponseFormat = responseFormat };
+        var result = await service.GetTextContentsAsync(new AudioContent(new BinaryData("data"), mimeType: null), settings);
+
+        // Assert
+        Assert.NotNull(this._messageHandlerStub.RequestContent);
+        Assert.NotNull(result);
+
+        var multiPartData = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContent!);
+        var multiPartBreak = multiPartData.Substring(0, multiPartData.IndexOf("\r\n", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains($"{expectedFormat}\r\n{multiPartBreak}", multiPartData);
+    }
+
+    [Fact]
+    public async Task GetTextContentByDefaultWorksCorrectlyAsync()
+    {
+        // Arrange
+        var service = new AzureOpenAIAudioToTextService("deployment-name", "https://endpoint", "api-key", "model-id", this._httpClient);
+        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("Test audio-to-text response")
+        };
+
+        // Act
+        var result = await service.GetTextContentsAsync(new AudioContent(new BinaryData("data"), mimeType: null), new AzureOpenAIAudioToTextExecutionSettings("file.mp3"));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Test audio-to-text response", result[0].Text);
+    }
+
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+
+    public static TheoryData<AzureOpenAIAudioToTextExecutionSettings?, Type> ExecutionSettings => new()
+    {
+        { new AzureOpenAIAudioToTextExecutionSettings(""), typeof(ArgumentException) },
+        { new AzureOpenAIAudioToTextExecutionSettings("file"), typeof(ArgumentException) }
+    };
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAIAudioToTextExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAIAudioToTextExecutionSettingsTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text.Json;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Settings;
+
+/// <summary>
+/// Unit tests for <see cref="AzureOpenAIAudioToTextExecutionSettings"/> class.
+/// </summary>
+public sealed class AzureOpenAIAudioToTextExecutionSettingsTests
+{
+    [Fact]
+    public void ItReturnsDefaultSettingsWhenSettingsAreNull()
+    {
+        Assert.NotNull(AzureOpenAIAudioToTextExecutionSettings.FromExecutionSettings(null));
+    }
+
+    [Fact]
+    public void ItReturnsValidOpenAIAudioToTextExecutionSettings()
+    {
+        // Arrange
+        var audioToTextSettings = new AzureOpenAIAudioToTextExecutionSettings("file.mp3")
+        {
+            ModelId = "model_id",
+            Language = "en",
+            Prompt = "prompt",
+            ResponseFormat = AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple,
+            Temperature = 0.2f
+        };
+
+        // Act
+        var settings = AzureOpenAIAudioToTextExecutionSettings.FromExecutionSettings(audioToTextSettings);
+
+        // Assert
+        Assert.Same(audioToTextSettings, settings);
+    }
+
+    [Fact]
+    public void ItCreatesOpenAIAudioToTextExecutionSettingsFromJson()
+    {
+        // Arrange
+        var json = """
+        {
+            "model_id": "model_id",
+            "language": "en",
+            "filename": "file.mp3",
+            "prompt": "prompt",
+            "response_format": "verbose",
+            "temperature": 0.2
+        }
+        """;
+
+        var executionSettings = JsonSerializer.Deserialize<PromptExecutionSettings>(json);
+
+        // Act
+        var settings = AzureOpenAIAudioToTextExecutionSettings.FromExecutionSettings(executionSettings);
+
+        // Assert
+        Assert.NotNull(settings);
+        Assert.Equal("model_id", settings.ModelId);
+        Assert.Equal("en", settings.Language);
+        Assert.Equal("file.mp3", settings.Filename);
+        Assert.Equal("prompt", settings.Prompt);
+        Assert.Equal(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Verbose, settings.ResponseFormat);
+        Assert.Equal(0.2f, settings.Temperature);
+    }
+
+    [Fact]
+    public void ItClonesAllProperties()
+    {
+        var settings = new AzureOpenAIAudioToTextExecutionSettings()
+        {
+            ModelId = "model_id",
+            Language = "en",
+            Prompt = "prompt",
+            ResponseFormat = AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple,
+            Temperature = 0.2f,
+            Filename = "something.mp3",
+        };
+
+        var clone = (AzureOpenAIAudioToTextExecutionSettings)settings.Clone();
+        Assert.NotSame(settings, clone);
+
+        Assert.Equal("model_id", clone.ModelId);
+        Assert.Equal("en", clone.Language);
+        Assert.Equal("prompt", clone.Prompt);
+        Assert.Equal(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple, clone.ResponseFormat);
+        Assert.Equal(0.2f, clone.Temperature);
+        Assert.Equal("something.mp3", clone.Filename);
+    }
+
+    [Fact]
+    public void ItFreezesAndPreventsMutation()
+    {
+        var settings = new AzureOpenAIAudioToTextExecutionSettings()
+        {
+            ModelId = "model_id",
+            Language = "en",
+            Prompt = "prompt",
+            ResponseFormat = AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple,
+            Temperature = 0.2f,
+            Filename = "something.mp3",
+        };
+
+        settings.Freeze();
+        Assert.True(settings.IsFrozen);
+
+        Assert.Throws<InvalidOperationException>(() => settings.ModelId = "new_model");
+        Assert.Throws<InvalidOperationException>(() => settings.Language = "some_format");
+        Assert.Throws<InvalidOperationException>(() => settings.Prompt = "prompt");
+        Assert.Throws<InvalidOperationException>(() => settings.ResponseFormat = AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple);
+        Assert.Throws<InvalidOperationException>(() => settings.Temperature = 0.2f);
+        Assert.Throws<InvalidOperationException>(() => settings.Filename = "something");
+
+        settings.Freeze(); // idempotent
+        Assert.True(settings.IsFrozen);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAIPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAIPromptExecutionSettingsTests.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Settings;
+
+/// <summary>
+/// Unit tests for <see cref="AzureOpenAIPromptExecutionSettings"/> class.
+/// </summary>
+public class AzureOpenAIPromptExecutionSettingsTests
+{
+    [Fact]
+    public void ItCreatesOpenAIExecutionSettingsWithCorrectDefaults()
+    {
+        // Arrange
+        // Act
+        AzureOpenAIPromptExecutionSettings executionSettings = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(null, 128);
+
+        // Assert
+        Assert.Equal(1, executionSettings.Temperature);
+        Assert.Equal(1, executionSettings.TopP);
+        Assert.Equal(0, executionSettings.FrequencyPenalty);
+        Assert.Equal(0, executionSettings.PresencePenalty);
+        Assert.Null(executionSettings.StopSequences);
+        Assert.Null(executionSettings.TokenSelectionBiases);
+        Assert.Null(executionSettings.TopLogprobs);
+        Assert.Null(executionSettings.Logprobs);
+        Assert.Null(executionSettings.AzureChatDataSource);
+        Assert.Equal(128, executionSettings.MaxTokens);
+    }
+
+    [Fact]
+    public void ItUsesExistingOpenAIExecutionSettings()
+    {
+        // Arrange
+        AzureOpenAIPromptExecutionSettings actualSettings = new()
+        {
+            Temperature = 0.7,
+            TopP = 0.7,
+            FrequencyPenalty = 0.7,
+            PresencePenalty = 0.7,
+            StopSequences = new string[] { "foo", "bar" },
+            ChatSystemPrompt = "chat system prompt",
+            MaxTokens = 128,
+            Logprobs = true,
+            TopLogprobs = 5,
+            TokenSelectionBiases = new Dictionary<int, int>() { { 1, 2 }, { 3, 4 } },
+        };
+
+        // Act
+        AzureOpenAIPromptExecutionSettings executionSettings = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(actualSettings);
+
+        // Assert
+        Assert.Equal(actualSettings, executionSettings);
+    }
+
+    [Fact]
+    public void ItCanUseOpenAIExecutionSettings()
+    {
+        // Arrange
+        PromptExecutionSettings actualSettings = new()
+        {
+            ExtensionData = new Dictionary<string, object>() {
+                { "max_tokens", 1000 },
+                { "temperature", 0 }
+            }
+        };
+
+        // Act
+        AzureOpenAIPromptExecutionSettings executionSettings = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(actualSettings, null);
+
+        // Assert
+        Assert.NotNull(executionSettings);
+        Assert.Equal(1000, executionSettings.MaxTokens);
+        Assert.Equal(0, executionSettings.Temperature);
+    }
+
+    [Fact]
+    public void ItCreatesOpenAIExecutionSettingsFromExtraPropertiesSnakeCase()
+    {
+        // Arrange
+        PromptExecutionSettings actualSettings = new()
+        {
+            ExtensionData = new Dictionary<string, object>()
+            {
+                { "temperature", 0.7 },
+                { "top_p", 0.7 },
+                { "frequency_penalty", 0.7 },
+                { "presence_penalty", 0.7 },
+                { "results_per_prompt", 2 },
+                { "stop_sequences", new [] { "foo", "bar" } },
+                { "chat_system_prompt", "chat system prompt" },
+                { "max_tokens", 128 },
+                { "token_selection_biases", new Dictionary<int, int>() { { 1, 2 }, { 3, 4 } } },
+                { "seed", 123456 },
+                { "logprobs", true },
+                { "top_logprobs", 5 },
+            }
+        };
+
+        // Act
+        AzureOpenAIPromptExecutionSettings executionSettings = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(actualSettings, null);
+
+        // Assert
+        AssertExecutionSettings(executionSettings);
+    }
+
+    [Fact]
+    public void ItCreatesOpenAIExecutionSettingsFromExtraPropertiesAsStrings()
+    {
+        // Arrange
+        PromptExecutionSettings actualSettings = new()
+        {
+            ExtensionData = new Dictionary<string, object>()
+            {
+                { "temperature", "0.7" },
+                { "top_p", "0.7" },
+                { "frequency_penalty", "0.7" },
+                { "presence_penalty", "0.7" },
+                { "results_per_prompt", "2" },
+                { "stop_sequences", new [] { "foo", "bar" } },
+                { "chat_system_prompt", "chat system prompt" },
+                { "max_tokens", "128" },
+                { "token_selection_biases", new Dictionary<string, string>() { { "1", "2" }, { "3", "4" } } },
+                { "seed", 123456 },
+                { "logprobs", true },
+                { "top_logprobs", 5 }
+            }
+        };
+
+        // Act
+        AzureOpenAIPromptExecutionSettings executionSettings = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(actualSettings, null);
+
+        // Assert
+        AssertExecutionSettings(executionSettings);
+    }
+
+    [Fact]
+    public void ItCreatesOpenAIExecutionSettingsFromJsonSnakeCase()
+    {
+        // Arrange
+        var json = """
+            {
+              "temperature": 0.7,
+              "top_p": 0.7,
+              "frequency_penalty": 0.7,
+              "presence_penalty": 0.7,
+              "stop_sequences": [ "foo", "bar" ],
+              "chat_system_prompt": "chat system prompt",
+              "token_selection_biases": { "1": 2, "3": 4 },
+              "max_tokens": 128,
+              "seed": 123456,
+              "logprobs": true,
+              "top_logprobs": 5
+            }
+            """;
+        var actualSettings = JsonSerializer.Deserialize<PromptExecutionSettings>(json);
+
+        // Act
+        AzureOpenAIPromptExecutionSettings executionSettings = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(actualSettings);
+
+        // Assert
+        AssertExecutionSettings(executionSettings);
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("System prompt", "System prompt")]
+    public void ItUsesCorrectChatSystemPrompt(string chatSystemPrompt, string expectedChatSystemPrompt)
+    {
+        // Arrange & Act
+        var settings = new AzureOpenAIPromptExecutionSettings { ChatSystemPrompt = chatSystemPrompt };
+
+        // Assert
+        Assert.Equal(expectedChatSystemPrompt, settings.ChatSystemPrompt);
+    }
+
+    [Fact]
+    public void PromptExecutionSettingsCloneWorksAsExpected()
+    {
+        // Arrange
+        string configPayload = """
+        {
+            "max_tokens": 60,
+            "temperature": 0.5,
+            "top_p": 0.0,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0
+        }
+        """;
+        var executionSettings = JsonSerializer.Deserialize<AzureOpenAIPromptExecutionSettings>(configPayload);
+
+        // Act
+        var clone = executionSettings!.Clone();
+
+        // Assert
+        Assert.Equal(executionSettings.ModelId, clone.ModelId);
+        Assert.Equivalent(executionSettings.ExtensionData, clone.ExtensionData);
+    }
+
+    [Fact]
+    public void PromptExecutionSettingsFreezeWorksAsExpected()
+    {
+        // Arrange
+        string configPayload = """
+        {
+            "max_tokens": 60,
+            "temperature": 0.5,
+            "top_p": 0.0,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "stop_sequences": [ "DONE" ],
+            "token_selection_biases": { "1": 2, "3": 4 }
+        }
+        """;
+        var executionSettings = JsonSerializer.Deserialize<AzureOpenAIPromptExecutionSettings>(configPayload);
+
+        // Act
+        executionSettings!.Freeze();
+
+        // Assert
+        Assert.True(executionSettings.IsFrozen);
+        Assert.Throws<InvalidOperationException>(() => executionSettings.ModelId = "gpt-4");
+        Assert.Throws<InvalidOperationException>(() => executionSettings.Temperature = 1);
+        Assert.Throws<InvalidOperationException>(() => executionSettings.TopP = 1);
+        Assert.Throws<NotSupportedException>(() => executionSettings.StopSequences?.Add("STOP"));
+        Assert.Throws<NotSupportedException>(() => executionSettings.TokenSelectionBiases?.Add(5, 6));
+
+        executionSettings!.Freeze(); // idempotent
+        Assert.True(executionSettings.IsFrozen);
+    }
+
+    [Fact]
+    public void FromExecutionSettingsWithDataDoesNotIncludeEmptyStopSequences()
+    {
+        // Arrange
+        var executionSettings = new AzureOpenAIPromptExecutionSettings { StopSequences = [] };
+
+        // Act
+#pragma warning disable CS0618 // AzureOpenAIChatCompletionWithData is deprecated in favor of OpenAIPromptExecutionSettings.AzureChatExtensionsOptions
+        var executionSettingsWithData = AzureOpenAIPromptExecutionSettings.FromExecutionSettingsWithData(executionSettings);
+#pragma warning restore CS0618
+        // Assert
+        Assert.Null(executionSettingsWithData.StopSequences);
+    }
+
+    private static void AssertExecutionSettings(AzureOpenAIPromptExecutionSettings executionSettings)
+    {
+        Assert.NotNull(executionSettings);
+        Assert.Equal(0.7, executionSettings.Temperature);
+        Assert.Equal(0.7, executionSettings.TopP);
+        Assert.Equal(0.7, executionSettings.FrequencyPenalty);
+        Assert.Equal(0.7, executionSettings.PresencePenalty);
+        Assert.Equal(new string[] { "foo", "bar" }, executionSettings.StopSequences);
+        Assert.Equal("chat system prompt", executionSettings.ChatSystemPrompt);
+        Assert.Equal(new Dictionary<int, int>() { { 1, 2 }, { 3, 4 } }, executionSettings.TokenSelectionBiases);
+        Assert.Equal(128, executionSettings.MaxTokens);
+        Assert.Equal(123456, executionSettings.Seed);
+        Assert.Equal(true, executionSettings.Logprobs);
+        Assert.Equal(5, executionSettings.TopLogprobs);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAITextToAudioExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAITextToAudioExecutionSettingsTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text.Json;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Settings;
+
+/// <summary>
+/// Unit tests for <see cref="AzureOpenAITextToAudioExecutionSettings"/> class.
+/// </summary>
+public sealed class AzureOpenAITextToAudioExecutionSettingsTests
+{
+    [Fact]
+    public void ItReturnsDefaultSettingsWhenSettingsAreNull()
+    {
+        Assert.NotNull(AzureOpenAITextToAudioExecutionSettings.FromExecutionSettings(null));
+    }
+
+    [Fact]
+    public void ItReturnsValidOpenAITextToAudioExecutionSettings()
+    {
+        // Arrange
+        var textToAudioSettings = new AzureOpenAITextToAudioExecutionSettings("voice")
+        {
+            ModelId = "model_id",
+            ResponseFormat = "mp3",
+            Speed = 1.0f
+        };
+
+        // Act
+        var settings = AzureOpenAITextToAudioExecutionSettings.FromExecutionSettings(textToAudioSettings);
+
+        // Assert
+        Assert.Same(textToAudioSettings, settings);
+    }
+
+    [Fact]
+    public void ItCreatesOpenAIAudioToTextExecutionSettingsFromJson()
+    {
+        // Arrange
+        var json = """
+        {
+            "model_id": "model_id",
+            "voice": "voice",
+            "response_format": "mp3",
+            "speed": 1.2
+        }
+        """;
+
+        var executionSettings = JsonSerializer.Deserialize<PromptExecutionSettings>(json);
+
+        // Act
+        var settings = AzureOpenAITextToAudioExecutionSettings.FromExecutionSettings(executionSettings);
+
+        // Assert
+        Assert.NotNull(settings);
+        Assert.Equal("model_id", settings.ModelId);
+        Assert.Equal("voice", settings.Voice);
+        Assert.Equal("mp3", settings.ResponseFormat);
+        Assert.Equal(1.2f, settings.Speed);
+    }
+
+    [Fact]
+    public void ItClonesAllProperties()
+    {
+        var textToAudioSettings = new AzureOpenAITextToAudioExecutionSettings()
+        {
+            ModelId = "some_model",
+            ResponseFormat = "some_format",
+            Speed = 3.14f,
+            Voice = "something"
+        };
+
+        var clone = (AzureOpenAITextToAudioExecutionSettings)textToAudioSettings.Clone();
+        Assert.NotSame(textToAudioSettings, clone);
+
+        Assert.Equal("some_model", clone.ModelId);
+        Assert.Equal("some_format", clone.ResponseFormat);
+        Assert.Equal(3.14f, clone.Speed);
+        Assert.Equal("something", clone.Voice);
+    }
+
+    [Fact]
+    public void ItFreezesAndPreventsMutation()
+    {
+        var textToAudioSettings = new AzureOpenAITextToAudioExecutionSettings()
+        {
+            ModelId = "some_model",
+            ResponseFormat = "some_format",
+            Speed = 3.14f,
+            Voice = "something"
+        };
+
+        textToAudioSettings.Freeze();
+        Assert.True(textToAudioSettings.IsFrozen);
+
+        Assert.Throws<InvalidOperationException>(() => textToAudioSettings.ModelId = "new_model");
+        Assert.Throws<InvalidOperationException>(() => textToAudioSettings.ResponseFormat = "some_format");
+        Assert.Throws<InvalidOperationException>(() => textToAudioSettings.Speed = 3.14f);
+        Assert.Throws<InvalidOperationException>(() => textToAudioSettings.Voice = "something");
+
+        textToAudioSettings.Freeze(); // idempotent
+        Assert.True(textToAudioSettings.IsFrozen);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
@@ -22,17 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Core\ClientCore.AudioToText.cs" />
-    <Compile Remove="Services\AzureOpenAIAudioToTextService.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="SemanticKernel.Connectors.AzureOpenAI.UnitTests" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Core\ClientCore.AudioToText.cs" />
-    <None Include="Services\AzureOpenAIAudioToTextService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.AudioToText.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.AudioToText.cs
@@ -31,33 +31,34 @@ internal partial class ClientCore
             throw new ArgumentException("The input audio content is not readable.", nameof(input));
         }
 
-        OpenAIAudioToTextExecutionSettings audioExecutionSettings = OpenAIAudioToTextExecutionSettings.FromExecutionSettings(executionSettings)!;
-        AudioTranscriptionOptions? audioOptions = AudioOptionsFromExecutionSettings(audioExecutionSettings);
+        AzureOpenAIAudioToTextExecutionSettings audioExecutionSettings = AzureOpenAIAudioToTextExecutionSettings.FromExecutionSettings(executionSettings)!;
+        AudioTranscriptionOptions audioOptions = AudioOptionsFromExecutionSettings(audioExecutionSettings);
 
         Verify.ValidFilename(audioExecutionSettings?.Filename);
 
         using var memoryStream = new MemoryStream(input.Data!.Value.ToArray());
 
-        AudioTranscription responseData = (await RunRequestAsync(() => this.Client.GetAudioClient(this.ModelId).TranscribeAudioAsync(memoryStream, audioExecutionSettings?.Filename, audioOptions)).ConfigureAwait(false)).Value;
+        AudioTranscription responseData = (await RunRequestAsync(() => this.Client.GetAudioClient(this.DeploymentOrModelName).TranscribeAudioAsync(memoryStream, audioExecutionSettings?.Filename, audioOptions)).ConfigureAwait(false)).Value;
 
-        return [new(responseData.Text, this.ModelId, metadata: GetResponseMetadata(responseData))];
+        return [new(responseData.Text, this.DeploymentOrModelName, metadata: GetResponseMetadata(responseData))];
     }
 
     /// <summary>
-    /// Converts <see cref="PromptExecutionSettings"/> to <see cref="AudioTranscriptionOptions"/> type.
+    /// Converts <see cref="AzureOpenAIAudioToTextExecutionSettings"/> to <see cref="AudioTranscriptionOptions"/> type.
     /// </summary>
-    /// <param name="executionSettings">Instance of <see cref="PromptExecutionSettings"/>.</param>
+    /// <param name="executionSettings">Instance of <see cref="AzureOpenAIAudioToTextExecutionSettings"/>.</param>
     /// <returns>Instance of <see cref="AudioTranscriptionOptions"/>.</returns>
-    private static AudioTranscriptionOptions? AudioOptionsFromExecutionSettings(OpenAIAudioToTextExecutionSettings executionSettings)
+    private static AudioTranscriptionOptions AudioOptionsFromExecutionSettings(AzureOpenAIAudioToTextExecutionSettings executionSettings)
         => new()
         {
             Granularities = ConvertToAudioTimestampGranularities(executionSettings!.Granularities),
             Language = executionSettings.Language,
             Prompt = executionSettings.Prompt,
-            Temperature = executionSettings.Temperature
+            Temperature = executionSettings.Temperature,
+            ResponseFormat = ConvertResponseFormat(executionSettings.ResponseFormat)
         };
 
-    private static AudioTimestampGranularities ConvertToAudioTimestampGranularities(IEnumerable<OpenAIAudioToTextExecutionSettings.TimeStampGranularities>? granularities)
+    private static AudioTimestampGranularities ConvertToAudioTimestampGranularities(IEnumerable<AzureOpenAIAudioToTextExecutionSettings.TimeStampGranularities>? granularities)
     {
         AudioTimestampGranularities result = AudioTimestampGranularities.Default;
 
@@ -67,8 +68,8 @@ internal partial class ClientCore
             {
                 var openAIGranularity = granularity switch
                 {
-                    OpenAIAudioToTextExecutionSettings.TimeStampGranularities.Word => AudioTimestampGranularities.Word,
-                    OpenAIAudioToTextExecutionSettings.TimeStampGranularities.Segment => AudioTimestampGranularities.Segment,
+                    AzureOpenAIAudioToTextExecutionSettings.TimeStampGranularities.Word => AudioTimestampGranularities.Word,
+                    AzureOpenAIAudioToTextExecutionSettings.TimeStampGranularities.Segment => AudioTimestampGranularities.Segment,
                     _ => AudioTimestampGranularities.Default
                 };
 
@@ -86,4 +87,21 @@ internal partial class ClientCore
             [nameof(audioTranscription.Duration)] = audioTranscription.Duration,
             [nameof(audioTranscription.Segments)] = audioTranscription.Segments
         };
+
+    private static AudioTranscriptionFormat? ConvertResponseFormat(AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat? responseFormat)
+    {
+        if (responseFormat is null)
+        {
+            return null;
+        }
+
+        return responseFormat switch
+        {
+            AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple => AudioTranscriptionFormat.Simple,
+            AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Verbose => AudioTranscriptionFormat.Verbose,
+            AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Vtt => AudioTranscriptionFormat.Vtt,
+            AzureOpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Srt => AudioTranscriptionFormat.Srt,
+            _ => throw new NotSupportedException($"The audio transcription format '{responseFormat}' is not supported."),
+        };
+    }
 }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Azure.AI.OpenAI;
 using Azure.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.AudioToText;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
@@ -263,7 +264,7 @@ public static class AzureOpenAIKernelBuilderExtensions
     /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="builder"/>.</returns>
-    [Experimental("SKEXP0001")]
+    [Experimental("SKEXP0010")]
     public static IKernelBuilder AddAzureOpenAITextToAudio(
         this IKernelBuilder builder,
         string deploymentName,
@@ -397,6 +398,118 @@ public static class AzureOpenAIKernelBuilderExtensions
                 azureOpenAIClient ?? serviceProvider.GetRequiredService<AzureOpenAIClient>(),
                 modelId,
                 serviceProvider.GetService<ILoggerFactory>()));
+
+        return builder;
+    }
+
+    #endregion
+
+    #region Audio-to-Text
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAIAudioToTextService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAIAudioToText(
+        this IKernelBuilder builder,
+        string deploymentName,
+        string endpoint,
+        string apiKey,
+        string? serviceId = null,
+        string? modelId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(deploymentName);
+        Verify.NotNullOrWhiteSpace(endpoint);
+        Verify.NotNullOrWhiteSpace(apiKey);
+
+        Func<IServiceProvider, object?, AzureOpenAIAudioToTextService> factory = (serviceProvider, _) =>
+        {
+            AzureOpenAIClient client = CreateAzureOpenAIClient(
+                endpoint,
+                new AzureKeyCredential(apiKey),
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider));
+            return new(deploymentName, client, modelId, serviceProvider.GetService<ILoggerFactory>());
+        };
+
+        builder.Services.AddKeyedSingleton<IAudioToTextService>(serviceId, factory);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAIAudioToTextService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IServiceCollection"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="credentials">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAIAudioToText(
+        this IKernelBuilder builder,
+        string deploymentName,
+        string endpoint,
+        TokenCredential credentials,
+        string? serviceId = null,
+        string? modelId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(deploymentName);
+        Verify.NotNullOrWhiteSpace(endpoint);
+        Verify.NotNull(credentials);
+
+        Func<IServiceProvider, object?, AzureOpenAIAudioToTextService> factory = (serviceProvider, _) =>
+        {
+            AzureOpenAIClient client = CreateAzureOpenAIClient(
+                endpoint,
+                credentials,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider));
+            return new(deploymentName, client, modelId, serviceProvider.GetService<ILoggerFactory>());
+        };
+
+        builder.Services.AddKeyedSingleton<IAudioToTextService>(serviceId, factory);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAIAudioToTextService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="openAIClient"><see cref="AzureOpenAIClient"/> to use for the service. If null, one must be available in the service provider when this service is resolved.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAIAudioToText(
+        this IKernelBuilder builder,
+        string deploymentName,
+        AzureOpenAIClient? openAIClient = null,
+        string? serviceId = null,
+        string? modelId = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(deploymentName);
+
+        Func<IServiceProvider, object?, AzureOpenAIAudioToTextService> factory = (serviceProvider, _) =>
+            new(deploymentName, openAIClient ?? serviceProvider.GetRequiredService<AzureOpenAIClient>(), modelId, serviceProvider.GetService<ILoggerFactory>());
+
+        builder.Services.AddKeyedSingleton<IAudioToTextService>(serviceId, factory);
 
         return builder;
     }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAIAudioToTextService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAIAudioToTextService.cs
@@ -16,17 +16,17 @@ namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 /// <summary>
 /// Azure OpenAI audio-to-text service.
 /// </summary>
-[Experimental("SKEXP0001")]
+[Experimental("SKEXP0010")]
 public sealed class AzureOpenAIAudioToTextService : IAudioToTextService
 {
     /// <summary>Core implementation shared by Azure OpenAI services.</summary>
-    private readonly AzureOpenAIClientCore _core;
+    private readonly ClientCore _core;
 
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, object?> Attributes => this._core.Attributes;
 
     /// <summary>
-    /// Creates an instance of the <see cref="AzureOpenAIAudioToTextService"/> with API key auth.
+    /// Initializes a new instance of the <see cref="AzureOpenAIAudioToTextService"/> class.
     /// </summary>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
@@ -47,7 +47,7 @@ public sealed class AzureOpenAIAudioToTextService : IAudioToTextService
     }
 
     /// <summary>
-    /// Creates an instance of the <see cref="AzureOpenAIAudioToTextService"/> with AAD auth.
+    /// Initializes a new instance of the <see cref="AzureOpenAIAudioToTextService"/> class.
     /// </summary>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
@@ -68,19 +68,19 @@ public sealed class AzureOpenAIAudioToTextService : IAudioToTextService
     }
 
     /// <summary>
-    /// Creates an instance of the <see cref="AzureOpenAIAudioToTextService"/> using the specified <see cref="OpenAIClient"/>.
+    /// Initializes a new instance of the <see cref="AzureOpenAIAudioToTextService"/> class.
     /// </summary>
     /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
-    /// <param name="openAIClient">Custom <see cref="OpenAIClient"/>.</param>
+    /// <param name="azureOpenAIClient">Custom <see cref="AzureOpenAIClient"/>.</param>
     /// <param name="modelId">Azure OpenAI model id, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     public AzureOpenAIAudioToTextService(
         string deploymentName,
-        OpenAIClient openAIClient,
+        AzureOpenAIClient azureOpenAIClient,
         string? modelId = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._core = new(deploymentName, openAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIAudioToTextService)));
+        this._core = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAIAudioToTextService)));
         this._core.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
     }
 
@@ -90,5 +90,5 @@ public sealed class AzureOpenAIAudioToTextService : IAudioToTextService
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,
         CancellationToken cancellationToken = default)
-        => this._core.GetTextContentFromAudioAsync(content, executionSettings, cancellationToken);
+        => this._core.GetTextFromAudioContentsAsync(content, executionSettings, cancellationToken);
 }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIAudioToTextExecutionSettings.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.SemanticKernel.Text;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+
+/// <summary>
+/// Execution settings for Azure OpenAI audio-to-text request.
+/// </summary>
+[Experimental("SKEXP0010")]
+public sealed class AzureOpenAIAudioToTextExecutionSettings : PromptExecutionSettings
+{
+    /// <summary>
+    /// Filename or identifier associated with audio data.
+    /// Should be in format {filename}.{extension}
+    /// </summary>
+    [JsonPropertyName("filename")]
+    public string Filename
+    {
+        get => this._filename;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._filename = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional language of the audio data as two-letter ISO-639-1 language code (e.g. 'en' or 'es').
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language
+    {
+        get => this._language;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._language = value;
+        }
+    }
+
+    /// <summary>
+    /// An optional text to guide the model's style or continue a previous audio segment. The prompt should match the audio language.
+    /// </summary>
+    [JsonPropertyName("prompt")]
+    public string? Prompt
+    {
+        get => this._prompt;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._prompt = value;
+        }
+    }
+
+    /// <summary>
+    /// The format of the transcript output, in one of these options: Text, Simple, Verbose, Sttor vtt. Default is 'json'.
+    /// </summary>
+    [JsonPropertyName("response_format")]
+    public AudioTranscriptionFormat? ResponseFormat
+    {
+        get => this._responseFormat;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._responseFormat = value;
+        }
+    }
+
+    /// <summary>
+    /// The sampling temperature, between 0 and 1.
+    /// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+    /// If set to 0, the model will use log probability to automatically increase the temperature until certain thresholds are hit.
+    /// Default is 0.
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public float Temperature
+    {
+        get => this._temperature;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._temperature = value;
+        }
+    }
+
+    /// <summary>
+    /// The timestamp granularities to populate for this transcription. response_format must be set verbose_json to use timestamp granularities. Either or both of these options are supported: word, or segment.
+    /// </summary>
+    [JsonPropertyName("granularities")]
+    public IReadOnlyList<TimeStampGranularities>? Granularities { get; set; }
+
+    /// <summary>
+    /// Creates an instance of <see cref="AzureOpenAIAudioToTextExecutionSettings"/> class with default filename - "file.mp3".
+    /// </summary>
+    public AzureOpenAIAudioToTextExecutionSettings()
+        : this(DefaultFilename)
+    {
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="AzureOpenAIAudioToTextExecutionSettings"/> class.
+    /// </summary>
+    /// <param name="filename">Filename or identifier associated with audio data. Should be in format {filename}.{extension}</param>
+    public AzureOpenAIAudioToTextExecutionSettings(string filename)
+    {
+        this._filename = filename;
+    }
+
+    /// <inheritdoc/>
+    public override PromptExecutionSettings Clone()
+    {
+        return new AzureOpenAIAudioToTextExecutionSettings(this.Filename)
+        {
+            ModelId = this.ModelId,
+            ExtensionData = this.ExtensionData is not null ? new Dictionary<string, object>(this.ExtensionData) : null,
+            Temperature = this.Temperature,
+            ResponseFormat = this.ResponseFormat,
+            Language = this.Language,
+            Prompt = this.Prompt
+        };
+    }
+
+    /// <summary>
+    /// Converts <see cref="PromptExecutionSettings"/> to derived <see cref="AzureOpenAIAudioToTextExecutionSettings"/> type.
+    /// </summary>
+    /// <param name="executionSettings">Instance of <see cref="PromptExecutionSettings"/>.</param>
+    /// <returns>Instance of <see cref="AzureOpenAIAudioToTextExecutionSettings"/>.</returns>
+    public static AzureOpenAIAudioToTextExecutionSettings FromExecutionSettings(PromptExecutionSettings? executionSettings)
+    {
+        if (executionSettings is null)
+        {
+            return new AzureOpenAIAudioToTextExecutionSettings();
+        }
+
+        if (executionSettings is AzureOpenAIAudioToTextExecutionSettings settings)
+        {
+            return settings;
+        }
+
+        var json = JsonSerializer.Serialize(executionSettings);
+
+        var openAIExecutionSettings = JsonSerializer.Deserialize<AzureOpenAIAudioToTextExecutionSettings>(json, JsonOptionsCache.ReadPermissive);
+
+        if (openAIExecutionSettings is not null)
+        {
+            return openAIExecutionSettings;
+        }
+
+        throw new ArgumentException($"Invalid execution settings, cannot convert to {nameof(AzureOpenAIAudioToTextExecutionSettings)}", nameof(executionSettings));
+    }
+
+    /// <summary>
+    /// The timestamp granularities available to populate transcriptions.
+    /// </summary>
+    public enum TimeStampGranularities
+    {
+        /// <summary>
+        /// Not specified.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// The transcription is segmented by word.
+        /// </summary>
+        Word = 1,
+
+        /// <summary>
+        /// The timestamp of transcription is by segment.
+        /// </summary>
+        Segment = 2,
+    }
+
+    /// <summary>
+    /// Specifies the format of the audio transcription.
+    /// </summary>
+    public enum AudioTranscriptionFormat
+    {
+        /// <summary>
+        /// Response body that is a JSON object containing a single 'text' field for the transcription.
+        /// </summary>
+        Simple,
+
+        /// <summary>
+        /// Use a response body that is a JSON object containing transcription text along with timing, segments, and other metadata.
+        /// </summary>
+        Verbose,
+
+        /// <summary>
+        /// Response body that is plain text in SubRip (SRT) format that also includes timing information.
+        /// </summary>
+        Srt,
+
+        /// <summary>
+        /// Response body that is plain text in Web Video Text Tracks (VTT) format that also includes timing information.
+        /// </summary>
+        Vtt,
+    }
+
+    #region private ================================================================================
+
+    private const string DefaultFilename = "file.mp3";
+
+    private float _temperature = 0;
+    private AudioTranscriptionFormat? _responseFormat;
+    private string _filename;
+    private string? _language;
+    private string? _prompt;
+
+    #endregion
+}

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIAudioToTextExecutionSettings.cs
@@ -65,6 +65,7 @@ public sealed class AzureOpenAIAudioToTextExecutionSettings : PromptExecutionSet
     /// The format of the transcript output, in one of these options: Text, Simple, Verbose, Sttor vtt. Default is 'json'.
     /// </summary>
     [JsonPropertyName("response_format")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public AudioTranscriptionFormat? ResponseFormat
     {
         get => this._responseFormat;

--- a/dotnet/src/IntegrationTestsV2/Connectors/AzureOpenAI/AzureOpenAIAudioToTextTests.cs
+++ b/dotnet/src/IntegrationTestsV2/Connectors/AzureOpenAI/AzureOpenAIAudioToTextTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AudioToText;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTestsV2.Connectors.AzureOpenAI;
+
+public sealed class AzureOpenAIAudioToTextTests()
+{
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+        .AddJsonFile(path: "testsettings.json", optional: true, reloadOnChange: true)
+        .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+        .AddEnvironmentVariables()
+        .AddUserSecrets<AzureOpenAIAudioToTextTests>()
+        .Build();
+
+    [Fact]
+    public async Task AzureOpenAIAudioToTextTestAsync()
+    {
+        // Arrange
+        const string Filename = "test_audio.wav";
+
+        AzureOpenAIConfiguration? azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAIAudioToText").Get<AzureOpenAIConfiguration>();
+        Assert.NotNull(azureOpenAIConfiguration);
+
+        var kernel = Kernel.CreateBuilder()
+            .AddAzureOpenAIAudioToText(
+                azureOpenAIConfiguration.DeploymentName,
+                azureOpenAIConfiguration.Endpoint,
+                azureOpenAIConfiguration.ApiKey)
+            .Build();
+
+        var service = kernel.GetRequiredService<IAudioToTextService>();
+
+        await using Stream audio = File.OpenRead($"./TestData/{Filename}");
+        var audioData = await BinaryData.FromStreamAsync(audio);
+
+        // Act
+        var result = await service.GetTextContentAsync(new AudioContent(audioData, mimeType: "audio/wav"), new OpenAIAudioToTextExecutionSettings(Filename));
+
+        // Assert
+        Assert.Contains("The sun rises in the east and sets in the west.", result.Text, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
### Motivation and Context
This PR migrates the `AzureOpenAIAudioToTextService` to Azure.AI.OpenAI SDK v2.

### Description
1. The existing `OpenAIAudioToTextExecutionSettings` class is copied to the new `Connectors.AzureOpenAI` project and renamed to `AzureOpenAIAudioToTextExecutionSettings` to represent prompt execution settings for the `AzureOpenAIAudioToTextService`.
2. The `OpenAIAudioToTextExecutionSettings.ResponseFormat` property type has changed from string to the `AudioTranscriptionFormat` enum, which is a breaking change that is tracked in the issue - https://github.com/microsoft/semantic-kernel/issues/70533.
3. The `ClientCore.AudioToText.cs` class is refactored to use the new `AzureOpenAIAudioToTextExecutionSettings` class and to handle the new type of `OpenAIAudioToTextExecutionSettings.ResponseFormat` property.
4. Service collection and kernel builder extension methods are added to register the service in the DI container.
5. Unit and integration tests are added as well.