### PR TITLE
.Net: Pinecone RemoveBatchFromNamespaceAsync method performance optimization

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -25,7 +25,6 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Wait for unit tests to succeed
-        continue-on-error: true
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -37,7 +36,6 @@ jobs:
       - name: Setup filename variables
         run: echo "FILE_ID=${{ github.event.number }}-${{ matrix.os }}-${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Download coverage
-        continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
           name: python-coverage-${{ env.FILE_ID }}.txt
@@ -46,7 +44,6 @@ jobs:
           search_artifacts: true
           if_no_artifact_found: warn
       - name: Download pytest
-        continue-on-error: true
         uses: dawidd6/action-download-artifact@v3
         with:
           name: pytest-${{ env.FILE_ID }}.xml
@@ -55,7 +52,6 @@ jobs:
           search_artifacts: true
           if_no_artifact_found: warn
       - name: Pytest coverage comment
-        continue-on-error: true
         id: coverageComment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
@@ -423,7 +423,18 @@ public class PineconeMemoryStore : IPineconeMemoryStore
     /// <inheritdoc />
     public async Task RemoveBatchFromNamespaceAsync(string indexName, string indexNamespace, IEnumerable<string> keys, CancellationToken cancellationToken = default)
     {
-        await Task.WhenAll(keys.Select(async k => await this.RemoveFromNamespaceAsync(indexName, indexNamespace, k, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        try
+        {
+            await this._pineconeClient.DeleteAsync(indexName,
+                keys,
+                indexNamespace,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpOperationException ex)
+        {
+            this._logger.LogError(ex, "Failed to remove vector data from Pinecone: {Message}", ex.Message);
+            throw;
+        }
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeMemoryStoreTests.cs
@@ -199,6 +199,24 @@ public class PineconeMemoryStoreTests
     }
 
     [Fact]
+    public async Task TestRemoveBatchAsync()
+    {
+        // Arrange
+        string collectionName = "testCollection";
+        string[] keys = ["doc1", "doc2"];
+
+        this._mockPineconeClient
+            .Setup<Task>(x => x.DeleteAsync(collectionName, new[] { keys[0], keys[1] }, "", null, false, CancellationToken.None))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await this._pineconeMemoryStore.RemoveBatchAsync(collectionName, keys);
+
+        // Assert
+        this._mockPineconeClient.Verify(x => x.DeleteAsync(collectionName, new[] { keys[0], keys[1] }, "", null, false, CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
     public async Task TestRemoveAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context

To optimize the code by reducing the number of HTTP requests needed to remove a list of keys from a namespace. Instead of multiple HTTP calls, a single HTTP call will now handle the removal.

### Description

Previously, RemoveBatchFromNamespaceAsync executed multiple HTTP calls to remove keys. This optimized code reduces the overhead by executing a single HTTP request to remove the list of keys.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
