### PR TITLE
.Net: Fix bug where JsonSerializerOptions is not consistently used.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -135,7 +135,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         // Get storage names for data properties and store for later use.
         foreach (var property in properties.dataProperties)
         {
-            var jsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(JsonSerializerOptions.Default, property);
+            var jsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(jsonSerializerOptions, property);
             this._storagePropertyNames[property.Name] = jsonPropertyName;
             this._nonVectorStoragePropertyNames.Add(jsonPropertyName);
         }
@@ -143,7 +143,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         // Get storage names for vector properties and store for later use.
         foreach (var property in properties.vectorProperties)
         {
-            var jsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(JsonSerializerOptions.Default, property);
+            var jsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(jsonSerializerOptions, property);
             this._storagePropertyNames[property.Name] = jsonPropertyName;
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -135,7 +135,7 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         }
         else
         {
-            this._mapper = new RedisJsonVectorStoreRecordMapper<TRecord>(this._keyJsonPropertyName);
+            this._mapper = new RedisJsonVectorStoreRecordMapper<TRecord>(this._keyJsonPropertyName, this._jsonSerializerOptions);
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
@@ -23,6 +23,7 @@ internal sealed class RedisJsonVectorStoreRecordMapper<TConsumerDataModel> : IVe
     /// Initializes a new instance of the <see cref="RedisJsonVectorStoreRecordMapper{TConsumerDataModel}"/> class.
     /// </summary>
     /// <param name="keyFieldJsonPropertyName">The name of the key field on the model when serialized to json.</param>
+    /// <param name="jsonSerializerOptions">The JSON serializer options to use when converting between the data model and the Redis record.</param>
     public RedisJsonVectorStoreRecordMapper(string keyFieldJsonPropertyName, JsonSerializerOptions jsonSerializerOptions)
     {
         Verify.NotNullOrWhiteSpace(keyFieldJsonPropertyName);

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
@@ -16,14 +16,20 @@ internal sealed class RedisJsonVectorStoreRecordMapper<TConsumerDataModel> : IVe
     /// <summary>The name of the temporary json property that the key field will be serialized / parsed from.</summary>
     private readonly string _keyFieldJsonPropertyName;
 
+    /// <summary>The JSON serializer options to use when converting between the data model and the Redis record.</summary>
+    private readonly JsonSerializerOptions _jsonSerializerOptions;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RedisJsonVectorStoreRecordMapper{TConsumerDataModel}"/> class.
     /// </summary>
     /// <param name="keyFieldJsonPropertyName">The name of the key field on the model when serialized to json.</param>
-    public RedisJsonVectorStoreRecordMapper(string keyFieldJsonPropertyName)
+    public RedisJsonVectorStoreRecordMapper(string keyFieldJsonPropertyName, JsonSerializerOptions jsonSerializerOptions)
     {
         Verify.NotNullOrWhiteSpace(keyFieldJsonPropertyName);
+        Verify.NotNull(jsonSerializerOptions);
+
         this._keyFieldJsonPropertyName = keyFieldJsonPropertyName;
+        this._jsonSerializerOptions = jsonSerializerOptions;
     }
 
     /// <inheritdoc />
@@ -32,7 +38,7 @@ internal sealed class RedisJsonVectorStoreRecordMapper<TConsumerDataModel> : IVe
         // Convert the provided record into a JsonNode object and try to get the key field for it.
         // Since we already checked that the key field is a string in the constructor, and that it exists on the model,
         // the only edge case we have to be concerned about is if the key field is null.
-        var jsonNode = JsonSerializer.SerializeToNode(dataModel);
+        var jsonNode = JsonSerializer.SerializeToNode(dataModel, this._jsonSerializerOptions);
         if (jsonNode!.AsObject().TryGetPropertyValue(this._keyFieldJsonPropertyName, out var keyField) && keyField is JsonValue jsonValue)
         {
             // Remove the key field from the JSON object since we don't want to store it in the redis payload.
@@ -73,6 +79,6 @@ internal sealed class RedisJsonVectorStoreRecordMapper<TConsumerDataModel> : IVe
         // Since the key is not stored in the redis value, add it back in before deserializing into the data model.
         jsonObject.Add(this._keyFieldJsonPropertyName, storageModel.Key);
 
-        return JsonSerializer.Deserialize<TConsumerDataModel>(jsonObject)!;
+        return JsonSerializer.Deserialize<TConsumerDataModel>(jsonObject, this._jsonSerializerOptions)!;
     }
 }


### PR DESCRIPTION
### Motivation and Context

Both Redis and AzureAISearch uses Json as its serialization mechanism, however in various places, the field names in storage need to be used by the rest of the code.
E.g. to determine the names of properties when creating an index

### Description

- Adding tests to ensure all scenarios are covered
- Fix bugs where there are gaps

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
