### PR TITLE
.Net: Add vector search implementation for azure ai search

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionSearchMappingTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="AzureAISearchVectorStoreCollectionSearchMapping"/> class.
+/// </summary>
+public class AzureAISearchVectorStoreCollectionSearchMappingTests
+{
+    [Theory]
+    [MemberData(nameof(DataTypeMappingOptions))]
+    public void BuildFilterStringBuildsCorrectEqualityStringForEachFilterType(string fieldName, object? fieldValue, string expected)
+    {
+        // Arrange.
+        var filter = new VectorSearchFilter().Equality(fieldName, fieldValue!);
+
+        // Act.
+        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter, new Dictionary<string, string> { { fieldName, "storage_" + fieldName } });
+
+        // Assert.
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void BuildFilterStringBuildsCorrectTagContainsString()
+    {
+        // Arrange.
+        var filter = new VectorSearchFilter().TagListContains("Tags", "mytag");
+
+        // Act.
+        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter, new Dictionary<string, string> { { "Tags", "storage_tags" } });
+
+        // Assert.
+        Assert.Equal("storage_tags/any(t: t eq 'mytag')", actual);
+    }
+
+    [Fact]
+    public void BuildFilterStringCombinesFilterOptions()
+    {
+        // Arrange.
+        var filter = new VectorSearchFilter().Equality("intField", 5).TagListContains("Tags", "mytag");
+
+        // Act.
+        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter, new Dictionary<string, string> { { "Tags", "storage_tags" }, { "intField", "storage_intField" } });
+
+        // Assert.
+        Assert.Equal("storage_intField eq 5 and storage_tags/any(t: t eq 'mytag')", actual);
+    }
+
+    [Fact]
+    public void BuildFilterStringThrowsForUnknownPropertyName()
+    {
+        // Act and assert.
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(new VectorSearchFilter().Equality("unknown", "value"), new Dictionary<string, string>()));
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(new VectorSearchFilter().TagListContains("unknown", "value"), new Dictionary<string, string>()));
+    }
+
+    public static IEnumerable<object[]> DataTypeMappingOptions()
+    {
+        yield return new object[] { "stringField", "value", "storage_stringField eq 'value'" };
+        yield return new object[] { "boolField", true, "storage_boolField eq true" };
+        yield return new object[] { "intField", 5, "storage_intField eq 5" };
+        yield return new object[] { "longField", 5L, "storage_longField eq 5" };
+        yield return new object[] { "floatField", 5.5f, "storage_floatField eq 5.5" };
+        yield return new object[] { "doubleField", 5.5d, "storage_doubleField eq 5.5" };
+        yield return new object[] { "dateTimeOffSetField", new DateTimeOffset(2000, 10, 20, 5, 55, 55, TimeSpan.Zero), "storage_dateTimeOffSetField eq 2000-10-20T05:55:55.0000000Z" };
+        yield return new object[] { "nullField", null!, "storage_nullField eq null" };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -552,6 +552,89 @@ public class AzureAISearchVectorStoreRecordCollectionTests
             new() { VectorStoreRecordDefinition = definition, JsonObjectCustomMapper = Mock.Of<IVectorStoreRecordMapper<MultiPropsModel, JsonObject>>() });
     }
 
+    [Fact]
+    public async Task CanSearchWithVectorAndFilterAsync()
+    {
+        // Arrange.
+        var searchResultsMock = Mock.Of<SearchResults<MultiPropsModel>>();
+        this._searchClientMock
+            .Setup(x => x.SearchAsync<MultiPropsModel>(null, It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResultsMock, Mock.Of<Response>()));
+
+        var sut = new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
+            this._searchIndexClientMock.Object,
+            TestCollectionName);
+        var filter = new VectorSearchFilter().Equality(nameof(MultiPropsModel.Data1), "Data1FilterValue");
+
+        // Act.
+        var searchResults = await sut.SearchAsync(
+            VectorSearchQuery.CreateQuery(
+                new ReadOnlyMemory<float>(new float[4]),
+                new()
+                {
+                    Limit = 5,
+                    Offset = 3,
+                    VectorSearchFilter = filter,
+                    VectorFieldName = nameof(MultiPropsModel.Vector1)
+                }),
+            this._testCancellationToken).ToListAsync();
+
+        // Assert.
+        this._searchClientMock.Verify(
+            x => x.SearchAsync<MultiPropsModel>(
+                null,
+                It.Is<SearchOptions>(x =>
+                    x.Filter == "storage_data1 eq 'Data1FilterValue'" &&
+                    x.Size == 5 &&
+                    x.Skip == 3 &&
+                    x.VectorSearch.Queries.First().GetType() == typeof(VectorizedQuery) &&
+                    x.VectorSearch.Queries.First().Fields.First() == "storage_vector1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CanSearchWithTextAndFilterAsync()
+    {
+        // Arrange.
+        var searchResultsMock = Mock.Of<SearchResults<MultiPropsModel>>();
+        this._searchClientMock
+            .Setup(x => x.SearchAsync<MultiPropsModel>(null, It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResultsMock, Mock.Of<Response>()));
+
+        var sut = new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
+            this._searchIndexClientMock.Object,
+            TestCollectionName);
+        var filter = new VectorSearchFilter().Equality(nameof(MultiPropsModel.Data1), "Data1FilterValue");
+
+        // Act.
+        var searchResults = await sut.SearchAsync(
+            VectorSearchQuery.CreateQuery(
+                "search string",
+                new()
+                {
+                    Limit = 5,
+                    Offset = 3,
+                    VectorSearchFilter = filter,
+                    VectorFieldName = nameof(MultiPropsModel.Vector1)
+                }),
+            this._testCancellationToken).ToListAsync();
+
+        // Assert.
+        this._searchClientMock.Verify(
+            x => x.SearchAsync<MultiPropsModel>(
+                null,
+                It.Is<SearchOptions>(x =>
+                    x.Filter == "storage_data1 eq 'Data1FilterValue'" &&
+                    x.Size == 5 &&
+                    x.Skip == 3 &&
+                    x.VectorSearch.Queries.First().GetType() == typeof(VectorizableTextQuery) &&
+                    x.VectorSearch.Queries.First().Fields.First() == "storage_vector1" &&
+                    ((VectorizableTextQuery)x.VectorSearch.Queries.First()).Text == "search string"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private AzureAISearchVectorStoreRecordCollection<MultiPropsModel> CreateRecordCollection(bool useDefinition, bool useCustomJsonSerializerOptions = false)
     {
         return new AzureAISearchVectorStoreRecordCollection<MultiPropsModel>(
@@ -600,7 +683,7 @@ public class AzureAISearchVectorStoreRecordCollectionTests
         public string Key { get; set; } = string.Empty;
 
         [JsonPropertyName("storage_data1")]
-        [VectorStoreRecordData]
+        [VectorStoreRecordData(IsFilterable = true)]
         public string Data1 { get; set; } = string.Empty;
 
         [VectorStoreRecordData]

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionSearchMapping.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
+
+/// <summary>
+/// Contains mapping helpers to use when searching for documents using Azure AI Search.
+/// </summary>
+internal static class AzureAISearchVectorStoreCollectionSearchMapping
+{
+    /// <summary>
+    /// Build an OData filter string from the provided <see cref="VectorSearchFilter"/>.
+    /// </summary>
+    /// <param name="basicVectorSearchFilter">The <see cref="VectorSearchFilter"/> to build an OData filter string from.</param>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <returns>The OData filter string.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a provided filter value is not supported.</exception>
+    public static string BuildFilterString(VectorSearchFilter? basicVectorSearchFilter, Dictionary<string, string> storagePropertyNames)
+    {
+        var filterString = string.Empty;
+        if (basicVectorSearchFilter?.FilterClauses is not null)
+        {
+            // Map Equality clauses.
+            var filterStrings = basicVectorSearchFilter?.FilterClauses.OfType<EqualityFilterClause>().Select(x =>
+            {
+                string storageFieldName = GetStoragePropertyName(storagePropertyNames, x.FieldName);
+
+                return x.Value switch
+                {
+                    string stringValue => $"{storageFieldName} eq '{stringValue}'",
+#pragma warning disable CA1308 // Normalize strings to uppercase - OData filter strings use lowercase boolean literals. See https://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_PrimitiveLiterals
+                    bool boolValue => $"{storageFieldName} eq {boolValue.ToString().ToLowerInvariant()}",
+#pragma warning restore CA1308 // Normalize strings to uppercase
+                    int intValue => $"{storageFieldName} eq {intValue}",
+                    long longValue => $"{storageFieldName} eq {longValue}",
+                    float floatValue => $"{storageFieldName} eq {floatValue}",
+                    double doubleValue => $"{storageFieldName} eq {doubleValue}",
+                    DateTimeOffset dateTimeOffsetValue => $"{storageFieldName} eq {dateTimeOffsetValue.UtcDateTime:O}",
+                    null => $"{storageFieldName} eq null",
+                    _ => throw new InvalidOperationException($"Unsupported filter value type '{x.Value.GetType().Name}'.")
+                };
+            });
+
+            // Map tag contains clauses.
+            var tagListContainsStrings = basicVectorSearchFilter?.FilterClauses
+                .OfType<TagListContainsFilterClause>()
+                .Select(x =>
+                {
+                    string storageFieldName = GetStoragePropertyName(storagePropertyNames, x.FieldName);
+                    return $"{storageFieldName}/any(t: t eq '{x.Value}')";
+                });
+
+            // Combine clauses.
+            filterString = string.Join(" and ", filterStrings!.Concat(tagListContainsStrings!));
+        }
+
+        return filterString;
+    }
+
+    /// <summary>
+    /// Gets the name of the name under which the property with the given name is stored.
+    /// </summary>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <param name="fieldName">The name of the property in the data model.</param>
+    /// <returns>The name that the property os stored under.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the property name is not found.</exception>
+    private static string GetStoragePropertyName(Dictionary<string, string> storagePropertyNames, string fieldName)
+    {
+        if (!storagePropertyNames.TryGetValue(fieldName, out var storageFieldName))
+        {
+            throw new InvalidOperationException($"Property name '{fieldName}' provided as part of the filter clause is not a valid property name.");
+        }
+
+        return storageFieldName;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IVectorSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
@@ -86,6 +86,12 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
     /// <summary>The storage names of all non vector fields on the current model.</summary>
     private readonly List<string> _nonVectorStoragePropertyNames = new();
 
+    /// <summary>The name of the first vector field for the collections that this class is used with.</summary>
+    private readonly string? _firstVectorPropertyName = null;
+
+    /// <summary>The name of the first string data field for the collections that this class is used with.</summary>
+    private readonly string? _firstStringDataPropertyName = null;
+
     /// <summary>A dictionary that maps from a property name to the storage name that should be used when serializing it to json for data and vector properties.</summary>
     private readonly Dictionary<string, string> _storagePropertyNames = new();
 
@@ -125,6 +131,17 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
             .Concat([properties.KeyProperty])
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
             .ToList();
+
+        if (properties.VectorProperties.Count > 0)
+        {
+            this._firstVectorPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(properties.VectorProperties.First(), typeof(TRecord), jsonSerializerOptions);
+        }
+
+        var firstStringDataProperty = properties.DataProperties.FirstOrDefault(x => x.PropertyType == typeof(string));
+        if (firstStringDataProperty is not null)
+        {
+            this._firstStringDataPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(firstStringDataProperty, typeof(TRecord), jsonSerializerOptions);
+        }
     }
 
     /// <inheritdoc />
@@ -299,6 +316,75 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         foreach (var resultKey in resultKeys) { yield return resultKey; }
     }
 
+    /// <inheritdoc />
+    public IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync(VectorSearchQuery vectorQuery, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(vectorQuery);
+
+        if (this._firstVectorPropertyName is null)
+        {
+            throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
+        }
+
+        string? queryText = null;
+        string? filterString = null;
+        var searchFields = new List<string>();
+        var vectorQueries = new List<VectorQuery>();
+        int limit = 3;
+        int offset = 0;
+        bool includeVectors = false;
+
+        if (vectorQuery is VectorizedSearchQuery<ReadOnlyMemory<float>> floatVectorQuery)
+        {
+            // Resolve options.
+            var internalOptions = floatVectorQuery.SearchOptions ?? Data.VectorSearchOptions.Default;
+            string? vectorFieldName = this.ResolveVectorFieldName(internalOptions.VectorFieldName);
+
+            // Configure search settings.
+            filterString = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(internalOptions.VectorSearchFilter, this._storagePropertyNames);
+            vectorQueries.Add(new VectorizedQuery(floatVectorQuery.Vector) { KNearestNeighborsCount = internalOptions.Limit, Fields = { vectorFieldName } });
+            limit = internalOptions.Limit;
+            offset = internalOptions.Offset;
+            includeVectors = internalOptions.IncludeVectors;
+        }
+        else if (vectorQuery is VectorizableTextSearchQuery vectorizableTextQuery)
+        {
+            // Resolve options.
+            var internalOptions = vectorizableTextQuery.SearchOptions ?? Data.VectorSearchOptions.Default;
+            string? vectorFieldName = this.ResolveVectorFieldName(internalOptions.VectorFieldName);
+
+            // Configure search settings.
+            filterString = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(internalOptions.VectorSearchFilter, this._storagePropertyNames);
+            vectorQueries.Add(new VectorizableTextQuery(vectorizableTextQuery.QueryText) { KNearestNeighborsCount = internalOptions.Limit, Fields = { vectorFieldName } });
+            limit = internalOptions.Limit;
+            offset = internalOptions.Offset;
+            includeVectors = internalOptions.IncludeVectors;
+        }
+        else
+        {
+            throw new NotSupportedException($"A {nameof(VectorSearchQuery)} of type {vectorQuery.QueryType} is not supported by the Azure AI Search connector.");
+        }
+
+        // Build search options.
+        var searchOptions = new SearchOptions
+        {
+            VectorSearch = new(),
+            Size = limit,
+            Skip = offset,
+            Filter = filterString,
+        };
+        searchOptions.SearchFields.AddRange(searchFields);
+        searchOptions.VectorSearch.Queries.AddRange(vectorQueries);
+
+        // Filter out vector fields if requested.
+        if (!includeVectors)
+        {
+            searchOptions.Select.AddRange(this._nonVectorStoragePropertyNames);
+        }
+
+        return this.SearchAndMapToDataModelAsync(queryText, searchOptions, includeVectors, cancellationToken);
+    }
+
     /// <summary>
     /// Get the document with the given key and map it to the data model using the configured mapper type.
     /// </summary>
@@ -338,6 +424,48 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         return await this.RunOperationAsync(
             OperationName,
             () => GetDocumentWithNotFoundHandlingAsync<TRecord>(this._searchClient, key, innerOptions, cancellationToken)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Search for the documents matching the given options and map them to the data model using the configured mapper type.
+    /// </summary>
+    /// <param name="searchText">Text to use if doing a hybrid search. Null for non-hybrid search.</param>
+    /// <param name="searchOptions">The options controlling the behavior of the search operation.</param>
+    /// <param name="includeVectors">A value indicating whether to include vectors in the result or not.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns></returns>
+    private async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAndMapToDataModelAsync(
+        string? searchText,
+        SearchOptions searchOptions,
+        bool includeVectors,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        const string OperationName = "Search";
+
+        // Execute search and map using the user provided mapper.
+        if (this._options.JsonObjectCustomMapper is not null)
+        {
+            var jsonObjectResults = await this.RunOperationAsync(
+                OperationName,
+                () => this._searchClient.SearchAsync<JsonObject>(searchText, searchOptions, cancellationToken)).ConfigureAwait(false);
+
+            foreach (var result in jsonObjectResults.Value.GetResults())
+            {
+                var document = VectorStoreErrorHandler.RunModelConversion(
+                    DatabaseName,
+                    this._collectionName,
+                    OperationName,
+                    () => this._options.JsonObjectCustomMapper!.MapFromStorageToDataModel(result.Document, new() { IncludeVectors = includeVectors }));
+                yield return new(document, result.Score);
+            }
+        }
+
+        // Execute search and map using the built in Azure AI Search mapper.
+        Response<SearchResults<TRecord>> results = await this.RunOperationAsync(OperationName, () => this._searchClient.SearchAsync<TRecord>(searchText, searchOptions, cancellationToken)).ConfigureAwait(false);
+        foreach (var result in results.Value.GetResults())
+        {
+            yield return new(result.Document, result.Score);
+        }
     }
 
     /// <summary>
@@ -388,6 +516,31 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         }
 
         return innerOptions;
+    }
+
+    /// <summary>
+    /// Resolve the vector field name to use for a search by using the storage name for the field name from options
+    /// if available, and falling back to the first vector field name if not.
+    /// </summary>
+    /// <param name="optionsVectorFieldName">The vector field name provided via options.</param>
+    /// <returns>The resolved vector field name.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the provided field name is not a valid field name.</exception>
+    private string ResolveVectorFieldName(string? optionsVectorFieldName)
+    {
+        string? vectorFieldName;
+        if (optionsVectorFieldName is not null)
+        {
+            if (!this._storagePropertyNames.TryGetValue(optionsVectorFieldName, out vectorFieldName))
+            {
+                throw new InvalidOperationException($"The collection does not have a vector field named '{optionsVectorFieldName}'.");
+            }
+        }
+        else
+        {
+            vectorFieldName = this._firstVectorPropertyName;
+        }
+
+        return vectorFieldName!;
     }
 
     /// <summary>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -13,6 +13,7 @@ using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel.Data;
+using SemanticKernel.IntegrationTests.TestSettings;
 using SemanticKernel.IntegrationTests.TestSettings.Memory;
 using Xunit;
 
@@ -33,11 +34,11 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
     /// <summary>
     /// Test Configuration setup.
     /// </summary>
-    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+    private static readonly IConfigurationRoot s_configuration = new ConfigurationBuilder()
         .AddJsonFile(path: "testsettings.json", optional: false, reloadOnChange: true)
         .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
         .AddEnvironmentVariables()
-        .AddUserSecrets<AzureAISearchVectorStoreRecordCollectionTests>()
+        .AddUserSecrets<AzureAISearchVectorStoreFixture>()
         .Build();
 
     /// <summary>
@@ -45,7 +46,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
     /// </summary>
     public AzureAISearchVectorStoreFixture()
     {
-        var config = this._configuration.GetRequiredSection("AzureAISearch").Get<AzureAISearchConfiguration>();
+        var config = s_configuration.GetRequiredSection("AzureAISearch").Get<AzureAISearchConfiguration>();
         Assert.NotNull(config);
         this.Config = config;
         this.SearchIndexClient = new SearchIndexClient(new Uri(config.ServiceUrl), new AzureKeyCredential(config.ApiKey));
@@ -56,7 +57,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                 new VectorStoreRecordKeyProperty("HotelId", typeof(string)),
                 new VectorStoreRecordDataProperty("HotelName", typeof(string)) { IsFilterable = true, IsFullTextSearchable = true },
                 new VectorStoreRecordDataProperty("Description", typeof(string)),
-                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4 },
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 1536 },
                 new VectorStoreRecordDataProperty("Tags", typeof(string[])) { IsFilterable = true },
                 new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool?)) { IsFilterable = true },
                 new VectorStoreRecordDataProperty("LastRenovationDate", typeof(DateTimeOffset?)) { IsFilterable = true },
@@ -93,7 +94,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
     {
         await AzureAISearchVectorStoreFixture.DeleteIndexIfExistsAsync(this._testIndexName, this.SearchIndexClient);
         await AzureAISearchVectorStoreFixture.CreateIndexAsync(this._testIndexName, this.SearchIndexClient);
-        AzureAISearchVectorStoreFixture.UploadDocuments(this.SearchIndexClient.GetSearchClient(this._testIndexName));
+        await AzureAISearchVectorStoreFixture.UploadDocumentsAsync(this.SearchIndexClient.GetSearchClient(this._testIndexName));
     }
 
     /// <summary>
@@ -127,16 +128,31 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
     /// <returns>An async task.</returns>
     public static async Task CreateIndexAsync(string indexName, SearchIndexClient adminClient)
     {
+        AzureOpenAIConfiguration openAIConfiguration = s_configuration.GetRequiredSection("AzureOpenAIEmbeddings").Get<AzureOpenAIConfiguration>()!;
+
+        // Build the list of fields from the model, and then replace the DescriptionEmbedding field with a vector field, to work around
+        // issue where the field is not recognized as an array on parsing on the server side when apply the VectorSearchFieldAttribute.
         FieldBuilder fieldBuilder = new();
         var searchFields = fieldBuilder.Build(typeof(Hotel));
         var embeddingfield = searchFields.First(x => x.Name == "DescriptionEmbedding");
         searchFields.Remove(embeddingfield);
-        searchFields.Add(new VectorSearchField("DescriptionEmbedding", 4, "my-vector-profile"));
+        searchFields.Add(new VectorSearchField("DescriptionEmbedding", 1536, "my-vector-profile"));
 
+        // Create an index definition with a vectorizer to use when doing vector searches using text.
         var definition = new SearchIndex(indexName, searchFields);
         definition.VectorSearch = new VectorSearch();
+        definition.VectorSearch.Vectorizers.Add(new AzureOpenAIVectorizer("text-embedding-vectorizer")
+        {
+            Parameters = new AzureOpenAIVectorizerParameters
+            {
+                ResourceUri = new Uri(openAIConfiguration.Endpoint),
+                DeploymentName = openAIConfiguration.DeploymentName,
+                ApiKey = openAIConfiguration.ApiKey,
+                ModelName = openAIConfiguration.EmbeddingModelId
+            }
+        });
         definition.VectorSearch.Algorithms.Add(new HnswAlgorithmConfiguration("my-hnsw-vector-config-1") { Parameters = new HnswParameters { Metric = VectorSearchAlgorithmMetric.Cosine } });
-        definition.VectorSearch.Profiles.Add(new VectorSearchProfile("my-vector-profile", "my-hnsw-vector-config-1"));
+        definition.VectorSearch.Profiles.Add(new VectorSearchProfile("my-vector-profile", "my-hnsw-vector-config-1") { VectorizerName = "text-embedding-vectorizer" });
 
         var suggester = new SearchSuggester("sg", new[] { "HotelName" });
         definition.Suggesters.Add(suggester);
@@ -148,8 +164,10 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
     /// Upload test documents to the index.
     /// </summary>
     /// <param name="searchClient">The client to use for uploading the documents.</param>
-    public static void UploadDocuments(SearchClient searchClient)
+    public static async Task UploadDocumentsAsync(SearchClient searchClient)
     {
+        var embedding = CreateTestEmbedding();
+
         IndexDocumentsBatch<Hotel> batch = IndexDocumentsBatch.Create(
             IndexDocumentsAction.Upload(
                 new Hotel()
@@ -157,7 +175,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     HotelId = "BaseSet-1",
                     HotelName = "Hotel 1",
                     Description = "This is a great hotel",
-                    DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+                    DescriptionEmbedding = embedding,
                     Tags = new[] { "pool", "air conditioning", "concierge" },
                     ParkingIncluded = false,
                     LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
@@ -169,7 +187,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     HotelId = "BaseSet-2",
                     HotelName = "Hotel 2",
                     Description = "This is a great hotel",
-                    DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+                    DescriptionEmbedding = embedding,
                     Tags = new[] { "pool", "free wifi", "concierge" },
                     ParkingIncluded = false,
                     LastRenovationDate = new DateTimeOffset(1979, 2, 18, 0, 0, 0, TimeSpan.Zero),
@@ -181,7 +199,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     HotelId = "BaseSet-3",
                     HotelName = "Hotel 3",
                     Description = "This is a great hotel",
-                    DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+                    DescriptionEmbedding = embedding,
                     Tags = new[] { "air conditioning", "bar", "continental breakfast" },
                     ParkingIncluded = true,
                     LastRenovationDate = new DateTimeOffset(2015, 9, 20, 0, 0, 0, TimeSpan.Zero),
@@ -193,7 +211,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                     HotelId = "BaseSet-4",
                     HotelName = "Hotel 4",
                     Description = "This is a great hotel",
-                    DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+                    DescriptionEmbedding = embedding,
                     Tags = new[] { "concierge", "view", "24-hour front desk service" },
                     ParkingIncluded = true,
                     LastRenovationDate = new DateTimeOffset(1960, 2, 06, 0, 0, 0, TimeSpan.Zero),
@@ -201,7 +219,19 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                 })
             );
 
-        searchClient.IndexDocuments(batch);
+        await searchClient.IndexDocumentsAsync(batch);
+
+        // Add some delay to allow time for the documents to get indexed and show up in search.
+        await Task.Delay(5000);
+    }
+
+    /// <summary>
+    /// Create a test embedding.
+    /// </summary>
+    /// <returns>The test embedding.</returns>
+    public static float[] CreateTestEmbedding()
+    {
+        return Enumerable.Range(1, 1536).Select(x => (float)x).ToArray();
     }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -211,7 +241,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         [VectorStoreRecordKey]
         public string HotelId { get; set; }
 
-        [SearchableField(IsSortable = true)]
+        [SearchableField(IsFilterable = true, IsSortable = true)]
         [VectorStoreRecordData(IsFilterable = true, IsFullTextSearchable = true)]
         public string HotelName { get; set; }
 
@@ -219,7 +249,7 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
         [VectorStoreRecordData]
         public string Description { get; set; }
 
-        [VectorStoreRecordVector(4)]
+        [VectorStoreRecordVector(1536)]
         public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
 
         [SearchableField(IsFilterable = true, IsFacetable = true)]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -43,7 +43,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
     [Theory(Skip = SkipReason)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task ItCanCreateACollectionUpsertAndGetAsync(bool useRecordDefinition)
+    public async Task ItCanCreateACollectionUpsertGetAndSearchAsync(bool useRecordDefinition)
     {
         // Arrange
         var hotel = CreateTestHotel("Upsert-1");
@@ -60,6 +60,8 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         await sut.CreateCollectionAsync();
         var upsertResult = await sut.UpsertAsync(hotel);
         var getResult = await sut.GetAsync("Upsert-1");
+        var embedding = new ReadOnlyMemory<float>(AzureAISearchVectorStoreFixture.CreateTestEmbedding());
+        var searchResult = await sut.SearchAsync(VectorSearchQuery.CreateQuery(embedding, new VectorSearchOptions { IncludeVectors = true, VectorSearchFilter = new VectorSearchFilter().Equality("HotelName", "MyHotel Upsert-1") })).ToListAsync();
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
@@ -78,6 +80,17 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         Assert.Equal(hotel.ParkingIncluded, getResult.ParkingIncluded);
         Assert.Equal(hotel.LastRenovationDate, getResult.LastRenovationDate);
         Assert.Equal(hotel.Rating, getResult.Rating);
+
+        Assert.Single(searchResult);
+        var searchResultRecord = searchResult.First().Record;
+        Assert.Equal(hotel.HotelName, searchResultRecord.HotelName);
+        Assert.Equal(hotel.Description, searchResultRecord.Description);
+        Assert.NotNull(searchResultRecord.DescriptionEmbedding);
+        Assert.Equal(hotel.DescriptionEmbedding?.ToArray(), searchResultRecord.DescriptionEmbedding?.ToArray());
+        Assert.Equal(hotel.Tags, searchResultRecord.Tags);
+        Assert.Equal(hotel.ParkingIncluded, searchResultRecord.ParkingIncluded);
+        Assert.Equal(hotel.LastRenovationDate, searchResultRecord.LastRenovationDate);
+        Assert.Equal(hotel.Rating, searchResultRecord.Rating);
 
         // Output
         output.WriteLine(collectionExistResult.ToString());
@@ -191,7 +204,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         Assert.Equal(includeVectors, getResult.DescriptionEmbedding != null);
         if (includeVectors)
         {
-            Assert.Equal(new[] { 30f, 31f, 32f, 33f }, getResult.DescriptionEmbedding!.Value.ToArray());
+            Assert.Equal(AzureAISearchVectorStoreFixture.CreateTestEmbedding(), getResult.DescriptionEmbedding!.Value.ToArray());
         }
         Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, getResult.Tags);
         Assert.False(getResult.ParkingIncluded);
@@ -308,12 +321,78 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
     }
 
+    [Theory(Skip = SkipReason)]
+    [InlineData("equality", true)]
+    [InlineData("tagContains", false)]
+    public async Task ItCanSearchWithVectorAndFiltersAsync(string option, bool includeVectors)
+    {
+        // Arrange.
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+
+        // Act.
+        var filter = option == "equality" ? new VectorSearchFilter().Equality("HotelName", "Hotel 3") : new VectorSearchFilter().TagListContains("Tags", "bar");
+        var searchResults = sut.SearchAsync(
+            VectorSearchQuery.CreateQuery(
+                new ReadOnlyMemory<float>(AzureAISearchVectorStoreFixture.CreateTestEmbedding()),
+                new()
+                {
+                    IncludeVectors = includeVectors,
+                    VectorFieldName = "DescriptionEmbedding",
+                    VectorSearchFilter = filter,
+                }));
+
+        // Assert.
+        Assert.NotNull(searchResults);
+        var searchResultsList = await searchResults.ToListAsync();
+        Assert.Single(searchResultsList);
+        var searchResult = searchResultsList.First();
+        Assert.Equal("BaseSet-3", searchResult.Record.HotelId);
+        Assert.Equal("Hotel 3", searchResult.Record.HotelName);
+        Assert.Equal("This is a great hotel", searchResult.Record.Description);
+        Assert.Equal(new[] { "air conditioning", "bar", "continental breakfast" }, searchResult.Record.Tags);
+        Assert.True(searchResult.Record.ParkingIncluded);
+        Assert.Equal(new DateTimeOffset(2015, 9, 20, 0, 0, 0, TimeSpan.Zero), searchResult.Record.LastRenovationDate);
+        Assert.Equal(4.8, searchResult.Record.Rating);
+        if (includeVectors)
+        {
+            Assert.NotNull(searchResult.Record.DescriptionEmbedding);
+            Assert.Equal(AzureAISearchVectorStoreFixture.CreateTestEmbedding(), searchResult.Record.DescriptionEmbedding!.Value.ToArray());
+        }
+        else
+        {
+            Assert.Null(searchResult.Record.DescriptionEmbedding);
+        }
+    }
+
+    [Fact(Skip = SkipReason)]
+    public async Task ItCanSearchWithVectorizableTextAndFiltersAsync()
+    {
+        // Arrange.
+        var sut = new AzureAISearchVectorStoreRecordCollection<Hotel>(fixture.SearchIndexClient, fixture.TestIndexName);
+
+        // Act.
+        var filter = new VectorSearchFilter().Equality("HotelName", "Hotel 3");
+        var searchResults = sut.SearchAsync(
+            VectorSearchQuery.CreateQuery(
+                "A hotel with great views.",
+                new()
+                {
+                    VectorFieldName = "DescriptionEmbedding",
+                    VectorSearchFilter = filter,
+                }));
+
+        // Assert.
+        Assert.NotNull(searchResults);
+        var searchResultsList = await searchResults.ToListAsync();
+        Assert.Single(searchResultsList);
+    }
+
     private static Hotel CreateTestHotel(string hotelId) => new()
     {
         HotelId = hotelId,
         HotelName = $"MyHotel {hotelId}",
         Description = "My Hotel is great.",
-        DescriptionEmbedding = new[] { 30f, 31f, 32f, 33f },
+        DescriptionEmbedding = AzureAISearchVectorStoreFixture.CreateTestEmbedding(),
         Tags = ["pool", "air conditioning", "concierge"],
         ParkingIncluded = true,
         LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),


### PR DESCRIPTION
### Motivation and Context

As part of the work on vector storage we have to add vector search capabilities for each implementation.

### Description

1. Adding vector search for Azure AI Search.
2. Note that for now, the search interface is implemented directly by the collection, but in future it should be part of the collection interface. I'm doing it this way so that each implementation can be added one by one, and once all have been implemented, we can make the switch.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
