### PR TITLE
Python: add experimental unit tests for python 3.13

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -24,6 +24,9 @@ jobs:
         python-version: ["3.10"]
         os: [ubuntu-latest]
     steps:
+      - name: Setup filename variables
+        run: |
+          echo "FILE_ID=$(${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Wait for unit tests to succeed
         continue-on-error: true
         uses: lewagon/wait-on-check-action@v1.3.4
@@ -38,7 +41,7 @@ jobs:
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
-          name: python-coverage-${{ matrix.os }}-${{ matrix.python-version }}.txt
+          name: python-coverage-${{ $FILE_ID }}.txt
           github_token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
           workflow: python-unit-tests.yml
           search_artifacts: true
@@ -47,7 +50,7 @@ jobs:
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
-          name: pytest-${{ matrix.os }}-${{ matrix.python-version }}.xml
+          name: pytest-${{ $FILE_ID }}.xml
           github_token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
           workflow: python-unit-tests.yml
           search_artifacts: true

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
-          name: python-coverage-${{ $FILE_ID }}.txt
+          name: python-coverage-$FILE_ID.txt
           github_token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
           workflow: python-unit-tests.yml
           search_artifacts: true
@@ -50,7 +50,7 @@ jobs:
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
-          name: pytest-${{ $FILE_ID }}.xml
+          name: pytest-$FILE_ID.xml
           github_token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
           workflow: python-unit-tests.yml
           search_artifacts: true

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -24,9 +24,6 @@ jobs:
         python-version: ["3.10"]
         os: [ubuntu-latest]
     steps:
-      - name: Setup filename variables
-        run: |
-          echo "FILE_ID=${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Wait for unit tests to succeed
         continue-on-error: true
         uses: lewagon/wait-on-check-action@v1.3.4
@@ -37,6 +34,8 @@ jobs:
           wait-interval: 10
           allowed-conclusions: success
       - uses: actions/checkout@v4
+      - name: Setup filename variables
+        run: echo "FILE_ID=${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Download coverage
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Setup filename variables
         run: |
-          echo "FILE_ID=$(${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
+          echo "FILE_ID=${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Wait for unit tests to succeed
         continue-on-error: true
         uses: lewagon/wait-on-check-action@v1.3.4

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -40,7 +40,7 @@ jobs:
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
-          name: python-coverage-$FILE_ID.txt
+          name: python-coverage-${{ env.FILE_ID }}.txt
           github_token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
           workflow: python-unit-tests.yml
           search_artifacts: true
@@ -49,7 +49,7 @@ jobs:
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
-          name: pytest-$FILE_ID.xml
+          name: pytest-${{ env.FILE_ID }}.xml
           github_token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
           workflow: python-unit-tests.yml
           search_artifacts: true

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Setup filename variables
         run: |
-          echo "file_id=$(echo ${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
+          echo "FILE_ID=${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         experimental: [false]
         include:
-          - python-version: "3.13"
+          - python-version: "3.13.0-beta.3"
             os: "ubuntu-latest"
             experimental: true
     permissions:

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write
     defaults:
       run:
-        working-directory: ./python
+        working-directory: python
     steps:
       - name: Setup filename variables
         run: |
@@ -41,18 +41,18 @@ jobs:
       - name: Install dependencies
         run: poetry install --with unit-tests
       - name: Test with pytest
-        run: poetry run pytest -q --junitxml=pytest-$FILE_ID.xml  --cov=semantic_kernel --cov-report=term-missing:skip-covered ./tests/unit | tee python-coverage-$FILE_ID.txt
+        run: poetry run pytest -q --junitxml=pytest.xml  --cov=semantic_kernel --cov-report=term-missing:skip-covered ./tests/unit | tee python-coverage.txt
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
           name: python-coverage-$FILE_ID.txt
-          path: python/python-coverage-$FILE_ID.txt
+          path: python-coverage.txt
           overwrite: true
           retention-days: 1  
       - name: Upload pytest.xml
         uses: actions/upload-artifact@v4
         with:
           name: pytest-$FILE_ID.xml
-          path: python/pytest-$FILE_ID.xml
+          path: pytest.xml
           overwrite: true
           retention-days: 1

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -45,13 +45,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: python-coverage-$FILE_ID.txt
-          path: python-coverage.txt
+          path: python/python-coverage.txt
           overwrite: true
           retention-days: 1  
       - name: Upload pytest.xml
         uses: actions/upload-artifact@v4
         with:
           name: pytest-$FILE_ID.xml
-          path: pytest.xml
+          path: python/pytest.xml
           overwrite: true
           retention-days: 1

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -10,17 +10,26 @@ jobs:
   python-unit-tests:
     name: Python Unit Tests
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        experimental: [false]
+        include:
+          - python-version: "3.13"
+            os: "ubuntu-latest"
+            experimental: true
     permissions:
       contents: write
     defaults:
       run:
         working-directory: ./python
     steps:
+      - name: Setup filename variables
+        run: |
+          echo "FILE_ID=$(echo ${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
@@ -32,19 +41,18 @@ jobs:
       - name: Install dependencies
         run: poetry install --with unit-tests
       - name: Test with pytest
