### PR TITLE
.Net: Fix casting bug in VolatileVectorStore

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
@@ -43,8 +43,7 @@ public sealed class VolatileVectorStore : IVectorStore
             throw new NotSupportedException("Only string keys are supported.");
         }
 
-        var typedInternalCollection = this._internalCollection as ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>>;
-        var collection = new VolatileVectorStoreRecordCollection<TRecord>(typedInternalCollection!, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+        var collection = new VolatileVectorStoreRecordCollection<TRecord>(this._internalCollection, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
         return collection!;
     }
 

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -22,7 +22,7 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
     where TRecord : class
 {
     /// <summary>Internal storage for the record collection.</summary>
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> _internalCollection;
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object>> _internalCollection;
 
     /// <summary>Optional configuration options for this class.</summary>
     private readonly VolatileVectorStoreRecordCollectionOptions _options;
@@ -76,7 +76,7 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
     /// <param name="internalCollection">Allows passing in the dictionary used for storage, for testing purposes.</param>
     /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
-    internal VolatileVectorStoreRecordCollection(ConcurrentDictionary<string, ConcurrentDictionary<string, TRecord>> internalCollection, string collectionName, VolatileVectorStoreRecordCollectionOptions? options = default)
+    internal VolatileVectorStoreRecordCollection(ConcurrentDictionary<string, ConcurrentDictionary<string, object>> internalCollection, string collectionName, VolatileVectorStoreRecordCollectionOptions? options = default)
         : this(collectionName, options)
     {
         this._internalCollection = internalCollection;
@@ -94,7 +94,7 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
     /// <inheritdoc />
     public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
-        this._internalCollection.TryAdd(this._collectionName, new ConcurrentDictionary<string, TRecord>());
+        this._internalCollection.TryAdd(this._collectionName, new ConcurrentDictionary<string, object>());
         return Task.CompletedTask;
     }
 
@@ -121,7 +121,7 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
 
         if (collectionDictionary.TryGetValue(key, out var record))
         {
-            return Task.FromResult<TRecord?>(record);
+            return Task.FromResult<TRecord?>(record as TRecord);
         }
 
         return Task.FromResult<TRecord?>(null);
@@ -187,7 +187,7 @@ public sealed class VolatileVectorStoreRecordCollection<TRecord> : IVectorStoreR
     /// Get the collection dictionary from the internal storage, throws if it does not exist.
     /// </summary>
     /// <returns>The retrieved collection dictionary.</returns>
-    private ConcurrentDictionary<string, TRecord> GetCollectionDictionary()
+    private ConcurrentDictionary<string, object> GetCollectionDictionary()
     {
         if (!this._internalCollection.TryGetValue(this._collectionName, out var collectionDictionary))
         {

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -21,7 +21,7 @@ public class VolatileVectorStoreRecordCollectionTests
 
     private readonly CancellationToken _testCancellationToken = new(false);
 
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SinglePropsModel>> _collectionStore;
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object>> _collectionStore;
 
     public VolatileVectorStoreRecordCollectionTests()
     {
@@ -34,7 +34,7 @@ public class VolatileVectorStoreRecordCollectionTests
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
         var sut = new VolatileVectorStoreRecordCollection<SinglePropsModel>(
@@ -65,7 +65,7 @@ public class VolatileVectorStoreRecordCollectionTests
     public async Task DeleteCollectionRemovesCollectionFromDictionaryAsync()
     {
         // Arrange
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
         var sut = this.CreateRecordCollection(false);
@@ -84,7 +84,7 @@ public class VolatileVectorStoreRecordCollectionTests
     {
         // Arrange
         var record = CreateModel(TestRecordKey1, withVectors: true);
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         collection.TryAdd(TestRecordKey1, record);
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
@@ -116,7 +116,7 @@ public class VolatileVectorStoreRecordCollectionTests
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
         var record2 = CreateModel(TestRecordKey2, withVectors: true);
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         collection.TryAdd(TestRecordKey1, record1);
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
@@ -149,7 +149,7 @@ public class VolatileVectorStoreRecordCollectionTests
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
         var record2 = CreateModel(TestRecordKey2, withVectors: true);
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         collection.TryAdd(TestRecordKey1, record1);
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
@@ -174,7 +174,7 @@ public class VolatileVectorStoreRecordCollectionTests
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
         var record2 = CreateModel(TestRecordKey2, withVectors: true);
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         collection.TryAdd(TestRecordKey1, record1);
         collection.TryAdd(TestRecordKey2, record2);
         this._collectionStore.TryAdd(TestCollectionName, collection);
@@ -198,7 +198,7 @@ public class VolatileVectorStoreRecordCollectionTests
     {
         // Arrange
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
         var sut = this.CreateRecordCollection(useDefinition);
@@ -211,7 +211,8 @@ public class VolatileVectorStoreRecordCollectionTests
         // Assert
         Assert.Equal(TestRecordKey1, upsertResult);
         Assert.True(collection.ContainsKey(TestRecordKey1));
-        Assert.Equal("data testid1", collection[TestRecordKey1].Data);
+        Assert.IsType<SinglePropsModel>(collection[TestRecordKey1]);
+        Assert.Equal("data testid1", (collection[TestRecordKey1] as SinglePropsModel)!.Data);
     }
 
     [Theory]
@@ -223,7 +224,7 @@ public class VolatileVectorStoreRecordCollectionTests
         var record1 = CreateModel(TestRecordKey1, withVectors: true);
         var record2 = CreateModel(TestRecordKey2, withVectors: true);
 
-        var collection = new ConcurrentDictionary<string, SinglePropsModel>();
+        var collection = new ConcurrentDictionary<string, object>();
         this._collectionStore.TryAdd(TestCollectionName, collection);
 
         var sut = this.CreateRecordCollection(useDefinition);
@@ -240,7 +241,8 @@ public class VolatileVectorStoreRecordCollectionTests
         Assert.Equal(TestRecordKey2, actual[1]);
 
         Assert.True(collection.ContainsKey(TestRecordKey1));
-        Assert.Equal("data testid1", collection[TestRecordKey1].Data);
+        Assert.IsType<SinglePropsModel>(collection[TestRecordKey1]);
+        Assert.Equal("data testid1", (collection[TestRecordKey1] as SinglePropsModel)!.Data);
     }
 
     private static SinglePropsModel CreateModel(string key, bool withVectors)


### PR DESCRIPTION
### Motivation and Context

The VolatileVectorStore uses a ConcurrentDictionary of ConcurrentDictionary instances to store records. Each collection can contain different types of records.  It's not possible to cast the entire sub dictionary to the right generic type, so switching to casing on a per record basis.

### Description

Fixing bug where casting at the dictionary level was causing a null reference exception.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
