### PR TITLE
.Net: Add IVectorStore interface and Volatile implementation

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStore.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Interface for accessing the list of collections in a vector store.
+/// </summary>
+/// <remarks>
+/// This interface can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
+/// </remarks>
+public interface IVectorStore
+{
+    /// <summary>
+    /// Get a collection from the vector store.
+    /// </summary>
+    /// <typeparam name="TKey">The data type of the record key.</typeparam>
+    /// <typeparam name="TRecord">The record data model to use for adding, updating and retrieving data from the collection.</typeparam>
+    /// <param name="name">The name of the collection.</param>
+    /// <param name="vectorStoreRecordDefinition">Defines the schema of the record type.</param>
+    /// <returns>A new <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> instance for managing the records in the collection.</returns>
+    /// <remarks>
+    /// To successfully request a collection, either <typeparamref name="TRecord"/> must be annotated with attributes that define the schema of
+    /// the record type, or <paramref name="vectorStoreRecordDefinition"/> must be provided.
+    /// </remarks>
+    /// <seealso cref="VectorStoreRecordKeyAttribute"/>
+    /// <seealso cref="VectorStoreRecordDataAttribute"/>
+    /// <seealso cref="VectorStoreRecordVectorAttribute"/>
+    IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TRecord : class;
+
+    /// <summary>
+    /// Retrieve the names of all the collections in the vector store.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The list of names of all the collections in the vector store.</returns>
+    IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
@@ -6,8 +6,12 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Attribute to mark a property on a record class as data.
+/// Attribute to mark a property on a record class as 'data'.
 /// </summary>
+/// <remarks>
+/// Marking a property as 'data' means that the property is not a key, and not a vector, but optionally
+/// this property may have an associated vector field containing an embedding for this data.
+/// </remarks>
 [Experimental("SKEXP0001")]
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class VectorStoreRecordDataAttribute : Attribute

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Service for storing and retrieving vector records, and managing vector record collections, that uses an in memory dictionary as the underlying storage.
+/// </summary>
+[Experimental("SKEXP0001")]
+public sealed class VolatileVectorStore : IVectorStore
+{
+    /// <summary>Internal storage for the record collection.</summary>
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object>> _internalCollection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VolatileVectorStore"/> class.
+    /// </summary>
+    public VolatileVectorStore()
+    {
+        this._internalCollection = new();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VolatileVectorStore"/> class.
+    /// </summary>
+    /// <param name="internalCollection">Allows passing in the dictionary used for storage, for testing purposes.</param>
+    internal VolatileVectorStore(ConcurrentDictionary<string, ConcurrentDictionary<string, object>> internalCollection)
+    {
+        this._internalCollection = internalCollection;
+    }
+
+    /// <inheritdoc />
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    {
+        if (typeof(TKey) != typeof(string))
+        {
+            throw new NotSupportedException("Only string keys are supported.");
+        }
+
+        var typedInternalCollection = this._internalCollection as ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>>;
+        var collection = new VolatileVectorStoreRecordCollection<TRecord>(typedInternalCollection!, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+        return collection!;
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)
+    {
+        return this._internalCollection.Keys.ToAsyncEnumerable();
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Data;
+
+/// <summary>
+/// Contains tests for the <see cref="VolatileVectorStore"/> class.
+/// </summary>
+public class VolatileVectorStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+
+    [Fact]
+    public void GetCollectionReturnsCollection()
+    {
+        // Arrange.
+        var sut = new VolatileVectorStore();
+
+        // Act.
+        var actual = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.IsType<VolatileVectorStoreRecordCollection<SinglePropsModel<string>>>(actual);
+    }
+
+    [Fact]
+    public void GetCollectionThrowsForInvalidKeyType()
+    {
+        // Arrange.
+        var sut = new VolatileVectorStore();
+
+        // Act & Assert.
+        Assert.Throws<NotSupportedException>(() => sut.GetCollection<int, SinglePropsModel<int>>(TestCollectionName));
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesReadsDictionaryAsync()
+    {
+        // Arrange.
+        var collectionStore = new ConcurrentDictionary<string, ConcurrentDictionary<string, object>>();
+        collectionStore.TryAdd("collection1", new ConcurrentDictionary<string, object>());
+        collectionStore.TryAdd("collection2", new ConcurrentDictionary<string, object>());
+        var sut = new VolatileVectorStore(collectionStore);
+
+        // Act.
+        var collectionNames = sut.ListCollectionNamesAsync();
+
+        // Assert.
+        var collectionNamesList = await collectionNames.ToListAsync();
+        Assert.Equal(new[] { "collection1", "collection2" }, collectionNamesList);
+    }
+
+    public sealed class SinglePropsModel<TKey>
+    {
+        [VectorStoreRecordKey]
+        public required TKey Key { get; set; }
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This PR adds:
- The new IVectorStore interface that can serve collection instances and list collection names.
- An in memory (Volatile) implementation of the new interface.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
