### PR TITLE
.Net: Migrate remaining samples to new {Azure}OpenAI services

### DIFF
--- a/dotnet/samples/Concepts/Agents/ComplexChat_NestedShopper.cs
+++ b/dotnet/samples/Concepts/Agents/ComplexChat_NestedShopper.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-using Azure.AI.OpenAI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.Agents.Chat;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
+using OpenAI.Chat;
 using Resources;
 
 namespace Agents;
@@ -98,7 +98,7 @@ public class ComplexChat_NestedShopper(ITestOutputHelper output) : BaseTest(outp
     {
         Console.WriteLine($"! {Model}");
 
-        OpenAIPromptExecutionSettings jsonSettings = new() { ResponseFormat = ChatCompletionsResponseFormat.JsonObject };
+        OpenAIPromptExecutionSettings jsonSettings = new() { ResponseFormat = ChatResponseFormat.JsonObject };
         OpenAIPromptExecutionSettings autoInvokeSettings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
 
         ChatCompletionAgent internalLeaderAgent = CreateAgent(InternalLeaderName, InternalLeaderInstructions);

--- a/dotnet/samples/Concepts/Agents/Legacy_AgentCharts.cs
+++ b/dotnet/samples/Concepts/Agents/Legacy_AgentCharts.cs
@@ -91,13 +91,16 @@ Sum      426  1622     856 2904
         }
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     private static OpenAIFileService CreateFileService()
+
     {
         return
             ForceOpenAI || string.IsNullOrEmpty(TestConfiguration.AzureOpenAI.Endpoint) ?
                 new OpenAIFileService(TestConfiguration.OpenAI.ApiKey) :
                 new OpenAIFileService(new Uri(TestConfiguration.AzureOpenAI.Endpoint), apiKey: TestConfiguration.AzureOpenAI.ApiKey);
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     private static AgentBuilder CreateAgentBuilder()
     {

--- a/dotnet/samples/Concepts/Agents/Legacy_AgentTools.cs
+++ b/dotnet/samples/Concepts/Agents/Legacy_AgentTools.cs
@@ -80,11 +80,13 @@ public sealed class Legacy_AgentTools(ITestOutputHelper output) : BaseTest(outpu
         }
 
         Kernel kernel = CreateFileEnabledKernel();
+#pragma warning disable CS0618 // Type or member is obsolete
         var fileService = kernel.GetRequiredService<OpenAIFileService>();
         var result =
             await fileService.UploadContentAsync(
                 new BinaryContent(await EmbeddedResource.ReadAllAsync("travelinfo.txt")!, "text/plain"),
                 new OpenAIFileUploadExecutionSettings("travelinfo.txt", OpenAIFilePurpose.Assistants));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var fileId = result.Id;
         Console.WriteLine($"! {fileId}");
@@ -167,10 +169,12 @@ public sealed class Legacy_AgentTools(ITestOutputHelper output) : BaseTest(outpu
 
     private static Kernel CreateFileEnabledKernel()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         return
             ForceOpenAI || string.IsNullOrEmpty(TestConfiguration.AzureOpenAI.Endpoint) ?
                 Kernel.CreateBuilder().AddOpenAIFiles(TestConfiguration.OpenAI.ApiKey).Build() :
-                Kernel.CreateBuilder().AddAzureOpenAIFiles(TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey).Build();
+                throw new NotImplementedException("The file service is being deprecated and was not moved to AzureOpenAI connector.");
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private static AgentBuilder CreateAgentBuilder()

--- a/dotnet/samples/Concepts/Agents/OpenAIAssistant_FileManipulation.cs
+++ b/dotnet/samples/Concepts/Agents/OpenAIAssistant_FileManipulation.cs
@@ -22,12 +22,15 @@ public class OpenAIAssistant_FileManipulation(ITestOutputHelper output) : BaseTe
     [Fact]
     public async Task AnalyzeCSVFileUsingOpenAIAssistantAgentAsync()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         OpenAIFileService fileService = new(TestConfiguration.OpenAI.ApiKey);
 
         OpenAIFileReference uploadFile =
             await fileService.UploadContentAsync(
                 new BinaryContent(await EmbeddedResource.ReadAllAsync("sales.csv"), mimeType: "text/plain"),
                 new OpenAIFileUploadExecutionSettings("sales.csv", OpenAIFilePurpose.Assistants));
+
+#pragma warning restore CS0618 // Type or member is obsolete
 
         Console.WriteLine(this.ApiKey);
 

--- a/dotnet/samples/Concepts/Agents/OpenAIAssistant_FileService.cs
+++ b/dotnet/samples/Concepts/Agents/OpenAIAssistant_FileService.cs
@@ -18,6 +18,7 @@ public class OpenAIAssistant_FileService(ITestOutputHelper output) : BaseTest(ou
     [Fact]
     public async Task UploadAndRetrieveFilesAsync()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         OpenAIFileService fileService = new(TestConfiguration.OpenAI.ApiKey);
 
         BinaryContent[] files = [
@@ -62,5 +63,7 @@ public class OpenAIAssistant_FileService(ITestOutputHelper output) : BaseTest(ou
             // Delete the test file remotely
             await fileService.DeleteFileAsync(fileReference.Id);
         }
+
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/dotnet/samples/Concepts/Agents/OpenAIAssistant_Retrieval.cs
+++ b/dotnet/samples/Concepts/Agents/OpenAIAssistant_Retrieval.cs
@@ -21,12 +21,13 @@ public class OpenAIAssistant_Retrieval(ITestOutputHelper output) : BaseTest(outp
     [Fact]
     public async Task UseRetrievalToolWithOpenAIAssistantAgentAsync()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         OpenAIFileService fileService = new(TestConfiguration.OpenAI.ApiKey);
 
         OpenAIFileReference uploadFile =
             await fileService.UploadContentAsync(new BinaryContent(await EmbeddedResource.ReadAllAsync("travelinfo.txt")!, "text/plain"),
                 new OpenAIFileUploadExecutionSettings("travelinfo.txt", OpenAIFilePurpose.Assistants));
-
+#pragma warning restore CS0618 // Type or member is obsolete
         // Define the agent
         OpenAIAssistantAgent agent =
             await OpenAIAssistantAgent.CreateAsync(

--- a/dotnet/samples/Concepts/Concepts.csproj
+++ b/dotnet/samples/Concepts/Concepts.csproj
@@ -48,7 +48,7 @@
     <ProjectReference Include="..\..\src\Connectors\Connectors.MistralAI\Connectors.MistralAI.csproj" />
     <ProjectReference Include="..\..\src\Agents\Abstractions\Agents.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Agents\Core\Agents.Core.csproj" />
-    <!--ProjectReference Include="..\..\src\Agents\OpenAI\Agents.OpenAI.csproj" /-->
+    <ProjectReference Include="..\..\src\Agents\OpenAI\Agents.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Connectors\Connectors.Google\Connectors.Google.csproj" />
     <ProjectReference Include="..\..\src\Connectors\Connectors.HuggingFace\Connectors.HuggingFace.csproj" />
     <ProjectReference Include="..\..\src\Connectors\Connectors.Memory.AzureAISearch\Connectors.Memory.AzureAISearch.csproj" />
@@ -64,7 +64,7 @@
     <ProjectReference Include="..\..\src\Connectors\Connectors.Memory.Sqlite\Connectors.Memory.Sqlite.csproj" />
     <ProjectReference Include="..\..\src\Connectors\Connectors.Memory.Weaviate\Connectors.Memory.Weaviate.csproj" />
     <ProjectReference Include="..\..\src\Connectors\Connectors.OpenAIV2\Connectors.OpenAIV2.csproj" />
-    <!--ProjectReference Include="..\..\src\Experimental\Agents\Experimental.Agents.csproj" /-->
+    <ProjectReference Include="..\..\src\Experimental\Agents\Experimental.Agents.csproj" />
     <ProjectReference Include="..\..\src\Experimental\Orchestration.Flow\Experimental.Orchestration.Flow.csproj" />
     <ProjectReference Include="..\..\src\Extensions\PromptTemplates.Handlebars\PromptTemplates.Handlebars.csproj" />
     <ProjectReference Include="..\..\src\Extensions\PromptTemplates.Liquid\PromptTemplates.Liquid.csproj" />
@@ -108,41 +108,5 @@
     <EmbeddedResource Include="Resources\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="Agents\ChatCompletion_FunctionTermination.cs" />
-    <Compile Remove="Agents\ChatCompletion_Streaming.cs" />
-    <Compile Remove="Agents\ComplexChat_NestedShopper.cs" />
-    <Compile Remove="Agents\Legacy_AgentAuthoring.cs" />
-    <Compile Remove="Agents\Legacy_AgentCharts.cs" />
-    <Compile Remove="Agents\Legacy_AgentCollaboration.cs" />
-    <Compile Remove="Agents\Legacy_AgentDelegation.cs" />
-    <Compile Remove="Agents\Legacy_Agents.cs" />
-    <Compile Remove="Agents\Legacy_AgentTools.cs" />
-    <Compile Remove="Agents\Legacy_ChatCompletionAgent.cs" />
-    <Compile Remove="Agents\MixedChat_Agents.cs" />
-    <Compile Remove="Agents\OpenAIAssistant_ChartMaker.cs" />
-    <Compile Remove="Agents\OpenAIAssistant_CodeInterpreter.cs" />
-    <Compile Remove="Agents\OpenAIAssistant_FileManipulation.cs" />
-    <Compile Remove="Agents\OpenAIAssistant_FileService.cs" />
-    <Compile Remove="Agents\OpenAIAssistant_Retrieval.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Agents\ChatCompletion_FunctionTermination.cs" />
-    <None Include="Agents\ChatCompletion_Streaming.cs" />
-    <None Include="Agents\ComplexChat_NestedShopper.cs" />
-    <None Include="Agents\Legacy_AgentAuthoring.cs" />
-    <None Include="Agents\Legacy_AgentCharts.cs" />
-    <None Include="Agents\Legacy_AgentCollaboration.cs" />
-    <None Include="Agents\Legacy_AgentDelegation.cs" />
-    <None Include="Agents\Legacy_Agents.cs" />
-    <None Include="Agents\Legacy_AgentTools.cs" />
-    <None Include="Agents\Legacy_ChatCompletionAgent.cs" />
-    <None Include="Agents\MixedChat_Agents.cs" />
-    <None Include="Agents\OpenAIAssistant_ChartMaker.cs" />
-    <None Include="Agents\OpenAIAssistant_CodeInterpreter.cs" />
-    <None Include="Agents\OpenAIAssistant_FileManipulation.cs" />
-    <None Include="Agents\OpenAIAssistant_FileService.cs" />
-    <None Include="Agents\OpenAIAssistant_Retrieval.cs" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Experimental/Agents/Experimental.Agents.csproj
+++ b/dotnet/src/Experimental/Agents/Experimental.Agents.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
+    <ProjectReference Include="..\..\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
     <ProjectReference Include="..\..\Extensions\PromptTemplates.Handlebars\PromptTemplates.Handlebars.csproj" />
     <ProjectReference Include="..\..\Functions\Functions.Yaml\Functions.Yaml.csproj" />
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />

--- a/dotnet/src/Experimental/Agents/Extensions/OpenAIRestExtensions.cs
+++ b/dotnet/src/Experimental/Agents/Extensions/OpenAIRestExtensions.cs
@@ -92,7 +92,7 @@ internal static partial class OpenAIRestExtensions
     {
         request.Headers.Add(HeaderNameOpenAIAssistant, HeaderOpenAIValueAssistant);
         request.Headers.Add(HeaderNameUserAgent, HttpHeaderConstant.Values.UserAgent);
-        request.Headers.Add(HttpHeaderConstant.Names.SemanticKernelVersion, HttpHeaderConstant.Values.GetAssemblyVersion(typeof(OpenAIFileService)));
+        request.Headers.Add(HttpHeaderConstant.Names.SemanticKernelVersion, HttpHeaderConstant.Values.GetAssemblyVersion(typeof(OpenAIChatCompletionService)));
 
         if (context.HasVersion)
         {


### PR DESCRIPTION
### Motivation, Context, and Description
This PR migrates the remaining samples related to agents to the new {Azure}OpenAI services.

The agent samples will be updated again by this PR - https://github.com/microsoft/semantic-kernel/pull/7126 to use {Azure}OpenAI SDKs for operations with files and not use the deprecated file service. CC: @crickman