-        run: poetry run pytest -q --junitxml=pytest-${{ matrix.os }}-${{ matrix.python-version }}.xml  --cov=semantic_kernel --cov-report=term-missing:skip-covered ./tests/unit | tee python-coverage-${{ matrix.os }}-${{ matrix.python-version }}.txt
-        continue-on-error: false
+        run: poetry run pytest -q --junitxml=pytest-${{ $FILE_ID }}.xml  --cov=semantic_kernel --cov-report=term-missing:skip-covered ./tests/unit | tee python-coverage-${{ $FILE_ID }}.txt
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: python-coverage-${{ matrix.os }}-${{ matrix.python-version }}.txt
-          path: python/python-coverage-${{ matrix.os }}-${{ matrix.python-version }}.txt
+          name: python-coverage-${{ $FILE_ID }}.txt
+          path: python/python-coverage-${{ $FILE_ID }}.txt
           overwrite: true
           retention-days: 1  
       - name: Upload pytest.xml
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-${{ matrix.os }}-${{ matrix.python-version }}.xml
-          path: python/pytest-${{ matrix.os }}-${{ matrix.python-version }}.xml
+          name: pytest-${{ $FILE_ID }}.xml
+          path: python/pytest-${{ $FILE_ID }}.xml
           overwrite: true
           retention-days: 1

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -27,10 +27,9 @@ jobs:
       run:
         working-directory: python
     steps:
-      - name: Setup filename variables
-        run: |
-          echo "FILE_ID=${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
+      - name: Setup filename variables
+        run: echo "FILE_ID=${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: python-coverage-$FILE_ID.txt
+          name: python-coverage-${{ env.FILE_ID }}.txt
           path: python/python-coverage.txt
           overwrite: true
-          retention-days: 1  
+          retention-days: 1
       - name: Upload pytest.xml
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-$FILE_ID.xml
+          name: pytest-${{ env.FILE_ID }}.xml
           path: python/pytest.xml
           overwrite: true
           retention-days: 1

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Setup filename variables
         run: |
-          echo "FILE_ID=$(echo ${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
+          echo "file_id=$(echo ${{ github.run_id }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
@@ -41,18 +41,18 @@ jobs:
       - name: Install dependencies
         run: poetry install --with unit-tests
       - name: Test with pytest
-        run: poetry run pytest -q --junitxml=pytest-${{ $FILE_ID }}.xml  --cov=semantic_kernel --cov-report=term-missing:skip-covered ./tests/unit | tee python-coverage-${{ $FILE_ID }}.txt
+        run: poetry run pytest -q --junitxml=pytest-$FILE_ID.xml  --cov=semantic_kernel --cov-report=term-missing:skip-covered ./tests/unit | tee python-coverage-$FILE_ID.txt
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: python-coverage-${{ $FILE_ID }}.txt
-          path: python/python-coverage-${{ $FILE_ID }}.txt
+          name: python-coverage-$FILE_ID.txt
+          path: python/python-coverage-$FILE_ID.txt
           overwrite: true
           retention-days: 1  
       - name: Upload pytest.xml
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-${{ $FILE_ID }}.xml
-          path: python/pytest-${{ $FILE_ID }}.xml
+          name: pytest-$FILE_ID.xml
+          path: python/pytest-$FILE_ID.xml
           overwrite: true
           retention-days: 1

--- a/python/semantic_kernel/connectors/ai/prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/prompt_execution_settings.py
@@ -36,17 +36,15 @@ class PromptExecutionSettings(KernelBaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def parse_function_choice_behavior(cls, data: dict[str, Any]) -> dict[str, Any] | None:
+    def parse_function_choice_behavior(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Parse the function choice behavior data."""
-        if data:
-            function_choice_behavior_data = data.get("function_choice_behavior")
-            if function_choice_behavior_data:
-                if isinstance(function_choice_behavior_data, str):
-                    data["function_choice_behavior"] = FunctionChoiceBehavior.from_string(function_choice_behavior_data)
-                elif isinstance(function_choice_behavior_data, dict):
-                    data["function_choice_behavior"] = FunctionChoiceBehavior.from_dict(function_choice_behavior_data)
-            return data
-        return None
+        function_choice_behavior_data = data.get("function_choice_behavior")
+        if function_choice_behavior_data:
+            if isinstance(function_choice_behavior_data, str):
+                data["function_choice_behavior"] = FunctionChoiceBehavior.from_string(function_choice_behavior_data)
+            elif isinstance(function_choice_behavior_data, dict):
+                data["function_choice_behavior"] = FunctionChoiceBehavior.from_dict(function_choice_behavior_data)
+        return data
 
     def __init__(self, service_id: str | None = None, **kwargs: Any):
         """Initialize the prompt execution settings.

--- a/python/tests/unit/connectors/test_prompt_execution_settings.py
+++ b/python/tests/unit/connectors/test_prompt_execution_settings.py
@@ -3,13 +3,13 @@
 from semantic_kernel.connectors.ai import PromptExecutionSettings
 
 
-def test_default_complete_prompt_execution_settings():
+def test_init():
     settings = PromptExecutionSettings()
     assert settings.service_id is None
     assert settings.extension_data == {}
 
 
-def test_custom_complete_prompt_execution_settings():
+def test_init_with_data():
     ext_data = {"test": "test"}
     settings = PromptExecutionSettings(service_id="test", extension_data=ext_data)
     assert settings.service_id == "test"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Adds unit test run only for ubuntu for python 3.13, should not fail full job when it does fail.
Slight improvement of filename handling for the coverage.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
