### PR TITLE
.Net: OpenAI V2 Version Update and Adjustments

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -5,10 +5,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="OpenAI" Version="2.0.0-beta.8" />
+    <PackageVersion Include="OpenAI" Version="2.0.0-beta.10" />
     <PackageVersion Include="System.ClientModel" Version="1.1.0-beta.7" />
     <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.0.0-beta.2" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.0.0-beta.3" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.6.0" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -5,8 +5,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="OpenAI" Version="2.0.0-beta.5" />
-    <PackageVersion Include="System.ClientModel" Version="1.1.0-beta.4" />
+    <PackageVersion Include="OpenAI" Version="2.0.0-beta.8" />
+    <PackageVersion Include="System.ClientModel" Version="1.1.0-beta.7" />
     <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.0.0-beta.2" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />

--- a/dotnet/samples/GettingStartedWithAgents/Step11_AssistantTool_FileSearch.cs
+++ b/dotnet/samples/GettingStartedWithAgents/Step11_AssistantTool_FileSearch.cs
@@ -62,9 +62,9 @@ public class Step11_AssistantTool_FileSearch(ITestOutputHelper output) : BaseAge
         finally
         {
             await agent.DeleteThreadAsync(threadId);
-            await agent.DeleteAsync();
+            await agent.DeleteAsync(CancellationToken.None);
             await vectorStoreClient.DeleteVectorStoreAsync(vectorStore);
-            await fileClient.DeleteFileAsync(fileInfo);
+            await fileClient.DeleteFileAsync(fileInfo.Id);
         }
 
         // Local function to invoke agent and display the conversation messages.

--- a/dotnet/src/Agents/OpenAI/Extensions/KernelFunctionExtensions.cs
+++ b/dotnet/src/Agents/OpenAI/Extensions/KernelFunctionExtensions.cs
@@ -46,10 +46,17 @@ internal static class KernelFunctionExtensions
                     required,
                 };
 
-            return new FunctionToolDefinition(FunctionName.ToFullyQualifiedName(function.Name, pluginName), function.Description, BinaryData.FromObjectAsJson(spec));
+            return new FunctionToolDefinition(FunctionName.ToFullyQualifiedName(function.Name, pluginName))
+            {
+                Description = function.Description,
+                Parameters = BinaryData.FromObjectAsJson(spec)
+            };
         }
 
-        return new FunctionToolDefinition(FunctionName.ToFullyQualifiedName(function.Name, pluginName), function.Description);
+        return new FunctionToolDefinition(FunctionName.ToFullyQualifiedName(function.Name, pluginName))
+        {
+            Description = function.Description
+        };
     }
 
     private static string ConvertType(Type? type)

--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+using System.ClientModel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -52,7 +53,9 @@ internal static class AssistantThreadActions
         {
             foreach (ChatMessageContent message in options.Messages)
             {
-                ThreadInitializationMessage threadMessage = new(AssistantMessageFactory.GetMessageContents(message));
+                ThreadInitializationMessage threadMessage = new(
+                    role: message.Role == AuthorRole.User ? MessageRole.User : MessageRole.Assistant,
+                    content: AssistantMessageFactory.GetMessageContents(message));
                 createOptions.InitialMessages.Add(threadMessage);
             }
         }
@@ -89,6 +92,7 @@ internal static class AssistantThreadActions
 
         await client.CreateMessageAsync(
             threadId,
+            message.Role == AuthorRole.User ? MessageRole.User : MessageRole.Assistant,
             AssistantMessageFactory.GetMessageContents(message),
             options,
             cancellationToken).ConfigureAwait(false);
@@ -105,28 +109,31 @@ internal static class AssistantThreadActions
     {
         Dictionary<string, string?> agentNames = []; // Cache agent names by their identifier
 
-        await foreach (ThreadMessage message in client.GetMessagesAsync(threadId, ListOrder.NewestFirst, cancellationToken).ConfigureAwait(false))
+        await foreach (PageResult<ThreadMessage> page in client.GetMessagesAsync(threadId, new() { Order = ListOrder.NewestFirst }, cancellationToken).ConfigureAwait(false))
         {
-            AuthorRole role = new(message.Role.ToString());
-
-            string? assistantName = null;
-            if (!string.IsNullOrWhiteSpace(message.AssistantId) &&
-                !agentNames.TryGetValue(message.AssistantId, out assistantName))
+            foreach (var message in page.Values)
             {
-                Assistant assistant = await client.GetAssistantAsync(message.AssistantId).ConfigureAwait(false); // SDK BUG - CANCEL TOKEN (https://github.com/microsoft/semantic-kernel/issues/7431)
-                if (!string.IsNullOrWhiteSpace(assistant.Name))
+                AuthorRole role = new(message.Role.ToString());
+
+                string? assistantName = null;
+                if (!string.IsNullOrWhiteSpace(message.AssistantId) &&
+                    !agentNames.TryGetValue(message.AssistantId, out assistantName))
                 {
-                    agentNames.Add(assistant.Id, assistant.Name);
+                    Assistant assistant = await client.GetAssistantAsync(message.AssistantId, cancellationToken).ConfigureAwait(false); // SDK BUG - CANCEL TOKEN (https://github.com/microsoft/semantic-kernel/issues/7431)
+                    if (!string.IsNullOrWhiteSpace(assistant.Name))
+                    {
+                        agentNames.Add(assistant.Id, assistant.Name);
+                    }
                 }
-            }
 
-            assistantName ??= message.AssistantId;
+                assistantName ??= message.AssistantId;
 
-            ChatMessageContent content = GenerateMessageContent(assistantName, message);
+                ChatMessageContent content = GenerateMessageContent(assistantName, message);
 
-            if (content.Items.Count > 0)
-            {
-                yield return content;
+                if (content.Items.Count > 0)
+                {
+                    yield return content;
+                }
             }
         }
     }
@@ -190,7 +197,11 @@ internal static class AssistantThreadActions
                 throw new KernelException($"Agent Failure - Run terminated: {run.Status} [{run.Id}]: {run.LastError?.Message ?? "Unknown"}");
             }
 
-            RunStep[] steps = await client.GetRunStepsAsync(run).ToArrayAsync(cancellationToken).ConfigureAwait(false);
+            List<RunStep> steps = [];
+            await foreach (var page in client.GetRunStepsAsync(run).ConfigureAwait(false))
+            {
+                steps.AddRange(page.Values);
+            };
 
             // Is tool action required?
             if (run.Status == RunStatus.RequiresAction)

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -108,9 +108,12 @@ public sealed class OpenAIAssistantAgent : KernelAgent
         AssistantClient client = CreateClient(provider);
 
         // Query and enumerate assistant definitions
-        await foreach (Assistant model in client.GetAssistantsAsync(ListOrder.NewestFirst, cancellationToken).ConfigureAwait(false))
+        await foreach (var page in client.GetAssistantsAsync(new AssistantCollectionOptions() { Order = ListOrder.NewestFirst }, cancellationToken).ConfigureAwait(false))
         {
-            yield return CreateAssistantDefinition(model);
+            foreach (Assistant model in page.Values)
+            {
+                yield return CreateAssistantDefinition(model);
+            }
         }
     }
 
@@ -132,7 +135,7 @@ public sealed class OpenAIAssistantAgent : KernelAgent
         AssistantClient client = CreateClient(provider);
 
         // Retrieve the assistant
-        Assistant model = await client.GetAssistantAsync(id).ConfigureAwait(false); // SDK BUG - CANCEL TOKEN (https://github.com/microsoft/semantic-kernel/issues/7431)
+        Assistant model = await client.GetAssistantAsync(id, cancellationToken).ConfigureAwait(false);
 
         // Instantiate the agent
         return

--- a/dotnet/src/Agents/OpenAI/OpenAIClientProvider.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIClientProvider.cs
@@ -50,7 +50,7 @@ public sealed class OpenAIClientProvider
         Verify.NotNull(apiKey, nameof(apiKey));
         Verify.NotNull(endpoint, nameof(endpoint));
 
-        AzureOpenAIClientOptions clientOptions = CreateAzureClientOptions(endpoint, httpClient);
+        AzureOpenAIClientOptions clientOptions = CreateAzureClientOptions(httpClient);
 
         return new(new AzureOpenAIClient(endpoint, apiKey!, clientOptions), CreateConfigurationKeys(endpoint, httpClient));
     }
@@ -66,7 +66,7 @@ public sealed class OpenAIClientProvider
         Verify.NotNull(credential, nameof(credential));
         Verify.NotNull(endpoint, nameof(endpoint));
 
-        AzureOpenAIClientOptions clientOptions = CreateAzureClientOptions(endpoint, httpClient);
+        AzureOpenAIClientOptions clientOptions = CreateAzureClientOptions(httpClient);
 
         return new(new AzureOpenAIClient(endpoint, credential, clientOptions), CreateConfigurationKeys(endpoint, httpClient));
     }
@@ -102,12 +102,11 @@ public sealed class OpenAIClientProvider
         return new(client, [client.GetType().FullName!, client.GetHashCode().ToString()]);
     }
 
-    private static AzureOpenAIClientOptions CreateAzureClientOptions(Uri? endpoint, HttpClient? httpClient)
+    private static AzureOpenAIClientOptions CreateAzureClientOptions(HttpClient? httpClient)
     {
         AzureOpenAIClientOptions options = new()
         {
-            ApplicationId = HttpHeaderConstant.Values.UserAgent,
-            Endpoint = endpoint,
+            ApplicationId = HttpHeaderConstant.Values.UserAgent
         };
 
         ConfigureClientOptions(httpClient, options);
@@ -128,7 +127,7 @@ public sealed class OpenAIClientProvider
         return options;
     }
 
-    private static void ConfigureClientOptions(HttpClient? httpClient, OpenAIClientOptions options)
+    private static void ConfigureClientOptions(HttpClient? httpClient, ClientPipelineOptions options)
     {
         options.AddPolicy(CreateRequestHeaderPolicy(HttpHeaderConstant.Names.SemanticKernelVersion, HttpHeaderConstant.Values.GetAssemblyVersion(typeof(OpenAIAssistantAgent))), PipelinePosition.PerCall);
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
@@ -35,10 +35,10 @@ internal partial class AzureClientCore
         {
             { nameof(completions.Id), completions.Id },
             { nameof(completions.CreatedAt), completions.CreatedAt },
-            { ContentFilterResultForPromptKey, completions.GetContentFilterResultForPrompt() },
+            // { ContentFilterResultForPromptKey, completions.GetContentFilterResultForPrompt() },
             { nameof(completions.SystemFingerprint), completions.SystemFingerprint },
             { nameof(completions.Usage), completions.Usage },
-            { ContentFilterResultForResponseKey, completions.GetContentFilterResultForResponse() },
+            // { ContentFilterResultForResponseKey, completions.GetContentFilterResultForResponse() },
 
             // Serialization of this struct behaves as an empty object {}, need to cast to string to avoid it.
             { nameof(completions.FinishReason), completions.FinishReason.ToString() },

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -76,13 +76,10 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     }
 
     [Theory]
-    [InlineData("http://localhost:1234/chat/completions", "http://localhost:1234/chat/completions")] // Uses full path when provided
-    [InlineData("http://localhost:1234/v2/chat/completions", "http://localhost:1234/v2/chat/completions")] // Uses full path when provided
-    [InlineData("http://localhost:1234", "http://localhost:1234/v1/chat/completions")]
+    [InlineData("http://localhost:1234/v1/chat/completions", "http://localhost:1234/v1/chat/completions")] // Uses full path when provided
+    [InlineData("http://localhost:1234/", "http://localhost:1234/v1/chat/completions")]
     [InlineData("http://localhost:8080", "http://localhost:8080/v1/chat/completions")]
     [InlineData("https://something:8080", "https://something:8080/v1/chat/completions")] // Accepts TLS Secured endpoints
-    [InlineData("http://localhost:1234/v2", "http://localhost:1234/v2/chat/completions")]
-    [InlineData("http://localhost:8080/v2", "http://localhost:8080/v2/chat/completions")]
     public async Task ItUsesCustomEndpointsWhenProvidedDirectlyAsync(string endpointProvided, string expectedEndpoint)
     {
         // Arrange
@@ -98,13 +95,10 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     }
 
     [Theory]
-    [InlineData("http://localhost:1234/chat/completions", "http://localhost:1234/chat/completions")] // Uses full path when provided
-    [InlineData("http://localhost:1234/v2/chat/completions", "http://localhost:1234/v2/chat/completions")] // Uses full path when provided
-    [InlineData("http://localhost:1234", "http://localhost:1234/v1/chat/completions")]
+    [InlineData("http://localhost:1234/v1/chat/completions", "http://localhost:1234/v1/chat/completions")] // Uses full path when provided
+    [InlineData("http://localhost:1234/", "http://localhost:1234/v1/chat/completions")]
     [InlineData("http://localhost:8080", "http://localhost:8080/v1/chat/completions")]
     [InlineData("https://something:8080", "https://something:8080/v1/chat/completions")] // Accepts TLS Secured endpoints
-    [InlineData("http://localhost:1234/v2", "http://localhost:1234/v2/chat/completions")]
-    [InlineData("http://localhost:8080/v2", "http://localhost:8080/v2/chat/completions")]
     public async Task ItUsesCustomEndpointsWhenProvidedAsBaseAddressAsync(string endpointProvided, string expectedEndpoint)
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -644,7 +644,7 @@ internal partial class ClientCore
             FrequencyPenalty = (float?)executionSettings.FrequencyPenalty,
             PresencePenalty = (float?)executionSettings.PresencePenalty,
             Seed = executionSettings.Seed,
-            User = executionSettings.User,
+            EndUserId = executionSettings.User,
             TopLogProbabilityCount = executionSettings.TopLogprobs,
             IncludeLogProbabilities = executionSettings.Logprobs,
             ResponseFormat = GetResponseFormat(executionSettings) ?? ChatResponseFormat.Text,

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -364,7 +364,7 @@ internal partial class ClientCore
             using (var activity = this.StartCompletionActivity(chat, chatExecutionSettings))
             {
                 // Make the request.
-                AsyncResultCollection<StreamingChatCompletionUpdate> response;
+                AsyncCollectionResult<StreamingChatCompletionUpdate> response;
                 try
                 {
                     response = RunRequest(() => this.Client!.GetChatClient(targetModel).CompleteChatStreamingAsync(chatForRequest, chatOptions, cancellationToken));

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.TextToAudio.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.TextToAudio.cs
@@ -40,7 +40,7 @@ internal partial class ClientCore
             Speed = audioExecutionSettings.Speed,
         };
 
-        ClientResult<BinaryData> response = await RunRequestAsync(() => this.Client!.GetAudioClient(targetModel).GenerateSpeechFromTextAsync(prompt, GetGeneratedSpeechVoice(audioExecutionSettings?.Voice), options, cancellationToken)).ConfigureAwait(false);
+        ClientResult<BinaryData> response = await RunRequestAsync(() => this.Client!.GetAudioClient(targetModel).GenerateSpeechAsync(prompt, GetGeneratedSpeechVoice(audioExecutionSettings?.Voice), options, cancellationToken)).ConfigureAwait(false);
 
         return [new AudioContent(response.Value.ToArray(), mimeType)];
     }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
@@ -36,7 +36,7 @@ internal partial class ClientCore
     /// <summary>
     /// Default OpenAI API endpoint.
     /// </summary>
-    private const string OpenAIV1Endpoint = "https://api.openai.com/v1";
+    private const string OpenAIV1Endpoint = "https://api.openai.com/";
 
     /// <summary>
     /// Identifier of the default model to use

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIChatCompletionService.cs
@@ -71,25 +71,17 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
         var providedEndpoint = endpoint ?? httpClient?.BaseAddress;
         if (providedEndpoint is not null)
         {
-            // If the provided endpoint does not provide a path, we add a version to the base path for compatibility
-            if (providedEndpoint.PathAndQuery.Length == 0 || providedEndpoint.PathAndQuery == "/")
+            // As OpenAI Client automatically adds the chatcompletions endpoint, we remove it to avoid duplication.
+            const string PathAndQueryPattern = "v1/chat/completions";
+            var providedEndpointText = providedEndpoint.ToString();
+            int index = providedEndpointText.IndexOf(PathAndQueryPattern, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0)
             {
-                internalClientEndpoint = new Uri(providedEndpoint, "/v1/");
+                internalClientEndpoint = new Uri($"{providedEndpointText.Substring(0, index)}{providedEndpointText.Substring(index + PathAndQueryPattern.Length)}");
             }
             else
             {
-                // As OpenAI Client automatically adds the chatcompletions endpoint, we remove it to avoid duplication.
-                const string PathAndQueryPattern = "/chat/completions";
-                var providedEndpointText = providedEndpoint.ToString();
-                int index = providedEndpointText.IndexOf(PathAndQueryPattern, StringComparison.OrdinalIgnoreCase);
-                if (index >= 0)
-                {
-                    internalClientEndpoint = new Uri($"{providedEndpointText.Substring(0, index)}{providedEndpointText.Substring(index + PathAndQueryPattern.Length)}");
-                }
-                else
-                {
-                    internalClientEndpoint = providedEndpoint;
-                }
+                internalClientEndpoint = providedEndpoint;
             }
         }
 

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIChatCompletionService.cs
@@ -71,7 +71,7 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
         var providedEndpoint = endpoint ?? httpClient?.BaseAddress;
         if (providedEndpoint is not null)
         {
-            // As OpenAI Client automatically adds the chatcompletions endpoint, we remove it to avoid duplication.
+            // As OpenAI Client automatically adds the chat completions endpoint, we remove it to avoid duplication.
             const string PathAndQueryPattern = "v1/chat/completions";
             var providedEndpointText = providedEndpoint.ToString();
             int index = providedEndpointText.IndexOf(PathAndQueryPattern, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
### Motivation and Context

- Update Azure SDK to `beta.3`
- Update OpenAI SDK to `beta.10`
- Make Azure OpenAI Package Resilient for mismatching OpenAI SDK versions
- Adapt to latest breaking changes from `OpenAI beta.6` +
- Adapt to latest breaking changes from `System.ClientModel beta.5` +

### Impact

Some changes introduced by `OpenAI SDK beta.9` cannot be recovered for custom Endpoints, enforcing all endpoints to have `v1/` prefix, removal of non `v1` test scenarios was necessary.