### PR TITLE
.Net: Use function calls processor in {Azure}OpenAI connectors

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
@@ -55,7 +55,10 @@ internal partial class AzureClientCore
             options.ResponseFormat = responseFormat;
         }
 
-        options.ToolChoice = toolCallingConfig.Choice;
+        if (toolCallingConfig.Choice is not null)
+        {
+            options.ToolChoice = toolCallingConfig.Choice;
+        }
 
         if (toolCallingConfig.Tools is { Count: > 0 } tools)
         {

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
@@ -8,6 +8,7 @@ using Azure.AI.OpenAI;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Connectors.AI;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Http;
 using OpenAI;
@@ -55,6 +56,7 @@ internal partial class AzureClientCore : ClientCore
         this.DeploymentName = deploymentName;
         this.Endpoint = new Uri(endpoint);
         this.Client = new AzureOpenAIClient(this.Endpoint, apiKey, options);
+        this.FunctionCallsProcessor = new FunctionCallsProcessor(this.Logger);
 
         this.AddAttribute(DeploymentNameKey, deploymentName);
     }
@@ -84,6 +86,7 @@ internal partial class AzureClientCore : ClientCore
         this.DeploymentName = deploymentName;
         this.Endpoint = new Uri(endpoint);
         this.Client = new AzureOpenAIClient(this.Endpoint, credential, options);
+        this.FunctionCallsProcessor = new FunctionCallsProcessor(this.Logger);
 
         this.AddAttribute(DeploymentNameKey, deploymentName);
     }
@@ -107,6 +110,7 @@ internal partial class AzureClientCore : ClientCore
         this.Logger = logger ?? NullLogger.Instance;
         this.DeploymentName = deploymentName;
         this.Client = openAIClient;
+        this.FunctionCallsProcessor = new FunctionCallsProcessor(this.Logger);
 
         this.AddAttribute(DeploymentNameKey, deploymentName);
     }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
@@ -8,7 +8,9 @@ using Azure.AI.OpenAI;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+#pragma warning disable IDE0005 // Using directive is unnecessary
 using Microsoft.SemanticKernel.Connectors.AI;
+#pragma warning restore IDE0005 // Using directive is unnecessary
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Http;
 using OpenAI;

--- a/dotnet/src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj
@@ -18,6 +18,7 @@
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/openai/OpenAIUtilities.props" />
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/AI/AiConnectorsInternalUtilities.props" />
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -186,16 +186,13 @@ internal partial class ClientCore
             // Process function calls by invoking the functions and adding the results to the chat history.
             // Each function call will trigger auto-function-invocation filters, which can terminate the process.
             // In such cases, we'll return the last message in the chat history.
-#pragma warning disable CS0618 // Type or member is obsolete
             var lastMessage = await this.FunctionCallsProcessor.ProcessFunctionCallsAsync(
                 chatMessageContent,
                 chatHistory,
                 requestIndex,
                 (FunctionCallContent content) => IsRequestableTool(chatOptions.Tools, content),
                 kernel,
-                chatExecutionSettings.ToolCallBehavior?.ToolCallResultSerializerOptions,
                 cancellationToken).ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
             if (lastMessage != null)
             {
                 return [lastMessage];
@@ -364,16 +361,13 @@ internal partial class ClientCore
             // Process function calls by invoking the functions and adding the results to the chat history.
             // Each function call will trigger auto-function-invocation filters, which can terminate the process.
             // In such cases, we'll return the last message in the chat history.  
-#pragma warning disable CS0618 // Type or member is obsolete
             var lastMessage = await this.FunctionCallsProcessor.ProcessFunctionCallsAsync(
                 chatMessageContent,
                 chatHistory,
                 requestIndex,
                 (FunctionCallContent content) => IsRequestableTool(chatOptions.Tools, content),
                 kernel,
-                chatExecutionSettings.ToolCallBehavior?.ToolCallResultSerializerOptions,
                 cancellationToken).ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
             if (lastMessage != null)
             {
                 yield return new OpenAIStreamingChatMessageContent(lastMessage.Role, lastMessage.Content);

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
@@ -10,7 +10,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+#pragma warning disable IDE0005 // Using directive is unnecessary
 using Microsoft.SemanticKernel.Connectors.AI;
+#pragma warning restore IDE0005 // Using directive is unnecessary
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Services;
 using OpenAI;

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Connectors.AI;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Services;
 using OpenAI;
@@ -64,6 +65,11 @@ internal partial class ClientCore
     internal Dictionary<string, object?> Attributes { get; } = [];
 
     /// <summary>
+    /// The function calls processor.
+    /// </summary>
+    protected FunctionCallsProcessor FunctionCallsProcessor { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ClientCore"/> class.
     /// </summary>
     /// <param name="modelId">Model name.</param>
@@ -80,6 +86,8 @@ internal partial class ClientCore
         HttpClient? httpClient = null,
         ILogger? logger = null)
     {
+        this.FunctionCallsProcessor = new FunctionCallsProcessor(this.Logger);
+
         // Empty constructor will be used when inherited by a specialized Client.
         if (modelId is null
             && apiKey is null
@@ -149,6 +157,7 @@ internal partial class ClientCore
 
         this.Logger = logger ?? NullLogger.Instance;
         this.Client = openAIClient;
+        this.FunctionCallsProcessor = new FunctionCallsProcessor(this.Logger);
     }
 
     /// <summary>

--- a/dotnet/src/InternalUtilities/connectors/AI/AiConnectorsInternalUtilities.props
+++ b/dotnet/src/InternalUtilities/connectors/AI/AiConnectorsInternalUtilities.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/ai/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/connectors/AI/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCallsProcessor.cs
@@ -125,7 +125,6 @@ internal sealed class FunctionCallsProcessor
     /// <param name="requestIndex">AI model function(s) call request sequence index.</param>
     /// <param name="checkIfFunctionAdvertised">Callback to check if a function was advertised to AI model or not.</param>
     /// <param name="kernel">The <see cref="Kernel"/>.</param>
-    /// <param name="resultSerializerOptions">Options to control function result serialization behavior.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>Last chat history message if function invocation filter requested processing termination, otherwise null.</returns>
     public async Task<ChatMessageContent?> ProcessFunctionCallsAsync(
@@ -134,7 +133,6 @@ internal sealed class FunctionCallsProcessor
         int requestIndex,
         Func<FunctionCallContent, bool> checkIfFunctionAdvertised,
         Kernel? kernel,
-        JsonSerializerOptions? resultSerializerOptions,
         CancellationToken cancellationToken)
     {
         var functionCalls = FunctionCallContent.GetFunctionCalls(chatMessageContent).ToList();
@@ -230,7 +228,7 @@ internal sealed class FunctionCallsProcessor
 
             object functionResultValue = functionResult.GetValue<object>() ?? string.Empty;
 
-            var result = ProcessFunctionResult(functionResultValue, resultSerializerOptions);
+            var result = ProcessFunctionResult(functionResultValue);
 
             this.AddFunctionCallResultToChatHistory(chatHistory, functionCall, result);
 
@@ -317,9 +315,8 @@ internal sealed class FunctionCallsProcessor
     /// Processes the function result.
     /// </summary>
     /// <param name="functionResult">The result of the function call.</param>
-    /// <param name="resultSerializerOptions">The serializer options to use for the function result.</param>
     /// <returns>A string representation of the function result.</returns>
-    private static string? ProcessFunctionResult(object functionResult, JsonSerializerOptions? resultSerializerOptions)
+    private static string? ProcessFunctionResult(object functionResult)
     {
         if (functionResult is string stringResult)
         {
@@ -333,10 +330,6 @@ internal sealed class FunctionCallsProcessor
             return chatMessageContent.ToString();
         }
 
-        // For polymorphic serialization of unknown in advance child classes of the KernelContent class,  
-        // a corresponding JsonTypeInfoResolver should be provided via the JsonSerializerOptions.TypeInfoResolver property.  
-        // For more details about the polymorphic serialization, see the article at:  
-        // https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?pivots=dotnet-8-0
-        return JsonSerializer.Serialize(functionResult, resultSerializerOptions);
+        return JsonSerializer.Serialize(functionResult);
     }
 }

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
@@ -97,7 +97,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
         }
 
@@ -125,7 +124,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: CreateKernel(),
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -152,7 +150,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: CreateKernel(),
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -179,7 +176,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => false, // Return false to simulate that the function is not advertised
                 kernel: CreateKernel(),
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -206,7 +202,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: CreateKernel(),
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -242,7 +237,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -302,7 +296,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -377,7 +370,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -419,7 +411,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -466,7 +457,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         var firstFunctionResult = chatHistory[^2].Content;
@@ -513,7 +503,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -554,7 +543,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -597,7 +585,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel!,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -649,7 +636,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -683,7 +669,6 @@ public class FunctionCallsProcessorTests
                 requestIndex: 0,
                 checkIfFunctionAdvertised: (_) => true,
                 kernel: kernel,
-                resultSerializerOptions: null,
                 cancellationToken: CancellationToken.None);
 
         // Assert


### PR DESCRIPTION
### Motivation, Context and Description
Having the `FunctionCallsProcessor` class responsible for function calling it makes sense to replace function calling code some SK AI connectors have. This PR updates {Azure}OpenAI connectors to delegate function calling to the processor.

Both `OpenAIChatCompletionService` and `AzureOpenAIChatCompletionService` are refactored to use the `FunctionCallsProcessor` to obtain function calling configuration and process functions calls.

Closes: https://github.com/microsoft/semantic-kernel/issues/6744

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: