### PR TITLE
Python: Small docstring fix

### DIFF
--- a/python/semantic_kernel/functions/kernel_function_extension.py
+++ b/python/semantic_kernel/functions/kernel_function_extension.py
@@ -208,7 +208,7 @@ class KernelFunctionExtension(KernelBaseModel, ABC):
         execution_settings: "OpenAPIFunctionExecutionParameters | None" = None,
         description: str | None = None,
     ) -> KernelPlugin:
-        """Add a plugin from the Open AI manifest.
+        """Add a plugin from the OpenAPI manifest.
 
         Args:
             plugin_name (str): The name of the plugin


### PR DESCRIPTION
Docstring in add_plugin_from_openai method explain that it's a plugin from the openapi manifest, not open ai.

https://github.com/microsoft/semantic-kernel/blob/ed463329e7463b068a6669ecf3b7d03d040d1699/python/semantic_kernel/functions/kernel_function_extension.py#L211

### Motivation and Context
I found the add_plugin_from_openapi method because I needed a function related to the semantic function for calling the API. While reading the docstring, I saw an open AI description that had nothing to do with the method, so I am reporting this.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
See changes, it's a one-liner 😁

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile: