### PR TITLE
Add Redis vector search implementation

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IVectorSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
@@ -73,11 +73,20 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
     /// <summary>A definition of the current storage model.</summary>
     private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
 
+    /// <summary>An array of the names of all the data properties that are part of the Redis payload as RedisValue objects, i.e. all properties except the key and vector properties.</summary>
+    private readonly RedisValue[] _dataStoragePropertyNameRedisValues;
+
     /// <summary>An array of the names of all the data properties that are part of the Redis payload, i.e. all properties except the key and vector properties.</summary>
-    private readonly RedisValue[] _dataStoragePropertyNames;
+    private readonly string[] _dataStoragePropertyNames;
+
+    /// <summary>An array of the names of all the properties that are part of the Redis payload, i.e. all properties except the key property.</summary>
+    private readonly string[] _dataAndVectorStoragePropertyNames;
 
     /// <summary>A dictionary that maps from a property name to the storage name that should be used when serializing it to json for data and vector properties.</summary>
     private readonly Dictionary<string, string> _storagePropertyNames = new();
+
+    /// <summary>The name of the first vector field for the collections that this class is used with.</summary>
+    private readonly string? _firstVectorPropertyName = null;
 
     /// <summary>The mapper to use when mapping between the consumer data model and the Redis record.</summary>
     private readonly IVectorStoreRecordMapper<TRecord, (string Key, HashEntry[] HashEntries)> _mapper;
@@ -112,8 +121,21 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         this._dataStoragePropertyNames = properties
             .DataProperties
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
+            .ToArray();
+        this._dataStoragePropertyNameRedisValues = this._dataStoragePropertyNames
             .Select(RedisValue.Unbox)
             .ToArray();
+        this._dataAndVectorStoragePropertyNames = properties
+            .DataProperties
+            .Cast<VectorStoreRecordProperty>()
+            .Concat(properties.VectorProperties)
+            .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
+            .ToArray();
+
+        if (properties.VectorProperties.Count > 0)
+        {
+            this._firstVectorPropertyName = this._storagePropertyNames[properties.VectorProperties.First().DataModelPropertyName];
+        }
 
         // Assign Mapper.
         if (this._options.HashEntriesCustomMapper is not null)
@@ -203,7 +225,7 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         }
         else
         {
-            var fieldKeys = this._dataStoragePropertyNames;
+            var fieldKeys = this._dataStoragePropertyNameRedisValues;
             var retrievedValues = await this.RunOperationAsync(
                 operationName,
                 () => this._database.HashGetAsync(maybePrefixedKey, fieldKeys)).ConfigureAwait(false);
@@ -310,6 +332,53 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         }
     }
 
+    /// <inheritdoc />
+    public async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync(VectorSearchQuery vectorQuery, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(vectorQuery);
+
+        if (this._firstVectorPropertyName is null)
+        {
+            throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
+        }
+
+        if (vectorQuery is VectorizedSearchQuery<ReadOnlyMemory<float>> floatVectorQuery)
+        {
+            var internalOptions = floatVectorQuery.SearchOptions ?? Data.VectorSearchOptions.Default;
+
+            // Build query & search.
+            var selectFields = internalOptions.IncludeVectors ? null : this._dataStoragePropertyNames;
+            var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVectorQuery, this._storagePropertyNames, this._firstVectorPropertyName, selectFields);
+            var results = await this.RunOperationAsync(
+                "FT.SEARCH",
+                () => this._database
+                    .FT()
+                    .SearchAsync(this._collectionName, query)).ConfigureAwait(false);
+
+            // Loop through result and convert to the caller's data model.
+            foreach (var result in results.Documents)
+            {
+                var retrievedHashEntries = this._dataAndVectorStoragePropertyNames.Select(propertyName => new HashEntry(propertyName, result[propertyName])).ToArray();
+
+                // Convert to the caller's data model.
+                var dataModel = VectorStoreErrorHandler.RunModelConversion(
+                    DatabaseName,
+                    this._collectionName,
+                    "FT.SEARCH",
+                    () =>
+                    {
+                        return this._mapper.MapFromStorageToDataModel((this.RemoveKeyPrefixIfNeeded(result.Id), retrievedHashEntries), new() { IncludeVectors = internalOptions.IncludeVectors });
+                    });
+
+                yield return new VectorSearchResult<TRecord>(dataModel, result.Score);
+            }
+
+            yield break;
+        }
+
+        throw new NotSupportedException($"A {nameof(VectorSearchQuery)} of type {vectorQuery.QueryType} is not supported by the Redis HashSet connector.");
+    }
+
     /// <summary>
     /// Prefix the key with the collection name if the option is set.
     /// </summary>
@@ -320,6 +389,23 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         if (this._options.PrefixCollectionNameToKeyNames)
         {
             return $"{this._collectionName}:{key}";
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Remove the prefix of the given key if the option is set.
+    /// </summary>
+    /// <param name="key">The key to remove a prefix from.</param>
+    /// <returns>The updated key if updating is required, otherwise the input key.</returns>
+    private string RemoveKeyPrefixIfNeeded(string key)
+    {
+        var prefixLength = this._collectionName.Length + 1;
+
+        if (this._options.PrefixCollectionNameToKeyNames && key.Length > prefixLength)
+        {
+            return key.Substring(prefixLength);
         }
 
         return key;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IVectorSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TRecord : class
 {
@@ -62,6 +62,9 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
     /// <summary>A dictionary that maps from a property name to the storage name that should be used when serializing it to json for data and vector properties.</summary>
     private readonly Dictionary<string, string> _storagePropertyNames = new();
 
+    /// <summary>The name of the first vector field for the collections that this class is used with.</summary>
+    private readonly string? _firstVectorPropertyName = null;
+
     /// <summary>The mapper to use when mapping between the consumer data model and the Redis record.</summary>
     private readonly IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)> _mapper;
 
@@ -93,15 +96,18 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         VectorStoreRecordPropertyReader.VerifyPropertyTypes([properties.KeyProperty], s_supportedKeyTypes, "Key");
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.VectorProperties, s_supportedVectorTypes, "Vector");
 
-        // Lookup json storage property names.
-        var keyJsonPropertyName = VectorStoreRecordPropertyReader.GetJsonPropertyName(properties.KeyProperty, typeof(TRecord), this._jsonSerializerOptions);
-
         // Lookup storage property names.
         this._storagePropertyNames = VectorStoreRecordPropertyReader.BuildPropertyNameToJsonPropertyNameMap(properties, typeof(TRecord), this._jsonSerializerOptions);
         this._dataStoragePropertyNames = properties
             .DataProperties
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
             .ToArray();
+        var keyJsonPropertyName = this._storagePropertyNames[properties.KeyProperty.DataModelPropertyName];
+
+        if (properties.VectorProperties.Count > 0)
+        {
+            this._firstVectorPropertyName = this._storagePropertyNames[properties.VectorProperties.First().DataModelPropertyName];
+        }
 
         // Assign Mapper.
         if (this._options.JsonNodeCustomMapper is not null)
@@ -362,6 +368,53 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         }
     }
 
+    /// <inheritdoc />
+    public async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync(VectorSearchQuery vectorQuery, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(vectorQuery);
+
+        if (this._firstVectorPropertyName is null)
+        {
+            throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
+        }
+
+        if (vectorQuery is VectorizedSearchQuery<ReadOnlyMemory<float>> floatVectorQuery)
+        {
+            var internalOptions = floatVectorQuery.SearchOptions ?? Data.VectorSearchOptions.Default;
+
+            // Build query & search.
+            var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVectorQuery, this._storagePropertyNames, this._firstVectorPropertyName, null);
+            var results = await this.RunOperationAsync(
+                "FT.SEARCH",
+                () => this._database
+                    .FT()
+                    .SearchAsync(this._collectionName, query)).ConfigureAwait(false);
+
+            // Loop through result and convert to the caller's data model.
+            foreach (var result in results.Documents)
+            {
+                var redisResultString = result["json"].ToString();
+                var mappedRecord = VectorStoreErrorHandler.RunModelConversion(
+                    DatabaseName,
+                    this._collectionName,
+                    "FT.SEARCH",
+                    () =>
+                    {
+                        var node = JsonSerializer.Deserialize<JsonNode>(redisResultString, this._jsonSerializerOptions)!;
+                        return this._mapper.MapFromStorageToDataModel(
+                            (this.RemoveKeyPrefixIfNeeded(result.Id), node),
+                            new() { IncludeVectors = internalOptions.IncludeVectors });
+                    });
+
+                yield return new VectorSearchResult<TRecord>(mappedRecord, result.Score);
+            }
+
+            yield break;
+        }
+
+        throw new NotSupportedException($"A {nameof(VectorSearchQuery)} of type {vectorQuery.QueryType} is not supported by the Redis JSON connector.");
+    }
+
     /// <summary>
     /// Prefix the key with the collection name if the option is set.
     /// </summary>
@@ -372,6 +425,23 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         if (this._options.PrefixCollectionNameToKeyNames)
         {
             return $"{this._collectionName}:{key}";
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Remove the prefix of the given key if the option is set.
+    /// </summary>
+    /// <param name="key">The key to remove a prefix from.</param>
+    /// <returns>The updated key if updating is required, otherwise the input key.</returns>
+    private string RemoveKeyPrefixIfNeeded(string key)
+    {
+        var prefixLength = this._collectionName.Length + 1;
+
+        if (this._options.PrefixCollectionNameToKeyNames && key.Length > prefixLength)
+        {
+            return key.Substring(prefixLength);
         }
 
         return key;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.SemanticKernel.Data;
+using NRedisStack.Search;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Contains mapping helpers to use when searching in a redis vector collection.
+/// </summary>
+internal static class RedisVectorStoreCollectionSearchMapping
+{
+    /// <summary>
+    /// Build a Redis <see cref="Query"/> object from the given <see cref="VectorizedSearchQuery{TVector}"/>.
+    /// </summary>
+    /// <param name="floatVectorQuery">The <see cref="VectorizedSearchQuery{TVector}"/> to build the Redis query from.</param>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <param name="firstVectorPropertyName">The name of the first vector property in the data model.</param>
+    /// <param name="selectFields">The set of fields to limit the results to. Null for all.</param>
+    /// <returns>The <see cref="Query"/>.</returns>
+    public static Query BuildQuery(VectorizedSearchQuery<ReadOnlyMemory<float>> floatVectorQuery, Dictionary<string, string> storagePropertyNames, string firstVectorPropertyName, string[]? selectFields)
+    {
+        // Resolve options.
+        var internalOptions = floatVectorQuery.SearchOptions ?? Data.VectorSearchOptions.Default;
+        var vectorPropertyName = ResolveVectorFieldName(internalOptions.VectorFieldName, storagePropertyNames, firstVectorPropertyName);
+
+        // Build search query.
+        var filter = RedisVectorStoreCollectionSearchMapping.BuildFilter(internalOptions.VectorSearchFilter, storagePropertyNames);
+        var vectorBytes = MemoryMarshal.AsBytes(floatVectorQuery.Vector.Span).ToArray();
+        var query = new Query($"{filter}=>[KNN {internalOptions.Limit} @{vectorPropertyName} $embedding AS vector_score]")
+            .AddParam("embedding", vectorBytes)
+            .SetSortBy("vector_score")
+            .Limit(internalOptions.Offset, internalOptions.Limit)
+            .SetWithScores(true)
+            .Dialect(2);
+
+        if (selectFields != null)
+        {
+            query.ReturnFields(selectFields);
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    /// Build a redis filter string from the provided <see cref="VectorSearchFilter"/>.
+    /// </summary>
+    /// <param name="basicVectorSearchFilter">The <see cref="VectorSearchFilter"/> to build the Redis filter string from.</param>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <returns>The Redis filter string.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a provided filter value is not supported.</exception>
+    public static string BuildFilter(VectorSearchFilter? basicVectorSearchFilter, Dictionary<string, string> storagePropertyNames)
+    {
+        if (basicVectorSearchFilter == null)
+        {
+            return "*";
+        }
+
+        var filterClauses = basicVectorSearchFilter.FilterClauses.Select(clause =>
+        {
+            if (clause is EqualityFilterClause equalityFilterClause)
+            {
+                var storagePropertyName = GetStoragePropertyName(storagePropertyNames, equalityFilterClause.FieldName);
+
+                return equalityFilterClause.Value switch
+                {
+                    string stringValue => $"@{storagePropertyName}:{{{stringValue}}}",
+                    int intValue => $"@{storagePropertyName}:[{intValue} {intValue}]",
+                    long longValue => $"@{storagePropertyName}:[{longValue} {longValue}]",
+                    float floatValue => $"@{storagePropertyName}:[{floatValue} {floatValue}]",
+                    double doubleValue => $"@{storagePropertyName}:[{doubleValue} {doubleValue}]",
+                    _ => throw new InvalidOperationException($"Unsupported filter value type '{equalityFilterClause.Value.GetType().Name}'.")
+                };
+            }
+            else if (clause is TagListContainsFilterClause tagListContainsClause)
+            {
+                var storagePropertyName = GetStoragePropertyName(storagePropertyNames, tagListContainsClause.FieldName);
+                return $"@{storagePropertyName}:{{{tagListContainsClause.Value}}}";
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported filter clause type '{clause.GetType().Name}'.");
+            }
+        });
+
+        return $"({string.Join(" ", filterClauses)})";
+    }
+
+    /// <summary>
+    /// Resolve the vector field name to use for a search by using the storage name for the field name from options
+    /// if available, and falling back to the first vector field name if not.
+    /// </summary>
+    /// <param name="optionsVectorFieldName">The vector field name provided via options.</param>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <param name="firstVectorPropertyName">The name of the first vector property in the data model.</param>
+    /// <returns>The resolved vector field name.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the provided field name is not a valid field name.</exception>
+    private static string ResolveVectorFieldName(string? optionsVectorFieldName, Dictionary<string, string> storagePropertyNames, string firstVectorPropertyName)
+    {
+        string? vectorFieldName;
+        if (optionsVectorFieldName is not null)
+        {
+            if (!storagePropertyNames.TryGetValue(optionsVectorFieldName, out vectorFieldName))
+            {
+                throw new InvalidOperationException($"The collection does not have a vector field named '{optionsVectorFieldName}'.");
+            }
+        }
+        else
+        {
+            vectorFieldName = firstVectorPropertyName;
+        }
+
+        return vectorFieldName!;
+    }
+
+    /// <summary>
+    /// Gets the name of the name under which the property with the given name is stored.
+    /// </summary>
+    /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
+    /// <param name="fieldName">The name of the property in the data model.</param>
+    /// <returns>The name that the property os stored under.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the property name is not found.</exception>
+    private static string GetStoragePropertyName(Dictionary<string, string> storagePropertyNames, string fieldName)
+    {
+        if (!storagePropertyNames.TryGetValue(fieldName, out var storageFieldName))
+        {
+            throw new InvalidOperationException($"Property name '{fieldName}' provided as part of the filter clause is not a valid property name.");
+        }
+
+        return storageFieldName;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -415,6 +415,96 @@ public class RedisHashSetVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task CanSearchWithVectorAndFilterAsync(bool useDefinition, bool includeVectors)
+    {
+        // Arrange
+        SetupExecuteMock(this._redisDatabaseMock, new RedisResult[]
+        {
+            RedisResult.Create(new RedisValue("1")),
+            RedisResult.Create(new RedisValue(TestRecordKey1)),
+            RedisResult.Create(new RedisValue("0.5")),
+            RedisResult.Create(
+            [
+                new RedisValue("OriginalNameData"),
+                new RedisValue("original data 1"),
+                new RedisValue("data_storage_name"),
+                new RedisValue("data 1"),
+                new RedisValue("vector_storage_name"),
+                RedisValue.Unbox(MemoryMarshal.AsBytes(new ReadOnlySpan<float>(new float[] { 1, 2, 3, 4 })).ToArray()),
+            ]),
+        });
+        var sut = this.CreateRecordCollection(useDefinition);
+
+        var filter = new VectorSearchFilter().Equality(nameof(SinglePropsModel.Data), "data 1");
+
+        // Act.
+        var actual = await sut!.SearchAsync(VectorSearchQuery.CreateQuery(
+            new ReadOnlyMemory<float>(new[] { 1f, 2f, 3f, 4f }),
+            new()
+            {
+                IncludeVectors = includeVectors,
+                VectorSearchFilter = filter,
+                Limit = 5,
+                Offset = 2
+            })).ToListAsync();
+
+        // Assert.
+        var expectedArgsPart1 = new object[]
+        {
+            "testcollection",
+            "(@data_storage_name:{data 1})=>[KNN 5 @vector_storage_name $embedding AS vector_score]",
+            "WITHSCORES",
+            "SORTBY",
+            "vector_score",
+            "LIMIT",
+            2,
+            5
+        };
+        var returnArgs = includeVectors ? Array.Empty<object>() : new object[]
+        {
+            "RETURN",
+            2,
+            "OriginalNameData",
+            "data_storage_name"
+        };
+        var expectedArgsPart2 = new object[]
+        {
+            "PARAMS",
+            2,
+            "embedding",
+            MemoryMarshal.AsBytes(new ReadOnlySpan<float>(new float[] { 1, 2, 3, 4 })).ToArray(),
+            "DIALECT",
+            2
+        };
+        var expectedArgs = expectedArgsPart1.Concat(returnArgs).Concat(expectedArgsPart2).ToArray();
+
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "FT.SEARCH",
+                    It.Is<object[]>(x => x.Where(y => !(y is byte[])).SequenceEqual(expectedArgs.Where(y => !(y is byte[]))))),
+                Times.Once);
+
+        Assert.Single(actual);
+        Assert.Equal(TestRecordKey1, actual.First().Record.Key);
+        Assert.Equal(0.5d, actual.First().Score);
+        Assert.Equal("original data 1", actual.First().Record.OriginalNameData);
+        Assert.Equal("data 1", actual.First().Record.Data);
+        if (includeVectors)
+        {
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector!.Value.ToArray());
+        }
+        else
+        {
+            Assert.False(actual.First().Record.Vector.HasValue);
+        }
+    }
+
     /// <summary>
     /// Tests that the collection can be created even if the definition and the type do not match.
     /// In this case, the expectation is that a custom mapper will be provided to map between the
@@ -467,6 +557,19 @@ public class RedisHashSetVectorStoreRecordCollectionTests
     {
         var results = redisResultStrings
             .Select(x => RedisResult.Create(new RedisValue(x)))
+            .ToArray();
+        redisDatabaseMock
+            .Setup(
+                x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<object[]>()))
+            .ReturnsAsync(RedisResult.Create(results));
+    }
+
+    private static void SetupExecuteMock(Mock<IDatabase> redisDatabaseMock, IEnumerable<RedisResult> redisResultStrings)
+    {
+        var results = redisResultStrings
+            .Select(x => x)
             .ToArray();
         redisDatabaseMock
             .Setup(

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -438,6 +439,69 @@ public class RedisJsonVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanSearchWithVectorAndFilterAsync(bool useDefinition)
+    {
+        // Arrange
+        var jsonResult = """{ "data1_json_name": "data 1", "Data2": "data 2", "vector1_json_name": [1, 2, 3, 4], "Vector2": [1, 2, 3, 4] }""";
+        SetupExecuteMock(this._redisDatabaseMock, new RedisResult[]
+        {
+            RedisResult.Create(new RedisValue("1")),
+            RedisResult.Create(new RedisValue(TestRecordKey1)),
+            RedisResult.Create(new RedisValue("0.5")),
+            RedisResult.Create([new RedisValue("$"), new RedisValue(jsonResult)]),
+        });
+        var sut = this.CreateRecordCollection(useDefinition);
+
+        var filter = new VectorSearchFilter().Equality(nameof(MultiPropsModel.Data1), "data 1");
+
+        // Act.
+        var actual = await sut!.SearchAsync(VectorSearchQuery.CreateQuery(
+            new ReadOnlyMemory<float>(new[] { 1f, 2f, 3f, 4f }),
+            new()
+            {
+                IncludeVectors = true,
+                VectorSearchFilter = filter,
+                Limit = 5,
+                Offset = 2
+            })).ToListAsync();
+
+        // Assert.
+        var expectedArgs = new object[]
+        {
+            "testcollection",
+            "(@data1_json_name:{data 1})=>[KNN 5 @vector1_json_name $embedding AS vector_score]",
+            "WITHSCORES",
+            "SORTBY",
+            "vector_score",
+            "LIMIT",
+            2,
+            5,
+            "PARAMS",
+            2,
+            "embedding",
+            MemoryMarshal.AsBytes(new ReadOnlySpan<float>(new float[] { 1, 2, 3, 4 })).ToArray(),
+            "DIALECT",
+            2
+        };
+        this._redisDatabaseMock
+            .Verify(
+                x => x.ExecuteAsync(
+                    "FT.SEARCH",
+                    It.Is<object[]>(x => x.Where(y => !(y is byte[])).SequenceEqual(expectedArgs.Where(y => !(y is byte[]))))),
+                Times.Once);
+
+        Assert.Single(actual);
+        Assert.Equal(TestRecordKey1, actual.First().Record.Key);
+        Assert.Equal(0.5d, actual.First().Score);
+        Assert.Equal("data 1", actual.First().Record.Data1);
+        Assert.Equal("data 2", actual.First().Record.Data2);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector1!.Value.ToArray());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector2!.Value.ToArray());
+    }
+
     /// <summary>
     /// Tests that the collection can be created even if the definition and the type do not match.
     /// In this case, the expectation is that a custom mapper will be provided to map between the
@@ -491,6 +555,19 @@ public class RedisJsonVectorStoreRecordCollectionTests
     {
         var results = redisResultStrings
             .Select(x => RedisResult.Create(new RedisValue(x)))
+            .ToArray();
+        redisDatabaseMock
+            .Setup(
+                x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<object[]>()))
+            .ReturnsAsync(RedisResult.Create(results));
+    }
+
+    private static void SetupExecuteMock(Mock<IDatabase> redisDatabaseMock, IEnumerable<RedisResult> redisResultStrings)
+    {
+        var results = redisResultStrings
+            .Select(x => x)
             .ToArray();
         redisDatabaseMock
             .Setup(

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisVectorStoreCollectionSearchMapping"/> class.
+/// </summary>
+public class RedisVectorStoreCollectionSearchMappingTests
+{
+    [Fact]
+    public void BuildQueryBuildsRedisQueryWithDefaults()
+    {
+        // Arrange.
+        var floatVectorQuery = VectorSearchQuery.CreateQuery(
+            new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f }));
+        var storagePropertyNames = new Dictionary<string, string>()
+        {
+            { "Vector", "storage_Vector" },
+        };
+        var firstVectorPropertyName = "storage_Vector";
+
+        // Act.
+        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVectorQuery, storagePropertyNames, firstVectorPropertyName, null);
+
+        // Assert.
+        Assert.NotNull(query);
+        Assert.Equal("*=>[KNN 3 @storage_Vector $embedding AS vector_score]", query.QueryString);
+        Assert.Equal("vector_score", query.SortBy);
+        Assert.True(query.WithScores);
+        Assert.Equal(2, query.dialect);
+    }
+
+    [Fact]
+    public void BuildQueryBuildsRedisQueryWithCustomVectorName()
+    {
+        // Arrange.
+        var floatVectorQuery = VectorSearchQuery.CreateQuery(
+            new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f }),
+            new VectorSearchOptions { Limit = 5, Offset = 3, VectorFieldName = "Vector" });
+        var storagePropertyNames = new Dictionary<string, string>()
+        {
+            { "Vector", "storage_Vector" },
+        };
+        var firstVectorPropertyName = "storage_FirstVector";
+        var selectFields = new string[] { "storage_Field1", "storage_Field2" };
+
+        // Act.
+        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVectorQuery, storagePropertyNames, firstVectorPropertyName, selectFields);
+
+        // Assert.
+        Assert.NotNull(query);
+        Assert.Equal("*=>[KNN 5 @storage_Vector $embedding AS vector_score]", query.QueryString);
+    }
+
+    [Fact]
+    public void BuildQueryFailsForInvalidVectorName()
+    {
+        // Arrange.
+        var floatVectorQuery = VectorSearchQuery.CreateQuery(
+            new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f }),
+            new VectorSearchOptions { VectorFieldName = "UnknownVector" });
+        var storagePropertyNames = new Dictionary<string, string>()
+        {
+            { "Vector", "storage_Vector" },
+        };
+        var firstVectorPropertyName = "storage_FirstVector";
+
+        // Act & Assert.
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVectorQuery, storagePropertyNames, firstVectorPropertyName, null);
+        });
+    }
+
+    [Theory]
+    [InlineData("stringEquality")]
+    [InlineData("intEquality")]
+    [InlineData("longEquality")]
+    [InlineData("floatEquality")]
+    [InlineData("doubleEquality")]
+    [InlineData("tagContains")]
+    public void BuildFilterBuildsEqualityFilter(string filterType)
+    {
+        // Arrange.
+        var basicVectorSearchFilter = filterType switch
+        {
+            "stringEquality" => new VectorSearchFilter().Equality("Data1", "my value"),
+            "intEquality" => new VectorSearchFilter().Equality("Data1", 3),
+            "longEquality" => new VectorSearchFilter().Equality("Data1", 3L),
+            "floatEquality" => new VectorSearchFilter().Equality("Data1", 3.3f),
+            "doubleEquality" => new VectorSearchFilter().Equality("Data1", 3.3),
+            "tagContains" => new VectorSearchFilter().TagListContains("Data1", "my value"),
+            _ => throw new InvalidOperationException(),
+        };
+
+        var storagePropertyNames = new Dictionary<string, string>()
+        {
+            { "Data1", "storage_Data1" },
+        };
+
+        // Act.
+        var filter = RedisVectorStoreCollectionSearchMapping.BuildFilter(basicVectorSearchFilter, storagePropertyNames);
+
+        // Assert.
+        switch (filterType)
+        {
+            case "stringEquality":
+                Assert.Equal("(@storage_Data1:{my value})", filter);
+                break;
+            case "intEquality":
+            case "longEquality":
+                Assert.Equal("(@storage_Data1:[3 3])", filter);
+                break;
+            case "floatEquality":
+            case "doubleEquality":
+                Assert.Equal("(@storage_Data1:[3.3 3.3])", filter);
+                break;
+            case "tagContains":
+                Assert.Equal("(@storage_Data1:{my value})", filter);
+                break;
+        }
+    }
+
+    [Fact]
+    public void BuildFilterThrowsForInvalidValueType()
+    {
+        // Arrange.
+        var basicVectorSearchFilter = new VectorSearchFilter().Equality("Data1", true);
+        var storagePropertyNames = new Dictionary<string, string>()
+        {
+            { "Data1", "storage_Data1" },
+        };
+
+        // Act & Assert.
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var filter = RedisVectorStoreCollectionSearchMapping.BuildFilter(basicVectorSearchFilter, storagePropertyNames);
+        });
+    }
+
+    [Fact]
+    public void BuildFilterThrowsForUnknownFieldName()
+    {
+        // Arrange.
+        var basicVectorSearchFilter = new VectorSearchFilter().Equality("UnknownData", "value");
+        var storagePropertyNames = new Dictionary<string, string>()
+        {
+            { "Data1", "storage_Data1" },
+        };
+
+        // Act & Assert.
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var filter = RedisVectorStoreCollectionSearchMapping.BuildFilter(basicVectorSearchFilter, storagePropertyNames);
+        });
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -45,10 +45,10 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     [Theory(Skip = SkipReason)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task ItCanCreateACollectionUpsertAndGetAsync(bool useRecordDefinition)
+    public async Task ItCanCreateACollectionUpsertGetAndSearchAsync(bool useRecordDefinition)
     {
         // Arrange
-        var record = CreateTestHotel("Upsert-1", 1);
+        var record = CreateTestHotel("HUpsert-1", 1);
         var collectionNamePostfix = useRecordDefinition ? "WithDefinition" : "WithType";
         var testCollectionName = $"hashsetcreatetest{collectionNamePostfix}";
 
@@ -62,14 +62,20 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         // Act
         await sut.CreateCollectionAsync();
         var upsertResult = await sut.UpsertAsync(record);
-        var getResult = await sut.GetAsync("Upsert-1", new GetRecordOptions { IncludeVectors = true });
+        var getResult = await sut.GetAsync("HUpsert-1", new GetRecordOptions { IncludeVectors = true });
+        var searchResult = await sut
+            .SearchAsync(
+                VectorSearchQuery.CreateQuery(
+                    new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }),
+                    new VectorSearchOptions { VectorSearchFilter = new VectorSearchFilter().Equality("HotelCode", 1), IncludeVectors = true }))
+            .ToListAsync();
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
         Assert.True(collectionExistResult);
         await sut.DeleteCollectionAsync();
 
-        Assert.Equal("Upsert-1", upsertResult);
+        Assert.Equal("HUpsert-1", upsertResult);
         Assert.Equal(record.HotelId, getResult?.HotelId);
         Assert.Equal(record.HotelName, getResult?.HotelName);
         Assert.Equal(record.HotelCode, getResult?.HotelCode);
@@ -77,6 +83,16 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         Assert.Equal(record.Rating, getResult?.Rating);
         Assert.Equal(record.Description, getResult?.Description);
         Assert.Equal(record.DescriptionEmbedding?.ToArray(), getResult?.DescriptionEmbedding?.ToArray());
+
+        Assert.Single(searchResult);
+        var searchResultRecord = searchResult.First().Record;
+        Assert.Equal(record.HotelId, searchResultRecord?.HotelId);
+        Assert.Equal(record.HotelName, searchResultRecord?.HotelName);
+        Assert.Equal(record.HotelCode, searchResultRecord?.HotelCode);
+        Assert.Equal(record.ParkingIncluded, searchResultRecord?.ParkingIncluded);
+        Assert.Equal(record.Rating, searchResultRecord?.Rating);
+        Assert.Equal(record.Description, searchResultRecord?.Description);
+        Assert.Equal(record.DescriptionEmbedding?.ToArray(), searchResultRecord?.DescriptionEmbedding?.ToArray());
 
         // Output
         output.WriteLine(collectionExistResult.ToString());
@@ -116,14 +132,14 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
         var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
-        var record = CreateTestHotel("Upsert-2", 2);
+        var record = CreateTestHotel("HUpsert-2", 2);
 
         // Act.
         var upsertResult = await sut.UpsertAsync(record);
 
         // Assert.
-        var getResult = await sut.GetAsync("Upsert-2", new GetRecordOptions { IncludeVectors = true });
-        Assert.Equal("Upsert-2", upsertResult);
+        var getResult = await sut.GetAsync("HUpsert-2", new GetRecordOptions { IncludeVectors = true });
+        Assert.Equal("HUpsert-2", upsertResult);
         Assert.Equal(record.HotelId, getResult?.HotelId);
         Assert.Equal(record.HotelName, getResult?.HotelName);
         Assert.Equal(record.HotelCode, getResult?.HotelCode);
@@ -153,9 +169,9 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         // Act.
         var results = sut.UpsertBatchAsync(
             [
-                CreateTestHotel("UpsertMany-1", 1),
-                CreateTestHotel("UpsertMany-2", 2),
-                CreateTestHotel("UpsertMany-3", 3),
+                CreateTestHotel("HUpsertMany-1", 1),
+                CreateTestHotel("HUpsertMany-2", 2),
+                CreateTestHotel("HUpsertMany-3", 3),
             ]);
 
         // Assert.
