### PR TITLE
.Net: Adding a VectorStore implementation for Qdrant

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorStoreRecordCollectionFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Data;
+using Qdrant.Client;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Interface for constructing <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> Qdrant instances when using <see cref="IVectorStore"/> to retrieve these.
+/// </summary>
+public interface IQdrantVectorStoreRecordCollectionFactory
+{
+    /// <summary>
+    /// Constructs a new instance of the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The data type of the record key.</typeparam>
+    /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+    /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
+    /// <param name="name">The name of the collection to connect to.</param>
+    /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
+    /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(QdrantClient qdrantClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Grpc.Core;
+using Microsoft.SemanticKernel.Data;
+using Qdrant.Client;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Class for accessing the list of collections in a Qdrant vector store.
+/// </summary>
+/// <remarks>
+/// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
+/// </remarks>
+public sealed class QdrantVectorStore : IVectorStore
+{
+    /// <summary>The name of this database for telemetry purposes.</summary>
+    private const string DatabaseName = "Qdrant";
+
+    /// <summary>Qdrant client that can be used to manage the collections and points in a Qdrant store.</summary>
+    private readonly MockableQdrantClient _qdrantClient;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly QdrantVectorStoreOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantVectorStore"/> class.
+    /// </summary>
+    /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    public QdrantVectorStore(QdrantClient qdrantClient, QdrantVectorStoreOptions? options = default)
+        : this(new MockableQdrantClient(qdrantClient), options)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantVectorStore"/> class.
+    /// </summary>
+    /// <param name="qdrantClient">Qdrant client that can be used to manage the collections and points in a Qdrant store.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    internal QdrantVectorStore(MockableQdrantClient qdrantClient, QdrantVectorStoreOptions? options = default)
+    {
+        Verify.NotNull(qdrantClient);
+
+        this._qdrantClient = qdrantClient;
+        this._options = options ?? new QdrantVectorStoreOptions();
+    }
+
+    /// <inheritdoc />
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    {
+        if (typeof(TKey) != typeof(ulong) && typeof(TKey) != typeof(Guid))
+        {
+            throw new NotSupportedException("Only ulong and Guid keys are supported.");
+        }
+
+        if (this._options.VectorStoreCollectionFactory is not null)
+        {
+            return this._options.VectorStoreCollectionFactory.CreateVectorStoreRecordCollection<TKey, TRecord>(this._qdrantClient.QdrantClient, name, vectorStoreRecordDefinition);
+        }
+
+        var directlyCreatedStore = new QdrantVectorStoreRecordCollection<TRecord>(this._qdrantClient, name, new QdrantVectorStoreRecordCollectionOptions<TRecord>() { VectorStoreRecordDefinition = vectorStoreRecordDefinition });
+        var castCreatedStore = directlyCreatedStore as IVectorStoreRecordCollection<TKey, TRecord>;
+        return castCreatedStore!;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<string> collections;
+
+        try
+        {
+            collections = await this._qdrantClient.ListCollectionsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (RpcException ex)
+        {
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                VectorStoreType = DatabaseName,
+                OperationName = "ListCollections"
+            };
+        }
+
+        foreach (var collection in collections)
+        {
+            yield return collection;
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreOptions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Options when creating a <see cref="QdrantVectorStore"/>.
+/// </summary>
+public sealed class QdrantVectorStoreOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the vectors in the store are named and multiple vectors are supported, or whether there is just a single unnamed vector per qdrant point.
+    /// Defaults to single vector per point.
+    /// </summary>
+    public bool HasNamedVectors { get; set; } = false;
+
+    /// <summary>
+    /// An optional factory to use for constructing <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> instances, if custom options are required.
+    /// </summary>
+    public IQdrantVectorStoreRecordCollectionFactory? VectorStoreCollectionFactory { get; init; }
+}

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
 using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
@@ -383,6 +384,7 @@ public class QdrantVectorStoreRecordMapperTests
         [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
         public string DataString { get; set; } = string.Empty;
 
+        [JsonPropertyName("data_int_json")]
         [VectorStoreRecordData]
         public int DataInt { get; set; } = 0;
 

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Data;
+using Moq;
+using Qdrant.Client;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="QdrantVectorStore"/> class.
+/// </summary>
+public class QdrantVectorStoreTests
+{
+    private const string TestCollectionName = "testcollection";
+
+    private readonly Mock<MockableQdrantClient> _qdrantClientMock;
+
+    private readonly CancellationToken _testCancellationToken = new(false);
+
+    public QdrantVectorStoreTests()
+    {
+        this._qdrantClientMock = new Mock<MockableQdrantClient>(MockBehavior.Strict);
+    }
+
+    [Fact]
+    public void GetCollectionReturnsCollection()
+    {
+        // Arrange.
+        var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
+
+        // Act.
+        var actual = sut.GetCollection<ulong, SinglePropsModel<ulong>>(TestCollectionName);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.IsType<QdrantVectorStoreRecordCollection<SinglePropsModel<ulong>>>(actual);
+    }
+
+    [Fact]
+    public void GetCollectionCallsFactoryIfProvided()
+    {
+        // Arrange.
+        var factoryMock = new Mock<IQdrantVectorStoreRecordCollectionFactory>(MockBehavior.Strict);
+        var collectionMock = new Mock<IVectorStoreRecordCollection<ulong, SinglePropsModel<ulong>>>(MockBehavior.Strict);
+        factoryMock
+            .Setup(x => x.CreateVectorStoreRecordCollection<ulong, SinglePropsModel<ulong>>(It.IsAny<QdrantClient>(), TestCollectionName, null))
+            .Returns(collectionMock.Object);
+        var sut = new QdrantVectorStore(this._qdrantClientMock.Object, new() { VectorStoreCollectionFactory = factoryMock.Object });
+
+        // Act.
+        var actual = sut.GetCollection<ulong, SinglePropsModel<ulong>>(TestCollectionName);
+
+        // Assert.
+        Assert.Equal(collectionMock.Object, actual);
+        factoryMock.Verify(x => x.CreateVectorStoreRecordCollection<ulong, SinglePropsModel<ulong>>(It.IsAny<QdrantClient>(), TestCollectionName, null), Times.Once);
+    }
+
+    [Fact]
+    public void GetCollectionThrowsForInvalidKeyType()
+    {
+        // Arrange.
+        var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
+
+        // Act & Assert.
+        Assert.Throws<NotSupportedException>(() => sut.GetCollection<string, SinglePropsModel<string>>(TestCollectionName));
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesCallsSDKAsync()
+    {
+        // Arrange.
+        this._qdrantClientMock
+            .Setup(x => x.ListCollectionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "collection1", "collection2" });
+        var sut = new QdrantVectorStore(this._qdrantClientMock.Object);
+
+        // Act.
+        var collectionNames = sut.ListCollectionNamesAsync(this._testCancellationToken);
+
+        // Assert.
+        var collectionNamesList = await collectionNames.ToListAsync();
+        Assert.Equal(new[] { "collection1", "collection2" }, collectionNamesList);
+    }
+
+    public sealed class SinglePropsModel<TKey>
+    {
+        [VectorStoreRecordKey]
+        public required TKey Key { get; set; }
+
+        [VectorStoreRecordData]
+        public string Data { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public string? NotAnnotated { get; set; }
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.Qdrant;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
+
+[Collection("QdrantVectorStoreCollection")]
+public class QdrantVectorStoreTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
+{
+    [Fact]
+    public async Task ItCanGetAListOfExistingCollectionNamesAsync()
+    {
+        // Arrange
+        var sut = new QdrantVectorStore(fixture.QdrantClient);
+
+        // Act
+        var collectionNames = await sut.ListCollectionNamesAsync().ToListAsync();
+
+        // Assert
+        Assert.Equal(3, collectionNames.Count);
+        Assert.Contains("namedVectorsHotels", collectionNames);
+        Assert.Contains("singleVectorHotels", collectionNames);
+        Assert.Contains("singleVectorGuidIdHotels", collectionNames);
+
+        // Output
+        output.WriteLine(string.Join(",", collectionNames));
+    }
+}


### PR DESCRIPTION
### Motivation and Context

As part of the memory connector redesign we have fixed on a design where we have a VectorStore that produces VectorStoreRecordCollection instances. These are tied to a collection and will expose single collection operations.

### Description

This pr adds:
- An IVectorStore implementation for Qdrant
- Fix a bug in the mapping where using the json parser to create the caller object model needs json property names in order to correctly deserialize the json object.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
