### PR TITLE
.Net: Removing embedding generation attributes and fixing cloning bug.

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion.cs
@@ -183,7 +183,7 @@ public class VectorStore_DataIngestion(ITestOutputHelper output) : BaseTest(outp
         [VectorStoreRecordData]
         public string Term { get; set; }
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = nameof(DefinitionEmbedding))]
+        [VectorStoreRecordData]
         public string Definition { get; set; }
 
         [VectorStoreRecordVector(1536)]

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
@@ -381,7 +381,7 @@ public class QdrantVectorStoreRecordMapperTests
         [VectorStoreRecordKey]
         public TKey? Key { get; set; } = default;
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
+        [VectorStoreRecordData]
         public string DataString { get; set; } = string.Empty;
 
         [JsonPropertyName("data_int_json")]

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordMapperTests.cs
@@ -80,7 +80,7 @@ public sealed class RedisJsonVectorStoreRecordMapperTests
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1")]
+        [VectorStoreRecordData]
         public string Data1 { get; set; } = string.Empty;
 
         [VectorStoreRecordData]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -216,7 +216,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         public string HotelName { get; set; }
 
         [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        [VectorStoreRecordData]
         public string Description { get; set; }
 
         [VectorStoreRecordVector(4)]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
@@ -291,7 +291,7 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
         public List<string> Tags { get; set; } = new List<string>();
 
         /// <summary>A data field.</summary>
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        [VectorStoreRecordData]
         public string Description { get; set; }
 
         /// <summary>A vector field.</summary>
@@ -314,7 +314,7 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
         public string? HotelName { get; set; }
 
         /// <summary>A data field.</summary>
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        [VectorStoreRecordData]
         public string Description { get; set; }
 
         /// <summary>A vector field.</summary>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -230,7 +230,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         [VectorStoreRecordData(IsFilterable = true)]
         public int HotelCode { get; init; }
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        [VectorStoreRecordData]
         public string Description { get; init; }
 
         [VectorStoreRecordVector(4)]
@@ -278,7 +278,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         [VectorStoreRecordData(IsFilterable = true)]
         public int HotelCode { get; init; }
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "DescriptionEmbedding")]
+        [VectorStoreRecordData]
         public string Description { get; init; }
 
         [VectorStoreRecordVector(4)]

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -217,8 +217,6 @@ internal static class VectorStoreRecordPropertyReader
             {
                 definitionProperties.Add(new VectorStoreRecordDataProperty(dataProperty.Name)
                 {
-                    HasEmbedding = dataAttribute.HasEmbedding,
-                    EmbeddingPropertyName = dataAttribute.EmbeddingPropertyName,
                     IsFilterable = dataAttribute.IsFilterable,
                     PropertyType = dataProperty.PropertyType,
                     StoragePropertyName = dataAttribute.StoragePropertyName

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordAttributes/VectorStoreRecordDataAttribute.cs
@@ -17,17 +17,6 @@ namespace Microsoft.SemanticKernel.Data;
 public sealed class VectorStoreRecordDataAttribute : Attribute
 {
     /// <summary>
-    /// Gets or sets a value indicating whether this data field has an associated embedding field.
-    /// </summary>
-    /// <remarks>Defaults to <see langword="false" /></remarks>
-    public bool HasEmbedding { get; init; }
-
-    /// <summary>
-    /// Gets or sets the name of the property that contains the embedding for this data field.
-    /// </summary>
-    public string? EmbeddingPropertyName { get; init; }
-
-    /// <summary>
     /// Gets or sets a value indicating whether this data property is filterable.
     /// </summary>
     public bool IsFilterable { get; init; }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
@@ -25,22 +25,11 @@ public sealed class VectorStoreRecordDataProperty : VectorStoreRecordProperty
     /// </summary>
     /// <param name="source">The source to clone</param>
     public VectorStoreRecordDataProperty(VectorStoreRecordDataProperty source)
-        : base(source.PropertyName)
+        : base(source)
     {
-        this.HasEmbedding = source.HasEmbedding;
-        this.EmbeddingPropertyName = source.EmbeddingPropertyName;
+        this.IsFilterable = source.IsFilterable;
+        this.PropertyType = source.PropertyType;
     }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether this data property has an associated embedding property.
-    /// </summary>
-    /// <remarks>Defaults to <see langword="false" /></remarks>
-    public bool HasEmbedding { get; init; }
-
-    /// <summary>
-    /// Gets or sets the name of the property that contains the embedding for this data property.
-    /// </summary>
-    public string? EmbeddingPropertyName { get; init; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this data property is filterable.

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordKeyProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordKeyProperty.cs
@@ -24,7 +24,7 @@ public sealed class VectorStoreRecordKeyProperty : VectorStoreRecordProperty
     /// </summary>
     /// <param name="source">The source to clone</param>
     public VectorStoreRecordKeyProperty(VectorStoreRecordKeyProperty source)
-        : base(source.PropertyName)
+        : base(source)
     {
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
@@ -19,6 +19,12 @@ public abstract class VectorStoreRecordProperty
         this.PropertyName = propertyName;
     }
 
+    private protected VectorStoreRecordProperty(VectorStoreRecordProperty source)
+    {
+        this.PropertyName = source.PropertyName;
+        this.StoragePropertyName = source.StoragePropertyName;
+    }
+
     /// <summary>
     /// Gets or sets the name of the property.
     /// </summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
@@ -24,8 +24,11 @@ public sealed class VectorStoreRecordVectorProperty : VectorStoreRecordProperty
     /// </summary>
     /// <param name="source">The source to clone</param>
     public VectorStoreRecordVectorProperty(VectorStoreRecordVectorProperty source)
-        : base(source.PropertyName)
+        : base(source)
     {
+        this.Dimensions = source.Dimensions;
+        this.IndexKind = source.IndexKind;
+        this.DistanceFunction = source.DistanceFunction;
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -168,11 +168,6 @@ public class VectorStoreRecordPropertyReaderTests
         Assert.True(data1.IsFilterable);
         Assert.False(data2.IsFilterable);
 
-        Assert.True(data1.HasEmbedding);
-        Assert.False(data2.HasEmbedding);
-
-        Assert.Equal("Vector1", data1.EmbeddingPropertyName);
-
         Assert.Equal(typeof(string), data1.PropertyType);
         Assert.Equal(typeof(string), data2.PropertyType);
 
@@ -333,7 +328,7 @@ public class VectorStoreRecordPropertyReaderTests
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1", IsFilterable = true)]
+        [VectorStoreRecordData(IsFilterable = true)]
         public string Data1 { get; set; } = string.Empty;
 
         [VectorStoreRecordData]
@@ -354,7 +349,7 @@ public class VectorStoreRecordPropertyReaderTests
         Properties =
         [
             new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("Data1") { HasEmbedding = true, EmbeddingPropertyName = "Vector1", IsFilterable = true },
+            new VectorStoreRecordDataProperty("Data1") { IsFilterable = true },
             new VectorStoreRecordDataProperty("Data2") { StoragePropertyName = "data_2" },
             new VectorStoreRecordVectorProperty("Vector1") { Dimensions = 4, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.DotProductSimilarity },
             new VectorStoreRecordVectorProperty("Vector2")


### PR DESCRIPTION
### Motivation and Context

We decided to delay the automatic embedding generation until later, so any attributes related to embedding generation are not required for the time being, but can be added back easily later.

### Description

Removed HasEmbedding and EmbeddingPropertyName from record definition and attributes.
Fixed a small bug with definition cloning.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
