### PR TITLE
.Net: Adding VectorStore for Azure AI Search.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreTests.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Microsoft.SemanticKernel.Data;
 using Moq;
 using Xunit;
-using Microsoft.SemanticKernel.Connectors.AzureAISearch;
-using Azure;
-using Microsoft.SemanticKernel.Data;
-using Azure.Search.Documents;
 
 namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
 

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Search.Documents.Indexes;
+using Moq;
+using Xunit;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Azure;
+using Microsoft.SemanticKernel.Data;
+using Azure.Search.Documents;
+
+namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="AzureAISearchVectorStore"/> class.
+/// </summary>
+public class AzureAISearchVectorStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+
+    private readonly Mock<SearchIndexClient> _searchIndexClientMock;
+    private readonly Mock<SearchClient> _searchClientMock;
+
+    private readonly CancellationToken _testCancellationToken = new(false);
+
+    public AzureAISearchVectorStoreTests()
+    {
+        this._searchClientMock = new Mock<SearchClient>(MockBehavior.Strict);
+        this._searchIndexClientMock = new Mock<SearchIndexClient>(MockBehavior.Strict);
+        this._searchIndexClientMock.Setup(x => x.GetSearchClient(TestCollectionName)).Returns(this._searchClientMock.Object);
+    }
+
+    [Fact]
+    public void GetCollectionReturnsCollection()
+    {
+        // Arrange.
+        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
+
+        // Act.
+        var actual = sut.GetCollection<string, SinglePropsModel>(TestCollectionName);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<SinglePropsModel>>(actual);
+    }
+
+    [Fact]
+    public void GetCollectionCallsFactoryIfProvided()
+    {
+        // Arrange.
+        var factoryMock = new Mock<IAzureAISearchVectorStoreRecordCollectionFactory>(MockBehavior.Strict);
+        var collectionMock = new Mock<IVectorStoreRecordCollection<string, SinglePropsModel>>(MockBehavior.Strict);
+        factoryMock
+            .Setup(x => x.CreateVectorStoreRecordCollection<string, SinglePropsModel>(this._searchIndexClientMock.Object, TestCollectionName, null))
+            .Returns(collectionMock.Object);
+        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object, new() { VectorStoreCollectionFactory = factoryMock.Object });
+
+        // Act.
+        var actual = sut.GetCollection<string, SinglePropsModel>(TestCollectionName);
+
+        // Assert.
+        Assert.Equal(collectionMock.Object, actual);
+    }
+
+    [Fact]
+    public void GetCollectionThrowsForInvalidKeyType()
+    {
+        // Arrange.
+        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
+
+        // Act & Assert.
+        Assert.Throws<NotSupportedException>(() => sut.GetCollection<int, SinglePropsModel>(TestCollectionName));
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesCallsSDKAsync()
+    {
+        // Arrange async enumerator mock.
+        var iterationCounter = 0;
+        var asyncEnumeratorMock = new Mock<IAsyncEnumerator<string>>(MockBehavior.Strict);
+        asyncEnumeratorMock.Setup(x => x.MoveNextAsync()).Returns(() => ValueTask.FromResult(iterationCounter++ <= 4));
+        asyncEnumeratorMock.Setup(x => x.Current).Returns(() => $"testcollection{iterationCounter}");
+
+        // Arrange pageable mock.
+        var pageableMock = new Mock<AsyncPageable<string>>(MockBehavior.Strict);
+        pageableMock.Setup(x => x.GetAsyncEnumerator(this._testCancellationToken)).Returns(asyncEnumeratorMock.Object);
+
+        // Arrange search index client mock and sut.
+        this._searchIndexClientMock
+            .Setup(x => x.GetIndexNamesAsync(this._testCancellationToken))
+            .Returns(pageableMock.Object);
+        var sut = new AzureAISearchVectorStore(this._searchIndexClientMock.Object);
+
+        // Act.
+        var actual = sut.ListCollectionNamesAsync(this._testCancellationToken);
+
+        // Assert.
+        Assert.NotNull(actual);
+        var actualList = await actual.ToListAsync();
+        Assert.Equal(5, actualList.Count);
+        Assert.All(actualList, (value, index) => Assert.Equal($"testcollection{index + 1}", value));
+    }
+
+    public sealed class SinglePropsModel
+    {
+        [VectorStoreRecordKey]
+        public string Key { get; set; } = string.Empty;
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Search.Documents.Indexes;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
+
+/// <summary>
+/// Class for accessing the list of collections in a Azure AI Search vector store.
+/// </summary>
+/// <remarks>
+/// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
+/// </remarks>
+public sealed class AzureAISearchVectorStore : IVectorStore
+{
+    /// <summary>The name of this database for telemetry purposes.</summary>
+    private const string DatabaseName = "AzureAISearch";
+
+    /// <summary>Azure AI Search client that can be used to manage the list of indices in an Azure AI Search Service.</summary>
+    private readonly SearchIndexClient _searchIndexClient;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly AzureAISearchVectorStoreOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureAISearchVectorStore"/> class.
+    /// </summary>
+    /// <param name="searchIndexClient">Azure AI Search client that can be used to manage the list of indices in an Azure AI Search Service.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    public AzureAISearchVectorStore(SearchIndexClient searchIndexClient, AzureAISearchVectorStoreOptions? options = default)
+    {
+        Verify.NotNull(searchIndexClient);
+
+        this._searchIndexClient = searchIndexClient;
+        this._options = options ?? new AzureAISearchVectorStoreOptions();
+    }
+
+    /// <inheritdoc />
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    {
+        if (typeof(TKey) != typeof(string))
+        {
+            throw new NotSupportedException("Only string keys are supported.");
+        }
+
+        if (this._options.VectorStoreCollectionFactory is not null)
+        {
+            return this._options.VectorStoreCollectionFactory.CreateVectorStoreRecordCollection<TKey, TRecord>(this._searchIndexClient, name, vectorStoreRecordDefinition);
+        }
+
+        var directlyCreatedStore = new AzureAISearchVectorStoreRecordCollection<TRecord>(this._searchIndexClient, name, new AzureAISearchVectorStoreRecordCollectionOptions<TRecord>() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+        return directlyCreatedStore!;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var indexNamesEnumerable = this._searchIndexClient.GetIndexNamesAsync(cancellationToken).ConfigureAwait(false);
+        var indexNamesEnumerator = indexNamesEnumerable.GetAsyncEnumerator();
+
+        var nextResult = await GetNextIndexNameAsync(indexNamesEnumerator).ConfigureAwait(false);
+        while (nextResult.more)
+        {
+            yield return nextResult.name;
+            nextResult = await GetNextIndexNameAsync(indexNamesEnumerator).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Helper method to get the next index name from the enumerator with a try catch around the move next call to convert
+    /// any <see cref="RequestFailedException"/> to <see cref="HttpOperationException"/>, since try catch is not supported
+    /// around a yield return.
+    /// </summary>
+    /// <param name="enumerator">The enumerator to get the next result from.</param>
+    /// <returns>A value indicating whether there are more results and the current string if true.</returns>
+    private static async Task<(string name, bool more)> GetNextIndexNameAsync(ConfiguredCancelableAsyncEnumerable<string>.Enumerator enumerator)
+    {
+        const string OperationName = "GetIndexNames";
+
+        try
+        {
+            var more = await enumerator.MoveNextAsync();
+            return (enumerator.Current, more);
+        }
+        catch (AggregateException ex) when (ex.InnerException is RequestFailedException innerEx)
+        {
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                VectorStoreType = DatabaseName,
+                OperationName = OperationName
+            };
+        }
+        catch (RequestFailedException ex)
+        {
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                VectorStoreType = DatabaseName,
+                OperationName = OperationName
+            };
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
+
+/// <summary>
+/// Options when creating a <see cref="AzureAISearchVectorStore"/>.
+/// </summary>
+public sealed class AzureAISearchVectorStoreOptions
+{
+    /// <summary>
+    /// An optional factory to use for constructing <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> instances, if custom options are required.
+    /// </summary>
+    public IAzureAISearchVectorStoreRecordCollectionFactory? VectorStoreCollectionFactory { get; init; }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/IAzureAISearchVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/IAzureAISearchVectorStoreRecordCollectionFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Azure.Search.Documents.Indexes;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
+
+/// <summary>
+/// Interface for constructing <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> Azure AI Search instances when using <see cref="IVectorStore"/> to retrieve these.
+/// </summary>
+public interface IAzureAISearchVectorStoreRecordCollectionFactory
+{
+    /// <summary>
+    /// Constructs a new instance of the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The data type of the record key.</typeparam>
+    /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+    /// <param name="searchIndexClient">Azure AI Search client that can be used to manage the list of indices in an Azure AI Search Service.</param>
+    /// <param name="name">The name of the collection to connect to.</param>
+    /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
+    /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(SearchIndexClient searchIndexClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -16,7 +16,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch;
 
 /// <summary>
 /// Integration tests for <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> class.
-/// Tests work with Azure AI Search Instance.
+/// Tests work with an Azure AI Search Instance.
 /// </summary>
 [Collection("AzureAISearchVectorStoreCollection")]
 public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHelper output, AzureAISearchVectorStoreFixture fixture)

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -19,7 +19,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch;
 /// Tests work with Azure AI Search Instance.
 /// </summary>
 [Collection("AzureAISearchVectorStoreCollection")]
-public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHelper output, AzureAISearchVectorStoreFixture fixture) : IClassFixture<AzureAISearchVectorStoreFixture>
+public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHelper output, AzureAISearchVectorStoreFixture fixture)
 {
     // If null, all tests will be enabled
     private const string SkipReason = null; //"Requires Azure AI Search Service instance up and running";

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch;
+
+/// <summary>
+/// Contains integration tests for the <see cref="AzureAISearchVectorStore"/> class.
+/// Tests work with an Azure AI Search Instance.
+/// </summary>
+[Collection("AzureAISearchVectorStoreCollection")]
+public class AzureAISearchVectorStoreTests(ITestOutputHelper output, AzureAISearchVectorStoreFixture fixture)
+{
+    // If null, all tests will be enabled
+    private const string SkipReason = null; //"Requires Azure AI Search Service instance up and running";
+
+    [Fact(Skip = SkipReason)]
+    public async Task ItCanGetAListOfExistingCollectionNamesAsync()
+    {
+        // Arrange
+        var additionalCollectionName = fixture.TestIndexName + "-listnames";
+        await AzureAISearchVectorStoreFixture.DeleteIndexIfExistsAsync(additionalCollectionName, fixture.SearchIndexClient);
+        await AzureAISearchVectorStoreFixture.CreateIndexAsync(additionalCollectionName, fixture.SearchIndexClient);
+        var sut = new AzureAISearchVectorStore(fixture.SearchIndexClient);
+
+        // Act
+        var collectionNames = await sut.ListCollectionNamesAsync().ToListAsync();
+
+        // Assert
+        Assert.Equal(2, collectionNames.Where(x => x.StartsWith(fixture.TestIndexName, StringComparison.InvariantCultureIgnoreCase)).Count());
+        Assert.Contains(fixture.TestIndexName, collectionNames);
+        Assert.Contains(additionalCollectionName, collectionNames);
+
+        // Output
+        output.WriteLine(string.Join(",", collectionNames));
+
+        // Cleanup
+        await AzureAISearchVectorStoreFixture.DeleteIndexIfExistsAsync(additionalCollectionName, fixture.SearchIndexClient);
+    }
+}


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This pr adds
- A IVectorStore implementation for AzureAISearch

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
