### PR TITLE
.Net: Improve support for enumerable types and remove complex object support from azure ai search.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorRecordStore.cs
@@ -33,6 +33,24 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         typeof(string)
     ];
 
+    /// <summary>A set of types that data properties on the provided model may have.</summary>
+    private static readonly HashSet<Type> s_supportedDataTypes =
+    [
+        typeof(string),
+        typeof(int),
+        typeof(long),
+        typeof(double),
+        typeof(float),
+        typeof(bool),
+        typeof(DateTimeOffset),
+        typeof(int?),
+        typeof(long?),
+        typeof(double?),
+        typeof(float?),
+        typeof(bool?),
+        typeof(DateTimeOffset?),
+    ];
+
     /// <summary>A set of types that vectors on the provided model may have.</summary>
     /// <remarks>
     /// Azure AI Search is adding support for more types than just float32, but these are not available for use via the
@@ -103,6 +121,7 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         // Validate property types and store for later use.
         var jsonSerializerOptions = this._options.JsonSerializerOptions ?? JsonSerializerOptions.Default;
         VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, s_supportedDataTypes, "Data", supportEnumerable: true);
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
         this._keyPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(jsonSerializerOptions, properties.keyProperty);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -29,12 +29,6 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
     /// <summary>A set of types that data properties on the provided model may have.</summary>
     private static readonly HashSet<Type> s_supportedDataTypes =
     [
-        typeof(List<string>),
-        typeof(List<int>),
-        typeof(List<long>),
-        typeof(List<float>),
-        typeof(List<double>),
-        typeof(List<bool>),
         typeof(string),
         typeof(int),
         typeof(long),
@@ -98,7 +92,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
 
         // Validate property types and store for later use.
         VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, s_supportedDataTypes, "Data");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, s_supportedDataTypes, "Data", supportEnumerable: true);
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
 
         this._keyPropertyInfo = properties.keyProperty;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorRecordStoreTests.cs
@@ -54,8 +54,6 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         Assert.Equal(hotel.ParkingIncluded, getResult.ParkingIncluded);
         Assert.Equal(hotel.LastRenovationDate, getResult.LastRenovationDate);
         Assert.Equal(hotel.Rating, getResult.Rating);
-        Assert.Equal(hotel.Address.City, getResult.Address.City);
-        Assert.Equal(hotel.Address.Country, getResult.Address.Country);
 
         // Output
         output.WriteLine(upsertResult);
@@ -123,8 +121,6 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         Assert.False(getResult.ParkingIncluded);
         Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), getResult.LastRenovationDate);
         Assert.Equal(3.6, getResult.Rating);
-        Assert.Equal("New York", getResult.Address.City);
-        Assert.Equal("USA", getResult.Address.Country);
 
         // Output
         output.WriteLine(getResult.ToString());
@@ -245,12 +241,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
         Tags = ["pool", "air conditioning", "concierge"],
         ParkingIncluded = true,
         LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
-        Rating = 3.6,
-        Address = new Address
-        {
-            City = "New York",
-            Country = "USA"
-        }
+        Rating = 3.6
     };
 
     private sealed class FailingMapper : IVectorStoreRecordMapper<Hotel, JsonObject>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -60,8 +60,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                 new VectorStoreRecordDataProperty("Tags"),
                 new VectorStoreRecordDataProperty("ParkingIncluded"),
                 new VectorStoreRecordDataProperty("LastRenovationDate"),
-                new VectorStoreRecordDataProperty("Rating"),
-                new VectorStoreRecordDataProperty("Address")
+                new VectorStoreRecordDataProperty("Rating")
             }
         };
     }
@@ -139,7 +138,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         definition.VectorSearch.Algorithms.Add(new HnswAlgorithmConfiguration("my-hnsw-vector-config-1") { Parameters = new HnswParameters { Metric = VectorSearchAlgorithmMetric.Cosine } });
         definition.VectorSearch.Profiles.Add(new VectorSearchProfile("my-vector-profile", "my-hnsw-vector-config-1"));
 
-        var suggester = new SearchSuggester("sg", new[] { "HotelName", "Address/City" });
+        var suggester = new SearchSuggester("sg", new[] { "HotelName" });
         definition.Suggesters.Add(suggester);
 
         await adminClient.CreateOrUpdateIndexAsync(definition);
@@ -162,12 +161,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     Tags = new[] { "pool", "air conditioning", "concierge" },
                     ParkingIncluded = false,
                     LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
-                    Rating = 3.6,
-                    Address = new Address()
-                    {
-                        City = "New York",
-                        Country = "USA"
-                    }
+                    Rating = 3.6
                 }),
             IndexDocumentsAction.Upload(
                 new Hotel()
@@ -179,12 +173,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     Tags = new[] { "pool", "free wifi", "concierge" },
                     ParkingIncluded = false,
                     LastRenovationDate = new DateTimeOffset(1979, 2, 18, 0, 0, 0, TimeSpan.Zero),
-                    Rating = 3.60,
-                    Address = new Address()
-                    {
-                        City = "Sarasota",
-                        Country = "USA"
-                    }
+                    Rating = 3.60
                 }),
             IndexDocumentsAction.Upload(
                 new Hotel()
@@ -196,12 +185,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     Tags = new[] { "air conditioning", "bar", "continental breakfast" },
                     ParkingIncluded = true,
                     LastRenovationDate = new DateTimeOffset(2015, 9, 20, 0, 0, 0, TimeSpan.Zero),
-                    Rating = 4.80,
-                    Address = new Address()
-                    {
-                        City = "Atlanta",
-                        Country = "USA"
-                    }
+                    Rating = 4.80
                 }),
             IndexDocumentsAction.Upload(
                 new Hotel()
@@ -213,12 +197,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     Tags = new[] { "concierge", "view", "24-hour front desk service" },
                     ParkingIncluded = true,
                     LastRenovationDate = new DateTimeOffset(1960, 2, 06, 0, 0, 0, TimeSpan.Zero),
-                    Rating = 4.60,
-                    Address = new Address()
-                    {
-                        City = "San Antonio",
-                        Country = "USA"
-                    }
+                    Rating = 4.60
                 })
             );
 
@@ -261,19 +240,6 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         [SimpleField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
         [VectorStoreRecordData]
         public double? Rating { get; set; }
-
-        [SearchableField]
-        [VectorStoreRecordData]
-        public Address Address { get; set; }
-    }
-
-    public record Address
-    {
-        [SearchableField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
-        public string City { get; set; }
-
-        [SearchableField(IsFilterable = true, IsSortable = true, IsFacetable = true)]
-        public string Country { get; set; }
     }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -181,6 +183,16 @@ public class VectorStoreRecordPropertyReaderTests
     }
 
     [Fact]
+    public void VerifyPropertyTypesPassForAllowedEnumerableTypes()
+    {
+        // Arrange.
+        var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(EnumerablePropsModel), true);
+
+        // Act.
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, [typeof(string)], "Data", supportEnumerable: true);
+    }
+
+    [Fact]
     public void VerifyPropertyTypesFailsForDisallowedTypes()
     {
         // Arrange.
@@ -338,5 +350,25 @@ public class VectorStoreRecordPropertyReaderTests
             new VectorStoreRecordVectorProperty("Vector2")
         ]
     };
+
+    private sealed class EnumerablePropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public IEnumerable<string> EnumerableData { get; set; } = new List<string>();
+
+        [VectorStoreRecordData]
+        public string[] ArrayData { get; set; } = Array.Empty<string>();
+
+        [VectorStoreRecordData]
+        public List<string> ListData { get; set; } = new List<string>();
+
+        [VectorStoreRecordVector]
+        public ReadOnlyMemory<float> Vector { get; set; }
+
+        public string NotAnnotated { get; set; } = string.Empty;
+    }
 #pragma warning restore CA1812 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -256,6 +255,7 @@ public class VectorStoreRecordPropertyReaderTests
     }
 
 #pragma warning disable CA1812 // Invalid unused classes error, since I am using these for testing purposes above.
+
     private sealed class NoKeyModel
     {
     }
@@ -370,5 +370,6 @@ public class VectorStoreRecordPropertyReaderTests
 
         public string NotAnnotated { get; set; } = string.Empty;
     }
+
 #pragma warning restore CA1812 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 }


### PR DESCRIPTION
### Motivation and Context

Supporting complex types is difficult in Azure AI Search for create via the abstraction, so for now, removing support for it, until someone requests it.
This means doing type checking on data fields, so adding better support for enumerable types like Arrays, List<T>, IEnumerable<T>, etc.

### Description

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
