### PR TITLE
.Net: Add redis collection create support.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
@@ -58,6 +58,7 @@ internal static class RedisVectorStoreCollectionCreateMapping
             if (property is VectorStoreRecordKeyProperty keyProperty)
             {
                 // Do nothing, since key is not stored as part of the payload and therefore doesn't have to be added to the index.
+                continue;
             }
 
             // Data property.
@@ -77,6 +78,8 @@ internal static class RedisVectorStoreCollectionCreateMapping
                 {
                     schema.AddNumericField(new FieldName($"$.{dataProperty.PropertyName}", dataProperty.PropertyName));
                 }
+
+                continue;
             }
 
             // Vector property.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.SemanticKernel.Data;
+using NRedisStack.Search;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Contains mapping helpers to use when creating a redis vector collection.
+/// </summary>
+internal static class RedisVectorStoreCollectionCreateMapping
+{
+    /// <summary>A set of number types that are supported for filtering.</summary>
+    public static readonly HashSet<Type> s_supportedFilterableNumericDataTypes =
+    [
+        typeof(short),
+        typeof(sbyte),
+        typeof(byte),
+        typeof(ushort),
+        typeof(int),
+        typeof(uint),
+        typeof(long),
+        typeof(ulong),
+        typeof(float),
+        typeof(double),
+        typeof(decimal),
+
+        typeof(short?),
+        typeof(sbyte?),
+        typeof(byte?),
+        typeof(ushort?),
+        typeof(int?),
+        typeof(uint?),
+        typeof(long?),
+        typeof(ulong?),
+        typeof(float?),
+        typeof(double?),
+        typeof(decimal?),
+    ];
+
+    /// <summary>
+    /// Map from the given list of <see cref="VectorStoreRecordProperty"/> items to the Redis <see cref="Schema"/>.
+    /// </summary>
+    /// <param name="properties">The property definitions to map from.</param>
+    /// <returns>The mapped Redis <see cref="Schema"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if there are missing required or unsupported configuration options set.</exception>
+    public static Schema MapToSchema(IEnumerable<VectorStoreRecordProperty> properties)
+    {
+        var schema = new Schema();
+
+        // Loop through all properties and create the index fields.
+        foreach (var property in properties)
+        {
+            // Key property.
+            if (property is VectorStoreRecordKeyProperty keyProperty)
+            {
+                // Do nothing, since key is not stored as part of the payload and therefore doesn't have to be added to the index.
+            }
+
+            // Data property.
+            if (property is VectorStoreRecordDataProperty dataProperty && dataProperty.IsFilterable)
+            {
+                if (dataProperty.PropertyType is null)
+                {
+                    throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.PropertyName}' must be set to create a collection, since the property is filterable.");
+                }
+
+                if (dataProperty.PropertyType == typeof(string))
+                {
+                    schema.AddTextField(new FieldName($"$.{dataProperty.PropertyName}", dataProperty.PropertyName));
+                }
+
+                if (RedisVectorStoreCollectionCreateMapping.s_supportedFilterableNumericDataTypes.Contains(dataProperty.PropertyType))
+                {
+                    schema.AddNumericField(new FieldName($"$.{dataProperty.PropertyName}", dataProperty.PropertyName));
+                }
+            }
+
+            // Vector property.
+            if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                if (vectorProperty.Dimensions is not > 0)
+                {
+                    throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}' must be set to a positive ingeteger to create a collection.");
+                }
+
+                var indexKind = GetSDKIndexKind(vectorProperty);
+                var distanceAlgorithm = GetSDKDistanceAlgorithm(vectorProperty);
+                var dimensions = vectorProperty.Dimensions.Value.ToString(CultureInfo.InvariantCulture);
+                schema.AddVectorField(new FieldName($"$.{vectorProperty.PropertyName}", vectorProperty.PropertyName), indexKind, new Dictionary<string, object>()
+                {
+                    ["TYPE"] = "FLOAT32",
+                    ["DIM"] = dimensions,
+                    ["DISTANCE_METRIC"] = distanceAlgorithm
+                });
+            }
+        }
+
+        return schema;
+    }
+
+    /// <summary>
+    /// Get the configured <see cref="Schema.VectorField.VectorAlgo"/> from the given <paramref name="vectorProperty"/>.
+    /// If none is configured the default is <see cref="Schema.VectorField.VectorAlgo.HNSW"/>.
+    /// </summary>
+    /// <param name="vectorProperty">The vector property definition.</param>
+    /// <returns>The chosen <see cref="Schema.VectorField.VectorAlgo"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if a index type was chosen that isn't supported by Redis.</exception>
+    public static Schema.VectorField.VectorAlgo GetSDKIndexKind(VectorStoreRecordVectorProperty vectorProperty)
+    {
+        if (vectorProperty.IndexKind is null)
+        {
+            return Schema.VectorField.VectorAlgo.HNSW;
+        }
+
+        return vectorProperty.IndexKind switch
+        {
+            IndexKind.Hnsw => Schema.VectorField.VectorAlgo.HNSW,
+            IndexKind.Flat => Schema.VectorField.VectorAlgo.FLAT,
+            _ => throw new InvalidOperationException($"Unsupported index kind '{vectorProperty.IndexKind}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+        };
+    }
+
+    /// <summary>
+    /// Get the configured distance metric from the given <paramref name="vectorProperty"/>.
+    /// If none is configured, the default is cosine.
+    /// </summary>
+    /// <param name="vectorProperty">The vector property definition.</param>
+    /// <returns>The chosen distance metric.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if a distance function is chosen that isn't supported by Redis.</exception>
+    public static string GetSDKDistanceAlgorithm(VectorStoreRecordVectorProperty vectorProperty)
+    {
+        if (vectorProperty.DistanceFunction is null)
+        {
+            return "COSINE";
+        }
+
+        return vectorProperty.DistanceFunction switch
+        {
+            DistanceFunction.CosineSimilarity => "COSINE",
+            DistanceFunction.DotProductSimilarity => "IP",
+            DistanceFunction.EuclideanDistance => "L2",
+            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+        };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Data;
 using NRedisStack.Json.DataTypes;
 using NRedisStack.RedisStackCommands;
-using NRedisStack.Search.Literals.Enums;
 using NRedisStack.Search;
+using NRedisStack.Search.Literals.Enums;
 using StackExchange.Redis;
 
 namespace Microsoft.SemanticKernel.Connectors.Redis;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
@@ -12,6 +12,8 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Data;
 using NRedisStack.Json.DataTypes;
 using NRedisStack.RedisStackCommands;
+using NRedisStack.Search.Literals.Enums;
+using NRedisStack.Search;
 using StackExchange.Redis;
 
 namespace Microsoft.SemanticKernel.Connectors.Redis;
@@ -52,6 +54,9 @@ public sealed class RedisVectorStoreRecordCollection<TRecord> : IVectorStoreReco
     /// <summary>Optional configuration options for this class.</summary>
     private readonly RedisVectorStoreRecordCollectionOptions<TRecord> _options;
 
+    /// <summary>A definition of the current storage model.</summary>
+    private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
+
     /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
     private readonly PropertyInfo _keyPropertyInfo;
 
@@ -85,6 +90,7 @@ public sealed class RedisVectorStoreRecordCollection<TRecord> : IVectorStoreReco
         this._collectionName = collectionName;
         this._options = options ?? new RedisVectorStoreRecordCollectionOptions<TRecord>();
         this._jsonSerializerOptions = this._options.JsonSerializerOptions ?? JsonSerializerOptions.Default;
+        this._vectorStoreRecordDefinition = this._options.VectorStoreRecordDefinition ?? VectorStoreRecordPropertyReader.CreateVectorStoreRecordDefinitionFromType(typeof(TRecord), true);
 
         // Enumerate public properties using configuration or attributes.
         (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties;
@@ -148,6 +154,31 @@ public sealed class RedisVectorStoreRecordCollection<TRecord> : IVectorStoreReco
                 CollectionName = this._collectionName,
                 OperationName = "FT.INFO"
             };
+        }
+    }
+
+    /// <inheritdoc />
+    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        // Map the record definition to a schema.
+        var schema = RedisVectorStoreCollectionCreateMapping.MapToSchema(this._vectorStoreRecordDefinition.Properties);
+
+        // Create the index creation params.
+        // Add the collection name and colon as the index prefix, which means that any record where the key is prefixed with this text will be indexed by this index
+        var createParams = new FTCreateParams()
+            .AddPrefix($"{this._collectionName}:")
+            .On(IndexDataType.JSON);
+
+        // Create the index.
+        return this.RunOperationAsync("FT.CREATE", () => this._database.FT().CreateAsync(this._collectionName, createParams, schema));
+    }
+
+    /// <inheritdoc />
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await this.CreateCollectionAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Data;
+using NRedisStack.Search;
+using Xunit;
+using static NRedisStack.Search.Schema;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorStoreCollectionCreateMapping"/> class.
+/// </summary>
+public class RedisVectorStoreCollectionCreateMappingTests
+{
+    [Fact]
+    public void MapToSchemaCreatesSchema()
+    {
+        // Arrange.
+        var properties = new VectorStoreRecordProperty[]
+        {
+            new VectorStoreRecordKeyProperty("Key"),
+
+            new VectorStoreRecordDataProperty("FilterableString") { PropertyType = typeof(string), IsFilterable = true },
+            new VectorStoreRecordDataProperty("FilterableInt") { PropertyType = typeof(int), IsFilterable = true },
+            new VectorStoreRecordDataProperty("FilterableNullableInt") { PropertyType = typeof(int?), IsFilterable = true },
+
+            new VectorStoreRecordDataProperty("NonFilterableString") { PropertyType = typeof(string) },
+
+            new VectorStoreRecordVectorProperty("VectorDefaultIndexingOptions") { Dimensions = 10 },
+            new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions") { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanDistance },
+        };
+
+        // Act.
+        var schema = RedisVectorStoreCollectionCreateMapping.MapToSchema(properties);
+
+        // Assert.
+        Assert.NotNull(schema);
+        Assert.Equal(5, schema.Fields.Count);
+
+        Assert.IsType<TextField>(schema.Fields[0]);
+        Assert.IsType<NumericField>(schema.Fields[1]);
+        Assert.IsType<NumericField>(schema.Fields[2]);
+        Assert.IsType<VectorField>(schema.Fields[3]);
+        Assert.IsType<VectorField>(schema.Fields[4]);
+
+        VerifyFieldName(schema.Fields[0].FieldName, new List<object> { "$.FilterableString", "AS", "FilterableString" });
+        VerifyFieldName(schema.Fields[1].FieldName, new List<object> { "$.FilterableInt", "AS", "FilterableInt" });
+        VerifyFieldName(schema.Fields[2].FieldName, new List<object> { "$.FilterableNullableInt", "AS", "FilterableNullableInt" });
+
+        VerifyFieldName(schema.Fields[3].FieldName, new List<object> { "$.VectorDefaultIndexingOptions", "AS", "VectorDefaultIndexingOptions" });
+        VerifyFieldName(schema.Fields[4].FieldName, new List<object> { "$.VectorSpecificIndexingOptions", "AS", "VectorSpecificIndexingOptions" });
+
+        Assert.Equal("10", ((VectorField)schema.Fields[3]).Attributes!["DIM"]);
+        Assert.Equal("FLOAT32", ((VectorField)schema.Fields[3]).Attributes!["TYPE"]);
+        Assert.Equal("COSINE", ((VectorField)schema.Fields[3]).Attributes!["DISTANCE_METRIC"]);
+
+        Assert.Equal("20", ((VectorField)schema.Fields[4]).Attributes!["DIM"]);
+        Assert.Equal("FLOAT32", ((VectorField)schema.Fields[4]).Attributes!["TYPE"]);
+        Assert.Equal("L2", ((VectorField)schema.Fields[4]).Attributes!["DISTANCE_METRIC"]);
+    }
+
+    [Fact]
+    public void MapToSchemaThrowsOnMissingPropertyType()
+    {
+        // Arrange.
+        var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordDataProperty("FilterableString") { IsFilterable = true } };
+
+        // Act and assert.
+        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void MapToSchemaThrowsOnInvalidVectorDimensions(int? dimensions)
+    {
+        // Arrange.
+        var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordVectorProperty("VectorProperty") { Dimensions = dimensions } };
+
+        // Act and assert.
+        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties));
+    }
+
+    [Fact]
+    public void GetSDKIndexKindThrowsOnUnsupportedIndexKind()
+    {
+        // Arrange.
+        var vectorProperty = new VectorStoreRecordVectorProperty("VectorProperty") { IndexKind = "Unsupported" };
+
+        // Act and assert.
+        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.GetSDKIndexKind(vectorProperty));
+    }
+
+    [Fact]
+    public void GetSDKDistanceAlgorithmThrowsOnUnsupportedDistanceFunction()
+    {
+        // Arrange.
+        var vectorProperty = new VectorStoreRecordVectorProperty("VectorProperty") { DistanceFunction = "Unsupported" };
+
+        // Act and assert.
+        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.GetSDKDistanceAlgorithm(vectorProperty));
+    }
+
+    private static void VerifyFieldName(FieldName fieldName, List<object> expected)
+    {
+        var args = new List<object>();
+        fieldName.AddCommandArguments(args);
+        Assert.Equal(expected, args);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreRecordCollectionTests.cs
@@ -65,6 +65,26 @@ public class RedisVectorStoreRecordCollectionTests
     }
 
     [Fact]
+    public async Task CanCreateCollectionAsync()
+    {
+        // Arrange.
+        SetupExecuteMock(this._redisDatabaseMock, string.Empty);
+        var sut = new RedisVectorStoreRecordCollection<SinglePropsModel>(this._redisDatabaseMock.Object, TestCollectionName);
+
+        // Act.
+        await sut.CreateCollectionAsync();
+
+        // Assert.
+        var expectedArgs = new object[] { "testcollection", "ON", "JSON", "PREFIX", 1, "testcollection:", "SCHEMA", "$.Vector", "AS", "Vector", "VECTOR", "HNSW", 6, "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "COSINE" };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "FT.CREATE",
+                    It.Is<object[]>(x => x.SequenceEqual(expectedArgs))),
+                Times.Once);
+    }
+
+    [Fact]
     public async Task CanDeleteCollectionAsync()
     {
         // Arrange
@@ -435,7 +455,7 @@ public class RedisVectorStoreRecordCollectionTests
         [VectorStoreRecordData]
         public string Data { get; set; } = string.Empty;
 
-        [VectorStoreRecordVector]
+        [VectorStoreRecordVector(4)]
         public ReadOnlyMemory<float>? Vector { get; set; }
 
         public string? NotAnnotated { get; set; }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -38,10 +38,10 @@ public class RedisVectorStoreFixture : IAsyncLifetime
             Properties = new List<VectorStoreRecordProperty>
             {
                 new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName"),
-                new VectorStoreRecordDataProperty("HotelCode"),
+                new VectorStoreRecordDataProperty("HotelName") { IsFilterable = true, PropertyType = typeof(string) },
+                new VectorStoreRecordDataProperty("HotelCode") { IsFilterable = true, PropertyType = typeof(int) },
                 new VectorStoreRecordDataProperty("Description"),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding"),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding") { Dimensions = 4 },
                 new VectorStoreRecordDataProperty("Tags"),
                 new VectorStoreRecordDataProperty("ParkingIncluded"),
                 new VectorStoreRecordDataProperty("LastRenovationDate"),
@@ -166,16 +166,16 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         [VectorStoreRecordKey]
         public string HotelId { get; init; }
 
-        [VectorStoreRecordData]
+        [VectorStoreRecordData(IsFilterable = true)]
         public string HotelName { get; init; }
 
-        [VectorStoreRecordData]
+        [VectorStoreRecordData(IsFilterable = true)]
         public int HotelCode { get; init; }
 
         [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
         public string Description { get; init; }
 
-        [VectorStoreRecordVector]
+        [VectorStoreRecordVector(4)]
         public ReadOnlyMemory<float>? DescriptionEmbedding { get; init; }
 
 #pragma warning disable CA1819 // Properties should not return arrays

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreRecordCollectionTests.cs
@@ -37,6 +37,34 @@ public sealed class RedisVectorStoreRecordCollectionTests(ITestOutputHelper outp
         Assert.Equal(expectedExists, actual);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItCanCreateACollectionAsync(bool useRecordDefinition)
+    {
+        // Arrange
+        var collectionNamePostfix = useRecordDefinition ? "WithDefinition" : "WithType";
+        var testCollectionName = $"createtest{collectionNamePostfix}";
+
+        var options = new RedisVectorStoreRecordCollectionOptions<Hotel>
+        {
+            PrefixCollectionNameToKeyNames = true,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.VectorStoreRecordDefinition : null
+        };
+        var sut = new RedisVectorStoreRecordCollection<Hotel>(fixture.Database, testCollectionName, options);
+
+        // Act
+        await sut.CreateCollectionAsync();
+
+        // Assert
+        var existResult = await sut.CollectionExistsAsync();
+        Assert.True(existResult);
+        await sut.DeleteCollectionAsync();
+
+        // Output
+        output.WriteLine(existResult.ToString());
+    }
+
     [Fact]
     public async Task ItCanDeleteCollectionAsync()
     {


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This PR contains:
- The ability to create Redis collections

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
