### PR TITLE
.Net: Increase connection timeout for redis integration tests.

### DIFF
--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -85,7 +85,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         this._containerId = await SetupRedisContainerAsync(this._client);
 
         // Connect to redis.
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379,connectTimeout=60000");
+        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379,connectTimeout=60000,connectRetry=5");
         this.Database = redis.GetDatabase();
 
         // Create a schema for the vector store.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -85,7 +85,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         this._containerId = await SetupRedisContainerAsync(this._client);
 
         // Connect to redis.
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379");
+        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379,connectTimeout=60000");
         this.Database = redis.GetDatabase();
 
         // Create a schema for the vector store.


### PR DESCRIPTION
### Motivation and Context

Integration tests for redis are intermittently failing with connection errors, so increasing the connection timeout.

### Description

Increase connection timeout for redis integration tests.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
