### PR TITLE
.Net: Auto function choice behavior

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -246,7 +246,7 @@ internal partial class ClientCore
                     continue;
                 }
 
-                // Make sure the requested function is one we requested. If we're permitting any kernel function to be invoked,
+                // Make sure the requested function is one we advertised. If we're permitting any kernel function to be invoked,
                 // then we don't need to check this, as it'll be handled when we look up the function in the kernel to be able
                 // to invoke it. If we're permitting only a specific list of functions, though, then we need to explicitly check.
                 if (toolCallingConfig.AllowAnyRequestedKernelFunction is not true &&
@@ -513,7 +513,7 @@ internal partial class ClientCore
                     continue;
                 }
 
-                // Make sure the requested function is one we requested. If we're permitting any kernel function to be invoked,
+                // Make sure the requested function is one we advertised. If we're permitting any kernel function to be invoked,
                 // then we don't need to check this, as it'll be handled when we look up the function in the kernel to be able
                 // to invoke it. If we're permitting only a specific list of functions, though, then we need to explicitly check.
                 if (toolCallingConfig.AllowAnyRequestedKernelFunction is not true &&
@@ -1159,7 +1159,7 @@ internal partial class ClientCore
         // Handling new tool behavior represented by `PromptExecutionSettings.FunctionChoiceBehavior` property.
         if (executionSettings.FunctionChoiceBehavior is { } functionChoiceBehavior)
         {
-            (tools, choice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction) = this.ConfigureFunctionCalling(kernel, requestIndex, functionChoiceBehavior);
+            (tools, choice, autoInvoke, maximumAutoInvokeAttempts) = this.ConfigureFunctionCalling(kernel, requestIndex, functionChoiceBehavior);
         }
         // Handling old-style tool call behavior represented by `OpenAIPromptExecutionSettings.ToolCallBehavior` property.
         else if (executionSettings.ToolCallBehavior is { } toolCallBehavior)
@@ -1208,7 +1208,7 @@ internal partial class ClientCore
         return new(tools, choice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction);
     }
 
-    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int maximumAutoInvokeAttempts, bool AllowAnyRequestedKernelFunction) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, FunctionChoiceBehavior functionChoiceBehavior)
+    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int maximumAutoInvokeAttempts) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, FunctionChoiceBehavior functionChoiceBehavior)
     {
         FunctionChoiceBehaviorConfiguration config = functionChoiceBehavior.GetConfiguration(new() { Kernel = kernel });
 
@@ -1216,7 +1216,6 @@ internal partial class ClientCore
         ChatToolChoice? toolChoice = null;
         int maximumAutoInvokeAttempts = config.AutoInvoke ? MaximumAutoInvokeAttempts : 0;
         bool autoInvoke = kernel is not null && config.AutoInvoke;
-        bool allowAnyRequestedKernelFunction = config.AllowAnyRequestedKernelFunction;
 
         if (config.Choice == FunctionChoice.Auto)
         {
@@ -1231,7 +1230,7 @@ internal partial class ClientCore
                 }
             }
 
-            return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction);
+            return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts);
         }
 
         throw new NotSupportedException($"Unsupported function choice '{config.Choice}'.");

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -1213,7 +1213,7 @@ internal partial class ClientCore
         FunctionChoiceBehaviorConfiguration config = functionChoiceBehavior.GetConfiguration(new() { Kernel = kernel });
 
         IList<ChatTool>? tools = null;
-        ChatToolChoice? choice = null;
+        ChatToolChoice? toolChoice = null;
         int maximumAutoInvokeAttempts = config.AutoInvoke ? MaximumAutoInvokeAttempts : 0;
         bool autoInvoke = kernel is not null && config.AutoInvoke;
         bool allowAnyRequestedKernelFunction = config.AllowAnyRequestedKernelFunction;
@@ -1222,7 +1222,7 @@ internal partial class ClientCore
         {
             if (config.Functions is { Count: > 0 } functions)
             {
-                choice = ChatToolChoice.Auto;
+                toolChoice = ChatToolChoice.Auto;
                 tools = [];
 
                 foreach (var function in functions)
@@ -1231,7 +1231,7 @@ internal partial class ClientCore
                 }
             }
 
