### PR TITLE
.Net: VectorStore: Adding a simple example a custom mapper example.

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Memory.VectorStoreFixtures;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Connectors.Redis;
+using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Embeddings;
+using StackExchange.Redis;
+
+namespace Memory;
+
+/// <summary>
+/// An example showing how to ingest data into a vector store using <see cref="RedisVectorStore"/> with a custom mapper.
+/// In this example, the storage model differs significantly from the data model, so a custom mapper is used to map between the two.
+/// A <see cref="VectorStoreRecordDefinition"/> is used to define the schema of the storage model, and this means that the connector
+/// will not try and infer the schema from the data model.
+/// In storage the data is stored as a JSON object that looks similar to this:
+/// <code>
+/// {
+///   "Term": "API",
+///   "Definition": "Application Programming Interface. A set of rules and specifications that allow software components to communicate and exchange data.",
+///   "DefinitionEmbedding": [ ... ]
+/// }
+/// </code>
+/// However, the data model is a class with a property for key and two dictionaries for the data (Term and Definition) and vector (DefinitionEmbedding).
+///
+/// The example shows the following steps:
+/// 1. Create an embedding generator.
+/// 2. Create a Redis Vector Store using a custom factory for creating collections.
+///    When constructing a collection, the factory injects a custom mapper that maps between the data model and the storage model if required.
+/// 3. Ingest some data into the vector store.
+/// 4. Read the data back from the vector store.
+///
+/// You need a local instance of Docker running, since the associated fixture will try and start a Redis container in the local docker instance to run against.
+/// </summary>
+public class VectorStore_DataIngestion_CustomMapper(ITestOutputHelper output, VectorStoreRedisContainerFixture redisFixture) : BaseTest(output), IClassFixture<VectorStoreRedisContainerFixture>
+{
+    /// <summary>
+    /// A record definition for the glossary entries that defines the storage schema of the record.
+    /// </summary>
+    private static readonly VectorStoreRecordDefinition s_glossaryDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("Term", typeof(string)),
+            new VectorStoreRecordDataProperty("Definition", typeof(string)),
+            new VectorStoreRecordVectorProperty("DefinitionEmbedding", typeof(ReadOnlyMemory<float>)) { Dimensions = 1536, DistanceFunction = DistanceFunction.DotProductSimilarity }
+        }
+    };
+
+    [Fact]
+    public async Task ExampleAsync()
+    {
+        // Create an embedding generation service.
+        var textEmbeddingGenerationService = new AzureOpenAITextEmbeddingGenerationService(
+                TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
+                TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
+                TestConfiguration.AzureOpenAIEmbeddings.ApiKey);
+
+        // Initiate the docker container and construct the vector store using the custom factory for creating collections.
+        await redisFixture.ManualInitializeAsync();
+        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379");
+        var vectorStore = new RedisVectorStore(redis.GetDatabase(), new() { VectorStoreCollectionFactory = new Factory() });
+
+        // Get and create collection if it doesn't exist, using the record definition containing the storage model.
+        var collection = vectorStore.GetCollection<string, GenericDataModel>("skglossary", s_glossaryDefinition);
+        await collection.CreateCollectionIfNotExistsAsync();
+
+        // Create glossary entries and generate embeddings for them.
+        var glossaryEntries = CreateGlossaryEntries().ToList();
+        var tasks = glossaryEntries.Select(entry => Task.Run(async () =>
+        {
+            entry.Vectors["DefinitionEmbedding"] = await textEmbeddingGenerationService.GenerateEmbeddingAsync((string)entry.Data["Definition"]);
+        }));
+        await Task.WhenAll(tasks);
+
+        // Upsert the glossary entries into the collection and return their keys.
+        var upsertedKeysTasks = glossaryEntries.Select(x => collection.UpsertAsync(x));
+        var upsertedKeys = await Task.WhenAll(upsertedKeysTasks);
+
+        // Retrieve one of the upserted records from the collection.
+        var upsertedRecord = await collection.GetAsync(upsertedKeys.First(), new() { IncludeVectors = true });
+
+        // Write upserted keys and one of the upserted records to the console.
+        Console.WriteLine($"Upserted keys: {string.Join(", ", upsertedKeys)}");
+        Console.WriteLine($"Upserted record: {JsonSerializer.Serialize(upsertedRecord)}");
+    }
+
+    /// <summary>
+    /// A custom mapper that maps between the data model and the storage model.
+    /// </summary>
+    private sealed class Mapper : IVectorStoreRecordMapper<GenericDataModel, (string Key, JsonNode Node)>
+    {
+        public (string Key, JsonNode Node) MapFromDataToStorageModel(GenericDataModel dataModel)
+        {
+            var jsonObject = new JsonObject();
+
+            jsonObject.Add("Term", dataModel.Data["Term"].ToString());
+            jsonObject.Add("Definition", dataModel.Data["Definition"].ToString());
+
+            var vector = (ReadOnlyMemory<float>)dataModel.Vectors["DefinitionEmbedding"];
+            var jsonArray = new JsonArray(vector.ToArray().Select(x => JsonValue.Create(x)).ToArray());
+            jsonObject.Add("DefinitionEmbedding", jsonArray);
+
+            return (dataModel.Key, jsonObject);
+        }
+
+        public GenericDataModel MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, StorageToDataModelMapperOptions options)
+        {
+            var dataModel = new GenericDataModel
+            {
+                Key = storageModel.Key,
+                Data = new Dictionary<string, object>
+                {
+                    { "Term", (string)storageModel.Node["Term"]! },
+                    { "Definition", (string)storageModel.Node["Definition"]! }
+                },
+                Vectors = new Dictionary<string, object>
+                {
+                    { "DefinitionEmbedding", new ReadOnlyMemory<float>(storageModel.Node["DefinitionEmbedding"]!.AsArray().Select(x => (float)x!).ToArray()) }
+                }
+            };
+
+            return dataModel;
+        }
+    }
+
+    /// <summary>
+    /// A factory for creating collections in the vector store
+    /// </summary>
+    private sealed class Factory : IRedisVectorStoreRecordCollectionFactory
+    {
+        public IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IDatabase database, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+            where TKey : notnull
+            where TRecord : class
+        {
+            // If the record definition is the glossary definition and the record type is the generic data model, inject the custom mapper into the collection options.
+            if (vectorStoreRecordDefinition == s_glossaryDefinition && typeof(TRecord) == typeof(GenericDataModel))
+            {
+                var customCollection = new RedisJsonVectorStoreRecordCollection<GenericDataModel>(database, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition, JsonNodeCustomMapper = new Mapper() }) as IVectorStoreRecordCollection<TKey, TRecord>;
+                return customCollection!;
+            }
+
+            // Otherwise, just create a standard collection with the default mapper.
+            var collection = new RedisJsonVectorStoreRecordCollection<TRecord>(database, name, new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+            return collection!;
+        }
+    }
+
+    /// <summary>
+    /// Sample generic data model class that can store any data.
+    /// </summary>
+    private sealed class GenericDataModel
+    {
+        public string Key { get; set; }
+
+        public Dictionary<string, object> Data { get; set; }
+
+        public Dictionary<string, object> Vectors { get; set; }
+    }
+
+    /// <summary>
+    /// Create some sample glossary entries using the generic data model.
+    /// </summary>
+    /// <returns>A list of sample glossary entries.</returns>
+    private static IEnumerable<GenericDataModel> CreateGlossaryEntries()
+    {
+        yield return new GenericDataModel
+        {
+            Key = "1",
+            Data = new()
+            {
+                { "Term", "API" },
+                { "Definition", "Application Programming Interface. A set of rules and specifications that allow software components to communicate and exchange data." }
+            },
+            Vectors = new()
+        };
+
+        yield return new GenericDataModel
+        {
+            Key = "2",
+            Data = new()
+            {
+                { "Term", "Connectors" },
+                { "Definition", "Connectors allow you to integrate with various services provide AI capabilities, including LLM, AudioToText, TextToAudio, Embedding generation, etc." }
+            },
+            Vectors = new()
+        };
+
+        yield return new GenericDataModel
+        {
+            Key = "3",
+            Data = new()
+            {
+                { "Term", "RAG" },
+                { "Definition", "Retrieval Augmented Generation - a term that refers to the process of retrieving additional data to provide as context to an LLM to use when generating a response (completion) to a user’s question (prompt)." }
+            },
+            Vectors = new()
+        };
+    }
+}

--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_MultiStore.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_MultiStore.cs
@@ -28,7 +28,7 @@ namespace Memory;
 /// For some databases in this sample (Redis &amp; Qdrant), you need a local instance of Docker running, since the associated fixtures will try and start containers in the local docker instance to run against.
 /// </summary>
 [Collection("Sequential")]
-public class VectorStore_DataIngestion(ITestOutputHelper output, VectorStoreRedisContainerFixture redisFixture, VectorStoreQdrantContainerFixture qdrantFixture) : BaseTest(output), IClassFixture<VectorStoreRedisContainerFixture>, IClassFixture<VectorStoreQdrantContainerFixture>
+public class VectorStore_DataIngestion_MultiStore(ITestOutputHelper output, VectorStoreRedisContainerFixture redisFixture, VectorStoreQdrantContainerFixture qdrantFixture) : BaseTest(output), IClassFixture<VectorStoreRedisContainerFixture>, IClassFixture<VectorStoreQdrantContainerFixture>
 {
     /// <summary>
     /// Example with dependency injection.

--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_Simple.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_Simple.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using Memory.VectorStoreFixtures;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Connectors.Qdrant;
+using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Embeddings;
+using Qdrant.Client;
+
+namespace Memory;
+
+/// <summary>
+/// A simple example showing how to ingest data into a vector store using <see cref="QdrantVectorStore"/>.
+///
+/// The example shows the following steps:
+/// 1. Create an embedding generator.
+/// 2. Create a Qdrant Vector Store.
+/// 3. Ingest some data into the vector store.
+/// 4. Read the data back from the vector store.
+///
+/// You need a local instance of Docker running, since the associated fixture will try and start a Qdrant container in the local docker instance to run against.
+/// </summary>
+[Collection("Sequential")]
+public class VectorStore_DataIngestion_Simple(ITestOutputHelper output, VectorStoreQdrantContainerFixture qdrantFixture) : BaseTest(output), IClassFixture<VectorStoreQdrantContainerFixture>
+{
+    [Fact]
+    public async Task ExampleAsync()
+    {
+        // Create an embedding generation service.
+        var textEmbeddingGenerationService = new AzureOpenAITextEmbeddingGenerationService(
+                TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
+                TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
+                TestConfiguration.AzureOpenAIEmbeddings.ApiKey);
+
+        // Initiate the docker container and construct the vector store.
+        await qdrantFixture.ManualInitializeAsync();
+        var vectorStore = new QdrantVectorStore(new QdrantClient("localhost"));
+
+        // Get and create collection if it doesn't exist.
+        var collection = vectorStore.GetCollection<ulong, Glossary>("skglossary");
+        await collection.CreateCollectionIfNotExistsAsync();
+
+        // Create glossary entries and generate embeddings for them.
+        var glossaryEntries = CreateGlossaryEntries().ToList();
+        var tasks = glossaryEntries.Select(entry => Task.Run(async () =>
+        {
+            entry.DefinitionEmbedding = await textEmbeddingGenerationService.GenerateEmbeddingAsync(entry.Definition);
+        }));
+        await Task.WhenAll(tasks);
+
+        // Upsert the glossary entries into the collection and return their keys.
+        var upsertedKeysTasks = glossaryEntries.Select(x => collection.UpsertAsync(x));
+        var upsertedKeys = await Task.WhenAll(upsertedKeysTasks);
+
+        // Retrieve one of the upserted records from the collection.
+        var upsertedRecord = await collection.GetAsync(upsertedKeys.First(), new() { IncludeVectors = true });
+
+        // Write upserted keys and one of the upserted records to the console.
+        Console.WriteLine($"Upserted keys: {string.Join(", ", upsertedKeys)}");
+        Console.WriteLine($"Upserted record: {JsonSerializer.Serialize(upsertedRecord)}");
+    }
+
+    /// <summary>
+    /// Sample model class that represents a glossary entry.
+    /// </summary>
+    /// <remarks>
+    /// Note that each property is decorated with an attribute that specifies how the property should be treated by the vector store.
+    /// This allows us to create a collection in the vector store and upsert and retrieve instances of this class without any further configuration.
+    /// </remarks>
+    private sealed class Glossary
+    {
+        [VectorStoreRecordKey]
+        public ulong Key { get; set; }
+
+        [VectorStoreRecordData]
+        public string Term { get; set; }
+
+        [VectorStoreRecordData]
+        public string Definition { get; set; }
+
+        [VectorStoreRecordVector(1536)]
+        public ReadOnlyMemory<float> DefinitionEmbedding { get; set; }
+    }
+
+    /// <summary>
+    /// Create some sample glossary entries.
+    /// </summary>
+    /// <returns>A list of sample glossary entries.</returns>
+    private static IEnumerable<Glossary> CreateGlossaryEntries()
+    {
+        yield return new Glossary
+        {
+            Key = 1,
+            Term = "API",
+            Definition = "Application Programming Interface. A set of rules and specifications that allow software components to communicate and exchange data."
+        };
+
+        yield return new Glossary
+        {
+            Key = 2,
+            Term = "Connectors",
+            Definition = "Connectors allow you to integrate with various services provide AI capabilities, including LLM, AudioToText, TextToAudio, Embedding generation, etc."
+        };
+
+        yield return new Glossary
+        {
+            Key = 3,
+            Term = "RAG",
+            Definition = "Retrieval Augmented Generation - a term that refers to the process of retrieving additional data to provide as context to an LLM to use when generating a response (completion) to a user’s question (prompt)."
+        };
+    }
+}

--- a/dotnet/samples/Concepts/README.md
+++ b/dotnet/samples/Concepts/README.md
@@ -104,6 +104,9 @@ Down below you can find the code snippets that demonstrate the usage of many Sem
 - [TextMemoryPlugin_GeminiEmbeddingGeneration](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/TextMemoryPlugin_GeminiEmbeddingGeneration.cs)
 - [TextMemoryPlugin_MultipleMemoryStore](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/TextMemoryPlugin_MultipleMemoryStore.cs)
 - [TextMemoryPlugin_RecallJsonSerializationWithOptions](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/TextMemoryPlugin_RecallJsonSerializationWithOptions.cs)
+- [VectorStore_DataIngestion_Simple: A simple example of how to do data ingestion into a vector store when getting started.](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_Simple.cs)
+- [VectorStore_DataIngestion_MultiStore: An example of data ingestion that uses the same code to ingest into multiple vector stores types.](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_MultiStore.cs)
+- [VectorStore_DataIngestion_CustomMapper: An example that shows how to use a custom mapper for when your data model and storage model doesn't match.](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs)
 
 ## Optimization - Examples of different cost and performance optimization techniques
 


### PR DESCRIPTION
### Description

Adding two more examples for the VectorStore functionality:
- A super simple example, showing just the most basic of functionality, that's easier to get started with.
- An example which shows how to use a custom mapper for a case where your storage model and data model doesn't match or you need to optimize mapping.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
