### PR TITLE
.Net: Switching all vector record store instances to be tied to a single collection

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <!-- Tokenizers -->

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
@@ -57,10 +57,7 @@ public class AzureAISearchVectorRecordStoreTests
         // Act.
         var actual = await sut.GetAsync(
             TestRecordKey1,
-            new()
-            {
-                IncludeVectors = true,
-            },
+            new() { IncludeVectors = true },
             this._testCancellationToken);
 
         // Assert.
@@ -90,10 +87,7 @@ public class AzureAISearchVectorRecordStoreTests
         // Act.
         var actual = await sut.GetAsync(
             TestRecordKey1,
-            new()
-            {
-                IncludeVectors = false
-            },
+            new() { IncludeVectors = false },
             this._testCancellationToken);
 
         // Assert.
@@ -123,10 +117,7 @@ public class AzureAISearchVectorRecordStoreTests
         // Act.
         var actual = await sut.GetBatchAsync(
             [TestRecordKey1, TestRecordKey2],
-            new()
-            {
-                IncludeVectors = true
-            },
+            new() { IncludeVectors = true },
             this._testCancellationToken).ToListAsync();
 
         // Assert.

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorRecordStoreTests.cs
@@ -40,11 +40,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetRecordWithVectorsAsync(bool useDefinition)
     {
         // Arrange.
         this._searchClientMock.Setup(
@@ -54,7 +52,7 @@ public class AzureAISearchVectorRecordStoreTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act.
         var actual = await sut.GetAsync(
@@ -62,7 +60,6 @@ public class AzureAISearchVectorRecordStoreTests
             new()
             {
                 IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
             },
             this._testCancellationToken);
 
@@ -74,11 +71,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetRecordWithoutVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetRecordWithoutVectorsAsync(bool useDefinition)
     {
         // Arrange.
         var storageObject = JsonSerializer.SerializeToNode(CreateModel(TestRecordKey1, false))!.AsObject();
@@ -90,15 +85,14 @@ public class AzureAISearchVectorRecordStoreTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act.
         var actual = await sut.GetAsync(
             TestRecordKey1,
             new()
             {
-                IncludeVectors = false,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = false
             },
             this._testCancellationToken);
 
@@ -109,11 +103,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition)
     {
         // Arrange.
         this._searchClientMock.Setup(
@@ -126,15 +118,14 @@ public class AzureAISearchVectorRecordStoreTests
                 return Response.FromValue(CreateModel(id, true), Mock.Of<Response>());
             });
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act.
         var actual = await sut.GetBatchAsync(
             [TestRecordKey1, TestRecordKey2],
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken).ToListAsync();
 
@@ -170,9 +161,9 @@ public class AzureAISearchVectorRecordStoreTests
         // Arrange target with custom mapper.
         var sut = new AzureAISearchVectorRecordStore<SinglePropsModel>(
             this._searchIndexClientMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = TestCollectionName,
                 MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper,
                 JsonObjectCustomMapper = mapperMock.Object
             });
@@ -188,11 +179,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanDeleteRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDeleteRecordAsync(bool useDefinition)
     {
         // Arrange.
 #pragma warning disable Moq1002 // Moq: No matching constructor
@@ -207,13 +196,12 @@ public class AzureAISearchVectorRecordStoreTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act.
         await sut.DeleteAsync(
             TestRecordKey1,
-            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert.
         this._searchClientMock.Verify(
@@ -226,11 +214,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition)
     {
         // Arrange.
 #pragma warning disable Moq1002 // Moq: No matching constructor
@@ -245,13 +231,12 @@ public class AzureAISearchVectorRecordStoreTests
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act.
         await sut.DeleteBatchAsync(
             [TestRecordKey1, TestRecordKey2],
-            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert.
         this._searchClientMock.Verify(
@@ -264,11 +249,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanUpsertRecordAsync(bool useDefinition)
     {
         // Arrange upload result object.
 #pragma warning disable Moq1002 // Moq: No matching constructor
@@ -287,15 +270,14 @@ public class AzureAISearchVectorRecordStoreTests
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
         // Arrange sut.
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         var model = CreateModel(TestRecordKey1, true);
 
         // Act.
         var actual = await sut.UpsertAsync(
             model,
-            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert.
         Assert.NotNull(actual);
@@ -309,11 +291,9 @@ public class AzureAISearchVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanUpsertManyRecordsAsync(bool useDefinition)
     {
         // Arrange upload result object.
 #pragma warning disable Moq1002 // Moq: No matching constructor
@@ -335,7 +315,7 @@ public class AzureAISearchVectorRecordStoreTests
             .ReturnsAsync(Response.FromValue(indexDocumentsResultMock.Object, Mock.Of<Response>()));
 
         // Arrange sut.
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         var model1 = CreateModel(TestRecordKey1, true);
         var model2 = CreateModel(TestRecordKey2, true);
@@ -343,8 +323,7 @@ public class AzureAISearchVectorRecordStoreTests
         // Act.
         var actual = await sut.UpsertBatchAsync(
             [model1, model2],
-            new() { CollectionName = passCollectionToMethod ? TestCollectionName : null },
-            this._testCancellationToken).ToListAsync();
+            cancellationToken: this._testCancellationToken).ToListAsync();
 
         // Assert.
         Assert.NotNull(actual);
@@ -396,9 +375,9 @@ public class AzureAISearchVectorRecordStoreTests
         // Arrange target with custom mapper.
         var sut = new AzureAISearchVectorRecordStore<SinglePropsModel>(
             this._searchIndexClientMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = TestCollectionName,
                 MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper,
                 JsonObjectCustomMapper = mapperMock.Object
             });
@@ -416,13 +395,13 @@ public class AzureAISearchVectorRecordStoreTests
                 Times.Once);
     }
 
-    private AzureAISearchVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition, bool passCollectionToMethod)
+    private AzureAISearchVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
     {
         return new AzureAISearchVectorRecordStore<SinglePropsModel>(
             this._searchIndexClientMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
                 VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null
             });
     }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStoreOptions.cs
@@ -14,12 +14,6 @@ public sealed class AzureAISearchVectorRecordStoreOptions<TRecord>
     where TRecord : class
 {
     /// <summary>
-    /// Gets or sets the default collection name to use.
-    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
-    /// </summary>
-    public string? DefaultCollectionName { get; init; } = null;
-
-    /// <summary>
     /// Gets or sets the choice of mapper to use when converting between the data model and the Azure AI Search record.
     /// </summary>
     public AzureAISearchRecordMapperType MapperType { get; init; } = AzureAISearchRecordMapperType.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecordStoreOptions.cs
@@ -12,12 +12,6 @@ public sealed class QdrantVectorRecordStoreOptions<TRecord>
     where TRecord : class
 {
     /// <summary>
-    /// Gets or sets the default collection name to use.
-    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
-    /// </summary>
-    public string? DefaultCollectionName { get; init; } = null;
-
-    /// <summary>
     /// Gets or sets a value indicating whether the vectors in the store are named and multiple vectors are supported, or whether there is just a single unnamed vector per qdrant point.
     /// Defaults to single vector per point.
     /// </summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorRecordStoreOptions.cs
@@ -13,12 +13,6 @@ public sealed class RedisVectorRecordStoreOptions<TRecord>
     where TRecord : class
 {
     /// <summary>
-    /// Gets or sets the default collection name to use.
-    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
-    /// </summary>
-    public string? DefaultCollectionName { get; init; } = null;
-
-    /// <summary>
     /// Gets or sets a value indicating whether the collection name should be prefixed to the
     /// key names before reading or writing to the Redis store. Default is false.
     /// </summary>

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
@@ -34,9 +34,9 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(TestOptions))]
-    public async Task CanGetRecordWithVectorsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    public async Task CanGetRecordWithVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
     {
-        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, hasNamedVectors);
 
         // Arrange.
         var retrievedPoint = CreateRetrievedPoint(hasNamedVectors, testRecordKey);
@@ -47,8 +47,7 @@ public class QdrantVectorRecordStoreTests
             testRecordKey,
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken);
 
@@ -73,10 +72,10 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(TestOptions))]
-    public async Task CanGetRecordWithoutVectorsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    public async Task CanGetRecordWithoutVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
     {
         // Arrange.
-        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, hasNamedVectors);
         var retrievedPoint = CreateRetrievedPoint(hasNamedVectors, testRecordKey);
         this.SetupRetrieveMock([retrievedPoint]);
 
@@ -85,8 +84,7 @@ public class QdrantVectorRecordStoreTests
             testRecordKey,
             new()
             {
-                IncludeVectors = false,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = false
             },
             this._testCancellationToken);
 