-            return new(tools, choice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction);
+            return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction);
         }
 
         throw new NotSupportedException($"Unsupported function choice '{config.Choice}'.");

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -1,0 +1,380 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.AzureOpenAI;
+
+public sealed class AzureOpenAIAutoFunctionChoiceBehaviorTests : BaseIntegrationTest
+{
+    private readonly Kernel _kernel;
+    private readonly FakeFunctionFilter _autoFunctionInvocationFilter;
+    private readonly IChatCompletionService _chatCompletionService
+        ;
+
+    public AzureOpenAIAutoFunctionChoiceBehaviorTests()
+    {
+        this._autoFunctionInvocationFilter = new FakeFunctionFilter();
+
+        this._kernel = this.InitializeKernel();
+        this._kernel.AutoFunctionInvocationFilters.Add(this._autoFunctionInvocationFilter);
+        this._chatCompletionService = this._kernel.GetRequiredService<IChatCompletionService>();
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: auto
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    // Act
+    //    var result = await this._kernel.InvokeAsync(promptFunction);
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        string result = "";
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            result += content;
+        }
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: auto
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    string result = "";
+
+    //    // Act
+    //    await foreach (string c in promptFunction.InvokeStreamingAsync<string>(this._kernel))
+    //    {
+    //        result += c;
+    //    }
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.First()], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.First()], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    private Kernel InitializeKernel()
+    {
+        var azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
+        Assert.NotNull(azureOpenAIConfiguration);
+        Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
+        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
+        Assert.NotNull(azureOpenAIConfiguration.Endpoint);
+
+        var kernelBuilder = base.CreateKernelBuilder();
+
+        kernelBuilder.AddAzureOpenAIChatCompletion(
+            deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
+            modelId: azureOpenAIConfiguration.ChatModelId,
+            endpoint: azureOpenAIConfiguration.Endpoint,
+            apiKey: azureOpenAIConfiguration.ApiKey);
+
+        return kernelBuilder.Build();
+    }
+
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+        .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
+        .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+        .AddEnvironmentVariables()
+        .AddUserSecrets<AzureOpenAIChatCompletionTests>()
+        .Build();
+
+    /// <summary>
+    /// A plugin that returns the current time.
+    /// </summary>
+    public class DateTimeUtils
+    {
+        [KernelFunction]
+        [Description("Retrieves the current date.")]
+        public string GetCurrentDate() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture);
+    }
+
+    #region private
+
+    private sealed class FakeFunctionFilter : IAutoFunctionInvocationFilter
+    {
+        private Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? _onFunctionInvocation;
+
+        public void RegisterFunctionInvocationHandler(Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> onFunctionInvocation)
+        {
+            this._onFunctionInvocation = onFunctionInvocation;
+        }
+
+        public Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            if (this._onFunctionInvocation is null)
+            {
+                return next(context);
+            }
+
+            return this._onFunctionInvocation?.Invoke(context, next) ?? Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -346,7 +346,9 @@ public sealed class AzureOpenAIAutoFunctionChoiceBehaviorTests : BaseIntegration
     /// <summary>
     /// A plugin that returns the current time.
     /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
     private sealed class DateTimeUtils
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         [KernelFunction]
         [Description("Retrieves the current date.")]

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -346,7 +346,7 @@ public sealed class AzureOpenAIAutoFunctionChoiceBehaviorTests : BaseIntegration
     /// <summary>
     /// A plugin that returns the current time.
     /// </summary>
-    public class DateTimeUtils
+    private sealed class DateTimeUtils
     {
         [KernelFunction]
         [Description("Retrieves the current date.")]

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -20,8 +20,7 @@ public sealed class AzureOpenAIAutoFunctionChoiceBehaviorTests : BaseIntegration
 {
     private readonly Kernel _kernel;
     private readonly FakeFunctionFilter _autoFunctionInvocationFilter;
-    private readonly IChatCompletionService _chatCompletionService
-        ;
+    private readonly IChatCompletionService _chatCompletionService;
 
     public AzureOpenAIAutoFunctionChoiceBehaviorTests()
     {

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -342,7 +342,9 @@ public sealed class OpenAIAutoFunctionChoiceBehaviorTests : BaseIntegrationTest
     /// <summary>
     /// A plugin that returns the current time.
     /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
     private sealed class DateTimeUtils
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         [KernelFunction]
         [Description("Retrieves the current date.")]

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -1,0 +1,379 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.OpenAI;
+
+public sealed class OpenAIAutoFunctionChoiceBehaviorTests : BaseIntegrationTest
+{
+    private readonly Kernel _kernel;
+    private readonly FakeFunctionFilter _autoFunctionInvocationFilter;
+    private readonly IChatCompletionService _chatCompletionService;
+
+    public OpenAIAutoFunctionChoiceBehaviorTests()
+    {
+        this._autoFunctionInvocationFilter = new FakeFunctionFilter();
+
+        this._kernel = this.InitializeKernel();
+        this._kernel.AutoFunctionInvocationFilters.Add(this._autoFunctionInvocationFilter);
+        this._chatCompletionService = this._kernel.GetRequiredService<IChatCompletionService>();
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: auto
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    // Act
+    //    var result = await this._kernel.InvokeAsync(promptFunction);
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        string result = "";
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            result += content;
+        }
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: auto
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    string result = "";
+
+    //    // Act
+    //    await foreach (string c in promptFunction.InvokeStreamingAsync<string>(this._kernel))
+    //    {
+    //        result += c;
+    //    }
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.ElementAt(1)], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.ElementAt(1)], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    private Kernel InitializeKernel()
+    {
+        var openAIConfiguration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
+        Assert.NotNull(openAIConfiguration);
+        Assert.NotNull(openAIConfiguration.ChatModelId!);
+        Assert.NotNull(openAIConfiguration.ApiKey);
+
+        var kernelBuilder = base.CreateKernelBuilder();
+
+        kernelBuilder.AddOpenAIChatCompletion(
+            modelId: openAIConfiguration.ChatModelId,
+            apiKey: openAIConfiguration.ApiKey);
+
+        return kernelBuilder.Build();
+    }
+
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+        .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
+        .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+        .AddEnvironmentVariables()
+        .AddUserSecrets<OpenAIChatCompletionTests>()
+        .Build();
+
+    /// <summary>
+    /// A plugin that returns the current time.
+    /// </summary>
+    public class DateTimeUtils
+    {
+        [KernelFunction]
+        [Description("Retrieves the current time in UTC.")]
+        public string GetCurrentUtcTime() => DateTime.UtcNow.ToString("R");
+
+        [KernelFunction]
+        [Description("Retrieves the current date.")]
+        public string GetCurrentDate() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture);
+    }
+
+    #region private
+
+    private sealed class FakeFunctionFilter : IAutoFunctionInvocationFilter
+    {
+        private Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? _onFunctionInvocation;
+
+        public void RegisterFunctionInvocationHandler(Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> onFunctionInvocation)
+        {
+            this._onFunctionInvocation = onFunctionInvocation;
+        }
+
+        public Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            if (this._onFunctionInvocation is null)
+            {
+                return next(context);
+            }
+
+            return this._onFunctionInvocation?.Invoke(context, next) ?? Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -257,7 +257,7 @@ public sealed class OpenAIAutoFunctionChoiceBehaviorTests : BaseIntegrationTest
             await next(context);
         });
 
-        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.ElementAt(1)], autoInvoke: false) };
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.ElementAt(0)], autoInvoke: false) };
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("How many days until Christmas?");
@@ -295,7 +295,7 @@ public sealed class OpenAIAutoFunctionChoiceBehaviorTests : BaseIntegrationTest
 
         var functionsForManualInvocation = new List<string>();
 
-        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.ElementAt(1)], autoInvoke: false) };
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto([plugin.ElementAt(0)], autoInvoke: false) };
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("How many days until Christmas?");

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -342,12 +342,8 @@ public sealed class OpenAIAutoFunctionChoiceBehaviorTests : BaseIntegrationTest
     /// <summary>
     /// A plugin that returns the current time.
     /// </summary>
-    public class DateTimeUtils
+    private sealed class DateTimeUtils
     {
-        [KernelFunction]
-        [Description("Retrieves the current time in UTC.")]
-        public string GetCurrentUtcTime() => DateTime.UtcNow.ToString("R");
-
         [KernelFunction]
         [Description("Retrieves the current date.")]
         public string GetCurrentDate() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture);

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -53,7 +53,6 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
         }
 
         List<KernelFunction>? availableFunctions = null;
-        bool allowAnyRequestedKernelFunction = false;
 
         if (this._functions is not null)
         {
@@ -76,8 +75,6 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
         // Provide all kernel functions.
         else if (context.Kernel is not null)
         {
-            allowAnyRequestedKernelFunction = true;
-
             foreach (var plugin in context.Kernel.Plugins)
             {
                 (availableFunctions ??= new List<KernelFunction>(context.Kernel.Plugins.Count)).AddRange(plugin);
@@ -90,7 +87,6 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
             Choice = FunctionChoice.Auto,
             Functions = availableFunctions,
             AutoInvoke = this._autoInvoke,
-            AllowAnyRequestedKernelFunction = allowAnyRequestedKernelFunction
         };
 #pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Represents a <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to the LLM to call or specific ones.
+/// This behavior allows the LLM to decide whether to call the functions and, if so, which ones to call.
+/// </summary>
+internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
+{
+    /// <summary>
+    /// List of the functions to provide to LLM.
+    /// </summary>
+    private readonly IEnumerable<KernelFunction>? _functions;
+
+    /// <summary>
+    /// Indicates whether the functions should be automatically invoked by AI connectors.
+    /// </summary>
+    private readonly bool _autoInvoke;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AutoFunctionChoiceBehavior"/> class.
+    /// </summary>
+    /// <param name="functions">
+    /// Functions to provide to LLM. If null, all <see cref="Kernel"/>'s plugins' functions are provided to LLM.
+    /// If empty, no functions are provided to LLM, which is equivalent to disabling function calling.
+    /// </param>
+    /// <param name="autoInvoke">
+    /// Indicates whether the functions should be automatically invoked by AI connectors.
+    /// </param>
+    public AutoFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
+    {
+        this._functions = functions;
+        this._autoInvoke = autoInvoke;
+    }
+
+    /// <inheritdoc />
+#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
+#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    {
+        // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
+        // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
+        // and then fail to do so, so we fail before we get to that point. This is an error
+        // on the consumers behalf: if they specify auto-invocation with any functions, they must
+        // specify the kernel and the kernel must contain those functions.
+        if (this._autoInvoke && context.Kernel is null)
+        {
+            throw new KernelException("Auto-invocation is not supported when no kernel is provided.");
+        }
+
+        List<KernelFunction>? availableFunctions = null;
+        bool allowAnyRequestedKernelFunction = false;
+
+        if (this._functions is not null)
+        {
+            availableFunctions = new List<KernelFunction>(this._functions.Count());
+
+            foreach (var function in this._functions)
+            {
+                if (this._autoInvoke)
+                {
+                    // If auto-invocation is requested and no function is found in the kernel, fail early.
+                    if (!context.Kernel!.Plugins.TryGetFunction(function.PluginName, function.Name, out var _))
+                    {
+                        throw new KernelException($"The specified function {function} is not available in the kernel.");
+                    }
+                }
+
+                availableFunctions.Add(function);
+            }
+        }
+        // Provide all kernel functions.
+        else if (context.Kernel is not null)
+        {
+            allowAnyRequestedKernelFunction = true;
+
+            foreach (var plugin in context.Kernel.Plugins)
+            {
+                (availableFunctions ??= new List<KernelFunction>(context.Kernel.Plugins.Count)).AddRange(plugin);
+            }
+        }
+
+#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        return new FunctionChoiceBehaviorConfiguration()
+        {
+            Choice = FunctionChoice.Auto,
+            Functions = availableFunctions,
+            AutoInvoke = this._autoInvoke,
+            AllowAnyRequestedKernelFunction = allowAnyRequestedKernelFunction
+        };
+#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -38,9 +38,9 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     }
 
     /// <inheritdoc />
-#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
-#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     {
         // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
         // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
@@ -84,7 +84,7 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
             }
         }
 
-#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return new FunctionChoiceBehaviorConfiguration()
         {
             Choice = FunctionChoice.Auto,
@@ -92,6 +92,6 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
             AutoInvoke = this._autoInvoke,
             AllowAnyRequestedKernelFunction = allowAnyRequestedKernelFunction
         };
-#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoice.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoice.cs
@@ -9,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Represents an AI model's decision-making strategy for calling functions, offering predefined choices: Auto, Required, and None.
 /// Auto allows the model to decide if and which functions to call, Required enforces calling one or more functions, and None prevents any function calls, generating only a user-facing message.
 /// </summary>
+[Experimental("SKEXP0010")]
 public readonly struct FunctionChoice : IEquatable<FunctionChoice>
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoice.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoice.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Represents an AI model's decision-making strategy for calling functions, offering predefined choices: Auto, Required, and None.
 /// Auto allows the model to decide if and which functions to call, Required enforces calling one or more functions, and None prevents any function calls, generating only a user-facing message.
 /// </summary>
-[Experimental("SKEXP0010")]
+[Experimental("SKEXP0001")]
 public readonly struct FunctionChoice : IEquatable<FunctionChoice>
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -22,7 +22,7 @@ public abstract class FunctionChoiceBehavior
     /// <param name="autoInvoke">
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </param>
-    [Experimental("SKEXP0010")]
+    [Experimental("SKEXP0001")]
     public static FunctionChoiceBehavior Auto(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
     {
         return new AutoFunctionChoiceBehavior(functions, autoInvoke);
@@ -33,7 +33,7 @@ public abstract class FunctionChoiceBehavior
     /// </summary>
     /// <param name="context">The context provided by AI connectors, used to determine the configuration.</param>
     /// <returns>The configuration.</returns>
-#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public abstract FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context);
-#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -9,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// Represents the base class for different function choice behaviors.
 /// These behaviors define the way functions are chosen by LLM and various aspects of their invocation by AI connectors.
 /// </summary>
+[Experimental("SKEXP0001")]
 public abstract class FunctionChoiceBehavior
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
@@ -9,9 +12,28 @@ namespace Microsoft.SemanticKernel;
 public abstract class FunctionChoiceBehavior
 {
     /// <summary>
+    /// Gets an instance of the <see cref="FunctionChoiceBehavior"/> that provides either all of the<see cref="Kernel"/>'s plugins' functions to the LLM to call or specific ones.
+    /// This behavior allows the LLM to decide whether to call the functions and, if so, which ones to call.
+    /// </summary>
+    /// <param name="functions">
+    /// Functions to provide to LLM. If null, all <see cref="Kernel"/>'s plugins' functions are provided to LLM.
+    /// If empty, no functions are provided to LLM, which is equivalent to disabling function calling.
+    /// </param>
+    /// <param name="autoInvoke">
+    /// Indicates whether the functions should be automatically invoked by AI connectors.
+    /// </param>
+    [Experimental("SKEXP0010")]
+    public static FunctionChoiceBehavior Auto(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
+    {
+        return new AutoFunctionChoiceBehavior(functions, autoInvoke);
+    }
+
+    /// <summary>
     /// Returns the configuration used by AI connectors to determine function choice and invocation behavior.
     /// </summary>
     /// <param name="context">The context provided by AI connectors, used to determine the configuration.</param>
     /// <returns>The configuration.</returns>
+#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public abstract FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context);
+#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Represents function choice behavior configuration produced by a <see cref="FunctionChoiceBehavior" />.
 /// </summary>
+[Experimental("SKEXP0010")]
 public sealed class FunctionChoiceBehaviorConfiguration
 {
     /// <summary>
@@ -18,4 +20,14 @@ public sealed class FunctionChoiceBehaviorConfiguration
     /// The functions available for AI model.
     /// </summary>
     public IReadOnlyList<KernelFunction>? Functions { get; internal init; }
+
+    /// <summary>
+    /// Indicates whether the functions should be automatically invoked by the AI connector.
+    /// </summary>
+    public bool AutoInvoke { get; internal init; } = true;
+
+    /// <summary>
+    /// Specifies whether validation against a specified list of functions is required before allowing AI connector to invoke it.
+    /// </summary>
+    public bool AllowAnyRequestedKernelFunction { get; internal set; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Represents function choice behavior configuration produced by a <see cref="FunctionChoiceBehavior" />.
 /// </summary>
-[Experimental("SKEXP0010")]
+[Experimental("SKEXP0001")]
 public sealed class FunctionChoiceBehaviorConfiguration
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
@@ -25,9 +25,4 @@ public sealed class FunctionChoiceBehaviorConfiguration
     /// Indicates whether the functions should be automatically invoked by the AI connector.
     /// </summary>
     public bool AutoInvoke { get; internal init; } = true;
-
-    /// <summary>
-    /// Specifies whether validation against a specified list of functions is required before allowing AI connector to invoke it.
-    /// </summary>
-    public bool AllowAnyRequestedKernelFunction { get; internal set; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// The context to be provided by the choice behavior consumer in order to obtain the choice behavior configuration.
 /// </summary>
+[Experimental("SKEXP0010")]
 public sealed class FunctionChoiceBehaviorConfigurationContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
@@ -7,7 +7,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// The context to be provided by the choice behavior consumer in order to obtain the choice behavior configuration.
 /// </summary>
-[Experimental("SKEXP0010")]
+[Experimental("SKEXP0001")]
 public sealed class FunctionChoiceBehaviorConfigurationContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -66,6 +66,35 @@ public class PromptExecutionSettings
     }
 
     /// <summary>
+    /// Gets or sets the behavior defining the way functions are chosen by LLM and how they are invoked by AI connectors.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>To disable function calling, and have the model only generate a user-facing message, set the property to null (the default).</item>
+    /// <item>
+    /// To allow the model to decide whether to call the functions and, if so, which ones to call, set the property to an instance returned
+    /// from <see cref="FunctionChoiceBehavior.Auto(IEnumerable{KernelFunction}?, bool)"/> method.
+    /// </item>
+    /// </list>
+    /// For all the behaviors that presume the model to call functions, auto-invoke can be specified. If LLM
+    /// call a function and auto-invoke enabled, SK will attempt to resolve that function from the functions
+    /// available, and if found, rather than returning the response back to the caller, it will invoke the function automatically.
+    /// The intermediate messages will be retained in the provided <see cref="ChatHistory"/>.
+    /// </remarks>
+    [JsonPropertyName("function_choice_behavior")]
+    [Experimental("SKEXP0010")]
+    public FunctionChoiceBehavior? FunctionChoiceBehavior
+    {
+        get => this._functionChoiceBehavior;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._functionChoiceBehavior = value;
+        }
+    }
+
+    /// <summary>
     /// Extra properties that may be included in the serialized execution settings.
     /// </summary>
     /// <remarks>
@@ -112,12 +141,15 @@ public class PromptExecutionSettings
     /// </summary>
     public virtual PromptExecutionSettings Clone()
     {
+#pragma warning disable SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return new()
         {
             ModelId = this.ModelId,
             ServiceId = this.ServiceId,
+            FunctionChoiceBehavior = this.FunctionChoiceBehavior,
             ExtensionData = this.ExtensionData is not null ? new Dictionary<string, object>(this.ExtensionData) : null
         };
+#pragma warning restore SKEXP0010 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -137,6 +169,7 @@ public class PromptExecutionSettings
     private string? _modelId;
     private IDictionary<string, object>? _extensionData;
     private string? _serviceId;
+    private FunctionChoiceBehavior? _functionChoiceBehavior;
 
     #endregion
 }

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using Microsoft.SemanticKernel;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.AI.FunctionChoiceBehaviors;
+
+/// <summary>
+/// Unit tests for <see cref="AutoFunctionChoiceBehavior"/>
+/// </summary>
+public sealed class AutoFunctionChoiceBehaviorTests
+{
+    private readonly Kernel _kernel;
+
+    public AutoFunctionChoiceBehaviorTests()
+    {
+        this._kernel = new Kernel();
+    }
+
+    [Fact]
+    public void ItShouldAdvertiseAllKernelFunctions()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior();
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.NotNull(config.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.Name == "Function3");
+    }
+
+    [Fact]
+    public void ItShouldAdvertiseOnlyFunctionsSuppliedViaConstructor()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.NotNull(config.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+    }
+
+    //[Fact]
+    //public void ItShouldAdvertiseOnlyFunctionsSuppliedInFunctionsProperty()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = new AutoFunctionChoiceBehavior()
+    //    {
+    //        Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
+    //    };
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+
+    //    Assert.NotNull(config.Functions);
+    //    Assert.Equal(2, config.Functions.Count);
+    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
+    //}
+
+    [Fact]
+    public void ItShouldAdvertiseOnlyFunctionsSuppliedViaConstructorForManualInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior([plugin.ElementAt(0), plugin.ElementAt(1)], autoInvoke: false);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.NotNull(config.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+    }
+
+    [Fact]
+    public void ItShouldAdvertiseAllKernelFunctionsForManualInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.NotNull(config.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.Name == "Function3");
+    }
+
+    [Fact]
+    public void ItShouldAllowAutoInvocationByDefault()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior();
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.True(config.AutoInvoke);
+    }
+
+    [Fact]
+    public void ItShouldAllowManualInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.False(config.AutoInvoke);
+    }
+
+    //[Fact]
+    //public void ItShouldInitializeFunctionPropertyByFunctionsPassedViaConstructor()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+
+    //    // Assert
+    //    Assert.NotNull(choiceBehavior.Functions);
+    //    Assert.Equal(2, choiceBehavior.Functions.Count);
+
+    //    Assert.Equal("MyPlugin.Function1", choiceBehavior.Functions.ElementAt(0));
+    //    Assert.Equal("MyPlugin.Function2", choiceBehavior.Functions.ElementAt(1));
+    //}
+
+    [Fact]
+    public void ItShouldThrowExceptionIfAutoInvocationRequestedButNoKernelIsProvided()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        var choiceBehavior = new AutoFunctionChoiceBehavior();
+
+        // Act
+        var exception = Assert.Throws<KernelException>(() =>
+        {
+            choiceBehavior.GetConfiguration(new() { Kernel = null });
+        });
+
+        Assert.Equal("Auto-invocation is not supported when no kernel is provided.", exception.Message);
+    }
+
+    [Fact]
+    public void ItShouldThrowExceptionIfAutoInvocationRequestedAndFunctionIsNotRegisteredInKernel()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+
+        var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(0)]);
+
+        // Act
+        var exception = Assert.Throws<KernelException>(() =>
+        {
+            choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        });
+
+        Assert.Equal("The specified function MyPlugin.Function1 is not available in the kernel.", exception.Message);
+    }
+
+    //[Fact]
+    //public void ItShouldThrowExceptionIfNoFunctionFoundAndManualInvocationIsRequested()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false)
+    //    {
+    //        Functions = ["MyPlugin.NonKernelFunction"]
+    //    };
+
+    //    // Act
+    //    var exception = Assert.Throws<KernelException>(() =>
+    //    {
+    //        choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+    //    });
+
+    //    Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
+    //}
+
+    [Fact]
+    public void ItShouldAllowInvocationOfAnyRequestedKernelFunction()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior();
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.True(config.AllowAnyRequestedKernelFunction);
+    }
+
+    [Fact]
+    public void ItShouldNotAllowInvocationOfAnyRequestedKernelFunctionIfSubsetOfFunctionsSpecified()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(1)]);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.False(config.AllowAnyRequestedKernelFunction);
+    }
+
+    private static KernelPlugin GetTestPlugin()
+    {
+        var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function2");
+        var function3 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function3");
+
+        return KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2, function3]);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
@@ -235,40 +235,6 @@ public sealed class AutoFunctionChoiceBehaviorTests
     //    Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
     //}
 
