### PR TITLE
.Net: Fix collection create field naming bug and add tests to cover scenario.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
@@ -19,13 +19,14 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var keyProperty = new VectorStoreRecordKeyProperty("testkey");
+        var storagePropertyName = "test_key";
 
         // Act
-        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapKeyField(keyProperty);
+        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapKeyField(keyProperty, storagePropertyName);
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(keyProperty.PropertyName, result.Name);
+        Assert.Equal(storagePropertyName, result.Name);
         Assert.True(result.IsKey);
         Assert.True(result.IsFilterable);
     }
@@ -37,14 +38,15 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var dataProperty = new VectorStoreRecordDataProperty("testdata") { IsFilterable = isFilterable, PropertyType = typeof(string) };
+        var storagePropertyName = "test_data";
 
         // Act
-        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty);
+        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty, storagePropertyName);
 
         // Assert
         Assert.NotNull(result);
         Assert.IsType<SearchableField>(result);
-        Assert.Equal(dataProperty.PropertyName, result.Name);
+        Assert.Equal(storagePropertyName, result.Name);
         Assert.False(result.IsKey);
         Assert.Equal(isFilterable, result.IsFilterable);
     }
@@ -56,14 +58,15 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var dataProperty = new VectorStoreRecordDataProperty("testdata") { IsFilterable = isFilterable, PropertyType = typeof(int) };
+        var storagePropertyName = "test_data";
 
         // Act
-        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty);
+        var result = AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty, storagePropertyName);
 
         // Assert
         Assert.NotNull(result);
         Assert.IsType<SimpleField>(result);
-        Assert.Equal(dataProperty.PropertyName, result.Name);
+        Assert.Equal(storagePropertyName, result.Name);
         Assert.Equal(SearchFieldDataType.Int32, result.Type);
         Assert.False(result.IsKey);
         Assert.Equal(isFilterable, result.IsFilterable);
@@ -74,9 +77,10 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var dataProperty = new VectorStoreRecordDataProperty("testdata");
+        var storagePropertyName = "test_data";
 
         // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty));
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty, storagePropertyName));
     }
 
     [Fact]
@@ -84,24 +88,25 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.DotProductSimilarity };
+        var storagePropertyName = "test_vector";
 
         // Act
-        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty);
+        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty, storagePropertyName);
 
         // Assert
         Assert.NotNull(vectorSearchField);
         Assert.NotNull(algorithmConfiguration);
         Assert.NotNull(vectorSearchProfile);
-        Assert.Equal(vectorProperty.PropertyName, vectorSearchField.Name);
+        Assert.Equal(storagePropertyName, vectorSearchField.Name);
         Assert.Equal(vectorProperty.Dimensions, vectorSearchField.VectorSearchDimensions);
 
-        Assert.Equal("testvectorAlgoConfig", algorithmConfiguration.Name);
+        Assert.Equal("test_vectorAlgoConfig", algorithmConfiguration.Name);
         Assert.IsType<ExhaustiveKnnAlgorithmConfiguration>(algorithmConfiguration);
         var flatConfig = algorithmConfiguration as ExhaustiveKnnAlgorithmConfiguration;
         Assert.Equal(VectorSearchAlgorithmMetric.DotProduct, flatConfig!.Parameters.Metric);
 
-        Assert.Equal("testvectorProfile", vectorSearchProfile.Name);
-        Assert.Equal("testvectorAlgoConfig", vectorSearchProfile.AlgorithmConfigurationName);
+        Assert.Equal("test_vectorProfile", vectorSearchProfile.Name);
+        Assert.Equal("test_vectorAlgoConfig", vectorSearchProfile.AlgorithmConfigurationName);
     }
 
     [Theory]
@@ -111,12 +116,13 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, IndexKind = indexKind, DistanceFunction = DistanceFunction.DotProductSimilarity };
+        var storagePropertyName = "test_vector";
 
         // Act
-        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty);
+        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty, storagePropertyName);
 
         // Assert
-        Assert.Equal("testvectorAlgoConfig", algorithmConfiguration.Name);
+        Assert.Equal("test_vectorAlgoConfig", algorithmConfiguration.Name);
         Assert.Equal(algoConfigType, algorithmConfiguration.GetType());
     }
 
@@ -125,9 +131,10 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10 };
+        var storagePropertyName = "test_vector";
 
         // Act
-        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty);
+        var (vectorSearchField, algorithmConfiguration, vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty, storagePropertyName);
 
         // Assert
         Assert.IsType<HnswAlgorithmConfiguration>(algorithmConfiguration);
