### PR TITLE
.Net: Switch from API keys to DefaultAzureCredential

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIKernelBuilderExtensions.cs
@@ -249,6 +249,43 @@ public static class AzureOpenAIKernelBuilderExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Adds the <see cref="AzureOpenAITextToAudioService"/> to the <see cref="IKernelBuilder.Services"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IKernelBuilder"/> instance to augment.</param>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="credential">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="serviceId">A local identifier for the given AI service</param>
+    /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
+    /// <returns>The same instance as <paramref name="builder"/>.</returns>
+    [Experimental("SKEXP0010")]
+    public static IKernelBuilder AddAzureOpenAITextToAudio(
+        this IKernelBuilder builder,
+        string deploymentName,
+        string endpoint,
+        TokenCredential credential,
+        string? serviceId = null,
+        string? modelId = null,
+        HttpClient? httpClient = null)
+    {
+        Verify.NotNull(builder);
+        Verify.NotNullOrWhiteSpace(endpoint);
+        Verify.NotNull(credential);
+
+        builder.Services.AddKeyedSingleton<ITextToAudioService>(serviceId, (serviceProvider, _) =>
+            new AzureOpenAITextToAudioService(
+                deploymentName,
+                endpoint,
+                credential,
+                modelId,
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                serviceProvider.GetService<ILoggerFactory>()));
+
+        return builder;
+    }
+
     #endregion
 
     #region Text-to-Audio

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToAudioService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToAudioService.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.OpenAI;
+using Azure.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Services;
 using Microsoft.SemanticKernel.TextToAudio;
@@ -61,6 +62,38 @@ public sealed class AzureOpenAITextToAudioService : ITextToAudioService
             AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview); // https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#text-to-speech
 
         var azureOpenAIClient = new AzureOpenAIClient(new Uri(url), apiKey, options);
+
+        this._client = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextToAudioService)));
+
+        this._client.AddAttribute(AIServiceExtensions.ModelIdKey, modelId);
+
+        this._modelId = modelId;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureOpenAITextToAudioService"/> class.
+    /// </summary>
+    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
+    /// <param name="credential">Token credentials, e.g. DefaultAzureCredential, ManagedIdentityCredential, EnvironmentCredential, etc.</param>
+    /// <param name="modelId">Azure OpenAI model id, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    public AzureOpenAITextToAudioService(
+        string deploymentName,
+        string endpoint,
+        TokenCredential credential,
+        string? modelId = null,
+        HttpClient? httpClient = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var url = !string.IsNullOrWhiteSpace(httpClient?.BaseAddress?.AbsoluteUri) ? httpClient!.BaseAddress!.AbsoluteUri : endpoint;
+
+        var options = AzureClientCore.GetAzureOpenAIClientOptions(
+            httpClient,
+            AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview); // https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#text-to-speech
+
+        var azureOpenAIClient = new AzureOpenAIClient(new Uri(url), credential, options);
 
         this._client = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextToAudioService)));
 

--- a/dotnet/src/IntegrationTests/Agents/ChatCompletionAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/ChatCompletionAgentTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
@@ -41,9 +42,9 @@ public sealed class ChatCompletionAgentTests()
         KernelPlugin plugin = KernelPluginFactory.CreateFromType<MenuPlugin>();
 
         this._kernelBuilder.AddAzureOpenAIChatCompletion(
-            configuration.ChatDeploymentName!,
-            configuration.Endpoint,
-            configuration.ApiKey);
+            deploymentName: configuration.ChatDeploymentName!,
+            endpoint: configuration.Endpoint,
+            credentials: new DefaultAzureCredential());
 
         if (useAutoFunctionTermination)
         {

--- a/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
@@ -54,7 +55,7 @@ public sealed class OpenAIAssistantAgentTests
         Assert.NotNull(azureOpenAIConfiguration);
 
         await this.ExecuteAgentAsync(
-            OpenAIClientProvider.ForAzureOpenAI(azureOpenAIConfiguration.ApiKey, new Uri(azureOpenAIConfiguration.Endpoint)),
+            OpenAIClientProvider.ForAzureOpenAI(new DefaultAzureCredential(), new Uri(azureOpenAIConfiguration.Endpoint)),
             azureOpenAIConfiguration.ChatDeploymentName!,
             input,
             expectedAnswerContains);

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIAudioToTextTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIAudioToTextTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AudioToText;
@@ -33,9 +34,9 @@ public sealed class AzureOpenAIAudioToTextTests()
 
         var kernel = Kernel.CreateBuilder()
             .AddAzureOpenAIAudioToText(
-                azureOpenAIConfiguration.DeploymentName,
-                azureOpenAIConfiguration.Endpoint,
-                azureOpenAIConfiguration.ApiKey)
+                deploymentName: azureOpenAIConfiguration.DeploymentName,
+                endpoint: azureOpenAIConfiguration.Endpoint,
+                credentials: new DefaultAzureCredential())
             .Build();
 
         var service = kernel.GetRequiredService<IAudioToTextService>();

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionFunctionCallingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionFunctionCallingTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -865,7 +866,6 @@ public sealed class AzureOpenAIChatCompletionFunctionCallingTests : BaseIntegrat
         var azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIConfiguration);
         Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
