### PR TITLE
.Net: Remove time stamp granularities 

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIAudioToTextServiceTests.cs
@@ -11,7 +11,6 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Services;
 using Moq;
-using static Microsoft.SemanticKernel.Connectors.AzureOpenAI.AzureOpenAIAudioToTextExecutionSettings;
 
 namespace SemanticKernel.Connectors.AzureOpenAI.UnitTests.Services;
 
@@ -107,43 +106,6 @@ public sealed class AzureOpenAIAudioToTextServiceTests : IDisposable
         // Assert
         Assert.NotNull(exception);
         Assert.IsType(expectedExceptionType, exception);
-    }
-
-    [Theory]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default }, "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word }, "word")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment }, "segment")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment, TimeStampGranularities.Word }, "word", "segment")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word, TimeStampGranularities.Segment }, "word", "segment")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default, TimeStampGranularities.Word }, "word", "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word, TimeStampGranularities.Default }, "word", "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default, TimeStampGranularities.Segment }, "segment", "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment, TimeStampGranularities.Default }, "segment", "0")]
-    public async Task GetTextContentGranularitiesWorksAsync(TimeStampGranularities[] granularities, params string[] expectedGranularities)
-    {
-        // Arrange
-        var service = new AzureOpenAIAudioToTextService("deployment", "https://endpoint", "api-key", httpClient: this._httpClient);
-        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
-        {
-            Content = new StringContent("Test audio-to-text response")
-        };
-
-        // Act
-        var settings = new AzureOpenAIAudioToTextExecutionSettings("file.mp3") { Granularities = granularities };
-        var result = await service.GetTextContentsAsync(new AudioContent(new BinaryData("data"), mimeType: null), settings);
-
-        // Assert
-        Assert.NotNull(this._messageHandlerStub.RequestContent);
-        Assert.NotNull(result);
-
-        var multiPartData = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContent!);
-        var multiPartBreak = multiPartData.Substring(0, multiPartData.IndexOf("\r\n", StringComparison.OrdinalIgnoreCase));
-
-        foreach (var granularity in expectedGranularities)
-        {
-            var expectedMultipart = $"{granularity}\r\n{multiPartBreak}";
-            Assert.Contains(expectedMultipart, multiPartData);
-        }
     }
 
     [Theory]

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.AudioToText.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.AudioToText.cs
@@ -51,34 +51,12 @@ internal partial class ClientCore
     private static AudioTranscriptionOptions AudioOptionsFromExecutionSettings(AzureOpenAIAudioToTextExecutionSettings executionSettings)
         => new()
         {
-            Granularities = ConvertToAudioTimestampGranularities(executionSettings!.Granularities),
+            Granularities = AudioTimestampGranularities.Default,
             Language = executionSettings.Language,
             Prompt = executionSettings.Prompt,
             Temperature = executionSettings.Temperature,
             ResponseFormat = ConvertResponseFormat(executionSettings.ResponseFormat)
         };
-
-    private static AudioTimestampGranularities ConvertToAudioTimestampGranularities(IEnumerable<AzureOpenAIAudioToTextExecutionSettings.TimeStampGranularities>? granularities)
-    {
-        AudioTimestampGranularities result = AudioTimestampGranularities.Default;
-
-        if (granularities is not null)
-        {
-            foreach (var granularity in granularities)
-            {
-                var openAIGranularity = granularity switch
-                {
-                    AzureOpenAIAudioToTextExecutionSettings.TimeStampGranularities.Word => AudioTimestampGranularities.Word,
-                    AzureOpenAIAudioToTextExecutionSettings.TimeStampGranularities.Segment => AudioTimestampGranularities.Segment,
-                    _ => AudioTimestampGranularities.Default
-                };
-
-                result |= openAIGranularity;
-            }
-        }
-
-        return result;
-    }
 
     private static Dictionary<string, object?> GetResponseMetadata(AudioTranscription audioTranscription)
         => new(3)

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIAudioToTextExecutionSettings.cs
@@ -96,12 +96,6 @@ public sealed class AzureOpenAIAudioToTextExecutionSettings : PromptExecutionSet
     }
 
     /// <summary>
-    /// The timestamp granularities to populate for this transcription. response_format must be set verbose_json to use timestamp granularities. Either or both of these options are supported: word, or segment.
-    /// </summary>
-    [JsonPropertyName("granularities")]
-    public IReadOnlyList<TimeStampGranularities>? Granularities { get; set; }
-
-    /// <summary>
     /// Creates an instance of <see cref="AzureOpenAIAudioToTextExecutionSettings"/> class with default filename - "file.mp3".
     /// </summary>
     public AzureOpenAIAudioToTextExecutionSettings()
@@ -159,27 +153,6 @@ public sealed class AzureOpenAIAudioToTextExecutionSettings : PromptExecutionSet
         }
 
         throw new ArgumentException($"Invalid execution settings, cannot convert to {nameof(AzureOpenAIAudioToTextExecutionSettings)}", nameof(executionSettings));
