### PR TITLE
.Net: Add CreateCollection to Volatile vectorstore and abstraction

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
@@ -31,10 +31,24 @@ public interface IVectorStoreRecordCollection<TKey, TRecord>
     Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Create this collection in the vector store.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A <see cref="Task"/> that completes when the collection has been created.</returns>
+    Task CreateCollectionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create this collection in the vector store if it does not already exist.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A <see cref="Task"/> that completes when the collection has been created.</returns>
+    Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Delete the collection from the vector store.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>A task that completes when the collection has been deleted.</returns>
+    /// <returns>A <see cref="Task"/> that completes when the collection has been deleted.</returns>
     Task DeleteCollectionAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -82,6 +96,7 @@ public interface IVectorStoreRecordCollection<TKey, TRecord>
     /// <param name="keys">The unique ids associated with the records to remove.</param>
     /// <param name="options">Optional options for removing the records.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A <see cref="Task"/> that completes when the records have been deleted.</returns>
     /// <exception cref="VectorStoreOperationException">Throw when the command fails to execute for any reason other than that a record does not exist.</exception>
     Task DeleteBatchAsync(IEnumerable<TKey> keys, DeleteRecordOptions? options = default, CancellationToken cancellationToken = default);
 

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -92,6 +92,22 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
+    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        this._internalCollection.TryAdd(this._collectionName, new ConcurrentDictionary<string, TRecord>());
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await this.CreateCollectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         this._internalCollection.TryRemove(this._collectionName, out _);

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -49,6 +49,19 @@ public class VolatileVectorStoreRecordCollectionTests
     }
 
     [Fact]
+    public async Task CanCreateCollectionAsync()
+    {
+        // Arrange
+        var sut = this.CreateRecordCollection(false);
+
+        // Act
+        await sut.CreateCollectionAsync(this._testCancellationToken);
+
+        // Assert
+        Assert.True(this._collectionStore.ContainsKey(TestCollectionName));
+    }
+
+    [Fact]
     public async Task DeleteCollectionRemovesCollectionFromDictionaryAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This PR contains:

- The ability to create Volatile collections
- Updating the abstraction to include the new methods.

With this pr, all implementations now support create.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
