### PR TITLE
.Net: Required function choice behavior

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
@@ -97,10 +97,12 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
     {
         // Arrange
         var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         // Act
         var result = await service.GetTextContentsAsync("Prompt");
@@ -148,10 +150,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         chatHistory.AddSystemMessage("System Message");
         chatHistory.AddAssistantMessage("Assistant Message");
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         // Act
         var result = await service.GetChatMessageContentsAsync(chatHistory, settings);
@@ -218,10 +221,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
             ResponseFormat = responseFormat
         };
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         // Act
         var result = await service.GetChatMessageContentsAsync(new ChatHistory("System message"), settings);
@@ -245,10 +249,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
         var settings = new AzureOpenAIPromptExecutionSettings() { ToolCallBehavior = behavior };
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         // Act
         var result = await service.GetChatMessageContentsAsync(new ChatHistory("System message"), settings, kernel);
@@ -329,18 +334,25 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         var responses = new List<HttpResponseMessage>();
 
-        for (var i = 0; i < ModelResponsesCount; i++)
+        try
         {
-            responses.Add(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_single_function_call_test_response.json")) });
+            for (var i = 0; i < ModelResponsesCount; i++)
+            {
+                responses.Add(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_single_function_call_test_response.json")) });
+            }
+
+            this._messageHandlerStub.ResponsesToReturn = responses;
+
+            // Act
+            var result = await service.GetChatMessageContentsAsync(new ChatHistory("System message"), settings, kernel);
+
+            // Assert
+            Assert.Equal(DefaultMaximumAutoInvokeAttempts, functionCallCount);
         }
-
-        this._messageHandlerStub.ResponsesToReturn = responses;
-
-        // Act
-        var result = await service.GetChatMessageContentsAsync(new ChatHistory("System message"), settings, kernel);
-
-        // Assert
-        Assert.Equal(DefaultMaximumAutoInvokeAttempts, functionCallCount);
+        finally
+        {
+            responses.ForEach(r => r.Dispose());
+        }
     }
 
     [Fact]
@@ -400,10 +412,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(AzureOpenAITestHelper.GetTestResponse("chat_completion_streaming_test_response.txt")));
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(stream)
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         // Act & Assert
         var enumerator = service.GetStreamingTextContentsAsync("Prompt").GetAsyncEnumerator();
@@ -422,10 +435,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(AzureOpenAITestHelper.GetTestResponse("chat_completion_streaming_test_response.txt")));
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(stream)
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         // Act & Assert
         var enumerator = service.GetStreamingChatMessageContentsAsync([]).GetAsyncEnumerator();
@@ -507,20 +521,27 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         var responses = new List<HttpResponseMessage>();
 
-        for (var i = 0; i < ModelResponsesCount; i++)
+        try
         {
-            responses.Add(new HttpResponseMessage(HttpStatusCode.OK) { Content = AzureOpenAITestHelper.GetTestResponseAsStream("chat_completion_streaming_single_function_call_test_response.txt") });
+            for (var i = 0; i < ModelResponsesCount; i++)
+            {
+                responses.Add(new HttpResponseMessage(HttpStatusCode.OK) { Content = AzureOpenAITestHelper.GetTestResponseAsStream("chat_completion_streaming_single_function_call_test_response.txt") });
+            }
+
+            this._messageHandlerStub.ResponsesToReturn = responses;
+
+            // Act & Assert
+            await foreach (var chunk in service.GetStreamingChatMessageContentsAsync([], settings, kernel))
+            {
+                Assert.Equal("Test chat streaming response", chunk.Content);
+            }
+
+            Assert.Equal(DefaultMaximumAutoInvokeAttempts, functionCallCount);
         }
-
-        this._messageHandlerStub.ResponsesToReturn = responses;
-
-        // Act & Assert
-        await foreach (var chunk in service.GetStreamingChatMessageContentsAsync([], settings, kernel))
+        finally
         {
-            Assert.Equal("Test chat streaming response", chunk.Content);
+            responses.ForEach(r => r.Dispose());
         }
-
-        Assert.Equal(DefaultMaximumAutoInvokeAttempts, functionCallCount);
     }
 
     [Fact]
@@ -595,10 +616,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
         var settings = new AzureOpenAIPromptExecutionSettings() { ChatSystemPrompt = SystemMessage };
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         IKernelBuilder builder = Kernel.CreateBuilder();
         builder.Services.AddTransient<IChatCompletionService>((sp) => service);
@@ -639,10 +661,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var service = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
         var settings = new AzureOpenAIPromptExecutionSettings() { ChatSystemPrompt = SystemMessage };
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage(Prompt);
@@ -691,10 +714,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
     public async Task FunctionCallsShouldBePropagatedToCallersViaChatMessageItemsOfTypeFunctionCallContentAsync()
     {
         // Arrange
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_multiple_function_calls_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
@@ -753,10 +777,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
     public async Task FunctionCallsShouldBeReturnedToLLMAsync()
     {
         // Arrange
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
@@ -811,10 +836,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
     public async Task FunctionResultsCanBeProvidedToLLMAsOneResultPerChatMessageAsync()
     {
         // Arrange
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
@@ -859,10 +885,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
     public async Task FunctionResultsCanBeProvidedToLLMAsManyResultsInOneChatMessageAsync()
     {
         // Arrange
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
@@ -1056,10 +1083,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("Fake prompt");
@@ -1093,10 +1121,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         var chatCompletion = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("Fake prompt");
@@ -1130,10 +1159,11 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
 
-        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        using var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
-        });
+        };
+        this._messageHandlerStub.ResponsesToReturn.Add(responseMessage);
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("Fake prompt");

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
@@ -1118,6 +1118,42 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         Assert.Equal("none", optionsJson.GetProperty("tool_choice").ToString());
     }
 
+    [Fact]
+    public async Task ItCreatesCorrectFunctionToolCallsWhenUsingRequiredFunctionChoiceBehaviorAsync()
+    {
+        // Arrange
+        var kernel = new Kernel();
+        kernel.Plugins.AddFromFunctions("TimePlugin", [
+            KernelFunctionFactory.CreateFromMethod(() => { }, "Date"),
+            KernelFunctionFactory.CreateFromMethod(() => { }, "Now")
+        ]);
+
+        var sut = new AzureOpenAIChatCompletionService("deployment", "https://endpoint", "api-key", "model-id", this._httpClient);
+
+        this._messageHandlerStub.ResponsesToReturn.Add(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(AzureOpenAITestHelper.GetTestResponse("chat_completion_test_response.json"))
+        });
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("Fake prompt");
+
+        var executionSettings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required() };
+
+        // Act
+        await sut.GetChatMessageContentsAsync(chatHistory, executionSettings, kernel);
+
+        // Assert
+        var actualRequestContent = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContents[0]!);
+        Assert.NotNull(actualRequestContent);
+
+        var optionsJson = JsonSerializer.Deserialize<JsonElement>(actualRequestContent);
+        Assert.Equal(2, optionsJson.GetProperty("tools").GetArrayLength());
+        Assert.Equal("TimePlugin-Date", optionsJson.GetProperty("tools")[0].GetProperty("function").GetProperty("name").GetString());
+        Assert.Equal("TimePlugin-Now", optionsJson.GetProperty("tools")[1].GetProperty("function").GetProperty("name").GetString());
+
+        Assert.Equal("required", optionsJson.GetProperty("tool_choice").ToString());
+    }
     public void Dispose()
     {
         this._httpClient.Dispose();

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -1106,6 +1106,41 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
         Assert.Equal("none", optionsJson.GetProperty("tool_choice").ToString());
     }
 
+    [Fact]
+    public async Task ItCreatesCorrectFunctionToolCallsWhenUsingRequiredFunctionChoiceBehaviorAsync()
+    {
+        // Arrange
+        var kernel = new Kernel();
+        kernel.Plugins.AddFromFunctions("TimePlugin", [
+            KernelFunctionFactory.CreateFromMethod(() => { }, "Date"),
+            KernelFunctionFactory.CreateFromMethod(() => { }, "Now")
+        ]);
+
+        var chatCompletion = new OpenAIChatCompletionService(modelId: "gpt-3.5-turbo", apiKey: "NOKEY", httpClient: this._httpClient);
+
+        using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(File.ReadAllText("TestData/chat_completion_test_response.json")) };
+        this._messageHandlerStub.ResponseQueue.Enqueue(response);
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("Fake prompt");
+
+        var executionSettings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required() };
+
+        // Act
+        await chatCompletion.GetChatMessageContentsAsync(chatHistory, executionSettings, kernel);
+
+        // Assert
+        var actualRequestContent = Encoding.UTF8.GetString(this._messageHandlerStub.RequestContent!);
+        Assert.NotNull(actualRequestContent);
+
+        var optionsJson = JsonSerializer.Deserialize<JsonElement>(actualRequestContent);
+        Assert.Equal(2, optionsJson.GetProperty("tools").GetArrayLength());
+        Assert.Equal("TimePlugin-Date", optionsJson.GetProperty("tools")[0].GetProperty("function").GetProperty("name").GetString());
+        Assert.Equal("TimePlugin-Now", optionsJson.GetProperty("tools")[1].GetProperty("function").GetProperty("name").GetString());
+
+        Assert.Equal("required", optionsJson.GetProperty("tool_choice").ToString());
+    }
+
     public void Dispose()
     {
         this._httpClient.Dispose();

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -50,7 +50,7 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
 
             if (invokedFunctionNames.Contains("GetCurrentDate"))
             {
-                return null; // Don't advertise any more functions because the expected function has been invoked.
+                return []; // Don't advertise any more functions because the expected function has been invoked.
             }
 
             return context.Functions;
@@ -162,7 +162,7 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
 
             if (invokedFunctionNames.Contains("GetCurrentDate"))
             {
-                return null; // Don't advertise any more functions because the expected function has been invoked.
+                return []; // Don't advertise any more functions because the expected function has been invoked.
             }
 
             return context.Functions;

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -1,0 +1,403 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.AzureOpenAI;
+
+public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationTest
+{
+    private readonly Kernel _kernel;
+    private readonly FakeFunctionFilter _autoFunctionInvocationFilter;
+    private readonly IChatCompletionService _chatCompletionService;
+
+    public AzureOpenAIRequiredFunctionChoiceBehaviorTests()
+    {
+        this._autoFunctionInvocationFilter = new FakeFunctionFilter();
+
+        this._kernel = this.InitializeKernel();
+        this._kernel.AutoFunctionInvocationFilters.Add(this._autoFunctionInvocationFilter);
+        this._chatCompletionService = this._kernel.GetRequiredService<IChatCompletionService>();
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string?>();
+
+        IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        {
+            // Get all function names that have been invoked
+            var invokedFunctionNames = context.ChatHistory
+                .SelectMany(m => m.Items.OfType<FunctionResultContent>())
+                .Select(i => i.FunctionName);
+
+            invokedFunctions.AddRange(invokedFunctionNames);
+
+            if (invokedFunctionNames.Contains("GetCurrentDate"))
+            {
+                return null; // Don't advertise any more functions because the expected function has been invoked.
+            }
+
+            return context.Functions;
+        }
+
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: required
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    // Act
+    //    var result = await this._kernel.InvokeAsync(promptFunction);
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string?>();
+
+        IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        {
+            // Get all function names that have been invoked
+            var invokedFunctionNames = context.ChatHistory
+                .SelectMany(m => m.Items.OfType<FunctionResultContent>())
+                .Select(i => i.FunctionName);
+
+            invokedFunctions.AddRange(invokedFunctionNames);
+
+            if (invokedFunctionNames.Contains("GetCurrentDate"))
+            {
+                return null; // Don't advertise any more functions because the expected function has been invoked.
+            }
+
+            return context.Functions;
+        }
+
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        string result = "";
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            result += content;
+        }
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: required
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    string result = "";
+
+    //    // Act
+    //    await foreach (string c in promptFunction.InvokeStreamingAsync<string>(this._kernel))
+    //    {
+    //        result += c;
+    //    }
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required([plugin.First()], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required([plugin.First()], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    private Kernel InitializeKernel()
+    {
+        var azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
+        Assert.NotNull(azureOpenAIConfiguration);
+        Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
+        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
+        Assert.NotNull(azureOpenAIConfiguration.Endpoint);
+
+        var kernelBuilder = base.CreateKernelBuilder();
+
+        kernelBuilder.AddAzureOpenAIChatCompletion(
+            deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
+            modelId: azureOpenAIConfiguration.ChatModelId,
+            endpoint: azureOpenAIConfiguration.Endpoint,
+            apiKey: azureOpenAIConfiguration.ApiKey);
+
+        return kernelBuilder.Build();
+    }
+
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+        .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
+        .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+        .AddEnvironmentVariables()
+        .AddUserSecrets<AzureOpenAIChatCompletionTests>()
+        .Build();
+
+    /// <summary>
+    /// A plugin that returns the current time.
+    /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class DateTimeUtils
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [KernelFunction]
+        [Description("Retrieves the current date.")]
+        public string GetCurrentDate() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture);
+    }
+
+    #region private
+
+    private sealed class FakeFunctionFilter : IAutoFunctionInvocationFilter
+    {
+        private Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? _onFunctionInvocation;
+
+        public void RegisterFunctionInvocationHandler(Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> onFunctionInvocation)
+        {
+            this._onFunctionInvocation = onFunctionInvocation;
+        }
+
+        public Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            if (this._onFunctionInvocation is null)
+            {
+                return next(context);
+            }
+
+            return this._onFunctionInvocation?.Invoke(context, next) ?? Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -49,7 +49,7 @@ public sealed class OpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationT
 
             if (invokedFunctionNames.Contains("GetCurrentDate"))
             {
-                return null; // Don't advertise any more functions because the expected function has been invoked.
+                return []; // Don't advertise any more functions because the expected function has been invoked.
             }
 
             return context.Functions;
@@ -161,7 +161,7 @@ public sealed class OpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationT
 
             if (invokedFunctionNames.Contains("GetCurrentDate"))
             {
-                return null; // Don't advertise any more functions because the expected function has been invoked.
+                return []; // Don't advertise any more functions because the expected function has been invoked.
             }
 
             return context.Functions;

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -361,6 +361,8 @@ public sealed class OpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationT
         .AddUserSecrets<OpenAIChatCompletionTests>()
         .Build();
 
+    #region private
+
     /// <summary>
     /// A plugin that returns the current time.
     /// </summary>
@@ -372,8 +374,6 @@ public sealed class OpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationT
         [Description("Retrieves the current date.")]
         public string GetCurrentDate() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture);
     }
-
-    #region private
 
     private sealed class FakeFunctionFilter : IAutoFunctionInvocationFilter
     {

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -1,0 +1,399 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.OpenAI;
+
+public sealed class OpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationTest
+{
+    private readonly Kernel _kernel;
+    private readonly FakeFunctionFilter _autoFunctionInvocationFilter;
+    private readonly IChatCompletionService _chatCompletionService;
+
+    public OpenAIRequiredFunctionChoiceBehaviorTests()
+    {
+        this._autoFunctionInvocationFilter = new FakeFunctionFilter();
+
+        this._kernel = this.InitializeKernel();
+        this._kernel.AutoFunctionInvocationFilters.Add(this._autoFunctionInvocationFilter);
+        this._chatCompletionService = this._kernel.GetRequiredService<IChatCompletionService>();
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeRequiredFunctionAutomaticallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string?>();
+
+        IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        {
+            // Get all function names that have been invoked
+            var invokedFunctionNames = context.ChatHistory
+                .SelectMany(m => m.Items.OfType<FunctionResultContent>())
+                .Select(i => i.FunctionName);
+
+            invokedFunctions.AddRange(invokedFunctionNames);
+
+            if (invokedFunctionNames.Contains("GetCurrentDate"))
+            {
+                return null; // Don't advertise any more functions because the expected function has been invoked.
+            }
+
+            return context.Functions;
+        }
+
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: required
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    // Act
+    //    var result = await this._kernel.InvokeAsync(promptFunction);
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string?>();
+
+        IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        {
+            // Get all function names that have been invoked
+            var invokedFunctionNames = context.ChatHistory
+                .SelectMany(m => m.Items.OfType<FunctionResultContent>())
+                .Select(i => i.FunctionName);
+
+            invokedFunctions.AddRange(invokedFunctionNames);
+
+            if (invokedFunctionNames.Contains("GetCurrentDate"))
+            {
+                return null; // Don't advertise any more functions because the expected function has been invoked.
+            }
+
+            return context.Functions;
+        }
+
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        string result = "";
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            result += content;
+        }
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
+
+    //[Fact]
+    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string>();
+
+    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+    //    {
+    //        invokedFunctions.Add(context.Function.Name);
+    //        await next(context);
+    //    });
+
+    //    var promptTemplate = """"
+    //        template_format: semantic-kernel
+    //        template: How many days until Christmas?
+    //        execution_settings:
+    //          default:
+    //            temperature: 0.1
+    //            function_choice_behavior:
+    //              type: required
+    //        """";
+
+    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+
+    //    string result = "";
+
+    //    // Act
+    //    await foreach (string c in promptFunction.InvokeStreamingAsync<string>(this._kernel))
+    //    {
+    //        result += c;
+    //    }
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var settings = new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required([plugin.ElementAt(0)], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Empty(invokedFunctions);
+
+        var functionCalls = FunctionCallContent.GetFunctionCalls(result);
+        Assert.NotNull(functionCalls);
+        Assert.Single(functionCalls);
+
+        var functionCall = functionCalls.First();
+        Assert.Equal("DateTimeUtils", functionCall.PluginName);
+        Assert.Equal("GetCurrentDate", functionCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SpecifiedInCodeInstructsConnectorToInvokeNonKernelFunctionManuallyForStreamingAsync()
+    {
+        // Arrange
+        var plugin = this._kernel.CreatePluginFromType<DateTimeUtils>(); // Creating plugin without importing it to the kernel.
+
+        var invokedFunctions = new List<string>();
+
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
+
+        var functionsForManualInvocation = new List<string>();
+
+        var settings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required([plugin.ElementAt(0)], autoInvoke: false) };
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddUserMessage("How many days until Christmas?");
+
+        // Act
+        await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+        {
+            if (content is OpenAIStreamingChatMessageContent openAIContent && openAIContent.ToolCallUpdates is { Count: > 0 } && !string.IsNullOrEmpty(openAIContent.ToolCallUpdates[0].FunctionName))
+            {
+                functionsForManualInvocation.Add(openAIContent.ToolCallUpdates[0].FunctionName);
+            }
+        }
+
+        // Assert
+        Assert.Single(functionsForManualInvocation);
+        Assert.Contains("DateTimeUtils-GetCurrentDate", functionsForManualInvocation);
+
+        Assert.Empty(invokedFunctions);
+    }
+
+    private Kernel InitializeKernel()
+    {
+        var openAIConfiguration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
+        Assert.NotNull(openAIConfiguration);
+        Assert.NotNull(openAIConfiguration.ChatModelId!);
+        Assert.NotNull(openAIConfiguration.ApiKey);
+
+        var kernelBuilder = base.CreateKernelBuilder();
+
+        kernelBuilder.AddOpenAIChatCompletion(
+            modelId: openAIConfiguration.ChatModelId,
+            apiKey: openAIConfiguration.ApiKey);
+
+        return kernelBuilder.Build();
+    }
+
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+        .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
+        .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+        .AddEnvironmentVariables()
+        .AddUserSecrets<OpenAIChatCompletionTests>()
+        .Build();
+
+    /// <summary>
+    /// A plugin that returns the current time.
+    /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class DateTimeUtils
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [KernelFunction]
+        [Description("Retrieves the current date.")]
+        public string GetCurrentDate() => DateTime.UtcNow.ToString("d", CultureInfo.InvariantCulture);
+    }
+
+    #region private
+
+    private sealed class FakeFunctionFilter : IAutoFunctionInvocationFilter
+    {
+        private Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? _onFunctionInvocation;
+
+        public void RegisterFunctionInvocationHandler(Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task> onFunctionInvocation)
+        {
+            this._onFunctionInvocation = onFunctionInvocation;
+        }
+
+        public Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next)
+        {
+            if (this._onFunctionInvocation is null)
+            {
+                return next(context);
+            }
+
+            return this._onFunctionInvocation?.Invoke(context, next) ?? Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -172,17 +172,12 @@ public sealed class OpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegrationT
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("How many days until Christmas?");
 
-        string result = "";
-
         // Act
         await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
         {
-            result += content;
         }
 
         // Assert
-        Assert.NotNull(result);
-
         Assert.Single(invokedFunctions);
         Assert.Contains("GetCurrentDate", invokedFunctions);
     }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -28,6 +29,32 @@ public abstract class FunctionChoiceBehavior
     public static FunctionChoiceBehavior Auto(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
     {
         return new AutoFunctionChoiceBehavior(functions, autoInvoke);
+    }
+
+    /// <summary>
+    /// Gets an instance of the <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to the AI model to call or specific ones.
+    /// This behavior forces the model to always call one or more functions. The model will then select which function(s) to call.
+    /// </summary>
+    /// <param name="functions">
+    /// Functions to provide to the model. If null, all of the <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model, which is equivalent to disabling function calling.
+    /// </param>
+    /// <param name="autoInvoke">
+    /// Indicates whether the functions should be automatically invoked by AI connectors.
+    /// </param>
+    /// <param name="functionsSelector">
+    /// The callback function allows customization of function selection.
+    /// It accepts functions, chat history, and an optional kernel, and returns a list of functions to be used by the AI model.
+    /// This should be supplied to prevent the AI model from repeatedly calling functions even when the prompt has already been answered.
+    /// For example, if the AI model is prompted to calculate the sum of two numbers, 2 and 3, and is provided with the 'Add' function,
+    /// the model will keep calling the 'Add' function even if the sum - 5 - is already calculated, until the 'Add' function is no longer provided to the model.
+    /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
+    /// </param>
+    /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
+    [Experimental("SKEXP0001")]
+    public static FunctionChoiceBehavior Required(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null)
+    {
+        return new RequiredFunctionChoiceBehavior(functions, autoInvoke, functionsSelector);
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -33,7 +33,7 @@ public abstract class FunctionChoiceBehavior
 
     /// <summary>
     /// Gets an instance of the <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to the AI model to call or specific ones.
-    /// This behavior forces the model to always call one or more functions. The model will then select which function(s) to call.
+    /// This behavior forces the model to always call one or more functions.
     /// </summary>
     /// <param name="functions">
     /// Functions to provide to the model. If null, all of the <see cref="Kernel"/>'s plugins' functions are provided to the model.

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
@@ -29,4 +29,9 @@ public sealed class FunctionChoiceBehaviorConfigurationContext
     /// The <see cref="Kernel"/> to be used for function calling.
     /// </summary>
     public Kernel? Kernel { get; init; }
+
+    /// <summary>
+    /// Request sequence index of automatic function invocation process. Starts from 0.
+    /// </summary>
+    public int RequestSequenceIndex { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Microsoft.SemanticKernel;
 
@@ -10,6 +11,20 @@ namespace Microsoft.SemanticKernel;
 [Experimental("SKEXP0001")]
 public sealed class FunctionChoiceBehaviorConfigurationContext
 {
+    /// <summary>
+    /// Creates a new instance of <see cref="FunctionChoiceBehaviorConfigurationContext"/>.
+    /// </summary>
+    /// <param name="chatHistory">The chat history.</param>
+    public FunctionChoiceBehaviorConfigurationContext(ChatHistory chatHistory)
+    {
+        this.ChatHistory = chatHistory;
+    }
+
+    /// <summary>
+    /// The chat history.
+    /// </summary>
+    public ChatHistory ChatHistory { get; }
+
     /// <summary>
     /// The <see cref="Kernel"/> to be used for function calling.
     /// </summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfigurationContext.cs
@@ -6,7 +6,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// The context to be provided by the choice behavior consumer in order to obtain the choice behavior configuration.
+/// The context is to be provided by the choice behavior consumer – AI connector in order to obtain the choice behavior configuration.
 /// </summary>
 [Experimental("SKEXP0001")]
 public sealed class FunctionChoiceBehaviorConfigurationContext
@@ -14,19 +14,19 @@ public sealed class FunctionChoiceBehaviorConfigurationContext
     /// <summary>
     /// Creates a new instance of <see cref="FunctionChoiceBehaviorConfigurationContext"/>.
     /// </summary>
-    /// <param name="chatHistory">The chat history.</param>
+    /// <param name="chatHistory">History of the current chat session.</param>
     public FunctionChoiceBehaviorConfigurationContext(ChatHistory chatHistory)
     {
         this.ChatHistory = chatHistory;
     }
 
     /// <summary>
-    /// The chat history.
+    /// History of the current chat session.
     /// </summary>
     public ChatHistory ChatHistory { get; }
 
     /// <summary>
-    /// The <see cref="Kernel"/> to be used for function calling.
+    /// The <see cref="Kernel"/> used by in the current chat session.
     /// </summary>
     public Kernel? Kernel { get; init; }
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Context to be provided by function choice behavior in order to obtain the functions to be used by the AI model.
+/// </summary>
+public class FunctionChoiceBehaviorFunctionsSelectorContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionChoiceBehaviorFunctionsSelectorContext"/> class.
+    /// </summary>
+    /// <param name="chatHistory">The chat history.</param>
+    public FunctionChoiceBehaviorFunctionsSelectorContext(ChatHistory chatHistory)
+    {
+        this.ChatHistory = chatHistory;
+    }
+
+    /// <summary>
+    /// Functions to provide to AI model.
+    /// </summary>
+    public IReadOnlyList<KernelFunction>? Functions { get; init; }
+
+    /// <summary>
+    /// The <see cref="Kernel"/> to be used for function calling.
+    /// </summary>
+    public Kernel? Kernel { get; init; }
+
+    /// <summary>
+    /// The chat history.
+    /// </summary>
+    public ChatHistory ChatHistory { get; }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
@@ -6,7 +6,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Context to be provided by function choice behavior in order to obtain the functions to be used by the AI model.
+/// Context containing information to be used by the functions selector.
 /// </summary>
 public class FunctionChoiceBehaviorFunctionsSelectorContext
 {
@@ -25,7 +25,7 @@ public class FunctionChoiceBehaviorFunctionsSelectorContext
     public IReadOnlyList<KernelFunction>? Functions { get; init; }
 
     /// <summary>
-    /// The <see cref="Kernel"/> to be used for function calling.
+    /// The <see cref="Kernel"/>.
     /// </summary>
     public Kernel? Kernel { get; init; }
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
@@ -15,24 +15,24 @@ public sealed class FunctionChoiceBehaviorFunctionsSelectorContext
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionChoiceBehaviorFunctionsSelectorContext"/> class.
     /// </summary>
-    /// <param name="chatHistory">The chat history.</param>
+    /// <param name="chatHistory">History of the current chat session.</param>
     internal FunctionChoiceBehaviorFunctionsSelectorContext(ChatHistory chatHistory)
     {
         this.ChatHistory = chatHistory;
     }
 
     /// <summary>
-    /// Functions to provide to AI model.
+    /// Functions to provide to AI model for the current chat session.
     /// </summary>
     public IReadOnlyList<KernelFunction>? Functions { get; init; }
 
     /// <summary>
-    /// The chat history.
+    /// History of the current chat session.
     /// </summary>
     public ChatHistory ChatHistory { get; }
 
     /// <summary>
-    /// The <see cref="Kernel"/>.
+    /// The <see cref="Kernel"/> used by in the current chat session.
     /// </summary>
     public Kernel? Kernel { get; init; }
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
@@ -16,7 +16,7 @@ public sealed class FunctionChoiceBehaviorFunctionsSelectorContext
     /// Initializes a new instance of the <see cref="FunctionChoiceBehaviorFunctionsSelectorContext"/> class.
     /// </summary>
     /// <param name="chatHistory">The chat history.</param>
-    public FunctionChoiceBehaviorFunctionsSelectorContext(ChatHistory chatHistory)
+    internal FunctionChoiceBehaviorFunctionsSelectorContext(ChatHistory chatHistory)
     {
         this.ChatHistory = chatHistory;
     }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorFunctionsSelectorContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Microsoft.SemanticKernel;
@@ -8,7 +9,8 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Context containing information to be used by the functions selector.
 /// </summary>
-public class FunctionChoiceBehaviorFunctionsSelectorContext
+[Experimental("SKEXP0001")]
+public sealed class FunctionChoiceBehaviorFunctionsSelectorContext
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FunctionChoiceBehaviorFunctionsSelectorContext"/> class.
@@ -25,12 +27,17 @@ public class FunctionChoiceBehaviorFunctionsSelectorContext
     public IReadOnlyList<KernelFunction>? Functions { get; init; }
 
     /// <summary>
+    /// The chat history.
+    /// </summary>
+    public ChatHistory ChatHistory { get; }
+
+    /// <summary>
     /// The <see cref="Kernel"/>.
     /// </summary>
     public Kernel? Kernel { get; init; }
 
     /// <summary>
-    /// The chat history.
+    /// Request sequence index of automatic function invocation process. Starts from 0.
     /// </summary>
-    public ChatHistory ChatHistory { get; }
+    public int RequestSequenceIndex { get; init; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Represents <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to AI model to call or specific ones.
-/// This behavior forces the model to always call one or more functions. The model will then select which function(s) to call.
+/// This behavior forces the model to always call one or more functions.
 /// </summary>
 internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
 {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -96,21 +96,23 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
             }
         }
 
+        IReadOnlyList<KernelFunction>? selectedFunctions = null;
+
         // Invoke function selector, if provided, to get the final list of functions.
         if (this._functionsSelector is not null)
         {
-            availableFunctions = this._functionsSelector(new FunctionChoiceBehaviorFunctionsSelectorContext(context.ChatHistory)
+            selectedFunctions = this._functionsSelector(new FunctionChoiceBehaviorFunctionsSelectorContext(context.ChatHistory)
             {
                 Kernel = context.Kernel,
                 Functions = availableFunctions,
-            })?.ToList();
+            });
         }
 
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return new FunctionChoiceBehaviorConfiguration()
         {
             Choice = FunctionChoice.Required,
-            Functions = availableFunctions,
+            Functions = selectedFunctions ?? availableFunctions,
             AutoInvoke = this._autoInvoke,
         };
 #pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Represents <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to AI model to call or specific ones
+/// Represents <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to AI model to call or specific ones.
 /// This behavior forces the model to always call one or more functions. The model will then select which function(s) to call.
 /// </summary>
 internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
@@ -23,7 +23,7 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
     private readonly bool _autoInvoke;
 
     /// <summary>
-    /// Function selector to customize the function selection logic.
+    /// Functions selector to customize functions selection logic.
     /// </summary>
     private readonly Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? _functionsSelector;
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Represents <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to AI model to call or specific ones
+/// This behavior forces the model to always call one or more functions. The model will then select which function(s) to call.
+/// </summary>
+internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
+{
+    /// <summary>
+    /// List of the functions to provide to LLM.
+    /// </summary>
+    private readonly IEnumerable<KernelFunction>? _functions;
+
+    /// <summary>
+    /// Indicates whether the functions should be automatically invoked by AI connectors.
+    /// </summary>
+    private readonly bool _autoInvoke;
+
+    /// <summary>
+    /// Function selector to customize the function selection logic.
+    /// </summary>
+    private readonly Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? _functionsSelector;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AutoFunctionChoiceBehavior"/> class.
+    /// </summary>
+    /// <param name="functions">
+    /// Functions to provide to AI model. If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model, which is equivalent to disabling function calling.
+    /// </param>
+    /// <param name="autoInvoke">
+    /// Indicates whether the functions should be automatically invoked by AI connectors.
+    /// </param>
+    /// <param name="functionsSelector">
+    /// The callback function allows customization of function selection.
+    /// It accepts functions, chat history, and an optional kernel, and returns a list of functions to be used by the AI model.
+    /// This should be supplied to prevent the AI model from repeatedly calling functions even when the prompt has already been answered.
+    /// For example, if the AI model is prompted to calculate the sum of two numbers, 2 and 3, and is provided with the 'Add' function,
+    /// the model will keep calling the 'Add' function even if the sum - 5 - is already calculated, until the 'Add' function is no longer provided to the model.
+    /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
+    /// </param>
+    public RequiredFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null)
+    {
+        this._functions = functions;
+        this._autoInvoke = autoInvoke;
+        this._functionsSelector = functionsSelector;
+    }
+
+    /// <inheritdoc />
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    {
+        // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
+        // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
+        // and then fail to do so, so we fail before we get to that point. This is an error
+        // on the consumers behalf: if they specify auto-invocation with any functions, they must
+        // specify the kernel and the kernel must contain those functions.
+        if (this._autoInvoke && context.Kernel is null)
+        {
+            throw new KernelException("Auto-invocation is not supported when no kernel is provided.");
+        }
+
+        List<KernelFunction>? availableFunctions = null;
+
+        if (this._functions is not null)
+        {
+            availableFunctions = new List<KernelFunction>(this._functions.Count());
+
+            foreach (var function in this._functions)
+            {
+                if (this._autoInvoke)
+                {
+                    // If auto-invocation is requested and no function is found in the kernel, fail early.
+                    if (!context.Kernel!.Plugins.TryGetFunction(function.PluginName, function.Name, out var _))
+                    {
+                        throw new KernelException($"The specified function {function} is not available in the kernel.");
+                    }
+                }
+
+                availableFunctions.Add(function);
+            }
+        }
+        // Provide all kernel functions.
+        else if (context.Kernel is not null)
+        {
+            foreach (var plugin in context.Kernel.Plugins)
+            {
+                (availableFunctions ??= new List<KernelFunction>(context.Kernel.Plugins.Count)).AddRange(plugin);
+            }
+        }
+
+        // Invoke function selector, if provided, to get the final list of functions.
+        if (this._functionsSelector is not null)
+        {
+            availableFunctions = this._functionsSelector(new FunctionChoiceBehaviorFunctionsSelectorContext(context.ChatHistory)
+            {
+                Kernel = context.Kernel,
+                Functions = availableFunctions,
+            })?.ToList();
+        }
+
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        return new FunctionChoiceBehaviorConfiguration()
+        {
+            Choice = FunctionChoice.Required,
+            Functions = availableFunctions,
+            AutoInvoke = this._autoInvoke,
+        };
+#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -76,6 +76,10 @@ public class PromptExecutionSettings
     /// by the <see cref="FunctionChoiceBehavior.Auto(IEnumerable{KernelFunction}?, bool)"/> method.
     /// </item>
     /// <item>
+    /// To force the model to always call one or more functions set the property to an instance returned
+    /// by the <see cref="FunctionChoiceBehavior.Required(IEnumerable{KernelFunction}?, bool, Func{FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList{KernelFunction}?}?)"/> method.
+    /// </item>
+    /// <item>
     /// To instruct the model to not call any functions and only generate a user-facing message, set the property to an instance returned
     /// by the <see cref="FunctionChoiceBehavior.None(IEnumerable{KernelFunction}?)"/> method.
     /// </item>

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SemanticKernel;
 using Xunit;
@@ -28,15 +29,15 @@ public sealed class FunctionChoiceBehaviorTests
         Assert.IsType<AutoFunctionChoiceBehavior>(choiceBehavior);
     }
 
-    //[Fact]
-    //public void RequiredFunctionChoiceShouldBeUsed()
-    //{
-    //    // Act
-    //    var choiceBehavior = FunctionChoiceBehavior.Required();
+    [Fact]
+    public void RequiredFunctionChoiceShouldBeUsed()
+    {
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required();
 
-    //    // Assert
-    //    Assert.IsType<RequiredFunctionChoiceBehavior>(choiceBehavior);
-    //}
+        // Assert
+        Assert.IsType<RequiredFunctionChoiceBehavior>(choiceBehavior);
+    }
 
     [Fact]
     public void NoneFunctionChoiceShouldBeUsed()
@@ -58,7 +59,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(functions: null);
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -80,7 +81,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -101,7 +102,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true);
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -118,89 +119,134 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
         Assert.False(config.AutoInvoke);
     }
 
-    //[Fact]
-    //public void RequiredFunctionChoiceShouldAdvertiseKernelFunctions()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void RequiredFunctionChoiceShouldAdvertiseKernelFunctions()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = FunctionChoiceBehavior.Required(functions: null);
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(functions: null);
 
-    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
-    //    // Assert
-    //    Assert.NotNull(config);
+        // Assert
+        Assert.NotNull(config);
 
-    //    Assert.NotNull(config.Functions);
-    //    Assert.Equal(3, config.Functions.Count);
-    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
-    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
-    //    Assert.Contains(config.Functions, f => f.Name == "Function3");
-    //}
+        Assert.NotNull(config.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.Name == "Function3");
+    }
 
-    //[Fact]
-    //public void RequiredFunctionChoiceShouldAdvertiseProvidedFunctions()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void RequiredFunctionChoiceShouldAdvertiseProvidedFunctions()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = FunctionChoiceBehavior.Required(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
-    //    // Assert
-    //    Assert.NotNull(config);
+        // Assert
+        Assert.NotNull(config);
 
-    //    Assert.NotNull(config.Functions);
-    //    Assert.Equal(2, config.Functions.Count);
-    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
-    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
-    //}
+        Assert.NotNull(config.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+    }
 
-    //[Fact]
-    //public void RequiredFunctionChoiceShouldAllowAutoInvocation()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void RequiredFunctionChoiceShouldAllowAutoInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = FunctionChoiceBehavior.Required(options: new() { AutoInvoke = true });
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true);
 
-    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
-    //    // Assert
-    //    Assert.NotNull(config);
-    //    Assert.True(config.Options.AutoInvoke);
-    //}
+        // Assert
+        Assert.NotNull(config);
+        Assert.True(config.AutoInvoke);
+    }
 
-    //[Fact]
-    //public void RequiredFunctionChoiceShouldAllowManualInvocation()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void RequiredFunctionChoiceShouldReturnNoFunctionAsSpecifiedByFunctionsSelector()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = FunctionChoiceBehavior.Required(options: new() { AutoInvoke = false });
+        static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        {
+            return null;
+        }
 
-    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-    //    // Assert
-    //    Assert.NotNull(config);
-    //    Assert.False(config.Options.AutoInvoke);
-    //}
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.Null(config.Functions);
+    }
+
+    [Fact]
+    public void RequiredFunctionChoiceShouldReturnFunctionsAsSpecifiedByFunctionsSelector()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        {
+            return context.Functions!.Where(f => f.Name == "Function1").ToList();
+        }
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
+
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config?.Functions);
+        Assert.Single(config.Functions);
+        Assert.Equal("Function1", config.Functions[0].Name);
+    }
+
+    [Fact]
+    public void RequiredFunctionChoiceShouldAllowManualInvocation()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false);
+
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.False(config.AutoInvoke);
+    }
 
     [Fact]
     public void NoneFunctionChoiceShouldAdvertiseProvidedFunctions()