@@ -111,10 +109,10 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(MultiRecordTestOptions))]
-    public async Task CanGetManyRecordsWithVectorsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
+    public async Task CanGetManyRecordsWithVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey[] testRecordKeys)
     {
         // Arrange.
-        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, hasNamedVectors);
         var retrievedPoint1 = CreateRetrievedPoint(hasNamedVectors, UlongTestRecordKey1);
         var retrievedPoint2 = CreateRetrievedPoint(hasNamedVectors, UlongTestRecordKey2);
         this.SetupRetrieveMock(testRecordKeys.Select(x => CreateRetrievedPoint(hasNamedVectors, x)).ToList());
@@ -124,8 +122,7 @@ public class QdrantVectorRecordStoreTests
             testRecordKeys,
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken).ToListAsync();
 
@@ -169,9 +166,9 @@ public class QdrantVectorRecordStoreTests
         // Arrange target with custom mapper.
         var sut = new QdrantVectorRecordStore<SinglePropsModel<ulong>>(
             this._qdrantClientMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = TestCollectionName,
                 HasNamedVectors = true,
                 MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper,
                 PointStructCustomMapper = mapperMock.Object
@@ -198,28 +195,20 @@ public class QdrantVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true, true)]
-    [InlineData(true, true, false)]
-    [InlineData(true, false, true)]
-    [InlineData(true, false, false)]
-    [InlineData(false, true, true)]
-    [InlineData(false, true, false)]
-    [InlineData(false, false, true)]
-    [InlineData(false, false, false)]
-    public async Task CanDeleteUlongRecordAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteUlongRecordAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateVectorRecordStore<ulong>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<ulong>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
         await sut.DeleteAsync(
             UlongTestRecordKey1,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         this._qdrantClientMock
@@ -235,28 +224,20 @@ public class QdrantVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true, true)]
-    [InlineData(true, true, false)]
-    [InlineData(true, false, true)]
-    [InlineData(true, false, false)]
-    [InlineData(false, true, true)]
-    [InlineData(false, true, false)]
-    [InlineData(false, false, true)]
-    [InlineData(false, false, false)]
-    public async Task CanDeleteGuidRecordAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteGuidRecordAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateVectorRecordStore<Guid>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<Guid>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
         await sut.DeleteAsync(
             s_guidTestRecordKey1,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         this._qdrantClientMock
@@ -272,28 +253,20 @@ public class QdrantVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true, true)]
-    [InlineData(true, true, false)]
-    [InlineData(true, false, true)]
-    [InlineData(true, false, false)]
-    [InlineData(false, true, true)]
-    [InlineData(false, true, false)]
-    [InlineData(false, false, true)]
-    [InlineData(false, false, false)]
-    public async Task CanDeleteManyUlongRecordsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteManyUlongRecordsAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateVectorRecordStore<ulong>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<ulong>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
         await sut.DeleteBatchAsync(
             [UlongTestRecordKey1, UlongTestRecordKey2],
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         this._qdrantClientMock
@@ -309,28 +282,20 @@ public class QdrantVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true, true)]
-    [InlineData(true, true, false)]
-    [InlineData(true, false, true)]
-    [InlineData(true, false, false)]
-    [InlineData(false, true, true)]
-    [InlineData(false, true, false)]
-    [InlineData(false, false, true)]
-    [InlineData(false, false, false)]
-    public async Task CanDeleteManyGuidRecordsAsync(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanDeleteManyGuidRecordsAsync(bool useDefinition, bool hasNamedVectors)
     {
         // Arrange
-        var sut = this.CreateVectorRecordStore<Guid>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<Guid>(useDefinition, hasNamedVectors);
         this.SetupDeleteMocks();
 
         // Act
         await sut.DeleteBatchAsync(
             [s_guidTestRecordKey1, s_guidTestRecordKey2],
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         this._qdrantClientMock
@@ -347,20 +312,16 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(TestOptions))]
-    public async Task CanUpsertRecordAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey testRecordKey)
+    public async Task CanUpsertRecordAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
     {
         // Arrange
-        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, hasNamedVectors);
         this.SetupUpsertMock();
 
         // Act
         await sut.UpsertAsync(
             CreateModel(testRecordKey, true),
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         this._qdrantClientMock
@@ -377,10 +338,10 @@ public class QdrantVectorRecordStoreTests
 
     [Theory]
     [MemberData(nameof(MultiRecordTestOptions))]
-    public async Task CanUpsertManyRecordsAsync<TKey>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors, TKey[] testRecordKeys)
+    public async Task CanUpsertManyRecordsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey[] testRecordKeys)
     {
         // Arrange
-        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, passCollectionToMethod, hasNamedVectors);
+        var sut = this.CreateVectorRecordStore<TKey>(useDefinition, hasNamedVectors);
         this.SetupUpsertMock();
 
         var models = testRecordKeys.Select(x => CreateModel(x, true));
