### PR TITLE
Python: Introduce agent chat reset functionality. Add unit tests and a sample.

### DIFF
--- a/python/samples/concepts/agents/mixed_chat_reset.py
+++ b/python/samples/concepts/agents/mixed_chat_reset.py
@@ -1,0 +1,83 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent
+from semantic_kernel.agents.open_ai import OpenAIAssistantAgent
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.kernel import Kernel
+
+if TYPE_CHECKING:
+    from semantic_kernel.agents.agent import Agent
+
+#####################################################################
+# The following sample demonstrates how to create an OpenAI         #
+# assistant using either Azure OpenAI or OpenAI, a chat completion  #
+# agent and have them participate in a group chat to work towards   #
+# the user's requirement. It also demonstrates how the underlying   #
+# agent reset method is used to clear the current state of the chat #
+#####################################################################
+
+INSTRUCTIONS = """
+The user may either provide information or query on information previously provided. 
+If the query does not correspond with information provided, inform the user that their query cannot be answered.
+"""
+
+
+def _create_kernel_with_chat_completion(service_id: str) -> Kernel:
+    kernel = Kernel()
+    kernel.add_service(AzureChatCompletion(service_id=service_id))
+    return kernel
+
+
+async def main():
+    try:
+        assistant_agent = await OpenAIAssistantAgent.create(
+            service_id="copywriter",
+            kernel=Kernel(),
+            name=f"{OpenAIAssistantAgent.__name__}",
+            instructions=INSTRUCTIONS,
+        )
+
+        chat_agent = ChatCompletionAgent(
+            service_id="chat",
+            kernel=_create_kernel_with_chat_completion("chat"),
+            name=f"{ChatCompletionAgent.__name__}",
+            instructions=INSTRUCTIONS,
+        )
+
+        chat = AgentGroupChat()
+
+        async def invoke_agent(agent: "Agent", input: str | None = None):
+            if input is not None:
+                await chat.add_chat_message(ChatMessageContent(role=AuthorRole.USER, content=input))
+                print(f"\n{AuthorRole.USER}: '{input}'")
+
+            async for message in chat.invoke(agent=agent):
+                if message.content is not None:
+                    print(f"\n# {message.role} - {message.name or '*'}: '{message.content}'")
+
+        await invoke_agent(agent=assistant_agent, input="What is my favorite color?")
+        await invoke_agent(agent=chat_agent)
+
+        await invoke_agent(agent=assistant_agent, input="I like green.")
+        await invoke_agent(agent=chat_agent)
+
+        await invoke_agent(agent=assistant_agent, input="What is my favorite color?")
+        await invoke_agent(agent=chat_agent)
+
+        print("\nResetting chat...")
+        await chat.reset()
+
+        await invoke_agent(agent=assistant_agent, input="What is my favorite color?")
+        await invoke_agent(agent=chat_agent)
+    finally:
+        await chat.reset()
+        await assistant_agent.delete()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/semantic_kernel/agents/channels/agent_channel.py
+++ b/python/semantic_kernel/agents/channels/agent_channel.py
@@ -57,3 +57,8 @@ class AgentChannel(ABC):
             An async iterable of ChatMessageContent.
         """
         ...
+
+    @abstractmethod
+    async def reset(self) -> None:
+        """Reset any persistent state associated with the channel."""
+        ...

--- a/python/semantic_kernel/agents/channels/chat_history_channel.py
+++ b/python/semantic_kernel/agents/channels/chat_history_channel.py
@@ -130,3 +130,8 @@ class ChatHistoryChannel(AgentChannel, ChatHistory):
         """
         for message in reversed(self.messages):
             yield message
+
+    @override
+    async def reset(self) -> None:
+        """Reset the channel state."""
+        self.messages.clear()

--- a/python/semantic_kernel/agents/group_chat/agent_chat.py
+++ b/python/semantic_kernel/agents/group_chat/agent_chat.py
@@ -166,3 +166,15 @@ class AgentChat(KernelBaseModel):
             await self.broadcast_queue.enqueue(channel_refs, messages)
         finally:
             self.clear_activity_signal()
+
+    async def reset(self) -> None:
+        """Reset the agent chat."""
+        self.set_activity_or_throw()
+
+        try:
+            await asyncio.gather(*(channel.reset() for channel in self.agent_channels.values()))
+            self.agent_channels.clear()
+            self.channel_map.clear()
+            self.history.messages.clear()
+        finally:
+            self.clear_activity_signal()

--- a/python/tests/unit/agents/test_agent_chat.py
+++ b/python/tests/unit/agents/test_agent_chat.py
@@ -129,6 +129,7 @@ async def test_invoke_agent(agent_chat, agent, chat_message):
             pass
 
     mock_channel.invoke.assert_called_once_with(agent)
+    await agent_chat.reset()
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/agents/test_chat_history_channel.py
+++ b/python/tests/unit/agents/test_chat_history_channel.py
@@ -143,3 +143,25 @@ async def test_get_history():
     assert messages[0].role == AuthorRole.USER
     assert messages[1].content == "test message 1"
     assert messages[1].role == AuthorRole.SYSTEM
+
+
+@pytest.mark.asyncio
+async def test_reset_history():
+    channel = ChatHistoryChannel()
+    history = [
+        ChatMessageContent(role=AuthorRole.SYSTEM, content="test message 1"),
+        ChatMessageContent(role=AuthorRole.USER, content="test message 2"),
+    ]
+    channel.messages.extend(history)
+
+    messages = [message async for message in channel.get_history()]
+
+    assert len(messages) == 2
+    assert messages[0].content == "test message 2"
+    assert messages[0].role == AuthorRole.USER
+    assert messages[1].content == "test message 1"
+    assert messages[1].role == AuthorRole.SYSTEM
+
+    await channel.reset()
+
+    assert len(channel.messages) == 0


### PR DESCRIPTION
### Motivation and Context

There have been requests from customers to be able to reset an agent channel during the middle of an agent convo/interaction. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR introduces functionality to be able to reset the various types of SK agent channels. 
- Adds a sample showing how the reset affects the agent interactions.
- Adds unit tests to exercise the new code.
- Closes #8275 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