@@ -211,7 +257,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.None([plugin.ElementAt(0), plugin.ElementAt(2)]);
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -232,7 +278,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.None();
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
@@ -195,7 +195,7 @@ public sealed class FunctionChoiceBehaviorTests
 
         static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
         {
-            return null;
+            return [];
         }
 
         // Act
@@ -204,8 +204,8 @@ public sealed class FunctionChoiceBehaviorTests
         var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
-        Assert.NotNull(config);
-        Assert.Null(config.Functions);
+        Assert.NotNull(config.Functions);
+        Assert.Empty(config.Functions);
     }
 
     [Fact]

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehaviorTests.cs
@@ -28,7 +28,7 @@ public sealed class NoneFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new NoneFunctionChoiceBehavior();
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -49,7 +49,7 @@ public sealed class NoneFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new NoneFunctionChoiceBehavior([plugin.ElementAt(0), plugin.ElementAt(2)]);
 
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -67,7 +67,7 @@ public sealed class NoneFunctionChoiceBehaviorTests
         var choiceBehavior = new NoneFunctionChoiceBehavior();
 
         // Act
-        var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
@@ -245,7 +245,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
 
         static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
         {
-            return null;
+            return [];
         }
 
         // Act
@@ -254,8 +254,8 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
-        Assert.NotNull(config);
-        Assert.Null(config.Functions);
+        Assert.NotNull(config.Functions);
+        Assert.Empty(config.Functions);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation, Context and Description
This PR adds a new `RequiredFunctionChoiceBehavior` class that is used by AI connectors to get a list of the functions to advertise to the AI model and force it to call one or more functions. Additionally, it provides information on whether the functions should be auto-invoked and accepts a function selector callback to stop advertising functions if the AI model prompt has already been answered.