@@ -388,11 +349,7 @@ public class QdrantVectorRecordStoreTests
         // Act
         var actual = await sut.UpsertBatchAsync(
             models,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken).ToListAsync();
+            cancellationToken: this._testCancellationToken).ToListAsync();
 
         // Assert
         Assert.NotNull(actual);
@@ -436,9 +393,9 @@ public class QdrantVectorRecordStoreTests
         // Arrange target with custom mapper.
         var sut = new QdrantVectorRecordStore<SinglePropsModel<ulong>>(
             this._qdrantClientMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = TestCollectionName,
                 HasNamedVectors = false,
                 MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper,
                 PointStructCustomMapper = mapperMock.Object
@@ -564,13 +521,13 @@ public class QdrantVectorRecordStoreTests
         return point;
     }
 
-    private IVectorRecordStore<T, SinglePropsModel<T>> CreateVectorRecordStore<T>(bool useDefinition, bool passCollectionToMethod, bool hasNamedVectors)
+    private IVectorRecordStore<T, SinglePropsModel<T>> CreateVectorRecordStore<T>(bool useDefinition, bool hasNamedVectors)
     {
         var store = new QdrantVectorRecordStore<SinglePropsModel<T>>(
             this._qdrantClientMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
                 VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null,
                 HasNamedVectors = hasNamedVectors
             }) as IVectorRecordStore<T, SinglePropsModel<T>>;
@@ -616,13 +573,11 @@ public class QdrantVectorRecordStoreTests
         => GenerateAllCombinations(new object[][] {
                 new object[] { true, false },
                 new object[] { true, false },
-                new object[] { true, false },
                 new object[] { UlongTestRecordKey1, s_guidTestRecordKey1 }
         });
 
     public static IEnumerable<object[]> MultiRecordTestOptions
     => GenerateAllCombinations(new object[][] {
-                new object[] { true, false },
                 new object[] { true, false },
                 new object[] { true, false },
                 new object[] { new ulong[] { UlongTestRecordKey1, UlongTestRecordKey2 }, new Guid[] { s_guidTestRecordKey1, s_guidTestRecordKey2 } }

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorRecordStoreTests.cs
@@ -45,10 +45,7 @@ public class QdrantVectorRecordStoreTests
         // Act.
         var actual = await sut.GetAsync(
             testRecordKey,
-            new()
-            {
-                IncludeVectors = true
-            },
+            new() { IncludeVectors = true },
             this._testCancellationToken);
 
         // Assert.
@@ -82,10 +79,7 @@ public class QdrantVectorRecordStoreTests
         // Act.
         var actual = await sut.GetAsync(
             testRecordKey,
-            new()
-            {
-                IncludeVectors = false
-            },
+            new() { IncludeVectors = false },
             this._testCancellationToken);
 
         // Assert.
@@ -120,10 +114,7 @@ public class QdrantVectorRecordStoreTests
         // Act.
         var actual = await sut.GetBatchAsync(
             testRecordKeys,
-            new()
-            {
-                IncludeVectors = true
-            },
+            new() { IncludeVectors = true },
             this._testCancellationToken).ToListAsync();
 
         // Assert.

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
@@ -25,8 +25,6 @@ public class RedisVectorRecordStoreTests
 
     private readonly Mock<IDatabase> _redisDatabaseMock;
 
-    private readonly CancellationToken _testCancellationToken = new(false);
-
     public RedisVectorRecordStoreTests()
     {
         this._redisDatabaseMock = new Mock<IDatabase>(MockBehavior.Strict);
@@ -48,11 +46,7 @@ public class RedisVectorRecordStoreTests
         // Act
         var actual = await sut.GetAsync(
             TestRecordKey1,
-            new()
-            {
-                IncludeVectors = true
-            },
-            this._testCancellationToken);
+            new() { IncludeVectors = true });
 
         // Assert
         var expectedArgs = new object[] { TestRecordKey1 };
@@ -82,11 +76,7 @@ public class RedisVectorRecordStoreTests
         // Act
         var actual = await sut.GetAsync(
             TestRecordKey1,
-            new()
-            {
-                IncludeVectors = false
-            },
-            this._testCancellationToken);
+            new() { IncludeVectors = false });
 
         // Assert
         var expectedArgs = new object[] { TestRecordKey1, "Data" };
@@ -117,11 +107,7 @@ public class RedisVectorRecordStoreTests
         // Act
         var actual = await sut.GetBatchAsync(
             [TestRecordKey1, TestRecordKey2],
-            new()
-            {
-                IncludeVectors = true
-            },
-            this._testCancellationToken).ToListAsync();
+            new() { IncludeVectors = true }).ToListAsync();
 
         // Assert
         var expectedArgs = new object[] { TestRecordKey1, TestRecordKey2, "$" };
@@ -168,8 +154,7 @@ public class RedisVectorRecordStoreTests
         // Act
         var actual = await sut.GetAsync(
             TestRecordKey1,
-            new() { IncludeVectors = true },
-            this._testCancellationToken);
+            new() { IncludeVectors = true });
 
         // Assert
         Assert.NotNull(actual);
@@ -195,9 +180,7 @@ public class RedisVectorRecordStoreTests
         var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
-        await sut.DeleteAsync(
-            TestRecordKey1,
-            cancellationToken: this._testCancellationToken);
+        await sut.DeleteAsync(TestRecordKey1);
 
         // Assert
         var expectedArgs = new object[] { TestRecordKey1 };
@@ -219,9 +202,7 @@ public class RedisVectorRecordStoreTests
         var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
-        await sut.DeleteBatchAsync(
-            [TestRecordKey1, TestRecordKey2],
-            cancellationToken: this._testCancellationToken);
+        await sut.DeleteBatchAsync([TestRecordKey1, TestRecordKey2]);
 
         // Assert
         var expectedArgs1 = new object[] { TestRecordKey1 };
@@ -251,9 +232,7 @@ public class RedisVectorRecordStoreTests
         var model = CreateModel(TestRecordKey1, true);
 
         // Act
-        await sut.UpsertAsync(
-            model,
-            cancellationToken: this._testCancellationToken);
+        await sut.UpsertAsync(model);
 
         // Assert
         // TODO: Fix issue where NotAnnotated is being included in the JSON.
@@ -279,9 +258,7 @@ public class RedisVectorRecordStoreTests
         var model2 = CreateModel(TestRecordKey2, true);
 
         // Act
-        var actual = await sut.UpsertBatchAsync(
-            [model1, model2],
-            cancellationToken: this._testCancellationToken).ToListAsync();
+        var actual = await sut.UpsertBatchAsync([model1, model2]).ToListAsync();
 
         // Assert
         Assert.NotNull(actual);
@@ -325,10 +302,7 @@ public class RedisVectorRecordStoreTests
         var model = CreateModel(TestRecordKey1, true);
 
         // Act
-        await sut.UpsertAsync(
-            model,
-            null,
-            this._testCancellationToken);
+        await sut.UpsertAsync(model);
 
         // Assert
         mapperMock

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Data;
 using Moq;

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorRecordStoreTests.cs
@@ -36,24 +36,21 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetRecordWithVectorsAsync(bool useDefinition)
     {
         // Arrange
         var redisResultString = """{ "Data": "data 1", "Vector": [1, 2, 3, 4] }""";
         SetupExecuteMock(this._redisDatabaseMock, redisResultString);
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
             TestRecordKey1,
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken);
 
@@ -73,24 +70,21 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetRecordWithoutVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetRecordWithoutVectorsAsync(bool useDefinition)
     {
         // Arrange
         var redisResultString = """{ "Data": "data 1" }""";
         SetupExecuteMock(this._redisDatabaseMock, redisResultString);
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
             TestRecordKey1,
             new()
             {
-                IncludeVectors = false,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = false
             },
             this._testCancellationToken);
 
@@ -110,25 +104,22 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition)
     {
         // Arrange
         var redisResultString1 = """{ "Data": "data 1", "Vector": [1, 2, 3, 4] }""";
         var redisResultString2 = """{ "Data": "data 2", "Vector": [5, 6, 7, 8] }""";
         SetupExecuteMock(this._redisDatabaseMock, [redisResultString1, redisResultString2]);
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var actual = await sut.GetBatchAsync(
             [TestRecordKey1, TestRecordKey2],
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken).ToListAsync();
 
@@ -167,9 +158,9 @@ public class RedisVectorRecordStoreTests
         // Arrange target with custom mapper.
         var sut = new RedisVectorRecordStore<SinglePropsModel>(
             this._redisDatabaseMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = TestCollectionName,
                 MapperType = RedisRecordMapperType.JsonNodeCustomMapper,
                 JsonNodeCustomMapper = mapperMock.Object
             });
@@ -195,24 +186,18 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanDeleteRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDeleteRecordAsync(bool useDefinition)
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "200");
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         await sut.DeleteAsync(
             TestRecordKey1,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         var expectedArgs = new object[] { TestRecordKey1 };
@@ -225,24 +210,18 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition)
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "200");
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         await sut.DeleteBatchAsync(
             [TestRecordKey1, TestRecordKey2],
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         var expectedArgs1 = new object[] { TestRecordKey1 };
@@ -262,25 +241,19 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanUpsertRecordAsync(bool useDefinition)
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "OK");
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
         var model = CreateModel(TestRecordKey1, true);
 
         // Act
         await sut.UpsertAsync(
             model,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         // TODO: Fix issue where NotAnnotated is being included in the JSON.
@@ -294,15 +267,13 @@ public class RedisVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanUpsertManyRecordsAsync(bool useDefinition)
     {
         // Arrange
         SetupExecuteMock(this._redisDatabaseMock, "OK");
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         var model1 = CreateModel(TestRecordKey1, true);
         var model2 = CreateModel(TestRecordKey2, true);
@@ -310,11 +281,7 @@ public class RedisVectorRecordStoreTests
         // Act
         var actual = await sut.UpsertBatchAsync(
             [model1, model2],
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken).ToListAsync();
+            cancellationToken: this._testCancellationToken).ToListAsync();
 
         // Assert
         Assert.NotNull(actual);
@@ -348,9 +315,9 @@ public class RedisVectorRecordStoreTests
         // Arrange target with custom mapper.
         var sut = new RedisVectorRecordStore<SinglePropsModel>(
             this._redisDatabaseMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = TestCollectionName,
                 MapperType = RedisRecordMapperType.JsonNodeCustomMapper,
                 JsonNodeCustomMapper = mapperMock.Object
             });
@@ -370,13 +337,13 @@ public class RedisVectorRecordStoreTests
                 Times.Once);
     }
 
-    private RedisVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition, bool passCollectionToMethod)
+    private RedisVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
     {
         return new RedisVectorRecordStore<SinglePropsModel>(
             this._redisDatabaseMock.Object,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
                 VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null
             });
     }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
@@ -32,10 +32,9 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         // Arrange
         var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = fixture.TestIndexName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var hotel = CreateTestHotel("Upsert-1");