@@ -163,9 +179,9 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var resultsList = await results.ToListAsync();
 
         Assert.Equal(3, resultsList.Count);
-        Assert.Contains("UpsertMany-1", resultsList);
-        Assert.Contains("UpsertMany-2", resultsList);
-        Assert.Contains("UpsertMany-3", resultsList);
+        Assert.Contains("HUpsertMany-1", resultsList);
+        Assert.Contains("HUpsertMany-2", resultsList);
+        Assert.Contains("HUpsertMany-3", resultsList);
 
         // Output
         foreach (var result in resultsList)
@@ -190,10 +206,10 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
-        var getResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
+        var getResult = await sut.GetAsync("HBaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
 
         // Assert.
-        Assert.Equal("BaseSet-1", getResult?.HotelId);
+        Assert.Equal("HBaseSet-1", getResult?.HotelId);
         Assert.Equal("My Hotel 1", getResult?.HotelName);
         Assert.Equal(1, getResult?.HotelCode);
         Assert.True(getResult?.ParkingIncluded);
@@ -221,7 +237,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
-        var hotels = sut.GetBatchAsync(["BaseSet-1", "BaseSet-5", "BaseSet-2"], new GetRecordOptions { IncludeVectors = true });
+        var hotels = sut.GetBatchAsync(["HBaseSet-1", "HBaseSet-5", "HBaseSet-2"], new GetRecordOptions { IncludeVectors = true });
 
         // Assert
         Assert.NotNull(hotels);
@@ -249,7 +265,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
         var record = new BasicHotel
         {
-            HotelId = "Remove-1",
+            HotelId = "HRemove-1",
             HotelName = "Remove Test Hotel",
             HotelCode = 20,
             Description = "This is a great hotel.",
@@ -259,12 +275,12 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         await sut.UpsertAsync(record);
 
         // Act.
-        await sut.DeleteAsync("Remove-1");
+        await sut.DeleteAsync("HRemove-1");
         // Also delete a non-existing key to test that the operation does not fail for these.
-        await sut.DeleteAsync("Remove-2");
+        await sut.DeleteAsync("HRemove-2");
 
         // Assert.
-        Assert.Null(await sut.GetAsync("Remove-1"));
+        Assert.Null(await sut.GetAsync("HRemove-1"));
     }
 
     [Fact(Skip = SkipReason)]
@@ -273,18 +289,57 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         // Arrange
         var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel> { PrefixCollectionNameToKeyNames = true };
         var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
-        await sut.UpsertAsync(CreateTestHotel("RemoveMany-1", 1));
-        await sut.UpsertAsync(CreateTestHotel("RemoveMany-2", 2));
-        await sut.UpsertAsync(CreateTestHotel("RemoveMany-3", 3));
+        await sut.UpsertAsync(CreateTestHotel("HRemoveMany-1", 1));
+        await sut.UpsertAsync(CreateTestHotel("HRemoveMany-2", 2));
+        await sut.UpsertAsync(CreateTestHotel("HRemoveMany-3", 3));
 
         // Act
         // Also include a non-existing key to test that the operation does not fail for these.
-        await sut.DeleteBatchAsync(["RemoveMany-1", "RemoveMany-2", "RemoveMany-3", "RemoveMany-4"]);
+        await sut.DeleteBatchAsync(["HRemoveMany-1", "HRemoveMany-2", "HRemoveMany-3", "HRemoveMany-4"]);
 
         // Assert
-        Assert.Null(await sut.GetAsync("RemoveMany-1", new GetRecordOptions { IncludeVectors = true }));
-        Assert.Null(await sut.GetAsync("RemoveMany-2", new GetRecordOptions { IncludeVectors = true }));
-        Assert.Null(await sut.GetAsync("RemoveMany-3", new GetRecordOptions { IncludeVectors = true }));
+        Assert.Null(await sut.GetAsync("HRemoveMany-1", new GetRecordOptions { IncludeVectors = true }));
+        Assert.Null(await sut.GetAsync("HRemoveMany-2", new GetRecordOptions { IncludeVectors = true }));
+        Assert.Null(await sut.GetAsync("HRemoveMany-3", new GetRecordOptions { IncludeVectors = true }));
+    }
+
+    [Theory(Skip = SkipReason)]
+    [InlineData("hotelCode", true)]
+    [InlineData("hotelName", false)]
+    public async Task ItCanSearchWithVectorAndFilterAsync(string filterType, bool includeVectors)
+    {
+        // Arrange
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var vector = new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f });
+        var filter = filterType == "equality" ? new VectorSearchFilter().Equality("HotelCode", 1) : new VectorSearchFilter().Equality("HotelName", "My Hotel 1");
+
+        // Act
+        var actual = await sut.SearchAsync(VectorSearchQuery.CreateQuery(
+            vector,
+            new VectorSearchOptions
+            {
+                IncludeVectors = includeVectors,
+                VectorSearchFilter = filter
+            })).ToListAsync();
+
+        // Assert
+        Assert.Single(actual);
+        var searchResult = actual.First().Record;
+        Assert.Equal("HBaseSet-1", searchResult?.HotelId);
+        Assert.Equal("My Hotel 1", searchResult?.HotelName);
+        Assert.Equal(1, searchResult?.HotelCode);
+        Assert.True(searchResult?.ParkingIncluded);
+        Assert.Equal(3.6, searchResult?.Rating);
+        Assert.Equal("This is a great hotel.", searchResult?.Description);
+        if (includeVectors)
+        {
+            Assert.Equal(new[] { 30f, 31f, 32f, 33f }, searchResult?.DescriptionEmbedding?.ToArray());
+        }
+        else
+        {
+            Assert.Null(searchResult?.DescriptionEmbedding);
+        }
     }
 
     [Fact(Skip = SkipReason)]
@@ -295,7 +350,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert
-        Assert.Null(await sut.GetAsync("BaseSet-5", new GetRecordOptions { IncludeVectors = true }));
+        Assert.Null(await sut.GetAsync("HBaseSet-5", new GetRecordOptions { IncludeVectors = true }));
     }
 
     [Fact(Skip = SkipReason)]
@@ -310,7 +365,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert
-        await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
+        await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("HBaseSet-1", new GetRecordOptions { IncludeVectors = true }));
     }
 
     private static BasicHotel CreateTestHotel(string hotelId, int hotelCode)

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -45,10 +45,10 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     [Theory(Skip = SkipReason)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task ItCanCreateACollectionUpsertAndGetAsync(bool useRecordDefinition)
+    public async Task ItCanCreateACollectionUpsertGetAndSearchAsync(bool useRecordDefinition)
     {
         // Arrange
-        var record = CreateTestHotel("Upsert-1", 1);
+        var record = CreateTestHotel("Upsert-10", 10);
         var collectionNamePostfix = useRecordDefinition ? "WithDefinition" : "WithType";
         var testCollectionName = $"jsoncreatetest{collectionNamePostfix}";
 
@@ -62,14 +62,15 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         // Act
         await sut.CreateCollectionAsync();
         var upsertResult = await sut.UpsertAsync(record);
-        var getResult = await sut.GetAsync("Upsert-1", new GetRecordOptions { IncludeVectors = true });
+        var getResult = await sut.GetAsync("Upsert-10", new GetRecordOptions { IncludeVectors = true });
+        var searchResult = await sut.SearchAsync(VectorSearchQuery.CreateQuery(new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }), new VectorSearchOptions { VectorSearchFilter = new VectorSearchFilter().Equality("HotelCode", 10) })).ToListAsync();
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
         Assert.True(collectionExistResult);
         await sut.DeleteCollectionAsync();
 
-        Assert.Equal("Upsert-1", upsertResult);
+        Assert.Equal("Upsert-10", upsertResult);
         Assert.Equal(record.HotelId, getResult?.HotelId);
         Assert.Equal(record.HotelName, getResult?.HotelName);
         Assert.Equal(record.HotelCode, getResult?.HotelCode);
@@ -82,6 +83,21 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         Assert.Equal(record.Address.City, getResult?.Address.City);
         Assert.Equal(record.Description, getResult?.Description);
         Assert.Equal(record.DescriptionEmbedding?.ToArray(), getResult?.DescriptionEmbedding?.ToArray());
+
+        Assert.Single(searchResult);
+        var searchResultRecord = searchResult.First().Record;
+        Assert.Equal(record.HotelId, searchResultRecord?.HotelId);
+        Assert.Equal(record.HotelName, searchResultRecord?.HotelName);
+        Assert.Equal(record.HotelCode, searchResultRecord?.HotelCode);
+        Assert.Equal(record.Tags, searchResultRecord?.Tags);
+        Assert.Equal(record.FTSTags, searchResultRecord?.FTSTags);
+        Assert.Equal(record.ParkingIncluded, searchResultRecord?.ParkingIncluded);
+        Assert.Equal(record.LastRenovationDate, searchResultRecord?.LastRenovationDate);
+        Assert.Equal(record.Rating, searchResultRecord?.Rating);
+        Assert.Equal(record.Address.Country, searchResultRecord?.Address.Country);
+        Assert.Equal(record.Address.City, searchResultRecord?.Address.City);
+        Assert.Equal(record.Description, searchResultRecord?.Description);
+        Assert.Equal(record.DescriptionEmbedding?.ToArray(), searchResultRecord?.DescriptionEmbedding?.ToArray());
 
         // Output
         output.WriteLine(collectionExistResult.ToString());
@@ -313,6 +329,41 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         Assert.Null(await sut.GetAsync("RemoveMany-3", new GetRecordOptions { IncludeVectors = true }));
     }
 
+    [Theory]
+    [InlineData("equality")]
+    [InlineData("tagContains")]
+    public async Task ItCanSearchWithVectorAndFilterAsync(string filterType)
+    {
+        // Arrange
+        var options = new RedisJsonVectorStoreRecordCollectionOptions<Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisJsonVectorStoreRecordCollection<Hotel>(fixture.Database, TestCollectionName, options);
+        var vector = new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f });
+        var filter = filterType == "equality" ? new VectorSearchFilter().Equality("HotelCode", 1) : new VectorSearchFilter().TagListContains("Tags", "pool");
+
+        // Act
+        var actual = await sut.SearchAsync(
+            VectorSearchQuery.CreateQuery(
+                vector,
+                new VectorSearchOptions { IncludeVectors = true, VectorSearchFilter = filter }))
+            .ToListAsync();
+
+        // Assert
+        Assert.Single(actual);
+        var searchResult = actual.First().Record;
+        Assert.Equal("My Hotel 1", actual.First().Record.HotelName);
+        Assert.Equal("BaseSet-1", searchResult?.HotelId);
+        Assert.Equal("My Hotel 1", searchResult?.HotelName);
+        Assert.Equal(1, searchResult?.HotelCode);
+        Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, searchResult?.Tags);
+        Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, searchResult?.FTSTags);
+        Assert.True(searchResult?.ParkingIncluded);
+        Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), searchResult?.LastRenovationDate);
+        Assert.Equal(3.6, searchResult?.Rating);
+        Assert.Equal("Seattle", searchResult?.Address.City);
+        Assert.Equal("This is a great hotel.", searchResult?.Description);
+        Assert.Equal(new[] { 30f, 31f, 32f, 33f }, searchResult?.DescriptionEmbedding?.ToArray());
+    }
+
     [Fact(Skip = SkipReason)]
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
@@ -346,9 +397,9 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         {
             HotelId = hotelId,
             HotelName = $"My Hotel {hotelCode}",
-            HotelCode = 1,
-            Tags = ["pool", "air conditioning", "concierge"],
-            FTSTags = ["pool", "air conditioning", "concierge"],
+            HotelCode = hotelCode,
+            Tags = ["air conditioning", "concierge"],
+            FTSTags = ["air conditioning", "concierge"],
             ParkingIncluded = true,
             LastRenovationDate = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero),
             Rating = 3.6,

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -88,23 +88,36 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost:6379,connectTimeout=60000,connectRetry=5");
         this.Database = redis.GetDatabase();
 
-        // Create a schema for the vector store.
-        var schema = new Schema();
-        schema.AddTextField(new FieldName("$.HotelName", "HotelName"));
-        schema.AddNumericField(new FieldName("$.HotelCode", "HotelCode"));
-        schema.AddTextField(new FieldName("$.Description", "Description"));
-        schema.AddVectorField(new FieldName("$.DescriptionEmbedding", "DescriptionEmbedding"), Schema.VectorField.VectorAlgo.HNSW, new Dictionary<string, object>()
+        // Create a JSON index.
+        var jsonSchema = new Schema();
+        jsonSchema.AddTagField(new FieldName("$.HotelName", "HotelName"));
+        jsonSchema.AddNumericField(new FieldName("$.HotelCode", "HotelCode"));
+        jsonSchema.AddTextField(new FieldName("$.Description", "Description"));
+        jsonSchema.AddTagField(new FieldName("$.Tags", "Tags"));
+        jsonSchema.AddTextField(new FieldName("$.FTSTags", "FTSTags"));
+        jsonSchema.AddVectorField(new FieldName("$.DescriptionEmbedding", "DescriptionEmbedding"), Schema.VectorField.VectorAlgo.HNSW, new Dictionary<string, object>()
         {
             ["TYPE"] = "FLOAT32",
             ["DIM"] = "4",
             ["DISTANCE_METRIC"] = "L2"
         });
         var jsonCreateParams = new FTCreateParams().AddPrefix("jsonhotels:").On(IndexDataType.JSON);
-        await this.Database.FT().CreateAsync("jsonhotels", jsonCreateParams, schema);
+        await this.Database.FT().CreateAsync("jsonhotels", jsonCreateParams, jsonSchema);
 
         // Create a hashset index.
+        var hashSchema = new Schema();
+        hashSchema.AddTagField(new FieldName("HotelName", "HotelName"));
+        hashSchema.AddNumericField(new FieldName("HotelCode", "HotelCode"));
+        hashSchema.AddTextField(new FieldName("Description", "Description"));
+        hashSchema.AddVectorField(new FieldName("DescriptionEmbedding", "DescriptionEmbedding"), Schema.VectorField.VectorAlgo.HNSW, new Dictionary<string, object>()
+        {
+            ["TYPE"] = "FLOAT32",
+            ["DIM"] = "4",
+            ["DISTANCE_METRIC"] = "L2"
+        });
+
         var hashsetCreateParams = new FTCreateParams().AddPrefix("hashhotels:").On(IndexDataType.HASH);
-        await this.Database.FT().CreateAsync("hashhotels", hashsetCreateParams, schema);
+        await this.Database.FT().CreateAsync("hashhotels", hashsetCreateParams, hashSchema);
 
         // Create some test data.
         var address = new HotelAddress { City = "Seattle", Country = "USA" };
@@ -129,7 +142,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         await this.Database.JSON().SetAsync("jsonhotels:BaseSet-4-Invalid", "$", new { HotelId = "AnotherId", HotelName = "My Invalid Hotel", HotelCode = 4, Description = "This is an invalid hotel.", DescriptionEmbedding = embedding, parking_is_included = false });
 
         // Add hashset test data.
-        await this.Database.HashSetAsync("hashhotels:BaseSet-1", new HashEntry[]
+        await this.Database.HashSetAsync("hashhotels:HBaseSet-1", new HashEntry[]
         {
             new("HotelName", "My Hotel 1"),
             new("HotelCode", 1),
@@ -138,7 +151,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
             new("parking_is_included", true),
             new("Rating", 3.6)
         });
-        await this.Database.HashSetAsync("hashhotels:BaseSet-2", new HashEntry[]
+        await this.Database.HashSetAsync("hashhotels:HBaseSet-2", new HashEntry[]
         {
             new("HotelName", "My Hotel 2"),
             new("HotelCode", 2),
@@ -146,7 +159,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
             new("DescriptionEmbedding", MemoryMarshal.AsBytes(new ReadOnlySpan<float>(embedding)).ToArray()),
             new("parking_is_included", false),
         });
-        await this.Database.HashSetAsync("hashhotels:BaseSet-3", new HashEntry[]
+        await this.Database.HashSetAsync("hashhotels:HBaseSet-3", new HashEntry[]
         {
             new("HotelName", "My Hotel 3"),
             new("HotelCode", 3),
@@ -154,7 +167,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
             new("DescriptionEmbedding", MemoryMarshal.AsBytes(new ReadOnlySpan<float>(embedding)).ToArray()),
             new("parking_is_included", false),
         });
-        await this.Database.HashSetAsync("hashhotels:BaseSet-4-Invalid", new HashEntry[]
+        await this.Database.HashSetAsync("hashhotels:HBaseSet-4-Invalid", new HashEntry[]
         {
             new("HotelId", "AnotherId"),
             new("HotelName", "My Invalid Hotel"),
@@ -201,13 +214,15 @@ public class RedisVectorStoreFixture : IAsyncLifetime
             {
                 PortBindings = new Dictionary<string, IList<PortBinding>>
                 {
-                    {"6379", new List<PortBinding> {new() {HostPort = "6379"}}}
+                    {"6379", new List<PortBinding> {new() {HostPort = "6379"}}},
+                    {"8001", new List<PortBinding> {new() {HostPort = "8001"}}}
                 },
                 PublishAllPorts = true
             },
             ExposedPorts = new Dictionary<string, EmptyStruct>
             {
-                { "6379", default }
+                { "6379", default },
+                { "8001", default }
             },
         });
 


### PR DESCRIPTION
### Motivation and Context

As part of the work on vector storage we have to add vector search capabilities for each implementation.

### Description

1. Adding vector search for Redis.
2. Note that for now, the search interface is implemented directly by the collection, but in future it should be part of the collection interface. I'm doing it this way so that each implementation can be added one by one, and once all have been implemented, we can make the switch.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
