### PR TITLE
.Net: Removing reflection type checks where possible when using definitions.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionCreateMappingTests.cs
@@ -18,7 +18,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapKeyFieldCreatesSearchableField()
     {
         // Arrange
-        var keyProperty = new VectorStoreRecordKeyProperty("testkey");
+        var keyProperty = new VectorStoreRecordKeyProperty("testkey", typeof(string));
         var storagePropertyName = "test_key";
 
         // Act
@@ -37,7 +37,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapStringDataFieldCreatesSearchableField(bool isFilterable)
     {
         // Arrange
-        var dataProperty = new VectorStoreRecordDataProperty("testdata") { IsFilterable = isFilterable, PropertyType = typeof(string) };
+        var dataProperty = new VectorStoreRecordDataProperty("testdata", typeof(string)) { IsFilterable = isFilterable };
         var storagePropertyName = "test_data";
 
         // Act
@@ -57,7 +57,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapDataFieldCreatesSimpleField(bool isFilterable)
     {
         // Arrange
-        var dataProperty = new VectorStoreRecordDataProperty("testdata") { IsFilterable = isFilterable, PropertyType = typeof(int) };
+        var dataProperty = new VectorStoreRecordDataProperty("testdata", typeof(int)) { IsFilterable = isFilterable };
         var storagePropertyName = "test_data";
 
         // Act
@@ -73,21 +73,10 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     }
 
     [Fact]
-    public void MapDataFieldFailsForNullType()
-    {
-        // Arrange
-        var dataProperty = new VectorStoreRecordDataProperty("testdata");
-        var storagePropertyName = "test_data";
-
-        // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionCreateMapping.MapDataField(dataProperty, storagePropertyName));
-    }
-
-    [Fact]
     public void MapVectorFieldCreatesVectorSearchField()
     {
         // Arrange
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.DotProductSimilarity };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 10, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.DotProductSimilarity };
         var storagePropertyName = "test_vector";
 
         // Act
@@ -115,7 +104,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapVectorFieldCreatesExpectedAlgoConfigTypes(string indexKind, Type algoConfigType)
     {
         // Arrange
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, IndexKind = indexKind, DistanceFunction = DistanceFunction.DotProductSimilarity };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 10, IndexKind = indexKind, DistanceFunction = DistanceFunction.DotProductSimilarity };
         var storagePropertyName = "test_vector";
 
         // Act
@@ -130,7 +119,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapVectorFieldDefaultsToHsnwAndCosine()
     {
         // Arrange
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10 };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 10 };
         var storagePropertyName = "test_vector";
 
         // Act
@@ -146,7 +135,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapVectorFieldThrowsForUnsupportedDistanceFunction()
     {
         // Arrange
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 10, DistanceFunction = DistanceFunction.ManhattanDistance };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 10, DistanceFunction = DistanceFunction.ManhattanDistance };
         var storagePropertyName = "test_vector";
 
         // Act
@@ -157,7 +146,7 @@ public class AzureAISearchVectorStoreCollectionCreateMappingTests
     public void MapVectorFieldThrowsForMissingDimensionsCount()
     {
         // Arrange
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector");
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>));
         var storagePropertyName = "test_vector";
 
         // Act

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -546,7 +546,7 @@ public class AzureAISearchVectorStoreRecordCollectionTests
         };
 
         // Act.
-        new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
+        var sut = new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
             this._searchIndexClientMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, JsonObjectCustomMapper = Mock.Of<IVectorStoreRecordMapper<MultiPropsModel, JsonObject>>() });

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -206,11 +206,11 @@ public class AzureAISearchVectorStoreRecordCollectionTests
         // Arrange.
         var storageObject = JsonSerializer.SerializeToNode(CreateModel(TestRecordKey1, false))!.AsObject();
 
-        var expectedSelectFields = useCustomJsonSerializerOptions ? new[] { "key", "storage_data1", "data2" } : new[] { "Key", "storage_data1", "Data2" };
+        var expectedSelectFields = useCustomJsonSerializerOptions ? new[] { "storage_data1", "data2", "key" } : new[] { "storage_data1", "Data2", "Key" };
         this._searchClientMock.Setup(
             x => x.GetDocumentAsync<MultiPropsModel>(
                 TestRecordKey1,
-                It.Is<GetDocumentOptions>(x => x.SelectedFields.SequenceEqual(expectedSelectFields)),
+                It.IsAny<GetDocumentOptions>(),
                 this._testCancellationToken))
             .ReturnsAsync(Response.FromValue(CreateModel(TestRecordKey1, true), Mock.Of<Response>()));
 
@@ -227,6 +227,13 @@ public class AzureAISearchVectorStoreRecordCollectionTests
         Assert.Equal(TestRecordKey1, actual.Key);
         Assert.Equal("data 1", actual.Data1);
         Assert.Equal("data 2", actual.Data2);
+
+        this._searchClientMock.Verify(
+            x => x.GetDocumentAsync<MultiPropsModel>(
+                TestRecordKey1,
+                It.Is<GetDocumentOptions>(x => x.SelectedFields.SequenceEqual(expectedSelectFields)),
+                this._testCancellationToken),
+            Times.Once);
     }
 
     [Theory]
@@ -519,6 +526,32 @@ public class AzureAISearchVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+    /// <summary>
+    /// Tests that the collection can be created even if the definition and the type do not match.
+    /// In this case, the expectation is that a custom mapper will be provided to map between the
+    /// schema as defined by the definition and the different data model.
+    /// </summary>
+    [Fact]
+    public void CanCreateCollectionWithMismatchedDefinitionAndType()
+    {
+        // Arrange.
+        var definition = new VectorStoreRecordDefinition()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("Text", typeof(string)),
+                new VectorStoreRecordVectorProperty("Embedding", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 },
+            }
+        };
+
+        // Act.
+        new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
+            this._searchIndexClientMock.Object,
+            TestCollectionName,
+            new() { VectorStoreRecordDefinition = definition, JsonObjectCustomMapper = Mock.Of<IVectorStoreRecordMapper<MultiPropsModel, JsonObject>>() });
+    }
+
     private AzureAISearchVectorStoreRecordCollection<MultiPropsModel> CreateRecordCollection(bool useDefinition, bool useCustomJsonSerializerOptions = false)
     {
         return new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
@@ -553,11 +586,11 @@ public class AzureAISearchVectorStoreRecordCollectionTests
     {
         Properties =
         [
-            new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("Data1") { PropertyType = typeof(string) },
-            new VectorStoreRecordDataProperty("Data2") { PropertyType = typeof(string) },
-            new VectorStoreRecordVectorProperty("Vector1") { Dimensions = 4 },
-            new VectorStoreRecordVectorProperty("Vector2") { Dimensions = 4 }
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("Data1", typeof(string)),
+            new VectorStoreRecordDataProperty("Data2", typeof(string)),
+            new VectorStoreRecordVectorProperty("Vector1", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 },
+            new VectorStoreRecordVectorProperty("Vector2", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 }
         ]
     };
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionCreateMapping.cs
@@ -39,11 +39,6 @@ internal static class AzureAISearchVectorStoreCollectionCreateMapping
             return new SearchableField(storagePropertyName) { IsFilterable = dataProperty.IsFilterable };
         }
 
-        if (dataProperty.PropertyType is null)
-        {
-            throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.DataModelPropertyName}' must be set to create a collection.");
-        }
-
         return new SimpleField(storagePropertyName, AzureAISearchVectorStoreCollectionCreateMapping.GetSDKFieldDataType(dataProperty.PropertyType)) { IsFilterable = dataProperty.IsFilterable };
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -61,18 +60,7 @@ public sealed class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreR
 
         if (this._options.VectorCustomMapper is null)
         {
-            (PropertyInfo KeyProperty, List<PropertyInfo> DataProperties, List<PropertyInfo> VectorProperties) properties;
-            if (this._options.VectorStoreRecordDefinition is not null)
-            {
-                properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), this._options.VectorStoreRecordDefinition, supportsMultipleVectors: false);
-            }
-            else
-            {
-                properties = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), supportsMultipleVectors: false);
-            }
-
-            var storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToStorageNameMap(properties, this._options.VectorStoreRecordDefinition);
-            this._mapper = new PineconeVectorStoreRecordMapper<TRecord>(properties.KeyProperty, properties.DataProperties, properties.VectorProperties, storagePropertyNames);
+            this._mapper = new PineconeVectorStoreRecordMapper<TRecord>(this._vectorStoreRecordDefinition);
         }
         else
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
@@ -70,15 +70,15 @@ internal sealed class PineconeVectorStoreRecordMapper<TRecord> : IVectorStoreRec
         VectorStoreRecordDefinition vectorStoreRecordDefinition)
     {
         // Validate property types.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), vectorStoreRecordDefinition, supportsMultipleVectors: false);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes([keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(dataProperties, s_supportedDataTypes, s_supportedEnumerableDataElementTypes, "Data");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(vectorProperties, s_supportedVectorTypes, "Vector");
+        var propertiesInfo = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), vectorStoreRecordDefinition, supportsMultipleVectors: false);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([propertiesInfo.keyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.dataProperties, s_supportedDataTypes, s_supportedEnumerableDataElementTypes, "Data");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.vectorProperties, s_supportedVectorTypes, "Vector");
 
         // Assign.
-        this._keyPropertyInfo = keyProperty;
-        this._dataPropertiesInfo = dataProperties;
-        this._vectorPropertyInfo = vectorProperties[0];
+        this._keyPropertyInfo = propertiesInfo.keyProperty;
+        this._dataPropertiesInfo = propertiesInfo.dataProperties;
+        this._vectorPropertyInfo = propertiesInfo.vectorProperties[0];
 
         // Get storage names and store for later use.
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, vectorStoreRecordDefinition, supportsMultipleVectors: false, requiresAtLeastOneVector: true);

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
@@ -65,27 +65,25 @@ internal sealed class PineconeVectorStoreRecordMapper<TRecord> : IVectorStoreRec
     /// <summary>
     /// Initializes a new instance of the <see cref="PineconeVectorStoreRecordMapper{TDataModel}"/> class.
     /// </summary>
-    /// <param name="keyProperty">A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</param>
-    /// <param name="dataProperties">A list of property info objects that point at the data properties in the current model, and allows easy reading and writing of these properties.</param>
-    /// <param name="vectorProperties">A list of property info objects that point at the vector properties in the current model, and allows easy reading and writing of these properties.</param>
-    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the configured name that should be used when storing it.</param>
-    public PineconeVectorStoreRecordMapper(PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties, Dictionary<string, string> storagePropertyNames)
+    /// <param name="vectorStoreRecordDefinition">The record definition that defines the schema of the record type.</param>
+    public PineconeVectorStoreRecordMapper(
+        VectorStoreRecordDefinition vectorStoreRecordDefinition)
     {
-        Verify.True(vectorProperties.Count == 1, "There should be exactly one vector property in the data model.");
-
+        // Validate property types.
+        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), vectorStoreRecordDefinition, supportsMultipleVectors: false);
         VectorStoreRecordPropertyReader.VerifyPropertyTypes([keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(dataProperties, s_supportedDataTypes, "Data", s_supportedEnumerableDataElementTypes);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(dataProperties, s_supportedDataTypes, s_supportedEnumerableDataElementTypes, "Data");
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(vectorProperties, s_supportedVectorTypes, "Vector");
 
+        // Assign.
         this._keyPropertyInfo = keyProperty;
         this._dataPropertiesInfo = dataProperties;
         this._vectorPropertyInfo = vectorProperties[0];
-        this._storagePropertyNames = storagePropertyNames;
 
-        foreach (var property in dataProperties.Concat(vectorProperties).Concat([keyProperty]))
-        {
-            this._jsonPropertyNames[property.Name] = VectorStoreRecordPropertyReader.GetJsonPropertyName(JsonSerializerOptions.Default, property);
-        }
+        // Get storage names and store for later use.
+        var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, vectorStoreRecordDefinition, supportsMultipleVectors: false, requiresAtLeastOneVector: true);
+        this._jsonPropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(properties, typeof(TRecord), JsonSerializerOptions.Default);
+        this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToStorageNameMap(properties);
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
@@ -40,20 +40,16 @@ internal sealed class RedisHashSetVectorStoreRecordMapper<TConsumerDataModel> : 
     /// <summary>
     /// Initializes a new instance of the <see cref="RedisHashSetVectorStoreRecordMapper{TConsumerDataModel}"/> class.
     /// </summary>
-    /// <param name="keyPropertyInfo">The property info object that points at the key property for the current model.</param>
-    /// <param name="dataPropertiesInfo">The property info objects that point at the payload properties in the current model.</param>
-    /// <param name="vectorPropertiesInfo">The property info objects that point at the vector properties in the current model.</param>
+    /// <param name="vectorStoreRecordDefinition">The record definition that defines the schema of the record type.</param>
     /// <param name="storagePropertyNames">A dictionary that maps from a property name to the configured name that should be used when storing it.</param>
     public RedisHashSetVectorStoreRecordMapper(
-        PropertyInfo keyPropertyInfo,
-        IEnumerable<PropertyInfo> dataPropertiesInfo,
-        IEnumerable<PropertyInfo> vectorPropertiesInfo,
+        VectorStoreRecordDefinition vectorStoreRecordDefinition,
         Dictionary<string, string> storagePropertyNames)
     {
-        Verify.NotNull(keyPropertyInfo);
-        Verify.NotNull(dataPropertiesInfo);
-        Verify.NotNull(vectorPropertiesInfo);
+        Verify.NotNull(vectorStoreRecordDefinition);
         Verify.NotNull(storagePropertyNames);
+
+        (PropertyInfo keyPropertyInfo, List<PropertyInfo> dataPropertiesInfo, List<PropertyInfo> vectorPropertiesInfo) = VectorStoreRecordPropertyReader.FindProperties(typeof(TConsumerDataModel), vectorStoreRecordDefinition, supportsMultipleVectors: true);
 
         this._keyPropertyInfo = keyPropertyInfo;
         this._dataPropertiesInfo = dataPropertiesInfo;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
@@ -65,11 +65,6 @@ internal static class RedisVectorStoreCollectionCreateMapping
             // Data property.
             if (property is VectorStoreRecordDataProperty dataProperty && dataProperty.IsFilterable)
             {
-                if (dataProperty.PropertyType is null)
-                {
-                    throw new InvalidOperationException($"Property {nameof(dataProperty.PropertyType)} on {nameof(VectorStoreRecordDataProperty)} '{dataProperty.DataModelPropertyName}' must be set to create a collection, since the property is filterable.");
-                }
-
                 var storageName = storagePropertyNames[dataProperty.DataModelPropertyName];
 
                 if (dataProperty.PropertyType == typeof(string))

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreCollectionCreateMappingTests.cs
@@ -17,7 +17,7 @@ public class QdrantVectorStoreCollectionCreateMappingTests
     public void MapSingleVectorCreatesVectorParams()
     {
         // Arrange.
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 4, DistanceFunction = DistanceFunction.DotProductSimilarity };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 4, DistanceFunction = DistanceFunction.DotProductSimilarity };
 
         // Act.
         var actual = QdrantVectorStoreCollectionCreateMapping.MapSingleVector(vectorProperty);
@@ -32,7 +32,7 @@ public class QdrantVectorStoreCollectionCreateMappingTests
     public void MapSingleVectorDefaultsToCosine()
     {
         // Arrange.
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 4 };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 };
 
         // Act.
         var actual = QdrantVectorStoreCollectionCreateMapping.MapSingleVector(vectorProperty);
@@ -45,7 +45,7 @@ public class QdrantVectorStoreCollectionCreateMappingTests
     public void MapSingleVectorThrowsForUnsupportedDistanceFunction()
     {
         // Arrange.
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = 4, DistanceFunction = DistanceFunction.CosineDistance };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = 4, DistanceFunction = DistanceFunction.CosineDistance };
 
         // Act and assert.
         Assert.Throws<InvalidOperationException>(() => QdrantVectorStoreCollectionCreateMapping.MapSingleVector(vectorProperty));
@@ -57,7 +57,7 @@ public class QdrantVectorStoreCollectionCreateMappingTests
     public void MapSingleVectorThrowsIfDimensionsIsInvalid(int? dimensions)
     {
         // Arrange.
-        var vectorProperty = new VectorStoreRecordVectorProperty("testvector") { Dimensions = dimensions };
+        var vectorProperty = new VectorStoreRecordVectorProperty("testvector", typeof(ReadOnlyMemory<float>)) { Dimensions = dimensions };
 
         // Act and assert.
         Assert.Throws<InvalidOperationException>(() => QdrantVectorStoreCollectionCreateMapping.MapSingleVector(vectorProperty));
@@ -69,8 +69,8 @@ public class QdrantVectorStoreCollectionCreateMappingTests
         // Arrange.
         var vectorProperties = new VectorStoreRecordVectorProperty[]
         {
-            new("testvector1") { Dimensions = 10, DistanceFunction = DistanceFunction.EuclideanDistance },
-            new("testvector2") { Dimensions = 20 }
+            new("testvector1", typeof(ReadOnlyMemory<float>)) { Dimensions = 10, DistanceFunction = DistanceFunction.EuclideanDistance },
+            new("testvector2", typeof(ReadOnlyMemory<float>)) { Dimensions = 20 }
         };
 
         var storagePropertyNames = new Dictionary<string, string>

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -533,7 +533,7 @@ public class QdrantVectorStoreRecordCollectionTests
         };
 
         // Act.
-        new QdrantVectorStoreRecordCollection<SinglePropsModel<ulong>>(
+        var sut = new QdrantVectorStoreRecordCollection<SinglePropsModel<ulong>>(
             this._qdrantClientMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, PointStructCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel<ulong>, PointStruct>>() });

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -513,6 +513,32 @@ public class QdrantVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+    /// <summary>
+    /// Tests that the collection can be created even if the definition and the type do not match.
+    /// In this case, the expectation is that a custom mapper will be provided to map between the
+    /// schema as defined by the definition and the different data model.
+    /// </summary>
+    [Fact]
+    public void CanCreateCollectionWithMismatchedDefinitionAndType()
+    {
+        // Arrange.
+        var definition = new VectorStoreRecordDefinition()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(ulong)),
+                new VectorStoreRecordDataProperty("Text", typeof(string)),
+                new VectorStoreRecordVectorProperty("Embedding", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 },
+            }
+        };
+
+        // Act.
+        new QdrantVectorStoreRecordCollection<SinglePropsModel<ulong>>(
+            this._qdrantClientMock.Object,
+            TestCollectionName,
+            new() { VectorStoreRecordDefinition = definition, PointStructCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel<ulong>, PointStruct>>() });
+    }
+
     private void SetupRetrieveMock(List<RetrievedPoint> retrievedPoints)
     {
         this._qdrantClientMock
@@ -626,7 +652,7 @@ public class QdrantVectorStoreRecordCollectionTests
             TestCollectionName,
             new()
             {
-                VectorStoreRecordDefinition = useDefinition ? this._singlePropsDefinition : null,
+                VectorStoreRecordDefinition = useDefinition ? CreateSinglePropsDefinition(typeof(T)) : null,
                 HasNamedVectors = hasNamedVectors
             }) as IVectorStoreRecordCollection<T, SinglePropsModel<T>>;
         return store!;
@@ -644,16 +670,19 @@ public class QdrantVectorStoreRecordCollectionTests
         };
     }
 
-    private readonly VectorStoreRecordDefinition _singlePropsDefinition = new()
+    private static VectorStoreRecordDefinition CreateSinglePropsDefinition(Type keyType)
     {
-        Properties =
-        [
-            new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("OriginalNameData") { IsFilterable = true },
-            new VectorStoreRecordDataProperty("Data") { IsFilterable = true, StoragePropertyName = "data_storage_name" },
-            new VectorStoreRecordVectorProperty("Vector") { StoragePropertyName = "vector_storage_name" }
-        ]
-    };
+        return new()
+        {
+            Properties =
+            [
+                new VectorStoreRecordKeyProperty("Key", keyType),
+                new VectorStoreRecordDataProperty("OriginalNameData", typeof(string)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("Data", typeof(string)) { IsFilterable = true, StoragePropertyName = "data_storage_name" },
+                new VectorStoreRecordVectorProperty("Vector", typeof(ReadOnlyMemory<float>)) { StoragePropertyName = "vector_storage_name" }
+            ]
+        };
+    }
 
     public sealed class SinglePropsModel<T>
     {

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordMapperTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
 using Microsoft.SemanticKernel.Data;
@@ -23,8 +22,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsSinglePropsFromDataToStorageModelWithUlong(bool hasNamedVectors)
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel<ulong>), supportsMultipleVectors: hasNamedVectors);
-        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<ulong>>(hasNamedVectors, keyProperty, dataProperties, vectorProperties, s_singlePropsModelStorageNamesMap);
+        var definition = CreateSinglePropsVectorStoreRecordDefinition(typeof(ulong));
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<ulong>>(definition, hasNamedVectors, s_singlePropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromDataToStorageModel(CreateSinglePropsModel<ulong>(5ul));
@@ -51,8 +50,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsSinglePropsFromDataToStorageModelWithGuid(bool hasNamedVectors)
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel<Guid>), supportsMultipleVectors: hasNamedVectors);
-        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<Guid>>(hasNamedVectors, keyProperty, dataProperties, vectorProperties, s_singlePropsModelStorageNamesMap);
+        var definition = CreateSinglePropsVectorStoreRecordDefinition(typeof(Guid));
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<Guid>>(definition, hasNamedVectors, s_singlePropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromDataToStorageModel(CreateSinglePropsModel<Guid>(Guid.Parse("11111111-1111-1111-1111-111111111111")));
@@ -72,8 +71,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsSinglePropsFromStorageToDataModelWithUlong(bool hasNamedVectors, bool includeVectors)
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel<ulong>), supportsMultipleVectors: hasNamedVectors);
-        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<ulong>>(hasNamedVectors, keyProperty, dataProperties, vectorProperties, s_singlePropsModelStorageNamesMap);
+        var definition = CreateSinglePropsVectorStoreRecordDefinition(typeof(ulong));
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<ulong>>(definition, hasNamedVectors, s_singlePropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromStorageToDataModel(CreateSinglePropsPointStruct(5, hasNamedVectors), new() { IncludeVectors = includeVectors });
@@ -101,8 +100,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsSinglePropsFromStorageToDataModelWithGuid(bool hasNamedVectors, bool includeVectors)
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel<Guid>), supportsMultipleVectors: hasNamedVectors);
-        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<Guid>>(hasNamedVectors, keyProperty, dataProperties, vectorProperties, s_singlePropsModelStorageNamesMap);
+        var definition = CreateSinglePropsVectorStoreRecordDefinition(typeof(Guid));
+        var sut = new QdrantVectorStoreRecordMapper<SinglePropsModel<Guid>>(definition, hasNamedVectors, s_singlePropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromStorageToDataModel(CreateSinglePropsPointStruct(Guid.Parse("11111111-1111-1111-1111-111111111111"), hasNamedVectors), new() { IncludeVectors = includeVectors });
@@ -126,8 +125,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsMultiPropsFromDataToStorageModelWithUlong()
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel<ulong>), supportsMultipleVectors: true);
-        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<ulong>>(true, keyProperty, dataProperties, vectorProperties, s_multiPropsModelStorageNamesMap);
+        var definition = CreateMultiPropsVectorStoreRecordDefinition(typeof(ulong));
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<ulong>>(definition, true, s_multiPropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromDataToStorageModel(CreateMultiPropsModel<ulong>(5ul));
@@ -151,8 +150,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsMultiPropsFromDataToStorageModelWithGuid()
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel<Guid>), supportsMultipleVectors: true);
-        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<Guid>>(true, keyProperty, dataProperties, vectorProperties, s_multiPropsModelStorageNamesMap);
+        var definition = CreateMultiPropsVectorStoreRecordDefinition(typeof(Guid));
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<Guid>>(definition, true, s_multiPropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromDataToStorageModel(CreateMultiPropsModel<Guid>(Guid.Parse("11111111-1111-1111-1111-111111111111")));
@@ -178,8 +177,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsMultiPropsFromStorageToDataModelWithUlong(bool includeVectors)
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel<ulong>), supportsMultipleVectors: true);
-        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<ulong>>(true, keyProperty, dataProperties, vectorProperties, s_multiPropsModelStorageNamesMap);
+        var definition = CreateMultiPropsVectorStoreRecordDefinition(typeof(ulong));
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<ulong>>(definition, true, s_multiPropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromStorageToDataModel(CreateMultiPropsPointStruct(5), new() { IncludeVectors = includeVectors });
@@ -213,8 +212,8 @@ public class QdrantVectorStoreRecordMapperTests
     public void MapsMultiPropsFromStorageToDataModelWithGuid(bool includeVectors)
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel<Guid>), supportsMultipleVectors: true);
-        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<Guid>>(true, keyProperty, dataProperties, vectorProperties, s_multiPropsModelStorageNamesMap);
+        var definition = CreateMultiPropsVectorStoreRecordDefinition(typeof(Guid));
+        var sut = new QdrantVectorStoreRecordMapper<MultiPropsModel<Guid>>(definition, true, s_multiPropsModelStorageNamesMap);
 
         // Act.
         var actual = sut.MapFromStorageToDataModel(CreateMultiPropsPointStruct(Guid.Parse("11111111-1111-1111-1111-111111111111")), new() { IncludeVectors = includeVectors });
@@ -348,6 +347,16 @@ public class QdrantVectorStoreRecordMapperTests
         { "Vector", "vector" },
     };
 
+    private static VectorStoreRecordDefinition CreateSinglePropsVectorStoreRecordDefinition(Type keyType) => new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", keyType),
+            new VectorStoreRecordDataProperty("Data", typeof(string)),
+            new VectorStoreRecordVectorProperty("Vector", typeof(ReadOnlyMemory<float>)),
+        },
+    };
+
     private sealed class SinglePropsModel<TKey>
     {
         [VectorStoreRecordKey]
@@ -374,6 +383,23 @@ public class QdrantVectorStoreRecordMapperTests
         { "DataArrayInt", "dataArrayInt" },
         { "Vector1", "vector1" },
         { "Vector2", "vector2" },
+    };
+
+    private static VectorStoreRecordDefinition CreateMultiPropsVectorStoreRecordDefinition(Type keyType) => new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", keyType),
+            new VectorStoreRecordDataProperty("DataString", typeof(string)),
+            new VectorStoreRecordDataProperty("DataInt", typeof(int)),
+            new VectorStoreRecordDataProperty("DataLong", typeof(long)),
+            new VectorStoreRecordDataProperty("DataFloat", typeof(float)),
+            new VectorStoreRecordDataProperty("DataDouble", typeof(double)),
+            new VectorStoreRecordDataProperty("DataBool", typeof(bool)),
+            new VectorStoreRecordDataProperty("DataArrayInt", typeof(List<int>)),
+            new VectorStoreRecordVectorProperty("Vector1", typeof(ReadOnlyMemory<float>)),
+            new VectorStoreRecordVectorProperty("Vector2", typeof(ReadOnlyMemory<float>)),
+        },
     };
 
     private sealed class MultiPropsModel<TKey>

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -435,7 +435,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
         };
 
         // Act.
-        new RedisHashSetVectorStoreRecordCollection<SinglePropsModel>(
+        var sut = new RedisHashSetVectorStoreRecordCollection<SinglePropsModel>(
             this._redisDatabaseMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, HashEntriesCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel, (string key, HashEntry[] hashEntries)>>() });

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -415,6 +415,32 @@ public class RedisHashSetVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+    /// <summary>
+    /// Tests that the collection can be created even if the definition and the type do not match.
+    /// In this case, the expectation is that a custom mapper will be provided to map between the
+    /// schema as defined by the definition and the different data model.
+    /// </summary>
+    [Fact]
+    public void CanCreateCollectionWithMismatchedDefinitionAndType()
+    {
+        // Arrange.
+        var definition = new VectorStoreRecordDefinition()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("Text", typeof(string)),
+                new VectorStoreRecordVectorProperty("Embedding", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 },
+            }
+        };
+
+        // Act.
+        new RedisHashSetVectorStoreRecordCollection<SinglePropsModel>(
+            this._redisDatabaseMock.Object,
+            TestCollectionName,
+            new() { VectorStoreRecordDefinition = definition, HashEntriesCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel, (string key, HashEntry[] hashEntries)>>() });
+    }
+
     private RedisHashSetVectorStoreRecordCollection<SinglePropsModel> CreateRecordCollection(bool useDefinition)
     {
         return new RedisHashSetVectorStoreRecordCollection<SinglePropsModel>(
@@ -480,10 +506,10 @@ public class RedisHashSetVectorStoreRecordCollectionTests
     {
         Properties =
         [
-            new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("OriginalNameData"),
-            new VectorStoreRecordDataProperty("Data") { StoragePropertyName = "data_storage_name" },
-            new VectorStoreRecordVectorProperty("Vector") { StoragePropertyName = "vector_storage_name" }
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("OriginalNameData", typeof(string)),
+            new VectorStoreRecordDataProperty("Data", typeof(string)) { StoragePropertyName = "data_storage_name" },
+            new VectorStoreRecordVectorProperty("Vector", typeof(ReadOnlyMemory<float>)) { StoragePropertyName = "vector_storage_name" }
         ]
     };
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordMapperTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.SemanticKernel.Connectors.Redis;
 using Microsoft.SemanticKernel.Data;
@@ -20,8 +19,7 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
     public void MapsAllFieldsFromDataToStorageModel()
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(AllTypesModel), supportsMultipleVectors: true);
-        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(keyProperty, dataProperties, vectorProperties, s_storagePropertyNames);
+        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(s_vectorStoreRecordDefinition, s_storagePropertyNames);
 
         // Act.
         var actual = sut.MapFromDataToStorageModel(CreateModel("test key"));
@@ -86,8 +84,7 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
     public void MapsAllFieldsFromStorageToDataModel()
     {
         // Arrange.
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) = VectorStoreRecordPropertyReader.FindProperties(typeof(AllTypesModel), supportsMultipleVectors: true);
-        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(keyProperty, dataProperties, vectorProperties, s_storagePropertyNames);
+        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(s_vectorStoreRecordDefinition, s_storagePropertyNames);
 
         // Act.
         var actual = sut.MapFromStorageToDataModel(("test key", CreateHashSet()), new() { IncludeVectors = true });
@@ -183,6 +180,31 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
         ["NullableBoolData"] = "NullableBoolData",
         ["FloatVector"] = "FloatVector",
         ["DoubleVector"] = "DoubleVector",
+    };
+
+    private static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>()
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("StringData", typeof(string)),
+            new VectorStoreRecordDataProperty("IntData", typeof(int)),
+            new VectorStoreRecordDataProperty("UIntData", typeof(uint)),
+            new VectorStoreRecordDataProperty("LongData", typeof(long)),
+            new VectorStoreRecordDataProperty("ULongData", typeof(ulong)),
+            new VectorStoreRecordDataProperty("DoubleData", typeof(double)),
+            new VectorStoreRecordDataProperty("FloatData", typeof(float)),
+            new VectorStoreRecordDataProperty("BoolData", typeof(bool)),
+            new VectorStoreRecordDataProperty("NullableIntData", typeof(int?)),
+            new VectorStoreRecordDataProperty("NullableUIntData", typeof(uint?)),
+            new VectorStoreRecordDataProperty("NullableLongData", typeof(long?)),
+            new VectorStoreRecordDataProperty("NullableULongData", typeof(ulong?)),
+            new VectorStoreRecordDataProperty("NullableDoubleData", typeof(double?)),
+            new VectorStoreRecordDataProperty("NullableFloatData", typeof(float?)),
+            new VectorStoreRecordDataProperty("NullableBoolData", typeof(bool?)),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(float)),
+            new VectorStoreRecordVectorProperty("DoubleVector", typeof(double)),
+        }
     };
 
     private sealed class AllTypesModel

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -458,7 +458,7 @@ public class RedisJsonVectorStoreRecordCollectionTests
         };
 
         // Act.
-        new RedisJsonVectorStoreRecordCollection<MultiPropsModel>(
+        var sut = new RedisJsonVectorStoreRecordCollection<MultiPropsModel>(
             this._redisDatabaseMock.Object,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, JsonNodeCustomMapper = Mock.Of<IVectorStoreRecordMapper<MultiPropsModel, (string key, JsonNode node)>>() });

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -438,6 +438,32 @@ public class RedisJsonVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+    /// <summary>
+    /// Tests that the collection can be created even if the definition and the type do not match.
+    /// In this case, the expectation is that a custom mapper will be provided to map between the
+    /// schema as defined by the definition and the different data model.
+    /// </summary>
+    [Fact]
+    public void CanCreateCollectionWithMismatchedDefinitionAndType()
+    {
+        // Arrange.
+        var definition = new VectorStoreRecordDefinition()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("Text", typeof(string)),
+                new VectorStoreRecordVectorProperty("Embedding", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 },
+            }
+        };
+
+        // Act.
+        new RedisJsonVectorStoreRecordCollection<MultiPropsModel>(
+            this._redisDatabaseMock.Object,
+            TestCollectionName,
+            new() { VectorStoreRecordDefinition = definition, JsonNodeCustomMapper = Mock.Of<IVectorStoreRecordMapper<MultiPropsModel, (string key, JsonNode node)>>() });
+    }
+
     private RedisJsonVectorStoreRecordCollection<MultiPropsModel> CreateRecordCollection(bool useDefinition, bool useCustomJsonSerializerOptions = false)
     {
         return new RedisJsonVectorStoreRecordCollection<MultiPropsModel>(
@@ -510,11 +536,11 @@ public class RedisJsonVectorStoreRecordCollectionTests
     {
         Properties =
         [
-            new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("Data1") { IsFilterable = true, PropertyType = typeof(string), StoragePropertyName = "ignored_data1_storage_name" },
-            new VectorStoreRecordDataProperty("Data2") { IsFilterable = true, PropertyType = typeof(string) },
-            new VectorStoreRecordVectorProperty("Vector1") { Dimensions = 4, StoragePropertyName = "ignored_vector1_storage_name" },
-            new VectorStoreRecordVectorProperty("Vector2") { Dimensions = 4 }
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("Data1", typeof(string)) { IsFilterable = true, StoragePropertyName = "ignored_data1_storage_name" },
+            new VectorStoreRecordDataProperty("Data2", typeof(string)) { IsFilterable = true },
+            new VectorStoreRecordVectorProperty("Vector1", typeof(ReadOnlyMemory<float>)) { Dimensions = 4, StoragePropertyName = "ignored_vector1_storage_name" },
+            new VectorStoreRecordVectorProperty("Vector2", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 }
         ]
     };
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
@@ -20,16 +20,16 @@ public class RedisVectorStoreCollectionCreateMappingTests
         // Arrange.
         var properties = new VectorStoreRecordProperty[]
         {
-            new VectorStoreRecordKeyProperty("Key"),
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
 
-            new VectorStoreRecordDataProperty("FilterableString") { PropertyType = typeof(string), IsFilterable = true },
-            new VectorStoreRecordDataProperty("FilterableInt") { PropertyType = typeof(int), IsFilterable = true },
-            new VectorStoreRecordDataProperty("FilterableNullableInt") { PropertyType = typeof(int?), IsFilterable = true },
+            new VectorStoreRecordDataProperty("FilterableString", typeof(string)) { IsFilterable = true },
+            new VectorStoreRecordDataProperty("FilterableInt", typeof(int)) { IsFilterable = true },
+            new VectorStoreRecordDataProperty("FilterableNullableInt", typeof(int)) { IsFilterable = true },
 
-            new VectorStoreRecordDataProperty("NonFilterableString") { PropertyType = typeof(string) },
+            new VectorStoreRecordDataProperty("NonFilterableString", typeof(string)),
 
-            new VectorStoreRecordVectorProperty("VectorDefaultIndexingOptions") { Dimensions = 10 },
-            new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions") { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanDistance },
+            new VectorStoreRecordVectorProperty("VectorDefaultIndexingOptions", typeof(ReadOnlyMemory<float>)) { Dimensions = 10 },
+            new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions", typeof(ReadOnlyMemory<float>)) { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanDistance },
         };
 
         var storagePropertyNames = new Dictionary<string, string>()
@@ -71,24 +71,13 @@ public class RedisVectorStoreCollectionCreateMappingTests
         Assert.Equal("L2", ((VectorField)schema.Fields[4]).Attributes!["DISTANCE_METRIC"]);
     }
 
-    [Fact]
-    public void MapToSchemaThrowsOnMissingPropertyType()
-    {
-        // Arrange.
-        var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordDataProperty("FilterableString") { IsFilterable = true } };
-        var storagePropertyNames = new Dictionary<string, string>() { { "FilterableString", "FilterableString" } };
-
-        // Act and assert.
-        Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.MapToSchema(properties, storagePropertyNames));
-    }
-
     [Theory]
     [InlineData(null)]
     [InlineData(0)]
     public void MapToSchemaThrowsOnInvalidVectorDimensions(int? dimensions)
     {
         // Arrange.
-        var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordVectorProperty("VectorProperty") { Dimensions = dimensions } };
+        var properties = new VectorStoreRecordProperty[] { new VectorStoreRecordVectorProperty("VectorProperty", typeof(ReadOnlyMemory<float>)) { Dimensions = dimensions } };
         var storagePropertyNames = new Dictionary<string, string>() { { "VectorProperty", "VectorProperty" } };
 
         // Act and assert.
@@ -99,7 +88,7 @@ public class RedisVectorStoreCollectionCreateMappingTests
     public void GetSDKIndexKindThrowsOnUnsupportedIndexKind()
     {
         // Arrange.
-        var vectorProperty = new VectorStoreRecordVectorProperty("VectorProperty") { IndexKind = "Unsupported" };
+        var vectorProperty = new VectorStoreRecordVectorProperty("VectorProperty", typeof(ReadOnlyMemory<float>)) { IndexKind = "Unsupported" };
 
         // Act and assert.
         Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.GetSDKIndexKind(vectorProperty));
@@ -109,7 +98,7 @@ public class RedisVectorStoreCollectionCreateMappingTests
     public void GetSDKDistanceAlgorithmThrowsOnUnsupportedDistanceFunction()
     {
         // Arrange.
-        var vectorProperty = new VectorStoreRecordVectorProperty("VectorProperty") { DistanceFunction = "Unsupported" };
+        var vectorProperty = new VectorStoreRecordVectorProperty("VectorProperty", typeof(ReadOnlyMemory<float>)) { DistanceFunction = "Unsupported" };
 
         // Act and assert.
         Assert.Throws<InvalidOperationException>(() => RedisVectorStoreCollectionCreateMapping.GetSDKDistanceAlgorithm(vectorProperty));

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeVectorStoreRecordCollectionTests.cs
@@ -38,7 +38,7 @@ public class PineconeVectorStoreRecordCollectionTests
         using var pineconeClient = new Sdk.PineconeClient("fake api key");
 
         // Act.
-        new PineconeVectorStoreRecordCollection<SinglePropsModel>(
+        var sut = new PineconeVectorStoreRecordCollection<SinglePropsModel>(
             pineconeClient,
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, VectorCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel, Sdk.Vector>>() });

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Connectors.Pinecone;
+using Microsoft.SemanticKernel.Data;
+using Moq;
+using Xunit;
+using Sdk = Pinecone;
+
+namespace SemanticKernel.Connectors.UnitTests.Pinecone;
+
+/// <summary>
+/// Contains tests for the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/> class.
+/// </summary>
+public class PineconeVectorStoreRecordCollectionTests
+{
+    private const string TestCollectionName = "testcollection";
+
+    /// <summary>
+    /// Tests that the collection can be created even if the definition and the type do not match.
+    /// In this case, the expectation is that a custom mapper will be provided to map between the
+    /// schema as defined by the definition and the different data model.
+    /// </summary>
+    [Fact]
+    public void CanCreateCollectionWithMismatchedDefinitionAndType()
+    {
+        // Arrange.
+        var definition = new VectorStoreRecordDefinition()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("Text", typeof(string)),
+                new VectorStoreRecordVectorProperty("Embedding", typeof(ReadOnlyMemory<float>)) { Dimensions = 4 },
+            }
+        };
+        using var pineconeClient = new Sdk.PineconeClient("fake api key");
+
+        // Act.
+        new PineconeVectorStoreRecordCollection<SinglePropsModel>(
+            pineconeClient,
+            TestCollectionName,
+            new() { VectorStoreRecordDefinition = definition, VectorCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel, Sdk.Vector>>() });
+    }
+
+    public sealed class SinglePropsModel
+    {
+        public string Key { get; set; } = string.Empty;
+
+        public string OriginalNameData { get; set; } = string.Empty;
+
+        public string Data { get; set; } = string.Empty;
+
+        public ReadOnlyMemory<float>? Vector { get; set; }
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -53,14 +53,14 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         {
             Properties = new List<VectorStoreRecordProperty>
             {
-                new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName") { PropertyType = typeof(string) },
-                new VectorStoreRecordDataProperty("Description") { PropertyType = typeof(string) },
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding") { Dimensions = 4 },
-                new VectorStoreRecordDataProperty("Tags") { PropertyType = typeof(string[]) },
-                new VectorStoreRecordDataProperty("ParkingIncluded") { PropertyType = typeof(bool?) },
-                new VectorStoreRecordDataProperty("LastRenovationDate") { PropertyType = typeof(DateTimeOffset?) },
-                new VectorStoreRecordDataProperty("Rating") { PropertyType = typeof(float?) }
+                new VectorStoreRecordKeyProperty("HotelId", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)),
+                new VectorStoreRecordDataProperty("Description", typeof(string)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4 },
+                new VectorStoreRecordDataProperty("Tags", typeof(string[])),
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool?)),
+                new VectorStoreRecordDataProperty("LastRenovationDate", typeof(DateTimeOffset?)),
+                new VectorStoreRecordDataProperty("Rating", typeof(float?))
             }
         };
     }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreFixture.cs
@@ -42,14 +42,14 @@ public class PineconeVectorStoreFixture : IAsyncLifetime
         {
             Properties =
             [
-                new VectorStoreRecordKeyProperty(nameof(PineconeHotel.HotelId)),
-                new VectorStoreRecordDataProperty(nameof(PineconeHotel.HotelName)),
-                new VectorStoreRecordDataProperty(nameof(PineconeHotel.HotelCode)),
-                new VectorStoreRecordDataProperty(nameof(PineconeHotel.ParkingIncluded)) { StoragePropertyName = "parking_is_included" },
-                new VectorStoreRecordDataProperty(nameof(PineconeHotel.HotelRating)),
-                new VectorStoreRecordDataProperty(nameof(PineconeHotel.Tags)),
-                new VectorStoreRecordDataProperty(nameof(PineconeHotel.Description)),
-                new VectorStoreRecordVectorProperty(nameof(PineconeHotel.DescriptionEmbedding)) { Dimensions = 8, DistanceFunction = DistanceFunction.DotProductSimilarity }
+                new VectorStoreRecordKeyProperty(nameof(PineconeHotel.HotelId), typeof(string)),
+                new VectorStoreRecordDataProperty(nameof(PineconeHotel.HotelName), typeof(string)),
+                new VectorStoreRecordDataProperty(nameof(PineconeHotel.HotelCode), typeof(int)),
+                new VectorStoreRecordDataProperty(nameof(PineconeHotel.ParkingIncluded), typeof(bool)) { StoragePropertyName = "parking_is_included" },
+                new VectorStoreRecordDataProperty(nameof(PineconeHotel.HotelRating), typeof(float)),
+                new VectorStoreRecordDataProperty(nameof(PineconeHotel.Tags), typeof(List<string>)),
+                new VectorStoreRecordDataProperty(nameof(PineconeHotel.Description), typeof(string)),
+                new VectorStoreRecordVectorProperty(nameof(PineconeHotel.DescriptionEmbedding), typeof(ReadOnlyMemory<float>)) { Dimensions = 8, DistanceFunction = DistanceFunction.DotProductSimilarity }
             ]
         };
 
@@ -57,28 +57,28 @@ public class PineconeVectorStoreFixture : IAsyncLifetime
         {
             Properties =
             [
-                new VectorStoreRecordKeyProperty(nameof(PineconeAllTypes.Id)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.BoolProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableBoolProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.StringProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableStringProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.IntProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableIntProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.LongProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableLongProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.FloatProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableFloatProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.DoubleProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableDoubleProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.DecimalProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableDecimalProperty)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.StringArray)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableStringArray)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.StringList)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableStringList)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.Collection)),
-                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.Enumerable)),
-                new VectorStoreRecordVectorProperty(nameof(PineconeAllTypes.Embedding)) { Dimensions = 8, DistanceFunction = DistanceFunction.DotProductSimilarity }
+                new VectorStoreRecordKeyProperty(nameof(PineconeAllTypes.Id), typeof(string)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.BoolProperty), typeof(bool)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableBoolProperty), typeof(bool?)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.StringProperty), typeof(string)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableStringProperty), typeof(string)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.IntProperty), typeof(int)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableIntProperty), typeof(int?)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.LongProperty), typeof(long)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableLongProperty), typeof(long?)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.FloatProperty), typeof(float)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableFloatProperty), typeof(float?)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.DoubleProperty), typeof(double)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableDoubleProperty), typeof(double?)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.DecimalProperty), typeof(decimal)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableDecimalProperty), typeof(decimal?)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.StringArray), typeof(string[])),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableStringArray), typeof(string[])),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.StringList), typeof(List<string>)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.NullableStringList), typeof(List<string?>)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.Collection), typeof(IReadOnlyCollection<string>)),
+                new VectorStoreRecordDataProperty(nameof(PineconeAllTypes.Enumerable), typeof(IEnumerable<string>)),
+                new VectorStoreRecordVectorProperty(nameof(PineconeAllTypes.Embedding), typeof(ReadOnlyMemory<float>?)) { Dimensions = 8, DistanceFunction = DistanceFunction.DotProductSimilarity }
             ]
         };
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreFixture.cs
@@ -34,24 +34,24 @@ public class QdrantVectorStoreFixture : IAsyncLifetime
         {
             Properties = new List<VectorStoreRecordProperty>
             {
-                new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName") { IsFilterable = true, PropertyType = typeof(string) },
-                new VectorStoreRecordDataProperty("HotelCode") { IsFilterable = true, PropertyType = typeof(int) },
-                new VectorStoreRecordDataProperty("ParkingIncluded") { IsFilterable = true, PropertyType = typeof(bool), StoragePropertyName = "parking_is_included" },
-                new VectorStoreRecordDataProperty("HotelRating") { IsFilterable = true, PropertyType = typeof(float) },
-                new VectorStoreRecordDataProperty("Tags"),
-                new VectorStoreRecordDataProperty("Description"),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding") { Dimensions = 4, DistanceFunction = DistanceFunction.ManhattanDistance }
+                new VectorStoreRecordKeyProperty("HotelId", typeof(ulong)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("HotelCode", typeof(int)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool)) { IsFilterable = true, StoragePropertyName = "parking_is_included" },
+                new VectorStoreRecordDataProperty("HotelRating", typeof(float)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("Tags", typeof(List<string>)),
+                new VectorStoreRecordDataProperty("Description", typeof(string)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4, DistanceFunction = DistanceFunction.ManhattanDistance }
             }
         };
         this.HotelWithGuidIdVectorStoreRecordDefinition = new VectorStoreRecordDefinition
         {
             Properties = new List<VectorStoreRecordProperty>
             {
-                new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName"),
-                new VectorStoreRecordDataProperty("Description"),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding")
+                new VectorStoreRecordKeyProperty("HotelId", typeof(Guid)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)),
+                new VectorStoreRecordDataProperty("Description", typeof(string)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?))
             }
         };
     }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -39,29 +39,29 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         {
             Properties = new List<VectorStoreRecordProperty>
             {
-                new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName") { IsFilterable = true, PropertyType = typeof(string) },
-                new VectorStoreRecordDataProperty("HotelCode") { IsFilterable = true, PropertyType = typeof(int) },
-                new VectorStoreRecordDataProperty("Description"),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding") { Dimensions = 4 },
-                new VectorStoreRecordDataProperty("Tags"),
-                new VectorStoreRecordDataProperty("ParkingIncluded") { StoragePropertyName = "parking_is_included" },
-                new VectorStoreRecordDataProperty("LastRenovationDate"),
-                new VectorStoreRecordDataProperty("Rating"),
-                new VectorStoreRecordDataProperty("Address")
+                new VectorStoreRecordKeyProperty("HotelId", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("HotelCode", typeof(int)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("Description", typeof(string)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4 },
+                new VectorStoreRecordDataProperty("Tags", typeof(string[])),
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool)) { StoragePropertyName = "parking_is_included" },
+                new VectorStoreRecordDataProperty("LastRenovationDate", typeof(DateTimeOffset)),
+                new VectorStoreRecordDataProperty("Rating", typeof(double)),
+                new VectorStoreRecordDataProperty("Address", typeof(HotelAddress))
             }
         };
         this.BasicVectorStoreRecordDefinition = new VectorStoreRecordDefinition
         {
             Properties = new List<VectorStoreRecordProperty>
             {
-                new VectorStoreRecordKeyProperty("HotelId"),
-                new VectorStoreRecordDataProperty("HotelName") { IsFilterable = true, PropertyType = typeof(string) },
-                new VectorStoreRecordDataProperty("HotelCode") { IsFilterable = true, PropertyType = typeof(int) },
-                new VectorStoreRecordDataProperty("Description"),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding") { Dimensions = 4 },
-                new VectorStoreRecordDataProperty("ParkingIncluded") { StoragePropertyName = "parking_is_included" },
-                new VectorStoreRecordDataProperty("Rating")
+                new VectorStoreRecordKeyProperty("HotelId", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("HotelCode", typeof(int)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("Description", typeof(string)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4 },
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool)) { StoragePropertyName = "parking_is_included" },
+                new VectorStoreRecordDataProperty("Rating", typeof(double)),
             }
         };
     }

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -25,6 +25,50 @@ internal static class VectorStoreRecordPropertyReader
     private static readonly ConcurrentDictionary<Type, (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties)> s_multipleVectorsPropertiesCache = new();
 
     /// <summary>
+    /// Split the given <paramref name="definition"/> into key, data and vector properties and verify that we have the expected numbers of each type.
+    /// </summary>
+    /// <param name="typeName">The name of the type that the definition relates to.</param>
+    /// <param name="definition">The <see cref="VectorStoreRecordDefinition"/> to split.</param>
+    /// <param name="supportsMultipleVectors">A value indicating whether multiple vectors are supported.</param>
+    /// <param name="requiresAtLeastOneVector">A value indicating whether we need at least one vector.</param>
+    /// <returns>The properties on the <see cref="VectorStoreRecordDefinition"/> split into key, data and vector groupings.</returns>
+    /// <exception cref="ArgumentException">Thrown if there are any validation failures with the provided <paramref name="definition"/>.</exception>
+    public static (VectorStoreRecordKeyProperty keyProperty, List<VectorStoreRecordDataProperty> dataProperties, List<VectorStoreRecordVectorProperty> vectorProperties) SplitDefinitionAndVerify(
+        string typeName,
+        VectorStoreRecordDefinition definition,
+        bool supportsMultipleVectors,
+        bool requiresAtLeastOneVector)
+    {
+        var keyProperties = definition.Properties.OfType<VectorStoreRecordKeyProperty>().ToList();
+
+        if (keyProperties.Count > 1)
+        {
+            throw new ArgumentException($"Multiple key properties found on type {typeName} or the provided {nameof(VectorStoreRecordDefinition)}.");
+        }
+
+        var keyProperty = keyProperties.FirstOrDefault();
+        var dataProperties = definition.Properties.OfType<VectorStoreRecordDataProperty>().ToList();
+        var vectorProperties = definition.Properties.OfType<VectorStoreRecordVectorProperty>().ToList();
+
+        if (keyProperty is null)
+        {
+            throw new ArgumentException($"No key property found on type {typeName} or the provided {nameof(VectorStoreRecordDefinition)}.");
+        }
+
+        if (requiresAtLeastOneVector && vectorProperties.Count == 0)
+        {
+            throw new ArgumentException($"No vector property found on type {typeName} or the provided {nameof(VectorStoreRecordDefinition)}.");
+        }
+
+        if (!supportsMultipleVectors && vectorProperties.Count > 1)
+        {
+            throw new ArgumentException($"Multiple vector properties found on type {typeName} or the provided {nameof(VectorStoreRecordDefinition)} while only one is supported.");
+        }
+
+        return (keyProperty, dataProperties, vectorProperties);
+    }
+
+    /// <summary>
     /// Find the properties with <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/> attributes
     /// and verify that they exist and that we have the expected numbers of each type.
     /// Return those properties in separate categories.
@@ -207,7 +251,7 @@ internal static class VectorStoreRecordPropertyReader
 
         // Key property.
         var keyAttribute = properties.keyProperty.GetCustomAttribute<VectorStoreRecordKeyAttribute>();
-        definitionProperties.Add(new VectorStoreRecordKeyProperty(properties.keyProperty.Name) { StoragePropertyName = keyAttribute!.StoragePropertyName });
+        definitionProperties.Add(new VectorStoreRecordKeyProperty(properties.keyProperty.Name, properties.keyProperty.PropertyType) { StoragePropertyName = keyAttribute!.StoragePropertyName });
 
         // Data properties.
         foreach (var dataProperty in properties.dataProperties)
@@ -215,10 +259,9 @@ internal static class VectorStoreRecordPropertyReader
             var dataAttribute = dataProperty.GetCustomAttribute<VectorStoreRecordDataAttribute>();
             if (dataAttribute is not null)
             {
-                definitionProperties.Add(new VectorStoreRecordDataProperty(dataProperty.Name)
+                definitionProperties.Add(new VectorStoreRecordDataProperty(dataProperty.Name, dataProperty.PropertyType)
                 {
                     IsFilterable = dataAttribute.IsFilterable,
-                    PropertyType = dataProperty.PropertyType,
                     StoragePropertyName = dataAttribute.StoragePropertyName
                 });
             }
@@ -230,7 +273,7 @@ internal static class VectorStoreRecordPropertyReader
             var vectorAttribute = vectorProperty.GetCustomAttribute<VectorStoreRecordVectorAttribute>();
             if (vectorAttribute is not null)
             {
-                definitionProperties.Add(new VectorStoreRecordVectorProperty(vectorProperty.Name)
+                definitionProperties.Add(new VectorStoreRecordVectorProperty(vectorProperty.Name, vectorProperty.PropertyType)
                 {
                     Dimensions = vectorAttribute.Dimensions,
                     IndexKind = vectorAttribute.IndexKind,
@@ -257,7 +300,23 @@ internal static class VectorStoreRecordPropertyReader
             ? supportedTypes
             : [];
 
-        VerifyPropertyTypes(properties, supportedTypes, propertyCategoryDescription, supportedEnumerableTypes);
+        VerifyPropertyTypes(properties, supportedTypes, supportedEnumerableTypes, propertyCategoryDescription);
+    }
+
+    /// <summary>
+    /// Verify that the given properties are of the supported types.
+    /// </summary>
+    /// <param name="properties">The properties to check.</param>
+    /// <param name="supportedTypes">A set of supported types that the provided properties may have.</param>
+    /// <param name="supportedEnumerableTypes">A set of supported types that the provided enumerable properties may use as their element type.</param>
+    /// <param name="propertyCategoryDescription">A description of the category of properties being checked. Used for error messaging.</param>
+    /// <exception cref="ArgumentException">Thrown if any of the properties are not in the given set of types.</exception>
+    public static void VerifyPropertyTypes(List<PropertyInfo> properties, HashSet<Type> supportedTypes, HashSet<Type> supportedEnumerableTypes, string propertyCategoryDescription)
+    {
+        foreach (var property in properties)
+        {
+            VerifyPropertyType(property.Name, property.PropertyType, supportedTypes, supportedEnumerableTypes, propertyCategoryDescription);
+        }
     }
 
     /// <summary>
@@ -266,44 +325,134 @@ internal static class VectorStoreRecordPropertyReader
     /// <param name="properties">The properties to check.</param>
     /// <param name="supportedTypes">A set of supported types that the provided properties may have.</param>
     /// <param name="propertyCategoryDescription">A description of the category of properties being checked. Used for error messaging.</param>
-    /// <param name="supportedEnumerableTypes">A set of supported types that the provided enumerable properties may use as their element type.</param>
+    /// <param name="supportEnumerable">A value indicating whether <see cref="IEnumerable{T}"/> versions of all the types should also be supported.</param>
     /// <exception cref="ArgumentException">Thrown if any of the properties are not in the given set of types.</exception>
-    public static void VerifyPropertyTypes(List<PropertyInfo> properties, HashSet<Type> supportedTypes, string propertyCategoryDescription, HashSet<Type> supportedEnumerableTypes)
+    public static void VerifyPropertyTypes(IEnumerable<VectorStoreRecordProperty> properties, HashSet<Type> supportedTypes, string propertyCategoryDescription, bool? supportEnumerable = false)
+    {
+        var supportedEnumerableTypes = supportEnumerable == true
+            ? supportedTypes
+            : [];
+
+        VerifyPropertyTypes(properties, supportedTypes, supportedEnumerableTypes, propertyCategoryDescription);
+    }
+
+    /// <summary>
+    /// Verify that the given properties are of the supported types.
+    /// </summary>
+    /// <param name="properties">The properties to check.</param>
+    /// <param name="supportedTypes">A set of supported types that the provided properties may have.</param>
+    /// <param name="supportedEnumerableTypes">A set of supported types that the provided enumerable properties may use as their element type.</param>
+    /// <param name="propertyCategoryDescription">A description of the category of properties being checked. Used for error messaging.</param>
+    /// <exception cref="ArgumentException">Thrown if any of the properties are not in the given set of types.</exception>
+    public static void VerifyPropertyTypes(IEnumerable<VectorStoreRecordProperty> properties, HashSet<Type> supportedTypes, HashSet<Type> supportedEnumerableTypes, string propertyCategoryDescription)
     {
         foreach (var property in properties)
         {
-            // Add shortcut before testing all the more expensive scenarios.
-            if (supportedTypes.Contains(property.PropertyType))
-            {
-                continue;
-            }
+            VerifyPropertyType(property.DataModelPropertyName, property.PropertyType, supportedTypes, supportedEnumerableTypes, propertyCategoryDescription);
+        }
+    }
 
-            // Check all collection scenarios and get stored type.
-            if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && supportedEnumerableTypes.Count > 0)
-            {
-                var typeToCheck = property.PropertyType switch
-                {
-                    IEnumerable => typeof(object),
-                    var enumerableType when enumerableType.IsGenericType && enumerableType.GetGenericTypeDefinition() == typeof(IEnumerable<>) => enumerableType.GetGenericArguments()[0],
-                    var arrayType when arrayType.IsArray => arrayType.GetElementType()!,
-                    var interfaceType when interfaceType.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)) is Type enumerableInterface =>
-                        enumerableInterface.GetGenericArguments()[0],
-                    _ => property.PropertyType
-                };
+    /// <summary>
+    /// Verify that the given property is of the supported types.
+    /// </summary>
+    /// <param name="propertyName">The name of the property being checked. Used for error messaging.</param>
+    /// <param name="propertyType">The type of the property being checked.</param>
+    /// <param name="supportedTypes">A set of supported types that the provided property may have.</param>
+    /// <param name="supportedEnumerableTypes">A set of supported types that the provided property may use as its element type if it's enumerable.</param>
+    /// <param name="propertyCategoryDescription">A description of the category of property being checked. Used for error messaging.</param>
+    /// <exception cref="ArgumentException">Thrown if the property is not in the given set of types.</exception>
+    public static void VerifyPropertyType(string propertyName, Type propertyType, HashSet<Type> supportedTypes, HashSet<Type> supportedEnumerableTypes, string propertyCategoryDescription)
+    {
+        // Add shortcut before testing all the more expensive scenarios.
+        if (supportedTypes.Contains(propertyType))
+        {
+            return;
+        }
 
-                if (!supportedEnumerableTypes.Contains(typeToCheck))
-                {
-                    var supportedEnumerableElementTypesString = string.Join(", ", supportedEnumerableTypes!.Select(t => t.FullName));
-                    throw new ArgumentException($"Enumerable {propertyCategoryDescription} properties must have one of the supported element types: {supportedEnumerableElementTypesString}. Element type of the property '{property.Name}' is {typeToCheck.FullName}.");
-                }
-            }
-            else
+        // Check all collection scenarios and get stored type.
+        if (supportedEnumerableTypes.Count > 0 && typeof(IEnumerable).IsAssignableFrom(propertyType))
+        {
+            var typeToCheck = propertyType switch
             {
-                // if we got here, we know the type is not supported
-                var supportedTypesString = string.Join(", ", supportedTypes.Select(t => t.FullName));
-                throw new ArgumentException($"{propertyCategoryDescription} properties must be one of the supported types: {supportedTypesString}. Type of the property '{property.Name}' is {property.PropertyType.FullName}.");
+                IEnumerable => typeof(object),
+                var enumerableType when enumerableType.IsGenericType && enumerableType.GetGenericTypeDefinition() == typeof(IEnumerable<>) => enumerableType.GetGenericArguments()[0],
+                var arrayType when arrayType.IsArray => arrayType.GetElementType()!,
+                var interfaceType when interfaceType.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)) is Type enumerableInterface =>
+                    enumerableInterface.GetGenericArguments()[0],
+                _ => propertyType
+            };
+
+            if (!supportedEnumerableTypes.Contains(typeToCheck))
+            {
+                var supportedEnumerableElementTypesString = string.Join(", ", supportedEnumerableTypes!.Select(t => t.FullName));
+                throw new ArgumentException($"Enumerable {propertyCategoryDescription} properties must have one of the supported element types: {supportedEnumerableElementTypesString}. Element type of the property '{propertyName}' is {typeToCheck.FullName}.");
             }
         }
+        else
+        {
+            // if we got here, we know the type is not supported
+            var supportedTypesString = string.Join(", ", supportedTypes.Select(t => t.FullName));
+            throw new ArgumentException($"{propertyCategoryDescription} properties must be one of the supported types: {supportedTypesString}. Type of the property '{propertyName}' is {propertyType.FullName}.");
+        }
+    }
+
+    /// <summary>
+    /// Get the JSON property name of a property by using the <see cref="JsonPropertyNameAttribute"/> if available, otherwise
+    /// using the <see cref="JsonNamingPolicy"/> if available, otherwise falling back to the property name.
+    /// The provided <paramref name="dataModel"/> may not actually contain the property, e.g. when the user has a data model that
+    /// doesn't resemble the stored data and where they havea a custom mapper.
+    /// </summary>
+    /// <param name="property">The property to retrieve a storage name for.</param>
+    /// <param name="dataModel">The data model type that the property belongs to.</param>
+    /// <param name="options">The options used for JSON serialization.</param>
+    /// <returns>The JSON storage property name.</returns>
+    public static string GetJsonPropertyName(VectorStoreRecordProperty property, Type dataModel, JsonSerializerOptions options)
+    {
+        var propertyInfo = dataModel.GetProperty(property.DataModelPropertyName);
+
+        if (propertyInfo != null)
+        {
+            var jsonPropertyNameAttribute = propertyInfo.GetCustomAttribute<JsonPropertyNameAttribute>();
+            if (jsonPropertyNameAttribute is not null)
+            {
+                return jsonPropertyNameAttribute.Name;
+            }
+        }
+
+        if (options.PropertyNamingPolicy is not null)
+        {
+            return options.PropertyNamingPolicy.ConvertName(property.DataModelPropertyName);
+        }
+
+        return property.DataModelPropertyName;
+    }
+
+    /// <summary>
+    /// Build a map of property names to the names under which they should be saved in storage if using JSON serialization.
+    /// </summary>
+    /// <param name="properties">The properties to build the map for.</param>
+    /// <param name="dataModel">The data model type that the property belongs to.</param>
+    /// <param name="options">The options used for JSON serialization.</param>
+    /// <returns>The map from property names to the names under which they should be saved in storage if using JSON serialization.</returns>
+    public static Dictionary<string, string> BuildPropertyNameToJsonPropertyNameMap(
+        (VectorStoreRecordKeyProperty keyProperty, List<VectorStoreRecordDataProperty> dataProperties, List<VectorStoreRecordVectorProperty> vectorProperties) properties,
+        Type dataModel,
+        JsonSerializerOptions options)
+    {
+        var jsonPropertyNameMap = new Dictionary<string, string>();
+        jsonPropertyNameMap.Add(properties.keyProperty.DataModelPropertyName, GetJsonPropertyName(properties.keyProperty, dataModel, options));
+
+        foreach (var dataProperty in properties.dataProperties)
+        {
+            jsonPropertyNameMap.Add(dataProperty.DataModelPropertyName, GetJsonPropertyName(dataProperty, dataModel, options));
+        }
+
+        foreach (var vectorProperty in properties.vectorProperties)
+        {
+            jsonPropertyNameMap.Add(vectorProperty.DataModelPropertyName, GetJsonPropertyName(vectorProperty, dataModel, options));
+        }
+
+        return jsonPropertyNameMap;
     }
 
     /// <summary>
@@ -330,64 +479,23 @@ internal static class VectorStoreRecordPropertyReader
     }
 
     /// <summary>
