### PR TITLE
Java: feat: Add KernelFunction method for async prompt invocation with argu…

### DIFF
--- a/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
+++ b/java/semantickernel-api/src/main/java/com/microsoft/semantickernel/Kernel.java
@@ -9,6 +9,7 @@ import com.microsoft.semantickernel.orchestration.FunctionResult;
 import com.microsoft.semantickernel.orchestration.InvocationContext;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.KernelFunction.FromPromptBuilder;
 import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
 import com.microsoft.semantickernel.services.AIService;
 import com.microsoft.semantickernel.services.AIServiceCollection;
@@ -161,6 +162,24 @@ public class Kernel {
      */
     public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt) {
         return invokeAsync(KernelFunction.<T>createFromPrompt(prompt).build());
+    }
+
+    public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt,
+        @Nonnull KernelFunctionArguments arguments) {
+        KernelFunction<T> function = KernelFunction.<T>createFromPrompt(prompt).build();
+
+        return function.invokeAsync(this)
+            .withArguments(arguments);
+    }
+
+    public <T> FunctionInvocation<T> invokePromptAsync(@Nonnull String prompt,
+        @Nonnull KernelFunctionArguments arguments, @Nonnull InvocationContext invocationContext) {
+
+        KernelFunction<T> function = KernelFunction.<T>createFromPrompt(prompt).build();
+
+        return function.invokeAsync(this)
+            .withArguments(arguments)
+            .withInvocationContext(invocationContext);
     }
 
     /**


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This PR is related to microsoft/semantic-kernel-java#108 .

We need a more convenient overload method for Kernel.InvokePromptAsync. Currently, this method doesn't accept KernelFunctionArguments and InvocationContext.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
