### PR TITLE
.Net: Adding VectorStore for Redis.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/IRedisVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/IRedisVectorStoreRecordCollectionFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Data;
+using StackExchange.Redis;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Interface for constructing <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> Redis instances when using <see cref="IVectorStore"/> to retrieve these.
+/// </summary>
+public interface IRedisVectorStoreRecordCollectionFactory
+{
+    /// <summary>
+    /// Constructs a new instance of the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The data type of the record key.</typeparam>
+    /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+    /// <param name="database">The Redis database to read/write records from.</param>
+    /// <param name="name">The name of the collection to connect to.</param>
+    /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
+    /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IDatabase database, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.SemanticKernel.Data;
+using NRedisStack.RedisStackCommands;
+using StackExchange.Redis;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Class for accessing the list of collections in a Redis vector store.
+/// </summary>
+/// <remarks>
+/// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
+/// </remarks>
+public sealed class RedisVectorStore : IVectorStore
+{
+    /// <summary>The name of this database for telemetry purposes.</summary>
+    private const string DatabaseName = "Redis";
+
+    /// <summary>The redis database to read/write indices from.</summary>
+    private readonly IDatabase _database;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly RedisVectorStoreOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisVectorStore"/> class.
+    /// </summary>
+    /// <param name="database">The redis database to read/write indices from.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    public RedisVectorStore(IDatabase database, RedisVectorStoreOptions? options = default)
+    {
+        Verify.NotNull(database);
+
+        this._database = database;
+        this._options = options ?? new RedisVectorStoreOptions();
+    }
+
+    /// <inheritdoc />
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    {
+        if (typeof(TKey) != typeof(string))
+        {
+            throw new NotSupportedException("Only string keys are supported.");
+        }
+
+        if (this._options.VectorStoreCollectionFactory is not null)
+        {
+            return this._options.VectorStoreCollectionFactory.CreateVectorStoreRecordCollection<TKey, TRecord>(this._database, name, vectorStoreRecordDefinition);
+        }
+
+        var directlyCreatedStore = new RedisVectorStoreRecordCollection<TRecord>(this._database, name, new RedisVectorStoreRecordCollectionOptions<TRecord>() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+        return directlyCreatedStore!;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        const string OperationName = "";
+        RedisResult[] listResult;
+
+        try
+        {
+            listResult = await this._database.FT()._ListAsync().ConfigureAwait(false);
+        }
+        catch (RedisException ex)
+        {
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                VectorStoreType = DatabaseName,
+                OperationName = OperationName
+            };
+        }
+
+        foreach (var item in listResult)
+        {
+            var name = item.ToString();
+            if (name != null)
+            {
+                yield return name;
+            }
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// <summary>
 /// Options when creating a <see cref="RedisVectorStore"/>.
 /// </summary>
-public class RedisVectorStoreOptions
+public sealed class RedisVectorStoreOptions
 {
     /// <summary>
     /// An optional factory to use for constructing <see cref="RedisVectorStoreRecordCollection{TRecord}"/> instances, if custom options are required.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Options when creating a <see cref="RedisVectorStore"/>.
+/// </summary>
+public class RedisVectorStoreOptions
+{
+    /// <summary>
+    /// An optional factory to use for constructing <see cref="RedisVectorStoreRecordCollection{TRecord}"/> instances, if custom options are required.
+    /// </summary>
+    public IRedisVectorStoreRecordCollectionFactory? VectorStoreCollectionFactory { get; init; }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordCollection.cs
@@ -406,7 +406,7 @@ public sealed class RedisVectorStoreRecordCollection<TRecord> : IVectorStoreReco
         {
             await operation.Invoke().ConfigureAwait(false);
         }
-        catch (RedisConnectionException ex)
+        catch (RedisException ex)
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {
@@ -430,7 +430,7 @@ public sealed class RedisVectorStoreRecordCollection<TRecord> : IVectorStoreReco
         {
             return await operation.Invoke().ConfigureAwait(false);
         }
-        catch (RedisConnectionException ex)
+        catch (RedisException ex)
         {
             throw new VectorStoreOperationException("Call to vector store failed.", ex)
             {

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreTests.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Data;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorStore"/> class.
+/// </summary>
+public class RedisVectorStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+
+    private readonly Mock<IDatabase> _redisDatabaseMock;
+
+    public RedisVectorStoreTests()
+    {
+        this._redisDatabaseMock = new Mock<IDatabase>(MockBehavior.Strict);
+
+        var batchMock = new Mock<IBatch>();
+        this._redisDatabaseMock.Setup(x => x.CreateBatch(It.IsAny<object>())).Returns(batchMock.Object);
+    }
+
+    [Fact]
+    public void GetCollectionReturnsCollection()
+    {
+        // Arrange.
+        var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
+
+        // Act.
+        var actual = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.IsType<RedisVectorStoreRecordCollection<SinglePropsModel<string>>>(actual);
+    }
+
+    [Fact]
+    public void GetCollectionCallsFactoryIfProvided()
+    {
+        // Arrange.
+        var factoryMock = new Mock<IRedisVectorStoreRecordCollectionFactory>(MockBehavior.Strict);
+        var collectionMock = new Mock<IVectorStoreRecordCollection<string, SinglePropsModel<string>>>(MockBehavior.Strict);
+        factoryMock
+            .Setup(x => x.CreateVectorStoreRecordCollection<string, SinglePropsModel<string>>(It.IsAny<IDatabase>(), TestCollectionName, null))
+            .Returns(collectionMock.Object);
+        var sut = new RedisVectorStore(this._redisDatabaseMock.Object, new() { VectorStoreCollectionFactory = factoryMock.Object });
+
+        // Act.
+        var actual = sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName);
+
+        // Assert.
+        Assert.Equal(collectionMock.Object, actual);
+        factoryMock.Verify(x => x.CreateVectorStoreRecordCollection<string, SinglePropsModel<string>>(It.IsAny<IDatabase>(), TestCollectionName, null), Times.Once);
+    }
+
+    [Fact]
+    public void GetCollectionThrowsForInvalidKeyType()
+    {
+        // Arrange.
+        var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
+
+        // Act & Assert.
+        Assert.Throws<NotSupportedException>(() => sut.GetCollection<int, SinglePropsModel<int>>(TestCollectionName));
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesCallsSDKAsync()
+    {
+        // Arrange.
+        var redisResultStrings = new string[] { "collection1", "collection2" };
+        var results = redisResultStrings
+            .Select(x => RedisResult.Create(new RedisValue(x)))
+            .ToArray();
+        this._redisDatabaseMock
+            .Setup(
+                x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                It.IsAny<object[]>()))
+            .ReturnsAsync(RedisResult.Create(results));
+        var sut = new RedisVectorStore(this._redisDatabaseMock.Object);
+
+        // Act.
+        var collectionNames = sut.ListCollectionNamesAsync();
+
+        // Assert.
+        var collectionNamesList = await collectionNames.ToListAsync();
+        Assert.Equal(new[] { "collection1", "collection2" }, collectionNamesList);
+    }
+
+    public sealed class SinglePropsModel<TKey>
+    {
+        [VectorStoreRecordKey]
+        public required TKey Key { get; set; }
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.Redis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorStore"/> class.
+/// </summary>
+/// <param name="output">Used to write to the test output stream.</param>
+/// <param name="fixture">The test fixture.</param>
+[Collection("RedisVectorStoreCollection")]
+public class RedisVectorStoreTests(ITestOutputHelper output, RedisVectorStoreFixture fixture)
+{
+    [Fact]
+    public async Task ItCanGetAListOfExistingCollectionNamesAsync()
+    {
+        // Arrange
+        var sut = new RedisVectorStore(fixture.Database);
+
+        // Act
+        var collectionNames = await sut.ListCollectionNamesAsync().ToListAsync();
+
+        // Assert
+        Assert.Single(collectionNames);
+        Assert.Contains("hotels", collectionNames);
+
+        // Output
+        output.WriteLine(string.Join(",", collectionNames));
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// An interface for managing a collection of records in a vector store.
+/// A schema aware interface for managing a named collection of records in a vector store and for creating or deleting the collection itself.
 /// </summary>
 /// <typeparam name="TKey">The data type of the record key.</typeparam>
 /// <typeparam name="TRecord">The record data model to use for adding, updating and retrieving data from the store.</typeparam>


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This pr adds:
- An IVectorStore implementation for Redis

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
