### PR TITLE
Python: added singular get methods

### DIFF
--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -48,7 +48,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             kwargs (Dict[str, Any]): The optional arguments.
 
         Returns:
-            A string or list of strings representing the response(s) from the LLM.
+            A string representing the response from the LLM.
         """
         results = await self.get_chat_message_contents(chat_history, settings, **kwargs)
         if results:

--- a/python/semantic_kernel/connectors/ai/embeddings/embedding_generator_base.py
+++ b/python/semantic_kernel/connectors/ai/embeddings/embedding_generator_base.py
@@ -9,18 +9,42 @@ from semantic_kernel.utils.experimental_decorator import experimental_class
 if TYPE_CHECKING:
     from numpy import ndarray
 
+    from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+
 
 @experimental_class
 class EmbeddingGeneratorBase(AIServiceClientBase, ABC):
     """Base class for embedding generators."""
 
     @abstractmethod
-    async def generate_embeddings(self, texts: list[str], **kwargs: Any) -> "ndarray":
+    async def generate_embeddings(
+        self,
+        texts: list[str],
+        settings: "PromptExecutionSettings | None" = None,
+        **kwargs: Any,
+    ) -> "ndarray":
         """Returns embeddings for the given texts as ndarray.
 
         Args:
             texts (List[str]): The texts to generate embeddings for.
-            batch_size (Optional[int]): The batch size to use for the request.
-            kwargs (Dict[str, Any]): Additional arguments to pass to the request.
+            settings (PromptExecutionSettings): The settings to use for the request, optional.
+            kwargs (Any): Additional arguments to pass to the request.
         """
         pass
+
+    async def generate_raw_embeddings(
+        self,
+        texts: list[str],
+        settings: "PromptExecutionSettings | None" = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Returns embeddings for the given texts in the unedited format.
+
+        This is not implemented for all embedding services, falling back to the generate_embeddings method.
+
+        Args:
+            texts (List[str]): The texts to generate embeddings for.
+            settings (PromptExecutionSettings): The settings to use for the request, optional.
+            kwargs (Any): Additional arguments to pass to the request.
+        """
+        return await self.generate_embeddings(texts, settings, **kwargs)

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
@@ -2,8 +2,9 @@
 
 import logging
 from abc import ABC
+from typing import Any
 
-from numpy import array, ndarray
+from numpy import array
 from openai import AsyncOpenAI, AsyncStream, BadRequestError
 from openai.types import Completion, CreateEmbeddingResponse
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
@@ -57,7 +58,7 @@ class OpenAIHandler(KernelBaseModel, ABC):
                 ex,
             ) from ex
 
-    async def _send_embedding_request(self, settings: OpenAIEmbeddingPromptExecutionSettings) -> list[ndarray]:
+    async def _send_embedding_request(self, settings: OpenAIEmbeddingPromptExecutionSettings) -> list[Any]:
         try:
             response = await self.client.embeddings.create(**settings.prepare_settings_dict())
             self.store_usage(response)

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_embedding_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_embedding_base.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from numpy import array, ndarray
 
@@ -15,34 +15,59 @@ from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_pro
     OpenAIEmbeddingPromptExecutionSettings,
 )
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_handler import OpenAIHandler
-from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.utils.experimental_decorator import experimental_class
+
+if TYPE_CHECKING:
+    from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 
 
 @experimental_class
 class OpenAITextEmbeddingBase(OpenAIHandler, EmbeddingGeneratorBase):
     @override