-    [Fact]
-    public void ItShouldAllowInvocationOfAnyRequestedKernelFunction()
-    {
-        // Arrange
-        var plugin = GetTestPlugin();
-        this._kernel.Plugins.Add(plugin);
-
-        // Act
-        var choiceBehavior = new AutoFunctionChoiceBehavior();
-
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
-
-        // Assert
-        Assert.NotNull(config);
-        Assert.True(config.AllowAnyRequestedKernelFunction);
-    }
-
-    [Fact]
-    public void ItShouldNotAllowInvocationOfAnyRequestedKernelFunctionIfSubsetOfFunctionsSpecified()
-    {
-        // Arrange
-        var plugin = GetTestPlugin();
-        this._kernel.Plugins.Add(plugin);
-
-        // Act
-        var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(1)]);
-
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
-
-        // Assert
-        Assert.NotNull(config);
-        Assert.False(config.AllowAnyRequestedKernelFunction);
-    }
-
     private static KernelPlugin GetTestPlugin()
     {
         var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using Microsoft.SemanticKernel;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Functions;
+
+/// <summary>
+/// Unit tests for <see cref="FunctionChoiceBehavior"/>
+/// </summary>
+public sealed class FunctionChoiceBehaviorTests
+{
+    private readonly Kernel _kernel;
+
+    public FunctionChoiceBehaviorTests()
+    {
+        this._kernel = new Kernel();
+    }
+
+    [Fact]
+    public void AutoFunctionChoiceShouldBeUsed()
+    {
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Auto();
+
+        // Assert
+        Assert.IsType<AutoFunctionChoiceBehavior>(choiceBehavior);
+    }
+
+    //[Fact]
+    //public void RequiredFunctionChoiceShouldBeUsed()
+    //{
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required();
+
+    //    // Assert
+    //    Assert.IsType<RequiredFunctionChoiceBehavior>(choiceBehavior);
+    //}
+
+    //[Fact]
+    //public void NoneFunctionChoiceShouldBeUsed()
+    //{
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.None();
+
+    //    // Assert
+    //    Assert.IsType<NoneFunctionChoiceBehavior>(choiceBehavior);
+    //}
+
+    [Fact]
+    public void AutoFunctionChoiceShouldAdvertiseKernelFunctions()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Auto(functions: null);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.NotNull(config.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.Name == "Function3");
+    }
+
+    [Fact]
+    public void AutoFunctionChoiceShouldAdvertiseProvidedFunctions()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Auto(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.NotNull(config.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+    }
+
+    [Fact]
+    public void AutoFunctionChoiceShouldAllowAutoInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.True(config.AutoInvoke);
+    }
+
+    [Fact]
+    public void AutoFunctionChoiceShouldAllowManualInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false);
+
+        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.False(config.AutoInvoke);
+    }
+
+    //[Fact]
+    //public void RequiredFunctionChoiceShouldAdvertiseKernelFunctions()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required(functions: null);
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+
+    //    Assert.NotNull(config.Functions);
+    //    Assert.Equal(3, config.Functions.Count);
+    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function3");
+    //}
+
+    //[Fact]
+    //public void RequiredFunctionChoiceShouldAdvertiseProvidedFunctions()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+
+    //    Assert.NotNull(config.Functions);
+    //    Assert.Equal(2, config.Functions.Count);
+    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
+    //}
+
+    //[Fact]
+    //public void RequiredFunctionChoiceShouldAllowAutoInvocation()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required(options: new() { AutoInvoke = true });
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+    //    Assert.True(config.Options.AutoInvoke);
+    //}
+
+    //[Fact]
+    //public void RequiredFunctionChoiceShouldAllowManualInvocation()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required(options: new() { AutoInvoke = false });
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+    //    Assert.False(config.Options.AutoInvoke);
+    //}
+
+    //[Fact]
+    //public void NoneFunctionChoiceShouldAdvertiseProvidedFunctions()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.None([plugin.ElementAt(0), plugin.ElementAt(2)]);
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+
+    //    Assert.NotNull(config.Functions);
+    //    Assert.Equal(2, config.Functions.Count);
+    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function3");
+    //}
+
+    //[Fact]
+    //public void NoneFunctionChoiceShouldAdvertiseAllKernelFunctions()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
+
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.None();
+
+    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+
+    //    // Assert
+    //    Assert.NotNull(config);
+
+    //    Assert.NotNull(config.Functions);
+    //    Assert.Equal(3, config.Functions.Count);
+    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
+    //    Assert.Contains(config.Functions, f => f.Name == "Function3");
+    //}
+
+    private static KernelPlugin GetTestPlugin()
+    {
+        var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function2");
+        var function3 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function3");
+
+        return KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2, function3]);
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/AI/PromptExecutionSettingsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/PromptExecutionSettingsTests.cs
@@ -32,6 +32,7 @@ public class PromptExecutionSettingsTests
         Assert.NotNull(clone);
         Assert.Equal(executionSettings.ModelId, clone.ModelId);
         Assert.Equivalent(executionSettings.ExtensionData, clone.ExtensionData);
+        Assert.Equivalent(executionSettings.FunctionChoiceBehavior, clone.FunctionChoiceBehavior);
         Assert.Equal(executionSettings.ServiceId, clone.ServiceId);
     }
 
@@ -88,6 +89,7 @@ public class PromptExecutionSettingsTests
         Assert.NotNull(executionSettings.ExtensionData);
         Assert.Throws<NotSupportedException>(() => executionSettings.ExtensionData.Add("results_per_prompt", 2));
         Assert.Throws<NotSupportedException>(() => executionSettings.ExtensionData["temperature"] = 1);
+        Assert.Throws<InvalidOperationException>(() => executionSettings.FunctionChoiceBehavior = FunctionChoiceBehavior.Auto());
 
         executionSettings!.Freeze(); // idempotent
         Assert.True(executionSettings.IsFrozen);


### PR DESCRIPTION
### Motivation, Context and Description
This PR adds a new `AutoFunctionChoiceBehavior` class that contains information about functions to advertise to LLM, whether to auto-invoke them or not, and the Auto choice instructing LLM to consider calling one or many advertised functions. Additionally, it adds the new `FunctionChoiceBehavior` property to the `PromptExecutionSettings` class, which will be used by all AI connectors to configure function choice behavior in a connector agnostic way.