@@ -140,9 +147,10 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, DistanceFunction = DistanceFunction.ManhattanDistance };
+        var storagePropertyName = "test_vector";
 
         // Act
-        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty));
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty, storagePropertyName));
     }
 
     [Fact]
@@ -150,9 +158,10 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     {
         // Arrange
         var vectorProperty = new VectorStoreRecordVectorProperty("testvector");
+        var storagePropertyName = "test_vector";
 
         // Act
-        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty));
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(vectorProperty, storagePropertyName));
     }
 
     [Theory]

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
@@ -32,8 +32,18 @@ public class RedisVectorStoreCollectionCreateMappingTests
             new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions") { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanDistance },
         };
 
+        var stroragePropertyNames = new Dictionary<string, string>()
+        {
+            { "FilterableString", "FilterableString" },
+            { "FilterableInt", "FilterableInt" },
+            { "FilterableNullableInt", "FilterableNullableInt" },
+            { "NonFilterableString", "NonFilterableString" },
+            { "VectorDefaultIndexingOptions", "VectorDefaultIndexingOptions" },
+            { "VectorSpecificIndexingOptions", "vector_specific_indexing_options" },
+        };
+
         // Act.
-        var schema = RedisVectorStoreCollectionCreateMapping.MapToSchema(properties);
+        var schema = RedisVectorStoreCollectionCreateMapping.MapToSchema(properties, stroragePropertyNames);
 
         // Assert.
         Assert.NotNull(schema);
@@ -50,7 +60,7 @@ public class RedisVectorStoreCollectionCreateMappingTests
         VerifyFieldName(schema.Fields[2].FieldName, new List<object> { "$.FilterableNullableInt", "AS", "FilterableNullableInt" });
 
         VerifyFieldName(schema.Fields[3].FieldName, new List<object> { "$.VectorDefaultIndexingOptions", "AS", "VectorDefaultIndexingOptions" });
-        VerifyFieldName(schema.Fields[4].FieldName, new List<object> { "$.VectorSpecificIndexingOptions", "AS", "VectorSpecificIndexingOptions" });
+        VerifyFieldName(schema.Fields[4].FieldName, new List<object> { "$.vector_specific_indexing_options", "AS", "vector_specific_indexing_options" });
 
         Assert.Equal("10", ((VectorField)schema.Fields[3]).Attributes!["DIM"]);
         Assert.Equal("FLOAT32", ((VectorField)schema.Fields[3]).Attributes!["TYPE"]);
@@ -66,9 +76,10 @@ public class RedisVectorStoreCollectionCreateMappingTests
     {
         // Arrange.
         var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordDataProperty("FilterableString") { IsFilterable = true } };
+        var storagePropertyNames = new Dictionary<string, string>() { { "FilterableString", "FilterableString" } };
 
         // Act and assert.
-        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties));
+        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties, storagePropertyNames));
     }
 
     [Theory]
@@ -78,9 +89,10 @@ public class RedisVectorStoreCollectionCreateMappingTests
     {
         // Arrange.
         var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordVectorProperty("VectorProperty") { Dimensions = dimensions } };
+        var storagePropertyNames = new Dictionary<string, string>() { { "VectorProperty", "VectorProperty" } };
 
         // Act and assert.
-        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties));
+        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties, storagePropertyNames));
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
@@ -32,7 +32,7 @@ public class RedisVectorStoreCollectionCreateMappingTests
             new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions") { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanDistance },
         };
 
-        var stroragePropertyNames = new Dictionary<string, string>()
+        var storagePropertyNames = new Dictionary<string, string>()
         {
             { "FilterableString", "FilterableString" },
             { "FilterableInt", "FilterableInt" },
@@ -43,7 +43,7 @@ public class RedisVectorStoreCollectionCreateMappingTests
         };
 
         // Act.
-        var schema = RedisVectorStoreCollectionCreateMapping.MapToSchema(properties, stroragePropertyNames);
+        var schema = RedisVectorStoreCollectionCreateMapping.MapToSchema(properties, storagePropertyNames);
 
         // Assert.
         Assert.NotNull(schema);


### PR DESCRIPTION
### Motivation and Context

For some connectors users can use `JsonPropertyName` to indicate that a different name should be used in storage than on the model.  In other cases users can use `StoragePropertyName` in the definition.  We need to use this information when creating indexes / collections to name the properties in storage correctly, otherwise there will be a mismatch when reading/writing.

### Description

1. Updating create logic to use the right storage or json property names everywhere.
2. Adding tests to specifically cover these scenarios.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