-    async def generate_embeddings(self, texts: list[str], batch_size: int | None = None, **kwargs: Any) -> ndarray:
-        settings: OpenAIEmbeddingPromptExecutionSettings | None = kwargs.pop("settings", None)
-        if settings:
-            for key, value in kwargs.items():
-                setattr(settings, key, value)
+    async def generate_embeddings(
+        self,
+        texts: list[str],
+        settings: "PromptExecutionSettings | None" = None,
+        batch_size: int | None = None,
+        **kwargs: Any,
+    ) -> ndarray:
+        raw_embeddings = await self.generate_raw_embeddings(texts, settings, batch_size, **kwargs)
+        return array([array(emb) for emb in raw_embeddings])
+
+    @override
+    async def generate_raw_embeddings(
+        self,
+        texts: list[str],
+        settings: "PromptExecutionSettings | None" = None,
+        batch_size: int | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Returns embeddings for the given texts in the unedited format.
+
+        Args:
+            texts (List[str]): The texts to generate embeddings for.
+            settings (PromptExecutionSettings): The settings to use for the request.
+            batch_size (int): The batch size to use for the request.
+            kwargs (Dict[str, Any]): Additional arguments to pass to the request.
+        """
+        if not settings:
+            settings = OpenAIEmbeddingPromptExecutionSettings(ai_model_id=self.ai_model_id)
         else:
-            settings = OpenAIEmbeddingPromptExecutionSettings(
-                **kwargs,
-            )
+            if not isinstance(settings, OpenAIEmbeddingPromptExecutionSettings):
+                settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, OpenAIEmbeddingPromptExecutionSettings)  # nosec
         if settings.ai_model_id is None:
             settings.ai_model_id = self.ai_model_id
+        for key, value in kwargs.items():
+            setattr(settings, key, value)
         raw_embeddings = []
         batch_size = batch_size or len(texts)
         for i in range(0, len(texts), batch_size):
             batch = texts[i : i + batch_size]
             settings.input = batch
-            raw_embedding = await self._send_embedding_request(
-                settings=settings,
-            )
+            raw_embedding = await self._send_embedding_request(settings=settings)
             raw_embeddings.extend(raw_embedding)
-        return array(raw_embeddings)
+        return raw_embeddings
 
     @override
     def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:

--- a/python/semantic_kernel/connectors/ai/text_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/text_completion_client_base.py
@@ -30,6 +30,18 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             list[TextContent]: A string or list of strings representing the response(s) from the LLM.
         """
 
+    async def get_text_content(self, prompt: str, settings: "PromptExecutionSettings") -> "TextContent":
+        """This is the method that is called from the kernel to get a response from a text-optimized LLM.
+
+        Args:
+            prompt (str): The prompt to send to the LLM.
+            settings (PromptExecutionSettings): Settings for the request.
+
+        Returns:
+            TextContent: A string or list of strings representing the response(s) from the LLM.
+        """
+        return (await self.get_text_contents(prompt, settings))[0]
+
     @abstractmethod
     def get_streaming_text_contents(
         self,
@@ -46,3 +58,21 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             list[StreamingTextContent]: A stream representing the response(s) from the LLM.
         """
         ...
+
+    async def get_streaming_text_content(
+        self, prompt: str, settings: "PromptExecutionSettings"
+    ) -> "StreamingTextContent | Any":
+        """This is the method that is called from the kernel to get a stream response from a text-optimized LLM.
+
+        Args:
+            prompt (str): The prompt to send to the LLM.
+            settings (PromptExecutionSettings): Settings for the request.
+
+        Returns:
+            StreamingTextContent: A stream representing the response(s) from the LLM.
+        """
+        async for contents in self.get_streaming_text_contents(prompt, settings):
+            if isinstance(contents, list):
+                yield contents[0]
+            else:
+                yield contents

--- a/python/semantic_kernel/connectors/ai/text_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/text_completion_client_base.py
@@ -30,7 +30,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             list[TextContent]: A string or list of strings representing the response(s) from the LLM.
         """
 
-    async def get_text_content(self, prompt: str, settings: "PromptExecutionSettings") -> "TextContent":
+    async def get_text_content(self, prompt: str, settings: "PromptExecutionSettings") -> "TextContent | None":
         """This is the method that is called from the kernel to get a response from a text-optimized LLM.
 
         Args:
@@ -40,7 +40,10 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
         Returns:
             TextContent: A string or list of strings representing the response(s) from the LLM.
         """
-        return (await self.get_text_contents(prompt, settings))[0]
+        results = await self.get_text_contents(prompt, settings)
+        if results:
+            return results[0]
+        return None
 
     @abstractmethod
     def get_streaming_text_contents(
@@ -61,7 +64,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
 
     async def get_streaming_text_content(
         self, prompt: str, settings: "PromptExecutionSettings"
-    ) -> "StreamingTextContent | Any":
+    ) -> AsyncGenerator["StreamingTextContent | None", Any]:
         """This is the method that is called from the kernel to get a stream response from a text-optimized LLM.
 
         Args:
@@ -72,7 +75,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             StreamingTextContent: A stream representing the response(s) from the LLM.
         """
         async for contents in self.get_streaming_text_contents(prompt, settings):
-            if isinstance(contents, list):
+            if contents:
                 yield contents[0]
             else:
-                yield contents
+                yield None

--- a/python/semantic_kernel/connectors/ai/text_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/text_completion_client_base.py
@@ -30,7 +30,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             list[TextContent]: A string or list of strings representing the response(s) from the LLM.
         """
 
-    async def get_text_content(self, prompt: str, settings: "PromptExecutionSettings") -> "TextContent | None":
+    async def get_text_content(self, prompt: str, settings: "PromptExecutionSettings") -> "TextContent":
         """This is the method that is called from the kernel to get a response from a text-optimized LLM.
 
         Args:
@@ -40,10 +40,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
         Returns:
             TextContent: A string or list of strings representing the response(s) from the LLM.
         """
-        results = await self.get_text_contents(prompt, settings)
-        if results:
-            return results[0]
-        return None
+        return (await self.get_text_contents(prompt, settings))[0]
 
     @abstractmethod
     def get_streaming_text_contents(
@@ -64,7 +61,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
 
     async def get_streaming_text_content(
         self, prompt: str, settings: "PromptExecutionSettings"
-    ) -> AsyncGenerator["StreamingTextContent | None", Any]:
+    ) -> "StreamingTextContent | Any":
         """This is the method that is called from the kernel to get a stream response from a text-optimized LLM.
 
         Args:
@@ -75,7 +72,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             StreamingTextContent: A stream representing the response(s) from the LLM.
         """
         async for contents in self.get_streaming_text_contents(prompt, settings):
-            if contents:
+            if isinstance(contents, list):
                 yield contents[0]
             else:
-                yield None
+                yield contents

--- a/python/tests/unit/connectors/open_ai/services/test_openai_text_embedding.py
+++ b/python/tests/unit/connectors/open_ai/services/test_openai_text_embedding.py
@@ -10,6 +10,7 @@ from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_pro
     OpenAIEmbeddingPromptExecutionSettings,
 )
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_text_embedding import OpenAITextEmbedding
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceResponseException
 
 
@@ -108,3 +109,22 @@ async def test_embedding_fail(mock_create, openai_unit_test_env) -> None:
     )
     with pytest.raises(ServiceResponseException):
         await openai_text_embedding.generate_embeddings(texts, dimensions=embedding_dimensions)
+
+
+@pytest.mark.asyncio
+@patch.object(AsyncEmbeddings, "create", new_callable=AsyncMock)
+async def test_embedding_pes(mock_create, openai_unit_test_env) -> None:
+    ai_model_id = "test_model_id"
+    texts = ["hello world", "goodbye world"]
+    embedding_dimensions = 1536
+    pes = PromptExecutionSettings(ai_model_id=ai_model_id, dimensions=embedding_dimensions)
+
+    openai_text_embedding = OpenAITextEmbedding(ai_model_id=ai_model_id)
+
+    await openai_text_embedding.generate_raw_embeddings(texts, pes)
+
+    mock_create.assert_awaited_once_with(
+        input=texts,
+        model=ai_model_id,
+        dimensions=embedding_dimensions,
+    )


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Adds singular get_..._content methods to all services, initially implemented by calling the multi version and passing back the first result, it therefore does not check on the number of responses parameter, just provides the interface.

Also add `generate_raw_embeddings` to Embedding Base to allow models to return different types, while keeping generate_embeddings to return a numpy array.

Fixes #6926 


### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
