### PR TITLE
.Net: [Feature branch] Small formatting improvements

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -113,16 +113,16 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
 
         // Validate property types.
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, this._vectorStoreRecordDefinition, supportsMultipleVectors: true, requiresAtLeastOneVector: false);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, s_supportedDataTypes, "Data", supportEnumerable: true);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.KeyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.DataProperties, s_supportedDataTypes, "Data", supportEnumerable: true);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.VectorProperties, s_supportedVectorTypes, "Vector");
 
         // Get storage names and store for later use.
         this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(properties, typeof(TRecord), jsonSerializerOptions);
-        this._keyStoragePropertyName = this._storagePropertyNames[properties.keyProperty.DataModelPropertyName];
-        this._nonVectorStoragePropertyNames = properties.dataProperties
+        this._keyStoragePropertyName = this._storagePropertyNames[properties.KeyProperty.DataModelPropertyName];
+        this._nonVectorStoragePropertyNames = properties.DataProperties
             .Cast<VectorStoreRecordProperty>()
-            .Concat([properties.keyProperty])
+            .Concat([properties.KeyProperty])
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
             .ToList();
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
@@ -71,14 +71,14 @@ internal sealed class PineconeVectorStoreRecordMapper<TRecord> : IVectorStoreRec
     {
         // Validate property types.
         var propertiesInfo = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), vectorStoreRecordDefinition, supportsMultipleVectors: false);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes([propertiesInfo.keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.dataProperties, s_supportedDataTypes, s_supportedEnumerableDataElementTypes, "Data");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.vectorProperties, s_supportedVectorTypes, "Vector");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([propertiesInfo.KeyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.DataProperties, s_supportedDataTypes, s_supportedEnumerableDataElementTypes, "Data");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.VectorProperties, s_supportedVectorTypes, "Vector");
 
         // Assign.
-        this._keyPropertyInfo = propertiesInfo.keyProperty;
-        this._dataPropertiesInfo = propertiesInfo.dataProperties;
-        this._vectorPropertyInfo = propertiesInfo.vectorProperties[0];
+        this._keyPropertyInfo = propertiesInfo.KeyProperty;
+        this._dataPropertiesInfo = propertiesInfo.DataProperties;
+        this._vectorPropertyInfo = propertiesInfo.VectorProperties[0];
 
         // Get storage names and store for later use.
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, vectorStoreRecordDefinition, supportsMultipleVectors: false, requiresAtLeastOneVector: true);

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -91,7 +91,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
 
         // Validate property types.
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, this._vectorStoreRecordDefinition, supportsMultipleVectors: this._options.HasNamedVectors, requiresAtLeastOneVector: !this._options.HasNamedVectors);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.KeyProperty], s_supportedKeyTypes, "Key");
 
         // Build a map of property names to storage names.
         this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToStorageNameMap(properties);

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -82,14 +82,14 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
 
         // Validate property types.
         var propertiesInfo = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), vectorStoreRecordDefinition, supportsMultipleVectors: hasNamedVectors);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.dataProperties, s_supportedDataTypes, "Data", supportEnumerable: true);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.vectorProperties, s_supportedVectorTypes, "Vector");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.DataProperties, s_supportedDataTypes, "Data", supportEnumerable: true);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.VectorProperties, s_supportedVectorTypes, "Vector");
 
         // Assign.
         this._hasNamedVectors = hasNamedVectors;
-        this._keyPropertyInfo = propertiesInfo.keyProperty;
-        this._dataPropertiesInfo = propertiesInfo.dataProperties;
-        this._vectorPropertiesInfo = propertiesInfo.vectorProperties;
+        this._keyPropertyInfo = propertiesInfo.KeyProperty;
+        this._dataPropertiesInfo = propertiesInfo.DataProperties;
+        this._vectorPropertiesInfo = propertiesInfo.VectorProperties;
         this._storagePropertyNames = storagePropertyNames;
 
         // Get json storage names and store for later use.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -103,14 +103,14 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
 
         // Validate property types.
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, this._vectorStoreRecordDefinition, supportsMultipleVectors: true, requiresAtLeastOneVector: false);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, s_supportedDataTypes, "Data");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.KeyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.DataProperties, s_supportedDataTypes, "Data");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.VectorProperties, s_supportedVectorTypes, "Vector");
 
         // Lookup storage property names.
         this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToStorageNameMap(properties);
         this._dataStoragePropertyNames = properties
-            .dataProperties
+            .DataProperties
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
             .Select(RedisValue.Unbox)
             .ToArray();

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -90,16 +90,16 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
 
         // Validate property types.
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify(typeof(TRecord).Name, this._vectorStoreRecordDefinition, supportsMultipleVectors: true, requiresAtLeastOneVector: false);
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.keyProperty], s_supportedKeyTypes, "Key");
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.vectorProperties, s_supportedVectorTypes, "Vector");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.KeyProperty], s_supportedKeyTypes, "Key");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.VectorProperties, s_supportedVectorTypes, "Vector");
 
         // Lookup json storage property names.
-        var keyJsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(properties.keyProperty, typeof(TRecord), this._jsonSerializerOptions);
+        var keyJsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(properties.KeyProperty, typeof(TRecord), this._jsonSerializerOptions);
 
         // Lookup storage property names.
         this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(properties, typeof(TRecord), this._jsonSerializerOptions);
         this._dataStoragePropertyNames = properties
-            .dataProperties
+            .DataProperties
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
             .ToArray();
 

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -33,7 +33,7 @@ internal static class VectorStoreRecordPropertyReader
     /// <param name="requiresAtLeastOneVector">A value indicating whether we need at least one vector.</param>
     /// <returns>The properties on the <see cref="VectorStoreRecordDefinition"/> split into key, data and vector groupings.</returns>
     /// <exception cref="ArgumentException">Thrown if there are any validation failures with the provided <paramref name="definition"/>.</exception>
-    public static (VectorStoreRecordKeyProperty keyProperty, List<VectorStoreRecordDataProperty> dataProperties, List<VectorStoreRecordVectorProperty> vectorProperties) SplitDefinitionAndVerify(
+    public static (VectorStoreRecordKeyProperty KeyProperty, List<VectorStoreRecordDataProperty> DataProperties, List<VectorStoreRecordVectorProperty> VectorProperties) SplitDefinitionAndVerify(
         string typeName,
         VectorStoreRecordDefinition definition,
         bool supportsMultipleVectors,
@@ -76,7 +76,7 @@ internal static class VectorStoreRecordPropertyReader
     /// <param name="type">The data model to find the properties on.</param>
     /// <param name="supportsMultipleVectors">A value indicating whether multiple vector properties are supported instead of just one.</param>
     /// <returns>The categorized properties.</returns>
-    public static (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) FindProperties(Type type, bool supportsMultipleVectors)
+    public static (PropertyInfo KeyProperty, List<PropertyInfo> DataProperties, List<PropertyInfo> VectorProperties) FindProperties(Type type, bool supportsMultipleVectors)
     {
         var cache = supportsMultipleVectors ? s_multipleVectorsPropertiesCache : s_singleVectorPropertiesCache;
 
@@ -158,7 +158,7 @@ internal static class VectorStoreRecordPropertyReader
     /// <param name="vectorStoreRecordDefinition">The property configuration.</param>
     /// <param name="supportsMultipleVectors">A value indicating whether multiple vector properties are supported instead of just one.</param>
     /// <returns>The categorized properties.</returns>
-    public static (PropertyInfo keyProperty, List<PropertyInfo> dataProperties, List<PropertyInfo> vectorProperties) FindProperties(Type type, VectorStoreRecordDefinition vectorStoreRecordDefinition, bool supportsMultipleVectors)
+    public static (PropertyInfo KeyProperty, List<PropertyInfo> DataProperties, List<PropertyInfo> VectorProperties) FindProperties(Type type, VectorStoreRecordDefinition vectorStoreRecordDefinition, bool supportsMultipleVectors)
     {
         PropertyInfo? keyProperty = null;
         List<PropertyInfo> dataProperties = new();
@@ -250,11 +250,11 @@ internal static class VectorStoreRecordPropertyReader
         var definitionProperties = new List<VectorStoreRecordProperty>();
 
         // Key property.
-        var keyAttribute = properties.keyProperty.GetCustomAttribute<VectorStoreRecordKeyAttribute>();
-        definitionProperties.Add(new VectorStoreRecordKeyProperty(properties.keyProperty.Name, properties.keyProperty.PropertyType) { StoragePropertyName = keyAttribute!.StoragePropertyName });
+        var keyAttribute = properties.KeyProperty.GetCustomAttribute<VectorStoreRecordKeyAttribute>();
+        definitionProperties.Add(new VectorStoreRecordKeyProperty(properties.KeyProperty.Name, properties.KeyProperty.PropertyType) { StoragePropertyName = keyAttribute!.StoragePropertyName });
 
         // Data properties.
-        foreach (var dataProperty in properties.dataProperties)
+        foreach (var dataProperty in properties.DataProperties)
         {
             var dataAttribute = dataProperty.GetCustomAttribute<VectorStoreRecordDataAttribute>();
             if (dataAttribute is not null)
@@ -268,7 +268,7 @@ internal static class VectorStoreRecordPropertyReader
         }
 
         // Vector properties.
-        foreach (var vectorProperty in properties.vectorProperties)
+        foreach (var vectorProperty in properties.VectorProperties)
         {
             var vectorAttribute = vectorProperty.GetCustomAttribute<VectorStoreRecordVectorAttribute>();
             if (vectorAttribute is not null)

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -20,13 +20,13 @@ public class VectorStoreRecordPropertyReaderTests
         var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify("testType", this._multiPropsDefinition, true, true);
 
         // Assert.
-        Assert.Equal("Key", properties.keyProperty.DataModelPropertyName);
-        Assert.Equal(2, properties.dataProperties.Count);
-        Assert.Equal(2, properties.vectorProperties.Count);
-        Assert.Equal("Data1", properties.dataProperties[0].DataModelPropertyName);
-        Assert.Equal("Data2", properties.dataProperties[1].DataModelPropertyName);
-        Assert.Equal("Vector1", properties.vectorProperties[0].DataModelPropertyName);
-        Assert.Equal("Vector2", properties.vectorProperties[1].DataModelPropertyName);
+        Assert.Equal("Key", properties.KeyProperty.DataModelPropertyName);
+        Assert.Equal(2, properties.DataProperties.Count);
+        Assert.Equal(2, properties.VectorProperties.Count);
+        Assert.Equal("Data1", properties.DataProperties[0].DataModelPropertyName);
+        Assert.Equal("Data2", properties.DataProperties[1].DataModelPropertyName);
+        Assert.Equal("Vector1", properties.VectorProperties[0].DataModelPropertyName);
+        Assert.Equal("Vector2", properties.VectorProperties[1].DataModelPropertyName);
     }
 
     [Theory]
@@ -64,11 +64,11 @@ public class VectorStoreRecordPropertyReaderTests
             VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), supportsMultipleVectors);
 
         // Assert.
-        Assert.Equal("Key", properties.keyProperty.Name);
-        Assert.Single(properties.dataProperties);
-        Assert.Single(properties.vectorProperties);
-        Assert.Equal("Data", properties.dataProperties[0].Name);
-        Assert.Equal("Vector", properties.vectorProperties[0].Name);
+        Assert.Equal("Key", properties.KeyProperty.Name);
+        Assert.Single(properties.DataProperties);
+        Assert.Single(properties.VectorProperties);
+        Assert.Equal("Data", properties.DataProperties[0].Name);
+        Assert.Equal("Vector", properties.VectorProperties[0].Name);
     }
 
     [Theory]
@@ -82,13 +82,13 @@ public class VectorStoreRecordPropertyReaderTests
             VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), true);
 
         // Assert.
-        Assert.Equal("Key", properties.keyProperty.Name);
-        Assert.Equal(2, properties.dataProperties.Count);
-        Assert.Equal(2, properties.vectorProperties.Count);
-        Assert.Equal("Data1", properties.dataProperties[0].Name);
-        Assert.Equal("Data2", properties.dataProperties[1].Name);
-        Assert.Equal("Vector1", properties.vectorProperties[0].Name);
-        Assert.Equal("Vector2", properties.vectorProperties[1].Name);
+        Assert.Equal("Key", properties.KeyProperty.Name);
+        Assert.Equal(2, properties.DataProperties.Count);
+        Assert.Equal(2, properties.VectorProperties.Count);
+        Assert.Equal("Data1", properties.DataProperties[0].Name);
+        Assert.Equal("Data2", properties.DataProperties[1].Name);
+        Assert.Equal("Vector1", properties.VectorProperties[0].Name);
+        Assert.Equal("Vector2", properties.VectorProperties[1].Name);
     }
 
     [Theory]
@@ -221,7 +221,7 @@ public class VectorStoreRecordPropertyReaderTests
         var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), true);
 
         // Act.
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, [typeof(string)], "Data");
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.DataProperties, [typeof(string)], "Data");
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(this._singlePropsDefinition.Properties.OfType<VectorStoreRecordDataProperty>(), [typeof(string)], "Data");
     }
 
@@ -232,7 +232,7 @@ public class VectorStoreRecordPropertyReaderTests
         var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(EnumerablePropsModel), true);
 
         // Act.
-        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, [typeof(string)], "Data", supportEnumerable: true);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.DataProperties, [typeof(string)], "Data", supportEnumerable: true);
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(this._enumerablePropsDefinition.Properties.OfType<VectorStoreRecordDataProperty>(), [typeof(string)], "Data", supportEnumerable: true);
     }
 
@@ -243,7 +243,7 @@ public class VectorStoreRecordPropertyReaderTests
         var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(SinglePropsModel), true);
 
         // Act.
-        var ex1 = Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.dataProperties, [typeof(int), typeof(float)], "Data"));
+        var ex1 = Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.DataProperties, [typeof(int), typeof(float)], "Data"));
         var ex2 = Assert.Throws<ArgumentException>(() => VectorStoreRecordPropertyReader.VerifyPropertyTypes(this._singlePropsDefinition.Properties.OfType<VectorStoreRecordDataProperty>(), [typeof(int), typeof(float)], "Data"));
 
         // Assert.
@@ -279,9 +279,9 @@ public class VectorStoreRecordPropertyReaderTests
         // Arrange.
         var options = new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseUpper };
         var properties = VectorStoreRecordPropertyReader.FindProperties(typeof(MultiPropsModel), true);
-        var allProperties = (new PropertyInfo[] { properties.keyProperty })
-            .Concat(properties.dataProperties)
-            .Concat(properties.vectorProperties);
+        var allProperties = (new PropertyInfo[] { properties.KeyProperty })
+            .Concat(properties.DataProperties)
+            .Concat(properties.VectorProperties);
 
         // Act.
         var jsonNameMap = allProperties


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

As per https://github.com/dotnet/runtime/issues/27939#issuecomment-531420515, small formatting improvements to use PascalCase for tuple return variables. In this case, the usage of such variables will be similar to C# property naming conventions (e.g. `properties.KeyProperty` instead of `properties.keyProperty`)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
