### PR TITLE
.Net Extract and reuse common code for function calling

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -1217,55 +1217,33 @@ internal partial class ClientCore
         int maximumAutoInvokeAttempts = config.AutoInvoke ? MaximumAutoInvokeAttempts : 0;
         bool autoInvoke = kernel is not null && config.AutoInvoke;
 
-        // TODO: Extract common logic out of the `if` operators.
-        if (config.Choice == FunctionChoice.Auto)
+        if (config.Functions is { Count: > 0 } functions)
         {
-            if (config.Functions is { Count: > 0 } functions)
+            if (config.Choice == FunctionChoice.Auto)
             {
                 toolChoice = ChatToolChoice.Auto;
-                tools = [];
-
-                foreach (var function in functions)
-                {
-                    tools.Add(function.Metadata.ToOpenAIFunction().ToFunctionDefinition());
-                }
             }
-
-            return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts);
-        }
-
-        if (config.Choice == FunctionChoice.Required)
-        {
-            if (config.Functions is { Count: > 0 } functions)
+            else if (config.Choice == FunctionChoice.Required)
             {
                 toolChoice = ChatToolChoice.Required;
-                tools = [];
-
-                foreach (var function in functions)
-                {
-                    tools.Add(function.Metadata.ToOpenAIFunction().ToFunctionDefinition());
-                }
             }
-
-            return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts);
-        }
-
-        if (config.Choice == FunctionChoice.None)
-        {
-            if (config.Functions is { Count: > 0 } functions)
+            else if (config.Choice == FunctionChoice.None)
             {
                 toolChoice = ChatToolChoice.None;
-                tools = [];
-
-                foreach (var function in functions)
-                {
-                    tools.Add(function.Metadata.ToOpenAIFunction().ToFunctionDefinition());
-                }
+            }
+            else
+            {
+                throw new NotSupportedException($"Unsupported function choice '{config.Choice}'.");
             }
 
-            return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts);
+            tools = [];
+
+            foreach (var function in functions)
+            {
+                tools.Add(function.Metadata.ToOpenAIFunction().ToFunctionDefinition());
+            }
         }
 
-        throw new NotSupportedException($"Unsupported function choice '{config.Choice}'.");
+        return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts);
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.SemanticKernel;
 
@@ -40,52 +39,13 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     /// <inheritdoc />
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
-#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     {
-        // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
-        // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
-        // and then fail to do so, so we fail before we get to that point. This is an error
-        // on the consumers behalf: if they specify auto-invocation with any functions, they must
-        // specify the kernel and the kernel must contain those functions.
-        if (this._autoInvoke && context.Kernel is null)
-        {
-            throw new KernelException("Auto-invocation is not supported when no kernel is provided.");
-        }
+        var functions = base.GetFunctions(this._functions, context.Kernel, this._autoInvoke);
 
-        List<KernelFunction>? availableFunctions = null;
-
-        if (this._functions is not null)
-        {
-            availableFunctions = new List<KernelFunction>(this._functions.Count());
-
-            foreach (var function in this._functions)
-            {
-                if (this._autoInvoke)
-                {
-                    // If auto-invocation is requested and no function is found in the kernel, fail early.
-                    if (!context.Kernel!.Plugins.TryGetFunction(function.PluginName, function.Name, out var _))
-                    {
-                        throw new KernelException($"The specified function {function} is not available in the kernel.");
-                    }
-                }
-
-                availableFunctions.Add(function);
-            }
-        }
-        // Provide all kernel functions.
-        else if (context.Kernel is not null)
-        {
-            foreach (var plugin in context.Kernel.Plugins)
-            {
-                (availableFunctions ??= new List<KernelFunction>(context.Kernel.Plugins.Count)).AddRange(plugin);
-            }
-        }
-
-#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return new FunctionChoiceBehaviorConfiguration()
         {
             Choice = FunctionChoice.Auto,
-            Functions = availableFunctions,
+            Functions = functions,
             AutoInvoke = this._autoInvoke,
         };
 #pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -79,5 +79,55 @@ public abstract class FunctionChoiceBehavior
     /// <returns>The configuration.</returns>
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public abstract FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context);
+
+    /// <summary>
+    /// Returns functions AI connector should provide to the AI model.
+    /// </summary>
+    /// <param name="functions">Functions provided as instances of <see cref="KernelFunction"/>.</param>
+    /// <param name="kernel">The <see cref="Kernel"/> to be used for function calling.</param>
+    /// <param name="autoInvoke">Indicates whether the functions should be automatically invoked by the AI connector.</param>
+    /// <returns>The configuration.</returns>
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    public IReadOnlyList<KernelFunction>? GetFunctions(IEnumerable<KernelFunction>? functions, Kernel? kernel, bool autoInvoke)
 #pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    {