-    /// Get the storage name of a property by first checking the <see cref="VectorStoreRecordDefinition"/>, if one is available,
-    /// otherwise falling back to the attributes on the property and finally, the property name.
-    /// </summary>
-    /// <param name="property">The property to retrieve a storage name for.</param>
-    /// <param name="vectorStoreRecordDefinition">The property configuration, if available.</param>
-    /// <returns>The storage name for the property.</returns>
-    public static string GetStoragePropertyName(PropertyInfo property, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-    {
-        if (vectorStoreRecordDefinition is not null)
-        {
-            // First check to see if the developer configured a storage property name on the record definition.
-            if (vectorStoreRecordDefinition.Properties.FirstOrDefault(p => p.DataModelPropertyName == property.Name) is VectorStoreRecordProperty recordProperty && recordProperty.StoragePropertyName is not null)
-            {
-                return recordProperty.StoragePropertyName;
-            }
-
-            // Otherwise, return just the property name.
-            return property.Name;
-        }
-        // If no definition was supplied, check the attributes.
-        else if (property.GetCustomAttribute<VectorStoreRecordDataAttribute>() is VectorStoreRecordDataAttribute dataAttribute)
-        {
-            return dataAttribute.StoragePropertyName ?? property.Name;
-        }
-        else if (property.GetCustomAttribute<VectorStoreRecordVectorAttribute>() is VectorStoreRecordVectorAttribute vectorAttribute)
-        {
-            return vectorAttribute.StoragePropertyName ?? property.Name;
-        }
-        else if (property.GetCustomAttribute<VectorStoreRecordKeyAttribute>() is VectorStoreRecordKeyAttribute keyAttribute)
-        {
-            return keyAttribute.StoragePropertyName ?? property.Name;
-        }
-
-        // Otherwise, return just the property name.
-        return property.Name;
-    }
-
-    /// <summary>
     /// Build a map of property names to the names under which they should be saved in storage, for the given properties.
     /// </summary>
     /// <param name="properties">The properties to build the map for.</param>
-    /// <param name="vectorStoreRecordDefinition">The property configuration, if available.</param>
     /// <returns>The map from property names to the names under which they should be saved in storage.</returns>
-    public static Dictionary<string, string> BuildPropertyNameToStorageNameMap(
-        (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) properties,
-        VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    public static Dictionary<string, string> BuildPropertyNameToStorageNameMap((VectorStoreRecordKeyProperty keyProperty, List<VectorStoreRecordDataProperty> dataProperties, List<VectorStoreRecordVectorProperty> vectorProperties) properties)
     {
         var storagePropertyNameMap = new Dictionary<string, string>();
-        storagePropertyNameMap.Add(properties.keyProperty.Name, GetStoragePropertyName(properties.keyProperty, vectorStoreRecordDefinition));
+        storagePropertyNameMap.Add(properties.keyProperty.DataModelPropertyName, properties.keyProperty.StoragePropertyName ?? properties.keyProperty.DataModelPropertyName);
 
         foreach (var dataProperty in properties.dataProperties)
         {
-            storagePropertyNameMap.Add(dataProperty.Name, GetStoragePropertyName(dataProperty, vectorStoreRecordDefinition));
+            storagePropertyNameMap.Add(dataProperty.DataModelPropertyName, dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName);
         }
 
         foreach (var vectorProperty in properties.vectorProperties)
         {
-            storagePropertyNameMap.Add(vectorProperty.Name, GetStoragePropertyName(vectorProperty, vectorStoreRecordDefinition));
+            storagePropertyNameMap.Add(vectorProperty.DataModelPropertyName, vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName);
         }
 
         return storagePropertyNameMap;

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -400,7 +400,7 @@ internal static class VectorStoreRecordPropertyReader
     /// Get the JSON property name of a property by using the <see cref="JsonPropertyNameAttribute"/> if available, otherwise
     /// using the <see cref="JsonNamingPolicy"/> if available, otherwise falling back to the property name.
     /// The provided <paramref name="dataModel"/> may not actually contain the property, e.g. when the user has a data model that
-    /// doesn't resemble the stored data and where they havea a custom mapper.
+    /// doesn't resemble the stored data and where they are using a custom mapper.
     /// </summary>
     /// <param name="property">The property to retrieve a storage name for.</param>
     /// <param name="dataModel">The data model type that the property belongs to.</param>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordDataProperty.cs
@@ -15,8 +15,9 @@ public sealed class VectorStoreRecordDataProperty : VectorStoreRecordProperty
     /// Initializes a new instance of the <see cref="VectorStoreRecordDataProperty"/> class.
     /// </summary>
     /// <param name="propertyName">The name of the property.</param>
-    public VectorStoreRecordDataProperty(string propertyName)
-        : base(propertyName)
+    /// <param name="propertyType">The type of the property.</param>
+    public VectorStoreRecordDataProperty(string propertyName, Type propertyType)
+        : base(propertyName, propertyType)
     {
     }
 
@@ -28,16 +29,10 @@ public sealed class VectorStoreRecordDataProperty : VectorStoreRecordProperty
         : base(source)
     {
         this.IsFilterable = source.IsFilterable;
-        this.PropertyType = source.PropertyType;
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether this data property is filterable.
     /// </summary>
     public bool IsFilterable { get; init; }
-
-    /// <summary>
-    /// Gets or sets the type of the data property.
-    /// </summary>
-    public Type? PropertyType { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordKeyProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordKeyProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
@@ -14,8 +15,9 @@ public sealed class VectorStoreRecordKeyProperty : VectorStoreRecordProperty
     /// Initializes a new instance of the <see cref="VectorStoreRecordKeyProperty"/> class.
     /// </summary>
     /// <param name="propertyName">The name of the property.</param>
-    public VectorStoreRecordKeyProperty(string propertyName)
-        : base(propertyName)
+    /// <param name="propertyType">The type of the property.</param>
+    public VectorStoreRecordKeyProperty(string propertyName, Type propertyType)
+        : base(propertyName, propertyType)
     {
     }
 

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
@@ -14,15 +15,21 @@ public abstract class VectorStoreRecordProperty
     /// Initializes a new instance of the <see cref="VectorStoreRecordProperty"/> class.
     /// </summary>
     /// <param name="dataModelPropertyName">The name of the property on the data model.</param>
-    private protected VectorStoreRecordProperty(string dataModelPropertyName)
+    /// <param name="propertyType">The type of the property.</param>
+    private protected VectorStoreRecordProperty(string dataModelPropertyName, Type propertyType)
     {
+        Verify.NotNullOrWhiteSpace(dataModelPropertyName);
+        Verify.NotNull(propertyType);
+
         this.DataModelPropertyName = dataModelPropertyName;
+        this.PropertyType = propertyType;
     }
 
     private protected VectorStoreRecordProperty(VectorStoreRecordProperty source)
     {
         this.DataModelPropertyName = source.DataModelPropertyName;
         this.StoragePropertyName = source.StoragePropertyName;
+        this.PropertyType = source.PropertyType;
     }
 
     /// <summary>
@@ -38,4 +45,9 @@ public abstract class VectorStoreRecordProperty
     /// be used.
     /// </summary>
     public string? StoragePropertyName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of the property.
+    /// </summary>
+    public Type PropertyType { get; private set; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/RecordDefinition/VectorStoreRecordVectorProperty.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
@@ -14,8 +15,9 @@ public sealed class VectorStoreRecordVectorProperty : VectorStoreRecordProperty
     /// Initializes a new instance of the <see cref="VectorStoreRecordVectorProperty"/> class.
     /// </summary>
     /// <param name="propertyName">The name of the property.</param>
-    public VectorStoreRecordVectorProperty(string propertyName)
-        : base(propertyName)
+    /// <param name="propertyType">The type of the property.</param>
+    public VectorStoreRecordVectorProperty(string propertyName, Type propertyType)
+        : base(propertyName, propertyType)
     {
     }
 

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -393,7 +393,7 @@ public class VectorStoreRecordPropertyReaderTests
         [VectorStoreRecordKey]
         public string Key { get; set; } = string.Empty;
 
-        [VectorStoreRecordData(HasEmbedding = true, EmbeddingPropertyName = "Vector1", IsFilterable = true)]
+        [VectorStoreRecordData(IsFilterable = true)]
         public string Data1 { get; set; } = string.Empty;
 
         [VectorStoreRecordData]

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -307,21 +307,29 @@ public class VectorStoreRecordPropertyReaderTests
         // Arrange.
         var options = new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseUpper };
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify("testType", this._multiPropsDefinition, true, true);
+        var propertiesInfo = VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), true);
 
         // Act.
-        var jsonNameMap = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(properties, typeof(MultiPropsModel), options);
+        var jsonNameMap1 = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(properties, typeof(MultiPropsModel), options);
+        var jsonNameMap2 = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(propertiesInfo, typeof(MultiPropsModel), options);
+
+        void assertJsonNameMap(Dictionary<string, string> jsonNameMap)
+        {
+            Assert.Equal(5, jsonNameMap.Count);
+
+            // From JsonNamingPolicy.
+            Assert.Equal("KEY", jsonNameMap["Key"]);
+            Assert.Equal("DATA1", jsonNameMap["Data1"]);
+            Assert.Equal("DATA2", jsonNameMap["Data2"]);
+            Assert.Equal("VECTOR1", jsonNameMap["Vector1"]);
+
+            // From JsonPropertyName attribute.
+            Assert.Equal("vector-2", jsonNameMap["Vector2"]);
+        };
 
         // Assert.
-        Assert.Equal(5, jsonNameMap.Count);
-
-        // From JsonNamingPolicy.
-        Assert.Equal("KEY", jsonNameMap["Key"]);
-        Assert.Equal("DATA1", jsonNameMap["Data1"]);
-        Assert.Equal("DATA2", jsonNameMap["Data2"]);
-        Assert.Equal("VECTOR1", jsonNameMap["Vector1"]);
-
-        // From JsonPropertyName attribute.
-        Assert.Equal("vector-2", jsonNameMap["Vector2"]);
+        assertJsonNameMap(jsonNameMap1);
+        assertJsonNameMap(jsonNameMap2);
     }
 
 #pragma warning disable CA1812 // Invalid unused classes error, since I am using these for testing purposes above.

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -292,9 +292,9 @@ public class VolatileVectorStoreRecordCollectionTests
     {
         Properties =
         [
-            new VectorStoreRecordKeyProperty("Key"),
-            new VectorStoreRecordDataProperty("Data"),
-            new VectorStoreRecordVectorProperty("Vector")
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("Data", typeof(string)),
+            new VectorStoreRecordVectorProperty("Vector", typeof(ReadOnlyMemory<float>))
         ]
     };
 


### PR DESCRIPTION
### Motivation and Context

When developers supply a property definition object, the expectation is that this should be used instead of using reflection on the data model to determine the list of properties.  This is especially useful when a developer wishes to supply a definition that doesn't look like the data model at all and wants to use a custom mapper to map between the storage and data models.
Most default mappers will continue to use reflection and do checks on the data model, since that is their primary mechanism of mapping.

See: [#7473](https://github.com/microsoft/semantic-kernel/issues/7473)

### Description

- Require the data type of each property on the property definition objects.
- Remove checks where we verify that the properties defined in the definition matches those on the data model.
- Change validation logic to always use the definition where possible.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
