### PR TITLE
Python: Add application ID for Azure AI Inference

### DIFF
--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_base.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_base.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 from abc import ABC
+from typing import ClassVar
 
 from azure.ai.inference.aio import ChatCompletionsClient, EmbeddingsClient
 
@@ -13,6 +14,14 @@ from semantic_kernel.utils.experimental_decorator import experimental_class
 @experimental_class
 class AzureAIInferenceBase(KernelBaseModel, ABC):
     """Azure AI Inference Chat Completion Service."""
+
+    # All Microsoft tools/SDKs that internally use the Azure AI Inference SDK are required to set
+    # a unique application ID, which will be part of the "use-agent" HTTP request header. This will
+    # allow teams to track usage from that tool/SDK, using service-side telemetry dashboards.
+    # Semantic Kernel's application ID is registered as "semantic-kernel". Note that the application
+    # ID is set only when a custom client is not provided, unless the custom client also sets the
+    # application ID.
+    _APPLICATION_ID: ClassVar[str] = "semantic-kernel"
 
     client: ChatCompletionsClient | EmbeddingsClient
 

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_base.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_base.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 
 from azure.ai.inference.aio import ChatCompletionsClient, EmbeddingsClient
 
+from semantic_kernel.connectors.telemetry import APPLICATION_ID
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
@@ -18,10 +19,10 @@ class AzureAIInferenceBase(KernelBaseModel, ABC):
     # All Microsoft tools/SDKs that internally use the Azure AI Inference SDK are required to set
     # a unique application ID, which will be part of the "use-agent" HTTP request header. This will
     # allow teams to track usage from that tool/SDK, using service-side telemetry dashboards.
-    # Semantic Kernel's application ID is registered as "semantic-kernel". Note that the application
-    # ID is set only when a custom client is not provided, unless the custom client also sets the
-    # application ID.
-    _APPLICATION_ID: ClassVar[str] = "semantic-kernel"
+    # Semantic Kernel's application ID is registered as "semantic-kernel-python/{version}".
+    # Note that the application ID is set only when a custom client is not provided, unless the
+    # custom client also sets the application ID.
+    _APPLICATION_ID: ClassVar[str] = APPLICATION_ID
 
     client: ChatCompletionsClient | EmbeddingsClient
 

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_base.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_base.py
@@ -3,11 +3,9 @@
 import asyncio
 import contextlib
 from abc import ABC
-from typing import ClassVar
 
 from azure.ai.inference.aio import ChatCompletionsClient, EmbeddingsClient
 
-from semantic_kernel.connectors.telemetry import APPLICATION_ID
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
@@ -15,14 +13,6 @@ from semantic_kernel.utils.experimental_decorator import experimental_class
 @experimental_class
 class AzureAIInferenceBase(KernelBaseModel, ABC):
     """Azure AI Inference Chat Completion Service."""
-
-    # All Microsoft tools/SDKs that internally use the Azure AI Inference SDK are required to set
-    # a unique application ID, which will be part of the "use-agent" HTTP request header. This will
-    # allow teams to track usage from that tool/SDK, using service-side telemetry dashboards.
-    # Semantic Kernel's application ID is registered as "semantic-kernel-python/{version}".
-    # Note that the application ID is set only when a custom client is not provided, unless the
-    # custom client also sets the application ID.
-    _APPLICATION_ID: ClassVar[str] = APPLICATION_ID
 
     client: ChatCompletionsClient | EmbeddingsClient
 

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -7,6 +7,8 @@ from collections.abc import AsyncGenerator
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
+from semantic_kernel.connectors.telemetry import SEMANTIC_KERNEL_USER_AGENT
+
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
 else:
@@ -104,7 +106,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
             client = ChatCompletionsClient(
                 endpoint=str(azure_ai_inference_settings.endpoint),
                 credential=AzureKeyCredential(azure_ai_inference_settings.api_key.get_secret_value()),
-                user_agent=self._APPLICATION_ID,
+                user_agent=SEMANTIC_KERNEL_USER_AGENT,
             )
 
         super().__init__(

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -104,6 +104,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
             client = ChatCompletionsClient(
                 endpoint=str(azure_ai_inference_settings.endpoint),
                 credential=AzureKeyCredential(azure_ai_inference_settings.api_key.get_secret_value()),
+                user_agent=self._APPLICATION_ID,
             )
 
         super().__init__(

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_text_embedding.py
@@ -14,6 +14,7 @@ from semantic_kernel.connectors.ai.azure_ai_inference.azure_ai_inference_prompt_
 from semantic_kernel.connectors.ai.azure_ai_inference.azure_ai_inference_settings import AzureAIInferenceSettings
 from semantic_kernel.connectors.ai.azure_ai_inference.services.azure_ai_inference_base import AzureAIInferenceBase
 from semantic_kernel.connectors.ai.embeddings.embedding_generator_base import EmbeddingGeneratorBase
+from semantic_kernel.connectors.telemetry import SEMANTIC_KERNEL_USER_AGENT
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
@@ -68,7 +69,7 @@ class AzureAIInferenceTextEmbedding(EmbeddingGeneratorBase, AzureAIInferenceBase
             client = EmbeddingsClient(
                 endpoint=str(azure_ai_inference_settings.endpoint),
                 credential=AzureKeyCredential(azure_ai_inference_settings.api_key.get_secret_value()),
-                user_agent=self._APPLICATION_ID,
+                user_agent=SEMANTIC_KERNEL_USER_AGENT,
             )
 
         super().__init__(

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_text_embedding.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_text_embedding.py
@@ -68,6 +68,7 @@ class AzureAIInferenceTextEmbedding(EmbeddingGeneratorBase, AzureAIInferenceBase
             client = EmbeddingsClient(
                 endpoint=str(azure_ai_inference_settings.endpoint),
                 credential=AzureKeyCredential(azure_ai_inference_settings.api_key.get_secret_value()),
+                user_agent=self._APPLICATION_ID,
             )
 
         super().__init__(

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from semantic_kernel.const import USER_AGENT
 
+# Note that if this environment variable does not exist, telemetry is enabled.
 TELEMETRY_DISABLED_ENV_VAR = "AZURE_TELEMETRY_DISABLED"
 
 IS_TELEMETRY_ENABLED = os.environ.get(TELEMETRY_DISABLED_ENV_VAR, "false").lower() not in ["true", "1"]

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -27,6 +27,9 @@ APP_INFO = (
 )
 
 
+APPLICATION_ID = f"{HTTP_USER_AGENT}/{version_info}"
+
+
 def prepend_semantic_kernel_to_user_agent(headers: dict[str, Any]):
     """Prepend "semantic-kernel" to the User-Agent in the headers.
 
@@ -34,12 +37,8 @@ def prepend_semantic_kernel_to_user_agent(headers: dict[str, Any]):
         headers: The existing headers dictionary.
 
     Returns:
-        The modified headers dictionary with "semantic-kernel" prepended to the User-Agent.
+        The modified headers dictionary with "semantic-kernel-python/{version}" prepended to the User-Agent.
     """
-    headers[USER_AGENT] = (
-        f"{HTTP_USER_AGENT}/{version_info} {headers[USER_AGENT]}"
-        if USER_AGENT in headers
-        else f"{HTTP_USER_AGENT}/{version_info}"
-    )
+    headers[USER_AGENT] = f"{APPLICATION_ID} {headers[USER_AGENT]}" if USER_AGENT in headers else APPLICATION_ID
 
     return headers

--- a/python/semantic_kernel/connectors/telemetry.py
+++ b/python/semantic_kernel/connectors/telemetry.py
@@ -27,7 +27,7 @@ APP_INFO = (
 )
 
 
-APPLICATION_ID = f"{HTTP_USER_AGENT}/{version_info}"
+SEMANTIC_KERNEL_USER_AGENT = f"{HTTP_USER_AGENT}/{version_info}"
 
 
 def prepend_semantic_kernel_to_user_agent(headers: dict[str, Any]):
@@ -39,6 +39,8 @@ def prepend_semantic_kernel_to_user_agent(headers: dict[str, Any]):
     Returns:
         The modified headers dictionary with "semantic-kernel-python/{version}" prepended to the User-Agent.
     """
-    headers[USER_AGENT] = f"{APPLICATION_ID} {headers[USER_AGENT]}" if USER_AGENT in headers else APPLICATION_ID
+    headers[USER_AGENT] = (
+        f"{SEMANTIC_KERNEL_USER_AGENT} {headers[USER_AGENT]}" if USER_AGENT in headers else SEMANTIC_KERNEL_USER_AGENT
+    )
 
     return headers

--- a/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_chat_completion.py
+++ b/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_chat_completion.py
@@ -13,7 +13,7 @@ from semantic_kernel.connectors.ai.azure_ai_inference import (
 )
 from semantic_kernel.connectors.ai.azure_ai_inference.azure_ai_inference_settings import AzureAIInferenceSettings
 from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
-from semantic_kernel.connectors.telemetry import APPLICATION_ID
+from semantic_kernel.connectors.telemetry import SEMANTIC_KERNEL_USER_AGENT
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.utils.finish_reason import FinishReason
 from semantic_kernel.exceptions.service_exceptions import (
@@ -49,7 +49,7 @@ def test_azure_ai_inference_chat_completion_client_init(
     assert mock_client.call_args.kwargs["endpoint"] == str(settings.endpoint)
     assert isinstance(mock_client.call_args.kwargs["credential"], AzureKeyCredential)
     assert mock_client.call_args.kwargs["credential"].key == settings.api_key.get_secret_value()
-    assert mock_client.call_args.kwargs["user_agent"] == APPLICATION_ID
+    assert mock_client.call_args.kwargs["user_agent"] == SEMANTIC_KERNEL_USER_AGENT
 
 
 def test_azure_ai_inference_chat_completion_init_with_service_id(

--- a/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_chat_completion.py
+++ b/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_chat_completion.py
@@ -5,12 +5,15 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from azure.ai.inference.aio import ChatCompletionsClient
 from azure.ai.inference.models import UserMessage
+from azure.core.credentials import AzureKeyCredential
 
 from semantic_kernel.connectors.ai.azure_ai_inference import (
     AzureAIInferenceChatCompletion,
     AzureAIInferenceChatPromptExecutionSettings,
 )
+from semantic_kernel.connectors.ai.azure_ai_inference.azure_ai_inference_settings import AzureAIInferenceSettings
 from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+from semantic_kernel.connectors.telemetry import APPLICATION_ID
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.utils.finish_reason import FinishReason
 from semantic_kernel.exceptions.service_exceptions import (
@@ -22,6 +25,7 @@ from semantic_kernel.functions.kernel_arguments import KernelArguments
 
 # region init
 def test_azure_ai_inference_chat_completion_init(azure_ai_inference_unit_test_env, model_id) -> None:
+    """Test initialization of AzureAIInferenceChatCompletion"""
     azure_ai_inference = AzureAIInferenceChatCompletion(model_id)
 
     assert azure_ai_inference.ai_model_id == model_id
@@ -29,9 +33,29 @@ def test_azure_ai_inference_chat_completion_init(azure_ai_inference_unit_test_en
     assert isinstance(azure_ai_inference.client, ChatCompletionsClient)
 
 
+@patch("azure.ai.inference.aio.ChatCompletionsClient.__init__", return_value=None)
+def test_azure_ai_inference_chat_completion_client_init(
+    mock_client, azure_ai_inference_unit_test_env, model_id
+) -> None:
+    """Test initialization of the Azure AI Inference client"""
+    endpoint = azure_ai_inference_unit_test_env["AZURE_AI_INFERENCE_ENDPOINT"]
+    api_key = azure_ai_inference_unit_test_env["AZURE_AI_INFERENCE_API_KEY"]
+    settings = AzureAIInferenceSettings(endpoint=endpoint, api_key=api_key)
+
+    _ = AzureAIInferenceChatCompletion(model_id)
+
+    assert mock_client.call_count == 1
+    assert isinstance(mock_client.call_args.kwargs["endpoint"], str)
+    assert mock_client.call_args.kwargs["endpoint"] == str(settings.endpoint)
+    assert isinstance(mock_client.call_args.kwargs["credential"], AzureKeyCredential)
+    assert mock_client.call_args.kwargs["credential"].key == settings.api_key.get_secret_value()
+    assert mock_client.call_args.kwargs["user_agent"] == APPLICATION_ID
+
+
 def test_azure_ai_inference_chat_completion_init_with_service_id(
     azure_ai_inference_unit_test_env, model_id, service_id
 ) -> None:
+    """Test initialization of AzureAIInferenceChatCompletion with service_id"""
     azure_ai_inference = AzureAIInferenceChatCompletion(model_id, service_id=service_id)
 
     assert azure_ai_inference.ai_model_id == model_id

--- a/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_text_embedding.py
+++ b/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_text_embedding.py
@@ -11,7 +11,7 @@ from semantic_kernel.connectors.ai.azure_ai_inference import (
     AzureAIInferenceTextEmbedding,
 )
 from semantic_kernel.connectors.ai.azure_ai_inference.azure_ai_inference_settings import AzureAIInferenceSettings
-from semantic_kernel.connectors.telemetry import APPLICATION_ID
+from semantic_kernel.connectors.telemetry import SEMANTIC_KERNEL_USER_AGENT
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
 
 
@@ -38,7 +38,7 @@ def test_azure_ai_inference_text_embedding_client_init(mock_client, azure_ai_inf
     assert mock_client.call_args.kwargs["endpoint"] == str(settings.endpoint)
     assert isinstance(mock_client.call_args.kwargs["credential"], AzureKeyCredential)
     assert mock_client.call_args.kwargs["credential"].key == settings.api_key.get_secret_value()
-    assert mock_client.call_args.kwargs["user_agent"] == APPLICATION_ID
+    assert mock_client.call_args.kwargs["user_agent"] == SEMANTIC_KERNEL_USER_AGENT
 
 
 def test_azure_ai_inference_text_embedding_init_with_service_id(

--- a/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_text_embedding.py
+++ b/python/tests/unit/connectors/azure_ai_inference/services/test_azure_ai_inference_text_embedding.py
@@ -4,11 +4,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from azure.ai.inference.aio import EmbeddingsClient
+from azure.core.credentials import AzureKeyCredential
 
 from semantic_kernel.connectors.ai.azure_ai_inference import (
     AzureAIInferenceEmbeddingPromptExecutionSettings,
     AzureAIInferenceTextEmbedding,
 )
+from semantic_kernel.connectors.ai.azure_ai_inference.azure_ai_inference_settings import AzureAIInferenceSettings
+from semantic_kernel.connectors.telemetry import APPLICATION_ID
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
 
 
@@ -19,6 +22,23 @@ def test_azure_ai_inference_text_embedding_init(azure_ai_inference_unit_test_env
     assert azure_ai_inference.ai_model_id == model_id
     assert azure_ai_inference.service_id == model_id
     assert isinstance(azure_ai_inference.client, EmbeddingsClient)
+
+
+@patch("azure.ai.inference.aio.EmbeddingsClient.__init__", return_value=None)
+def test_azure_ai_inference_text_embedding_client_init(mock_client, azure_ai_inference_unit_test_env, model_id) -> None:
+    """Test initialization of the Azure AI Inference client"""
+    endpoint = azure_ai_inference_unit_test_env["AZURE_AI_INFERENCE_ENDPOINT"]
+    api_key = azure_ai_inference_unit_test_env["AZURE_AI_INFERENCE_API_KEY"]
+    settings = AzureAIInferenceSettings(endpoint=endpoint, api_key=api_key)
+
+    _ = AzureAIInferenceTextEmbedding(model_id)
+
+    assert mock_client.call_count == 1
+    assert isinstance(mock_client.call_args.kwargs["endpoint"], str)
+    assert mock_client.call_args.kwargs["endpoint"] == str(settings.endpoint)
+    assert isinstance(mock_client.call_args.kwargs["credential"], AzureKeyCredential)
+    assert mock_client.call_args.kwargs["credential"].key == settings.api_key.get_secret_value()
+    assert mock_client.call_args.kwargs["user_agent"] == APPLICATION_ID
 
 
 def test_azure_ai_inference_text_embedding_init_with_service_id(

--- a/python/tests/unit/telemetry/test_user_agent.py
+++ b/python/tests/unit/telemetry/test_user_agent.py
@@ -15,6 +15,11 @@ def test_append_to_existing_user_agent(monkeypatch):
     monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
     monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
 
+    # need to reload the module to get the updated version number
+    import semantic_kernel.connectors.telemetry
+
+    importlib.reload(semantic_kernel.connectors.telemetry)
+
     headers = {USER_AGENT: "existing-agent"}
     expected = {USER_AGENT: f"{HTTP_USER_AGENT}/1.0.0 existing-agent"}
     result = prepend_semantic_kernel_to_user_agent(headers)
@@ -25,6 +30,11 @@ def test_create_new_user_agent(monkeypatch):
     monkeypatch.setenv(TELEMETRY_DISABLED_ENV_VAR, "false")
     monkeypatch.setattr("importlib.metadata.version", lambda _: "1.0.0")
     monkeypatch.setattr("semantic_kernel.connectors.telemetry.version_info", "1.0.0")
+
+    # need to reload the module to get the updated version number
+    import semantic_kernel.connectors.telemetry
+
+    importlib.reload(semantic_kernel.connectors.telemetry)
 
     headers = {}
     expected = {USER_AGENT: f"{HTTP_USER_AGENT}/1.0.0"}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
All Microsoft tools/SDKs that internally use the Azure AI Inference SDK are required to set a unique application ID, which will be part of the "use-agent" HTTP request header. This will allow teams to track usage from that tool/SDK, using service-side telemetry dashboards.

Semantic Kernel's application ID is registered as "semantic-kernel-python/{version}" according to this [list](https://microsoft.sharepoint.com/:x:/t/AzureMLExperiences-AgentsandCommonInferenceSDKteam/EUVgsgpFtdRLnkhxrdtJ1MIBDMl3wVfoza4c13MI_K6ywg?e=MEpwyo&ovuser=72f988bf-86f1-41af-91ab-2d7cd011db47%2Ctaochen%40microsoft.com&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNDA2MjcyNDgwNyJ9).

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Add "semantic-kernel-python/{version}" as the application ID where we use the Azure AI Inference SDK.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
