### PR TITLE
.Net: Adding collectionName, exists and delete to collection interface

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -139,7 +139,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
     {
         try
         {
-            var getResult = await this._searchIndexClient.GetIndexAsync(this._collectionName, cancellationToken).ConfigureAwait(false);
+            await this._searchIndexClient.GetIndexAsync(this._collectionName, cancellationToken).ConfigureAwait(false);
             return true;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
@@ -37,13 +37,39 @@ internal class MockableQdrantClient
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
     /// <summary>
+    /// Check if a collection exists.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<bool> CollectionExistsAsync(
+        string collectionName,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.CollectionExistsAsync(collectionName, cancellationToken);
+
+    /// <summary>
+    /// Drop a collection and all its associated data.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="timeout">Wait timeout for operation commit in seconds, if not specified - default value will be supplied</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task DeleteCollectionAsync(
+        string collectionName,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.DeleteCollectionAsync(collectionName, timeout, cancellationToken);
+
+    /// <summary>
     /// Delete a point.
     /// </summary>
     /// <param name="collectionName">The name of the collection.</param>
     /// <param name="id">The ID to delete.</param>
     /// <param name="wait">Whether to wait until the changes have been applied. Defaults to <c>true</c>.</param>
-	/// <param name="ordering">Write ordering guarantees. Defaults to <c>Weak</c>.</param>
-	/// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+    /// <param name="ordering">Write ordering guarantees. Defaults to <c>Weak</c>.</param>
+    /// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
     /// <param name="cancellationToken">
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
     /// </param>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -27,6 +27,37 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     [Theory(Skip = SkipReason)]
     [InlineData(true)]
     [InlineData(false)]
+    public async Task CollectionExistsReturnsCollectionStateAsync(bool expectedExists)
+    {
+        // Arrange.
+        var collectionName = expectedExists ? fixture.TestIndexName : "nonexistentcollection";
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, collectionName);
+
+        // Act.
+        var actual = await sut.CollectionExistsAsync();
+
+        // Assert.
+        Assert.Equal(expectedExists, actual);
+    }
+
+    [Fact(Skip = SkipReason)]
+    public async Task ItCanDeleteCollectionAsync()
+    {
+        // Arrange
+        var tempCollectionName = fixture.TestIndexName + "-delete";
+        await AzureAISearchVectorStoreFixture.CreateIndexAsync(tempCollectionName, fixture.SearchIndexClient);
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, tempCollectionName);
+
+        // Act
+        await sut.DeleteCollectionAsync();
+
+        // Assert
+        Assert.False(await sut.CollectionExistsAsync());
+    }
+
+    [Theory(Skip = SkipReason)]
+    [InlineData(true)]
+    [InlineData(false)]
     public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
@@ -22,6 +22,39 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
 {
     [Theory]
+    [InlineData("singleVectorHotels", true)]
+    [InlineData("nonexistentcollection", false)]
+    public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
+    {
+        // Arrange.
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, collectionName);
+
+        // Act.
+        var actual = await sut.CollectionExistsAsync();
+
+        // Assert.
+        Assert.Equal(expectedExists, actual);
+    }
+
+    [Fact]
+    public async Task ItCanDeleteCollectionAsync()
+    {
+        // Arrange
+        var tempCollectionName = "temp-test";
+        await fixture.QdrantClient.CreateCollectionAsync(
+            tempCollectionName,
+            new VectorParams { Size = 4, Distance = Distance.Cosine });
+
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, tempCollectionName);
+
+        // Act
+        await sut.DeleteCollectionAsync();
+
+        // Assert
+        Assert.False(await sut.CollectionExistsAsync());
+    }
+
+    [Theory]
     [InlineData(true, "singleVectorHotels", false)]
     [InlineData(false, "singleVectorHotels", false)]
     [InlineData(true, "namedVectorsHotels", true)]

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
@@ -19,6 +19,25 @@ public interface IVectorStoreRecordCollection<TKey, TRecord>
     where TRecord : class
 {
     /// <summary>
+    /// Gets the name of the collection.
+    /// </summary>
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Check if the collection exists in the vector store.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns><see langword="true"/> if the collection exists, <see langword="false"/> otherwise.</returns>
+    Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete the collection from the vector store.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A task that completes when the collection has been deleted.</returns>
+    Task DeleteCollectionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a record from the vector store. Does not guarantee that the collection exists.
     /// Returns null if the record is not found.
     /// </summary>

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -83,6 +83,22 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
+    public string CollectionName => this._collectionName;
+
+    /// <inheritdoc />
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    {
+        return this._internalCollection.ContainsKey(this._collectionName) ? Task.FromResult(true) : Task.FromResult(false);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        this._internalCollection.TryRemove(this._collectionName, out _);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     public Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         var collectionDictionary = this.GetCollectionDictionary();

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -29,6 +29,42 @@ public class VolatileVectorStoreRecordCollectionTests
     }
 
     [Theory]
+    [InlineData(TestCollectionName, true)]
+    [InlineData("nonexistentcollection", false)]
+    public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
+    {
+        // Arrange
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = new VolatileVectorStoreRecordCollection<SinglePropsModel>(
+            this._collectionStore,
+            collectionName);
+
+        // Act
+        var actual = await sut.CollectionExistsAsync(this._testCancellationToken);
+
+        // Assert
+        Assert.Equal(expectedExists, actual);
+    }
+
+    [Fact]
+    public async Task DeleteCollectionRemovesCollectionFromDictionaryAsync()
+    {
+        // Arrange
+        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        this._collectionStore.TryAdd(TestCollectionName, collection);
+
+        var sut = this.CreateRecordCollection(false);
+
+        // Act
+        await sut.DeleteCollectionAsync(this._testCancellationToken);
+
+        // Assert
+        Assert.Empty(this._collectionStore);
+    }
+
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task CanGetRecordWithVectorsAsync(bool useDefinition)
@@ -39,7 +75,7 @@ public class VolatileVectorStoreRecordCollectionTests
         collection.TryAdd(TestRecordKey1, record);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition);
+        var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.GetAsync(
@@ -72,7 +108,7 @@ public class VolatileVectorStoreRecordCollectionTests
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition);
+        var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.GetBatchAsync(
@@ -105,7 +141,7 @@ public class VolatileVectorStoreRecordCollectionTests
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition);
+        var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         await sut.DeleteAsync(
@@ -130,7 +166,7 @@ public class VolatileVectorStoreRecordCollectionTests
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition);
+        var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         await sut.DeleteBatchAsync(
@@ -152,7 +188,7 @@ public class VolatileVectorStoreRecordCollectionTests
         var collection = new ConcurrentDictionary<string, SinglePropsModel>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition);
+        var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var upsertResult = await sut.UpsertAsync(
@@ -177,7 +213,7 @@ public class VolatileVectorStoreRecordCollectionTests
         var collection = new ConcurrentDictionary<string, SinglePropsModel>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
-        var sut = this.CreateVectorRecordStore(useDefinition);
+        var sut = this.CreateRecordCollection(useDefinition);
 
         // Act
         var actual = await sut.UpsertBatchAsync(
@@ -205,7 +241,7 @@ public class VolatileVectorStoreRecordCollectionTests
         };
     }
 
-    private VolatileVectorStoreRecordCollection<SinglePropsModel> CreateVectorRecordStore(bool useDefinition)
+    private VolatileVectorStoreRecordCollection<SinglePropsModel> CreateRecordCollection(bool useDefinition)
     {
         return new VolatileVectorStoreRecordCollection<SinglePropsModel>(
             this._collectionStore,


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances.  These are tied to a collection and will expose single collection operations.

### Description

This PR adds some of the single collection operations to the VectorStoreRecordCollection, namely:
1. CollectionExists
2. DeleteCollection

As well as exposing the name of the collection.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