-        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
         Assert.NotNull(azureOpenAIConfiguration.Endpoint);
 
         var kernelBuilder = base.CreateKernelBuilder();
@@ -874,7 +874,7 @@ public sealed class AzureOpenAIChatCompletionFunctionCallingTests : BaseIntegrat
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            apiKey: azureOpenAIConfiguration.ApiKey);
+            credentials: new DefaultAzureCredential());
 
         var kernel = kernelBuilder.Build();
 

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionNonStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionNonStreamingTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
@@ -147,7 +148,6 @@ public sealed class AzureOpenAIChatCompletionNonStreamingTests : BaseIntegration
         var azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIConfiguration);
         Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
-        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
         Assert.NotNull(azureOpenAIConfiguration.Endpoint);
 
         var kernelBuilder = base.CreateKernelBuilder();
@@ -156,7 +156,7 @@ public sealed class AzureOpenAIChatCompletionNonStreamingTests : BaseIntegration
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            apiKey: azureOpenAIConfiguration.ApiKey);
+            credentials: new DefaultAzureCredential());
 
         return kernelBuilder.Build();
     }

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionStreamingTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
@@ -148,7 +149,6 @@ public sealed class AzureOpenAIChatCompletionStreamingTests : BaseIntegrationTes
         var azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIConfiguration);
         Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
-        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
         Assert.NotNull(azureOpenAIConfiguration.Endpoint);
 
         var kernelBuilder = base.CreateKernelBuilder();
@@ -157,7 +157,7 @@ public sealed class AzureOpenAIChatCompletionStreamingTests : BaseIntegrationTes
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            apiKey: azureOpenAIConfiguration.ApiKey);
+            credentials: new DefaultAzureCredential());
 
         return kernelBuilder.Build();
     }

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
@@ -232,7 +233,6 @@ public sealed class AzureOpenAIChatCompletionTests : BaseIntegrationTest
         var azureOpenAIConfiguration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>();
         Assert.NotNull(azureOpenAIConfiguration);
         Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
-        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
         Assert.NotNull(azureOpenAIConfiguration.Endpoint);
         Assert.NotNull(azureOpenAIConfiguration.ServiceId);
 
@@ -242,7 +242,7 @@ public sealed class AzureOpenAIChatCompletionTests : BaseIntegrationTest
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            apiKey: azureOpenAIConfiguration.ApiKey,
+            credentials: new DefaultAzureCredential(),
             serviceId: azureOpenAIConfiguration.ServiceId,
             httpClient: httpClient);
 

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextEmbeddingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextEmbeddingTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Embeddings;
@@ -24,9 +25,9 @@ public sealed class AzureOpenAITextEmbeddingTests
     {
         // Arrange
         var embeddingGenerator = new AzureOpenAITextEmbeddingGenerationService(
-            this._azureOpenAIConfiguration.DeploymentName,
-            this._azureOpenAIConfiguration.Endpoint,
-            this._azureOpenAIConfiguration.ApiKey);
+            deploymentName: this._azureOpenAIConfiguration.DeploymentName,
+            endpoint: this._azureOpenAIConfiguration.Endpoint,
+            credential: new DefaultAzureCredential());
 
         // Act
         var singleResult = await embeddingGenerator.GenerateEmbeddingAsync(testInputString);
@@ -46,9 +47,9 @@ public sealed class AzureOpenAITextEmbeddingTests
         const string TestInputString = "test sentence";
 
         var embeddingGenerator = new AzureOpenAITextEmbeddingGenerationService(
-            "text-embedding-3-large",
-            this._azureOpenAIConfiguration.Endpoint,
-            this._azureOpenAIConfiguration.ApiKey,
+            deploymentName: "text-embedding-3-large",
+            endpoint: this._azureOpenAIConfiguration.Endpoint,
+            credential: new DefaultAzureCredential(),
             dimensions: dimensions);
 
         // Act

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToAudioTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToAudioTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.TextToAudio;
@@ -27,9 +28,9 @@ public sealed class AzureOpenAITextToAudioTests
 
         var kernel = Kernel.CreateBuilder()
             .AddAzureOpenAITextToAudio(
-                azureOpenAIConfiguration.DeploymentName,
-                azureOpenAIConfiguration.Endpoint,
-                azureOpenAIConfiguration.ApiKey)
+                deploymentName: azureOpenAIConfiguration.DeploymentName,
+                endpoint: azureOpenAIConfiguration.Endpoint,
+                credential: new DefaultAzureCredential())
             .Build();
 
         var service = kernel.GetRequiredService<ITextToAudioService>();

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToImageTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToImageTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.TextToImage;
@@ -26,7 +27,10 @@ public sealed class AzureOpenAITextToImageTests
         Assert.NotNull(configuration);
 
         var kernel = Kernel.CreateBuilder()
-            .AddAzureOpenAITextToImage(configuration.DeploymentName, configuration.Endpoint, configuration.ApiKey)
+            .AddAzureOpenAITextToImage(
+                deploymentName: configuration.DeploymentName,
+                endpoint: configuration.Endpoint,
+                credentials: new DefaultAzureCredential())
             .Build();
 
         var service = kernel.GetRequiredService<ITextToImageService>();

--- a/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
@@ -117,7 +118,7 @@ public sealed class HandlebarsPlannerTests
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName!,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            apiKey: azureOpenAIConfiguration.ApiKey);
+            credentials: new DefaultAzureCredential());
 
         if (useEmbeddings)
         {
@@ -125,7 +126,7 @@ public sealed class HandlebarsPlannerTests
                 deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                 modelId: azureOpenAIEmbeddingsConfiguration.EmbeddingModelId,
                 endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
-                apiKey: azureOpenAIEmbeddingsConfiguration.ApiKey);
+                credential: new DefaultAzureCredential());
         }
 
         return builder.Build();

--- a/dotnet/src/IntegrationTests/PromptTests.cs
+++ b/dotnet/src/IntegrationTests/PromptTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -77,13 +78,12 @@ public sealed class PromptTests : IDisposable
         Assert.NotNull(azureOpenAIConfiguration);
         Assert.NotNull(azureOpenAIConfiguration.ChatDeploymentName);
         Assert.NotNull(azureOpenAIConfiguration.Endpoint);
-        Assert.NotNull(azureOpenAIConfiguration.ApiKey);
         Assert.NotNull(azureOpenAIConfiguration.ServiceId);
 
         kernelBuilder.AddAzureOpenAIChatCompletion(
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            apiKey: azureOpenAIConfiguration.ApiKey,
+            credentials: new DefaultAzureCredential(),
             serviceId: azureOpenAIConfiguration.ServiceId);
     }
     #endregion

--- a/dotnet/src/IntegrationTests/README.md
+++ b/dotnet/src/IntegrationTests/README.md
@@ -42,27 +42,22 @@ dotnet user-secrets set "AzureOpenAI:ServiceId" "azure-gpt-35-turbo-instruct"
 dotnet user-secrets set "AzureOpenAI:DeploymentName" "gpt-35-turbo-instruct"
 dotnet user-secrets set "AzureOpenAI:ChatDeploymentName" "gpt-4"
 dotnet user-secrets set "AzureOpenAI:Endpoint" "https://contoso.openai.azure.com/"
-dotnet user-secrets set "AzureOpenAI:ApiKey" "..."
 
 dotnet user-secrets set "AzureOpenAIEmbeddings:ServiceId" "azure-text-embedding-ada-002"
 dotnet user-secrets set "AzureOpenAIEmbeddings:DeploymentName" "text-embedding-ada-002"
 dotnet user-secrets set "AzureOpenAIEmbeddings:Endpoint" "https://contoso.openai.azure.com/"
-dotnet user-secrets set "AzureOpenAIEmbeddings:ApiKey" "..."
 
 dotnet user-secrets set "AzureOpenAIAudioToText:ServiceId" "azure-audio-to-text"
 dotnet user-secrets set "AzureOpenAIAudioToText:DeploymentName" "whisper-1"
 dotnet user-secrets set "AzureOpenAIAudioToText:Endpoint" "https://contoso.openai.azure.com/"
-dotnet user-secrets set "AzureOpenAIAudioToText:ApiKey" "..."
 
 dotnet user-secrets set "AzureOpenAITextToAudio:ServiceId" "azure-text-to-audio"
 dotnet user-secrets set "AzureOpenAITextToAudio:DeploymentName" "tts-1"
 dotnet user-secrets set "AzureOpenAITextToAudio:Endpoint" "https://contoso.openai.azure.com/"
-dotnet user-secrets set "AzureOpenAITextToAudio:ApiKey" "..."
 
 dotnet user-secrets set "AzureOpenAITextToImage:ServiceId" "azure-text-to-image"
 dotnet user-secrets set "AzureOpenAITextToImage:DeploymentName" "dall-e-3"
 dotnet user-secrets set "AzureOpenAITextToImage:Endpoint" "https://contoso.openai.azure.com/"
-dotnet user-secrets set "AzureOpenAITextToImage:ApiKey" "..."
 
 dotnet user-secrets set "MistralAI:ChatModel" "mistral-large-latest"
 dotnet user-secrets set "MistralAI:EmbeddingModel" "mistral-embed"

--- a/dotnet/src/IntegrationTests/TestSettings/AzureOpenAIConfiguration.cs
+++ b/dotnet/src/IntegrationTests/TestSettings/AzureOpenAIConfiguration.cs
@@ -6,7 +6,7 @@ namespace SemanticKernel.IntegrationTests.TestSettings;
 
 [SuppressMessage("Performance", "CA1812:Internal class that is apparently never instantiated",
     Justification = "Configuration classes are instantiated through IConfiguration.")]
-internal sealed class AzureOpenAIConfiguration(string serviceId, string deploymentName, string endpoint, string apiKey, string? chatDeploymentName = null, string? modelId = null, string? chatModelId = null, string? embeddingModelId = null)
+internal sealed class AzureOpenAIConfiguration(string serviceId, string deploymentName, string endpoint, string? apiKey = null, string? chatDeploymentName = null, string? modelId = null, string? chatModelId = null, string? embeddingModelId = null)
 {
     public string ServiceId { get; set; } = serviceId;
 
@@ -22,5 +22,5 @@ internal sealed class AzureOpenAIConfiguration(string serviceId, string deployme
 
     public string Endpoint { get; set; } = endpoint;
 
-    public string ApiKey { get; set; } = apiKey;
+    public string? ApiKey { get; set; } = apiKey;
 }

--- a/dotnet/src/IntegrationTests/testsettings.json
+++ b/dotnet/src/IntegrationTests/testsettings.json
@@ -6,11 +6,10 @@
     "ApiKey": ""
   },
   "AzureOpenAI": {
-    "ServiceId": "azure-gpt-35-turbo-instruct",
+    "ServiceId": "azure-gpt",
     "DeploymentName": "gpt-35-turbo-instruct",
     "ChatDeploymentName": "gpt-4o",
-    "Endpoint": "",
-    "ApiKey": ""
+    "Endpoint": ""
   },
   "OpenAIEmbeddings": {
     "ServiceId": "text-embedding-ada-002",
@@ -20,8 +19,7 @@
   "AzureOpenAIEmbeddings": {
     "ServiceId": "azure-text-embedding-ada-002",
     "DeploymentName": "ada-002",
-    "Endpoint": "",
-    "ApiKey": ""
+    "Endpoint": ""
   },
   "OpenAITextToAudio": {
     "ServiceId": "tts-1",
@@ -31,8 +29,7 @@
   "AzureOpenAITextToAudio": {
     "ServiceId": "azure-tts",
     "DeploymentName": "tts",
-    "Endpoint": "",
-    "ApiKey": ""
+    "Endpoint": ""
   },
   "OpenAIAudioToText": {
     "ServiceId": "whisper-1",
@@ -42,8 +39,7 @@
   "AzureOpenAIAudioToText": {
     "ServiceId": "azure-whisper",
     "DeploymentName": "whisper",
-    "Endpoint": "",
-    "ApiKey": ""
+    "Endpoint": ""
   },
   "OpenAITextToImage": {
     "ServiceId": "dall-e-2",
@@ -52,9 +48,8 @@
   },
   "AzureOpenAITextToImage": {
     "ServiceId": "azure-dalle3",
-    "DeploymentName": "dall-e-3",
-    "Endpoint": "",
-    "ApiKey": ""
+    "DeploymentName": "Dalle3",
+    "Endpoint": ""
   },
   "HuggingFace": {
     "ApiKey": ""


### PR DESCRIPTION
### Motivation and Context

Switch to using DefaultAzureCredential and get all tests passing locally

See: #6966 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
