### PR TITLE
.Net: Options support for function choice behaviors

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 internal partial class ClientCore
 {
     protected const string ModelProvider = "openai";
-    protected record ToolCallingConfig(IList<ChatTool>? Tools, ChatToolChoice Choice, bool AutoInvoke, bool AllowAnyRequestedKernelFunction, FunctionChoiceBehaviorOptions Options);
+    protected record ToolCallingConfig(IList<ChatTool>? Tools, ChatToolChoice Choice, bool AutoInvoke, bool AllowAnyRequestedKernelFunction, FunctionChoiceBehaviorOptions? Options);
 
     /// <summary>
     /// The maximum number of auto-invokes that can be in-flight at any given time as part of the current
@@ -1155,7 +1155,7 @@ internal partial class ClientCore
         bool autoInvoke = false;
         bool allowAnyRequestedKernelFunction = false;
         int maximumAutoInvokeAttempts = 0;
-        FunctionChoiceBehaviorOptions options = new();
+        FunctionChoiceBehaviorOptions? options = null;
 
         // Handling new tool behavior represented by `PromptExecutionSettings.FunctionChoiceBehavior` property.
         if (executionSettings.FunctionChoiceBehavior is { } functionChoiceBehavior)
@@ -1186,7 +1186,7 @@ internal partial class ClientCore
             Options: options);
     }
 
-    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int maximumAutoInvokeAttempts, bool AllowAnyRequestedKernelFunction) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, ToolCallBehavior toolCallBehavior)
+    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int MaximumAutoInvokeAttempts, bool AllowAnyRequestedKernelFunction) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, ToolCallBehavior toolCallBehavior)
     {
         IList<ChatTool>? tools = null;
         ChatToolChoice? choice = null;
@@ -1210,7 +1210,7 @@ internal partial class ClientCore
         return new(tools, choice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction);
     }
 
-    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int MaximumAutoInvokeAttemptsm, FunctionChoiceBehaviorOptions Options) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, FunctionChoiceBehavior functionChoiceBehavior, ChatHistory chatHistory)
+    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int MaximumAutoInvokeAttempts, FunctionChoiceBehaviorOptions Options) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, FunctionChoiceBehavior functionChoiceBehavior, ChatHistory chatHistory)
     {
         FunctionChoiceBehaviorConfiguration config = functionChoiceBehavior.GetConfiguration(new(chatHistory) { Kernel = kernel, RequestSequenceIndex = requestIndex });
 

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 internal partial class ClientCore
 {
     protected const string ModelProvider = "openai";
-    protected record ToolCallingConfig(IList<ChatTool>? Tools, ChatToolChoice Choice, bool AutoInvoke, bool AllowAnyRequestedKernelFunction);
+    protected record ToolCallingConfig(IList<ChatTool>? Tools, ChatToolChoice Choice, bool AutoInvoke, bool AllowAnyRequestedKernelFunction, FunctionChoiceBehaviorOptions Options);
 
     /// <summary>
     /// The maximum number of auto-invokes that can be in-flight at any given time as part of the current
@@ -1155,11 +1155,12 @@ internal partial class ClientCore
         bool autoInvoke = false;
         bool allowAnyRequestedKernelFunction = false;
         int maximumAutoInvokeAttempts = 0;
+        FunctionChoiceBehaviorOptions options = new();
 
         // Handling new tool behavior represented by `PromptExecutionSettings.FunctionChoiceBehavior` property.
         if (executionSettings.FunctionChoiceBehavior is { } functionChoiceBehavior)
         {
-            (tools, choice, autoInvoke, maximumAutoInvokeAttempts) = this.ConfigureFunctionCalling(kernel, requestIndex, functionChoiceBehavior, chatHistory);
+            (tools, choice, autoInvoke, maximumAutoInvokeAttempts, options) = this.ConfigureFunctionCalling(kernel, requestIndex, functionChoiceBehavior, chatHistory);
         }
         // Handling old-style tool call behavior represented by `OpenAIPromptExecutionSettings.ToolCallBehavior` property.
         else if (executionSettings.ToolCallBehavior is { } toolCallBehavior)
@@ -1181,7 +1182,8 @@ internal partial class ClientCore
             Tools: tools ?? [s_nonInvocableFunctionTool],
             Choice: choice ?? ChatToolChoice.None,
             AutoInvoke: autoInvoke && s_inflightAutoInvokes.Value < MaxInflightAutoInvokes,
-            AllowAnyRequestedKernelFunction: allowAnyRequestedKernelFunction);
+            AllowAnyRequestedKernelFunction: allowAnyRequestedKernelFunction,
+            Options: options);
     }
 
     private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int maximumAutoInvokeAttempts, bool AllowAnyRequestedKernelFunction) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, ToolCallBehavior toolCallBehavior)
@@ -1208,7 +1210,7 @@ internal partial class ClientCore
         return new(tools, choice, autoInvoke, maximumAutoInvokeAttempts, allowAnyRequestedKernelFunction);
     }
 
-    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int maximumAutoInvokeAttempts) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, FunctionChoiceBehavior functionChoiceBehavior, ChatHistory chatHistory)
+    private (IList<ChatTool>? Tools, ChatToolChoice? Choice, bool AutoInvoke, int MaximumAutoInvokeAttemptsm, FunctionChoiceBehaviorOptions Options) ConfigureFunctionCalling(Kernel? kernel, int requestIndex, FunctionChoiceBehavior functionChoiceBehavior, ChatHistory chatHistory)
     {
         FunctionChoiceBehaviorConfiguration config = functionChoiceBehavior.GetConfiguration(new(chatHistory) { Kernel = kernel, RequestSequenceIndex = requestIndex });
 
@@ -1244,6 +1246,6 @@ internal partial class ClientCore
             }
         }
 
-        return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts);
+        return new(tools, toolChoice, autoInvoke, maximumAutoInvokeAttempts, config.Options);
     }
 }

--- a/dotnet/src/IntegrationTests/Agents/ChatCompletionAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/ChatCompletionAgentTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.ChatCompletion;
-using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using SemanticKernel.IntegrationTests.TestSettings;
 using Xunit;

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehavior.cs
@@ -35,10 +35,12 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     /// <param name="autoInvoke">
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </param>
-    public AutoFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true) : base(functions)
+    /// <param name="options">The behavior options.</param>
+    public AutoFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, FunctionChoiceBehaviorOptions? options = null) : base(functions)
     {
         this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
         this._autoInvoke = autoInvoke;
+        this.Options = options;
     }
 
     /// <summary>
@@ -49,12 +51,18 @@ internal sealed class AutoFunctionChoiceBehavior : FunctionChoiceBehavior
     [JsonPropertyName("functions")]
     public IList<string>? Functions { get; set; }
 
+    /// <summary>
+    /// The behavior options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public FunctionChoiceBehaviorOptions? Options { get; set; }
+
     /// <inheritdoc />
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
         var functions = base.GetFunctions(this.Functions, context.Kernel, this._autoInvoke);
 
-        return new FunctionChoiceBehaviorConfiguration()
+        return new FunctionChoiceBehaviorConfiguration(this.Options ?? DefaultOptions)
         {
             Choice = FunctionChoice.Auto,
             Functions = functions,

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -22,6 +22,9 @@ public abstract class FunctionChoiceBehavior
     /// <summary>The separator used to separate plugin name and function name.</summary>
     protected const string FunctionNameSeparator = ".";
 
+    /// <summary>The behavior default options.</summary>
+    protected static readonly FunctionChoiceBehaviorOptions DefaultOptions = new();
+
     /// <summary>
     /// List of the functions to provide to AI model.
     /// </summary>
@@ -57,10 +60,11 @@ public abstract class FunctionChoiceBehavior
     /// <param name="autoInvoke">
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </param>
+    /// <param name="options">The behavior options.</param>
     /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
-    public static FunctionChoiceBehavior Auto(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true)
+    public static FunctionChoiceBehavior Auto(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, FunctionChoiceBehaviorOptions? options = null)
     {
-        return new AutoFunctionChoiceBehavior(functions, autoInvoke);
+        return new AutoFunctionChoiceBehavior(functions, autoInvoke, options);
     }
 
     /// <summary>
@@ -82,10 +86,14 @@ public abstract class FunctionChoiceBehavior
     /// the model will keep calling the 'Add' function even if the sum - 5 - is already calculated, until the 'Add' function is no longer provided to the model.
     /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
     /// </param>
+    /// <param name="options">The behavior options.</param>
     /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
-    public static FunctionChoiceBehavior Required(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null)
+    public static FunctionChoiceBehavior Required(
+        IEnumerable<KernelFunction>? functions = null,
+        bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null,
+        FunctionChoiceBehaviorOptions? options = null)
     {
-        return new RequiredFunctionChoiceBehavior(functions, autoInvoke, functionsSelector);
+        return new RequiredFunctionChoiceBehavior(functions, autoInvoke, functionsSelector, options);
     }
 
     /// <summary>
@@ -97,10 +105,11 @@ public abstract class FunctionChoiceBehavior
     /// Functions to provide to the model. If null, all of the <see cref="Kernel"/>'s plugins' functions are provided to the model.
     /// If empty, no functions are provided to the model.
     /// </param>
+    /// <param name="options">The behavior options.</param>
     /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
-    public static FunctionChoiceBehavior None(IEnumerable<KernelFunction>? functions = null)
+    public static FunctionChoiceBehavior None(IEnumerable<KernelFunction>? functions = null, FunctionChoiceBehaviorOptions? options = null)
     {
-        return new NoneFunctionChoiceBehavior(functions);
+        return new NoneFunctionChoiceBehavior(functions, options);
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
@@ -12,6 +12,15 @@ namespace Microsoft.SemanticKernel;
 public sealed class FunctionChoiceBehaviorConfiguration
 {
     /// <summary>
+    /// Creates a new instance of the <see cref="FunctionChoiceBehaviorConfiguration"/> class.
+    /// <param name="options">The options for the behavior.</param>"
+    /// </summary>
+    internal FunctionChoiceBehaviorConfiguration(FunctionChoiceBehaviorOptions options)
+    {
+        this.Options = options;
+    }
+
+    /// <summary>
     /// Represents an AI model's decision-making strategy for calling functions.
     /// </summary>
     public FunctionChoice Choice { get; internal init; }
@@ -25,4 +34,9 @@ public sealed class FunctionChoiceBehaviorConfiguration
     /// Indicates whether the functions should be automatically invoked by the AI connector.
     /// </summary>
     public bool AutoInvoke { get; internal init; } = true;
+
+    /// <summary>
+    /// The behavior options.
+    /// </summary>
+    public FunctionChoiceBehaviorOptions Options { get; }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
@@ -13,7 +13,7 @@ public sealed class FunctionChoiceBehaviorConfiguration
 {
     /// <summary>
     /// Creates a new instance of the <see cref="FunctionChoiceBehaviorConfiguration"/> class.
-    /// <param name="options">The options for the behavior.</param>"
+    /// <param name="options">The behavior options.</param>
     /// </summary>
     internal FunctionChoiceBehaviorConfiguration(FunctionChoiceBehaviorOptions options)
     {

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
 /// Represents the options for a function choice behavior.
 /// </summary>
+[Experimental("SKEXP0001")]
 public sealed class FunctionChoiceBehaviorOptions
 {
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Represents the options for a function choice behavior.
+/// </summary>
+public sealed class FunctionChoiceBehaviorOptions
+{
+}

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehavior.cs
@@ -28,9 +28,11 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
     /// Functions to provide to AI model. If null, all <see cref="Kernel"/>'s plugins' functions are provided to the model.
     /// If empty, no functions are provided to the model.
     /// </param>
-    public NoneFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null) : base(functions)
+    /// <param name="options">The behavior options.</param>
+    public NoneFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, FunctionChoiceBehaviorOptions? options = null) : base(functions)
     {
         this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
+        this.Options = options;
     }
 
     /// <summary>
@@ -41,12 +43,18 @@ internal sealed class NoneFunctionChoiceBehavior : FunctionChoiceBehavior
     [JsonPropertyName("functions")]
     public IList<string>? Functions { get; set; }
 
+    /// <summary>
+    /// The behavior options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public FunctionChoiceBehaviorOptions? Options { get; set; }
+
     /// <inheritdoc />
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
         var functions = base.GetFunctions(this.Functions, context.Kernel, autoInvoke: false);
 
-        return new FunctionChoiceBehaviorConfiguration()
+        return new FunctionChoiceBehaviorConfiguration(this.Options ?? DefaultOptions)
         {
             Choice = FunctionChoice.None,
             Functions = functions,

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -49,11 +49,17 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
     /// the model will keep calling the 'Add' function even if the sum - 5 - is already calculated, until the 'Add' function is no longer provided to the model.
     /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
     /// </param>
-    public RequiredFunctionChoiceBehavior(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null) : base(functions)
+    /// <param name="options">The behavior options.</param>
+    public RequiredFunctionChoiceBehavior(
+        IEnumerable<KernelFunction>? functions = null,
+        bool autoInvoke = true,
+        Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null,
+        FunctionChoiceBehaviorOptions? options = null) : base(functions)
     {
         this.Functions = functions?.Select(f => FunctionName.ToFullyQualifiedName(f.Name, f.PluginName, FunctionNameSeparator)).ToList();
         this._autoInvoke = autoInvoke;
         this._functionsSelector = functionsSelector;
+        this.Options = options;
     }
 
     /// <summary>
@@ -63,6 +69,12 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
     /// </summary>
     [JsonPropertyName("functions")]
     public IList<string>? Functions { get; set; }
+
+    /// <summary>
+    /// The behavior options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public FunctionChoiceBehaviorOptions? Options { get; set; }
 
     /// <inheritdoc />
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
@@ -81,7 +93,7 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
             });
         }
 
-        return new FunctionChoiceBehaviorConfiguration()
+        return new FunctionChoiceBehaviorConfiguration(this.Options ?? DefaultOptions)
         {
             Choice = FunctionChoice.Required,
             Functions = selectedFunctions ?? functions,

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -73,15 +73,15 @@ public class PromptExecutionSettings
     /// <item>To disable function calling, and have the model only generate a user-facing message, set the property to null (the default).</item>
     /// <item>
     /// To allow the model to decide whether to call the functions and, if so, which ones to call, set the property to an instance returned
-    /// by the <see cref="FunctionChoiceBehavior.Auto(IEnumerable{KernelFunction}?, bool)"/> method.
+    /// by the <see cref="FunctionChoiceBehavior.Auto(IEnumerable{KernelFunction}?, bool, FunctionChoiceBehaviorOptions?)"/> method.
     /// </item>
     /// <item>
     /// To force the model to always call one or more functions set the property to an instance returned
-    /// by the <see cref="FunctionChoiceBehavior.Required(IEnumerable{KernelFunction}?, bool, Func{FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList{KernelFunction}?}?)"/> method.
+    /// by the <see cref="FunctionChoiceBehavior.Required(IEnumerable{KernelFunction}?, bool, Func{FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList{KernelFunction}?}?, FunctionChoiceBehaviorOptions?)"/> method.
     /// </item>
     /// <item>
     /// To instruct the model to not call any functions and only generate a user-facing message, set the property to an instance returned
-    /// by the <see cref="FunctionChoiceBehavior.None(IEnumerable{KernelFunction}?)"/> method.
+    /// by the <see cref="FunctionChoiceBehavior.None(IEnumerable{KernelFunction}?, FunctionChoiceBehaviorOptions?)"/> method.
     /// </item>
     /// </list>
     /// For all the behaviors that presume the model to call functions, auto-invoke can be specified. If LLM

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/AutoFunctionChoiceBehaviorTests.cs
@@ -235,6 +235,33 @@ public sealed class AutoFunctionChoiceBehaviorTests
         Assert.Equal("The specified function MyPlugin.NonKernelFunction was not found.", exception.Message);
     }
 
+    [Fact]
+    public void ItShouldPropagateOptionsToConfiguration()
+    {
+        // Arrange
+        var options = new FunctionChoiceBehaviorOptions();
+
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false, options: options);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.Same(options, configuration.Options);
+    }
+
+    [Fact]
+    public void ItShouldUseDefaultOptionsIfNoneAreProvided()
+    {
+        // Act
+        var choiceBehavior = new AutoFunctionChoiceBehavior(autoInvoke: false);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.NotNull(configuration.Options);
+    }
+
     private static KernelPlugin GetTestPlugin()
     {
         var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
@@ -290,6 +290,51 @@ public sealed class FunctionChoiceBehaviorTests
         Assert.Contains(config.Functions, f => f.Name == "Function3");
     }
 
+    [Fact]
+    public void FunctionChoiceBehaviorShouldPassOptionsToAutoFunctionChoiceBehaviorClass()
+    {
+        // Arrange
+        var options = new FunctionChoiceBehaviorOptions();
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false, options: options);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.Same(options, configuration.Options);
+    }
+
+    [Fact]
+    public void FunctionChoiceBehaviorShouldPassOptionsToRequiredFunctionChoiceBehaviorClass()
+    {
+        // Arrange
+        var options = new FunctionChoiceBehaviorOptions();
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: false, options: options);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.Same(options, configuration.Options);
+    }
+
+    [Fact]
+    public void FunctionChoiceBehaviorShouldPassOptionsToNoneFunctionChoiceBehaviorClass()
+    {
+        // Arrange
+        var options = new FunctionChoiceBehaviorOptions();
+
+        // Act
+        var choiceBehavior = FunctionChoiceBehavior.None(options: options);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.Same(options, configuration.Options);
+    }
+
     private static KernelPlugin GetTestPlugin()
     {
         var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/NoneFunctionChoiceBehaviorTests.cs
@@ -74,6 +74,33 @@ public sealed class NoneFunctionChoiceBehaviorTests
         Assert.False(config.AutoInvoke);
     }
 
+    [Fact]
+    public void ItShouldPropagateOptionsToConfiguration()
+    {
+        // Arrange
+        var options = new FunctionChoiceBehaviorOptions();
+
+        // Act
+        var choiceBehavior = new NoneFunctionChoiceBehavior(options: options);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.Same(options, configuration.Options);
+    }
+
+    [Fact]
+    public void ItShouldPropagateDefaultOptionsIfNoneAreProvided()
+    {
+        // Arrange & Act
+        var choiceBehavior = new NoneFunctionChoiceBehavior(options: null);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.NotNull(configuration.Options);
+    }
+
     private static KernelPlugin GetTestPlugin()
     {
         var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
@@ -281,6 +281,33 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         Assert.Equal("Function1", config.Functions[0].Name);
     }
 
+    [Fact]
+    public void ItShouldPropagateOptionsToConfiguration()
+    {
+        // Arrange
+        var options = new FunctionChoiceBehaviorOptions();
+
+        // Act
+        var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: false, options: options);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.Same(options, configuration.Options);
+    }
+
+    [Fact]
+    public void ItShouldPropagateDefaultOptionsIfNoneAreProvided()
+    {
+        // Arrange & Act
+        var choiceBehavior = new RequiredFunctionChoiceBehavior(autoInvoke: false, options: null);
+
+        // Assert
+        var configuration = choiceBehavior.GetConfiguration(new FunctionChoiceBehaviorConfigurationContext(chatHistory: []));
+
+        Assert.NotNull(configuration.Options);
+    }
+
     private static KernelPlugin GetTestPlugin()
     {
         var function1 = KernelFunctionFactory.CreateFromMethod(() => { }, "Function1");


### PR DESCRIPTION
### Motivation and Context
The new function choice behavior model should be extensible enough to support new function-calling-related options that AI models will add later and that SK consumers might want to configure. Moreover, there could be cases when certain AI models have specific function-calling-related options that are not relevant to any other models and thus cannot be abstracted. This PR adds functionality to achieve both goals.

### Description
This PR adds the `FunctionChoiceBehaviorOptions` class, which will later be extended with options such as [parallel function calling](https://platform.openai.com/docs/guides/function-calling/configuring-parallel-function-calling) that might not be relevant to the majority of AI models yet but eventually will be. AI-specific model options will be modeled as derivatives of the `FunctionChoiceBehaviorOptions` class, and the specific connectors can downcast options represented by the `FunctionChoiceBehaviorOptions` base class to specific ones to access the options.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