@@ -67,11 +66,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanUpsertManyDocumentsToVectorStoreAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
-        {
-            DefaultCollectionName = fixture.TestIndexName
-        };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act
         var results = sut.UpsertBatchAsync(
@@ -107,10 +102,9 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         // Arrange
         var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = fixture.TestIndexName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var getResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
@@ -140,11 +134,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
-        {
-            DefaultCollectionName = fixture.TestIndexName
-        };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -170,10 +160,9 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         // Arrange
         var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = fixture.TestIndexName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
         await sut.UpsertAsync(CreateTestHotel("Remove-1"));
 
         // Act
@@ -189,11 +178,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
-        {
-            DefaultCollectionName = fixture.TestIndexName
-        };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-1"));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-2"));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-3"));
@@ -212,8 +197,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { DefaultCollectionName = fixture.TestIndexName };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("BaseSet-5", new GetRecordOptions { IncludeVectors = true }));
@@ -223,9 +207,8 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItThrowsOperationExceptionForFailedConnectionAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { DefaultCollectionName = fixture.TestIndexName };
         var searchIndexClient = new SearchIndexClient(new Uri("https://localhost:12345"), new AzureKeyCredential("12345"));
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(searchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(searchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
@@ -235,9 +218,8 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItThrowsOperationExceptionForFailedAuthenticationAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { DefaultCollectionName = fixture.TestIndexName };
         var searchIndexClient = new SearchIndexClient(new Uri(fixture.Config.ServiceUrl), new AzureKeyCredential("12345"));
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(searchIndexClient, options);
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(searchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
@@ -247,8 +229,8 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItThrowsMappingExceptionForFailedMapperAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { DefaultCollectionName = fixture.TestIndexName, MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper, JsonObjectCustomMapper = new FailingMapper() };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, options);
+        var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper, JsonObjectCustomMapper = new FailingMapper() };
+        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorRecordStoreTests.cs
@@ -32,10 +32,9 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
         var options = new QdrantVectorRecordStoreOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
-            DefaultCollectionName = collectionName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         var record = this.CreateTestHotel(20);
 
@@ -65,8 +64,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanUpsertAndRemoveDocumentWithGuidIdToVectorStoreAsync()
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId> { HasNamedVectors = false, DefaultCollectionName = "singleVectorGuidIdHotels" };
-        IVectorRecordStore<Guid, HotelInfoWithGuidId> sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, options);
+        var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId> { HasNamedVectors = false };
+        IVectorRecordStore<Guid, HotelInfoWithGuidId> sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
 
         var record = new HotelInfoWithGuidId
         {
@@ -112,10 +111,9 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
         var options = new QdrantVectorRecordStoreOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
-            DefaultCollectionName = collectionName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         // Act.
         var getResult = await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = withEmbeddings });
@@ -154,10 +152,9 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
         var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId>
         {
             HasNamedVectors = false,
-            DefaultCollectionName = "singleVectorGuidIdHotels",
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelWithGuidIdVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, options);
+        var sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
 
         // Act.
         var getResult = await sut.GetAsync(Guid.Parse("11111111-1111-1111-1111-111111111111"), new GetRecordOptions { IncludeVectors = withEmbeddings });
@@ -183,8 +180,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = true, DefaultCollectionName = "namedVectorsHotels" };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = true };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -213,10 +210,9 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
         var options = new QdrantVectorRecordStoreOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
-            DefaultCollectionName = collectionName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         await sut.UpsertAsync(this.CreateTestHotel(20));
 
@@ -240,10 +236,9 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
         var options = new QdrantVectorRecordStoreOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
-            DefaultCollectionName = collectionName,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         await sut.UpsertAsync(this.CreateTestHotel(20));
 
@@ -259,8 +254,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = false, DefaultCollectionName = "singleVectorHotels" };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = false };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync(15, new GetRecordOptions { IncludeVectors = true }));
@@ -270,8 +265,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItThrowsMappingExceptionForFailedMapperAsync()
     {
         // Arrange
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { DefaultCollectionName = "singleVectorHotels", MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper, PointStructCustomMapper = new FailingMapper() };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, options);
+        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper, PointStructCustomMapper = new FailingMapper() };
+        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = true }));

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorRecordStoreTests.cs
@@ -28,11 +28,10 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
         // Arrange.
         var options = new RedisVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = "hotels",
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
         Hotel record = CreateTestHotel("Upsert-1", 1);
 
         // Act.
