### PR TITLE
.Net: Add support for any key type to the VolatileVectorStore.

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion.cs
@@ -142,6 +142,7 @@ public class VectorStore_DataIngestion(ITestOutputHelper output, VectorStoreRedi
     }
 
     private async Task UpsertDataAndReadFromVectorStoreAsync<TKey>(DataIngestor dataIngestor, Func<TKey> uniqueKeyGenerator)
+            where TKey : notnull
     {
         // Ingest some data into the vector store.
         var upsertedKeys = await dataIngestor.ImportDataAsync(uniqueKeyGenerator);
@@ -167,6 +168,7 @@ public class VectorStore_DataIngestion(ITestOutputHelper output, VectorStoreRedi
         /// <returns>The keys of the upserted glossary entries.</returns>
         /// <typeparam name="TKey">The type of the keys in the vector store.</typeparam>
         public async Task<IEnumerable<TKey>> ImportDataAsync<TKey>(Func<TKey> uniqueKeyGenerator)
+            where TKey : notnull
         {
             // Get and create collection if it doesn't exist.
             var collection = vectorStore.GetCollection<TKey, Glossary<TKey>>("skglossary");
@@ -192,6 +194,7 @@ public class VectorStore_DataIngestion(ITestOutputHelper output, VectorStoreRedi
         /// <returns>The glossary entry.</returns>
         /// <typeparam name="TKey">The type of the keys in the vector store.</typeparam>
         public Task<Glossary<TKey>?> GetGlossaryAsync<TKey>(TKey key)
+            where TKey : notnull
         {
             var collection = vectorStore.GetCollection<TKey, Glossary<TKey>>("skglossary");
             return collection.GetAsync(key, new() { IncludeVectors = true });

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
@@ -42,7 +42,9 @@ public sealed class AzureAISearchVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
+        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/IAzureAISearchVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/IAzureAISearchVectorStoreRecordCollectionFactory.cs
@@ -19,5 +19,7 @@ public interface IAzureAISearchVectorStoreRecordCollectionFactory
     /// <param name="name">The name of the collection to connect to.</param>
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
-    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(SearchIndexClient searchIndexClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(SearchIndexClient searchIndexClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+        where TKey : notnull
+        where TRecord : class;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeVectorStoreRecordCollectionFactory.cs
@@ -19,5 +19,7 @@ public interface IPineconeVectorStoreRecordCollectionFactory
     /// <param name="name">The name of the collection to connect to.</param>
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
-    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(Sdk.PineconeClient pineconeClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(Sdk.PineconeClient pineconeClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+        where TKey : notnull
+        where TRecord : class;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
@@ -39,7 +39,9 @@ public sealed class PineconeVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
+        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorStoreRecordCollectionFactory.cs
@@ -19,5 +19,7 @@ public interface IQdrantVectorStoreRecordCollectionFactory
     /// <param name="name">The name of the collection to connect to.</param>
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
-    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(QdrantClient qdrantClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(QdrantClient qdrantClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+        where TKey : notnull
+        where TRecord : class;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -51,7 +51,9 @@ public sealed class QdrantVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
+        where TRecord : class
     {
         if (typeof(TKey) != typeof(ulong) && typeof(TKey) != typeof(Guid))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/IRedisVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/IRedisVectorStoreRecordCollectionFactory.cs
@@ -19,5 +19,7 @@ public interface IRedisVectorStoreRecordCollectionFactory
     /// <param name="name">The name of the collection to connect to.</param>
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
-    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IDatabase database, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class;
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IDatabase database, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+        where TKey : notnull
+        where TRecord : class;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
@@ -41,7 +41,9 @@ public sealed class RedisVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
+        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -135,6 +135,7 @@ public class QdrantVectorStoreRecordCollectionTests
     [Theory]
     [MemberData(nameof(TestOptions))]
     public async Task CanGetRecordWithVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
+        where TKey : notnull
     {
         var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
 
@@ -171,6 +172,7 @@ public class QdrantVectorStoreRecordCollectionTests
     [Theory]
     [MemberData(nameof(TestOptions))]
     public async Task CanGetRecordWithoutVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
+        where TKey : notnull
     {
         // Arrange.
         var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
@@ -206,6 +208,7 @@ public class QdrantVectorStoreRecordCollectionTests
     [Theory]
     [MemberData(nameof(MultiRecordTestOptions))]
     public async Task CanGetManyRecordsWithVectorsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey[] testRecordKeys)
+        where TKey : notnull
     {
         // Arrange.
         var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
@@ -406,6 +409,7 @@ public class QdrantVectorStoreRecordCollectionTests
     [Theory]
     [MemberData(nameof(TestOptions))]
     public async Task CanUpsertRecordAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
+        where TKey : notnull
     {
         // Arrange
         var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
@@ -432,6 +436,7 @@ public class QdrantVectorStoreRecordCollectionTests
     [Theory]
     [MemberData(nameof(MultiRecordTestOptions))]
     public async Task CanUpsertManyRecordsAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey[] testRecordKeys)
+        where TKey : notnull
     {
         // Arrange
         var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors);
@@ -614,6 +619,7 @@ public class QdrantVectorStoreRecordCollectionTests
     }
 
     private IVectorStoreRecordCollection<T, SinglePropsModel<T>> CreateRecordCollection<T>(bool useDefinition, bool hasNamedVectors)
+        where T : notnull
     {
         var store = new QdrantVectorStoreRecordCollection<SinglePropsModel<T>>(
             this._qdrantClientMock.Object,

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreTests.cs
@@ -46,7 +46,9 @@ public class PineconeVectorStoreTests(PineconeVectorStoreFixture fixture) : ICla
         public IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(
             Sdk.PineconeClient pineconeClient,
             string name,
-            VectorStoreRecordDefinition? vectorStoreRecordDefinition) where TRecord : class
+            VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+            where TKey : notnull
+            where TRecord : class
         {
             if (typeof(TKey) != typeof(string))
             {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStore.cs
@@ -31,6 +31,7 @@ public interface IVectorStore
     /// <seealso cref="VectorStoreRecordDataAttribute"/>
     /// <seealso cref="VectorStoreRecordVectorAttribute"/>
     IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
         where TRecord : class;
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/IVectorStoreRecordCollection.cs
@@ -16,6 +16,7 @@ namespace Microsoft.SemanticKernel.Data;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public interface IVectorStoreRecordCollection<TKey, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+    where TKey : notnull
     where TRecord : class
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -16,7 +15,7 @@ namespace Microsoft.SemanticKernel.Data;
 public sealed class VolatileVectorStore : IVectorStore
 {
     /// <summary>Internal storage for the record collection.</summary>
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object>> _internalCollection;
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<object, object>> _internalCollection;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VolatileVectorStore"/> class.
@@ -30,20 +29,17 @@ public sealed class VolatileVectorStore : IVectorStore
     /// Initializes a new instance of the <see cref="VolatileVectorStore"/> class.
     /// </summary>
     /// <param name="internalCollection">Allows passing in the dictionary used for storage, for testing purposes.</param>
-    internal VolatileVectorStore(ConcurrentDictionary<string, ConcurrentDictionary<string, object>> internalCollection)
+    internal VolatileVectorStore(ConcurrentDictionary<string, ConcurrentDictionary<object, object>> internalCollection)
     {
         this._internalCollection = internalCollection;
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TRecord : class
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
+        where TRecord : class
     {
-        if (typeof(TKey) != typeof(string))
-        {
-            throw new NotSupportedException("Only string keys are supported.");
-        }
-
-        var collection = new VolatileVectorStoreRecordCollection<TRecord>(this._internalCollection, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+        var collection = new VolatileVectorStoreRecordCollection<TKey, TRecord>(this._internalCollection, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
         return collection!;
     }
 

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollectionOptions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
-/// Options when creating a <see cref="VolatileVectorStoreRecordCollection{TRecord}"/>.
+/// Options when creating a <see cref="VolatileVectorStoreRecordCollection{TKey,TRecord}"/>.
 /// </summary>
 [Experimental("SKEXP0001")]
 public sealed class VolatileVectorStoreRecordCollectionOptions

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreTests.cs
@@ -27,26 +27,30 @@ public class VolatileVectorStoreTests
 
         // Assert.
         Assert.NotNull(actual);
-        Assert.IsType<VolatileVectorStoreRecordCollection<SinglePropsModel<string>>>(actual);
+        Assert.IsType<VolatileVectorStoreRecordCollection<string, SinglePropsModel<string>>>(actual);
     }
 
     [Fact]
-    public void GetCollectionThrowsForInvalidKeyType()
+    public void GetCollectionReturnsCollectionWithNonStringKey()
     {
         // Arrange.
         var sut = new VolatileVectorStore();
 
-        // Act & Assert.
-        Assert.Throws<NotSupportedException>(() => sut.GetCollection<int, SinglePropsModel<int>>(TestCollectionName));
+        // Act.
+        var actual = sut.GetCollection<int, SinglePropsModel<int>>(TestCollectionName);
+
+        // Assert.
+        Assert.NotNull(actual);
+        Assert.IsType<VolatileVectorStoreRecordCollection<int, SinglePropsModel<int>>>(actual);
     }
 
     [Fact]
     public async Task ListCollectionNamesReadsDictionaryAsync()
     {
         // Arrange.
-        var collectionStore = new ConcurrentDictionary<string, ConcurrentDictionary<string, object>>();
-        collectionStore.TryAdd("collection1", new ConcurrentDictionary<string, object>());
-        collectionStore.TryAdd("collection2", new ConcurrentDictionary<string, object>());
+        var collectionStore = new ConcurrentDictionary<string, ConcurrentDictionary<object, object>>();
+        collectionStore.TryAdd("collection1", new ConcurrentDictionary<object, object>());
+        collectionStore.TryAdd("collection2", new ConcurrentDictionary<object, object>());
         var sut = new VolatileVectorStore(collectionStore);
 
         // Act.


### PR DESCRIPTION
### Motivation and Context

Addressing feedback on Volatile VectorStore key types from bugbash.  See:
[#7468](https://github.com/microsoft/semantic-kernel/issues/7468)

### Description

- Adding support for any key type to VolatileVectorStore.
- Updated VolatileVectorStore unit tests to test with multiple types of keys.
- This also caused a knock-on effect of requiring keys to not be nullable, which is a good constraint to have regardless.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
