### PR TITLE
AzureCosmosDBNoSQLMemoryStore GetAsync with embeddings false implementation

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
@@ -283,7 +283,7 @@ public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
             """
                 SELECT x.id, x.key, x.metadata, x.timestamp
                 FROM x
-                WHERE (x.key = @key)
+                WHERE (x.id = @key AND x.key = @key)
             """)
             .WithParameter("@key", key);
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
@@ -261,19 +261,43 @@ public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 
     /// <inheritdoc/>
     public async Task<MemoryRecord?> GetAsync(
-        string collectionName,
-        string key,
-        bool withEmbedding = false,
-        CancellationToken cancellationToken = default)
+    string collectionName,
+    string key,
+    bool withEmbedding = false,
+    CancellationToken cancellationToken = default)
     {
-        // TODO: Consider using a query when `withEmbedding` is false to avoid passing it over the wire.
-        var result = await this._cosmosClient
-         .GetDatabase(this._databaseName)
-         .GetContainer(collectionName)
-         .ReadItemAsync<MemoryRecord>(key, new PartitionKey(key), cancellationToken: cancellationToken)
-         .ConfigureAwait(false);
+        var container = this._cosmosClient
+            .GetDatabase(this._databaseName)
+            .GetContainer(collectionName);
 
-        return result.Resource;
+        if (withEmbedding)
+        {
+            var result = await container
+                .ReadItemAsync<MemoryRecord>(key, new PartitionKey(key), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return result.Resource;
+        }
+
+        var queryDefinition = new QueryDefinition(
+            """
+                SELECT x.id, x.key, x.metadata, x.timestamp
+                FROM x
+                WHERE (x.key = @key)
+            """)
+            .WithParameter("@key", key);
+
+        var queryIterator = container.GetItemQueryIterator<MemoryRecord>(queryDefinition);
+
+        if (queryIterator.HasMoreResults)
+        {
+            foreach (var memoryRecord in await queryIterator.ReadNextAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return memoryRecord;
+            }
+        }
+
+        return null;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION

### Motivation and Context
GetAsync was returning with embedding even if the withEmbedding parameter is false.

### Description
Current implementation will return MemoryRecord based on withEmbedding flag.

###Note
The method isn't being called yet, but I updated it because the implementation was missing.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
 