### PR TITLE
.Net Agents - Fix `ChatCompletion_FunctionTermination` to actually use `IAutoFunctionInvocationFilter` (as intended)

### DIFF
--- a/dotnet/samples/Concepts/Agents/ChatCompletion_FunctionTermination.cs
+++ b/dotnet/samples/Concepts/Agents/ChatCompletion_FunctionTermination.cs
@@ -36,8 +36,6 @@ public class ChatCompletion_FunctionTermination(ITestOutputHelper output) : Base
         await InvokeAgentAsync("Hello");
         await InvokeAgentAsync("What is the special soup?");
         await InvokeAgentAsync("What is the special drink?");
-        //await InvokeAgentAsync("What is the special soup and what is its price?");
-        //await InvokeAgentAsync("What is the special drink and what is its price?");
         await InvokeAgentAsync("Thank you");
 
         // Display the chat history.
@@ -91,8 +89,6 @@ public class ChatCompletion_FunctionTermination(ITestOutputHelper output) : Base
         await InvokeAgentAsync("Hello");
         await InvokeAgentAsync("What is the special soup?");
         await InvokeAgentAsync("What is the special drink?");
-        //await InvokeAgentAsync("What is the special soup and what is its price?");
-        //await InvokeAgentAsync("What is the special drink and what is its price?");
         await InvokeAgentAsync("Thank you");
 
         // Display the chat history.
@@ -160,18 +156,6 @@ public class ChatCompletion_FunctionTermination(ITestOutputHelper output) : Base
                 Special Drink: Chai Tea
                 """;
         }
-
-        //[KernelFunction, Description("Provides the prices of the specials from the menu.")]
-        //[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Too smart")]
-        //public string GetPrices()
-        //{
-        //    return
-        //        """
-        //        Clam Chowder: $9.99
-        //        Cobb Salad: $9.99
-        //        Chai Tea: $9.99"
-        //        """;
-        //}
 
         [KernelFunction, Description("Provides the price of the requested menu item.")]
         public string GetItemPrice(


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The `ChatCompletion_FunctionTermination` sample is intended to use `IAutoFunctionInvocationFilter` but it isn't.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Update to build a `Kernel` that includes service-injection of  `IAutoFunctionInvocationFilter`

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
