### PR TITLE
.Net: Ollama - Adding metadata to chat messages

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -34,10 +34,10 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-    <PackageVersion Include="OllamaSharp" Version="2.0.6" />
+    <PackageVersion Include="OllamaSharp" Version="2.0.10" />
     <!-- Tokenizers -->
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24271.1" />
     <PackageVersion Include="Microsoft.DeepDev.TokenizerLib" Version="1.3.3" />

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Connectors.Ollama.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Connectors.Ollama.UnitTests.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Numerics.Tensors" />
-    <PackageReference Include="System.Text.Json" VersionOverride="8.0.3" />
+    <PackageReference Include="System.Text.Json"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/OllamaPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/OllamaPromptExecutionSettingsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Linq;
 using System.Text.Json;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Ollama;
@@ -46,7 +47,7 @@ public class OllamaPromptExecutionSettingsTests
     {
         string jsonSettings = """
                                 {
-                                    "stop": "stop me",
+                                    "stop": ["stop me"],
                                     "temperature": 0.5,
                                     "top_p": 0.9,
                                     "top_k": 100
@@ -56,7 +57,7 @@ public class OllamaPromptExecutionSettingsTests
         var executionSettings = JsonSerializer.Deserialize<PromptExecutionSettings>(jsonSettings);
         var ollamaExecutionSettings = OllamaPromptExecutionSettings.FromExecutionSettings(executionSettings);
 
-        Assert.Equal("stop me", ollamaExecutionSettings.Stop);
+        Assert.Equal("stop me", ollamaExecutionSettings.Stop?.FirstOrDefault());
         Assert.Equal(0.5f, ollamaExecutionSettings.Temperature);
         Assert.Equal(0.9f, ollamaExecutionSettings.TopP!.Value, 0.1f);
         Assert.Equal(100, ollamaExecutionSettings.TopK);

--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Services/OllamaChatCompletionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Services/OllamaChatCompletionTests.cs
@@ -109,11 +109,11 @@ public sealed class OllamaChatCompletionTests : IDisposable
     }
 
     [Fact]
-    public async Task GetChatMessageContentsShouldHaveModelIdDefinedAsync()
+    public async Task GetChatMessageContentsShouldHaveModelAndMetadataAsync()
     {
         //Arrange
         var sut = new OllamaChatCompletionService(
-            "fake-model",
+            "phi3",
             new Uri("http://localhost:11434"),
             httpClient: this._httpClient);
 
@@ -135,11 +135,11 @@ public sealed class OllamaChatCompletionTests : IDisposable
 
         // Assert
         Assert.NotNull(message.ModelId);
-        Assert.Equal("fake-model", message.ModelId);
+        Assert.Equal("phi3", message.ModelId);
     }
 
     [Fact]
-    public async Task GetStreamingChatMessageContentsShouldHaveModelIdDefinedAsync()
+    public async Task GetStreamingChatMessageContentsShouldHaveModelAndMetadataAsync()
     {
         //Arrange
         var expectedModel = "phi3";
@@ -161,11 +161,18 @@ public sealed class OllamaChatCompletionTests : IDisposable
         await foreach (var message in sut.GetStreamingChatMessageContentsAsync(chat))
         {
             lastMessage = message;
+            Assert.NotNull(message.Metadata);
         }
 
         // Assert
         Assert.NotNull(lastMessage!.ModelId);
         Assert.Equal(expectedModel, lastMessage.ModelId);
+
+        Assert.IsType<OllamaMetadata>(lastMessage.Metadata);
+        var metadata = lastMessage.Metadata as OllamaMetadata;
+        Assert.NotNull(metadata);
+        Assert.NotEmpty(metadata);
+        Assert.True(metadata.Done);
     }
 
     public void Dispose()

--- a/dotnet/src/Connectors/Connectors.Ollama/OllamaMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/OllamaMetadata.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 using OllamaSharp.Models;
+using OllamaSharp.Models.Chat;
 
 namespace Microsoft.SemanticKernel.Connectors.Ollama;
 
@@ -21,6 +22,24 @@ public sealed class OllamaMetadata : ReadOnlyDictionary<string, object?>
         this.LoadDuration = ollamaResponse.LoadDuration;
         this.PromptEvalCount = ollamaResponse.PromptEvalCount;
         this.PromptEvalDuration = ollamaResponse.PromptEvalDuration;
+        this.Done = ollamaResponse.Done;
+    }
+
+    internal OllamaMetadata(ChatResponse response) : base(new Dictionary<string, object?>())
+    {
+        this.TotalDuration = response.TotalDuration;
+        this.EvalCount = response.EvalCount;
+        this.EvalDuration = response.EvalDuration;
+        this.CreatedAt = response.CreatedAt;
+        this.LoadDuration = response.LoadDuration;
+        this.PromptEvalDuration = response.PromptEvalDuration;
+        this.CreatedAt = response.CreatedAt;
+    }
+
+    internal OllamaMetadata(ChatResponseStream message) : base(new Dictionary<string, object?>())
+    {
+        this.CreatedAt = message.CreatedAt;
+        this.Done = message.Done;
     }
 
     /// <summary>
@@ -83,6 +102,15 @@ public sealed class OllamaMetadata : ReadOnlyDictionary<string, object?>
     public long TotalDuration
     {
         get => this.GetValueFromDictionary() as long? ?? 0;
+        internal init => this.SetValueInDictionary(value);
+    }
+
+    /// <summary>
+    /// Informs when the response generation process is complete.
+    /// </summary>
+    public bool? Done
+    {
+        get => this.GetValueFromDictionary() as bool?;
         internal init => this.SetValueInDictionary(value);
     }
 

--- a/dotnet/src/Connectors/Connectors.Ollama/OllamaMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/OllamaMetadata.cs
@@ -65,12 +65,6 @@ public sealed class OllamaMetadata : ReadOnlyDictionary<string, object?>
         this.CreatedAt = response.CreatedAt;
     }
 
-    internal OllamaMetadata(ChatResponseStream message) : base(new Dictionary<string, object?>())
-    {
-        this.CreatedAt = message.CreatedAt;
-        this.Done = message.Done;
-    }
-
     /// <summary>
     /// Time spent in nanoseconds evaluating the prompt
     /// </summary>

--- a/dotnet/src/Connectors/Connectors.Ollama/OllamaPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/OllamaPromptExecutionSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Text;
@@ -46,7 +47,7 @@ public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
     /// </summary>
     [JsonPropertyName("stop")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Stop
+    public List<string>? Stop
     {
         get => this._stop;
 
@@ -112,7 +113,7 @@ public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
 
     #region private ================================================================================
 
-    private string? _stop;
+    private List<string>? _stop;
     private float? _temperature;
     private float? _topP;
     private int? _topK;

--- a/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaChatCompletionService.cs
@@ -63,17 +63,14 @@ public sealed class OllamaChatCompletionService : ServiceBase, IChatCompletionSe
         var settings = OllamaPromptExecutionSettings.FromExecutionSettings(executionSettings);
         var request = CreateChatRequest(chatHistory, settings, this._client.SelectedModel);
 
-        var answer = await this._client.SendChat(request, _ => { }, cancellationToken).ConfigureAwait(false);
-
-        // Ollama Client gives back the same requested history with added message at the end
-        // To be compatible with this API behavior, we only return the added message (last).
-        var message = answer.Last();
+        var response = await this._client.Chat(request, cancellationToken).ConfigureAwait(false);
 
         return [new ChatMessageContent(
-            role: GetAuthorRole(message.Role) ?? AuthorRole.Assistant,
-            content: message.Content,
-            modelId: this._client.SelectedModel,
-            innerContent: message)];
+            role: GetAuthorRole(response.Message.Role) ?? AuthorRole.Assistant,
+            content: response.Message.Content,
+            modelId: response.Model,
+            innerContent: response,
+            metadata: new OllamaMetadata(response))];
     }
 
     /// <inheritdoc />
@@ -88,7 +85,12 @@ public sealed class OllamaChatCompletionService : ServiceBase, IChatCompletionSe
 
         await foreach (var message in this._client.StreamChat(request, cancellationToken).ConfigureAwait(false))
         {
-            yield return new StreamingChatMessageContent(GetAuthorRole(message?.Message.Role), message?.Message.Content, modelId: message?.Model, innerContent: message);
+            yield return new StreamingChatMessageContent(
+                role: GetAuthorRole(message!.Message.Role),
+                content: message.Message.Content,
+                modelId: message.Model,
+                innerContent: message,
+                metadata: new OllamaMetadata(message));
         }
     }
 
@@ -125,7 +127,7 @@ public sealed class OllamaChatCompletionService : ServiceBase, IChatCompletionSe
                 Temperature = settings.Temperature,
                 TopP = settings.TopP,
                 TopK = settings.TopK,
-                Stop = settings.Stop
+                Stop = settings.Stop?.ToArray()
             },
             Messages = messages.ToList(),
             Model = selectedModel,


### PR DESCRIPTION
### Motivation and Context

Using most recent update where a ChatMessage metadata can be used by OllamaSharp Client Chat().

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
