### PR TITLE
.Net: Function choice behavior in JSON prompts

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAIPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/AzureOpenAIPromptExecutionSettingsTests.cs
@@ -276,6 +276,22 @@ public class AzureOpenAIPromptExecutionSettingsTests
         AssertExecutionSettings(executionSettings);
     }
 
+    [Fact]
+    public void ItRestoresOriginalFunctionChoiceBehavior()
+    {
+        // Arrange
+        var functionChoiceBehavior = FunctionChoiceBehavior.Auto();
+
+        var originalExecutionSettings = new PromptExecutionSettings();
+        originalExecutionSettings.FunctionChoiceBehavior = functionChoiceBehavior;
+
+        // Act
+        var result = AzureOpenAIPromptExecutionSettings.FromExecutionSettings(originalExecutionSettings);
+
+        // Assert
+        Assert.Equal(functionChoiceBehavior, result.FunctionChoiceBehavior);
+    }
+
     private static void AssertExecutionSettings(AzureOpenAIPromptExecutionSettings executionSettings)
     {
         Assert.NotNull(executionSettings);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/OpenAIPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Settings/OpenAIPromptExecutionSettingsTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Azure.AI.OpenAI.Chat;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 
@@ -43,6 +44,22 @@ public class OpenAIPromptExecutionSettingsTests
 
         // Assert
         AssertExecutionSettings(executionSettings);
+    }
+
+    [Fact]
+    public void ItRestoresOriginalFunctionChoiceBehavior()
+    {
+        // Arrange
+        var functionChoiceBehavior = FunctionChoiceBehavior.Auto();
+
+        var originalExecutionSettings = new PromptExecutionSettings();
+        originalExecutionSettings.FunctionChoiceBehavior = functionChoiceBehavior;
+
+        // Act
+        var result = OpenAIPromptExecutionSettings.FromExecutionSettings(originalExecutionSettings);
+
+        // Assert
+        Assert.Equal(functionChoiceBehavior, result.FunctionChoiceBehavior);
     }
 
     private static void AssertExecutionSettings(OpenAIPromptExecutionSettings executionSettings)

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIPromptExecutionSettings.cs
@@ -73,6 +73,9 @@ public sealed class AzureOpenAIPromptExecutionSettings : OpenAIPromptExecutionSe
 
         var openAIExecutionSettings = JsonSerializer.Deserialize<AzureOpenAIPromptExecutionSettings>(json, JsonOptionsCache.ReadPermissive);
 
+        // Restore the function choice behavior that lost internal state(list of function instances) during serialization/deserialization process.
+        openAIExecutionSettings!.FunctionChoiceBehavior = executionSettings.FunctionChoiceBehavior;
+
         return openAIExecutionSettings!;
     }
 

--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
@@ -333,7 +333,10 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
 
         var openAIExecutionSettings = JsonSerializer.Deserialize<OpenAIPromptExecutionSettings>(json, JsonOptionsCache.ReadPermissive);
 
-        return openAIExecutionSettings!;
+        // Restore the function choice behavior that lost internal state(list of function instances) during serialization/deserialization process.
+        openAIExecutionSettings!.FunctionChoiceBehavior = executionSettings.FunctionChoiceBehavior;
+
+        return openAIExecutionSettings;
     }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,CA1869,VSTHRD111,CS1591,SKEXP0040,SKEXP0001,SKEXP0001</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,CA1869,VSTHRD111,CS1591,SKEXP0040,SKEXP0001</NoWarn>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/test/TestInternalUtilities.props" />
   <ItemGroup>

--- a/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,CA1869,VSTHRD111,CS1591,SKEXP0040,SKEXP0001, SKEXP0010</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,CA1869,VSTHRD111,CS1591,SKEXP0040,SKEXP0001,SKEXP0001</NoWarn>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/test/TestInternalUtilities.props" />
   <ItemGroup>

--- a/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,CA1869,VSTHRD111,CS1591,SKEXP0040,SKEXP0001</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,CA1869,VSTHRD111,CS1591,SKEXP0040,SKEXP0001, SKEXP0010</NoWarn>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/test/TestInternalUtilities.props" />
   <ItemGroup>

--- a/dotnet/src/Functions/Functions.UnitTests/Markdown/Functions/KernelFunctionMarkdownTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Markdown/Functions/KernelFunctionMarkdownTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Linq;
 using Microsoft.SemanticKernel;
 using Xunit;
 
@@ -18,9 +19,61 @@ public class KernelFunctionMarkdownTests
         Assert.NotNull(model);
         Assert.Equal("TellMeAbout", model.Name);
         Assert.Equal("Hello AI, tell me about {{$input}}", model.Template);
-        Assert.Equal(2, model.ExecutionSettings.Count);
+        Assert.Equal(3, model.ExecutionSettings.Count);
         Assert.Equal("gpt4", model.ExecutionSettings["service1"].ModelId);
         Assert.Equal("gpt3.5", model.ExecutionSettings["service2"].ModelId);
+    }
+
+    [Fact]
+    public void ItShouldInitializeFunctionChoiceBehaviorsFromMarkdown()
+    {
+        // Arrange
+        var kernel = new Kernel();
+        kernel.Plugins.AddFromFunctions("p1", [KernelFunctionFactory.CreateFromMethod(() => { }, "f1")]);
+        kernel.Plugins.AddFromFunctions("p2", [KernelFunctionFactory.CreateFromMethod(() => { }, "f2")]);
+        kernel.Plugins.AddFromFunctions("p3", [KernelFunctionFactory.CreateFromMethod(() => { }, "f3")]);
+
+        // Act
+        var function = KernelFunctionMarkdown.CreateFromPromptMarkdown(Markdown, "TellMeAbout");
+
+        // Assert
+        Assert.NotNull(function);
+        Assert.NotEmpty(function.ExecutionSettings);
+
+        Assert.Equal(3, function.ExecutionSettings.Count);
+
+        // AutoFunctionCallChoice for service1
+        var service1ExecutionSettings = function.ExecutionSettings["service1"];
+        Assert.NotNull(service1ExecutionSettings?.FunctionChoiceBehavior);
+
+        var autoConfig = service1ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        Assert.NotNull(autoConfig);
+        Assert.Equal(FunctionChoice.Auto, autoConfig.Choice);
+        Assert.NotNull(autoConfig.Functions);
+        Assert.Equal("p1", autoConfig.Functions.Single().PluginName);
+        Assert.Equal("f1", autoConfig.Functions.Single().Name);
+
+        // RequiredFunctionCallChoice for service2
+        var service2ExecutionSettings = function.ExecutionSettings["service2"];
+        Assert.NotNull(service2ExecutionSettings?.FunctionChoiceBehavior);
+
+        var requiredConfig = service2ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        Assert.NotNull(requiredConfig);
+        Assert.Equal(FunctionChoice.Required, requiredConfig.Choice);
+        Assert.NotNull(requiredConfig.Functions);
+        Assert.Equal("p2", requiredConfig.Functions.Single().PluginName);
+        Assert.Equal("f2", requiredConfig.Functions.Single().Name);
+
+        // NoneFunctionCallChoice for service3
+        var service3ExecutionSettings = function.ExecutionSettings["service3"];
+        Assert.NotNull(service3ExecutionSettings?.FunctionChoiceBehavior);
+
+        var noneConfig = service3ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        Assert.NotNull(noneConfig);
+        Assert.Equal(FunctionChoice.None, noneConfig.Choice);
+        Assert.NotNull(noneConfig.Functions);
+        Assert.Equal("p3", noneConfig.Functions.Single().PluginName);
+        Assert.Equal("f3", noneConfig.Functions.Single().Name);
     }
 
     [Fact]
@@ -47,7 +100,11 @@ public class KernelFunctionMarkdownTests
         {
             "service1" : {
                 "model_id": "gpt4",
-                "temperature": 0.7
+                "temperature": 0.7,
+                "function_choice_behavior": {
+                    "type": "auto",
+                    "functions": ["p1.f1"]
+                }
             }
         }
         ```
@@ -56,7 +113,24 @@ public class KernelFunctionMarkdownTests
         {
             "service2" : {
                 "model_id": "gpt3.5",
-                "temperature": 0.8
+                "temperature": 0.8,
+                "function_choice_behavior": {
+                    "type": "required",
+                    "functions": ["p2.f2"]
+                }
+            }
+        }
+        ```
+        These are AI execution settings as well
+        ```sk.execution_settings
+        {
+            "service3" : {
+                "model_id": "gpt3.5-turbo",
+                "temperature": 0.8,
+                "function_choice_behavior": {
+                    "type": "none",
+                    "functions": ["p3.f3"]
+                }
             }
         }
         ```

--- a/dotnet/src/Functions/Functions.UnitTests/Markdown/Functions/KernelFunctionMarkdownTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Markdown/Functions/KernelFunctionMarkdownTests.cs
@@ -19,9 +19,13 @@ public class KernelFunctionMarkdownTests
         Assert.NotNull(model);
         Assert.Equal("TellMeAbout", model.Name);
         Assert.Equal("Hello AI, tell me about {{$input}}", model.Template);
-        Assert.Equal(3, model.ExecutionSettings.Count);
+        Assert.Equal(6, model.ExecutionSettings.Count);
         Assert.Equal("gpt4", model.ExecutionSettings["service1"].ModelId);
         Assert.Equal("gpt3.5", model.ExecutionSettings["service2"].ModelId);
+        Assert.Equal("gpt3.5-turbo", model.ExecutionSettings["service3"].ModelId);
+        Assert.Equal("gpt4", model.ExecutionSettings["service4"].ModelId);
+        Assert.Equal("gpt4", model.ExecutionSettings["service5"].ModelId);
+        Assert.Equal("gpt4", model.ExecutionSettings["service6"].ModelId);
     }
 
     [Fact]
@@ -40,7 +44,7 @@ public class KernelFunctionMarkdownTests
         Assert.NotNull(function);
         Assert.NotEmpty(function.ExecutionSettings);
 
-        Assert.Equal(3, function.ExecutionSettings.Count);
+        Assert.Equal(6, function.ExecutionSettings.Count);
 
         // AutoFunctionCallChoice for service1
         var service1ExecutionSettings = function.ExecutionSettings["service1"];
@@ -74,6 +78,32 @@ public class KernelFunctionMarkdownTests
         Assert.NotNull(noneConfig.Functions);
         Assert.Equal("p3", noneConfig.Functions.Single().PluginName);
         Assert.Equal("f3", noneConfig.Functions.Single().Name);
+
+        // AutoFunctionCallChoice with empty functions collection for service4
+        var service4ExecutionSettings = function.ExecutionSettings["service4"];
+        Assert.NotNull(service4ExecutionSettings?.FunctionChoiceBehavior);
+
+        var autoWithEmptyFunctionsConfig = service4ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        Assert.NotNull(autoWithEmptyFunctionsConfig);
+        Assert.Equal(FunctionChoice.Auto, autoWithEmptyFunctionsConfig.Choice);
+        Assert.Null(autoWithEmptyFunctionsConfig.Functions);
+
+        // AutoFunctionCallChoice with no functions collection for service5
+        var service5ExecutionSettings = function.ExecutionSettings["service5"];
+        Assert.NotNull(service5ExecutionSettings?.FunctionChoiceBehavior);
+
+        var autoWithNoFunctionsConfig = service5ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        Assert.NotNull(autoWithNoFunctionsConfig);
+        Assert.Equal(FunctionChoice.Auto, autoWithNoFunctionsConfig.Choice);
+        Assert.NotNull(autoWithNoFunctionsConfig.Functions);
+        Assert.Equal(3, autoWithNoFunctionsConfig.Functions.Count);
+        Assert.Contains(autoWithNoFunctionsConfig.Functions, f => f.PluginName == "p1" && f.Name == "f1");
+        Assert.Contains(autoWithNoFunctionsConfig.Functions, f => f.PluginName == "p2" && f.Name == "f2");
+        Assert.Contains(autoWithNoFunctionsConfig.Functions, f => f.PluginName == "p3" && f.Name == "f3");
+
+        // No function choice behavior for service6
+        var service6ExecutionSettings = function.ExecutionSettings["service6"];
+        Assert.Null(service6ExecutionSettings?.FunctionChoiceBehavior);
     }
 
     [Fact]
@@ -131,6 +161,40 @@ public class KernelFunctionMarkdownTests
                     "type": "none",
                     "functions": ["p3.f3"]
                 }
+            }
+        }
+        ```
+        These are AI execution settings
+        ```sk.execution_settings
+        {
+            "service4" : {
+                "model_id": "gpt4",
+                "temperature": 0.7,
+                "function_choice_behavior": {
+                    "type": "auto",
+                    "functions": []
+                }
+            }
+        }
+        ```
+        These are AI execution settings
+        ```sk.execution_settings
+        {
+            "service5" : {
+                "model_id": "gpt4",
+                "temperature": 0.7,
+                "function_choice_behavior": {
+                    "type": "auto"
+                }
+            }
+        }
+        ```
+        These are AI execution settings
+        ```sk.execution_settings
+        {
+            "service6" : {
+                "model_id": "gpt4",
+                "temperature": 0.7
             }
         }
         ```

--- a/dotnet/src/Functions/Functions.UnitTests/Markdown/Functions/KernelFunctionMarkdownTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/Markdown/Functions/KernelFunctionMarkdownTests.cs
@@ -50,7 +50,7 @@ public class KernelFunctionMarkdownTests
         var service1ExecutionSettings = function.ExecutionSettings["service1"];
         Assert.NotNull(service1ExecutionSettings?.FunctionChoiceBehavior);
 
-        var autoConfig = service1ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        var autoConfig = service1ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []) { Kernel = kernel });
         Assert.NotNull(autoConfig);
         Assert.Equal(FunctionChoice.Auto, autoConfig.Choice);
         Assert.NotNull(autoConfig.Functions);
@@ -61,7 +61,7 @@ public class KernelFunctionMarkdownTests
         var service2ExecutionSettings = function.ExecutionSettings["service2"];
         Assert.NotNull(service2ExecutionSettings?.FunctionChoiceBehavior);
 
-        var requiredConfig = service2ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        var requiredConfig = service2ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []) { Kernel = kernel });
         Assert.NotNull(requiredConfig);
         Assert.Equal(FunctionChoice.Required, requiredConfig.Choice);
         Assert.NotNull(requiredConfig.Functions);
@@ -72,7 +72,7 @@ public class KernelFunctionMarkdownTests
         var service3ExecutionSettings = function.ExecutionSettings["service3"];
         Assert.NotNull(service3ExecutionSettings?.FunctionChoiceBehavior);
 
-        var noneConfig = service3ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        var noneConfig = service3ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []) { Kernel = kernel });
         Assert.NotNull(noneConfig);
         Assert.Equal(FunctionChoice.None, noneConfig.Choice);
         Assert.NotNull(noneConfig.Functions);
@@ -83,7 +83,7 @@ public class KernelFunctionMarkdownTests
         var service4ExecutionSettings = function.ExecutionSettings["service4"];
         Assert.NotNull(service4ExecutionSettings?.FunctionChoiceBehavior);
 
-        var autoWithEmptyFunctionsConfig = service4ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        var autoWithEmptyFunctionsConfig = service4ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []) { Kernel = kernel });
         Assert.NotNull(autoWithEmptyFunctionsConfig);
         Assert.Equal(FunctionChoice.Auto, autoWithEmptyFunctionsConfig.Choice);
         Assert.Null(autoWithEmptyFunctionsConfig.Functions);
@@ -92,7 +92,7 @@ public class KernelFunctionMarkdownTests
         var service5ExecutionSettings = function.ExecutionSettings["service5"];
         Assert.NotNull(service5ExecutionSettings?.FunctionChoiceBehavior);
 
-        var autoWithNoFunctionsConfig = service5ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext([]) { Kernel = kernel });
+        var autoWithNoFunctionsConfig = service5ExecutionSettings.FunctionChoiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []) { Kernel = kernel });
         Assert.NotNull(autoWithNoFunctionsConfig);
         Assert.Equal(FunctionChoice.Auto, autoWithNoFunctionsConfig.Choice);
         Assert.NotNull(autoWithNoFunctionsConfig.Functions);

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -7,13 +7,13 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Represents a <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to the LLM to call or specific ones.
-/// This behavior allows the LLM to decide whether to call the functions and, if so, which ones to call.
+/// Represents a <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to AI model to call or specific ones.
+/// This behavior allows the model to decide whether to call the functions and, if so, which ones to call.
 /// </summary>
 internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
 {
     /// <summary>
-    /// List of the functions to provide to LLM.
+    /// List of the functions to provide to AI model.
     /// </summary>
     private readonly IEnumerable<KernelFunction>? _functions;
 
@@ -34,8 +34,8 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     /// Initializes a new instance of the <see cref="AutoFunctionChoiceBehavior"/> class.
     /// </summary>
     /// <param name="functions">
-    /// Functions to provide to LLM. If null, all <see cref="Kernel"/>'s plugins' functions are provided to LLM.
-    /// If empty, no functions are provided to LLM, which is equivalent to disabling function calling.
+    /// Functions to provide to AI model. If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model, which is equivalent to disabling function calling.
     /// </param>
     /// <param name="autoInvoke">
     /// Indicates whether the functions should be automatically invoked by AI connectors.
@@ -49,7 +49,8 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
 
     /// <summary>
     /// Fully qualified names of the functions to provide to AI model.
-    /// If null or empty, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model, which is equivalent to disabling function calling.
     /// </summary>
     [JsonPropertyName("functions")]
     public IList<string>? Functions { get; set; }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel;
 
@@ -18,7 +20,15 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     /// <summary>
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </summary>
-    private readonly bool _autoInvoke;
+    private readonly bool _autoInvoke = true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AutoFunctionChoiceBehavior"/> class.
+    /// </summary>
+    [JsonConstructor]
+    public AutoFunctionChoiceBehavior()
+    {
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AutoFunctionChoiceBehavior"/> class.
@@ -32,15 +42,23 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     /// </param>
     public AutoFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
     {
+        this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
         this._functions = functions;
         this._autoInvoke = autoInvoke;
     }
+
+    /// <summary>
+    /// Fully qualified names of the functions to provide to AI model.
+    /// If null or empty, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// </summary>
+    [JsonPropertyName("functions")]
+    public IList<string>? Functions { get; set; }
 
     /// <inheritdoc />
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
-        var functions = base.GetFunctions(this._functions, context.Kernel, this._autoInvoke);
+        var functions = base.GetFunctions(this.Functions, this._functions, context.Kernel, this._autoInvoke);
 
         return new FunctionChoiceBehaviorConfiguration()
         {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -13,11 +13,6 @@ namespace Microsoft.SemanticKernel;
 internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
 {
     /// <summary>
-    /// List of the functions to provide to AI model.
-    /// </summary>
-    private readonly IEnumerable<KernelFunction>? _functions;
-
-    /// <summary>
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </summary>
     private readonly bool _autoInvoke = true;
@@ -40,10 +35,9 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     /// <param name="autoInvoke">
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </param>
-    public AutoFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
+    public AutoFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true) : base(functions)
     {
         this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
-        this._functions = functions;
         this._autoInvoke = autoInvoke;
     }
 
@@ -56,10 +50,9 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     public IList<string>? Functions { get; set; }
 
     /// <inheritdoc />
-#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
-        var functions = base.GetFunctions(this.Functions, this._functions, context.Kernel, this._autoInvoke);
+        var functions = base.GetFunctions(this.Functions, context.Kernel, this._autoInvoke);
 
         return new FunctionChoiceBehaviorConfiguration()
         {
@@ -67,6 +60,5 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
             Functions = functions,
             AutoInvoke = this._autoInvoke,
         };
-#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -102,7 +102,7 @@ public abstract class FunctionChoiceBehavior
     /// <param name="kernel">The <see cref="Kernel"/> to be used for function calling.</param>
     /// <param name="autoInvoke">Indicates whether the functions should be automatically invoked by the AI connector.</param>
     /// <returns>The configuration.</returns>
-    public IReadOnlyList<KernelFunction>? GetFunctions(IList<string>? functionFQNs, IEnumerable<KernelFunction>? functions, Kernel? kernel, bool autoInvoke)
+    protected IReadOnlyList<KernelFunction>? GetFunctions(IList<string>? functionFQNs, IEnumerable<KernelFunction>? functions, Kernel? kernel, bool autoInvoke)
     {
         // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
         // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -19,6 +19,11 @@ namespace Microsoft.SemanticKernel;
 [JsonDerivedType(typeof(NoneFunctionChoiceBehavior), typeDiscriminator: "none")]
 public abstract class FunctionChoiceBehavior
 {
+    /// <summary>
+    /// List of the functions to provide to AI model.
+    /// </summary>
+    private readonly IEnumerable<KernelFunction>? _functions;
+
     /// <summary>The separator used to separate plugin name and function name.</summary>
     protected const string FunctionNameSeparator = ".";
 
@@ -27,6 +32,18 @@ public abstract class FunctionChoiceBehavior
     /// </summary>
     internal FunctionChoiceBehavior()
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionChoiceBehavior"/> class.
+    /// </summary>
+    /// <param name="functions">
+    /// Functions to provide to AI model. If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model.
+    /// </param>
+    internal FunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null)
+    {
+        this._functions = functions;
     }
 
     /// <summary>
@@ -98,11 +115,10 @@ public abstract class FunctionChoiceBehavior
     /// Returns functions AI connector should provide to the AI model.
     /// </summary>
     /// <param name="functionFQNs">Functions provided as fully qualified names.</param>
-    /// <param name="functions">Functions provided as instances of <see cref="KernelFunction"/>.</param>
     /// <param name="kernel">The <see cref="Kernel"/> to be used for function calling.</param>
     /// <param name="autoInvoke">Indicates whether the functions should be automatically invoked by the AI connector.</param>
     /// <returns>The configuration.</returns>
-    protected IReadOnlyList<KernelFunction>? GetFunctions(IList<string>? functionFQNs, IEnumerable<KernelFunction>? functions, Kernel? kernel, bool autoInvoke)
+    protected IReadOnlyList<KernelFunction>? GetFunctions(IList<string>? functionFQNs, Kernel? kernel, bool autoInvoke)
     {
         // If auto-invocation is specified, we need a kernel to be able to invoke the functions.
         // Lack of a kernel is fatal: we don't want to tell the model we can handle the functions
@@ -138,7 +154,7 @@ public abstract class FunctionChoiceBehavior
                 }
 
                 // Look up the function in the list of functions provided as instances of KernelFunction.
-                function = functions?.FirstOrDefault(f => f.Name == nameParts.Name && f.PluginName == nameParts.PluginName);
+                function = this._functions?.FirstOrDefault(f => f.Name == nameParts.Name && f.PluginName == nameParts.PluginName);
                 if (function is not null)
                 {
                     availableFunctions.Add(function);

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -41,7 +41,6 @@ public abstract class FunctionChoiceBehavior
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </param>
     /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
-    [Experimental("SKEXP0001")]
     public static FunctionChoiceBehavior Auto(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
     {
         return new AutoFunctionChoiceBehavior(functions, autoInvoke);
@@ -67,7 +66,6 @@ public abstract class FunctionChoiceBehavior
     /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
     /// </param>
     /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
-    [Experimental("SKEXP0001")]
     public static FunctionChoiceBehavior Required(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null)
     {
         return new RequiredFunctionChoiceBehavior(functions, autoInvoke, functionsSelector);
@@ -149,6 +147,11 @@ public abstract class FunctionChoiceBehavior
 
                 throw new KernelException($"The specified function {functionFQN} was not found.");
             }
+        }
+        // Disable function calling.
+        else if (functionFQNs is { Count: 0 })
+        {
+            return availableFunctions;
         }
         // Provide all kernel functions.
         else if (kernel is not null)

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
@@ -41,7 +41,8 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
 
     /// <summary>
     /// Fully qualified names of the functions to provide to AI model.
-    /// If null or empty, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model, which is equivalent to disabling function calling.
     /// </summary>
     [JsonPropertyName("functions")]
     public IList<string>? Functions { get; set; }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
@@ -14,11 +14,6 @@ namespace Microsoft.SemanticKernel;
 internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
 {
     /// <summary>
-    /// List of the functions to provide to AI model.
-    /// </summary>
-    private readonly IEnumerable<KernelFunction>? _functions;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="NoneFunctionChoiceBehavior"/> class.
     /// </summary>
     [JsonConstructor]
@@ -33,9 +28,8 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
     /// Functions to provide to AI model. If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
     /// If empty, no functions are provided to the model.
     /// </param>
-    public NoneFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null)
+    public NoneFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null) : base(functions)
     {
-        this._functions = functions;
         this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
     }
 
@@ -48,10 +42,9 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
     public IList<string>? Functions { get; set; }
 
     /// <inheritdoc />
-#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
-        var functions = base.GetFunctions(this.Functions, this._functions, context.Kernel, autoInvoke: false);
+        var functions = base.GetFunctions(this.Functions, context.Kernel, autoInvoke: false);
 
         return new FunctionChoiceBehaviorConfiguration()
         {
@@ -59,6 +52,5 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
             Functions = functions,
             AutoInvoke = false,
         };
-#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel;
 
@@ -19,6 +21,14 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
     /// <summary>
     /// Initializes a new instance of the <see cref="NoneFunctionChoiceBehavior"/> class.
     /// </summary>
+    [JsonConstructor]
+    public NoneFunctionChoiceBehavior()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoneFunctionChoiceBehavior"/> class.
+    /// </summary>
     /// <param name="functions">
     /// Functions to provide to AI model. If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
     /// If empty, no functions are provided to the model.
@@ -26,13 +36,21 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
     public NoneFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null)
     {
         this._functions = functions;
+        this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
     }
+
+    /// <summary>
+    /// Fully qualified names of the functions to provide to AI model.
+    /// If null or empty, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// </summary>
+    [JsonPropertyName("functions")]
+    public IList<string>? Functions { get; set; }
 
     /// <inheritdoc />
 #pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
-        var functions = base.GetFunctions(this._functions, context.Kernel, autoInvoke: false);
+        var functions = base.GetFunctions(this.Functions, this._functions, context.Kernel, autoInvoke: false);
 
         return new FunctionChoiceBehaviorConfiguration()
         {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel;
 internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
 {
     /// <summary>
-    /// List of the functions to provide to LLM.
+    /// List of the functions to provide to AI model.
     /// </summary>
     private readonly IEnumerable<KernelFunction>? _functions;
 
@@ -64,7 +64,8 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
 
     /// <summary>
     /// Fully qualified names of the functions to provide to AI model.
-    /// If null or empty, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
+    /// If empty, no functions are provided to the model, which is equivalent to disabling function calling.
     /// </summary>
     [JsonPropertyName("functions")]
     public IList<string>? Functions { get; set; }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -14,11 +14,6 @@ namespace Microsoft.SemanticKernel;
 internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
 {
     /// <summary>
-    /// List of the functions to provide to AI model.
-    /// </summary>
-    private readonly IEnumerable<KernelFunction>? _functions;
-
-    /// <summary>
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </summary>
     private readonly bool _autoInvoke = true;
@@ -54,10 +49,9 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
     /// the model will keep calling the 'Add' function even if the sum - 5 - is already calculated, until the 'Add' function is no longer provided to the model.
     /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
     /// </param>
-    public RequiredFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null)
+    public RequiredFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null) : base(functions)
     {
         this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
-        this._functions = functions;
         this._autoInvoke = autoInvoke;
         this._functionsSelector = functionsSelector;
     }
@@ -71,10 +65,9 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
     public IList<string>? Functions { get; set; }
 
     /// <inheritdoc />
-#pragma warning disable SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
-        var functions = base.GetFunctions(this.Functions, this._functions, context.Kernel, this._autoInvoke);
+        var functions = base.GetFunctions(this.Functions, context.Kernel, this._autoInvoke);
 
         IReadOnlyList<KernelFunction>? selectedFunctions = null;
 
@@ -94,6 +87,5 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
             Functions = selectedFunctions ?? functions,
             AutoInvoke = this._autoInvoke,
         };
-#pragma warning restore SKEXP0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -90,7 +90,7 @@ public class PromptExecutionSettings
     /// The intermediate messages will be retained in the provided <see cref="ChatHistory"/>.
     /// </remarks>
     [JsonPropertyName("function_choice_behavior")]
-    [Experimental("SKEXP0010")]
+    [Experimental("SKEXP0001")]
     public FunctionChoiceBehavior? FunctionChoiceBehavior
     {
         get => this._functionChoiceBehavior;

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
@@ -28,7 +28,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new AutoFunctionChoiceBehavior();
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -50,7 +50,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -74,7 +74,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
             Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
         };
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -94,7 +94,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new AutoFunctionChoiceBehavior([plugin.ElementAt(0), plugin.ElementAt(1)], autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -115,7 +115,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -137,7 +137,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new AutoFunctionChoiceBehavior();
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -154,7 +154,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -191,7 +191,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var exception = Assert.Throws<KernelException>(() =>
         {
-            choiceBehavior.GetConfiguration(new([]) { Kernel = null });
+            choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = null });
         });
 
         Assert.Equal("Auto-invocation is not supported when no kernel is provided.", exception.Message);
@@ -208,7 +208,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var exception = Assert.Throws<KernelException>(() =>
         {
-            choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+            choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
         });
 
         Assert.Equal("The specified function MyPlugin.Function1 is not available in the kernel.", exception.Message);
@@ -229,7 +229,7 @@ public sealed class AutoFunctionChoiceBehaviorTests
         // Act
         var exception = Assert.Throws<KernelException>(() =>
         {
-            choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+            choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
         });
 
         Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
@@ -61,29 +61,29 @@ public sealed class AutoFunctionChoiceBehaviorTests
         Assert.Contains(config.Functions, f => f.Name == "Function2");
     }
 
-    //[Fact]
-    //public void ItShouldAdvertiseOnlyFunctionsSuppliedInFunctionsProperty()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void ItShouldAdvertiseOnlyFunctionsSuppliedInFunctionsProperty()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = new AutoFunctionChoiceBehavior()
-    //    {
-    //        Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
-    //    };
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior()
+        {
+            Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
+        };
 
-    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
-    //    // Assert
-    //    Assert.NotNull(config);
+        // Assert
+        Assert.NotNull(config);
 
-    //    Assert.NotNull(config.Functions);
-    //    Assert.Equal(2, config.Functions.Count);
-    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
-    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
-    //}
+        Assert.NotNull(config.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+    }
 
     [Fact]
     public void ItShouldAdvertiseOnlyFunctionsSuppliedViaConstructorForManualInvocation()
@@ -161,23 +161,23 @@ public sealed class AutoFunctionChoiceBehaviorTests
         Assert.False(config.AutoInvoke);
     }
 
-    //[Fact]
-    //public void ItShouldInitializeFunctionPropertyByFunctionsPassedViaConstructor()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void ItShouldInitializeFunctionPropertyByFunctionsPassedViaConstructor()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-    //    // Assert
-    //    Assert.NotNull(choiceBehavior.Functions);
-    //    Assert.Equal(2, choiceBehavior.Functions.Count);
+        // Assert
+        Assert.NotNull(choiceBehavior.Functions);
+        Assert.Equal(2, choiceBehavior.Functions.Count);
 
-    //    Assert.Equal("MyPlugin.Function1", choiceBehavior.Functions.ElementAt(0));
-    //    Assert.Equal("MyPlugin.Function2", choiceBehavior.Functions.ElementAt(1));
-    //}
+        Assert.Equal("MyPlugin.Function1", choiceBehavior.Functions.ElementAt(0));
+        Assert.Equal("MyPlugin.Function2", choiceBehavior.Functions.ElementAt(1));
+    }
 
     [Fact]
     public void ItShouldThrowExceptionIfAutoInvocationRequestedButNoKernelIsProvided()
@@ -214,26 +214,26 @@ public sealed class AutoFunctionChoiceBehaviorTests
         Assert.Equal("The specified function MyPlugin.Function1 is not available in the kernel.", exception.Message);
     }
 
-    //[Fact]
-    //public void ItShouldThrowExceptionIfNoFunctionFoundAndManualInvocationIsRequested()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void ItShouldThrowExceptionIfNoFunctionFoundAndManualInvocationIsRequested()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false)
-    //    {
-    //        Functions = ["MyPlugin.NonKernelFunction"]
-    //    };
+        var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false)
+        {
+            Functions = ["MyPlugin.NonKernelFunction"]
+        };
 
-    //    // Act
-    //    var exception = Assert.Throws<KernelException>(() =>
-    //    {
-    //        choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
-    //    });
+        // Act
+        var exception = Assert.Throws<KernelException>(() =>
+        {
+            choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        });
 
-    //    Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
-    //}
+        Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
+    }
 
     private static KernelPlugin GetTestPlugin()
     {

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorDeserializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorDeserializationTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Text.Json;
+using Microsoft.SemanticKernel;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.AI.FunctionChoiceBehaviors;
+
+public class FunctionChoiceBehaviorDeserializationTests
+{
+    [Fact]
+    public void ItShouldDeserializeAutoFunctionChoiceBehavior()
+    {
+        // Arrange
+        var json = """
+            {
+                "type": "auto",
+                "functions": ["p1.f1"]
+            }
+            """;
+
+        // Act
+        var behavior = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
+
+        // Assert
+        Assert.NotNull(behavior?.Functions);
+        Assert.Single(behavior.Functions);
+        Assert.Equal("p1.f1", behavior.Functions.Single());
+    }
+
+    [Fact]
+    public void ItShouldDeserializeRequiredFunctionChoiceBehavior()
+    {
+        // Arrange
+        var json = """
+            {
+                "type": "required",
+                "functions": ["p1.f1"]
+            }
+            """;
+
+        // Act
+        var behavior = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
+
+        // Assert
+        Assert.NotNull(behavior?.Functions);
+        Assert.Single(behavior.Functions);
+        Assert.Equal("p1.f1", behavior.Functions.Single());
+    }
+
+    [Fact]
+    public void ItShouldDeserializeNoneFunctionChoiceBehavior()
+    {
+        // Arrange
+        var json = """
+            {
+                "type": "none",
+                "functions": ["p1.f1"]
+            }
+            """;
+
+        // Act
+        var behavior = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
+
+        // Assert
+        Assert.NotNull(behavior?.Functions);
+        Assert.Single(behavior.Functions);
+        Assert.Equal("p1.f1", behavior.Functions.Single());
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorDeserializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorDeserializationTests.cs
@@ -31,7 +31,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -61,7 +61,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -87,7 +87,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -115,7 +115,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -145,7 +145,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -171,7 +171,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -199,7 +199,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -229,7 +229,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -255,7 +255,7 @@ public class FunctionChoiceBehaviorDeserializationTests
         var sut = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
 
         // Act
-        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = sut!.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorDeserializationTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorDeserializationTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Linq;
 using System.Text.Json;
 using Microsoft.SemanticKernel;
 using Xunit;
@@ -9,63 +8,274 @@ namespace SemanticKernel.UnitTests.AI.FunctionChoiceBehaviors;
 
 public class FunctionChoiceBehaviorDeserializationTests
 {
-    [Fact]
-    public void ItShouldDeserializeAutoFunctionChoiceBehavior()
+    private readonly Kernel _kernel;
+
+    public FunctionChoiceBehaviorDeserializationTests()
     {
-        // Arrange
-        var json = """
-            {
-                "type": "auto",
-                "functions": ["p1.f1"]
-            }
-            """;
+        var plugin = GetTestPlugin();
 
-        // Act
-        var behavior = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
-
-        // Assert
-        Assert.NotNull(behavior?.Functions);
-        Assert.Single(behavior.Functions);
-        Assert.Equal("p1.f1", behavior.Functions.Single());
+        this._kernel = new Kernel();
+        this._kernel.Plugins.Add(plugin);
     }
 
     [Fact]
-    public void ItShouldDeserializeRequiredFunctionChoiceBehavior()
+    public void ItShouldDeserializeAutoFunctionChoiceBehaviorFromJsonWithNoFunctionsProperty()
     {
         // Arrange
         var json = """
-            {
-                "type": "required",
-                "functions": ["p1.f1"]
-            }
-            """;
+        {
+            "type": "auto"
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
 
         // Act
-        var behavior = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
-        Assert.NotNull(behavior?.Functions);
-        Assert.Single(behavior.Functions);
-        Assert.Equal("p1.f1", behavior.Functions.Single());
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.Auto, config.Choice);
+
+        Assert.True(config.AutoInvoke);
+
+        Assert.NotNull(config?.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function3");
     }
 
     [Fact]
-    public void ItShouldDeserializeNoneFunctionChoiceBehavior()
+    public void ItShouldDeserializeAutoFunctionChoiceBehaviorFromJsonWithEmptyFunctionsProperty()
     {
         // Arrange
         var json = """
-            {
-                "type": "none",
-                "functions": ["p1.f1"]
-            }
-            """;
+        {
+            "type": "auto",
+            "functions": []
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
 
         // Act
-        var behavior = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
 
         // Assert
-        Assert.NotNull(behavior?.Functions);
-        Assert.Single(behavior.Functions);
-        Assert.Equal("p1.f1", behavior.Functions.Single());
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.Auto, config.Choice);
+
+        Assert.True(config.AutoInvoke);
+
+        Assert.Null(config?.Functions);
+    }
+
+    [Fact]
+    public void ItShouldDeserializeAutoFunctionChoiceBehaviorFromJsonWithNotEmptyFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "auto",
+            "functions": ["MyPlugin.Function1", "MyPlugin.Function3"]
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<AutoFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.Auto, config.Choice);
+
+        Assert.True(config.AutoInvoke);
+
+        Assert.NotNull(config?.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function3");
+    }
+
+    [Fact]
+    public void ItShouldDeserializeRequiredFunctionChoiceBehaviorFromJsonWithNoFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "required"
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.Required, config.Choice);
+
+        Assert.True(config.AutoInvoke);
+
+        Assert.NotNull(config?.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function3");
+    }
+
+    [Fact]
+    public void ItShouldDeserializeRequiredFunctionChoiceBehaviorFromJsonWithEmptyFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "required",
+            "functions": []
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.Required, config.Choice);
+
+        Assert.True(config.AutoInvoke);
+
+        Assert.Null(config?.Functions);
+    }
+
+    [Fact]
+    public void ItShouldDeserializeRequiredFunctionChoiceBehaviorFromJsonWithNotEmptyFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "required",
+            "functions": ["MyPlugin.Function1", "MyPlugin.Function3"]
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<RequiredFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.Required, config.Choice);
+
+        Assert.True(config.AutoInvoke);
+
+        Assert.NotNull(config?.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function3");
+    }
+
+    [Fact]
+    public void ItShouldDeserializedNoneFunctionChoiceBehaviorFromJsonWithNoFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "none"
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.None, config.Choice);
+
+        Assert.False(config.AutoInvoke);
+
+        Assert.NotNull(config?.Functions);
+        Assert.Equal(3, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function2");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function3");
+    }
+
+    [Fact]
+    public void ItShouldDeserializedNoneFunctionChoiceBehaviorFromJsonWithEmptyFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "none",
+            "functions": []
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.None, config.Choice);
+
+        Assert.False(config.AutoInvoke);
+
+        Assert.Null(config?.Functions);
+    }
+
+    [Fact]
+    public void ItShouldDeserializedNoneFunctionChoiceBehaviorFromJsonWithNotEmptyFunctionsProperty()
+    {
+        // Arrange
+        var json = """
+        {
+            "type": "none",
+            "functions": ["MyPlugin.Function1", "MyPlugin.Function3"]
+        }
+        """;
+
+        var sut = JsonSerializer.Deserialize<NoneFunctionChoiceBehavior>(json);
+
+        // Act
+        var config = sut!.GetConfiguration(new([]) { Kernel = this._kernel });
+
+        // Assert
+        Assert.NotNull(config);
+
+        Assert.Equal(FunctionChoice.None, config.Choice);
+
+        Assert.False(config.AutoInvoke);
+
+        Assert.NotNull(config?.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.PluginName == "MyPlugin" && f.Name == "Function3");
+    }
+
+    private static KernelPlugin GetTestPlugin()
+    {
+        var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function2");
+        var function3 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function3");
+
+        return KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2, function3]);
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
@@ -59,7 +59,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(functions: null);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -81,7 +81,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -102,7 +102,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -119,7 +119,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -136,7 +136,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Required(functions: null);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -158,7 +158,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Required(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -179,7 +179,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -201,7 +201,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config.Functions);
@@ -223,7 +223,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config?.Functions);
@@ -241,7 +241,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -257,7 +257,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.None([plugin.ElementAt(0), plugin.ElementAt(2)]);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -278,7 +278,7 @@ public sealed class FunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = FunctionChoiceBehavior.None();
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehaviorTests.cs
@@ -28,7 +28,7 @@ public sealed class NoneFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new NoneFunctionChoiceBehavior();
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -49,7 +49,7 @@ public sealed class NoneFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new NoneFunctionChoiceBehavior([plugin.ElementAt(0), plugin.ElementAt(2)]);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -67,7 +67,7 @@ public sealed class NoneFunctionChoiceBehaviorTests
         var choiceBehavior = new NoneFunctionChoiceBehavior();
 
         // Act
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
@@ -62,29 +62,29 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         Assert.Contains(config.Functions, f => f.Name == "Function2");
     }
 
-    //[Fact]
-    //public void ItShouldAdvertiseOnlyFunctionsSuppliedInFunctionsProperty()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void ItShouldAdvertiseOnlyFunctionsSuppliedInFunctionsProperty()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = new RequiredFunctionChoiceBehavior()
-    //    {
-    //        Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
-    //    };
+        // Act
+        var choiceBehavior = new RequiredFunctionChoiceBehavior()
+        {
+            Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
+        };
 
-    //    var config = choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
 
-    //    // Assert
-    //    Assert.NotNull(config);
+        // Assert
+        Assert.NotNull(config);
 
-    //    Assert.NotNull(config.Functions);
-    //    Assert.Equal(2, config.Functions.Count);
-    //    Assert.Contains(config.Functions, f => f.Name == "Function1");
-    //    Assert.Contains(config.Functions, f => f.Name == "Function2");
-    //}
+        Assert.NotNull(config.Functions);
+        Assert.Equal(2, config.Functions.Count);
+        Assert.Contains(config.Functions, f => f.Name == "Function1");
+        Assert.Contains(config.Functions, f => f.Name == "Function2");
+    }
 
     [Fact]
     public void ItShouldAdvertiseOnlyFunctionsSuppliedViaConstructorForManualInvocation()
@@ -162,23 +162,23 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         Assert.False(config.AutoInvoke);
     }
 
-    //[Fact]
-    //public void ItShouldInitializeFunctionPropertyByFunctionsPassedViaConstructor()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void ItShouldInitializeFunctionPropertyByFunctionsPassedViaConstructor()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    // Act
-    //    var choiceBehavior = new RequiredFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+        // Act
+        var choiceBehavior = new RequiredFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-    //    // Assert
-    //    Assert.NotNull(choiceBehavior.Functions);
-    //    Assert.Equal(2, choiceBehavior.Functions.Count);
+        // Assert
+        Assert.NotNull(choiceBehavior.Functions);
+        Assert.Equal(2, choiceBehavior.Functions.Count);
 
-    //    Assert.Equal("MyPlugin.Function1", choiceBehavior.Functions.ElementAt(0));
-    //    Assert.Equal("MyPlugin.Function2", choiceBehavior.Functions.ElementAt(1));
-    //}
+        Assert.Equal("MyPlugin.Function1", choiceBehavior.Functions.ElementAt(0));
+        Assert.Equal("MyPlugin.Function2", choiceBehavior.Functions.ElementAt(1));
+    }
 
     [Fact]
     public void ItShouldThrowExceptionIfAutoInvocationRequestedButNoKernelIsProvided()
@@ -215,26 +215,26 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         Assert.Equal("The specified function MyPlugin.Function1 is not available in the kernel.", exception.Message);
     }
 
-    //[Fact]
-    //public void ItShouldThrowExceptionIfNoFunctionFoundAndManualInvocationIsRequested()
-    //{
-    //    // Arrange
-    //    var plugin = GetTestPlugin();
-    //    this._kernel.Plugins.Add(plugin);
+    [Fact]
+    public void ItShouldThrowExceptionIfNoFunctionFoundAndManualInvocationIsRequested()
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
 
-    //    var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: false)
-    //    {
-    //        Functions = ["MyPlugin.NonKernelFunction"]
-    //    };
+        var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: false)
+        {
+            Functions = ["MyPlugin.NonKernelFunction"]
+        };
 
-    //    // Act
-    //    var exception = Assert.Throws<KernelException>(() =>
-    //    {
-    //        choiceBehavior.GetConfiguration(new() { Kernel = this._kernel });
-    //    });
+        // Act
+        var exception = Assert.Throws<KernelException>(() =>
+        {
+            choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        });
 
-    //    Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
-    //}
+        Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
+    }
 
     [Fact]
     public void ItShouldReturnNoFunctionAsSpecifiedByFunctionsSelector()

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
@@ -29,7 +29,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior();
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -51,7 +51,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -75,7 +75,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
             Functions = ["MyPlugin.Function1", "MyPlugin.Function2"]
         };
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -95,7 +95,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior([plugin.ElementAt(0), plugin.ElementAt(1)], autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -116,7 +116,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -138,7 +138,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior();
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -155,7 +155,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: false);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config);
@@ -192,7 +192,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var exception = Assert.Throws<KernelException>(() =>
         {
-            choiceBehavior.GetConfiguration(new([]) { Kernel = null });
+            choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = null });
         });
 
         Assert.Equal("Auto-invocation is not supported when no kernel is provided.", exception.Message);
@@ -209,7 +209,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var exception = Assert.Throws<KernelException>(() =>
         {
-            choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+            choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
         });
 
         Assert.Equal("The specified function MyPlugin.Function1 is not available in the kernel.", exception.Message);
@@ -230,7 +230,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var exception = Assert.Throws<KernelException>(() =>
         {
-            choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+            choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
         });
 
         Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
@@ -251,7 +251,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config.Functions);
@@ -273,7 +273,7 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         // Act
         var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-        var config = choiceBehavior.GetConfiguration(new([]) { Kernel = this._kernel });
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
         // Assert
         Assert.NotNull(config?.Functions);

--- a/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/PromptTemplateConfigTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/PromptTemplate/PromptTemplateConfigTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
@@ -374,6 +375,108 @@ public class PromptTemplateConfigTests
         Assert.NotNull(promptTemplateConfig);
         Assert.NotNull(promptTemplateConfig.DefaultExecutionSettings);
         Assert.Equal("gpt-4", promptTemplateConfig.DefaultExecutionSettings?.ModelId);
+    }
+
+    [Fact]
+    public void DeserializingAutoFunctionCallingChoice()
+    {
+        // Arrange
+        string configPayload = """
+            {
+              "schema": 1,
+              "execution_settings": {
+                "default": {
+                  "model_id": "gpt-4",
+                  "function_choice_behavior": {
+                    "type": "auto",
+                    "functions":["p1.f1"]
+                  }
+                }
+              }
+            }
+            """;
+
+        // Act
+        var promptTemplateConfig = PromptTemplateConfig.FromJson(configPayload);
+
+        // Assert
+        Assert.NotNull(promptTemplateConfig);
+        Assert.Single(promptTemplateConfig.ExecutionSettings);
+
+        var executionSettings = promptTemplateConfig.ExecutionSettings.Single().Value;
+
+        var autoFunctionCallChoice = executionSettings.FunctionChoiceBehavior as AutoFunctionChoiceBehavior;
+        Assert.NotNull(autoFunctionCallChoice);
+
+        Assert.NotNull(autoFunctionCallChoice.Functions);
+        Assert.Equal("p1.f1", autoFunctionCallChoice.Functions.Single());
+    }
+
+    [Fact]
+    public void DeserializingRequiredFunctionCallingChoice()
+    {
+        // Arrange
+        string configPayload = """
+            {
+              "schema": 1,
+              "execution_settings": {
+                "default": {
+                  "model_id": "gpt-4",
+                  "function_choice_behavior": {
+                    "type": "required",
+                    "functions":["p1.f1"]
+                  }
+                }
+              }
+            }
+            """;
+
+        // Act
+        var promptTemplateConfig = PromptTemplateConfig.FromJson(configPayload);
+
+        // Assert
+        Assert.NotNull(promptTemplateConfig);
+        Assert.Single(promptTemplateConfig.ExecutionSettings);
+
+        var executionSettings = promptTemplateConfig.ExecutionSettings.Single().Value;
+        Assert.NotNull(executionSettings);
+
+        var requiredFunctionCallChoice = executionSettings.FunctionChoiceBehavior as RequiredFunctionChoiceBehavior;
+        Assert.NotNull(requiredFunctionCallChoice);
+
+        Assert.NotNull(requiredFunctionCallChoice.Functions);
+        Assert.Equal("p1.f1", requiredFunctionCallChoice.Functions.Single());
+    }
+
+    [Fact]
+    public void DeserializingNoneFunctionCallingChoice()
+    {
+        // Arrange
+        string configPayload = """
+            {
+              "schema": 1,
+              "execution_settings": {
+                "default": {
+                  "model_id": "gpt-4",
+                  "function_choice_behavior": {
+                    "type": "none"
+                  }
+                }
+              }
+            }
+            """;
+
+        // Act
+        var promptTemplateConfig = PromptTemplateConfig.FromJson(configPayload);
+
+        // Assert
+        Assert.NotNull(promptTemplateConfig);
+        Assert.Single(promptTemplateConfig.ExecutionSettings);
+
+        var executionSettings = promptTemplateConfig.ExecutionSettings.Single().Value;
+
+        var noneFunctionCallChoice = executionSettings.FunctionChoiceBehavior as NoneFunctionChoiceBehavior;
+        Assert.NotNull(noneFunctionCallChoice);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation and Context
The only way to configure function choice behavior at the moment is via the code. However, it would be good to configure the behavior in SK prompts as well. This PR adds support for function choice behavior in JSON prompts.

### Description
This PR extends all existing `auto`, `none`, and `required` function choice behavior classes to be JSON serialization-friendly so they can easily be deserialized during JSON prompt loading.

Support for YAML prompts will be added in the next PR.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
