### PR TITLE
.Net: Restricting property writability and renaming data model name property on VectorStoreRecordProperty

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
@@ -41,7 +41,7 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
 
         if (dataProperty.PropertyType is null)
         {
-            throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.PropertyName}' must be set to create a collection.");
+            throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.DataModelPropertyName}' must be set to create a collection.");
         }
 
         return new SimpleField(storagePropertyName, AzureAISearchVectorStoreCollectionCreateMapping.GetSDKFieldDataType(dataProperty.PropertyType)) { IsFilterable = dataProperty.IsFilterable };
@@ -58,7 +58,7 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
     {
         if (vectorProperty.Dimensions is not > 0)
         {
-            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}' must be set to a positive integer to create a collection.");
+            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' must be set to a positive integer to create a collection.");
         }
 
         // Build a name for the profile and algorithm configuration based on the property name
@@ -74,7 +74,7 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
         {
             IndexKind.Hnsw => new HnswAlgorithmConfiguration(algorithmConfigName) { Parameters = new HnswParameters { Metric = algorithmMetric } },
             IndexKind.Flat => new ExhaustiveKnnAlgorithmConfiguration(algorithmConfigName) { Parameters = new ExhaustiveKnnParameters { Metric = algorithmMetric } },
-            _ => throw new InvalidOperationException($"Unsupported index kind '{indexKind}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+            _ => throw new InvalidOperationException($"Unsupported index kind '{indexKind}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.")
         };
         var vectorSearchProfile = new VectorSearchProfile(vectorSearchProfileName, algorithmConfigName);
 
@@ -116,7 +116,7 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
             DistanceFunction.CosineSimilarity => VectorSearchAlgorithmMetric.Cosine,
             DistanceFunction.DotProductSimilarity => VectorSearchAlgorithmMetric.DotProduct,
             DistanceFunction.EuclideanDistance => VectorSearchAlgorithmMetric.Euclidean,
-            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.")
         };
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -192,7 +192,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
             // Data property.
             if (property is VectorStoreRecordDataProperty dataProperty)
             {
-                searchFields.Add(AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty, this._storagePropertyNames[dataProperty.PropertyName]));
+                searchFields.Add(AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty, this._storagePropertyNames[dataProperty.DataModelPropertyName]));
             }
 
             // Vector property.
@@ -200,7 +200,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
             {
                 (VectorSearchField vectorSearchField, VectorSearchAlgorithmConfiguration algorithmConfiguration, VectorSearchProfile vectorSearchProfile) = AzureAISearchVectorStoreCollectionCreateMapping.MapVectorField(
                     vectorProperty,
-                    this._storagePropertyNames[vectorProperty.PropertyName]);
+                    this._storagePropertyNames[vectorProperty.DataModelPropertyName]);
 
                 // Add the search field, plus its profile and algorithm configuration to the search config.
                 searchFields.Add(vectorSearchField);

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreCollectionCreateMapping.cs
@@ -21,7 +21,7 @@ internal static class PineconeVectorStoreCollectionCreateMapping
     {
         if (vectorProperty!.Dimensions is not > 0)
         {
-            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}' must be set to a positive integer to create a collection.");
+            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' must be set to a positive integer to create a collection.");
         }
 
         return (Dimension: (uint)vectorProperty.Dimensions, Metric: GetSDKMetricAlgorithm(vectorProperty));
@@ -41,6 +41,6 @@ internal static class PineconeVectorStoreCollectionCreateMapping
             DistanceFunction.DotProductSimilarity => Metric.DotProduct,
             DistanceFunction.EuclideanDistance => Metric.Euclidean,
             null => Metric.Cosine,
-            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.")
         };
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionCreateMapping.cs
@@ -57,12 +57,12 @@ internal static class QdrantVectorStoreCollectionCreateMapping
     {
         if (vectorProperty!.Dimensions is not > 0)
         {
-            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}' must be set to a positive integer to create a collection.");
+            throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' must be set to a positive integer to create a collection.");
         }
 
         if (vectorProperty!.IndexKind is not null && vectorProperty!.IndexKind != IndexKind.Hnsw)
         {
-            throw new InvalidOperationException($"Unsupported index kind '{vectorProperty!.IndexKind}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.");
+            throw new InvalidOperationException($"Unsupported index kind '{vectorProperty!.IndexKind}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.");
         }
 
         return new VectorParams { Size = (ulong)vectorProperty.Dimensions, Distance = QdrantVectorStoreCollectionCreateMapping.GetSDKDistanceAlgorithm(vectorProperty) };
@@ -81,7 +81,7 @@ internal static class QdrantVectorStoreCollectionCreateMapping
 
         foreach (var vectorProperty in vectorProperties)
         {
-            var storageName = storagePropertyNames[vectorProperty.PropertyName];
+            var storageName = storagePropertyNames[vectorProperty.DataModelPropertyName];
 
             // Add each vector property to the vectors map.
             vectorParamsMap.Map.Add(
@@ -112,7 +112,7 @@ internal static class QdrantVectorStoreCollectionCreateMapping
             DistanceFunction.DotProductSimilarity => Distance.Dot,
             DistanceFunction.EuclideanDistance => Distance.Euclid,
             DistanceFunction.ManhattanDistance => Distance.Manhattan,
-            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.")
         };
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -178,10 +178,10 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
         {
             if (dataProperty.PropertyType is null)
             {
-                throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.PropertyName}' must be set to create a collection, since the property is filterable.");
+                throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.DataModelPropertyName}' must be set to create a collection, since the property is filterable.");
             }
 
-            var storageFieldName = this._storagePropertyNames[dataProperty.PropertyName];
+            var storageFieldName = this._storagePropertyNames[dataProperty.DataModelPropertyName];
             var schemaType = QdrantVectorStoreCollectionCreateMapping.s_schemaTypeMap[dataProperty.PropertyType!];
 
             await this.RunOperationAsync(

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
@@ -67,10 +67,10 @@ internal static class RedisVectorStoreCollectionCreateMapping
             {
                 if (dataProperty.PropertyType is null)
                 {
-                    throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.PropertyName}' must be set to create a collection, since the property is filterable.");
+                    throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.DataModelPropertyName}' must be set to create a collection, since the property is filterable.");
                 }
 
-                var storageName = storagePropertyNames[dataProperty.PropertyName];
+                var storageName = storagePropertyNames[dataProperty.DataModelPropertyName];
 
                 if (dataProperty.PropertyType == typeof(string))
                 {
@@ -90,10 +90,10 @@ internal static class RedisVectorStoreCollectionCreateMapping
             {
                 if (vectorProperty.Dimensions is not > 0)
                 {
-                    throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}' must be set to a positive integer to create a collection.");
+                    throw new InvalidOperationException($"Property {nameof(vectorProperty.Dimensions)} on {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' must be set to a positive integer to create a collection.");
                 }
 
-                var storageName = storagePropertyNames[vectorProperty.PropertyName];
+                var storageName = storagePropertyNames[vectorProperty.DataModelPropertyName];
                 var indexKind = GetSDKIndexKind(vectorProperty);
                 var distanceAlgorithm = GetSDKDistanceAlgorithm(vectorProperty);
                 var dimensions = vectorProperty.Dimensions.Value.ToString(CultureInfo.InvariantCulture);
@@ -127,7 +127,7 @@ internal static class RedisVectorStoreCollectionCreateMapping
         {
             IndexKind.Hnsw => Schema.VectorField.VectorAlgo.HNSW,
             IndexKind.Flat => Schema.VectorField.VectorAlgo.FLAT,
-            _ => throw new InvalidOperationException($"Unsupported index kind '{vectorProperty.IndexKind}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+            _ => throw new InvalidOperationException($"Unsupported index kind '{vectorProperty.IndexKind}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.")
         };
     }
 
@@ -150,7 +150,7 @@ internal static class RedisVectorStoreCollectionCreateMapping
             DistanceFunction.CosineSimilarity => "COSINE",
             DistanceFunction.DotProductSimilarity => "IP",
             DistanceFunction.EuclideanDistance => "L2",
-            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.PropertyName}'.")
+            _ => throw new InvalidOperationException($"Unsupported distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}'.")
         };
     }
 }

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -131,19 +131,19 @@ internal static class VectorStoreRecordPropertyReader
                     throw new ArgumentException($"Multiple key properties configured for type {type.FullName}.");
                 }
 
-                keyProperty = type.GetProperty(keyPropertyInfo.PropertyName);
+                keyProperty = type.GetProperty(keyPropertyInfo.DataModelPropertyName);
                 if (keyProperty == null)
                 {
-                    throw new ArgumentException($"Key property '{keyPropertyInfo.PropertyName}' not found on type {type.FullName}.");
+                    throw new ArgumentException($"Key property '{keyPropertyInfo.DataModelPropertyName}' not found on type {type.FullName}.");
                 }
             }
             // Data.
             else if (property is VectorStoreRecordDataProperty dataPropertyInfo)
             {
-                var dataProperty = type.GetProperty(dataPropertyInfo.PropertyName);
+                var dataProperty = type.GetProperty(dataPropertyInfo.DataModelPropertyName);
                 if (dataProperty == null)
                 {
-                    throw new ArgumentException($"Data property '{dataPropertyInfo.PropertyName}' not found on type {type.FullName}.");
+                    throw new ArgumentException($"Data property '{dataPropertyInfo.DataModelPropertyName}' not found on type {type.FullName}.");
                 }
 
                 dataProperties.Add(dataProperty);
@@ -151,10 +151,10 @@ internal static class VectorStoreRecordPropertyReader
             // Vector.
             else if (property is VectorStoreRecordVectorProperty vectorPropertyInfo)
             {
-                var vectorProperty = type.GetProperty(vectorPropertyInfo.PropertyName);
+                var vectorProperty = type.GetProperty(vectorPropertyInfo.DataModelPropertyName);
                 if (vectorProperty == null)
                 {
-                    throw new ArgumentException($"Vector property '{vectorPropertyInfo.PropertyName}' not found on type {type.FullName}.");
+                    throw new ArgumentException($"Vector property '{vectorPropertyInfo.DataModelPropertyName}' not found on type {type.FullName}.");
                 }
 
                 // Add all vector properties if we support multiple vectors.
@@ -341,7 +341,7 @@ internal static class VectorStoreRecordPropertyReader
         if (vectorStoreRecordDefinition is not null)
         {
             // First check to see if the developer configured a storage property name on the record definition.
-            if (vectorStoreRecordDefinition.Properties.FirstOrDefault(p => p.PropertyName == property.Name) is VectorStoreRecordProperty recordProperty && recordProperty.StoragePropertyName is not null)
+            if (vectorStoreRecordDefinition.Properties.FirstOrDefault(p => p.DataModelPropertyName == property.Name) is VectorStoreRecordProperty recordProperty && recordProperty.StoragePropertyName is not null)
             {
                 return recordProperty.StoragePropertyName;
             }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
@@ -13,26 +13,29 @@ public abstract class VectorStoreRecordProperty
     /// <summary>
     /// Initializes a new instance of the <see cref="VectorStoreRecordProperty"/> class.
     /// </summary>
-    /// <param name="propertyName">The name of the property.</param>
-    private protected VectorStoreRecordProperty(string propertyName)
+    /// <param name="dataModelPropertyName">The name of the property on the data model.</param>
+    private protected VectorStoreRecordProperty(string dataModelPropertyName)
     {
-        this.PropertyName = propertyName;
+        this.DataModelPropertyName = dataModelPropertyName;
     }
 
     private protected VectorStoreRecordProperty(VectorStoreRecordProperty source)
     {
-        this.PropertyName = source.PropertyName;
+        this.DataModelPropertyName = source.DataModelPropertyName;
         this.StoragePropertyName = source.StoragePropertyName;
     }
 
     /// <summary>
-    /// Gets or sets the name of the property.
+    /// Gets or sets the name of the property on the data model.
     /// </summary>
-    public string PropertyName { get; set; }
+    public string DataModelPropertyName { get; private set; }
 
     /// <summary>
     /// Gets or sets an optional name to use for the property in storage, if different from the property name.
     /// E.g. the property name might be "MyProperty" but the storage name might be "my_property".
+    /// This property will only be respected by implementations that do not support a well known
+    /// serialization mechanism like JSON, in which case the attributes used by that seriallization system will
+    /// be used.
     /// </summary>
-    public string? StoragePropertyName { get; set; }
+    public string? StoragePropertyName { get; init; }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -150,11 +150,11 @@ public class VectorStoreRecordPropertyReaderTests
 
         // Assert.
         Assert.Equal(5, definition.Properties.Count);
-        Assert.Equal("Key", definition.Properties[0].PropertyName);
-        Assert.Equal("Data1", definition.Properties[1].PropertyName);
-        Assert.Equal("Data2", definition.Properties[2].PropertyName);
-        Assert.Equal("Vector1", definition.Properties[3].PropertyName);
-        Assert.Equal("Vector2", definition.Properties[4].PropertyName);
+        Assert.Equal("Key", definition.Properties[0].DataModelPropertyName);
+        Assert.Equal("Data1", definition.Properties[1].DataModelPropertyName);
+        Assert.Equal("Data2", definition.Properties[2].DataModelPropertyName);
+        Assert.Equal("Vector1", definition.Properties[3].DataModelPropertyName);
+        Assert.Equal("Vector2", definition.Properties[4].DataModelPropertyName);
 
         Assert.IsType<VectorStoreRecordKeyProperty>(definition.Properties[0]);
         Assert.IsType<VectorStoreRecordDataProperty>(definition.Properties[1]);


### PR DESCRIPTION
### Motivation and Context

The writability of properties on VectorStoreRecordProperty wasn't great and the naming of the data model property name wasn't appropriately differentiated from the storage property name.
See issue for more info:
[#7469](https://github.com/microsoft/semantic-kernel/issues/7469)

### Description

- Make properties read-only or init only.
- Rename PropertyName to DataModelPropertyName to better differentiate it from the StoragePropertyName

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
