### PR TITLE
Python: support all auth options for azure ai search

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
@@ -39,7 +39,7 @@ class ApiKeyAuthentication(AzureChatRequestBase):
     """API key authentication."""
 
     type: Annotated[Literal["APIKey", "api_key"], AfterValidator(to_snake)] = "api_key"
-    key: str | None
+    key: str | None = None
 
 
 class SystemAssignedManagedIdentityAuthentication(AzureChatRequestBase):

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
@@ -52,12 +52,14 @@ class UserAssignedManagedIdentityAuthentication(AzureChatRequestBase):
     """User assigned managed identity authentication."""
 
     type: Annotated[Literal["UserAssignedManagedIdentity", "user_assigned_managed_identity"], AfterValidator(to_snake)] = "user_assigned_managed_identity"
+    managed_identity_resource_id: str | None = None
 
 
 class AccessTokenAuthentication(AzureChatRequestBase):
     """Access token authentication."""
 
     type: Annotated[Literal["AccessToken", "access_token"], AfterValidator(to_snake)] = "access_token"
+    access_token: str | None = None
 
 
 class AzureEmbeddingDependency(AzureChatRequestBase):

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
@@ -39,27 +39,31 @@ class ApiKeyAuthentication(AzureChatRequestBase):
     """API key authentication."""
 
     type: Annotated[Literal["APIKey", "api_key"], AfterValidator(to_snake)] = "api_key"
-    key: str | None = None
+    key: str | None
 
 
 class SystemAssignedManagedIdentityAuthentication(AzureChatRequestBase):
     """System assigned managed identity authentication."""
 
-    type: Annotated[Literal["SystemAssignedManagedIdentity", "system_assigned_managed_identity"], AfterValidator(to_snake)] = "system_assigned_managed_identity"
+    type: Annotated[
+        Literal["SystemAssignedManagedIdentity", "system_assigned_managed_identity"], AfterValidator(to_snake)
+    ] = "system_assigned_managed_identity"
 
 
 class UserAssignedManagedIdentityAuthentication(AzureChatRequestBase):
     """User assigned managed identity authentication."""
 
-    type: Annotated[Literal["UserAssignedManagedIdentity", "user_assigned_managed_identity"], AfterValidator(to_snake)] = "user_assigned_managed_identity"
-    managed_identity_resource_id: str | None = None
+    type: Annotated[
+        Literal["UserAssignedManagedIdentity", "user_assigned_managed_identity"], AfterValidator(to_snake)
+    ] = "user_assigned_managed_identity"
+    managed_identity_resource_id: str | None
 
 
 class AccessTokenAuthentication(AzureChatRequestBase):
     """Access token authentication."""
 
     type: Annotated[Literal["AccessToken", "access_token"], AfterValidator(to_snake)] = "access_token"
-    access_token: str | None = None
+    access_token: str | None
 
 
 class AzureEmbeddingDependency(AzureChatRequestBase):
@@ -118,7 +122,13 @@ class AzureAISearchDataSourceParameters(AzureDataSourceParameters):
     query_type: Annotated[
         Literal["simple", "semantic", "vector", "vectorSimpleHybrid", "vectorSemanticHybrid"], AfterValidator(to_snake)
     ] = "simple"
-    authentication: ApiKeyAuthentication | SystemAssignedManagedIdentityAuthentication | UserAssignedManagedIdentityAuthentication | AccessTokenAuthentication | None = None
+    authentication: (
+        ApiKeyAuthentication
+        | SystemAssignedManagedIdentityAuthentication
+        | UserAssignedManagedIdentityAuthentication
+        | AccessTokenAuthentication
+        | None
+    ) = None
 
 
 class AzureAISearchDataSource(AzureChatRequestBase):

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/azure_chat_prompt_execution_settings.py
@@ -42,6 +42,24 @@ class ApiKeyAuthentication(AzureChatRequestBase):
     key: str | None = None
 
 
+class SystemAssignedManagedIdentityAuthentication(AzureChatRequestBase):
+    """System assigned managed identity authentication."""
+
+    type: Annotated[Literal["SystemAssignedManagedIdentity", "system_assigned_managed_identity"], AfterValidator(to_snake)] = "system_assigned_managed_identity"
+
+
+class UserAssignedManagedIdentityAuthentication(AzureChatRequestBase):
+    """User assigned managed identity authentication."""
+
+    type: Annotated[Literal["UserAssignedManagedIdentity", "user_assigned_managed_identity"], AfterValidator(to_snake)] = "user_assigned_managed_identity"
+
+
+class AccessTokenAuthentication(AzureChatRequestBase):
+    """Access token authentication."""
+
+    type: Annotated[Literal["AccessToken", "access_token"], AfterValidator(to_snake)] = "access_token"
+
+
 class AzureEmbeddingDependency(AzureChatRequestBase):
     """Azure embedding dependency."""
 
@@ -98,7 +116,7 @@ class AzureAISearchDataSourceParameters(AzureDataSourceParameters):
     query_type: Annotated[
         Literal["simple", "semantic", "vector", "vectorSimpleHybrid", "vectorSemanticHybrid"], AfterValidator(to_snake)
     ] = "simple"
-    authentication: ApiKeyAuthentication | None = None
+    authentication: ApiKeyAuthentication | SystemAssignedManagedIdentityAuthentication | UserAssignedManagedIdentityAuthentication | AccessTokenAuthentication | None = None
 
 
 class AzureAISearchDataSource(AzureChatRequestBase):

--- a/python/tests/unit/connectors/open_ai/test_openai_request_settings.py
+++ b/python/tests/unit/connectors/open_ai/test_openai_request_settings.py
@@ -200,7 +200,7 @@ def test_create_options_azure_data():
         parameters={
             "indexName": "test-index",
             "endpoint": "test-endpoint",
-            "authentication": {"type": "api_key", "api_key": "test-key"},
+            "authentication": {"type": "api_key", "key": "test-key"},
         }
     )
     extra = ExtraBody(data_sources=[az_source])

--- a/python/tests/unit/connectors/open_ai/test_openai_request_settings.py
+++ b/python/tests/unit/connectors/open_ai/test_openai_request_settings.py
@@ -4,6 +4,7 @@ import pytest
 
 from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.azure_chat_prompt_execution_settings import (
     AzureAISearchDataSource,
+    AzureAISearchDataSourceParameters,
     AzureChatPromptExecutionSettings,
     ExtraBody,
 )
@@ -277,6 +278,27 @@ def test_azure_open_ai_chat_prompt_execution_settings_with_aisearch_data_sources
     }
     settings = AzureChatPromptExecutionSettings.model_validate(input_dict, strict=True, from_attributes=True)
     assert settings.extra_body["dataSources"][0]["type"] == "AzureCognitiveSearch"
+
+
+@pytest.mark.parametrize(
+    "authentication",
+    [
+        {"type": "APIKey", "key": "test_key"},
+        {"type": "api_key", "key": "test_key"},
+        pytest.param({"type": "api_key"}, marks=pytest.mark.xfail),
+        {"type": "SystemAssignedManagedIdentity"},
+        {"type": "system_assigned_managed_identity"},
+        {"type": "UserAssignedManagedIdentity", "managed_identity_resource_id": "test_id"},
+        {"type": "user_assigned_managed_identity", "managed_identity_resource_id": "test_id"},
+        pytest.param({"type": "user_assigned_managed_identity"}, marks=pytest.mark.xfail),
+        {"type": "AccessToken", "access_token": "test_token"},
+        {"type": "access_token", "access_token": "test_token"},
+        pytest.param({"type": "access_token"}, marks=pytest.mark.xfail),
+        pytest.param({"type": "invalid"}, marks=pytest.mark.xfail),
+    ],
+)
+def test_aisearch_data_source_parameters(authentication) -> None:
+    AzureAISearchDataSourceParameters(index_name="test_index", authentication=authentication)
 
 
 def test_azure_open_ai_chat_prompt_execution_settings_with_response_format_json():


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
Azure AI Search data source supports 4 types of authentication but semantic kernel only supports `ApiKey`api key.

This PR adds support to the other authentication options as defined in its [docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/references/azure-search?tabs=python#parameters), which are
- system_assigned_managed_identity
- user_assigned_managed_identity
- access_token

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
