### PR TITLE
.Net: Adding Azure AI Search CollectionCreate

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Xunit;
+using Microsoft.SemanticKernel.Data;
+using Azure.Search.Documents.Indexes.Models;
+using System;
+using System.Collections.Generic;
+
+namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="AzureAISearchVectorStoreCollectionCreateMapping"/> class.
+/// </summary>
+public class AzureAISearchVectorStoreCollectionCreateMappingTests
+{
+    [Fact]
+    public void MapKeyFieldCreatesSearchableField()
+    {
+        // Arrange
+        var keyProperty = new VectorStoreRecordKeyProperty("testkey");
+
+        // Act
+        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapKeyField(keyProperty);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(keyProperty.PropertyName, result.Name);
+        Assert.True(result.IsKey);
+        Assert.True(result.IsFilterable);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapStringDataFieldCreatesSearchableField(bool isFilterable)
+    {
+        // Arrange
+        var dataProperty = new VectorStoreRecordDataProperty("testdata") { IsFilterable = isFilterable, PropertyType = typeof(string) };
+
+        // Act
+        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<SearchableField>(result);
+        Assert.Equal(dataProperty.PropertyName, result.Name);
+        Assert.False(result.IsKey);
+        Assert.Equal(isFilterable, result.IsFilterable);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapDataFieldCreatesSimpleField(bool isFilterable)
+    {
+        // Arrange
+        var dataProperty = new VectorStoreRecordDataProperty("testdata") { IsFilterable = isFilterable, PropertyType = typeof(int) };
+
+        // Act
+        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<SimpleField>(result);
+        Assert.Equal(dataProperty.PropertyName, result.Name);
+        Assert.Equal(SearchFieldDataType.Int32, result.Type);
+        Assert.False(result.IsKey);
+        Assert.Equal(isFilterable, result.IsFilterable);
+    }
+
+    [Fact]
+    public void MapDataFieldFailsForNullType()
+    {
+        // Arrange
+        var dataProperty = new VectorStoreRecordDataProperty("testdata");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty));
+    }
+
+    [Fact]
+    public void MapVectorFieldCreatesVectorSearchField()
+    {
+        // Arrange
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.DotProductSimilarity };
+
+        // Act
+        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty);
+
+        // Assert
+        Assert.NotNull(vectorSearchField);
+        Assert.NotNull(algorithmConfiguration);
+        Assert.NotNull(vectorSearchProfile);
+        Assert.Equal(vectorProperty.PropertyName, vectorSearchField.Name);
+        Assert.Equal(vectorProperty.Dimensions, vectorSearchField.VectorSearchDimensions);
+
+        Assert.Equal("testvectorAlgoConfig", algorithmConfiguration.Name);
+        Assert.IsType<ExhaustiveKnnAlgorithmConfiguration>(algorithmConfiguration);
+        var flatConfig = algorithmConfiguration as ExhaustiveKnnAlgorithmConfiguration;
+        Assert.Equal(VectorSearchAlgorithmMetric.DotProduct, flatConfig!.Parameters.Metric);
+
+        Assert.Equal("testvectorProfile", vectorSearchProfile.Name);
+        Assert.Equal("testvectorAlgoConfig", vectorSearchProfile.AlgorithmConfigurationName);
+    }
+
+    [Theory]
+    [InlineData(IndexKind.Hnsw, typeof(HnswAlgorithmConfiguration))]
+    [InlineData(IndexKind.Flat, typeof(ExhaustiveKnnAlgorithmConfiguration))]
+    public void MapVectorFieldCreatesExpectedAlgoConfigTypes(string indexKind, Type algoConfigType)
+    {
+        // Arrange
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, IndexKind = indexKind, DistanceFunction = DistanceFunction.DotProductSimilarity };
+
+        // Act
+        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty);
+
+        // Assert
+        Assert.Equal("testvectorAlgoConfig", algorithmConfiguration.Name);
+        Assert.Equal(algoConfigType, algorithmConfiguration.GetType());
+    }
+
+    [Fact]
+    public void MapVectorFieldDefaultsToHsnwAndCosine()
+    {
+        // Arrange
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10 };
+
+        // Act
+        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty);
+
+        // Assert
+        Assert.IsType<HnswAlgorithmConfiguration>(algorithmConfiguration);
+        var hnswConfig = algorithmConfiguration as HnswAlgorithmConfiguration;
+        Assert.Equal(VectorSearchAlgorithmMetric.Cosine, hnswConfig!.Parameters.Metric);
+    }
+
+    [Fact]
+    public void MapVectorFieldThrowsForUnsupportedDistanceFunction()
+    {
+        // Arrange
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, DistanceFunction = DistanceFunction.ManhattanDistance };
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty));
+    }
+
+    [Fact]
+    public void MapVectorFieldThrowsForMissingDimensionsCount()
+    {
+        // Arrange
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector");
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty));
+    }
+
+    [Theory]
+    [MemberData(nameof(DataTypeMappingOptions))]
+    public void GetSDKFieldDataTypeMapsTypesCorrectly(Type propertyType, SearchFieldDataType searchFieldDataType)
+    {
+        // Act & Assert
+        Assert.Equal(searchFieldDataType, AzureAISearchVectorStoreCollectionCreateMapping.GetSDKFieldDataType(propertyType));
+    }
+
+    public static IEnumerable<object[]> DataTypeMappingOptions()
+    {
+        yield return new object[] { typeof(string), SearchFieldDataType.String };
+        yield return new object[] { typeof(bool), SearchFieldDataType.Boolean };
+        yield return new object[] { typeof(int), SearchFieldDataType.Int32 };
+        yield return new object[] { typeof(long), SearchFieldDataType.Int64 };
+        yield return new object[] { typeof(float), SearchFieldDataType.Double };
+        yield return new object[] { typeof(double), SearchFieldDataType.Double };
+        yield return new object[] { typeof(DateTime), SearchFieldDataType.DateTimeOffset };
+        yield return new object[] { typeof(DateTimeOffset), SearchFieldDataType.DateTimeOffset };
+
+        yield return new object[] { typeof(string[]), SearchFieldDataType.Collection(SearchFieldDataType.String) };
+        yield return new object[] { typeof(IEnumerable<string>), SearchFieldDataType.Collection(SearchFieldDataType.String) };
+        yield return new object[] { typeof(List<string>), SearchFieldDataType.Collection(SearchFieldDataType.String) };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.Connectors.AzureAISearch;
-using Xunit;
-using Microsoft.SemanticKernel.Data;
-using Azure.Search.Documents.Indexes.Models;
 using System;
 using System.Collections.Generic;
+using Azure.Search.Documents.Indexes.Models;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
 
 namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Search.Documents.Indexes.Models;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
+
+/// <summary>
+/// Contains mapping helpers to use when creating a Azure AI Search vector collection.
+/// </summary>
+internal static class AzureAISearchVectorStoreCollectionCreateMapping
+{
+    /// <summary>
+    /// Map from a <see cref="VectorStoreRecordKeyProperty"/> to an Azure AI Search <see cref="SearchableField"/>.
+    /// </summary>
+    /// <param name="keyProperty">The key property definition.</param>
+    /// <returns>The <see cref="SearchableField"/> for the provided property definition.</returns>
+    public static SearchableField MapKeyField(VectorStoreRecordKeyProperty keyProperty)
+    {
+        return new SearchableField(keyProperty.PropertyName) { IsKey = true, IsFilterable = true };
+    }
+
+    /// <summary>
+    /// Map from a <see cref="VectorStoreRecordDataProperty"/> to an Azure AI Search <see cref="SimpleField"/>.
+    /// </summary>
+    /// <param name="dataProperty">The data property definition.</param>
+    /// <returns>The <see cref="SimpleField"/> for the provided property definition.</returns>
+    /// <exception cref="InvalidOperationException">Throws when the definition is missing required information.</exception>
+    public static SimpleField MapDataField(VectorStoreRecordDataProperty dataProperty)
+    {
+        if (dataProperty.PropertyType == typeof(string))
+        {
+            return new SearchableField(dataProperty.PropertyName) { IsFilterable = dataProperty.IsFilterable };
+        }
+
+        if (dataProperty.PropertyType is null)
+        {
+            throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.PropertyName}' must be set to create a collection.");
+        }
+
+        return new SimpleField(dataProperty.PropertyName, AzureAISearchVectorStoreCollectionCreateMapping.GetSDKFieldDataType(dataProperty.PropertyType)) { IsFilterable = dataProperty.IsFilterable };
+    }
+
+    /// <summary>
+    /// Map form a <see cref="VectorStoreRecordVectorProperty"/> to an Azure AI Search <see cref="VectorSearchField"/> and generate the required index configuration.
+    /// </summary>
+    /// <param name="vectorProperty">The vector property definition.</param>
+    /// <returns>The <see cref="VectorSearchField"/> and requried index configuration.</returns>
+    /// <exception cref="InvalidOperationException">Throws when the definition is missing required information, or unsupported options are configured.</exception>
+    public static (VectorSearchField vectorSearchField, VectorSearchAlgorithmConfiguration algorithmConfiguration, VectorSearchProfile vectorSearchProfile) MapVectorField(VectorStoreRecordVectorProperty vectorProperty)
+    {
+        if (vectorProperty.Dimensions is not > 0)
+        {
+            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}' must be set to a positive ingeteger to create a collection.");
+        }
+
+        // Build a name for the profile and algorithm configuration based on the property name
+        // since we'll just create a separate one for each vector property.
+        var vectorSearchProfileName = $"{vectorProperty.PropertyName}Profile";
+        var algorithmConfigName = $"{vectorProperty.PropertyName}AlgoConfig";
+
+        // Read the vector index settings from the property definition and create the right index configuration.
+        var indexKind = AzureAISearchVectorStoreCollectionCreateMapping.GetSKIndexKind(vectorProperty);
+        var algorithmMetric = AzureAISearchVectorStoreCollectionCreateMapping.GetSDKDistanceAlgorithm(vectorProperty);
+
+        VectorSearchAlgorithmConfiguration algorithmConfiguration = indexKind switch
+        {
+            IndexKind.Hnsw => new HnswAlgorithmConfiguration(algorithmConfigName) { Parameters = new HnswParameters { Metric = algorithmMetric } },
+            IndexKind.Flat => new ExhaustiveKnnAlgorithmConfiguration(algorithmConfigName) { Parameters = new ExhaustiveKnnParameters { Metric = algorithmMetric } },
+            _ => throw new InvalidOperationException($"Unsupported index kind '{indexKind}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+        };
+        var vectorSearchProfile = new VectorSearchProfile(vectorSearchProfileName, algorithmConfigName);
+
+        return (new VectorSearchField(vectorProperty.PropertyName, vectorProperty.Dimensions.Value, vectorSearchProfileName), algorithmConfiguration, vectorSearchProfile);
+    }
+
+    /// <summary>
+    /// Get the configured <see cref="IndexKind"/> from the given <paramref name="vectorProperty"/>.
+    /// If none is configured the default is <see cref="IndexKind.Hnsw"/>.
+    /// </summary>
+    /// <param name="vectorProperty">The vector property definition.</param>
+    /// <returns>The configured or default <see cref="IndexKind"/>.</returns>
+    public static string GetSKIndexKind(VectorStoreRecordVectorProperty vectorProperty)
+    {
+        if (vectorProperty.IndexKind is null)
+        {
+            return IndexKind.Hnsw;
+        }
+
+        return vectorProperty.IndexKind;
+    }
+
+    /// <summary>
+    /// Get the configured <see cref="VectorSearchAlgorithmMetric"/> from the given <paramref name="vectorProperty"/>.
+    /// If none is configured, the default is <see cref="VectorSearchAlgorithmMetric.Cosine"/>.
+    /// </summary>
+    /// <param name="vectorProperty">The vector property definition.</param>
+    /// <returns>The chosen <see cref="VectorSearchAlgorithmMetric"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if a distance function is chosen that isn't suported by Azure AI Search.</exception>
+    public static VectorSearchAlgorithmMetric GetSDKDistanceAlgorithm(VectorStoreRecordVectorProperty vectorProperty)
+    {
+        if (vectorProperty.DistanceFunction is null)
+        {
+            return VectorSearchAlgorithmMetric.Cosine;
+        }
+
+        return vectorProperty.DistanceFunction switch
+        {
+            DistanceFunction.CosineSimilarity => VectorSearchAlgorithmMetric.Cosine,
+            DistanceFunction.DotProductSimilarity => VectorSearchAlgorithmMetric.DotProduct,
+            DistanceFunction.EuclideanDistance => VectorSearchAlgorithmMetric.Euclidean,
+            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+        };
+    }
+
+    /// <summary>
+    /// Maps the given property type to the corresponding <see cref="SearchFieldDataType"/>.
+    /// </summary>
+    /// <param name="propertyType">The property type to map.</param>
+    /// <returns>The <see cref="SearchFieldDataType"/> that corresponds to the given property type.</returns>"
+    /// <exception cref="InvalidOperationException">Thrown if the given type is not supported.</exception>
+    public static SearchFieldDataType GetSDKFieldDataType(Type propertyType)
+    {
+        return propertyType switch
+        {
+            Type stringType when stringType == typeof(string) => SearchFieldDataType.String,
+            Type boolType when boolType == typeof(bool) || boolType == typeof(bool?) => SearchFieldDataType.Boolean,
+            Type intType when intType == typeof(int) || intType == typeof(int?) => SearchFieldDataType.Int32,
+            Type longType when longType == typeof(long) || longType == typeof(long?) => SearchFieldDataType.Int64,
+            Type floatType when floatType == typeof(float) || floatType == typeof(float?) => SearchFieldDataType.Double,
+            Type doubleType when doubleType == typeof(double) || doubleType == typeof(double?) => SearchFieldDataType.Double,
+            Type dateTimeType when dateTimeType == typeof(DateTime) || dateTimeType == typeof(DateTime?) => SearchFieldDataType.DateTimeOffset,
+            Type dateTimeOffsetType when dateTimeOffsetType == typeof(DateTimeOffset) || dateTimeOffsetType == typeof(DateTimeOffset?) => SearchFieldDataType.DateTimeOffset,
+            Type collectionType when typeof(IEnumerable).IsAssignableFrom(collectionType) => SearchFieldDataType.Collection(GetSDKFieldDataType(GetEnumerableType(propertyType))),
+            _ => throw new InvalidOperationException($"Unsupported data type '{propertyType}' for {nameof(VectorStoreRecordDataProperty)}.")
+        };
+    }
+
+    /// <summary>
+    /// Gets the type of object stored in the given enumerable type.
+    /// </summary>
+    /// <param name="type">The enumerable to get the stored type for.</param>
+    /// <returns>The type of object stored in the given enumerable type.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the given type is not enumerable.</exception>
+    public static Type GetEnumerableType(Type type)
+    {
+        if (type is IEnumerable)
+        {
+            return typeof(object);
+        }
+        else if (type.IsArray)
+        {
+            return type.GetElementType()!;
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        if (type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)) is Type enumerableInterface)
+        {
+            return enumerableInterface.GetGenericArguments()[0];
+        }
+
+        throw new InvalidOperationException($"Unsupported data type '{type}' for {nameof(VectorStoreRecordDataProperty)}.");
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
@@ -49,7 +49,7 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
     /// Map form a <see cref="VectorStoreRecordVectorProperty"/> to an Azure AI Search <see cref="VectorSearchField"/> and generate the required index configuration.
     /// </summary>
     /// <param name="vectorProperty">The vector property definition.</param>
-    /// <returns>The <see cref="VectorSearchField"/> and requried index configuration.</returns>
+    /// <returns>The <see cref="VectorSearchField"/> and required index configuration.</returns>
     /// <exception cref="InvalidOperationException">Throws when the definition is missing required information, or unsupported options are configured.</exception>
     public static (VectorSearchField vectorSearchField, VectorSearchAlgorithmConfiguration algorithmConfiguration, VectorSearchProfile vectorSearchProfile) MapVectorField(VectorStoreRecordVectorProperty vectorProperty)
     {
@@ -100,7 +100,7 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
     /// </summary>
     /// <param name="vectorProperty">The vector property definition.</param>
     /// <returns>The chosen <see cref="VectorSearchAlgorithmMetric"/>.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if a distance function is chosen that isn't suported by Azure AI Search.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if a distance function is chosen that isn't supported by Azure AI Search.</exception>
     public static VectorSearchAlgorithmMetric GetSDKDistanceAlgorithm(VectorStoreRecordVectorProperty vectorProperty)
     {
         if (vectorProperty.DistanceFunction is null)

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -54,13 +54,13 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
             Properties = new List<VectorStoreRecordProperty>
             {
                 new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName"),
-                new VectorStoreRecordDataProperty("Description"),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding"),
-                new VectorStoreRecordDataProperty("Tags"),
-                new VectorStoreRecordDataProperty("ParkingIncluded"),
-                new VectorStoreRecordDataProperty("LastRenovationDate"),
-                new VectorStoreRecordDataProperty("Rating")
+                new VectorStoreRecordDataProperty("HotelName") { PropertyType = typeof(string) },
+                new VectorStoreRecordDataProperty("Description") { PropertyType = typeof(string) },
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding") { Dimensions = 4 },
+                new VectorStoreRecordDataProperty("Tags") { PropertyType = typeof(string[]) },
+                new VectorStoreRecordDataProperty("ParkingIncluded") { PropertyType = typeof(bool?) },
+                new VectorStoreRecordDataProperty("LastRenovationDate") { PropertyType = typeof(DateTimeOffset?) },
+                new VectorStoreRecordDataProperty("Rating") { PropertyType = typeof(float?) }
             }
         };
     }
@@ -219,7 +219,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
         public string Description { get; set; }
 
-        [VectorStoreRecordVector]
+        [VectorStoreRecordVector(4)]
         public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
 
         [SearchableField(IsFilterable = true, IsFacetable = true)]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -40,6 +40,33 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         Assert.Equal(expectedExists, actual);
     }
 
+    [Theory(Skip = SkipReason)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItCanCreateACollectionAsync(bool useRecordDefinition)
+    {
+        // Arrange
+        var testCollectionName = $"{fixture.TestIndexName}-createtest";
+        var options = new AzureAISearchVectorStoreRecordCollectionOptions<Hotel>
+        {
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
+        };
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, testCollectionName, options);
+
+        await sut.DeleteCollectionAsync();
+
+        // Act
+        await sut.CreateCollectionAsync();
+
+        // Assert
+        var existResult = await sut.CollectionExistsAsync();
+        Assert.True(existResult);
+        await sut.DeleteCollectionAsync();
+
+        // Output
+        output.WriteLine(existResult.ToString());
+    }
+
     [Fact(Skip = SkipReason)]
     public async Task ItCanDeleteCollectionAsync()
     {

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -219,6 +219,8 @@ internal static class VectorStoreRecordPropertyReader
                 {
                     HasEmbedding = dataAttribute.HasEmbedding,
                     EmbeddingPropertyName = dataAttribute.EmbeddingPropertyName,
+                    IsFilterable = dataAttribute.IsFilterable,
+                    PropertyType = dataProperty.PropertyType,
                     StoragePropertyName = dataAttribute.StoragePropertyName
                 });
             }
@@ -232,6 +234,9 @@ internal static class VectorStoreRecordPropertyReader
             {
                 definitionProperties.Add(new VectorStoreRecordVectorProperty(vectorProperty.Name)
                 {
+                    Dimensions = vectorAttribute.Dimensions,
+                    IndexKind = vectorAttribute.IndexKind,
+                    DistanceFunction = vectorAttribute.DistanceFunction,
                     StoragePropertyName = vectorAttribute.StoragePropertyName
                 });
             }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
@@ -24,6 +24,11 @@ public sealed class VectorStoreRecordDataAttribute : Attribute
     public string? EmbeddingPropertyName { get; init; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this data property is filterable.
+    /// </summary>
+    public bool IsFilterable { get; init; }
+
+    /// <summary>
     /// Gets or sets an optional name to use for the property in storage, if different from the property name.
     /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
     /// </summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordVectorAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordVectorAttribute.cs
@@ -13,6 +13,52 @@ namespace Microsoft.SemanticKernel.Data;
 public sealed class VectorStoreRecordVectorAttribute : Attribute
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreRecordVectorAttribute"/> class.
+    /// </summary>
+    public VectorStoreRecordVectorAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreRecordVectorAttribute"/> class.
+    /// </summary>
+    /// <param name="Dimensions">The number of dimensions that the vector has.</param>
+    public VectorStoreRecordVectorAttribute(int Dimensions)
+    {
+        this.Dimensions = Dimensions;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorStoreRecordVectorAttribute"/> class.
+    /// </summary>
+    /// <param name="Dimensions">The number of dimensions that the vector has.</param>
+    /// <param name="IndexKind">The kind of index to use.</param>
+    /// <param name="DistanceFunction">The distance function to use when comparing vectors.</param>
+    public VectorStoreRecordVectorAttribute(int Dimensions, string IndexKind, string DistanceFunction)
+    {
+        this.Dimensions = Dimensions;
+        this.IndexKind = IndexKind;
+        this.DistanceFunction = DistanceFunction;
+    }
+
+    /// <summary>
+    /// Gets or sets the number of dimensions that the vector has.
+    /// </summary>
+    public int? Dimensions { get; private set; }
+
+    /// <summary>
+    /// Gets the kind of index to use.
+    /// </summary>
+    /// <seealso cref="IndexKind"/>
+    public string? IndexKind { get; private set; }
+
+    /// <summary>
+    /// Gets the distance function to use when comparing vectors.
+    /// </summary>
+    /// <seealso cref="DistanceFunction"/>
+    public string? DistanceFunction { get; private set; }
+
+    /// <summary>
     /// Gets or sets an optional name to use for the property in storage, if different from the property name.
     /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
     /// </summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/DistanceFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/DistanceFunction.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Defines the distance functions that can be used to compare vectors.
+/// </summary>
+public static class DistanceFunction
+{
+    /// <summary>
+    /// The cosine (angular) similarty between two vectors.
+    /// </summary>
+    /// <remarks>
+    /// Measures only the angle between the two vectors, without taking into account the length of the vectors.
+    /// ConsineSimilarity = 1 - CosineDistance.
+    /// -1 means vectors are opposite.
+    /// 0 means vectors are orthogonal.
+    /// 1 means vectors are identical.
+    /// </remarks>
+    public const string CosineSimilarity = nameof(CosineSimilarity);
+
+    /// <summary>
+    /// The cosine (angular) similarty between two vectors.
+    /// </summary>
+    /// <remarks>
+    /// CosineDistance = 1 - CosineSimilarity.
+    /// 2 means vectors are opposite.
+    /// 1 means vectors are orthogonal.
+    /// 0 means vectors are identical.
+    /// </remarks>
+    public const string CosineDistance = nameof(CosineDistance);
+
+    /// <summary>
+    /// Measures both the length and angle between two vectors.
+    /// </summary>
+    /// <remarks>
+    /// Same as cosine similarity if the vectors are the same length, but more performant.
+    /// </remarks>
+    public const string DotProductSimilarity = nameof(DotProductSimilarity);
+
+    /// <summary>
+    /// Measures the Euclidean distance between two vectors.
+    /// </summary>
+    /// <remarks>
+    /// Also known as l2-norm.
+    /// </remarks>
+    public const string EuclideanDistance = nameof(EuclideanDistance);
+
+    /// <summary>
+    /// Measures the Manhattan distance between two vectors.
+    /// </summary>
+    public const string ManhattanDistance = nameof(ManhattanDistance);
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/IndexKind.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/IndexKind.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Data;
 public static class IndexKind
 {
     /// <summary>
-    /// Hierarchical Navigable Small World, which performs an aproximate nearest neighbour (ANN) search.
+    /// Hierarchical Navigable Small World, which performs an approximate nearest neighbour (ANN) search.
     /// </summary>
     /// <remarks>
     /// Lower accuracy than exhaustive k nearest neighbor, but faster and more efficient.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/IndexKind.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/IndexKind.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Defines the index types that can be used to index vectors.
+/// </summary>
+public static class IndexKind
+{
+    /// <summary>
+    /// Hierarchical Navigable Small World, which performs an aproximate nearest neighbour (ANN) search.
+    /// </summary>
+    /// <remarks>
+    /// Lower accuracy than exhaustive k nearest neighbor, but faster and more efficient.
+    /// </remarks>
+    public const string Hnsw = nameof(Hnsw);
+
+    /// <summary>
+    /// Does a brute force search to find the nearest neighbors.
+    /// Calculates the distances between all pairs of data points, so has a linear time complexity, that grows directly proportional to the number of points.
+    /// Also referred to as exhaustive k nearest neighbor in some databases.
+    /// </summary>
+    /// <remarks>
+    /// High recall accuracy, but slower and more expensive than HNSW.
+    /// Better with smaller datasets.
+    /// </remarks>
+    public const string Flat = nameof(Flat);
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
@@ -40,4 +41,14 @@ public sealed class VectorStoreRecordDataProperty : VectorStoreRecordProperty
     /// Gets or sets the name of the property that contains the embedding for this data property.
     /// </summary>
     public string? EmbeddingPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this data property is filterable.
+    /// </summary>
+    public bool IsFilterable { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of the data property.
+    /// </summary>
+    public Type? PropertyType { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
@@ -27,4 +27,21 @@ public sealed class VectorStoreRecordVectorProperty : VectorStoreRecordProperty
         : base(source.PropertyName)
     {
     }
+
+    /// <summary>
+    /// Gets or sets the number of dimensions that the vector has.
+    /// </summary>
+    public int? Dimensions { get; init; }
+
+    /// <summary>
+    /// Gets the kind of index to use.
+    /// </summary>
+    /// <seealso cref="IndexKind"/>
+    public string? IndexKind { get; init; }
+
+    /// <summary>
+    /// Gets the distance function to use when comparing vectors.
+    /// </summary>
+    /// <seealso cref="DistanceFunction"/>
+    public string? DistanceFunction { get; init; }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -165,10 +165,20 @@ public class VectorStoreRecordPropertyReaderTests
         var data1 = (VectorStoreRecordDataProperty)definition.Properties[1];
         var data2 = (VectorStoreRecordDataProperty)definition.Properties[2];
 
+        Assert.True(data1.IsFilterable);
+        Assert.False(data2.IsFilterable);
+
         Assert.True(data1.HasEmbedding);
         Assert.False(data2.HasEmbedding);
 
         Assert.Equal("Vector1", data1.EmbeddingPropertyName);
+
+        Assert.Equal(typeof(string), data1.PropertyType);
+        Assert.Equal(typeof(string), data2.PropertyType);
+
+        var vector1 = (VectorStoreRecordVectorProperty)definition.Properties[3];
+
+        Assert.Equal(4, vector1.Dimensions);
     }
 
     [Fact]
@@ -323,13 +333,13 @@ public class VectorStoreRecordPropertyReaderTests
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
+        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1", IsFilterable = true)]
         public string Data1 { get; set; } = string.Empty;
 
         [VectorStoreRecordData]
         public string Data2 { get; set; } = string.Empty;
 
-        [VectorStoreRecordVector]
+        [VectorStoreRecordVector(4, IndexKind.Flat, DistanceFunction.DotProductSimilarity)]
         public ReadOnlyMemory<float> Vector1 { get; set; }
 
         [VectorStoreRecordVector]
@@ -344,9 +354,9 @@ public class VectorStoreRecordPropertyReaderTests
         Properties =
         [
             new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("Data1") { HasEmbedding = true, EmbeddingPropertyName = "Vector1" },
+            new VectorStoreRecordDataProperty("Data1") { HasEmbedding = true, EmbeddingPropertyName = "Vector1", IsFilterable = true },
             new VectorStoreRecordDataProperty("Data2") { StoragePropertyName = "data_2" },
-            new VectorStoreRecordVectorProperty("Vector1"),
+            new VectorStoreRecordVectorProperty("Vector1") { Dimensions = 4, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.DotProductSimilarity },
             new VectorStoreRecordVectorProperty("Vector2")
         ]
     };


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This PR adds:
- The ability to create Azure AI Search collections
- Additional properties to the attributes and record definitions to support vector configuration and index creation.
- Code to parse and map those new properties

I'll update the IVectorStoreRecordCollection interface with the CreateCollection and CreateCollectionIfNotExists methods once I've added create to more implementations, to avoid having one very large pr.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
