### PR TITLE
.Net: AI function calls processor

### DIFF
--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -96,6 +96,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5C246969-D
 		src\InternalUtilities\test\TestInternalUtilities.props = src\InternalUtilities\test\TestInternalUtilities.props
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "connectors", "connectors", "{314A2705-0F70-44B6-8988-C6DF77BDFD42}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ai", "ai", "{C7299F56-3A55-471E-B10E-B1FBE101C625}"
+	ProjectSection(SolutionItems) = preProject
+		src\InternalUtilities\connectors\AI\FunctionCallsProcessor.cs = src\InternalUtilities\connectors\AI\FunctionCallsProcessor.cs
+		src\InternalUtilities\connectors\AI\AiConnectorsInternalUtilities.props = src\InternalUtilities\connectors\AI\AiConnectorsInternalUtilities.props
+	EndProjectSection
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{958AD708-F048-4FAF-94ED-D2F2B92748B9}"
 	ProjectSection(SolutionItems) = preProject
 		src\InternalUtilities\src\InternalUtilities.props = src\InternalUtilities\src\InternalUtilities.props
@@ -879,6 +887,8 @@ Global
 		{6AAB0620-33A1-4A98-A63B-6560B9BA47A4} = {24503383-A8C4-4255-9998-28D70FE8E99A}
 		{50FAE231-6F24-4779-9D02-12ABBC9A49E2} = {24503383-A8C4-4255-9998-28D70FE8E99A}
 		{5C246969-D794-4EC3-8E8F-F90D4D166420} = {4D3DAE63-41C6-4E1C-A35A-E77BDFC40675}
+		{314A2705-0F70-44B6-8988-C6DF77BDFD42} = {4D3DAE63-41C6-4E1C-A35A-E77BDFC40675}
+		{C7299F56-3A55-471E-B10E-B1FBE101C625} = {314A2705-0F70-44B6-8988-C6DF77BDFD42}
 		{958AD708-F048-4FAF-94ED-D2F2B92748B9} = {4D3DAE63-41C6-4E1C-A35A-E77BDFC40675}
 		{29E7D971-1308-4171-9872-E8E4669A1134} = {958AD708-F048-4FAF-94ED-D2F2B92748B9}
 		{B00AD427-0047-4850-BEF9-BA8237EA9D8B} = {958AD708-F048-4FAF-94ED-D2F2B92748B9}

--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -98,7 +98,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5C246969-D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "connectors", "connectors", "{314A2705-0F70-44B6-8988-C6DF77BDFD42}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ai", "ai", "{C7299F56-3A55-471E-B10E-B1FBE101C625}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AI", "AI", "{C7299F56-3A55-471E-B10E-B1FBE101C625}"
 	ProjectSection(SolutionItems) = preProject
 		src\InternalUtilities\connectors\AI\FunctionCallsProcessor.cs = src\InternalUtilities\connectors\AI\FunctionCallsProcessor.cs
 		src\InternalUtilities\connectors\AI\AiConnectorsInternalUtilities.props = src\InternalUtilities\connectors\AI\AiConnectorsInternalUtilities.props

--- a/dotnet/src/InternalUtilities/connectors/AI/AiConnectorsInternalUtilities.props
+++ b/dotnet/src/InternalUtilities/connectors/AI/AiConnectorsInternalUtilities.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/ai/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
@@ -149,7 +148,8 @@ internal sealed class FunctionCallsProcessor
             foreach (var call in functionCalls)
             {
                 var argumentsString = call.Arguments is not null ? $"({string.Join(",", call.Arguments.Select(a => $"{a.Key}={a.Value}"))})" : "()";
-                messages.Add($"{call.FunctionName}{argumentsString}");
+                var pluginName = string.IsNullOrEmpty(call.PluginName) ? string.Empty : $"{call.PluginName}-";
+                messages.Add($"{pluginName}{call.FunctionName}{argumentsString}");
             }
             this._logger.LogTrace("Function calls: {Calls}", string.Join(", ", messages));
         }
@@ -260,7 +260,6 @@ internal sealed class FunctionCallsProcessor
         // Log any error
         if (errorMessage is not null && this._logger.IsEnabled(LogLevel.Debug))
         {
-            Debug.Assert(result is null);
             this._logger.LogDebug("Failed to handle function request ({Id}). {Error}", functionCall.Id, errorMessage);
         }
 

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
@@ -178,14 +178,14 @@ internal sealed class FunctionCallsProcessor
                 continue;
             }
 
-            // Look up the function in the kernel and get the function arguments.
+            // Look up the function in the kernel
             if (!kernel!.Plugins.TryGetFunction(functionCall.PluginName, functionCall.FunctionName, out KernelFunction? function))
             {
                 this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result: null, errorMessage: "Error: Requested function could not be found.");
                 continue;
             }
 
-            // Prepare context for the function invocation filters and invoke it.
+            // Prepare context for the auto function invocation filter and invoke it.
             FunctionResult functionResult = new(function) { Culture = kernel.Culture };
             AutoFunctionInvocationContext invocationContext = new(kernel, function, functionResult, chatHistory, chatMessageContent)
             {

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
@@ -55,6 +55,7 @@ internal sealed class FunctionCallsProcessor
     /// <remarks>
     /// It is temporarily made internal to allow code that uses the old function model to read it and decide whether to continue auto-invocation or not.
     /// It should be made private when the old model is deprecated.
+    /// Despite the field being static, its value is unique per execution flow. So if thousands of requests hit it in parallel, each request will see its unique value.
     /// </remarks>
     internal static readonly AsyncLocal<int> s_inflightAutoInvokes = new();
 

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
@@ -1,0 +1,342 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace Microsoft.SemanticKernel.Connectors.AI;
+
+/// <summary>
+/// Class responsible for providing function calling configuration and processing AI function calls. As part of the processing, it will:
+/// 1. Iterate over <see cref="FunctionCallContent"/> items representing AI model function calls in the <see cref="ChatMessageContent.Items"/> collection.
+/// 2. Look up each function in the <see cref="Kernel"/>.
+/// 3. Invoke the auto function invocation filter, if registered, for each function.
+/// 4. Invoke each function and add the function result to the <see cref="ChatHistory"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class FunctionCallsProcessor
+{
+    /// <summary>
+    /// The maximum number of auto-invokes that can be in-flight at any given time as part of the current
+    /// asynchronous chain of execution.
+    /// </summary>
+    /// <remarks>
+    /// This is a fail-safe mechanism. If someone accidentally manages to set up execution settings in such a way that
+    /// auto-invocation is invoked recursively, and in particular where a prompt function is able to auto-invoke itself,
+    /// we could end up in an infinite loop. This const is a backstop against that happening. We should never come close
+    /// to this limit, but if we do, auto-invoke will be disabled for the current flow in order to prevent runaway execution.
+    /// With the current setup, the way this could possibly happen is if a prompt function is configured with built-in
+    /// execution settings that opt-in to auto-invocation of everything in the kernel, in which case the invocation of that
+    /// prompt function could advertize itself as a candidate for auto-invocation. We don't want to outright block that,
+    /// if that's something a developer has asked to do (e.g. it might be invoked with different arguments than its parent
+    /// was invoked with), but we do want to limit it. This limit is arbitrary and can be tweaked in the future and/or made
+    /// configurable should need arise.
+    /// </remarks>
+    private const int MaxInflightAutoInvokes = 128;
+
+    /// <summary>
+    /// The maximum number of function auto-invokes that can be made in a single user request.
+    /// </summary>
+    /// <remarks>
+    /// After this number of iterations as part of a single user request is reached, auto-invocation
+    /// will be disabled. This is a safeguard against possible runaway execution if the model routinely re-requests
+    /// the same function over and over.
+    /// </remarks>
+    private const int MaximumAutoInvokeAttempts = 128;
+
+    /// <summary>Tracking <see cref="AsyncLocal{Int32}"/> for <see cref="MaxInflightAutoInvokes"/>.</summary>
+    /// <remarks>
+    /// It is temporarily made internal to allow code that uses the old function model to read it and decide whether to continue auto-invocation or not.
+    /// It should be made private when the old model is deprecated.
+    /// </remarks>
+    internal static readonly AsyncLocal<int> s_inflightAutoInvokes = new();
+
+    /// <summary>
+    /// The logger.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FunctionCallsProcessor"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public FunctionCallsProcessor(ILogger? logger = null)
+    {
+        this._logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// Retrieves the configuration of the specified <see cref="FunctionChoiceBehavior"/>.
+    /// </summary>
+    /// <param name="behavior">The function choice behavior.</param>
+    /// <param name="chatHistory">The chat history.</param>
+    /// <param name="requestIndex">Request sequence index.</param>
+    /// <param name="kernel">The <see cref="Kernel"/>.</param>
+    /// <returns>The configuration of the specified <see cref="FunctionChoiceBehavior"/>.</returns>
+    public FunctionChoiceBehaviorConfiguration? GetConfiguration(FunctionChoiceBehavior? behavior, ChatHistory chatHistory, int requestIndex, Kernel? kernel)
+    {
+        // If no behavior is specified, return null.
+        if (behavior is null)
+        {
+            return null;
+        }
+
+        var configuration = behavior.GetConfiguration(new(chatHistory) { Kernel = kernel, RequestSequenceIndex = requestIndex });
+
+        // Disable auto invocation if no kernel is provided.
+        configuration.AutoInvoke = kernel is not null && configuration.AutoInvoke;
+
+        // Disable auto invocation if we've exceeded the allowed auto-invoke limit.
+        int maximumAutoInvokeAttempts = configuration.AutoInvoke ? MaximumAutoInvokeAttempts : 0;
+        if (requestIndex >= maximumAutoInvokeAttempts)
+        {
+            configuration.AutoInvoke = false;
+            if (this._logger!.IsEnabled(LogLevel.Debug))
+            {
+                this._logger.LogDebug("Maximum auto-invoke ({MaximumAutoInvoke}) reached.", maximumAutoInvokeAttempts);
+            }
+        }
+        // Disable auto invocation if we've exceeded the allowed limit of in-flight auto-invokes. See XML comment for the "MaxInflightAutoInvokes" const for more details.
+        else if (s_inflightAutoInvokes.Value >= MaxInflightAutoInvokes)
+        {
+            configuration.AutoInvoke = false;
+            if (this._logger!.IsEnabled(LogLevel.Debug))
+            {
+                this._logger.LogDebug("Maximum auto-invoke ({MaxInflightAutoInvoke}) reached.", MaxInflightAutoInvokes);
+            }
+        }
+
+        return configuration;
+    }
+
+    /// <summary>
+    /// Processes AI function calls by iterating over the function calls, invoking them and adding the results to the chat history.
+    /// </summary>
+    /// <param name="chatMessageContent">The chat message content representing AI model response and containing function calls.</param>
+    /// <param name="chatHistory">The chat history to add function invocation results to.</param>
+    /// <param name="requestIndex">AI model function(s) call request sequence index.</param>
+    /// <param name="checkIfFunctionAdvertised">Callback to check if a function was advertised to AI model or not.</param>
+    /// <param name="kernel">The <see cref="Kernel"/>.</param>
+    /// <param name="resultSerializerOptions">Options to control function result serialization behavior.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
+    /// <returns>Last chat history message if function invocation filter requested processing termination, otherwise null.</returns>
+    public async Task<ChatMessageContent?> ProcessFunctionCallsAsync(
+        ChatMessageContent chatMessageContent,
+        ChatHistory chatHistory,
+        int requestIndex,
+        Func<FunctionCallContent, bool> checkIfFunctionAdvertised,
+        Kernel? kernel,
+        JsonSerializerOptions? resultSerializerOptions,
+        CancellationToken cancellationToken)
+    {
+        var functionCalls = FunctionCallContent.GetFunctionCalls(chatMessageContent).ToList();
+
+        if (this._logger.IsEnabled(LogLevel.Debug))
+        {
+            this._logger.LogDebug("Function calls: {Calls}", functionCalls.Count);
+        }
+        if (this._logger.IsEnabled(LogLevel.Trace))
+        {
+            var messages = new List<string>(functionCalls.Count);
+            foreach (var call in functionCalls)
+            {
+                var argumentsString = call.Arguments is not null ? $"({string.Join(",", call.Arguments.Select(a => $"{a.Key}={a.Value}"))})" : "()";
+                messages.Add($"{call.FunctionName}{argumentsString}");
+            }
+            this._logger.LogTrace("Function calls: {Calls}", string.Join(", ", messages));
+        }
+
+        // Add the result message to the caller's chat history;
+        // this is required for AI model to understand the function results.
+        chatHistory.Add(chatMessageContent);
+
+        // We must send back a result for every function call, regardless of whether we successfully executed it or not.
+        // If we successfully execute it, we'll add the result. If we don't, we'll add an error.
+        for (int functionCallIndex = 0; functionCallIndex < functionCalls.Count; functionCallIndex++)
+        {
+            FunctionCallContent functionCall = functionCalls[functionCallIndex];
+
+            // Check if the function call has an exception.
+            if (functionCall.Exception is not null)
+            {
+                this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result: null, errorMessage: $"Error: Function call processing failed. {functionCall.Exception.Message}");
+                continue;
+            }
+
+            // Make sure the requested function is one of the functions that was advertised to the AI model.
+            if (!checkIfFunctionAdvertised(functionCall))
+            {
+                this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result: null, errorMessage: "Error: Function call request for a function that wasn't defined.");
+                continue;
+            }
+
+            // Look up the function in the kernel and get the function arguments.
+            if (!kernel!.Plugins.TryGetFunction(functionCall.PluginName, functionCall.FunctionName, out KernelFunction? function))
+            {
+                this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result: null, errorMessage: "Error: Requested function could not be found.");
+                continue;
+            }
+
+            // Prepare context for the function invocation filters and invoke it.
+            FunctionResult functionResult = new(function) { Culture = kernel.Culture };
+            AutoFunctionInvocationContext invocationContext = new(kernel, function, functionResult, chatHistory, chatMessageContent)
+            {
+                Arguments = functionCall.Arguments,
+                RequestSequenceIndex = requestIndex,
+                FunctionSequenceIndex = functionCallIndex,
+                FunctionCount = functionCalls.Count
+            };
+
+            s_inflightAutoInvokes.Value++;
+            try
+            {
+                invocationContext = await OnAutoFunctionInvocationAsync(kernel, invocationContext, async (context) =>
+                {
+                    // Check if filter requested termination.
+                    if (context.Terminate)
+                    {
+                        return;
+                    }
+
+                    // Note that we explicitly do not use executionSettings here; those pertain to the all-up operation and not necessarily to any
+                    // further calls made as part of this function invocation. In particular, we must not use function calling settings naively here,
+                    // as the called function could in turn telling the model about itself as a possible candidate for invocation.
+                    context.Result = await function.InvokeAsync(kernel, invocationContext.Arguments, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result: null, errorMessage: $"Error: Exception while invoking function. {e.Message}");
+                continue;
+            }
+            finally
+            {
+                s_inflightAutoInvokes.Value--;
+            }
+
+            // Apply any changes from the auto function invocation filters context to final result.
+            functionResult = invocationContext.Result;
+
+            object functionResultValue = functionResult.GetValue<object>() ?? string.Empty;
+
+            var result = ProcessFunctionResult(functionResultValue, resultSerializerOptions);
+
+            this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result);
+
+            // If filter requested termination, return last chat history message.
+            if (invocationContext.Terminate)
+            {
+                if (this._logger.IsEnabled(LogLevel.Debug))
+                {
+                    this._logger.LogDebug("Filter requested termination of automatic function invocation.");
+                }
+
+                return chatHistory.Last();
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Adds the function call result or error message to the chat history.
+    /// </summary>
+    /// <param name="chatHistory">The chat history to add the function call result to.</param>
+    /// <param name="functionCall">The function call.</param>
+    /// <param name="result">The function result to add to the chat history.</param>
+    /// <param name="errorMessage">The error message to add to the chat history.</param>
+    private void AddFunctionCallResultToChatHistory(ChatHistory chatHistory, FunctionCallContent functionCall, string? result, string? errorMessage = null)
+    {
+        // Log any error
+        if (errorMessage is not null && this._logger.IsEnabled(LogLevel.Debug))
+        {
+            Debug.Assert(result is null);
+            this._logger.LogDebug("Failed to handle function request ({Id}). {Error}", functionCall.Id, errorMessage);
+        }
+
+        result ??= errorMessage ?? string.Empty;
+
+        var message = new ChatMessageContent(role: AuthorRole.Tool, content: result);
+        message.Items.Add(new FunctionResultContent(functionCall.FunctionName, functionCall.PluginName, functionCall.Id, result));
+
+        chatHistory.Add(message);
+    }
+
+    /// <summary>
+    /// Invokes the auto function invocation filters.
+    /// </summary>
+    /// <param name="kernel">The <see cref="Kernel"/>.</param>
+    /// <param name="context">The auto function invocation context.</param>
+    /// <param name="functionCallCallback">The function to call after the filters.</param>
+    /// <returns>The auto function invocation context.</returns>
+    private static async Task<AutoFunctionInvocationContext> OnAutoFunctionInvocationAsync(
+        Kernel kernel,
+        AutoFunctionInvocationContext context,
+        Func<AutoFunctionInvocationContext, Task> functionCallCallback)
+    {
+        await InvokeFilterOrFunctionAsync(kernel.AutoFunctionInvocationFilters, functionCallCallback, context).ConfigureAwait(false);
+
+        return context;
+    }
+
+    /// <summary>
+    /// This method will execute auto function invocation filters and function recursively.
+    /// If there are no registered filters, just function will be executed.
+    /// If there are registered filters, filter on <paramref name="index"/> position will be executed.
+    /// Second parameter of filter is callback. It can be either filter on <paramref name="index"/> + 1 position or function if there are no remaining filters to execute.
+    /// Function will be always executed as last step after all filters.
+    /// </summary>
+    private static async Task InvokeFilterOrFunctionAsync(
+        IList<IAutoFunctionInvocationFilter>? autoFunctionInvocationFilters,
+        Func<AutoFunctionInvocationContext, Task> functionCallCallback,
+        AutoFunctionInvocationContext context,
+        int index = 0)
+    {
+        if (autoFunctionInvocationFilters is { Count: > 0 } && index < autoFunctionInvocationFilters.Count)
+        {
+            await autoFunctionInvocationFilters[index].OnAutoFunctionInvocationAsync(context,
+                (context) => InvokeFilterOrFunctionAsync(autoFunctionInvocationFilters, functionCallCallback, context, index + 1)).ConfigureAwait(false);
+        }
+        else
+        {
+            await functionCallCallback(context).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Processes the function result.
+    /// </summary>
+    /// <param name="functionResult">The result of the function call.</param>
+    /// <param name="resultSerializerOptions">The serializer options to use for the function result.</param>
+    /// <returns>A string representation of the function result.</returns>
+    private static string? ProcessFunctionResult(object functionResult, JsonSerializerOptions? resultSerializerOptions)
+    {
+        if (functionResult is string stringResult)
+        {
+            return stringResult;
+        }
+
+        // This is an optimization to use ChatMessageContent content directly  
+        // without unnecessary serialization of the whole message content class.  
+        if (functionResult is ChatMessageContent chatMessageContent)
+        {
+            return chatMessageContent.ToString();
+        }
+
+        // For polymorphic serialization of unknown in advance child classes of the KernelContent class,  
+        // a corresponding JsonTypeInfoResolver should be provided via the JsonSerializerOptions.TypeInfoResolver property.  
+        // For more details about the polymorphic serialization, see the article at:  
+        // https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-8-0
+        return JsonSerializer.Serialize(functionResult, resultSerializerOptions);
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorConfiguration.cs
@@ -33,7 +33,7 @@ public sealed class FunctionChoiceBehaviorConfiguration
     /// <summary>
     /// Indicates whether the functions should be automatically invoked by the AI connector.
     /// </summary>
-    public bool AutoInvoke { get; internal init; } = true;
+    public bool AutoInvoke { get; set; } = true;
 
     /// <summary>
     /// The behavior options.

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/test/AssertExtensions.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/openai/**/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/ai/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/test/AssertExtensions.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/openai/**/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/ai/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/AI/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
@@ -1,0 +1,620 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AI;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Utilities.AIConnectors;
+public class FunctionCallsProcessorTests
+{
+    private readonly FunctionCallsProcessor _sut;
+
+    public FunctionCallsProcessorTests()
+    {
+        this._sut = new FunctionCallsProcessor();
+    }
+
+    [Fact]
+    public void ItShouldReturnNoConfigurationIfNoBehaviorProvided()
+    {
+        // Act
+        var config = this._sut.GetConfiguration(behavior: null, chatHistory: [], requestIndex: 0, kernel: null);
+
+        // Assert
+        Assert.Null(config);
+    }
+
+    [Fact]
+    public void ItShouldNotDisableAutoInvocationIfMaximumAutoInvocationLimitNotReached()
+    {
+        // Act
+        var config = this._sut.GetConfiguration(behavior: FunctionChoiceBehavior.Auto(), chatHistory: [], requestIndex: 127, kernel: CreateKernel());
+
+        // Assert
+        Assert.True(config!.AutoInvoke);
+    }
+
+    [Fact]
+    public void ItShouldDisableAutoInvocationIfMaximumAutoInvocationLimitReached()
+    {
+        // Act
+        var config = this._sut.GetConfiguration(behavior: FunctionChoiceBehavior.Auto(), chatHistory: [], requestIndex: 128, kernel: CreateKernel());
+
+        // Assert
+        Assert.False(config!.AutoInvoke);
+    }
+
+    [Fact]
+    public async Task ItShouldDisableAutoInvocationIfMaximumInflightAutoInvocationLimitReachedAsync()
+    {
+        // Arrange
+        var kernel = CreateKernel();
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("ProcessFunctionCallsRecursivelyToReachInflightLimitAsync", "test"));
+
+        int invocationNumber = 0;
+        FunctionChoiceBehaviorConfiguration? expectedConfiguration = null;
+
+        async Task ProcessFunctionCallsRecursivelyToReachInflightLimitAsync()
+        {
+            if (invocationNumber++ == 128) // 128 is the current Inflight limit
+            {
+                expectedConfiguration = this._sut.GetConfiguration(behavior: FunctionChoiceBehavior.Auto(), chatHistory: [], requestIndex: 0, kernel: kernel);
+                return;
+            }
+
+            await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: [],
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+        }
+
+        kernel.Plugins.AddFromFunctions("test", [KernelFunctionFactory.CreateFromMethod(ProcessFunctionCallsRecursivelyToReachInflightLimitAsync, "ProcessFunctionCallsRecursivelyToReachInflightLimitAsync")]);
+
+        // Act
+        var res = await kernel.InvokeAsync("test", "ProcessFunctionCallsRecursivelyToReachInflightLimitAsync");
+
+        // Assert
+        Assert.NotNull(expectedConfiguration);
+        Assert.False(expectedConfiguration!.AutoInvoke);
+    }
+
+    [Fact]
+    public async Task ItShouldAddFunctionCallAssistantMessageToChatHistoryAsync()
+    {
+        // Arrange
+        var chatHistory = new ChatHistory();
+        var chatMessageContent = new ChatMessageContent();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: CreateKernel(),
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Single(chatHistory);
+        Assert.Contains(chatMessageContent, chatHistory);
+    }
+
+    [Fact]
+    public async Task ItShouldAddFunctionCallExceptionToChatHistoryAsync()
+    {
+        // Arrange
+        var chatHistory = new ChatHistory();
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin")
+        {
+            Exception = new JsonException("Deserialization failed.") // Simulate an exception
+        });
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: CreateKernel(),
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        var functionResult = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+
+        Assert.Equal("MyPlugin", functionResult.PluginName);
+        Assert.Equal("Function1", functionResult.FunctionName);
+        Assert.Equal("Error: Function call processing failed. Deserialization failed.", functionResult.Result);
+    }
+
+    [Fact]
+    public async Task ItShouldAddErrorToChatHistoryIfFunctionCallNotAdvertisedAsync()
+    {
+        // Arrange
+        var chatHistory = new ChatHistory();
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin"));
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => false, // Return false to simulate that the function is not advertised
+                kernel: CreateKernel(),
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        var functionResult = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+
+        Assert.Equal("MyPlugin", functionResult.PluginName);
+        Assert.Equal("Function1", functionResult.FunctionName);
+        Assert.Equal("Error: Function call request for a function that wasn't defined.", functionResult.Result);
+    }
+
+    [Fact]
+    public async Task ItShouldAddErrorToChatHistoryIfFunctionIsNotRegisteredOnKernelAsync()
+    {
+        // Arrange
+        var chatHistory = new ChatHistory();
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin")); // The call for function that is not registered on the kernel
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: CreateKernel(),
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        var functionResult = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+
+        Assert.Equal("MyPlugin", functionResult.PluginName);
+        Assert.Equal("Function1", functionResult.FunctionName);
+        Assert.Equal("Error: Requested function could not be found.", functionResult.Result);
+    }
+
+    [Fact]
+    public async Task ItShouldInvokeFunctionsAsync()
+    {
+        // Arrange
+        int functionInvocations = 0;
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { functionInvocations++; return parameter; }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => { functionInvocations++; return parameter; }, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var kernel = CreateKernel(plugin);
+
+        var chatHistory = new ChatHistory();
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, functionInvocations);
+
+        Assert.Equal(3, chatHistory.Count);
+
+        var function1Result = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("MyPlugin", function1Result.PluginName);
+        Assert.Equal("Function1", function1Result.FunctionName);
+        Assert.Equal("function1-result", function1Result.Result);
+
+        var function2Result = chatHistory[2].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("MyPlugin", function2Result.PluginName);
+        Assert.Equal("Function2", function2Result.FunctionName);
+        Assert.Equal("function2-result", function2Result.Result);
+    }
+
+    [Fact]
+    public async Task ItShouldInvokeFiltersAsync()
+    {
+        // Arrange
+        int filterInvocations = 0;
+        int functionInvocations = 0;
+        int[] expectedRequestSequenceNumbers = [0, 0];
+        int[] expectedFunctionSequenceNumbers = [0, 1];
+        List<int> requestSequenceNumbers = [];
+        List<int> functionSequenceNumbers = [];
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { functionInvocations++; return parameter; }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => { functionInvocations++; return parameter; }, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        Kernel? kernel = null;
+        kernel = CreateKernel(plugin, async (context, next) =>
+        {
+            Assert.Equal(kernel, context.Kernel);
+
+            requestSequenceNumbers.Add(context.RequestSequenceIndex);
+            functionSequenceNumbers.Add(context.FunctionSequenceIndex);
+
+            await next(context);
+
+            filterInvocations++;
+        });
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, filterInvocations);
+        Assert.Equal(2, functionInvocations);
+        Assert.Equal(expectedRequestSequenceNumbers, requestSequenceNumbers);
+        Assert.Equal(expectedFunctionSequenceNumbers, functionSequenceNumbers);
+
+        Assert.Equal(3, chatHistory.Count);
+
+        Assert.Same(chatMessageContent, chatHistory[0]);
+
+        var function1Result = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("function1-result", function1Result.Result);
+
+        var function2Result = chatHistory[2].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("function2-result", function2Result.Result);
+    }
+
+    [Fact]
+    public async Task ItShouldInvokeMultipleFiltersInOrderAsync()
+    {
+        // Arrange
+        var function = KernelFunctionFactory.CreateFromMethod(() => "Result");
+        var executionOrder = new List<string>();
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => parameter, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => parameter, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var filter1 = new AutoFunctionInvocationFilter(async (context, next) =>
+        {
+            executionOrder.Add("Filter1-Invoking");
+            await next(context);
+            executionOrder.Add("Filter1-Invoked");
+        });
+
+        var filter2 = new AutoFunctionInvocationFilter(async (context, next) =>
+        {
+            executionOrder.Add("Filter2-Invoking");
+            await next(context);
+            executionOrder.Add("Filter2-Invoked");
+        });
+
+        var filter3 = new AutoFunctionInvocationFilter(async (context, next) =>
+        {
+            executionOrder.Add("Filter3-Invoking");
+            await next(context);
+            executionOrder.Add("Filter3-Invoked");
+        });
+
+        var builder = Kernel.CreateBuilder();
+
+        builder.Plugins.Add(plugin);
+
+        builder.Services.AddSingleton<IAutoFunctionInvocationFilter>(filter1);
+        builder.Services.AddSingleton<IAutoFunctionInvocationFilter>(filter2);
+        builder.Services.AddSingleton<IAutoFunctionInvocationFilter>(filter3);
+
+        var kernel = builder.Build();
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal("Filter1-Invoking", executionOrder[0]);
+        Assert.Equal("Filter2-Invoking", executionOrder[1]);
+        Assert.Equal("Filter3-Invoking", executionOrder[2]);
+        Assert.Equal("Filter3-Invoked", executionOrder[3]);
+        Assert.Equal("Filter2-Invoked", executionOrder[4]);
+        Assert.Equal("Filter1-Invoked", executionOrder[5]);
+        Assert.Equal(3, chatHistory.Count);
+    }
+
+    [Fact]
+    public async Task FilterCanOverrideArgumentsAsync()
+    {
+        // Arrange
+        const string NewValue = "NewValue";
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { return parameter; }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => { return parameter; }, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var kernel = CreateKernel(plugin, async (context, next) =>
+        {
+            context.Arguments!["parameter"] = NewValue;
+            await next(context);
+        });
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(3, chatHistory.Count);
+        Assert.Same(chatMessageContent, chatHistory[0]);
+        var function1Result = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("NewValue", function1Result.Result);
+        var function2Result = chatHistory[2].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("NewValue", function2Result.Result);
+    }
+
+    [Fact]
+    public async Task FilterCanHandleExceptionAsync()
+    {
+        // Arrange
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { throw new KernelException("Exception from Function1"); }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => "Result from Function2", "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var kernel = CreateKernel(plugin, async (context, next) =>
+        {
+            try
+            {
+                await next(context);
+            }
+            catch (KernelException exception)
+            {
+                Assert.Equal("Exception from Function1", exception.Message);
+                context.Result = new FunctionResult(context.Result, "Result from filter");
+            }
+        });
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddSystemMessage("System message");
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        var firstFunctionResult = chatHistory[^2].Content;
+        var secondFunctionResult = chatHistory[^1].Content;
+
+        // Assert
+        Assert.Equal("Result from filter", firstFunctionResult);
+        Assert.Equal("Result from Function2", secondFunctionResult);
+    }
+
+    [Fact]
+    public async Task FiltersCanSkipFunctionExecutionAsync()
+    {
+        // Arrange
+        int filterInvocations = 0;
+        int firstFunctionInvocations = 0;
+        int secondFunctionInvocations = 0;
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { firstFunctionInvocations++; return parameter; }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => { secondFunctionInvocations++; return parameter; }, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var kernel = CreateKernel(plugin, async (context, next) =>
+        {
+            // Filter delegate is invoked only for second function, the first one should be skipped.
+            if (context.Function.Name == "Function2")
+            {
+                await next(context);
+            }
+
+            filterInvocations++;
+        });
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, filterInvocations);
+        Assert.Equal(0, firstFunctionInvocations);
+        Assert.Equal(1, secondFunctionInvocations);
+    }
+
+    [Fact]
+    public async Task PreFilterCanTerminateOperationAsync()
+    {
+        // Arrange
+        int firstFunctionInvocations = 0;
+        int secondFunctionInvocations = 0;
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { firstFunctionInvocations++; return parameter; }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => { secondFunctionInvocations++; return parameter; }, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var kernel = CreateKernel(plugin, async (context, next) =>
+        {
+            // Terminating before first function, so all functions won't be invoked.
+            context.Terminate = true;
+
+            await next(context);
+        });
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, firstFunctionInvocations);
+        Assert.Equal(0, secondFunctionInvocations);
+    }
+
+    [Fact]
+    public async Task PostFilterCanTerminateOperationAsync()
+    {
+        // Arrange
+        int firstFunctionInvocations = 0;
+        int secondFunctionInvocations = 0;
+        List<int> functionSequenceNumbers = [];
+
+        var function1 = KernelFunctionFactory.CreateFromMethod((string parameter) => { firstFunctionInvocations++; return parameter; }, "Function1");
+        var function2 = KernelFunctionFactory.CreateFromMethod((string parameter) => { secondFunctionInvocations++; return parameter; }, "Function2");
+        var plugin = KernelPluginFactory.CreateFromFunctions("MyPlugin", [function1, function2]);
+
+        var kernel = CreateKernel(plugin, async (context, next) =>
+        {
+            functionSequenceNumbers.Add(context.FunctionSequenceIndex);
+
+            await next(context);
+
+            // Terminating after first function, so second function won't be invoked.
+            context.Terminate = true;
+        });
+
+        var chatMessageContent = new ChatMessageContent();
+        chatMessageContent.Items.Add(new FunctionCallContent("Function1", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function1-result" }));
+        chatMessageContent.Items.Add(new FunctionCallContent("Function2", "MyPlugin", arguments: new KernelArguments() { ["parameter"] = "function2-result" }));
+
+        var chatHistory = new ChatHistory();
+
+        // Act
+        await this._sut.ProcessFunctionCallsAsync(
+                chatMessageContent: chatMessageContent,
+                chatHistory: chatHistory,
+                requestIndex: 0,
+                checkIfFunctionAdvertised: (_) => true,
+                kernel: kernel!,
+                resultSerializerOptions: null,
+                cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, firstFunctionInvocations);
+        Assert.Equal(0, secondFunctionInvocations);
+        Assert.Equal([0], functionSequenceNumbers);
+
+        Assert.Equal(2, chatHistory.Count);
+
+        var function1Result = chatHistory[1].Items.OfType<FunctionResultContent>().Single();
+        Assert.Equal("function1-result", function1Result.Result);
+    }
+
+    private static Kernel CreateKernel(KernelPlugin? plugin = null, Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? onAutoFunctionInvocation = null)
+    {
+        var builder = Kernel.CreateBuilder();
+
+        if (plugin is not null)
+        {
+            builder.Plugins.Add(plugin);
+        }
+
+        if (onAutoFunctionInvocation is not null)
+        {
+            builder.Services.AddSingleton<IAutoFunctionInvocationFilter>(new AutoFunctionInvocationFilter(onAutoFunctionInvocation));
+        }
+
+        return builder.Build();
+    }
+
+    private sealed class AutoFunctionInvocationFilter(
+        Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? onAutoFunctionInvocation) : IAutoFunctionInvocationFilter
+    {
+        private readonly Func<AutoFunctionInvocationContext, Func<AutoFunctionInvocationContext, Task>, Task>? _onAutoFunctionInvocation = onAutoFunctionInvocation;
+
+        public Task OnAutoFunctionInvocationAsync(AutoFunctionInvocationContext context, Func<AutoFunctionInvocationContext, Task> next) =>
+            this._onAutoFunctionInvocation?.Invoke(context, next) ?? Task.CompletedTask;
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
@@ -9,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+#pragma warning disable IDE0005 // Using directive is unnecessary
 using Microsoft.SemanticKernel.Connectors.AI;
+#pragma warning restore IDE0005 // Using directive is unnecessary
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Utilities.AIConnectors;


### PR DESCRIPTION
### Motivation and Context
Today, each AI connector that works with an AI model having function calling capabilities has to implement the same function calling functionality: iterating over function calls, looking up the function, invoking the auto-invocation filter, invoking the function, and putting the function invocation result into the chat history.

### Description
This PR encapsulates the function-calling functionality into the `FunctionCallsProcessor` class, which will be reused by AI connectors for function calling. The class has two methods:     
1. `GetConfiguration`: retrieves function-calling-related configuration that each AI connector will use to get a list of functions to advertise to the AI model, the function choice the AI model should use, whether to auto-invoke functions or not, etc.  
2. `ProcessFunctionCallsAsync`: iterates over function calls, looking up the function, invoking the auto-invocation filter, invoking the function, and putting the function invocation result/error into the chat history.

The code in the class is an abstracted function calling functionality from the OpenAI connector. The function-calling code from the OpenAI connector was copied to the class as is and slightly reworked to remove OpenAI specifics so that it can work with other AI connectors, with an emphasis on preserving existing function-calling logic to minimize the number of behavior changes and potential regressions.

#### Behavioral change:
The `ChatCompletionsToolCall.Id` metadata piece is not added to chat message contents representing function results anymore:

```csharp
result ??= errorMessage ?? string.Empty;

/// Before
var message = new ChatMessageContent(role: AuthorRole.Tool, content: result, metadata: new Dictionary<string, object?> { {{OpenAIChatMessageContent.ToolIdProperty, toolCall.Id } });

/// After
var message = new ChatMessageContent(role: AuthorRole.Tool, content: result);

/// The other code
message.Items.Add(new FunctionResultContent(functionCall.FunctionName, functionCall.PluginName, functionCall.Id, result));

chatHistory.Add(message);
```

The metadata is used by the current function-calling model to associate the function id with the chat message content representing the function result, in order to later map it to the underlying SDK model class representing a function result. There's no need for this functionality anymore because there's a fallback that analyzes the `ChatMessageContent.Items` collection for the presence of the `FunctionResultContent` items to get both the id and result for the mapping.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