@@ -66,11 +65,10 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
         // Arrange.
         var options = new RedisVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = "hotels",
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
 
         // Act.
         var results = sut.UpsertBatchAsync(
@@ -106,11 +104,10 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
         // Arrange.
         var options = new RedisVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = "hotels",
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
 
         // Act.
         var getResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
@@ -142,8 +139,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -165,8 +162,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItFailsToGetDocumentsWithInvalidSchemaAsync()
     {
         // Arrange.
-        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
 
         // Act & Assert.
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-4-Invalid", new GetRecordOptions { IncludeVectors = true }));
@@ -180,11 +177,10 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
         // Arrange.
         var options = new RedisVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = "hotels",
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
         var address = new HotelAddress { City = "Seattle", Country = "USA" };
         var record = new Hotel
         {
@@ -210,8 +206,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-1", 1));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-2", 2));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-3", 3));
@@ -230,8 +226,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel> { DefaultCollectionName = "hotels", PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("BaseSet-5", new GetRecordOptions { IncludeVectors = true }));
@@ -243,12 +239,11 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
         // Arrange
         var options = new RedisVectorRecordStoreOptions<Hotel>
         {
-            DefaultCollectionName = "hotels",
             PrefixCollectionNameToKeyNames = true,
             MapperType = RedisRecordMapperType.JsonNodeCustomMapper,
             JsonNodeCustomMapper = new FailingMapper()
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, options);
+        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/DeleteRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/DeleteRecordOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.DeleteAsync"/>.
+/// Reserved for future use.
 /// </summary>
 [Experimental("SKEXP0001")]
 public class DeleteRecordOptions
@@ -23,11 +24,5 @@ public class DeleteRecordOptions
     /// <param name="source">The options to clone</param>
     public DeleteRecordOptions(DeleteRecordOptions source)
     {
-        this.CollectionName = source.CollectionName;
     }
-
-    /// <summary>
-    /// Get or sets an optional collection name to use for this operation that is different to the default.
-    /// </summary>
-    public string? CollectionName { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/GetRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/GetRecordOptions.cs
@@ -23,14 +23,8 @@ public class GetRecordOptions
     /// <param name="source">The options to clone</param>
     public GetRecordOptions(GetRecordOptions source)
     {
-        this.CollectionName = source.CollectionName;
         this.IncludeVectors = source.IncludeVectors;
     }
-
-    /// <summary>
-    /// Get or sets an optional collection name to use for this operation that is different to the default.
-    /// </summary>
-    public string? CollectionName { get; init; }
 
     /// <summary>
     /// Get or sets a value indicating whether to include vectors in the retrieval result.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/UpsertRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/UpsertRecordOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.UpsertAsync"/>.
+/// Reserved for future use.
 /// </summary>
 [Experimental("SKEXP0001")]
 public class UpsertRecordOptions
@@ -23,11 +24,5 @@ public class UpsertRecordOptions
     /// <param name="source">The options to clone</param>
     public UpsertRecordOptions(UpsertRecordOptions source)
     {
-        this.CollectionName = source.CollectionName;
     }
-
-    /// <summary>
-    /// Get or sets an optional collection name to use for this operation that is different to the default.
-    /// </summary>
-    public string? CollectionName { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStore.cs
@@ -25,6 +25,9 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// <summary>Optional configuration options for this class.</summary>
     private readonly VolatileVectorRecordStoreOptions _options;
 
+    /// <summary>The name of the collection that this <see cref="VolatileVectorRecordStore{TRecord}"/> will access.</summary>
+    private readonly string _collectionName;
+
     /// <summary>A set of types that a key on the provided model may have.</summary>
     private static readonly HashSet<Type> s_supportedKeyTypes =
     [
@@ -37,10 +40,15 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// <summary>
     /// Initializes a new instance of the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
     /// </summary>
+    /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorRecordStore{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    public VolatileVectorRecordStore(VolatileVectorRecordStoreOptions? options = default)
+    public VolatileVectorRecordStore(string collectionName, VolatileVectorRecordStoreOptions? options = default)
     {
+        // Verify.
+        Verify.NotNull(collectionName);
+
         // Assign.
+        this._collectionName = collectionName;
         this._internalCollection = new();
         this._options = options ?? new VolatileVectorRecordStoreOptions();
 
@@ -64,9 +72,10 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// Initializes a new instance of the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
     /// </summary>
     /// <param name="internalCollection">Allows passing in the dictionary used for storage, for testing purposes.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorRecordStore{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    internal VolatileVectorRecordStore(ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> internalCollection, VolatileVectorRecordStoreOptions? options = default)
-        : this(options)
+    internal VolatileVectorRecordStore(ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> internalCollection, string collectionName, VolatileVectorRecordStoreOptions? options = default)
+        : this(collectionName, options)
     {
         this._internalCollection = internalCollection;
     }
@@ -74,7 +83,7 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// <inheritdoc />
     public Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+        var collectionDictionary = this.GetCollectionDictionary();
 
         if (collectionDictionary.TryGetValue(key, out var record))
         {
@@ -101,7 +110,7 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// <inheritdoc />
     public Task DeleteAsync(string key, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+        var collectionDictionary = this.GetCollectionDictionary();
 
         collectionDictionary.TryRemove(key, out _);
         return Task.CompletedTask;
@@ -110,7 +119,7 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// <inheritdoc />
     public Task DeleteBatchAsync(IEnumerable<string> keys, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+        var collectionDictionary = this.GetCollectionDictionary();
 
         foreach (var key in keys)
         {
@@ -123,7 +132,7 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     /// <inheritdoc />
     public Task<string> UpsertAsync(TRecord record, UpsertRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var collectionDictionary = this.GetCollectionDictionary(options?.CollectionName);
+        var collectionDictionary = this.GetCollectionDictionary();
 
         var key = this._keyPropertyInfo.GetValue(record) as string;
         collectionDictionary.AddOrUpdate(key!, record, (key, currentValue) => record);
@@ -141,30 +150,16 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     }
 
     /// <summary>
-    /// Get a collection dictionary from the internal storage, creating it if it does not exist.
-    /// Use the provided collection name if not null, and fall back to the default collection name otherwise.
+    /// Get the collection dictionary from the internal storage, throws if it does not exist.
     /// </summary>
-    /// <param name="collectionName">The collection name passed to the operation.</param>
     /// <returns>The retrieved collection dictionary.</returns>
-    private ConcurrentDictionary<string, TRecord> GetCollectionDictionary(string? collectionName)
+    private ConcurrentDictionary<string, TRecord> GetCollectionDictionary()
     {
-        string? chosenCollectionName = null;
-
-        if (collectionName is not null)
+        if (!this._internalCollection.TryGetValue(this._collectionName, out var collectionDictionary))
         {
-            chosenCollectionName = collectionName;
-        }
-        else if (this._options.DefaultCollectionName is not null)
-        {
-            chosenCollectionName = this._options.DefaultCollectionName;
-        }
-        else
-        {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
-            throw new ArgumentException("Collection name must be provided in the operation options, since no default was provided at construction time.", "options");
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
+            throw new VectorStoreOperationException($"Call to vector store failed. Collection '{this._collectionName}' does not exist.");
         }
 
-        return this._internalCollection.GetOrAdd(chosenCollectionName, _ => new());
+        return collectionDictionary;
     }
 }

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStore.cs
@@ -45,7 +45,7 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     public VolatileVectorRecordStore(string collectionName, VolatileVectorRecordStoreOptions? options = default)
     {
         // Verify.
-        Verify.NotNull(collectionName);
+        Verify.NotNullOrWhiteSpace(collectionName);
 
         // Assign.
         this._collectionName = collectionName;

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStoreOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorRecordStoreOptions.cs
@@ -11,12 +11,6 @@ namespace Microsoft.SemanticKernel.Data;
 public sealed class VolatileVectorRecordStoreOptions
 {
     /// <summary>
-    /// Gets or sets the default collection name to use.
-    /// If not provided here, the collection name will need to be provided for each operation or the operation will throw.
-    /// </summary>
-    public string? DefaultCollectionName { get; init; } = null;
-
-    /// <summary>
     /// Gets or sets an optional record definition that defines the schema of the record type.
     /// </summary>
     /// <remarks>

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorRecordStoreTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorRecordStoreTests.cs
@@ -29,11 +29,9 @@ public class VolatileVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetRecordWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetRecordWithVectorsAsync(bool useDefinition)
     {
         // Arrange
         var record = CreateModel(TestRecordKey1, withVectors: true);
@@ -41,15 +39,14 @@ public class VolatileVectorRecordStoreTests
         collection.TryAdd(TestRecordKey1, record);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
             TestRecordKey1,
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken);
 
@@ -63,11 +60,9 @@ public class VolatileVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanGetManyRecordsWithVectorsAsync(bool useDefinition)
     {
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
@@ -77,15 +72,14 @@ public class VolatileVectorRecordStoreTests
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var actual = await sut.GetBatchAsync(
             [TestRecordKey1, TestRecordKey2],
             new()
             {
-                IncludeVectors = true,
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
+                IncludeVectors = true
             },
             this._testCancellationToken).ToListAsync();
 
@@ -99,11 +93,9 @@ public class VolatileVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanDeleteRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDeleteRecordAsync(bool useDefinition)
     {
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
@@ -113,16 +105,12 @@ public class VolatileVectorRecordStoreTests
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         await sut.DeleteAsync(
             TestRecordKey1,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         Assert.False(collection.ContainsKey(TestRecordKey1));
@@ -130,11 +118,9 @@ public class VolatileVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDeleteManyRecordsWithVectorsAsync(bool useDefinition)
     {
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
@@ -144,16 +130,12 @@ public class VolatileVectorRecordStoreTests
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         await sut.DeleteBatchAsync(
             [TestRecordKey1, TestRecordKey2],
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         Assert.False(collection.ContainsKey(TestRecordKey1));
@@ -161,27 +143,21 @@ public class VolatileVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanUpsertRecordAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanUpsertRecordAsync(bool useDefinition)
     {
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
         var collection = new ConcurrentDictionary<string, SinglePropsModel>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var upsertResult = await sut.UpsertAsync(
             record1,
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken);
+            cancellationToken: this._testCancellationToken);
 
         // Assert
         Assert.Equal(TestRecordKey1, upsertResult);
@@ -190,11 +166,9 @@ public class VolatileVectorRecordStoreTests
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task CanUpsertManyRecordsAsync(bool useDefinition, bool passCollectionToMethod)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanUpsertManyRecordsAsync(bool useDefinition)
     {
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
@@ -203,16 +177,12 @@ public class VolatileVectorRecordStoreTests
         var collection = new ConcurrentDictionary<string, SinglePropsModel>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition, passCollectionToMethod);
+        var sut = this.CreateVectorRecordStore(useDefinition);
 
         // Act
         var actual = await sut.UpsertBatchAsync(
             [record1, record2],
-            new()
-            {
-                CollectionName = passCollectionToMethod ? TestCollectionName : null
-            },
-            this._testCancellationToken).ToListAsync();
+            cancellationToken: this._testCancellationToken).ToListAsync();
 
         // Assert
         Assert.NotNull(actual);
@@ -235,13 +205,13 @@ public class VolatileVectorRecordStoreTests
         };
     }
 
-    private VolatileVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition, bool passCollectionToMethod)
+    private VolatileVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
     {
         return new VolatileVectorRecordStore<SinglePropsModel>(
             this._collectionStore,
+            TestCollectionName,
             new()
             {
-                DefaultCollectionName = passCollectionToMethod ? null : TestCollectionName,
                 VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null
             });
     }


### PR DESCRIPTION
### Motivation and Context

As part of the new vector store design, we have decided to follow a pattern where each vector record store instance is tied to a single collection and we will have a separate factory interface for getting instances by collection name.

### Description

- Removing optional collection names from all options classes.
- Adding mandatory collection name to vector record store constructors.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