+        // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
+        // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
+        // and then fail to do so, so we fail before we get to that point. This is an error
+        // on the consumers behalf: if they specify auto-invocation with any functions, they must
+        // specify the kernel and the kernel must contain those functions.
+        if (autoInvoke && kernel is null)
+        {
+            throw new KernelException("Auto-invocation is not supported when no kernel is provided.");
+        }
+
+        List<KernelFunction>? availableFunctions = null;
+
+        if (functions is not null)
+        {
+            availableFunctions = new List<KernelFunction>(functions);
+
+            if (autoInvoke)
+            {
+                foreach (var function in availableFunctions)
+                {
+                    // If auto-invocation is requested and no function is found in the kernel, fail early.
+                    if (!kernel!.Plugins.TryGetFunction(function.PluginName, function.Name, out var _))
+                    {
+                        throw new KernelException($"The specified function {function} is not available in the kernel.");
+                    }
+                }
+            }
+        }
+        // Provide all kernel functions.
+        else if (kernel is not null)
+        {
+            foreach (var plugin in kernel.Plugins)
+            {
+                (availableFunctions ??= new List<KernelFunction>(kernel.Plugins.Count)).AddRange(plugin);
+            }
+        }
+
+        return availableFunctions;
+    }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -87,9 +87,7 @@ public abstract class FunctionChoiceBehavior
     /// <param name="kernel">The <see cref="Kernel"/> to be used for function calling.</param>
     /// <param name="autoInvoke">Indicates whether the functions should be automatically invoked by the AI connector.</param>
     /// <returns>The configuration.</returns>
-#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public IReadOnlyList<KernelFunction>? GetFunctions(IEnumerable<KernelFunction>? functions, Kernel? kernel, bool autoInvoke)
-#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     {
         // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
         // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
@@ -28,29 +28,16 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
         this._functions = functions;
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
+#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
-        List<KernelFunction>? availableFunctions = null;
+        var functions = base.GetFunctions(this._functions, context.Kernel, autoInvoke: false);
 
-        if (this._functions is not null)
-        {
-            availableFunctions = new List<KernelFunction>(this._functions);
-        }
-        // Provide all kernel functions.
-        else if (context.Kernel is not null)
-        {
-            foreach (var plugin in context.Kernel.Plugins)
-            {
-                (availableFunctions ??= new List<KernelFunction>(context.Kernel.Plugins.Count)).AddRange(plugin);
-            }
-        }
-
-#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return new FunctionChoiceBehaviorConfiguration()
         {
             Choice = FunctionChoice.None,
-            Functions = availableFunctions,
+            Functions = functions,
             AutoInvoke = false,
         };
 #pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.


### PR DESCRIPTION
### Motivation and Context
While working on the new function choice behavior functionality, a few inefficiencies were identified during development and PR reviews. This PR is one of a few follow-up ones that will remove those inefficiencies.

### Description
This PR extracts and reuses common code for function selection and mapping function choice behavior to the underlying Azure SDK model.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
