### PR TITLE
.Net: OpenAI V2 - Prompty UT Fix

### DIFF
--- a/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatJsonObject.prompty
+++ b/dotnet/src/Functions/Functions.Prompty.UnitTests/TestData/chatJsonObject.prompty
@@ -11,6 +11,7 @@ model:
   parameters:
     temperature: 0.0
     max_tokens: 3000
+    top_p: 1.0
     response_format: 
       type: json_object
     


### PR DESCRIPTION
### Motivation and Context

Settings are nullable in the Execution Settings V2 moving forward, the top_p is not by default 1.0 if not set, setting the value in the yml to comply with the test.