### PR TITLE
.Net: Chat history serialization test + bug fix

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -16,6 +16,7 @@ extend-exclude = [
     "test_code_tokenizer.py",
     "*response.json",
     "test_content.txt",
+    "serializedChatHistoryV1_15_1.json"
 ]
 
 [default.extend-words]

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/ClientCore.ChatCompletion.cs
@@ -876,6 +876,13 @@ internal partial class ClientCore
                 toolCalls.Add(ChatToolCall.CreateFunctionToolCall(callRequest.Id, FunctionName.ToFullyQualifiedName(callRequest.FunctionName, callRequest.PluginName, OpenAIFunction.NameSeparator), argument ?? string.Empty));
             }
 
+            // This check is necessary to prevent an exception that will be thrown if the toolCalls collection is empty.
+            // HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'  
+            if (toolCalls.Count == 0)
+            {
+                return [new AssistantChatMessage(message.Content) { ParticipantName = message.AuthorName }];
+            }
+
             return [new AssistantChatMessage(toolCalls, message.Content) { ParticipantName = message.AuthorName }];
         }
 

--- a/dotnet/src/Connectors/Connectors.OpenAIV2/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAIV2/Core/ClientCore.ChatCompletion.cs
@@ -861,6 +861,13 @@ internal partial class ClientCore
                 toolCalls.Add(ChatToolCall.CreateFunctionToolCall(callRequest.Id, FunctionName.ToFullyQualifiedName(callRequest.FunctionName, callRequest.PluginName, OpenAIFunction.NameSeparator), argument ?? string.Empty));
             }
 
+            // This check is necessary to prevent an exception that will be thrown if the toolCalls collection is empty.
+            // HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'  
+            if (toolCalls.Count == 0)
+            {
+                return [new AssistantChatMessage(message.Content) { ParticipantName = message.AuthorName }];
+            }
+
             return [new AssistantChatMessage(toolCalls, message.Content) { ParticipantName = message.AuthorName }];
         }
 

--- a/dotnet/src/IntegrationTestsV2/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_FunctionCallingTests.cs
+++ b/dotnet/src/IntegrationTestsV2/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_FunctionCallingTests.cs
@@ -777,11 +777,11 @@ public sealed class AzureOpenAIChatCompletionFunctionCallingTests : BaseIntegrat
     }
 
     /// <summary>
-    /// This test verifies that the connector can handle the scenario where the assistance response message is added to the chat history.
-    /// The assistance response message with no function calls added to chat history caused the error: HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'
+    /// This test verifies that the connector can handle the scenario where the assistant response message is added to the chat history.
+    /// The assistant response message with no function calls added to chat history caused the error: HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'
     /// </summary>
     [Fact]
-    public async Task AssistanceResponseAddedToChatHistoryShouldBeHandledCorrectlyAsync()
+    public async Task AssistantResponseAddedToChatHistoryShouldBeHandledCorrectlyAsync()
     {
         // Arrange
         var kernel = this.CreateAndInitializeKernel(importHelperPlugin: true);

--- a/dotnet/src/IntegrationTestsV2/Connectors/OpenAI/OpenAIChatCompletion_FunctionCallingTests.cs
+++ b/dotnet/src/IntegrationTestsV2/Connectors/OpenAI/OpenAIChatCompletion_FunctionCallingTests.cs
@@ -776,11 +776,11 @@ public sealed class OpenAIChatCompletionFunctionCallingTests : BaseIntegrationTe
     }
 
     /// <summary>
-    /// This test verifies that the connector can handle the scenario where the assistance response message is added to the chat history.
-    /// The assistance response message with no function calls added to chat history caused the error: HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'
+    /// This test verifies that the connector can handle the scenario where the assistant response message is added to the chat history.
+    /// The assistant response message with no function calls added to chat history caused the error: HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'
     /// </summary>
     [Fact]
-    public async Task AssistanceResponseAddedToChatHistoryShouldBeHandledCorrectlyAsync()
+    public async Task AssistantResponseAddedToChatHistoryShouldBeHandledCorrectlyAsync()
     {
         // Arrange
         var kernel = this.CreateAndInitializeKernel(importHelperPlugin: true);

--- a/dotnet/src/IntegrationTestsV2/Connectors/OpenAI/OpenAIChatCompletion_FunctionCallingTests.cs
+++ b/dotnet/src/IntegrationTestsV2/Connectors/OpenAI/OpenAIChatCompletion_FunctionCallingTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -696,6 +697,108 @@ public sealed class OpenAIChatCompletionFunctionCallingTests : BaseIntegrationTe
 
         // Assert
         Assert.Contains("tornado", result, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ItShouldSupportOldFunctionCallingModelSerializedIntoChatHistoryByPreviousVersionOfSKAsync()
+    {
+        // Arrange
+        var chatHistory = JsonSerializer.Deserialize<ChatHistory>(File.ReadAllText("./TestData/serializedChatHistoryV1_15_1.json"));
+
+        // Remove connector-agnostic function-calling items to check if the old function-calling model, which relies on function information in metadata, is handled correctly.
+        foreach (var chatMessage in chatHistory!)
+        {
+            var index = 0;
+            while (index < chatMessage.Items.Count)
+            {
+                var item = chatMessage.Items[index];
+                if (item is FunctionCallContent || item is FunctionResultContent)
+                {
+                    chatMessage.Items.Remove(item);
+                    continue;
+                }
+                index++;
+            }
+        }
+
+        string? emailBody = null, emailRecipient = null;
+
+        var kernel = this.CreateAndInitializeKernel(importHelperPlugin: true);
+        kernel.ImportPluginFromFunctions("EmailPlugin", [KernelFunctionFactory.CreateFromMethod((string body, string recipient) => { emailBody = body; emailRecipient = recipient; }, "SendEmail")]);
+
+        // The deserialized chat history contains a list of function calls and the final answer to the question regarding the color of the sky in Boston.
+        chatHistory.AddUserMessage("Send it to my email: abc@domain.com");
+
+        var settings = new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+
+        // Act
+        var result = await kernel.GetRequiredService<IChatCompletionService>().GetChatMessageContentAsync(chatHistory, settings, kernel);
+
+        // Assert
+        Assert.Equal("abc@domain.com", emailRecipient);
+        Assert.Equal("Given the current weather in Boston is 61\u00B0F and rainy, the likely color of the sky would be gray or overcast due to the presence of rain clouds.", emailBody);
+    }
+
+    [Fact]
+    public async Task ItShouldSupportNewFunctionCallingModelSerializedIntoChatHistoryByPreviousVersionOfSKAsync()
+    {
+        // Arrange
+        var chatHistory = JsonSerializer.Deserialize<ChatHistory>(File.ReadAllText("./TestData/serializedChatHistoryV1_15_1.json"));
+
+        // Remove metadata related to the old function-calling model to check if the new model, which relies on function call content/result classes, is handled correctly.
+        foreach (var chatMessage in chatHistory!)
+        {
+            if (chatMessage.Metadata is not null)
+            {
+                var metadata = new Dictionary<string, object?>(chatMessage.Metadata);
+                metadata.Remove(OpenAIChatMessageContent.ToolIdProperty);
+                metadata.Remove("ChatResponseMessage.FunctionToolCalls");
+                chatMessage.Metadata = metadata;
+            }
+        }
+
+        string? emailBody = null, emailRecipient = null;
+
+        var kernel = this.CreateAndInitializeKernel(importHelperPlugin: true);
+        kernel.ImportPluginFromFunctions("EmailPlugin", [KernelFunctionFactory.CreateFromMethod((string body, string recipient) => { emailBody = body; emailRecipient = recipient; }, "SendEmail")]);
+
+        // The deserialized chat history contains a list of function calls and the final answer to the question regarding the color of the sky in Boston.
+        chatHistory.AddUserMessage("Send it to my email: abc@domain.com");
+
+        var settings = new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+
+        // Act
+        var result = await kernel.GetRequiredService<IChatCompletionService>().GetChatMessageContentAsync(chatHistory, settings, kernel);
+
+        // Assert
+        Assert.Equal("abc@domain.com", emailRecipient);
+        Assert.Equal("Given the current weather in Boston is 61\u00B0F and rainy, the likely color of the sky would be gray or overcast due to the presence of rain clouds.", emailBody);
+    }
+
+    /// <summary>
+    /// This test verifies that the connector can handle the scenario where the assistance response message is added to the chat history.
+    /// The assistance response message with no function calls added to chat history caused the error: HTTP 400 (invalid_request_error:) [] should be non-empty - 'messages.3.tool_calls'
+    /// </summary>
+    [Fact]
+    public async Task AssistanceResponseAddedToChatHistoryShouldBeHandledCorrectlyAsync()
+    {
+        // Arrange
+        var kernel = this.CreateAndInitializeKernel(importHelperPlugin: true);
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("Given the current time of day and weather, what is the likely color of the sky in Boston?");
+
+        var settings = new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+
+        var sut = kernel.GetRequiredService<IChatCompletionService>();
+
+        // Act
+        var assistanceResponse = await sut.GetChatMessageContentAsync(chatHistory, settings, kernel);
+
+        chatHistory.Add(assistanceResponse); // Adding assistance response to chat history.
+        chatHistory.AddUserMessage("Return only the color name.");
+
+        await sut.GetChatMessageContentAsync(chatHistory, settings, kernel);
     }
 
     private Kernel CreateAndInitializeKernel(bool importHelperPlugin = false)

--- a/dotnet/src/IntegrationTestsV2/TestData/serializedChatHistoryV1_15_1.json
+++ b/dotnet/src/IntegrationTestsV2/TestData/serializedChatHistoryV1_15_1.json
@@ -1,0 +1,125 @@
+﻿[
+  {
+    "Role": {
+      "Label": "user"
+    },
+    "Items": [
+      {
+        "$type": "TextContent",
+        "Text": "Given the current time of day and weather, what is the likely color of the sky in Boston?"
+      }
+    ]
+  },
+  {
+    "Role": {
+      "Label": "assistant"
+    },
+    "Items": [
+      {
+        "$type": "FunctionCallContent",
+        "Id": "call_q5FoU2fpfEyZmvC6iqtIXPYQ",
+        "PluginName": "HelperFunctions",
+        "FunctionName": "Get_Weather_For_City",
+        "Arguments": {
+          "cityName": "Boston"
+        }
+      }
+    ],
+    "ModelId": "gpt-4",
+    "Metadata": {
+      "Id": "chatcmpl-9lf5Qgx7xquKec3tc6lTn27y8Lmkz",
+      "Created": "2024-07-16T16:13:00+00:00",
+      "PromptFilterResults": [],
+      "SystemFingerprint": null,
+      "Usage": {
+        "CompletionTokens": 23,
+        "PromptTokens": 196,
+        "TotalTokens": 219
+      },
+      "ContentFilterResults": null,
+      "FinishReason": "tool_calls",
+      "FinishDetails": null,
+      "LogProbabilityInfo": null,
+      "Index": 0,
+      "Enhancements": null,
+      "ChatResponseMessage.FunctionToolCalls": [
+        {
+          "Name": "HelperFunctions-Get_Weather_For_City",
+          "Arguments": "{\n  \u0022cityName\u0022: \u0022Boston\u0022\n}",
+          "Id": "call_q5FoU2fpfEyZmvC6iqtIXPYQ"
+        }
+      ]
+    }
+  },
+  {
+    "Role": {
+      "Label": "tool"
+    },
+    "Items": [
+      {
+        "$type": "TextContent",
+        "Text": "61 and rainy",
+        "Metadata": {
+          "ChatCompletionsToolCall.Id": "call_q5FoU2fpfEyZmvC6iqtIXPYQ"
+        }
+      },
+      {
+        "$type": "FunctionResultContent",
+        "CallId": "call_q5FoU2fpfEyZmvC6iqtIXPYQ",
+        "PluginName": "HelperFunctions",
+        "FunctionName": "Get_Weather_For_City",
+        "Result": "61 and rainy"
+      }
+    ],
+    "Metadata": {
+      "ChatCompletionsToolCall.Id": "call_q5FoU2fpfEyZmvC6iqtIXPYQ"
+    }
+  },
+  {
+    "Role": {
+      "Label": "assistant"
+    },
+    "Items": [
+      {
+        "$type": "TextContent",
+        "Text": "Given the current weather in Boston is 61\u00B0F and rainy, the likely color of the sky would be gray or overcast due to the presence of rain clouds.",
+        "ModelId": "gpt-4",
+        "Metadata": {
+          "Id": "chatcmpl-9lf5RibNr9h4bzq7JJjUXj6ITz7wN",
+          "Created": "2024-07-16T16:13:01+00:00",
+          "PromptFilterResults": [],
+          "SystemFingerprint": null,
+          "Usage": {
+            "CompletionTokens": 34,
+            "PromptTokens": 237,
+            "TotalTokens": 271
+          },
+          "ContentFilterResults": null,
+          "FinishReason": "stop",
+          "FinishDetails": null,
+          "LogProbabilityInfo": null,
+          "Index": 0,
+          "Enhancements": null
+        }
+      }
+    ],
+    "ModelId": "gpt-4",
+    "Metadata": {
+      "Id": "chatcmpl-9lf5RibNr9h4bzq7JJjUXj6ITz7wN",
+      "Created": "2024-07-16T16:13:01+00:00",
+      "PromptFilterResults": [],
+      "SystemFingerprint": null,
+      "Usage": {
+        "CompletionTokens": 34,
+        "PromptTokens": 237,
+        "TotalTokens": 271
+      },
+      "ContentFilterResults": null,
+      "FinishReason": "stop",
+      "FinishDetails": null,
+      "LogProbabilityInfo": null,
+      "Index": 0,
+      "Enhancements": null
+    }
+  }
+]


### PR DESCRIPTION
### Motivation, Context and Description
This PR adds a few integration tests to ensure that the chat history, filled by existing {Azure}OpenAI chat completion connectors and serialized, is backward-compatible with the migrated {Azure}OpenAI chat completion connectors, so it can be deserialized and used as is.

Additionally, this PR fixes the issue caused by using the wrong constructor of the `AssistantChatMessage` class. A corresponding integration test is added to test this scenario.

Closes: https://github.com/microsoft/semantic-kernel/issues/7055