### PR TITLE
.Net: OpenAI V2 - Audio to Text - Response Format as Enum conversion for format

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAIV2.UnitTests/Settings/OpenAIAudioToTextExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2.UnitTests/Settings/OpenAIAudioToTextExecutionSettingsTests.cs
@@ -28,7 +28,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
             ModelId = "model_id",
             Language = "en",
             Prompt = "prompt",
-            ResponseFormat = "text",
+            ResponseFormat = OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple,
             Temperature = 0.2f
         };
 
@@ -49,7 +49,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
             "language": "en",
             "filename": "file.mp3",
             "prompt": "prompt",
-            "response_format": "text",
+            "response_format": "verbose",
             "temperature": 0.2
         }
         """;
@@ -65,7 +65,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
         Assert.Equal("en", settings.Language);
         Assert.Equal("file.mp3", settings.Filename);
         Assert.Equal("prompt", settings.Prompt);
-        Assert.Equal("text", settings.ResponseFormat);
+        Assert.Equal(OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Verbose, settings.ResponseFormat);
         Assert.Equal(0.2f, settings.Temperature);
     }
 
@@ -77,7 +77,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
             ModelId = "model_id",
             Language = "en",
             Prompt = "prompt",
-            ResponseFormat = "text",
+            ResponseFormat = OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple,
             Temperature = 0.2f,
             Filename = "something.mp3",
         };
@@ -88,7 +88,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
         Assert.Equal("model_id", clone.ModelId);
         Assert.Equal("en", clone.Language);
         Assert.Equal("prompt", clone.Prompt);
-        Assert.Equal("text", clone.ResponseFormat);
+        Assert.Equal(OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple, clone.ResponseFormat);
         Assert.Equal(0.2f, clone.Temperature);
         Assert.Equal("something.mp3", clone.Filename);
     }
@@ -101,7 +101,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
             ModelId = "model_id",
             Language = "en",
             Prompt = "prompt",
-            ResponseFormat = "text",
+            ResponseFormat = OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple,
             Temperature = 0.2f,
             Filename = "something.mp3",
         };
@@ -112,7 +112,7 @@ public sealed class OpenAIAudioToTextExecutionSettingsTests
         Assert.Throws<InvalidOperationException>(() => settings.ModelId = "new_model");
         Assert.Throws<InvalidOperationException>(() => settings.Language = "some_format");
         Assert.Throws<InvalidOperationException>(() => settings.Prompt = "prompt");
-        Assert.Throws<InvalidOperationException>(() => settings.ResponseFormat = "something");
+        Assert.Throws<InvalidOperationException>(() => settings.ResponseFormat = OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple);
         Assert.Throws<InvalidOperationException>(() => settings.Temperature = 0.2f);
         Assert.Throws<InvalidOperationException>(() => settings.Filename = "something");
 

--- a/dotnet/src/Connectors/Connectors.OpenAIV2/Core/ClientCore.AudioToText.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2/Core/ClientCore.AudioToText.cs
@@ -54,7 +54,8 @@ internal partial class ClientCore
             Granularities = ConvertToAudioTimestampGranularities(executionSettings!.Granularities),
             Language = executionSettings.Language,
             Prompt = executionSettings.Prompt,
-            Temperature = executionSettings.Temperature
+            Temperature = executionSettings.Temperature,
+            ResponseFormat = ConvertResponseFormat(executionSettings.ResponseFormat)
         };
 
     private static AudioTimestampGranularities ConvertToAudioTimestampGranularities(IEnumerable<OpenAIAudioToTextExecutionSettings.TimeStampGranularities>? granularities)
@@ -77,6 +78,23 @@ internal partial class ClientCore
         }
 
         return result;
+    }
+
+    private static AudioTranscriptionFormat? ConvertResponseFormat(OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat? responseFormat)
+    {
+        if (responseFormat is null)
+        {
+            return null;
+        }
+
+        return responseFormat switch
+        {
+            OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Simple => AudioTranscriptionFormat.Simple,
+            OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Verbose => AudioTranscriptionFormat.Verbose,
+            OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Vtt => AudioTranscriptionFormat.Vtt,
+            OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat.Srt => AudioTranscriptionFormat.Srt,
+            _ => throw new NotSupportedException($"The audio transcription format '{responseFormat}' is not supported."),
+        };
     }
 
     private static Dictionary<string, object?> GetResponseMetadata(AudioTranscription audioTranscription)

--- a/dotnet/src/Connectors/Connectors.OpenAIV2/Settings/OpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2/Settings/OpenAIAudioToTextExecutionSettings.cs
@@ -61,10 +61,11 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
     }
 
     /// <summary>
-    /// The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt. Default is 'json'.
+    /// The format of the transcript output, in one of these options: Text, Simple, Verbose, Sttor vtt. Default is 'json'.
     /// </summary>
     [JsonPropertyName("response_format")]
-    public string ResponseFormat
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public AudioTranscriptionFormat? ResponseFormat
     {
         get => this._responseFormat;
 
@@ -175,12 +176,38 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
         Segment = 2,
     }
 
+    /// <summary>
+    /// Specifies the format of the audio transcription.
+    /// </summary>
+    public enum AudioTranscriptionFormat
+    {
+        /// <summary>
+        /// Response body that is a JSON object containing a single 'text' field for the transcription.
+        /// </summary>
+        Simple,
+
+        /// <summary>
+        /// Use a response body that is a JSON object containing transcription text along with timing, segments, and other metadata.
+        /// </summary>
+        Verbose,
+
+        /// <summary>
+        /// Response body that is plain text in SubRip (SRT) format that also includes timing information.
+        /// </summary>
+        Srt,
+
+        /// <summary>
+        /// Response body that is plain text in Web Video Text Tracks (VTT) format that also includes timing information.
+        /// </summary>
+        Vtt,
+    }
+
     #region private ================================================================================
 
     private const string DefaultFilename = "file.mp3";
 
     private float _temperature = 0;
-    private string _responseFormat = "json";
+    private AudioTranscriptionFormat? _responseFormat;
     private string _filename;
     private string? _language;
     private string? _prompt;


### PR DESCRIPTION
### Motivation and Context

- Updates Execution Settings for `ResponseFormat` from `string` to `enum`.
- Updates the Unit Tests to validate.
