### PR TITLE
.Net: Share method for processing function invocation results

### DIFF
--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/FunctionCallsProcessor.cs
@@ -316,7 +316,7 @@ internal sealed class FunctionCallsProcessor
     /// </summary>
     /// <param name="functionResult">The result of the function call.</param>
     /// <returns>A string representation of the function result.</returns>
-    private static string? ProcessFunctionResult(object functionResult)
+    public static string? ProcessFunctionResult(object functionResult)
     {
         if (functionResult is string stringResult)
         {


### PR DESCRIPTION
### Motivation, Context, and Description
Both the function calls processor and AI connectors need to convert function results, which can be of any type, into a string that AI can understand. This PR makes the `FunctionCallsProcessor.ProcessFunctionResult` method public to avoid duplication and let both the processor and AI connectors use the same serialization function. It also removes unnecessary code that was moved to the function calls processor but not deleted from the connector.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: