### PR TITLE
.Net: Rename VectorRecordStore to VetorStoreRecordCollection

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -19,9 +19,9 @@ using Xunit;
 namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
 
 /// <summary>
-/// Contains tests for the <see cref="AzureAISearchVectorRecordStore{TRecord}"/> class.
+/// Contains tests for the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> class.
 /// </summary>
-public class AzureAISearchVectorRecordStoreTests
+public class AzureAISearchVectorStoreRecordCollectionTests
 {
     private const string TestCollectionName = "testcollection";
     private const string TestRecordKey1 = "testid1";
@@ -32,7 +32,7 @@ public class AzureAISearchVectorRecordStoreTests
 
     private readonly CancellationToken _testCancellationToken = new(false);
 
-    public AzureAISearchVectorRecordStoreTests()
+    public AzureAISearchVectorStoreRecordCollectionTests()
     {
         this._searchClientMock = new Mock<SearchClient>(MockBehavior.Strict);
         this._searchIndexClientMock = new Mock<SearchIndexClient>(MockBehavior.Strict);
@@ -150,7 +150,7 @@ public class AzureAISearchVectorRecordStoreTests
             .Returns(CreateModel(TestRecordKey1, true));
 
         // Arrange target with custom mapper.
-        var sut = new AzureAISearchVectorRecordStore<SinglePropsModel>(
+        var sut = new AzureAISearchVectorStoreRecordCollection<SinglePropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName,
             new()
@@ -364,7 +364,7 @@ public class AzureAISearchVectorRecordStoreTests
             .Returns(storageObject);
 
         // Arrange target with custom mapper.
-        var sut = new AzureAISearchVectorRecordStore<SinglePropsModel>(
+        var sut = new AzureAISearchVectorStoreRecordCollection<SinglePropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName,
             new()
@@ -386,9 +386,9 @@ public class AzureAISearchVectorRecordStoreTests
                 Times.Once);
     }
 
-    private AzureAISearchVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
+    private AzureAISearchVectorStoreRecordCollection<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
     {
-        return new AzureAISearchVectorRecordStore<SinglePropsModel>(
+        return new AzureAISearchVectorStoreRecordCollection<SinglePropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName,
             new()

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchRecordMapperType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchRecordMapperType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Nodes;
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 
 /// <summary>
-/// The types of mapper supported by <see cref="AzureAISearchVectorRecordStore{TRecord}"/>.
+/// The types of mapper supported by <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public enum AzureAISearchRecordMapperType
 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -21,7 +21,9 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// Service for storing and retrieving vector records, that uses Azure AI Search as the underlying storage.
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
-public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore<string, TRecord>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -69,11 +71,11 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     /// <summary>Azure AI Search client that can be used to manage data in an Azure AI Search Service index.</summary>
     private readonly SearchClient _searchClient;
 
-    /// <summary>The name of the collection that this <see cref="AzureAISearchVectorRecordStore{TRecord}"/> will access.</summary>
+    /// <summary>The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</summary>
     private readonly string _collectionName;
 
     /// <summary>Optional configuration options for this class.</summary>
-    private readonly AzureAISearchVectorRecordStoreOptions<TRecord> _options;
+    private readonly AzureAISearchVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>The name of the key field for the collections that this class is used with.</summary>
     private readonly string _keyPropertyName;
@@ -82,14 +84,14 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
     private readonly List<string> _nonVectorPropertyNames;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureAISearchVectorRecordStore{TRecord}"/> class.
+    /// Initializes a new instance of the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> class.
     /// </summary>
     /// <param name="searchIndexClient">Azure AI Search client that can be used to manage the list of indices in an Azure AI Search Service.</param>
-    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorRecordStore{TRecord}"/> will access.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="searchIndexClient"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when options are misconfigured.</exception>
-    public AzureAISearchVectorRecordStore(SearchIndexClient searchIndexClient, string collectionName, AzureAISearchVectorRecordStoreOptions<TRecord>? options = default)
+    public AzureAISearchVectorStoreRecordCollection(SearchIndexClient searchIndexClient, string collectionName, AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default)
     {
         // Verify.
         Verify.NotNull(searchIndexClient);
@@ -98,13 +100,13 @@ public sealed class AzureAISearchVectorRecordStore<TRecord> : IVectorRecordStore
         // Assign.
         this._searchIndexClient = searchIndexClient;
         this._collectionName = collectionName;
-        this._options = options ?? new AzureAISearchVectorRecordStoreOptions<TRecord>();
+        this._options = options ?? new AzureAISearchVectorStoreRecordCollectionOptions<TRecord>();
         this._searchClient = this._searchIndexClient.GetSearchClient(collectionName);
 
         // Verify custom mapper.
         if (this._options.MapperType == AzureAISearchRecordMapperType.JsonObjectCustomMapper && this._options.JsonObjectCustomMapper is null)
         {
-            throw new ArgumentException($"The {nameof(AzureAISearchVectorRecordStoreOptions<TRecord>.JsonObjectCustomMapper)} option needs to be set if a {nameof(AzureAISearchVectorRecordStoreOptions<TRecord>.MapperType)} of {nameof(AzureAISearchRecordMapperType.JsonObjectCustomMapper)} has been chosen.", nameof(options));
+            throw new ArgumentException($"The {nameof(AzureAISearchVectorStoreRecordCollectionOptions<TRecord>.JsonObjectCustomMapper)} option needs to be set if a {nameof(AzureAISearchVectorStoreRecordCollectionOptions<TRecord>.MapperType)} of {nameof(AzureAISearchRecordMapperType.JsonObjectCustomMapper)} has been chosen.", nameof(options));
         }
 
         // Enumerate public properties using configuration or attributes.

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollectionOptions.cs
@@ -8,9 +8,9 @@ using Microsoft.SemanticKernel.Data;
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 
 /// <summary>
-/// Options when creating a <see cref="AzureAISearchVectorRecordStore{TRecord}"/>.
+/// Options when creating a <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
-public sealed class AzureAISearchVectorRecordStoreOptions<TRecord>
+public sealed class AzureAISearchVectorStoreRecordCollectionOptions<TRecord>
     where TRecord : class
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantRecordMapperType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantRecordMapperType.cs
@@ -5,7 +5,7 @@ using Qdrant.Client.Grpc;
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 /// <summary>
-/// The types of mapper supported by <see cref="QdrantVectorRecordStore{TRecord}"/>.
+/// The types of mapper supported by <see cref="QdrantVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public enum QdrantRecordMapperType
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -17,7 +17,9 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// Service for storing and retrieving vector records, that uses Qdrant as the underlying storage.
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
-public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong, TRecord>, IVectorRecordStore<Guid, TRecord>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<ulong, TRecord>, IVectorStoreRecordCollection<Guid, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -32,37 +34,37 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
     /// <summary>Qdrant client that can be used to manage the collections and points in a Qdrant store.</summary>
     private readonly MockableQdrantClient _qdrantClient;
 
-    /// <summary>The name of the collection that this <see cref="QdrantVectorRecordStore{TRecord}"/> will access.</summary>
+    /// <summary>The name of the collection that this <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> will access.</summary>
     private readonly string _collectionName;
 
     /// <summary>Optional configuration options for this class.</summary>
-    private readonly QdrantVectorRecordStoreOptions<TRecord> _options;
+    private readonly QdrantVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>A mapper to use for converting between qdrant point and consumer models.</summary>
     private readonly IVectorStoreRecordMapper<TRecord, PointStruct> _mapper;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+    /// Initializes a new instance of the <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> class.
     /// </summary>
     /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
-    /// <param name="collectionName">The name of the collection that this <see cref="QdrantVectorRecordStore{TRecord}"/> will access.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     /// <exception cref="ArgumentNullException">Thrown if the <paramref name="qdrantClient"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown for any misconfigured options.</exception>
-    public QdrantVectorRecordStore(QdrantClient qdrantClient, string collectionName, QdrantVectorRecordStoreOptions<TRecord>? options = null)
+    public QdrantVectorStoreRecordCollection(QdrantClient qdrantClient, string collectionName, QdrantVectorStoreRecordCollectionOptions<TRecord>? options = null)
         : this(new MockableQdrantClient(qdrantClient), collectionName, options)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+    /// Initializes a new instance of the <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> class.
     /// </summary>
     /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
-    /// <param name="collectionName">The name of the collection that this <see cref="QdrantVectorRecordStore{TRecord}"/> will access.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     /// <exception cref="ArgumentNullException">Thrown if the <paramref name="qdrantClient"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown for any misconfigured options.</exception>
-    internal QdrantVectorRecordStore(MockableQdrantClient qdrantClient, string collectionName, QdrantVectorRecordStoreOptions<TRecord>? options = null)
+    internal QdrantVectorStoreRecordCollection(MockableQdrantClient qdrantClient, string collectionName, QdrantVectorStoreRecordCollectionOptions<TRecord>? options = null)
     {
         // Verify.
         Verify.NotNull(qdrantClient);
@@ -71,7 +73,7 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
         // Assign.
         this._qdrantClient = qdrantClient;
         this._collectionName = collectionName;
-        this._options = options ?? new QdrantVectorRecordStoreOptions<TRecord>();
+        this._options = options ?? new QdrantVectorStoreRecordCollectionOptions<TRecord>();
 
         // Assign Mapper.
         if (this._options.MapperType == QdrantRecordMapperType.QdrantPointStructCustomMapper)
@@ -79,7 +81,7 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
             // Custom Mapper.
             if (this._options.PointStructCustomMapper is null)
             {
-                throw new ArgumentException($"The {nameof(QdrantVectorRecordStoreOptions<TRecord>.PointStructCustomMapper)} option needs to be set if a {nameof(QdrantVectorRecordStoreOptions<TRecord>.MapperType)} of {nameof(QdrantRecordMapperType.QdrantPointStructCustomMapper)} has been chosen.", nameof(options));
+                throw new ArgumentException($"The {nameof(QdrantVectorStoreRecordCollectionOptions<TRecord>.PointStructCustomMapper)} option needs to be set if a {nameof(QdrantVectorStoreRecordCollectionOptions<TRecord>.MapperType)} of {nameof(QdrantRecordMapperType.QdrantPointStructCustomMapper)} has been chosen.", nameof(options));
             }
 
             this._mapper = this._options.PointStructCustomMapper;
@@ -201,7 +203,7 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
     }
 
     /// <inheritdoc />
-    async Task<Guid> IVectorRecordStore<Guid, TRecord>.UpsertAsync(TRecord record, UpsertRecordOptions? options, CancellationToken cancellationToken)
+    async Task<Guid> IVectorStoreRecordCollection<Guid, TRecord>.UpsertAsync(TRecord record, UpsertRecordOptions? options, CancellationToken cancellationToken)
     {
         Verify.NotNull(record);
 
@@ -243,7 +245,7 @@ public sealed class QdrantVectorRecordStore<TRecord> : IVectorRecordStore<ulong,
     }
 
     /// <inheritdoc />
-    async IAsyncEnumerable<Guid> IVectorRecordStore<Guid, TRecord>.UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
+    async IAsyncEnumerable<Guid> IVectorStoreRecordCollection<Guid, TRecord>.UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         Verify.NotNull(records);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollectionOptions.cs
@@ -6,9 +6,9 @@ using Qdrant.Client.Grpc;
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 /// <summary>
-/// Options when creating a <see cref="QdrantVectorRecordStore{TRecord}"/>.
+/// Options when creating a <see cref="QdrantVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
-public sealed class QdrantVectorRecordStoreOptions<TRecord>
+public sealed class QdrantVectorStoreRecordCollectionOptions<TRecord>
     where TRecord : class
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisRecordMapperType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisRecordMapperType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Nodes;
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 
 /// <summary>
-/// The types of mapper supported by <see cref="RedisVectorRecordStore{TRecord}"/>.
+/// The types of mapper supported by <see cref="RedisVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public enum RedisRecordMapperType
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
@@ -20,7 +20,9 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// Service for storing and retrieving vector records, that uses Redis as the underlying storage.
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
-public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string, TRecord>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class RedisVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -44,11 +46,11 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
     /// <summary>The Redis database to read/write records from.</summary>
     private readonly IDatabase _database;
 
-    /// <summary>The name of the collection that this <see cref="RedisVectorRecordStore{TRecord}"/> will access.</summary>
+    /// <summary>The name of the collection that this <see cref="RedisVectorStoreRecordCollection{TRecord}"/> will access.</summary>
     private readonly string _collectionName;
 
     /// <summary>Optional configuration options for this class.</summary>
-    private readonly RedisVectorRecordStoreOptions<TRecord> _options;
+    private readonly RedisVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
     private readonly PropertyInfo _keyPropertyInfo;
@@ -66,13 +68,13 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
     private readonly JsonSerializerOptions _jsonSerializerOptions;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RedisVectorRecordStore{TRecord}"/> class.
+    /// Initializes a new instance of the <see cref="RedisVectorStoreRecordCollection{TRecord}"/> class.
     /// </summary>
     /// <param name="database">The Redis database to read/write records from.</param>
-    /// <param name="collectionName">The name of the collection that this <see cref="RedisVectorRecordStore{TRecord}"/> will access.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="RedisVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
     /// <exception cref="ArgumentNullException">Throw when parameters are invalid.</exception>
-    public RedisVectorRecordStore(IDatabase database, string collectionName, RedisVectorRecordStoreOptions<TRecord>? options = null)
+    public RedisVectorStoreRecordCollection(IDatabase database, string collectionName, RedisVectorStoreRecordCollectionOptions<TRecord>? options = null)
     {
         // Verify.
         Verify.NotNull(database);
@@ -81,7 +83,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         // Assign.
         this._database = database;
         this._collectionName = collectionName;
-        this._options = options ?? new RedisVectorRecordStoreOptions<TRecord>();
+        this._options = options ?? new RedisVectorStoreRecordCollectionOptions<TRecord>();
         this._jsonSerializerOptions = this._options.JsonSerializerOptions ?? JsonSerializerOptions.Default;
 
         // Enumerate public properties using configuration or attributes.
@@ -112,7 +114,7 @@ public sealed class RedisVectorRecordStore<TRecord> : IVectorRecordStore<string,
         {
             if (this._options.JsonNodeCustomMapper is null)
             {
-                throw new ArgumentException($"The {nameof(RedisVectorRecordStoreOptions<TRecord>.JsonNodeCustomMapper)} option needs to be set if a {nameof(RedisVectorRecordStoreOptions<TRecord>.MapperType)} of {nameof(RedisRecordMapperType.JsonNodeCustomMapper)} has been chosen.", nameof(options));
+                throw new ArgumentException($"The {nameof(RedisVectorStoreRecordCollectionOptions<TRecord>.JsonNodeCustomMapper)} option needs to be set if a {nameof(RedisVectorStoreRecordCollectionOptions<TRecord>.MapperType)} of {nameof(RedisRecordMapperType.JsonNodeCustomMapper)} has been chosen.", nameof(options));
             }
 
             this._mapper = this._options.JsonNodeCustomMapper;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollectionOptions.cs
@@ -7,9 +7,9 @@ using Microsoft.SemanticKernel.Data;
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 
 /// <summary>
-/// Options when creating a <see cref="RedisVectorRecordStore{TRecord}"/>.
+/// Options when creating a <see cref="RedisVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
-public sealed class RedisVectorRecordStoreOptions<TRecord>
+public sealed class RedisVectorStoreRecordCollectionOptions<TRecord>
     where TRecord : class
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -13,9 +13,9 @@ using Xunit;
 namespace Microsoft.SemanticKernel.Connectors.Qdrant.UnitTests;
 
 /// <summary>
-/// Contains tests for the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+/// Contains tests for the <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> class.
 /// </summary>
-public class QdrantVectorRecordStoreTests
+public class QdrantVectorStoreRecordCollectionTests
 {
     private const string TestCollectionName = "testcollection";
     private const ulong UlongTestRecordKey1 = 1;
@@ -27,7 +27,7 @@ public class QdrantVectorRecordStoreTests
 
     private readonly CancellationToken _testCancellationToken = new(false);
 
-    public QdrantVectorRecordStoreTests()
+    public QdrantVectorStoreRecordCollectionTests()
     {
         this._qdrantClientMock = new Mock<MockableQdrantClient>(MockBehavior.Strict);
     }
@@ -155,7 +155,7 @@ public class QdrantVectorRecordStoreTests
             .Returns(CreateModel(UlongTestRecordKey1, true));
 
         // Arrange target with custom mapper.
-        var sut = new QdrantVectorRecordStore<SinglePropsModel<ulong>>(
+        var sut = new QdrantVectorStoreRecordCollection<SinglePropsModel<ulong>>(
             this._qdrantClientMock.Object,
             TestCollectionName,
             new()
@@ -382,7 +382,7 @@ public class QdrantVectorRecordStoreTests
             .Returns(pointStruct);
 
         // Arrange target with custom mapper.
-        var sut = new QdrantVectorRecordStore<SinglePropsModel<ulong>>(
+        var sut = new QdrantVectorStoreRecordCollection<SinglePropsModel<ulong>>(
             this._qdrantClientMock.Object,
             TestCollectionName,
             new()
@@ -512,16 +512,16 @@ public class QdrantVectorRecordStoreTests
         return point;
     }
 
-    private IVectorRecordStore<T, SinglePropsModel<T>> CreateVectorRecordStore<T>(bool useDefinition, bool hasNamedVectors)
+    private IVectorStoreRecordCollection<T, SinglePropsModel<T>> CreateVectorRecordStore<T>(bool useDefinition, bool hasNamedVectors)
     {
-        var store = new QdrantVectorRecordStore<SinglePropsModel<T>>(
+        var store = new QdrantVectorStoreRecordCollection<SinglePropsModel<T>>(
             this._qdrantClientMock.Object,
             TestCollectionName,
             new()
             {
                 VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null,
                 HasNamedVectors = hasNamedVectors
-            }) as IVectorRecordStore<T, SinglePropsModel<T>>;
+            }) as IVectorStoreRecordCollection<T, SinglePropsModel<T>>;
         return store!;
     }
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordCollectionTests.cs
@@ -14,9 +14,9 @@ using Xunit;
 namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
 
 /// <summary>
-/// Contains tests for the <see cref="RedisVectorRecordStore{TRecord}"/> class.
+/// Contains tests for the <see cref="RedisVectorStoreRecordCollection{TRecord}"/> class.
 /// </summary>
-public class RedisVectorRecordStoreTests
+public class RedisVectorStoreRecordCollectionTests
 {
     private const string TestCollectionName = "testcollection";
     private const string TestRecordKey1 = "testid1";
@@ -24,7 +24,7 @@ public class RedisVectorRecordStoreTests
 
     private readonly Mock<IDatabase> _redisDatabaseMock;
 
-    public RedisVectorRecordStoreTests()
+    public RedisVectorStoreRecordCollectionTests()
     {
         this._redisDatabaseMock = new Mock<IDatabase>(MockBehavior.Strict);
 
@@ -141,7 +141,7 @@ public class RedisVectorRecordStoreTests
             .Returns(CreateModel(TestRecordKey1, true));
 
         // Arrange target with custom mapper.
-        var sut = new RedisVectorRecordStore<SinglePropsModel>(
+        var sut = new RedisVectorStoreRecordCollection<SinglePropsModel>(
             this._redisDatabaseMock.Object,
             TestCollectionName,
             new()
@@ -289,7 +289,7 @@ public class RedisVectorRecordStoreTests
             .Returns((TestRecordKey1, JsonNode.Parse(jsonNode)!));
 
         // Arrange target with custom mapper.
-        var sut = new RedisVectorRecordStore<SinglePropsModel>(
+        var sut = new RedisVectorStoreRecordCollection<SinglePropsModel>(
             this._redisDatabaseMock.Object,
             TestCollectionName,
             new()
@@ -310,9 +310,9 @@ public class RedisVectorRecordStoreTests
                 Times.Once);
     }
 
-    private RedisVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
+    private RedisVectorStoreRecordCollection<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
     {
-        return new RedisVectorRecordStore<SinglePropsModel>(
+        return new RedisVectorStoreRecordCollection<SinglePropsModel>(
             this._redisDatabaseMock.Object,
             TestCollectionName,
             new()

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -37,7 +37,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
         .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
         .AddEnvironmentVariables()
-        .AddUserSecrets<AzureAISearchVectorRecordStoreTests>()
+        .AddUserSecrets<AzureAISearchVectorStoreRecordCollectionTests>()
         .Build();
 
     /// <summary>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -15,11 +15,11 @@ using static SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch.Azu
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch;
 
 /// <summary>
-/// Integration tests for <see cref="AzureAISearchVectorRecordStore{TRecord}"/> class.
+/// Integration tests for <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> class.
 /// Tests work with Azure AI Search Instance.
 /// </summary>
 [Collection("AzureAISearchVectorStoreCollection")]
-public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output, AzureAISearchVectorStoreFixture fixture) : IClassFixture<AzureAISearchVectorStoreFixture>
+public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHelper output, AzureAISearchVectorStoreFixture fixture) : IClassFixture<AzureAISearchVectorStoreFixture>
 {
     // If null, all tests will be enabled
     private const string SkipReason = null; //"Requires Azure AI Search Service instance up and running";
@@ -30,11 +30,11 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
+        var options = new AzureAISearchVectorStoreRecordCollectionOptions<Hotel>
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var hotel = CreateTestHotel("Upsert-1");
@@ -64,7 +64,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanUpsertManyDocumentsToVectorStoreAsync()
     {
         // Arrange
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act
         var results = sut.UpsertBatchAsync(
@@ -98,11 +98,11 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanGetDocumentFromVectorStoreAsync(bool includeVectors, bool useRecordDefinition)
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
+        var options = new AzureAISearchVectorStoreRecordCollectionOptions<Hotel>
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act
         var getResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
@@ -130,7 +130,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -154,11 +154,11 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanRemoveDocumentFromVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel>
+        var options = new AzureAISearchVectorStoreRecordCollectionOptions<Hotel>
         {
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
         await sut.UpsertAsync(CreateTestHotel("Remove-1"));
 
         // Act
@@ -174,7 +174,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-1"));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-2"));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-3"));
@@ -193,7 +193,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("BaseSet-5", new GetRecordOptions { IncludeVectors = true }));
@@ -204,7 +204,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     {
         // Arrange
         var searchIndexClient = new SearchIndexClient(new Uri("https://localhost:12345"), new AzureKeyCredential("12345"));
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(searchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(searchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
@@ -215,7 +215,7 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     {
         // Arrange
         var searchIndexClient = new SearchIndexClient(new Uri(fixture.Config.ServiceUrl), new AzureKeyCredential("12345"));
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(searchIndexClient, fixture.TestIndexName);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(searchIndexClient, fixture.TestIndexName);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreOperationException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
@@ -225,8 +225,8 @@ public sealed class AzureAISearchVectorRecordStoreTests(ITestOutputHelper output
     public async Task ItThrowsMappingExceptionForFailedMapperAsync()
     {
         // Arrange
-        var options = new AzureAISearchVectorRecordStoreOptions<Hotel> { MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper, JsonObjectCustomMapper = new FailingMapper() };
-        var sut = new AzureAISearchVectorRecordStore<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+        var options = new AzureAISearchVectorStoreRecordCollectionOptions<Hotel> { MapperType = AzureAISearchRecordMapperType.JsonObjectCustomMapper, JsonObjectCustomMapper = new FailingMapper() };
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName, options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
@@ -14,12 +14,12 @@ using static SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant.QdrantVect
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 
 /// <summary>
-/// Contains tests for the <see cref="QdrantVectorRecordStore{TRecord}"/> class.
+/// Contains tests for the <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> class.
 /// </summary>
 /// <param name="output">Used for logging.</param>
 /// <param name="fixture">Qdrant setup and teardown.</param>
 [Collection("QdrantVectorStoreCollection")]
-public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
+public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
 {
     [Theory]
     [InlineData(true, "singleVectorHotels", false)]
@@ -29,12 +29,12 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition, string collectionName, bool hasNamedVectors)
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         var record = this.CreateTestHotel(20);
 
@@ -64,8 +64,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanUpsertAndRemoveDocumentWithGuidIdToVectorStoreAsync()
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId> { HasNamedVectors = false };
-        IVectorRecordStore<Guid, HotelInfoWithGuidId> sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfoWithGuidId> { HasNamedVectors = false };
+        IVectorStoreRecordCollection<Guid, HotelInfoWithGuidId> sut = new QdrantVectorStoreRecordCollection<HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
 
         var record = new HotelInfoWithGuidId
         {
@@ -108,12 +108,12 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanGetDocumentFromVectorStoreAsync(bool useRecordDefinition, bool withEmbeddings, string collectionName, bool hasNamedVectors)
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         // Act.
         var getResult = await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = withEmbeddings });
@@ -149,12 +149,12 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanGetDocumentWithGuidIdFromVectorStoreAsync(bool useRecordDefinition, bool withEmbeddings)
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfoWithGuidId>
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfoWithGuidId>
         {
             HasNamedVectors = false,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelWithGuidIdVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfoWithGuidId>(fixture.QdrantClient, "singleVectorGuidIdHotels", options);
 
         // Act.
         var getResult = await sut.GetAsync(Guid.Parse("11111111-1111-1111-1111-111111111111"), new GetRecordOptions { IncludeVectors = withEmbeddings });
@@ -180,8 +180,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = true };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo> { HasNamedVectors = true };
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, "namedVectorsHotels", options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -207,12 +207,12 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanRemoveDocumentFromVectorStoreAsync(bool useRecordDefinition, string collectionName, bool hasNamedVectors)
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         await sut.UpsertAsync(this.CreateTestHotel(20));
 
@@ -233,12 +233,12 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync(bool useRecordDefinition, string collectionName, bool hasNamedVectors)
     {
         // Arrange.
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo>
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo>
         {
             HasNamedVectors = hasNamedVectors,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
         };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, collectionName, options);
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, collectionName, options);
 
         await sut.UpsertAsync(this.CreateTestHotel(20));
 
@@ -254,8 +254,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { HasNamedVectors = false };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo> { HasNamedVectors = false };
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync(15, new GetRecordOptions { IncludeVectors = true }));
@@ -265,8 +265,8 @@ public sealed class QdrantVectorRecordStoreTests(ITestOutputHelper output, Qdran
     public async Task ItThrowsMappingExceptionForFailedMapperAsync()
     {
         // Arrange
-        var options = new QdrantVectorRecordStoreOptions<HotelInfo> { MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper, PointStructCustomMapper = new FailingMapper() };
-        var sut = new QdrantVectorRecordStore<HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo> { MapperType = QdrantRecordMapperType.QdrantPointStructCustomMapper, PointStructCustomMapper = new FailingMapper() };
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, "singleVectorHotels", options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = true }));

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreRecordCollectionTests.cs
@@ -13,12 +13,12 @@ using static SemanticKernel.IntegrationTests.Connectors.Memory.Redis.RedisVector
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
 
 /// <summary>
-/// Contains tests for the <see cref="RedisVectorRecordStore{TRecord}"/> class.
+/// Contains tests for the <see cref="RedisVectorStoreRecordCollection{TRecord}"/> class.
 /// </summary>
 /// <param name="output">Used for logging.</param>
 /// <param name="fixture">Redis setup and teardown.</param>
 [Collection("RedisVectorStoreCollection")]
-public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisVectorStoreFixture fixture)
+public sealed class RedisVectorStoreRecordCollectionTests(ITestOutputHelper output, RedisVectorStoreFixture fixture)
 {
     [Theory]
     [InlineData(true)]
@@ -26,12 +26,12 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisVectorRecordStoreOptions<Hotel>
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
         Hotel record = CreateTestHotel("Upsert-1", 1);
 
         // Act.
@@ -63,12 +63,12 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanUpsertManyDocumentsToVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisVectorRecordStoreOptions<Hotel>
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
 
         // Act.
         var results = sut.UpsertBatchAsync(
@@ -102,12 +102,12 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanGetDocumentFromVectorStoreAsync(bool includeVectors, bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisVectorRecordStoreOptions<Hotel>
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
 
         // Act.
         var getResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
@@ -139,8 +139,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -162,8 +162,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItFailsToGetDocumentsWithInvalidSchemaAsync()
     {
         // Arrange.
-        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
 
         // Act & Assert.
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-4-Invalid", new GetRecordOptions { IncludeVectors = true }));
@@ -175,12 +175,12 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanRemoveDocumentFromVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisVectorRecordStoreOptions<Hotel>
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
         var address = new HotelAddress { City = "Seattle", Country = "USA" };
         var record = new Hotel
         {
@@ -206,8 +206,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-1", 1));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-2", 2));
         await sut.UpsertAsync(CreateTestHotel("RemoveMany-3", 3));
@@ -226,8 +226,8 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("BaseSet-5", new GetRecordOptions { IncludeVectors = true }));
@@ -237,13 +237,13 @@ public sealed class RedisVectorRecordStoreTests(ITestOutputHelper output, RedisV
     public async Task ItThrowsMappingExceptionForFailedMapperAsync()
     {
         // Arrange
-        var options = new RedisVectorRecordStoreOptions<Hotel>
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             MapperType = RedisRecordMapperType.JsonNodeCustomMapper,
             JsonNodeCustomMapper = new FailingMapper()
         };
-        var sut = new RedisVectorRecordStore<Hotel>(fixture.Database, "hotels", options);
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, "hotels", options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
@@ -8,12 +8,14 @@ using System.Threading.Tasks;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// An interface for adding, updating, deleting and retrieving records from a vector store.
+/// An interface for managing a collection of records in a vector store.
 /// </summary>
 /// <typeparam name="TKey">The data type of the record key.</typeparam>
 /// <typeparam name="TRecord">The record data model to use for adding, updating and retrieving data from the store.</typeparam>
 [Experimental("SKEXP0001")]
-public interface IVectorRecordStore<TKey, TRecord>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public interface IVectorStoreRecordCollection<TKey, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/DeleteRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/DeleteRecordOptions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.DeleteAsync"/>.
+/// Optional options when calling <see cref="IVectorStoreRecordCollection{TKey, TDataModel}.DeleteAsync"/>.
 /// Reserved for future use.
 /// </summary>
 [Experimental("SKEXP0001")]

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/GetRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/GetRecordOptions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.GetAsync"/>.
+/// Optional options when calling <see cref="IVectorStoreRecordCollection{TKey, TDataModel}.GetAsync"/>.
 /// </summary>
 [Experimental("SKEXP0001")]
 public class GetRecordOptions

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/UpsertRecordOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordOptions/UpsertRecordOptions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Optional options when calling <see cref="IVectorRecordStore{TKey, TDataModel}.UpsertAsync"/>.
+/// Optional options when calling <see cref="IVectorStoreRecordCollection{TKey, TDataModel}.UpsertAsync"/>.
 /// Reserved for future use.
 /// </summary>
 [Experimental("SKEXP0001")]

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -16,16 +16,18 @@ namespace Microsoft.SemanticKernel.Data;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 [Experimental("SKEXP0001")]
-public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<string, TRecord>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
-    /// <summary>Internal storage for the record store.</summary>
+    /// <summary>Internal storage for the record collection.</summary>
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> _internalCollection;
 
     /// <summary>Optional configuration options for this class.</summary>
-    private readonly VolatileVectorRecordStoreOptions _options;
+    private readonly VolatileVectorStoreRecordCollectionOptions _options;
 
-    /// <summary>The name of the collection that this <see cref="VolatileVectorRecordStore{TRecord}"/> will access.</summary>
+    /// <summary>The name of the collection that this <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> will access.</summary>
     private readonly string _collectionName;
 
     /// <summary>A set of types that a key on the provided model may have.</summary>
@@ -38,11 +40,11 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     private readonly PropertyInfo _keyPropertyInfo;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
+    /// Initializes a new instance of the <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> class.
     /// </summary>
-    /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorRecordStore{TRecord}"/> will access.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    public VolatileVectorRecordStore(string collectionName, VolatileVectorRecordStoreOptions? options = default)
+    public VolatileVectorStoreRecordCollection(string collectionName, VolatileVectorStoreRecordCollectionOptions? options = default)
     {
         // Verify.
         Verify.NotNullOrWhiteSpace(collectionName);
@@ -50,7 +52,7 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
         // Assign.
         this._collectionName = collectionName;
         this._internalCollection = new();
-        this._options = options ?? new VolatileVectorRecordStoreOptions();
+        this._options = options ?? new VolatileVectorStoreRecordCollectionOptions();
 
         // Enumerate public properties using configuration or attributes.
         (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;
@@ -69,12 +71,12 @@ public sealed class VolatileVectorRecordStore<TRecord> : IVectorRecordStore<stri
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
+    /// Initializes a new instance of the <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> class.
     /// </summary>
     /// <param name="internalCollection">Allows passing in the dictionary used for storage, for testing purposes.</param>
-    /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorRecordStore{TRecord}"/> will access.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    internal VolatileVectorRecordStore(ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> internalCollection, string collectionName, VolatileVectorRecordStoreOptions? options = default)
+    internal VolatileVectorStoreRecordCollection(ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> internalCollection, string collectionName, VolatileVectorStoreRecordCollectionOptions? options = default)
         : this(collectionName, options)
     {
         this._internalCollection = internalCollection;

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollectionOptions.cs
@@ -5,10 +5,10 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Options when creating a <see cref="VolatileVectorRecordStore{TRecord}"/>.
+/// Options when creating a <see cref="VolatileVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 [Experimental("SKEXP0001")]
-public sealed class VolatileVectorRecordStoreOptions
+public sealed class VolatileVectorStoreRecordCollectionOptions
 {
     /// <summary>
     /// Gets or sets an optional record definition that defines the schema of the record type.

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -11,9 +11,9 @@ using Xunit;
 namespace SemanticKernel.UnitTests.Data;
 
 /// <summary>
-/// Contains tests for the <see cref="VolatileVectorRecordStore{TRecord}"/> class.
+/// Contains tests for the <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> class.
 /// </summary>
-public class VolatileVectorRecordStoreTests
+public class VolatileVectorStoreRecordCollectionTests
 {
     private const string TestCollectionName = "testcollection";
     private const string TestRecordKey1 = "testid1";
@@ -23,7 +23,7 @@ public class VolatileVectorRecordStoreTests
 
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SinglePropsModel>> _collectionStore;
 
-    public VolatileVectorRecordStoreTests()
+    public VolatileVectorStoreRecordCollectionTests()
     {
         this._collectionStore = new();
     }
@@ -205,9 +205,9 @@ public class VolatileVectorRecordStoreTests
         };
     }
 
-    private VolatileVectorRecordStore<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
+    private VolatileVectorStoreRecordCollection<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
     {
-        return new VolatileVectorRecordStore<SinglePropsModel>(
+        return new VolatileVectorStoreRecordCollection<SinglePropsModel>(
             this._collectionStore,
             TestCollectionName,
             new()


### PR DESCRIPTION
### Motivation and Context

After long discussion we decided to move to a model whereby we have a VectorStore that can provide VectorStoreRecordCollection instances.  All record and collection specific operations will reside on VectorStoreRecordCollection and all cross collection operations will reside on VectorStore.

### Description

This change renames VectorRecordStore to VectorStoreRecordCollection as agreed.
The required collection operations will be moved to VectorStoreRecordCollection in a separate pr.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