-    }
-
-    /// <summary>
-    /// The timestamp granularities available to populate transcriptions.
-    /// </summary>
-    public enum TimeStampGranularities
-    {
-        /// <summary>
-        /// Not specified.
-        /// </summary>
-        Default = 0,
-
-        /// <summary>
-        /// The transcription is segmented by word.
-        /// </summary>
-        Word = 1,
-
-        /// <summary>
-        /// The timestamp of transcription is by segment.
-        /// </summary>
-        Segment = 2,
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAIV2.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
@@ -10,7 +9,6 @@ using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Moq;
 using OpenAI;
 using Xunit;
-using static Microsoft.SemanticKernel.Connectors.OpenAI.OpenAIAudioToTextExecutionSettings;
 
 namespace SemanticKernel.Connectors.OpenAI.UnitTests.Services;
 
@@ -71,43 +69,6 @@ public sealed class OpenAIAudioToTextServiceTests : IDisposable
         // Assert
         Assert.NotNull(service);
         Assert.Equal("model-id", service.Attributes["ModelId"]);
-    }
-
-    [Theory]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default }, "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word }, "word")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment }, "segment")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment, TimeStampGranularities.Word }, "word", "segment")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word, TimeStampGranularities.Segment }, "word", "segment")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default, TimeStampGranularities.Word }, "word", "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Word, TimeStampGranularities.Default }, "word", "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Default, TimeStampGranularities.Segment }, "segment", "0")]
-    [InlineData(new TimeStampGranularities[] { TimeStampGranularities.Segment, TimeStampGranularities.Default }, "segment", "0")]
-    public async Task GetTextContentGranularitiesWorksAsync(TimeStampGranularities[] granularities, params string[] expectedGranularities)
-    {
-        // Arrange
-        var service = new OpenAIAudioToTextService("model-id", "api-key", httpClient: this._httpClient);
-        this._messageHandlerStub.ResponseToReturn = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
-        {
-            Content = new StringContent("Test audio-to-text response")
-        };
-
-        // Act
-        var settings = new OpenAIAudioToTextExecutionSettings("file.mp3") { Granularities = granularities };
-        var result = await service.GetTextContentsAsync(new AudioContent(new BinaryData("data"), mimeType: null), settings);
-
-        // Assert
-        Assert.NotNull(this._messageHandlerStub.RequestContent);
-        Assert.NotNull(result);
-
-        var multiPartData = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContent!);
-        var multiPartBreak = multiPartData.Substring(0, multiPartData.IndexOf("\r\n", StringComparison.OrdinalIgnoreCase));
-
-        foreach (var granularity in expectedGranularities)
-        {
-            var expectedMultipart = $"{granularity}\r\n{multiPartBreak}";
-            Assert.Contains(expectedMultipart, multiPartData);
-        }
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.OpenAIV2/Core/ClientCore.AudioToText.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2/Core/ClientCore.AudioToText.cs
@@ -51,34 +51,12 @@ internal partial class ClientCore
     private static AudioTranscriptionOptions? AudioOptionsFromExecutionSettings(OpenAIAudioToTextExecutionSettings executionSettings)
         => new()
         {
-            Granularities = ConvertToAudioTimestampGranularities(executionSettings!.Granularities),
+            Granularities = AudioTimestampGranularities.Default,
             Language = executionSettings.Language,
             Prompt = executionSettings.Prompt,
             Temperature = executionSettings.Temperature,
             ResponseFormat = ConvertResponseFormat(executionSettings.ResponseFormat)
         };
-
-    private static AudioTimestampGranularities ConvertToAudioTimestampGranularities(IEnumerable<OpenAIAudioToTextExecutionSettings.TimeStampGranularities>? granularities)
-    {
-        AudioTimestampGranularities result = AudioTimestampGranularities.Default;
-
-        if (granularities is not null)
-        {
-            foreach (var granularity in granularities)
-            {
-                var openAIGranularity = granularity switch
-                {
-                    OpenAIAudioToTextExecutionSettings.TimeStampGranularities.Word => AudioTimestampGranularities.Word,
-                    OpenAIAudioToTextExecutionSettings.TimeStampGranularities.Segment => AudioTimestampGranularities.Segment,
-                    _ => AudioTimestampGranularities.Default
-                };
-
-                result |= openAIGranularity;
-            }
-        }
-
-        return result;
-    }
 
     private static AudioTranscriptionFormat? ConvertResponseFormat(OpenAIAudioToTextExecutionSettings.AudioTranscriptionFormat? responseFormat)
     {

--- a/dotnet/src/Connectors/Connectors.OpenAIV2/Settings/OpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2/Settings/OpenAIAudioToTextExecutionSettings.cs
@@ -95,12 +95,6 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
     }
 
     /// <summary>
-    /// The timestamp granularities to populate for this transcription. response_format must be set verbose_json to use timestamp granularities. Either or both of these options are supported: word, or segment.
-    /// </summary>
-    [JsonPropertyName("granularities")]
-    public IReadOnlyList<TimeStampGranularities>? Granularities { get; set; }
-
-    /// <summary>
     /// Creates an instance of <see cref="OpenAIAudioToTextExecutionSettings"/> class with default filename - "file.mp3".
     /// </summary>
     public OpenAIAudioToTextExecutionSettings()
@@ -153,27 +147,6 @@ public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
         var openAIExecutionSettings = JsonSerializer.Deserialize<OpenAIAudioToTextExecutionSettings>(json, JsonOptionsCache.ReadPermissive);
 
         return openAIExecutionSettings!;
-    }
-
-    /// <summary>
-    /// The timestamp granularities available to populate transcriptions.
-    /// </summary>
-    public enum TimeStampGranularities
-    {
-        /// <summary>
-        /// Not specified.
-        /// </summary>
-        Default = 0,
-
-        /// <summary>
-        /// The transcription is segmented by word.
-        /// </summary>
-        Word = 1,
-
-        /// <summary>
-        /// The timestamp of transcription is by segment.
-        /// </summary>
-        Segment = 2,
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation, Context and Description
The new Azure.AI.OpenAI V2 introduced timestamp granularities for the audio-to-text API. This PR removes the first attempt to expose the settings in execution settings for the service. The setting will be introduced later after the migration is over in scope in this task: https://github.com/microsoft/semantic-kernel/issues/7213.