### PR TITLE
.Net: VectorStore: Add DI extensions for Pinecone and reorder params for others.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
@@ -17,12 +17,12 @@ public static class AzureAISearchKernelBuilderExtensions
     /// Register an Azure AI Search <see cref="IVectorStore"/> with the specified service ID and where <see cref="SearchIndexClient"/> is retrieved from the dependency injection container.
     /// </summary>
     /// <param name="builder">The builder to register the <see cref="IVectorStore"/> on.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, string? serviceId = default, AzureAISearchVectorStoreOptions? options = default)
+    public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStore(serviceId, options);
+        builder.Services.AddAzureAISearchVectorStore(options, serviceId);
         return builder;
     }
 
@@ -32,12 +32,12 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <param name="builder">The builder to register the <see cref="IVectorStore"/> on.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, Uri endpoint, TokenCredential tokenCredential, string? serviceId = default, AzureAISearchVectorStoreOptions? options = default)
+    public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, Uri endpoint, TokenCredential tokenCredential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStore(endpoint, tokenCredential, serviceId, options);
+        builder.Services.AddAzureAISearchVectorStore(endpoint, tokenCredential, options, serviceId);
         return builder;
     }
 
@@ -47,12 +47,12 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <param name="builder">The builder to register the <see cref="IVectorStore"/> on.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, Uri endpoint, AzureKeyCredential credential, string? serviceId = default, AzureAISearchVectorStoreOptions? options = default)
+    public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, Uri endpoint, AzureKeyCredential credential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStore(endpoint, credential, serviceId, options);
+        builder.Services.AddAzureAISearchVectorStore(endpoint, credential, options, serviceId);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
@@ -18,10 +18,10 @@ public static class AzureAISearchServiceCollectionExtensions
     /// Register an Azure AI Search <see cref="IVectorStore"/> with the specified service ID and where <see cref="SearchIndexClient"/> is retrieved from the dependency injection container.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, string? serviceId = default, AzureAISearchVectorStoreOptions? options = default)
+    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
         services.AddKeyedTransient<IVectorStore>(
             serviceId,
@@ -44,10 +44,10 @@ public static class AzureAISearchServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, Uri endpoint, TokenCredential tokenCredential, string? serviceId = default, AzureAISearchVectorStoreOptions? options = default)
+    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, Uri endpoint, TokenCredential tokenCredential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(tokenCredential);
@@ -73,10 +73,10 @@ public static class AzureAISearchServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, Uri endpoint, AzureKeyCredential credential, string? serviceId = default, AzureAISearchVectorStoreOptions? options = default)
+    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, Uri endpoint, AzureKeyCredential credential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(credential);

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel.Data;
+using Sdk = Pinecone;
+
+namespace Microsoft.SemanticKernel.Connectors.Pinecone;
+
+/// <summary>
+/// Extension methods to register Pinecone <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
+/// </summary>
+public static class PineconeKernelBuilderExtensions
+{
+    /// <summary>
+    /// Register a Pinecone <see cref="IVectorStore"/> with the specified service ID and where <see cref="Sdk.PineconeClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <param name="builder">The builder to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="apiKey">The api key for Pinecone.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddPineconeVectorStore(this IKernelBuilder builder, string? apiKey = default, PineconeVectorStoreOptions? options = default, string? serviceId = default)
+    {
+        builder.Services.AddPineconeVectorStore(apiKey, options, serviceId);
+        return builder;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.Data;
+using Sdk = Pinecone;
+
+namespace Microsoft.SemanticKernel.Connectors.Pinecone;
+
+/// <summary>
+/// Extension methods to register Pinecone <see cref="IVectorStore"/> instances on an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class PineconeServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register a Pinecone <see cref="IVectorStore"/> with the specified service ID and where <see cref="Sdk.PineconeClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="apiKey">The api key for Pinecone.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IServiceCollection AddPineconeVectorStore(this IServiceCollection services, string? apiKey = default, PineconeVectorStoreOptions? options = default, string? serviceId = default)
+    {
+        services.AddKeyedTransient<IVectorStore>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var pineconeClient = apiKey == null ? sp.GetRequiredService<Sdk.PineconeClient>() : new Sdk.PineconeClient(apiKey);
+                var selectedOptions = options ?? sp.GetService<PineconeVectorStoreOptions>();
+
+                return new PineconeVectorStore(
+                    pineconeClient,
+                    selectedOptions);
+            });
+
+        return services;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
@@ -17,12 +17,12 @@ public static class QdrantKernelBuilderExtensions
     /// <param name="port">The Qdrant service port.</param>
     /// <param name="https">A value indicating whether to use HTTPS for communicating with Qdrant.</param>
     /// <param name="apiKey">The Qdrant service API key.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IKernelBuilder AddQdrantVectorStore(this IKernelBuilder builder, string? host = default, int port = 6334, bool https = false, string? apiKey = default, string? serviceId = default, QdrantVectorStoreOptions? options = default)
+    public static IKernelBuilder AddQdrantVectorStore(this IKernelBuilder builder, string? host = default, int port = 6334, bool https = false, string? apiKey = default, QdrantVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddQdrantVectorStore(host, port, https, apiKey, serviceId, options);
+        builder.Services.AddQdrantVectorStore(host, port, https, apiKey, options, serviceId);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
@@ -19,10 +19,10 @@ public static class QdrantServiceCollectionExtensions
     /// <param name="port">The Qdrant service port.</param>
     /// <param name="https">A value indicating whether to use HTTPS for communicating with Qdrant.</param>
     /// <param name="apiKey">The Qdrant service API key.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IServiceCollection AddQdrantVectorStore(this IServiceCollection services, string? host = default, int port = 6334, bool https = false, string? apiKey = default, string? serviceId = default, QdrantVectorStoreOptions? options = default)
+    public static IServiceCollection AddQdrantVectorStore(this IServiceCollection services, string? host = default, int port = 6334, bool https = false, string? apiKey = default, QdrantVectorStoreOptions? options = default, string? serviceId = default)
     {
         services.AddKeyedTransient<IVectorStore>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
@@ -15,12 +15,12 @@ public static class RedisKernelBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder to register the <see cref="IVectorStore"/> on.</param>
     /// <param name="redisConnectionConfiguration">The Redis connection configuration string. If not provided, an <see cref="IDatabase"/> instance will be requested from the dependency injection container.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IKernelBuilder AddRedisVectorStore(this IKernelBuilder builder, string? redisConnectionConfiguration = default, string? serviceId = default, RedisVectorStoreOptions? options = default)
+    public static IKernelBuilder AddRedisVectorStore(this IKernelBuilder builder, string? redisConnectionConfiguration = default, RedisVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddRedisVectorStore(redisConnectionConfiguration, serviceId, options);
+        builder.Services.AddRedisVectorStore(redisConnectionConfiguration, options, serviceId);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisServiceCollectionExtensions.cs
@@ -16,10 +16,10 @@ public static class RedisServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
     /// <param name="redisConnectionConfiguration">The Redis connection configuration string. If not provided, an <see cref="IDatabase"/> instance will be requested from the dependency injection container.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IServiceCollection AddRedisVectorStore(this IServiceCollection services, string? redisConnectionConfiguration = default, string? serviceId = default, RedisVectorStoreOptions? options = default)
+    public static IServiceCollection AddRedisVectorStore(this IServiceCollection services, string? redisConnectionConfiguration = default, RedisVectorStoreOptions? options = default, string? serviceId = default)
     {
         if (redisConnectionConfiguration == null)
         {

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.Pinecone;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+using Sdk = Pinecone;
+
+namespace SemanticKernel.Connectors.UnitTests.Pinecone;
+
+/// <summary>
+/// Tests for the <see cref="PineconeKernelBuilderExtensions"/> class.
+/// </summary>
+public class PineconeKernelBuilderExtensionsTests
+{
+    private readonly IKernelBuilder _kernelBuilder;
+
+    public PineconeKernelBuilderExtensionsTests()
+    {
+        this._kernelBuilder = Kernel.CreateBuilder();
+    }
+
+    [Fact]
+    public void AddVectorStoreRegistersClass()
+    {
+        // Arrange.
+        using var client = new Sdk.PineconeClient("fake api key");
+        this._kernelBuilder.Services.AddSingleton<Sdk.PineconeClient>(client);
+
+        // Act.
+        this._kernelBuilder.AddPineconeVectorStore();
+
+        // Assert.
+        this.AssertVectorStoreCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreWithApiKeyRegistersClass()
+    {
+        // Act.
+        this._kernelBuilder.AddPineconeVectorStore("fake api key");
+
+        // Assert.
+        this.AssertVectorStoreCreated();
+    }
+
+    private void AssertVectorStoreCreated()
+    {
+        var kernel = this._kernelBuilder.Build();
+        var vectorStore = kernel.Services.GetRequiredService<IVectorStore>();
+        Assert.NotNull(vectorStore);
+        Assert.IsType<PineconeVectorStore>(vectorStore);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.Connectors.Pinecone;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+using Sdk = Pinecone;
+
+namespace SemanticKernel.Connectors.UnitTests.Pinecone;
+
+/// <summary>
+/// Tests for the <see cref="PineconeServiceCollectionExtensions"/> class.
+/// </summary>
+public class PineconeServiceCollectionExtensionsTests
+{
+    private readonly IServiceCollection _serviceCollection;
+
+    public PineconeServiceCollectionExtensionsTests()
+    {
+        this._serviceCollection = new ServiceCollection();
+    }
+
+    [Fact]
+    public void AddVectorStoreRegistersClass()
+    {
+        // Arrange.
+        using var client = new Sdk.PineconeClient("fake api key");
+        this._serviceCollection.AddSingleton<Sdk.PineconeClient>(client);
+
+        // Act.
+        this._serviceCollection.AddPineconeVectorStore();
+
+        // Assert.
+        this.AssertVectorStoreCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreWithApiKeyRegistersClass()
+    {
+        // Act.
+        this._serviceCollection.AddPineconeVectorStore("fake api key");
+
+        // Assert.
+        this.AssertVectorStoreCreated();
+    }
+
+    private void AssertVectorStoreCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
+        Assert.NotNull(vectorStore);
+        Assert.IsType<PineconeVectorStore>(vectorStore);
+    }
+}


### PR DESCRIPTION
### Description

Adding DI extensions for the new Pinecone VectorStore implementation.
Reordering the parameters for all VectorStore DI extensions so that ServiceId is last.  This reduces the risk of ambiguous method signatures where we have to have multiple method overloads, since options is now before the serviceId, meaning that any optional string parameters to construct a client will not clash with the optional serviceId.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
