### PR TITLE
.Net: DuckDBMemoryStore RemoveBatchAsync method performance improvement

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.DuckDB/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.DuckDB/Database.cs
@@ -203,4 +203,29 @@ internal sealed class Database
         cmd.Parameters.Add(new DuckDBParameter(nameof(key), key));
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    public async Task DeleteBatchAsync(DuckDBConnection conn, string collectionName, string[] keys, CancellationToken cancellationToken = default)
+    {
+        if (keys.Length == 0)
+        {
+            return;
+        }
+
+        using var cmd = conn.CreateCommand();
+        var keyPlaceholders = string.Join(", ", keys.Select((k) => "?"));
+
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+        cmd.CommandText = $@"
+         DELETE FROM {TableName}
+         WHERE collection={collectionName}
+            AND key IN ({keyPlaceholders});";
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+
+        // Add the key parameters
+        foreach (var key in keys)
+        {
+            cmd.Parameters.Add(new DuckDBParameter { Value = key });
+        }
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.DuckDB/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.DuckDB/Database.cs
@@ -217,10 +217,10 @@ internal sealed class Database
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
         cmd.CommandText = $@"
          DELETE FROM {TableName}
-         WHERE collection={collectionName}
+         WHERE collection=?
             AND key IN ({keyPlaceholders});";
 #pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
-
+        cmd.Parameters.Add(new DuckDBParameter { Value = collectionName });
         // Add the key parameters
         foreach (var key in keys)
         {

--- a/dotnet/src/Connectors/Connectors.Memory.DuckDB/DuckDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.DuckDB/DuckDBMemoryStore.cs
@@ -130,7 +130,7 @@ public sealed class DuckDBMemoryStore : IMemoryStore, IDisposable
     /// <inheritdoc/>
     public async Task RemoveBatchAsync(string collectionName, IEnumerable<string> keys, CancellationToken cancellationToken = default)
     {
-        await Task.WhenAll(keys.Select(k => this._dbConnector.DeleteAsync(this._dbConnection, collectionName, k, cancellationToken))).ConfigureAwait(false);
+        await this._dbConnector.DeleteBatchAsync(this._dbConnection, collectionName, keys.ToArray(), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -232,8 +232,7 @@ public sealed class DuckDBMemoryStore : IMemoryStore, IDisposable
 
     private static DateTimeOffset? ParseTimestamp(string? str)
     {
-        if (!string.IsNullOrEmpty(str)
-            && DateTimeOffset.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTimeOffset timestamp))
+        if (DateTimeOffset.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTimeOffset timestamp))
         {
             return timestamp;
         }


### PR DESCRIPTION
### Motivation and Context

To optimize performance by reducing the number of database calls during batch deletions in DuckDBMemoryStore.

### Description

The updated **RemoveBatchAsync** method now executes a single SQL DELETE query to remove multiple keys at once, replacing the previous approach of executing individual delete queries for each key.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and existing test is okay for this change
- [ ] I didn't break anyone :smile:
