### PR TITLE
.Net: Fix Prompty Issue of parsing ResponseFormat (issue #8148, #8154)

### DIFF
--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/PromptyTest.cs
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/PromptyTest.cs
@@ -70,6 +70,39 @@ public sealed class PromptyTest
     }
 
     [Fact]
+    public void ChatPromptyShouldSupportCreatingOpenAIExecutionSettingsWithJsonObject()
+    {
+        // Arrange
+        Kernel kernel = new();
+        var chatPromptyPath = Path.Combine("TestData", "chatJsonObject.prompty");
+
+        // Act
+        var kernelFunction = kernel.CreateFunctionFromPromptyFile(chatPromptyPath);
+
+        // Assert
+        // kernel function created from chat.prompty should have a single execution setting
+        Assert.Single(kernelFunction.ExecutionSettings!);
+        Assert.True(kernelFunction.ExecutionSettings!.ContainsKey("default"));
+
+        // Arrange
+        var defaultExecutionSetting = kernelFunction.ExecutionSettings["default"];
+
+        // Act
+        var executionSettings = OpenAIPromptExecutionSettings.FromExecutionSettings(defaultExecutionSetting);
+
+        // Assert
+        Assert.NotNull(executionSettings);
+        Assert.Equal("gpt-4o", executionSettings.ModelId);
+        Assert.Equal(0, executionSettings.Temperature);
+        Assert.Equal(1.0, executionSettings.TopP);
+        Assert.Null(executionSettings.StopSequences);
+        Assert.Equal("json_object", executionSettings.ResponseFormat?.ToString());
+        Assert.Null(executionSettings.TokenSelectionBiases);
+        Assert.Equal(3000, executionSettings.MaxTokens);
+        Assert.Null(executionSettings.Seed);
+    }
+
+    [Fact]
     public void ItShouldCreateFunctionFromPromptYamlWithNoExecutionSettings()
     {
         // Arrange

--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatJsonObject.prompty
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatJsonObject.prompty
@@ -1,0 +1,26 @@
+---
+name: Contoso_Chat_Prompt
+description: A classifier assistant
+authors:
+  - ????
+model:  
+  api: chat
+  configuration:
+    type: azure_openai
+    azure_deployment: gpt-4o
+  parameters:
+    temperature: 0.0
+    max_tokens: 3000
+    response_format: 
+      type: json_object
+    
+---
+system:
+You are a classifier agent that should know classify a problem into Easy/Medium/Hard based on the problem description.
+your response should be in a json format with the following structure:
+{
+  "difficulty": "Easy/Medium/Hard"
+}
+
+user:
+{{question}}

--- a/dotnet/src/Functions/Functions.Prompty/Core/PromptyModelParameters.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Core/PromptyModelParameters.cs
@@ -10,7 +10,7 @@ internal sealed class PromptyModelParameters
 {
     /// <summary>Specify the format for model output (e.g., JSON mode).</summary>
     [YamlMember(Alias = "response_format")]
-    public string? ResponseFormat { get; set; }
+    public PromptyResponseFormat? ResponseFormat { get; set; }
 
     /// <summary>Seed for deterministic sampling (Beta feature).</summary>
     [YamlMember(Alias = "seed")]

--- a/dotnet/src/Functions/Functions.Prompty/Core/PromptyResponseFormat.cs
+++ b/dotnet/src/Functions/Functions.Prompty/Core/PromptyResponseFormat.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using YamlDotNet.Serialization;
+
+namespace Microsoft.SemanticKernel.Prompty.Core;
+
+/// <summary>The response format of prompty.</summary>
+internal sealed class PromptyResponseFormat
+{
+    /// <summary>The response format type (e.g: json_object).</summary>
+    [YamlMember(Alias = "type")]
+    public string? Type { get; set; }
+}

--- a/dotnet/src/Functions/Functions.Prompty/KernelFunctionPrompty.cs
+++ b/dotnet/src/Functions/Functions.Prompty/KernelFunctionPrompty.cs
@@ -171,7 +171,7 @@ public static partial class KernelFunctionPrompty
                 extensionData.Add("stop_sequences", stop);
             }
 
-            if (prompty.Model?.Parameters?.ResponseFormat == "json_object")
+            if (prompty.Model?.Parameters?.ResponseFormat?.Type == "json_object")
             {
                 extensionData.Add("response_format", "json_object");
             }


### PR DESCRIPTION
### Motivation and Context

Fixing these issues:
- https://github.com/microsoft/semantic-kernel/issues/8148
- https://github.com/microsoft/semantic-kernel/issues/8154
-->

### Description

- Fixing yaml schema around prompty response_type (more details in the original reported issues)
- Adding tests for regression

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
