### PR TITLE
.Net: Handle null parameter values in Handlebars positional arguments

### DIFF
--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelFunctionHelpersTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelFunctionHelpersTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Threading.Tasks;
@@ -91,6 +92,21 @@ public sealed class KernelFunctionHelpersTests
     }
 
     [Fact]
+    public async Task ItRendersFunctionHelpersWitHashArgumentsAndInputVariableAsync()
+    {
+        // Arrange and Act
+        const string varName = "param_x";
+        var template = """{{Foo-StringifyInt (param_x)}}""";
+        var inputVariables = new List<InputVariable> { new() { Name = varName } };
+        var arguments = new KernelArguments { [varName] = 5 };
+
+        var result = await this.RenderPromptTemplateAsync(template, inputVariables, arguments);
+
+        // Assert
+        Assert.Equal("5", result);
+    }
+
+    [Fact]
     public async Task ShouldThrowExceptionWhenMissingRequiredParameterAsync()
     {
         // Arrange and Act
@@ -121,6 +137,34 @@ public sealed class KernelFunctionHelpersTests
         // Assert
         var exception = await Assert.ThrowsAsync<KernelException>(() => this.RenderPromptTemplateAsync(template));
         Assert.Contains("Invalid argument type", exception.Message, StringComparison.CurrentCultureIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ShouldThrowExceptionWhenFunctionHasNullPositionalParameterAsync()
+    {
+        // Arrange and Act
+        var template = """{{Foo-StringifyInt (nullParameter)}}""";
+        var inputVariables = new List<InputVariable> { new() { Name = "nullParameter" } };
+        var arguments = new KernelArguments { ["nullParameter"] = null };
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<KernelException>(() => this.RenderPromptTemplateAsync(template, inputVariables, arguments));
+        Assert.Contains("Invalid parameter type for function", exception.Message, StringComparison.CurrentCultureIgnoreCase);
+        Assert.Contains("<null>", exception.Message, StringComparison.CurrentCultureIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ShouldThrowExceptionWhenFunctionHasNullHashParameterAsync()
+    {
+        // Arrange and Act
+        var template = """{{Foo-StringifyInt x=(nullParameter)}}""";
+        var inputVariables = new List<InputVariable> { new() { Name = "nullParameter" } };
+        var arguments = new KernelArguments { ["nullParameter"] = null };
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<KernelException>(() => this.RenderPromptTemplateAsync(template, inputVariables, arguments));
+        Assert.Contains("Invalid argument type for function", exception.Message, StringComparison.CurrentCultureIgnoreCase);
+        Assert.Contains("<null>", exception.Message, StringComparison.CurrentCultureIgnoreCase);
     }
 
     [Fact]
@@ -176,15 +220,20 @@ public sealed class KernelFunctionHelpersTests
     private readonly Kernel _kernel;
     private readonly KernelArguments _arguments;
 
-    private async Task<string> RenderPromptTemplateAsync(string template)
+    private async Task<string> RenderPromptTemplateAsync(string template, List<InputVariable>? inputVariables = null, KernelArguments? arguments = null)
     {
         // Arrange
         this._kernel.ImportPluginFromObject(new Foo());
         var resultConfig = InitializeHbPromptConfig(template);
+        if (inputVariables != null)
+        {
+            resultConfig.InputVariables = inputVariables;
+        }
+
         var target = (HandlebarsPromptTemplate)this._factory.Create(resultConfig);
 
         // Act
-        var result = await target.RenderAsync(this._kernel, this._arguments);
+        var result = await target.RenderAsync(this._kernel, arguments ?? this._arguments);
 
         return result;
     }

--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelFunctionHelpersTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelFunctionHelpersTests.cs
@@ -96,7 +96,7 @@ public sealed class KernelFunctionHelpersTests
     {
         // Arrange and Act
         const string VarName = "param_x";
-        var template = """{{Foo-StringifyInt (param_x)}}""";
+        var template = """{{Foo-StringifyInt (""" + VarName + """)}}""";
         var inputVariables = new List<InputVariable> { new() { Name = VarName } };
         var arguments = new KernelArguments { [VarName] = 5 };
 

--- a/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelFunctionHelpersTests.cs
+++ b/dotnet/src/Extensions/Extensions.UnitTests/PromptTemplates/Handlebars/Helpers/KernelFunctionHelpersTests.cs
@@ -95,10 +95,10 @@ public sealed class KernelFunctionHelpersTests
     public async Task ItRendersFunctionHelpersWitHashArgumentsAndInputVariableAsync()
     {
         // Arrange and Act
-        const string varName = "param_x";
+        const string VarName = "param_x";
         var template = """{{Foo-StringifyInt (param_x)}}""";
-        var inputVariables = new List<InputVariable> { new() { Name = varName } };
-        var arguments = new KernelArguments { [varName] = 5 };
+        var inputVariables = new List<InputVariable> { new() { Name = VarName } };
+        var arguments = new KernelArguments { [VarName] = 5 };
 
         var result = await this.RenderPromptTemplateAsync(template, inputVariables, arguments);
 

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Web;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
+using static Microsoft.SemanticKernel.Http.HttpHeaderConstant;
 
 namespace Microsoft.SemanticKernel.PromptTemplates.Handlebars.Helpers;
 
@@ -101,8 +102,13 @@ internal static class KernelFunctionHelpers
     /// </summary>
     /// <param name="parameterMetadata">Function parameter metadata.</param>
     /// <param name="argument">Handlebar argument.</param>
-    private static bool IsExpectedParameterType(KernelParameterMetadata parameterMetadata, object argument)
+    private static bool IsExpectedParameterType(KernelParameterMetadata parameterMetadata, object? argument)
     {
+        if (argument == null)
+        {
+            return false;
+        }
+
         var actualParameterType = parameterMetadata.ParameterType is Type parameterType && Nullable.GetUnderlyingType(parameterType) is Type underlyingType
             ? underlyingType
             : parameterMetadata.ParameterType;
@@ -140,13 +146,13 @@ internal static class KernelFunctionHelpers
             if (handlebarsArguments is not null && (handlebarsArguments.TryGetValue(fullyQualifiedParamName, out var value) || handlebarsArguments.TryGetValue(param.Name, out value)))
             {
                 value = KernelHelpersUtils.GetArgumentValue(value, executionContext);
-                if (value is not null && IsExpectedParameterType(param, value))
+                if (IsExpectedParameterType(param, value))
                 {
                     executionContext[param.Name] = value;
                 }
                 else
                 {
-                    throw new KernelException($"Invalid argument type for function {functionMetadata.Name}. Parameter {param.Name} expects type {param.ParameterType ?? (object?)param.Schema} but received {value?.GetType()}.");
+                    throw new KernelException($"Invalid argument type for function {functionMetadata.Name}. Parameter {param.Name} expects type {param.ParameterType ?? (object?)param.Schema} but received {value?.GetType().ToString() ?? "<null>"}.");
                 }
             }
             else if (param.IsRequired)
@@ -180,7 +186,7 @@ internal static class KernelFunctionHelpers
                 }
                 else
                 {
-                    throw new KernelException($"Invalid parameter type for function {functionMetadata.Name}. Parameter {param.Name} expects type {param.ParameterType ?? (object?)param.Schema} but received {arg.GetType()}.");
+                    throw new KernelException($"Invalid parameter type for function {functionMetadata.Name}. Parameter {param.Name} expects type {param.ParameterType ?? (object?)param.Schema} but received {arg?.GetType().ToString() ?? "<null>"}.");
                 }
             }
         }

--- a/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
+++ b/dotnet/src/Extensions/PromptTemplates.Handlebars/Helpers/KernelHelpers/KernelFunctionHelpers.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Web;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
-using static Microsoft.SemanticKernel.Http.HttpHeaderConstant;
 
 namespace Microsoft.SemanticKernel.PromptTemplates.Handlebars.Helpers;
 


### PR DESCRIPTION
### Motivation and Context

This change makes it easier to debug issues with parameter passing using positional arguments in Handlebars templates by matching the behavior of hash arguments when a null InputVariable is passed.

Previously, the IsExpectedParameterType method would throw when it tried to check the type of a null object

### Description

Passing a null parameter would previous cause a null reference exception for positional arguments. It would throw a KernelException for hash arguments. Change behavior of positional arguments to throw a KernelException to match behavior.

Adds tests for both cases as well as the positive test case where a argument is passed properly

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
