### PR TITLE
.Net: Allow chat history mutation from auto-function invocation filters in MistralAI connector

### DIFF
--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Client/MistralClientTests.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Client/MistralClientTests.cs
@@ -566,7 +566,7 @@ public sealed class MistralClientTests : MistralTestBase
     private MistralClient CreateMistralClientStreaming(string modelId, string requestUri, params string[] responseData)
     {
         var responses = responseData.Select(this.GetTestResponseAsBytes).ToArray();
-        this.DelegatingHandler = new AssertingDelegatingHandler(requestUri, responses);
+        this.DelegatingHandler = new AssertingDelegatingHandler(requestUri, true, responses);
         this.HttpClient = new HttpClient(this.DelegatingHandler, false);
         var client = new MistralClient(modelId, this.HttpClient, "key");
         return client;

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/MistralTestBase.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/MistralTestBase.cs
@@ -81,10 +81,10 @@ public abstract class MistralTestBase : IDisposable
             this._responseStringArray = responseStringArray;
         }
 
-        internal AssertingDelegatingHandler(string requestUri, params byte[][] responseBytesArray)
+        internal AssertingDelegatingHandler(string requestUri, bool stream = true, params byte[][] responseBytesArray)
         {
             this.RequestUri = new Uri(requestUri);
-            this.RequestHeaders = GetDefaultRequestHeaders("key", true);
+            this.RequestHeaders = GetDefaultRequestHeaders("key", stream);
             this._responseBytesArray = responseBytesArray;
         }
 

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Services/MistralAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/Services/MistralAIChatCompletionServiceTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -42,7 +44,7 @@ public sealed class MistralAIChatCompletionServiceTests : MistralTestBase
     {
         // Arrange
         var content = this.GetTestResponseAsBytes("chat_completions_streaming_response.txt");
-        this.DelegatingHandler = new AssertingDelegatingHandler("https://api.mistral.ai/v1/chat/completions", content);
+        this.DelegatingHandler = new AssertingDelegatingHandler("https://api.mistral.ai/v1/chat/completions", true, content);
         this.HttpClient = new HttpClient(this.DelegatingHandler, false);
         var service = new MistralAIChatCompletionService("mistral-small-latest", "key", httpClient: this.HttpClient);
 
@@ -68,6 +70,172 @@ public sealed class MistralAIChatCompletionServiceTests : MistralTestBase
             Assert.NotNull(chunk.Content);
             Assert.NotNull(chunk.Role);
             Assert.NotNull(chunk.Metadata);
+        }
+    }
+
+    [Fact]
+    public async Task GetChatMessageContentShouldSendMutatedChatHistoryToLLMAsync()
+    {
+        // Arrange
+        static void MutateChatHistory(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            // Remove the function call messages from the chat history to reduce token count.
+            context.ChatHistory.RemoveRange(1, 2); // Remove the `Date` function call and function result messages.
+
+            next(context);
+        }
+
+        var kernel = new Kernel();
+        kernel.ImportPluginFromFunctions("WeatherPlugin", [KernelFunctionFactory.CreateFromMethod((string location) => "rainy", "GetWeather")]);
+        kernel.AutoFunctionInvocationFilters.Add(new AutoFunctionInvocationFilter(MutateChatHistory));
+
+        var firstResponse = this.GetTestResponseAsBytes("chat_completions_function_call_response.json");
+        var secondResponse = this.GetTestResponseAsBytes("chat_completions_function_called_response.json");
+
+        this.DelegatingHandler = new AssertingDelegatingHandler("https://api.mistral.ai/v1/chat/completions", false, firstResponse, secondResponse);
+        this.HttpClient = new HttpClient(this.DelegatingHandler, false);
+
+        var sut = new MistralAIChatCompletionService("mistral-small-latest", "key", httpClient: this.HttpClient);
+
+        var chatHistory = new ChatHistory
+        {
+            new ChatMessageContent(AuthorRole.User, "What time is it?"),
+            new ChatMessageContent(AuthorRole.Assistant, [
+                new FunctionCallContent("Date", "TimePlugin", "2")
+            ]),
+            new ChatMessageContent(AuthorRole.Tool, [
+                new FunctionResultContent("Date",  "TimePlugin", "2", "rainy")
+            ]),
+            new ChatMessageContent(AuthorRole.Assistant, "08/06/2024 00:00:00"),
+            new ChatMessageContent(AuthorRole.User, "Given the current time of day and weather, what is the likely color of the sky in Boston?")
+        };
+
+        // Act
+        await sut.GetChatMessageContentAsync(chatHistory, new MistralAIPromptExecutionSettings() { ToolCallBehavior = MistralAIToolCallBehavior.AutoInvokeKernelFunctions }, kernel);
+
+        // Assert
+        var actualRequestContent = this.DelegatingHandler.RequestContent!;
+        Assert.NotNull(actualRequestContent);
+
+        var optionsJson = JsonSerializer.Deserialize<JsonElement>(actualRequestContent);
+
+        var messages = optionsJson.GetProperty("messages");
+        Assert.Equal(5, messages.GetArrayLength());
+
+        var userFirstPrompt = messages[0];
+        Assert.Equal("user", userFirstPrompt.GetProperty("role").GetString());
+        Assert.Equal("What time is it?", userFirstPrompt.GetProperty("content").ToString());
+
+        var assistantFirstResponse = messages[1];
+        Assert.Equal("assistant", assistantFirstResponse.GetProperty("role").GetString());
+        Assert.Equal("08/06/2024 00:00:00", assistantFirstResponse.GetProperty("content").GetString());
+
+        var userSecondPrompt = messages[2];
+        Assert.Equal("user", userSecondPrompt.GetProperty("role").GetString());
+        Assert.Equal("Given the current time of day and weather, what is the likely color of the sky in Boston?", userSecondPrompt.GetProperty("content").ToString());
+
+        var assistantSecondResponse = messages[3];
+        Assert.Equal("assistant", assistantSecondResponse.GetProperty("role").GetString());
+        Assert.Equal("ejOH4Z1A2", assistantSecondResponse.GetProperty("tool_calls")[0].GetProperty("id").GetString());
+        Assert.Equal("WeatherPlugin-GetWeather", assistantSecondResponse.GetProperty("tool_calls")[0].GetProperty("function").GetProperty("name").GetString());
+
+        var functionResult = messages[4];
+        Assert.Equal("tool", functionResult.GetProperty("role").GetString());
+        Assert.Equal("rainy", functionResult.GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task GetStreamingChatMessageContentsShouldSendMutatedChatHistoryToLLMAsync()
+    {
+        // Arrange
+        static void MutateChatHistory(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            // Remove the function call messages from the chat history to reduce token count.
+            context.ChatHistory.RemoveRange(1, 2); // Remove the `Date` function call and function result messages.
+
+            next(context);
+        }
+
+        var kernel = new Kernel();
+        kernel.ImportPluginFromFunctions("WeatherPlugin", [KernelFunctionFactory.CreateFromMethod(() => "rainy", "GetWeather")]);
+        kernel.AutoFunctionInvocationFilters.Add(new AutoFunctionInvocationFilter(MutateChatHistory));
+
+        var firstResponse = this.GetTestResponseAsBytes("chat_completions_streaming_function_call_response.txt");
+        var secondResponse = this.GetTestResponseAsBytes("chat_completions_streaming_function_called_response.txt");
+
+        this.DelegatingHandler = new AssertingDelegatingHandler("https://api.mistral.ai/v1/chat/completions", true, firstResponse, secondResponse);
+        this.HttpClient = new HttpClient(this.DelegatingHandler, false);
+
+        var sut = new MistralAIChatCompletionService("mistral-small-latest", "key", httpClient: this.HttpClient);
+
+        var chatHistory = new ChatHistory
+        {
+            new ChatMessageContent(AuthorRole.User, "What time is it?"),
+            new ChatMessageContent(AuthorRole.Assistant, [
+                new FunctionCallContent("Date", "TimePlugin", "2")
+            ]),
+            new ChatMessageContent(AuthorRole.Tool, [
+                new FunctionResultContent("Date",  "TimePlugin", "2", "rainy")
+            ]),
+            new ChatMessageContent(AuthorRole.Assistant, "08/06/2024 00:00:00"),
+            new ChatMessageContent(AuthorRole.User, "Given the current time of day and weather, what is the likely color of the sky in Boston?")
+        };
+
+        // Act
+        await foreach (var update in sut.GetStreamingChatMessageContentsAsync(chatHistory, new MistralAIPromptExecutionSettings() { ToolCallBehavior = MistralAIToolCallBehavior.AutoInvokeKernelFunctions }, kernel))
+        {
+        }
+
+        // Assert
+        var actualRequestContent = this.DelegatingHandler.RequestContent!;
+        Assert.NotNull(actualRequestContent);
+
+        var optionsJson = JsonSerializer.Deserialize<JsonElement>(actualRequestContent);
+
+        var messages = optionsJson.GetProperty("messages");
+        Assert.Equal(5, messages.GetArrayLength());
+
+        var userFirstPrompt = messages[0];
+        Assert.Equal("user", userFirstPrompt.GetProperty("role").GetString());
+        Assert.Equal("What time is it?", userFirstPrompt.GetProperty("content").ToString());
+
+        var assistantFirstResponse = messages[1];
+        Assert.Equal("assistant", assistantFirstResponse.GetProperty("role").GetString());
+        Assert.Equal("08/06/2024 00:00:00", assistantFirstResponse.GetProperty("content").GetString());
+
+        var userSecondPrompt = messages[2];
+        Assert.Equal("user", userSecondPrompt.GetProperty("role").GetString());
+        Assert.Equal("Given the current time of day and weather, what is the likely color of the sky in Boston?", userSecondPrompt.GetProperty("content").ToString());
+
+        var assistantSecondResponse = messages[3];
+        Assert.Equal("assistant", assistantSecondResponse.GetProperty("role").GetString());
+        Assert.Equal("u2ef3Udel", assistantSecondResponse.GetProperty("tool_calls")[0].GetProperty("id").GetString());
+        Assert.Equal("WeatherPlugin-GetWeather", assistantSecondResponse.GetProperty("tool_calls")[0].GetProperty("function").GetProperty("name").GetString());
+
+        var functionResult = messages[4];
+        Assert.Equal("tool", functionResult.GetProperty("role").GetString());
+        Assert.Equal("rainy", functionResult.GetProperty("content").GetString());
+    }
+
+    private sealed class AutoFunctionInvocationFilter : IAutoFunctionInvocationFilter
+    {
+        private readonly Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> _callback;
+
+        public AutoFunctionInvocationFilter(Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> callback)
+        {
+            Verify.NotNull(callback, nameof(callback));
+            this._callback = callback;
+        }
+
+        public AutoFunctionInvocationFilter(Action<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>> callback)
+        {
+            Verify.NotNull(callback, nameof(callback));
+            this._callback = (c, n) => { callback(c, n); return Task.CompletedTask; };
+        }
+
+        public async Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            await this._callback(context, next);
         }
     }
 }

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/TestData/chat_completions_function_call_response.json
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/TestData/chat_completions_function_call_response.json
@@ -11,7 +11,7 @@
         "content": "",
         "tool_calls": [
           {
-            "id": "ejOH4ZAso",
+            "id": "ejOH4Z1A2",
             "function": {
               "name": "WeatherPlugin-GetWeather",
               "arguments": "{\"location\": \"Paris, 75\"}"

--- a/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/TestData/chat_completions_streaming_function_call_response.txt
+++ b/dotnet/src/Connectors/Connectors.MistralAI.UnitTests/TestData/chat_completions_streaming_function_call_response.txt
@@ -1,5 +1,5 @@
 data: {"id":"355a4e457cfb44348d5feda493ce2102","object":"chat.completion.chunk","created":1712601685,"model":"mistral-small-latest","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"logprobs":null}]}
 
-data: {"id":"355a4e457cfb44348d5feda493ce2102","object":"chat.completion.chunk","created":1712601685,"model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"function":{"name":"WeatherPlugin-GetWeather","arguments":"{\"location\": \"Paris\", \"unit\": \"celsius\"}"}}]},"finish_reason":"tool_calls","logprobs":null}],"usage":{"prompt_tokens":118,"total_tokens":149,"completion_tokens":31}}
+data: {"id":"355a4e457cfb44348d5feda493ce2102","object":"chat.completion.chunk","created":1712601685,"model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"id":"u2ef3Udel", "function":{"name":"WeatherPlugin-GetWeather","arguments":"{\"location\": \"Paris\", \"unit\": \"celsius\"}"}}]},"finish_reason":"tool_calls","logprobs":null}],"usage":{"prompt_tokens":118,"total_tokens":149,"completion_tokens":31}}
 
 data: [DONE]


### PR DESCRIPTION
### Motivation and Context
Today, MistralAI connector don't allow auto-function invocation filters to update/mutate chat history. The mutation can be useful to reduce the number of tokens sent to LLM by removing no longer needed function-calling messages from the chat history.

Closes: https://github.com/microsoft/semantic-kernel/issues/7590.

### Description
This PR updates the `MistralClient` class to generate a list of messages to send to the LLM based on the latest chat history for every function-calling loop iteration, rather than separately updating the list of LLM messages and chat history.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
