### PR TITLE
Python: added is_full_text_searchable option

### DIFF
--- a/python/semantic_kernel/connectors/memory/azure_ai_search/utils.py
+++ b/python/semantic_kernel/connectors/memory/azure_ai_search/utils.py
@@ -98,7 +98,11 @@ def data_model_definition_to_azure_ai_search_index(
                     name=field.name,
                     type=type_,
                     filterable=field.is_filterable,
-                    searchable=type_ in ("Edm.String", "Collection(Edm.String)"),
+                    # searchable is set first on the value of is_full_text_searchable,
+                    # if it is None it checks the field type, if text then it is searchable
+                    searchable=type_ in ("Edm.String", "Collection(Edm.String)")
+                    if field.is_full_text_searchable is None
+                    else field.is_full_text_searchable,
                     sortable=True,
                     hidden=False,
                 )

--- a/python/semantic_kernel/data/vector_store_record_fields.py
+++ b/python/semantic_kernel/data/vector_store_record_fields.py
@@ -29,6 +29,7 @@ class VectorStoreRecordDataField(VectorStoreRecordField):
     has_embedding: bool = False
     embedding_property_name: str | None = None
     is_filterable: bool | None = None
+    is_full_text_searchable: bool | None = None
 
 
 @dataclass


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
is full text searchable option for vector store data record fields.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
