### PR TITLE
.Net: Optimize Pinecone GetBatchAsync to retrieve multiple entries with a single request

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
@@ -271,7 +271,7 @@ public class PineconeMemoryStore : IPineconeMemoryStore
         bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await foreach (MemoryRecord? record in this.GetBatchFromNamespaceAsync(collectionName, string.Empty, keys, withEmbeddings, cancellationToken).ConfigureAwait(false))
+        await foreach (MemoryRecord record in this.GetBatchFromNamespaceAsync(collectionName, string.Empty, keys, withEmbeddings, cancellationToken).ConfigureAwait(false))
         {
             yield return record;
         }
@@ -285,13 +285,16 @@ public class PineconeMemoryStore : IPineconeMemoryStore
         bool withEmbeddings = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        foreach (string? key in keys)
+        await foreach (PineconeDocument? pineconeDocument in this._pineconeClient.FetchVectorsAsync(
+                               indexName,
+                               keys,
+                               indexNamespace,
+                               withEmbeddings,
+                               cancellationToken).ConfigureAwait(false))
         {
-            MemoryRecord? record = await this.GetFromNamespaceAsync(indexName, indexNamespace, key, withEmbeddings, cancellationToken).ConfigureAwait(false);
-
-            if (record is not null)
+            if (pineconeDocument is not null)
             {
-                yield return record;
+                yield return pineconeDocument.ToMemoryRecord();
             }
         }
     }


### PR DESCRIPTION
### Motivation and Context

**GetBatchAsync** is sending n (equal to the number of keys) requests, where a single request could retrieve multiple entries at once.

### Description

Now current implementation will execute a single request to retrieve multiple entries.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, integration test run is required.
- [ ] I didn't break anyone :smile:
