### PR TITLE
Python: Update auto invoke function filter handling for proper functionality for OpenAI models.

### DIFF
--- a/python/samples/concepts/filtering/auto_function_invoke_filters.py
+++ b/python/samples/concepts/filtering/auto_function_invoke_filters.py
@@ -9,6 +9,7 @@ from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion, OpenAICh
 from semantic_kernel.contents import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
+from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.core_plugins import MathPlugin, TimePlugin
 from semantic_kernel.filters.auto_function_invocation.auto_function_invocation_context import (
     AutoFunctionInvocationContext,
@@ -139,16 +140,22 @@ async def chat() -> bool:
 
     result = await kernel.invoke(chat_function, arguments=arguments)
 
-    # If tools are used, and auto invoke tool calls is False, the response will be of type
-    # ChatMessageContent with information about the tool calls, which need to be sent
-    # back to the model to get the final response.
-    if isinstance(result.value[0].items[0], FunctionCallContent):
-        print_tool_calls(result.value[0])
-        return True
-
     history.add_user_message(user_input)
-    history.add_assistant_message(str(result))
-    print(f"Mosscap:> {result}")
+
+    # Check if any result.value is a FunctionResult
+    if any(isinstance(item, FunctionResultContent) for item in result.value[0].items):
+        # Iterate through each result to process FunctionResult instances
+        for fr in result.value[0].items:
+            if isinstance(fr, FunctionResultContent):
+                print(f"Mosscap:> {fr.result}")
+    elif any(isinstance(item, FunctionCallContent) for item in result.value[0].items):
+        # If tools are used, and auto invoke tool calls is False, the response will be of type
+        # ChatMessageContent with information about the tool calls, which need to be sent
+        # back to the model to get the final response.
+        for fcc in result.value[0].items:
+            if isinstance(fcc, FunctionCallContent):
+                print_tool_calls(fcc)
+
     return True
 
 

--- a/python/samples/concepts/filtering/auto_function_invoke_filters.py
+++ b/python/samples/concepts/filtering/auto_function_invoke_filters.py
@@ -148,6 +148,7 @@ async def chat() -> bool:
         for fr in result.value[0].items:
             if isinstance(fr, FunctionResultContent):
                 print(f"Mosscap:> {fr.result}")
+                history.add_assistant_message(str(fr.result))
     elif any(isinstance(item, FunctionCallContent) for item in result.value[0].items):
         # If tools are used, and auto invoke tool calls is False, the response will be of type
         # ChatMessageContent with information about the tool calls, which need to be sent
@@ -155,6 +156,10 @@ async def chat() -> bool:
         for fcc in result.value[0].items:
             if isinstance(fcc, FunctionCallContent):
                 print_tool_calls(fcc)
+        history.add_assistant_message(str(result))
+    else:
+        print(f"Mosscap:> {result}")
+        history.add_assistant_message(str(result))
 
     return True
 

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -135,7 +135,7 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
             )
 
             if any(result.terminate for result in results if result is not None):
-                return completions
+                return [chat_history.messages[-1]]
 
             self._update_settings(settings, chat_history, kernel=kernel)
         else:
@@ -235,7 +235,8 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
                 ],
             )
             if any(result.terminate for result in results if result is not None):
-                return
+                yield [chat_history.messages[-1]]  # type: ignore
+                break
 
             self._update_settings(settings, chat_history, kernel=kernel)
 

--- a/python/semantic_kernel/kernel.py
+++ b/python/semantic_kernel/kernel.py
@@ -403,14 +403,12 @@ class Kernel(KernelFilterExtension, KernelFunctionExtension, KernelServicesExten
         )
         await stack(invocation_context)
 
-        if invocation_context.terminate:
-            return invocation_context
-
         frc = FunctionResultContent.from_function_call_content_and_result(
             function_call_content=function_call, result=invocation_context.function_result
         )
         chat_history.add_message(message=frc.to_chat_message_content())
-        return None
+
+        return invocation_context if invocation_context.terminate else None
 
     async def _inner_auto_function_invoke_handler(self, context: AutoFunctionInvocationContext):
         """Inner auto function invocation handler."""


### PR DESCRIPTION
### Motivation and Context

Our auto function invoke filter does not have the correct behavior. Currently, it will return the straight chat completion results which contain the function call content, instead of the function result content. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR fixes this by adding the function result content to the chat history, and if the auto function invoke filter has the context as terminated then it will return the last item of the chat history (function result content) otherwise it will be the completions (in the event that the function isn't run for some reason).
- It also fixes the `auto_function_invoke_filters` sample to show the FunctionResultContent if it exists.
- Aligns to the same behavior as in dotnet.
- Fixes #8020 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
