### PR TITLE
.Net: Add qdrant vector search implementation.

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -94,7 +94,7 @@
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="Testcontainers.Milvus" Version="3.8.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-    <PackageVersion Include="Qdrant.Client" Version="1.9.0" />
+    <PackageVersion Include="Qdrant.Client" Version="1.11.0" />
     <!-- Symbols -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Toolset -->

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/MockableQdrantClient.cs
@@ -255,4 +255,61 @@ internal class MockableQdrantClient
         ShardKeySelector? shardKeySelector = null,
         CancellationToken cancellationToken = default)
         => this._qdrantClient.RetrieveAsync(collectionName, ids, withPayload, withVectors, readConsistency, shardKeySelector, cancellationToken);
+
+    /// <summary>
+    /// Universally query points.
+    /// Covers all capabilities of search, recommend, discover, filters.
+    /// Also enables hybrid and multi-stage queries.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="query">Query to perform. If missing, returns points ordered by their IDs.</param>
+    /// <param name="prefetch">Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.</param>
+    /// <param name="usingVector">Name of the vector to use for querying. If missing, the default vector is used..</param>
+    /// <param name="filter">Filter conditions - return only those points that satisfy the specified conditions.</param>
+    /// <param name="scoreThreshold">Return points with scores better than this threshold.</param>
+    /// <param name="searchParams">Search config.</param>
+    /// <param name="limit">Max number of results.</param>
+    /// <param name="offset">Offset of the result.</param>
+    /// <param name="payloadSelector">Options for specifying which payload to include or not.</param>
+    /// <param name="vectorsSelector">Options for specifying which vectors to include into the response.</param>
+    /// <param name="readConsistency">Options for specifying read consistency guarantees.</param>
+    /// <param name="shardKeySelector">Specify in which shards to look for the points, if not specified - look in all shards.</param>
+    /// <param name="lookupFrom">The location to use for IDs lookup, if not specified - use the current collection and the 'usingVector' vector</param>
+    /// <param name="timeout">If set, overrides global timeout setting for this request.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    public virtual Task<IReadOnlyList<ScoredPoint>> QueryAsync(
+        string collectionName,
+        Query? query = null,
+        IReadOnlyList<PrefetchQuery>? prefetch = null,
+        string? usingVector = null,
+        Filter? filter = null,
+        float? scoreThreshold = null,
+        SearchParams? searchParams = null,
+        ulong limit = 10,
+        ulong offset = 0,
+        WithPayloadSelector? payloadSelector = null,
+        WithVectorsSelector? vectorsSelector = null,
+        ReadConsistency? readConsistency = null,
+        ShardKeySelector? shardKeySelector = null,
+        LookupLocation? lookupFrom = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+        => this._qdrantClient.QueryAsync(
+            collectionName,
+            query,
+            prefetch,
+            usingVector,
+            filter,
+            scoreThreshold,
+            searchParams,
+            limit,
+            offset,
+            payloadSelector,
+            vectorsSelector,
+            readConsistency,
+            shardKeySelector,
+            lookupFrom,
+            timeout,
+            cancellationToken);
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Data;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Contains mapping helpers to use when searching for documents using Qdrant.
+/// </summary>
+internal static class QdrantVectorStoreCollectionSearchMapping
+{
+    /// <summary>
+    /// Build a Qdrant <see cref="Filter"/> from the provided <see cref="VectorSearchFilter"/>.
+    /// </summary>
+    /// <param name="basicVectorSearchFilter">The <see cref="VectorSearchFilter"/> to build a Qdrant <see cref="Filter"/> from.</param>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <returns>The Qdrant <see cref="Filter"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the provided filter contains unsupported types, values or unknown properties.</exception>
+    public static Filter BuildFilter(VectorSearchFilter? basicVectorSearchFilter, Dictionary<string, string> storagePropertyNames)
+    {
+        var filter = new Filter();
+
+        // Return an empty filter if no filter clauses are provided.
+        if (basicVectorSearchFilter?.FilterClauses is null)
+        {
+            return filter;
+        }
+
+        foreach (var filterClause in basicVectorSearchFilter.FilterClauses)
+        {
+            string fieldName;
+            object filterValue;
+
+            // In Qdrant, tag list contains is handled using a keyword match, which is the same as a string equality check.
+            // We can therefore just extract the field name and value from each clause and handle them the same.
+            if (filterClause is EqualityFilterClause equalityFilterClause)
+            {
+                fieldName = equalityFilterClause.FieldName;
+                filterValue = equalityFilterClause.Value;
+            }
+            else if (filterClause is TagListContainsFilterClause tagListContainsClause)
+            {
+                fieldName = tagListContainsClause.FieldName;
+                filterValue = tagListContainsClause.Value;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported filter clause type '{filterClause.GetType().Name}'.");
+            }
+
+            // Map each type of filter value to the appropriate Qdrant match type.
+            var match = filterValue switch
+            {
+                string stringValue => new Match { Keyword = stringValue },
+                int intValue => new Match { Integer = intValue },
+                long longValue => new Match { Integer = longValue },
+                bool boolValue => new Match { Boolean = boolValue },
+                _ => throw new InvalidOperationException($"Unsupported filter value type '{filterValue.GetType().Name}'.")
+            };
+
+            // Get the storage name for the field.
+            if (!storagePropertyNames.TryGetValue(fieldName, out var storagePropertyName))
+            {
+                throw new InvalidOperationException($"Property name '{fieldName}' provided as part of the filter clause is not a valid property name.");
+            }
+
+            filter.Must.Add(new Condition() { Field = new FieldCondition() { Key = storagePropertyName, Match = match } });
+        }
+
+        return filter;
+    }
+
+    /// <summary>
+    /// Map the given <see cref="ScoredPoint"/> to a <see cref="VectorSearchResult{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record to map to.</typeparam>
+    /// <param name="point">The point to map to a <see cref="VectorSearchResult{TRecord}"/>.</param>
+    /// <param name="mapper">The mapper to perform the main mapping operation with.</param>
+    /// <param name="includeVectors">A value indicating whether to include vectors in the mapped result.</param>
+    /// <param name="databaseSystemName">The name of the database system the operation is being run on.</param>
+    /// <param name="collectionName">The name of the collection the operation is being run on.</param>
+    /// <param name="operationName">The type of database operation being run.</param>
+    /// <returns>The mapped <see cref="VectorSearchResult{TRecord}"/>.</returns>
+    public static VectorSearchResult<TRecord> MapScoredPointToVectorSearchResult<TRecord>(ScoredPoint point, IVectorStoreRecordMapper<TRecord, PointStruct> mapper, bool includeVectors, string databaseSystemName, string collectionName, string operationName)
+        where TRecord : class
+    {
+        // Since the mapper doesn't know about scored points, we need to convert the scored point to a point struct first.
+        var pointStruct = new PointStruct
+        {
+            Id = point.Id,
+            Vectors = point.Vectors,
+            Payload = { }
+        };
+
+        foreach (KeyValuePair<string, Value> payloadEntry in point.Payload)
+        {
+            pointStruct.Payload.Add(payloadEntry.Key, payloadEntry.Value);
+        }
+
+        // Do the mapping with error handling.
+        return new VectorSearchResult<TRecord>(
+            VectorStoreErrorHandler.RunModelConversion(
+                databaseSystemName,
+                collectionName,
+                operationName,
+                () => mapper.MapFromStorageToDataModel(pointStruct, new() { IncludeVectors = includeVectors })),
+            point.Score);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<ulong, TRecord>, IVectorStoreRecordCollection<Guid, TRecord>
+public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<ulong, TRecord>, IVectorStoreRecordCollection<Guid, TRecord>, IVectorSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
@@ -55,6 +55,9 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
 
     /// <summary>A dictionary that maps from a property name to the configured name that should be used when storing it.</summary>
     private readonly Dictionary<string, string> _storagePropertyNames = new();
+
+    /// <summary>The name of the first vector field for the collections that this class is used with.</summary>
+    private readonly string? _firstVectorPropertyName = null;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> class.
@@ -95,6 +98,10 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
 
         // Build a map of property names to storage names.
         this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToStorageNameMap(properties);
+        if (properties.VectorProperties.Count > 0)
+        {
+            this._firstVectorPropertyName = this._storagePropertyNames[properties.VectorProperties.First().DataModelPropertyName];
+        }
 
         // Assign Mapper.
         if (this._options.PointStructCustomMapper is not null)
@@ -430,6 +437,93 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
                 OperationName,
                 () => this._mapper.MapFromStorageToDataModel(pointStruct, new() { IncludeVectors = includeVectors }));
         }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync(VectorSearchQuery vectorQuery, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (this._firstVectorPropertyName is null)
+        {
+            throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
+        }
+
+        if (vectorQuery is VectorizedSearchQuery<ReadOnlyMemory<float>> floatVectorQuery)
+        {
+            var internalOptions = floatVectorQuery.SearchOptions ?? Data.VectorSearchOptions.Default;
+
+            // Build filter object.
+            var filter = QdrantVectorStoreCollectionSearchMapping.BuildFilter(internalOptions.VectorSearchFilter, this._storagePropertyNames);
+
+            // Specify the vector name if named vectors are used.
+            string? vectorName = null;
+            if (this._options.HasNamedVectors)
+            {
+                vectorName = this.ResolveVectorFieldName(internalOptions.VectorFieldName);
+            }
+
+            // Specify whether to include vectors in the search results.
+            var vectorsSelector = new WithVectorsSelector();
+            vectorsSelector.Enable = internalOptions.IncludeVectors;
+
+            var query = new Query
+            {
+                Nearest = new VectorInput(floatVectorQuery.Vector.ToArray()),
+            };
+
+            // Execute Search.
+            var points = await this.RunOperationAsync(
+                "Query",
+                () => this._qdrantClient.QueryAsync(
+                    this.CollectionName,
+                    query: query,
+                    usingVector: vectorName,
+                    filter: filter,
+                    limit: (ulong)internalOptions.Limit,
+                    offset: (ulong)internalOptions.Offset,
+                    vectorsSelector: vectorsSelector,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+            // Map to data model and return results.
+            foreach (var point in points)
+            {
+                yield return QdrantVectorStoreCollectionSearchMapping.MapScoredPointToVectorSearchResult(
+                    point,
+                    this._mapper,
+                    internalOptions.IncludeVectors,
+                    DatabaseName,
+                    this._collectionName,
+                    "Query");
+            }
+
+            yield break;
+        }
+
+        throw new NotSupportedException($"A {nameof(VectorSearchQuery)} of type {vectorQuery.QueryType} is not supported by the Qdrant connector.");
+    }
+
+    /// <summary>
+    /// Resolve the vector field name to use for a search by using the storage name for the field name from options
+    /// if available, and falling back to the first vector field name if not.
+    /// </summary>
+    /// <param name="optionsVectorFieldName">The vector field name provided via options.</param>
+    /// <returns>The resolved vector field name.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the provided field name is not a valid field name.</exception>
+    private string ResolveVectorFieldName(string? optionsVectorFieldName)
+    {
+        string? vectorFieldName;
+        if (optionsVectorFieldName is not null)
+        {
+            if (!this._storagePropertyNames.TryGetValue(optionsVectorFieldName, out vectorFieldName))
+            {
+                throw new InvalidOperationException($"The collection does not have a vector field named '{optionsVectorFieldName}'.");
+            }
+        }
+        else
+        {
+            vectorFieldName = this._firstVectorPropertyName;
+        }
+
+        return vectorFieldName!;
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreCollectionSearchMappingTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Data;
+using Moq;
+using Qdrant.Client.Grpc;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="QdrantVectorStoreCollectionSearchMapping"/> class.
+/// </summary>
+public class QdrantVectorStoreCollectionSearchMappingTests
+{
+    [Theory]
+    [InlineData("string")]
+    [InlineData("int")]
+    [InlineData("bool")]
+    [InlineData("long")]
+
+    public void BuildFilterMapsEqualityClause(string type)
+    {
+        // Arrange.
+        object expected = type switch
+        {
+            "string" => "Value",
+            "int" => 1,
+            "bool" => true,
+            "long" => 1L,
+            _ => throw new InvalidOperationException()
+        };
+        var filter = new VectorSearchFilter().Equality("FieldName", expected);
+
+        // Act.
+        var actual = QdrantVectorStoreCollectionSearchMapping.BuildFilter(filter, new Dictionary<string, string>() { { "FieldName", "storage_FieldName" } });
+
+        // Assert.
+        Assert.Single(actual.Must);
+        Assert.Equal("storage_FieldName", actual.Must.First().Field.Key);
+
+        var match = actual.Must.First().Field.Match;
+        object actualSearchValue = type switch
+        {
+            "string" => match.Keyword,
+            "int" => match.Integer,
+            "bool" => match.Boolean,
+            "long" => match.Integer,
+            _ => throw new InvalidOperationException()
+        };
+
+        if (type == "int")
+        {
+            // Qdrant uses long for integers so we have to cast the expected value to long.
+            Assert.Equal((long)(int)expected, actualSearchValue);
+        }
+        else
+        {
+            Assert.Equal(expected, actualSearchValue);
+        }
+    }
+
+    [Fact]
+    public void BuildFilterMapsTagContainsClause()
+    {
+        // Arrange.
+        var filter = new VectorSearchFilter().TagListContains("FieldName", "Value");
+
+        // Act.
+        var actual = QdrantVectorStoreCollectionSearchMapping.BuildFilter(filter, new Dictionary<string, string>() { { "FieldName", "storage_FieldName" } });
+
+        // Assert.
+        Assert.Single(actual.Must);
+        Assert.Equal("storage_FieldName", actual.Must.First().Field.Key);
+        Assert.Equal("Value", actual.Must.First().Field.Match.Keyword);
+    }
+
+    [Fact]
+    public void BuildFilterThrowsForUnknownFieldName()
+    {
+        // Arrange.
+        var filter = new VectorSearchFilter().Equality("FieldName", "Value");
+
+        // Act and Assert.
+        Assert.Throws<InvalidOperationException>(() => QdrantVectorStoreCollectionSearchMapping.BuildFilter(filter, new Dictionary<string, string>()));
+    }
+
+    [Fact]
+    public void MapScoredPointToVectorSearchResultMapsResults()
+    {
+        // Arrange.
+        var scoredPoint = new ScoredPoint
+        {
+            Id = 1,
+            Payload = { ["storage_DataField"] = "data 1" },
+            Vectors = new float[] { 1, 2, 3 },
+            Score = 0.5f
+        };
+
+        var mapperMock = new Mock<IVectorStoreRecordMapper<DataModel, PointStruct>>(MockBehavior.Strict);
+        mapperMock.Setup(x => x.MapFromStorageToDataModel(It.IsAny<PointStruct>(), It.IsAny<StorageToDataModelMapperOptions>())).Returns(new DataModel { Id = 1, DataField = "data 1", Embedding = new float[] { 1, 2, 3 } });
+
+        // Act.
+        var actual = QdrantVectorStoreCollectionSearchMapping.MapScoredPointToVectorSearchResult<DataModel>(scoredPoint, mapperMock.Object, true, "Qdrant", "mycollection", "query");
+
+        // Assert.
+        Assert.Equal(1ul, actual.Record.Id);
+        Assert.Equal("data 1", actual.Record.DataField);
+        Assert.Equal(new float[] { 1, 2, 3 }, actual.Record.Embedding.ToArray());
+        Assert.Equal(0.5f, actual.Score);
+    }
+
+    public class DataModel
+    {
+        public ulong Id { get; init; }
+
+        public string? DataField { get; init; }
+
+        public ReadOnlyMemory<float> Embedding { get; init; }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -548,6 +548,53 @@ public class QdrantVectorStoreRecordCollectionTests
             new() { VectorStoreRecordDefinition = definition, PointStructCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel<ulong>, PointStruct>>() });
     }
 
+    [Theory]
+    [MemberData(nameof(TestOptions))]
+    public async Task CanSearchWithVectorAndFilterAsync<TKey>(bool useDefinition, bool hasNamedVectors, TKey testRecordKey)
+        where TKey : notnull
+    {
+        var sut = this.CreateRecordCollection<TKey>(useDefinition, hasNamedVectors) as IVectorSearch<SinglePropsModel<TKey>>;
+
+        // Arrange.
+        var scoredPoint = CreateScoredPoint(hasNamedVectors, testRecordKey);
+        this.SetupQueryMock([scoredPoint]);
+        var filter = new VectorSearchFilter().Equality(nameof(SinglePropsModel<TKey>.Data), "data 1");
+
+        // Act.
+        var actual = await sut!.SearchAsync(
+            VectorSearchQuery.CreateQuery(new ReadOnlyMemory<float>(new[] { 1f, 2f, 3f, 4f }), new() { IncludeVectors = true, VectorSearchFilter = filter, Limit = 5, Offset = 2 }),
+            this._testCancellationToken).ToListAsync();
+
+        // Assert.
+        this._qdrantClientMock
+            .Verify(
+                x => x.QueryAsync(
+                    TestCollectionName,
+                    It.Is<Query?>(x => x!.Nearest.Dense.Data.ToArray().SequenceEqual(new[] { 1f, 2f, 3f, 4f })),
+                    null,
+                    hasNamedVectors ? "vector_storage_name" : null,
+                    It.Is<Filter?>(x => x!.Must.Count == 1 && x.Must.First().Field.Key == "data_storage_name" && x.Must.First().Field.Match.Keyword == "data 1"),
+                    null,
+                    null,
+                    5,
+                    2,
+                    null,
+                    It.Is<WithVectorsSelector?>(x => x!.Enable == true),
+                    null,
+                    null,
+                    null,
+                    null,
+                    this._testCancellationToken),
+                Times.Once);
+
+        Assert.Single(actual);
+        Assert.Equal(testRecordKey, actual.First().Record.Key);
+        Assert.Equal("data 1", actual.First().Record.OriginalNameData);
+        Assert.Equal("data 1", actual.First().Record.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector!.Value.ToArray());
+        Assert.Equal(0.5f, actual.First().Score);
+    }
+
     private void SetupRetrieveMock(List<RetrievedPoint> retrievedPoints)
     {
         this._qdrantClientMock
@@ -560,6 +607,29 @@ public class QdrantVectorStoreRecordCollectionTests
                 It.IsAny<ShardKeySelector>(),
                 this._testCancellationToken))
             .ReturnsAsync(retrievedPoints);
+    }
+
+    private void SetupQueryMock(List<ScoredPoint> scoredPoints)
+    {
+        this._qdrantClientMock
+            .Setup(x => x.QueryAsync(
+                It.IsAny<string>(),
+                It.IsAny<Query?>(),
+                null,
+                It.IsAny<string?>(),
+                It.IsAny<Filter?>(),
+                null,
+                null,
+                It.IsAny<ulong>(),
+                It.IsAny<ulong>(),
+                null,
+                It.IsAny<WithVectorsSelector?>(),
+                null,
+                null,
+                null,
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(scoredPoints);
     }
 
     private void SetupDeleteMocks()
@@ -635,6 +705,43 @@ public class QdrantVectorStoreRecordCollectionTests
         {
             point = new RetrievedPoint()
             {
+                Payload = { ["OriginalNameData"] = "data 1", ["data_storage_name"] = "data 1" },
+                Vectors = new[] { 1f, 2f, 3f, 4f }
+            };
+        }
+
+        if (recordKey is ulong ulongKey)
+        {
+            point.Id = ulongKey;
+        }
+
+        if (recordKey is Guid guidKey)
+        {
+            point.Id = guidKey;
+        }
+
+        return point;
+    }
+
+    private static ScoredPoint CreateScoredPoint<TKey>(bool hasNamedVectors, TKey recordKey)
+    {
+        ScoredPoint point;
+        if (hasNamedVectors)
+        {
+            var namedVectors = new NamedVectors();
+            namedVectors.Vectors.Add("vector_storage_name", new[] { 1f, 2f, 3f, 4f });
+            point = new ScoredPoint()
+            {
+                Score = 0.5f,
+                Payload = { ["OriginalNameData"] = "data 1", ["data_storage_name"] = "data 1" },
+                Vectors = new Vectors { Vectors_ = namedVectors }
+            };
+        }
+        else
+        {
+            point = new ScoredPoint()
+            {
+                Score = 0.5f,
                 Payload = { ["OriginalNameData"] = "data 1", ["data_storage_name"] = "data 1" },
                 Vectors = new[] { 1f, 2f, 3f, 4f }
             };

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
@@ -41,7 +41,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    public async Task ItCanCreateACollectionUpsertAndGetAsync(bool hasNamedVectors, bool useRecordDefinition)
+    public async Task ItCanCreateACollectionUpsertGetAndSearchAsync(bool hasNamedVectors, bool useRecordDefinition)
     {
         // Arrange
         var collectionNamePostfix1 = useRecordDefinition ? "WithDefinition" : "WithType";
@@ -61,6 +61,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
         await sut.CreateCollectionAsync();
         var upsertResult = await sut.UpsertAsync(record);
         var getResult = await sut.GetAsync(30, new GetRecordOptions { IncludeVectors = true });
+        var searchResult = await sut.SearchAsync(VectorSearchQuery.CreateQuery(new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }), new VectorSearchOptions { VectorSearchFilter = new VectorSearchFilter().Equality("HotelCode", 30) })).ToListAsync();
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
@@ -75,6 +76,16 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
         Assert.Equal(record.ParkingIncluded, getResult?.ParkingIncluded);
         Assert.Equal(record.Tags.ToArray(), getResult?.Tags.ToArray());
         Assert.Equal(record.Description, getResult?.Description);
+
+        Assert.Single(searchResult);
+        var searchResultRecord = searchResult.First().Record;
+        Assert.Equal(record.HotelId, searchResultRecord?.HotelId);
+        Assert.Equal(record.HotelName, searchResultRecord?.HotelName);
+        Assert.Equal(record.HotelCode, searchResultRecord?.HotelCode);
+        Assert.Equal(record.HotelRating, searchResultRecord?.HotelRating);
+        Assert.Equal(record.ParkingIncluded, searchResultRecord?.ParkingIncluded);
+        Assert.Equal(record.Tags.ToArray(), searchResultRecord?.Tags.ToArray());
+        Assert.Equal(record.Description, searchResultRecord?.Description);
 
         // Output
         output.WriteLine(collectionExistResult.ToString());
@@ -349,6 +360,50 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync(11, new GetRecordOptions { IncludeVectors = true }));
+    }
+
+    [Theory]
+    [InlineData(true, "singleVectorHotels", false, "equality")]
+    [InlineData(false, "singleVectorHotels", false, "equality")]
+    [InlineData(true, "namedVectorsHotels", true, "equality")]
+    [InlineData(false, "namedVectorsHotels", true, "equality")]
+    [InlineData(true, "singleVectorHotels", false, "tagContains")]
+    [InlineData(false, "singleVectorHotels", false, "tagContains")]
+    [InlineData(true, "namedVectorsHotels", true, "tagContains")]
+    [InlineData(false, "namedVectorsHotels", true, "tagContains")]
+    public async Task ItCanSearchWithFilterAsync(bool useRecordDefinition, string collectionName, bool hasNamedVectors, string filterType)
+    {
+        // Arrange.
+        var options = new QdrantVectorStoreRecordCollectionOptions<HotelInfo>
+        {
+            HasNamedVectors = hasNamedVectors,
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
+        };
+        var sut = new QdrantVectorStoreRecordCollection<HotelInfo>(fixture.QdrantClient, collectionName, options);
+
+        // Act.
+        var filter = filterType == "equality" ? new VectorSearchFilter().Equality("HotelName", "My Hotel 11") : new VectorSearchFilter().TagListContains("Tags", "t1");
+        var searchResults = sut.SearchAsync(
+            VectorSearchQuery.CreateQuery(
+                new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]),
+                new()
+                {
+                    VectorSearchFilter = filter
+                }));
+
+        // Assert.
+        Assert.NotNull(searchResults);
+        var searchResultsList = await searchResults.ToListAsync();
+        Assert.Single(searchResultsList);
+
+        var searchResultRecord = searchResultsList.First().Record;
+        Assert.Equal(11ul, searchResultRecord?.HotelId);
+        Assert.Equal("My Hotel 11", searchResultRecord?.HotelName);
+        Assert.Equal(11, searchResultRecord?.HotelCode);
+        Assert.Equal(4.5f, searchResultRecord?.HotelRating);
+        Assert.Equal(true, searchResultRecord?.ParkingIncluded);
+        Assert.Equal(new string[] { "t1", "t2" }, searchResultRecord?.Tags.ToArray());
+        Assert.Equal("This is a great hotel.", searchResultRecord?.Description);
     }
 
     private HotelInfo CreateTestHotel(uint hotelId)


### PR DESCRIPTION
### Motivation and Context

As part of the work on vector storage we have to add vector search capabilities for each implementation.

### Description

1. Adding vector search for Qdrant.
2. Note that for now, the search interface is implemented directly by the collection, but in future it should be part of the collection interface. I'm doing it this way so that each implementation can be added one by one, and once all have been implemented, we can make the switch.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
