### PR TITLE
.Net: using a more modern and compatible collation

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerClient.cs
@@ -56,7 +56,7 @@ internal sealed class SqlServerClient : ISqlServerClient
             cmd.CommandText = $"""
                 IF OBJECT_ID(N'{fullTableName}', N'U') IS NULL
                 CREATE TABLE {fullTableName} (
-                    [key] nvarchar(255) collate latin1_general_bin2 not null,
+                    [key] nvarchar(255) collate Latin1_General_100_BIN2 not null,
                     [metadata] {metadataType} not null,
                     [embedding] varbinary(8000),
                     [timestamp] datetimeoffset,


### PR DESCRIPTION
### Motivation and Context

Moved to use Latin1_General_100_BIN2 which is more compatible and updaed

### Description

Updated the collation in the "create table" statement

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ x I didn't break anyone :smile:
