### PR TITLE
Python: New AI Connector abstract methods

### DIFF
--- a/docs/decisions/0052-python-ai-connector-new-abstract-methods.md
+++ b/docs/decisions/0052-python-ai-connector-new-abstract-methods.md
@@ -30,24 +30,24 @@ Auto function invocation can cause a side effect where a single call to get_chat
 
 ### Two new abstract methods
 
+> Revision: In order to not break existing customers who have implemented their own AI connectors, these two methods are not decorated with the `@abstractmethod` decorator, but instead throw an exception if they are not implemented in the built-in AI connectors.
+
 ```python
-@abstractmethod
-async def _send_chat_request(
+async def _inner_get_chat_message_content(
     self,
     chat_history: ChatHistory,
     settings: PromptExecutionSettings
 ) -> list[ChatMessageContent]:
-    pass
+    raise NotImplementedError
 ```
 
 ```python
-@abstractmethod
-async def _send_streaming_chat_request(
+async def _inner_get_streaming_chat_message_content(
     self,
     chat_history: ChatHistory,
     settings: PromptExecutionSettings
 ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-    pass
+    raise NotImplementedError
 ```
 
 ### A new `ClassVar[bool]` variable in `ChatCompletionClientBase` to indicate whether a connector supports function calling

--- a/python/.cspell.json
+++ b/python/.cspell.json
@@ -57,6 +57,7 @@
         "contoso",
         "opentelemetry",
         "SEMANTICKERNEL",
-        "OTEL"
+        "OTEL",
+        "mistralai"
     ]
 }

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -15,9 +15,6 @@ no_implicit_reexport = true
 [mypy-semantic_kernel.connectors.ai.azure_ai_inference.*]
 ignore_errors = true
 
-[mypy-semantic_kernel.connectors.ai.google.*]
-ignore_errors = true
-
 [mypy-semantic_kernel.memory.*]
 ignore_errors = true
 # TODO (eavanvalkenburg): remove this

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -12,9 +12,6 @@ warn_untyped_fields = true
 [mypy-semantic_kernel]
 no_implicit_reexport = true
 
-[mypy-semantic_kernel.connectors.ai.azure_ai_inference.*]
-ignore_errors = true
-
 [mypy-semantic_kernel.memory.*]
 ignore_errors = true
 # TODO (eavanvalkenburg): remove this

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -12,6 +12,12 @@ warn_untyped_fields = true
 [mypy-semantic_kernel]
 no_implicit_reexport = true
 
+[mypy-semantic_kernel.connectors.ai.azure_ai_inference.*]
+ignore_errors = true
+
+[mypy-semantic_kernel.connectors.ai.google.*]
+ignore_errors = true
+
 [mypy-semantic_kernel.memory.*]
 ignore_errors = true
 # TODO (eavanvalkenburg): remove this

--- a/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
@@ -113,7 +113,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -142,7 +142,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
         ]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
@@ -113,7 +113,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -142,7 +142,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
         ]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/anthropic/services/anthropic_chat_completion.py
@@ -37,6 +37,7 @@ from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.contents.utils.finish_reason import FinishReason as SemanticKernelFinishReason
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceResponseException
 from semantic_kernel.utils.experimental_decorator import experimental_class
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 # map finish reasons from Anthropic to Semantic Kernel
 ANTHROPIC_TO_SEMANTIC_KERNEL_FINISH_REASON_MAP = {
@@ -111,6 +112,7 @@ class AnthropicChatCompletion(ChatCompletionClientBase):
         return AnthropicChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -190,9 +190,9 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
     @override
     def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
         if hasattr(settings, "tool_choice"):
-            delattr(settings, "tool_choice")
+            settings.tool_choice = None
         if hasattr(settings, "tools"):
-            delattr(settings, "tools")
+            settings.tools = None
 
     @override
     def _prepare_chat_history_for_request(

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -124,7 +124,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
 
     @override
     @trace_chat_completion(AzureAIInferenceBase.MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -144,7 +144,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 from semantic_kernel.utils.telemetry.user_agent import SEMANTIC_KERNEL_USER_AGENT
 
 if sys.version_info >= (3, 12):
@@ -122,6 +123,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
         return AzureAIInferenceChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(AzureAIInferenceBase.MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -1,13 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import asyncio
 import logging
 import sys
-from collections.abc import AsyncGenerator
-from functools import reduce
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncGenerator, Callable
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
+from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
 from semantic_kernel.utils.telemetry.user_agent import SEMANTIC_KERNEL_USER_AGENT
 
 if sys.version_info >= (3, 12):
@@ -35,11 +33,8 @@ from semantic_kernel.connectors.ai.azure_ai_inference import (
 from semantic_kernel.connectors.ai.azure_ai_inference.services.azure_ai_inference_base import AzureAIInferenceBase
 from semantic_kernel.connectors.ai.azure_ai_inference.services.utils import MESSAGE_CONVERTERS
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
-from semantic_kernel.connectors.ai.function_calling_utils import (
-    merge_function_results,
-    update_settings_from_function_call_configuration,
-)
-from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+from semantic_kernel.connectors.ai.function_calling_utils import update_settings_from_function_call_configuration
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceType
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ITEM_TYPES, ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
@@ -53,8 +48,6 @@ from semantic_kernel.exceptions.service_exceptions import (
     ServiceInitializationError,
     ServiceInvalidExecutionSettingsError,
 )
-from semantic_kernel.functions.kernel_arguments import KernelArguments
-from semantic_kernel.kernel import Kernel
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
 if TYPE_CHECKING:
@@ -66,6 +59,8 @@ logger: logging.Logger = logging.getLogger(__name__)
 @experimental_class
 class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceBase):
     """Azure AI Inference Chat Completion Service."""
+
+    SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -119,70 +114,23 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
             client=client,
         )
 
-    # region Non-streaming
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_chat_completion(AzureAIInferenceBase.MODEL_PROVIDER_NAME)
-    async def get_chat_message_contents(
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return AzureAIInferenceChatPromptExecutionSettings
+
+    @override
+    async def _send_chat_request(
         self,
-        chat_history: ChatHistory,
+        chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> list[ChatMessageContent]:
-        """Get chat message contents from the Azure AI Inference service.
-
-        Args:
-            chat_history: A list of chats in a chat_history object.
-            settings: Settings for the request.
-            kwargs: Optional arguments.
-
-        Returns:
-            A list of chat message contents.
-        """
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+    ) -> list["ChatMessageContent"]:
+        if not isinstance(settings, AzureAIInferenceChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, AzureAIInferenceChatPromptExecutionSettings)  # nosec
 
-        kernel = kwargs.get("kernel")
-        if settings.function_choice_behavior is not None and (not kernel or not isinstance(kernel, Kernel)):
-            raise ServiceInvalidExecutionSettingsError("Kernel is required for auto invoking functions.")
-
-        if kernel and settings.function_choice_behavior:
-            self._verify_function_choice_behavior(settings)
-            self._configure_function_choice_behavior(settings, kernel)
-
-        if (
-            settings.function_choice_behavior is None
-            or not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            return await self._send_chat_request(chat_history, settings)
-
-        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            completions = await self._send_chat_request(chat_history, settings)
-            function_calls = [item for item in completions[0].items if isinstance(item, FunctionCallContent)]
-            if (fc_count := len(function_calls)) == 0:
-                return completions
-
-            chat_history.add_message(message=completions[0])
-
-            results = await self._invoke_function_calls(
-                function_calls=function_calls,
-                chat_history=chat_history,
-                kernel=kernel,  # type: ignore
-                arguments=kwargs.get("arguments", None),
-                function_call_count=fc_count,
-                request_index=request_index,
-                function_behavior=settings.function_choice_behavior,
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                return merge_function_results(chat_history.messages[-len(results) :])
-        else:
-            # do a final call without auto function calling
-            return await self._send_chat_request(chat_history, settings)
-
-    async def _send_chat_request(
-        self, chat_history: ChatHistory, settings: AzureAIInferenceChatPromptExecutionSettings
-    ) -> list[ChatMessageContent]:
-        """Send a chat request to the Azure AI Inference service."""
         assert isinstance(self.client, ChatCompletionsClient)  # nosec
         response: ChatCompletions = await self.client.complete(
             messages=self._prepare_chat_history_for_request(chat_history),
@@ -192,6 +140,77 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
         response_metadata = self._get_metadata_from_response(response)
 
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
+
+    @override
+    async def _send_streaming_chat_request(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
+        if not isinstance(settings, AzureAIInferenceChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, AzureAIInferenceChatPromptExecutionSettings)  # nosec
+
+        assert isinstance(self.client, ChatCompletionsClient)  # nosec
+        response: AsyncStreamingChatCompletions = await self.client.complete(
+            stream=True,
+            messages=self._prepare_chat_history_for_request(chat_history),
+            model_extras=settings.extra_parameters,
+            **settings.prepare_settings_dict(),
+        )
+
+        async for chunk in response:
+            if len(chunk.choices) == 0:
+                continue
+            chunk_metadata = self._get_metadata_from_response(chunk)
+            yield [
+                self._create_streaming_chat_message_content(chunk, choice, chunk_metadata) for choice in chunk.choices
+            ]
+
+    @override
+    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if not isinstance(settings, AzureAIInferenceChatPromptExecutionSettings):
+            raise ServiceInvalidExecutionSettingsError(
+                "The settings must be an AzureAIInferenceChatPromptExecutionSettings."
+            )
+        if settings.extra_parameters is not None and settings.extra_parameters.get("n", 1) > 1:
+            # Currently only OpenAI models allow multiple completions but the Azure AI Inference service
+            # does not expose the functionality directly. If users want to have more than 1 responses, they
+            # need to configure `extra_parameters` with a key of "n" and a value greater than 1.
+            raise ServiceInvalidExecutionSettingsError(
+                "Auto invocation of tool calls may only be used with a single completion."
+            )
+
+    @override
+    def _update_function_choice_settings_callback(
+        self,
+    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
+        return update_settings_from_function_call_configuration
+
+    @override
+    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if hasattr(settings, "tool_choice"):
+            delattr(settings, "tool_choice")
+        if hasattr(settings, "tools"):
+            delattr(settings, "tools")
+
+    @override
+    def _prepare_chat_history_for_request(
+        self,
+        chat_history: ChatHistory,
+        role_key: str = "role",
+        content_key: str = "content",
+    ) -> list[ChatRequestMessage]:
+        chat_request_messages: list[ChatRequestMessage] = []
+
+        for message in chat_history.messages:
+            chat_request_messages.append(MESSAGE_CONVERTERS[message.role](message))
+
+        return chat_request_messages
+
+    # endregion
+
+    # region Non-streaming
 
     def _create_chat_message_content(
         self, response: ChatCompletions, choice: ChatChoice, metadata: dict[str, Any]
@@ -237,115 +256,6 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
     # endregion
 
     # region Streaming
-    async def get_streaming_chat_message_contents(
-        self,
-        chat_history: ChatHistory,
-        settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Get streaming chat message contents from the Azure AI Inference service.
-
-        Args:
-            chat_history: A list of chats in a chat_history object.
-            settings: Settings for the request.
-            kwargs: Optional arguments.
-
-        Returns:
-            A list of chat message contents.
-        """
-        settings = self.get_prompt_execution_settings_from_settings(settings)
-        assert isinstance(settings, AzureAIInferenceChatPromptExecutionSettings)  # nosec
-
-        kernel = kwargs.get("kernel")
-        if settings.function_choice_behavior is not None and (not kernel or not isinstance(kernel, Kernel)):
-            raise ServiceInvalidExecutionSettingsError("Kernel is required for auto invoking functions.")
-
-        if kernel and settings.function_choice_behavior:
-            self._verify_function_choice_behavior(settings)
-            self._configure_function_choice_behavior(settings, kernel)
-
-        if (
-            settings.function_choice_behavior is None
-            or not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            # No auto invoke is required.
-            async_generator = self._send_chat_streaming_request(chat_history, settings)
-        else:
-            # Auto invoke is required.
-            async_generator = self._get_streaming_chat_message_contents_auto_invoke(
-                kernel,  # type: ignore
-                kwargs.get("arguments"),
-                chat_history,
-                settings,
-            )
-
-        async for messages in async_generator:
-            yield messages
-
-    async def _get_streaming_chat_message_contents_auto_invoke(
-        self,
-        kernel: Kernel,
-        arguments: KernelArguments | None,
-        chat_history: ChatHistory,
-        settings: AzureAIInferenceChatPromptExecutionSettings,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Get streaming chat message contents from the Azure AI Inference service with auto invoking functions."""
-        # mypy doesn't recognize the settings.function_choice_behavior is not None by the check above
-        request_attempts = settings.function_choice_behavior.maximum_auto_invoke_attempts  # type: ignore
-
-        for request_index in range(request_attempts):
-            all_messages: list[StreamingChatMessageContent] = []
-            function_call_returned = False
-            async for messages in self._send_chat_streaming_request(chat_history, settings):
-                for message in messages:
-                    if message:
-                        all_messages.append(message)
-                        if any(isinstance(item, FunctionCallContent) for item in message.items):
-                            function_call_returned = True
-                yield messages
-
-            if not function_call_returned:
-                # Response doesn't contain any function calls. No need to proceed to the next request.
-                return
-
-            full_completion: StreamingChatMessageContent = reduce(lambda x, y: x + y, all_messages)
-            function_calls = [item for item in full_completion.items if isinstance(item, FunctionCallContent)]
-            chat_history.add_message(message=full_completion)
-
-            results = await self._invoke_function_calls(
-                function_calls=function_calls,
-                chat_history=chat_history,
-                kernel=kernel,
-                arguments=arguments,
-                function_call_count=len(function_calls),
-                request_index=request_index,
-                # mypy doesn't recognize the settings.function_choice_behavior is not None by the check above
-                function_behavior=settings.function_choice_behavior,  # type: ignore
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                yield merge_function_results(chat_history.messages[-len(results) :])  # type: ignore
-                break
-
-    async def _send_chat_streaming_request(
-        self, chat_history: ChatHistory, settings: AzureAIInferenceChatPromptExecutionSettings
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Send a streaming chat request to the Azure AI Inference service."""
-        assert isinstance(self.client, ChatCompletionsClient)  # nosec
-        response: AsyncStreamingChatCompletions = await self.client.complete(
-            stream=True,
-            messages=self._prepare_chat_history_for_request(chat_history),
-            model_extras=settings.extra_parameters,
-            **settings.prepare_settings_dict(),
-        )
-
-        async for chunk in response:
-            if len(chunk.choices) == 0:
-                continue
-            chunk_metadata = self._get_metadata_from_response(chunk)
-            yield [
-                self._create_streaming_chat_message_content(chunk, choice, chunk_metadata) for choice in chunk.choices
-            ]
 
     def _create_streaming_chat_message_content(
         self,
@@ -396,20 +306,6 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
 
     # endregion
 
-    @override
-    def _prepare_chat_history_for_request(
-        self,
-        chat_history: ChatHistory,
-        role_key: str = "role",
-        content_key: str = "content",
-    ) -> list[ChatRequestMessage]:
-        chat_request_messages: list[ChatRequestMessage] = []
-
-        for message in chat_history.messages:
-            chat_request_messages.append(MESSAGE_CONVERTERS[message.role](message))
-
-        return chat_request_messages
-
     def _get_metadata_from_response(self, response: ChatCompletions | StreamingChatCompletionsUpdate) -> dict[str, Any]:
         """Get metadata from the response.
 
@@ -425,58 +321,3 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
             "created": response.created,
             "usage": response.usage,
         }
-
-    def _verify_function_choice_behavior(self, settings: AzureAIInferenceChatPromptExecutionSettings):
-        """Verify the function choice behavior."""
-        if settings.extra_parameters is not None and settings.extra_parameters.get("n", 1) > 1:
-            # Currently only OpenAI models allow multiple completions but the Azure AI Inference service
-            # does not expose the functionality directly. If users want to have more than 1 responses, they
-            # need to configure `extra_parameters` with a key of "n" and a value greater than 1.
-            raise ServiceInvalidExecutionSettingsError(
-                "Auto invocation of tool calls may only be used with a single completion."
-            )
-
-    def _configure_function_choice_behavior(
-        self, settings: AzureAIInferenceChatPromptExecutionSettings, kernel: Kernel
-    ):
-        """Configure the function choice behavior to include the kernel functions."""
-        if not settings.function_choice_behavior:
-            return
-
-        settings.function_choice_behavior.configure(
-            kernel=kernel, update_settings_callback=update_settings_from_function_call_configuration, settings=settings
-        )
-
-    async def _invoke_function_calls(
-        self,
-        function_calls: list[FunctionCallContent],
-        chat_history: ChatHistory,
-        kernel: Kernel,
-        arguments: KernelArguments | None,
-        function_call_count: int,
-        request_index: int,
-        function_behavior: FunctionChoiceBehavior,
-    ):
-        """Invoke function calls."""
-        logger.info(f"processing {function_call_count} tool calls in parallel.")
-
-        return await asyncio.gather(
-            *[
-                kernel.invoke_function_call(
-                    function_call=function_call,
-                    chat_history=chat_history,
-                    arguments=arguments,
-                    function_call_count=function_call_count,
-                    request_index=request_index,
-                    function_behavior=function_behavior,
-                )
-                for function_call in function_calls
-            ],
-        )
-
-    @override
-    def get_prompt_execution_settings_class(
-        self,
-    ) -> type["PromptExecutionSettings"]:
-        """Get the request settings class."""
-        return AzureAIInferenceChatPromptExecutionSettings

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/azure_ai_inference_chat_completion.py
@@ -124,7 +124,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
 
     @override
     @trace_chat_completion(AzureAIInferenceBase.MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -144,7 +144,7 @@ class AzureAIInferenceChatCompletion(ChatCompletionClientBase, AzureAIInferenceB
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -1,11 +1,21 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import asyncio
+import copy
+import logging
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncGenerator, Callable
+from functools import reduce
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from semantic_kernel.connectors.ai.function_call_behavior import FunctionCallBehavior
+from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
+from semantic_kernel.connectors.ai.function_calling_utils import merge_function_results
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior, FunctionChoiceType
 from semantic_kernel.contents.annotation_content import AnnotationContent
 from semantic_kernel.contents.file_reference_content import FileReferenceContent
+from semantic_kernel.contents.function_call_content import FunctionCallContent
+from semantic_kernel.exceptions.service_exceptions import ServiceInvalidExecutionSettingsError
 from semantic_kernel.services.ai_service_client_base import AIServiceClientBase
 
 if TYPE_CHECKING:
@@ -14,11 +24,82 @@ if TYPE_CHECKING:
     from semantic_kernel.contents.chat_message_content import ChatMessageContent
     from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 
 class ChatCompletionClientBase(AIServiceClientBase, ABC):
     """Base class for chat completion AI services."""
 
+    # Connectors that support function calling should set this to True
+    SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = False
+
+    # region Abstract methods
+
     @abstractmethod
+    async def _send_chat_request(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> list["ChatMessageContent"]:
+        """Send a chat request to the AI service.
+
+        Args:
+            chat_history (ChatHistory): The chat history to send.
+            settings (PromptExecutionSettings): The settings for the request.
+
+        Returns:
+            chat_message_contents (list[ChatMessageContent]): The chat message contents representing the response(s).
+        """
+        ...
+
+    @abstractmethod
+    async def _send_streaming_chat_request(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
+        """Send a streaming chat request to the AI service.
+
+        Args:
+            chat_history (ChatHistory): The chat history to send.
+            settings (PromptExecutionSettings): The settings for the request.
+
+        Yields:
+            streaming_chat_message_contents (list[StreamingChatMessageContent]): The streaming chat message contents.
+        """
+        # Below is needed for mypy: https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
+        if False:
+            yield
+
+    @abstractmethod
+    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        """Additional verification to validate settings for function choice behavior.
+
+        Args:
+            settings (PromptExecutionSettings): The settings to verify.
+        """
+        pass
+
+    @abstractmethod
+    def _update_function_choice_settings_callback(
+        self,
+    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
+        """Return the callback function to update the settings from a function call configuration."""
+        pass
+
+    @abstractmethod
+    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        """Reset the settings updated by `_update_function_choice_settings_callback`.
+
+        Args:
+            settings (PromptExecutionSettings): The prompt execution settings to reset.
+        """
+        ...
+
+    # endregion
+
+    # region Public methods
+
     async def get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
@@ -36,7 +117,79 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         Returns:
             A list of chat message contents representing the response(s) from the LLM.
         """
-        pass
+        # Create a copy of the settings to avoid modifying the original settings
+        settings = copy.deepcopy(settings)
+
+        if not self.SUPPORTS_FUNCTION_CALLING:
+            return await self._send_chat_request(chat_history, settings)
+
+        # For backwards compatibility we need to convert the `FunctionCallBehavior` to `FunctionChoiceBehavior`
+        # if this method is called with a `FunctionCallBehavior` object as part of the settings
+        if hasattr(settings, "function_call_behavior") and isinstance(
+            settings.function_call_behavior, FunctionCallBehavior
+        ):
+            settings.function_choice_behavior = FunctionChoiceBehavior.from_function_call_behavior(
+                settings.function_call_behavior
+            )
+
+        kernel = kwargs.get("kernel", None)
+        if settings.function_choice_behavior is not None:
+            if kernel is None:
+                raise ServiceInvalidExecutionSettingsError("The kernel is required for function calls.")
+            self._verify_function_choice_settings(settings)
+
+        if settings.function_choice_behavior and kernel:
+            # Configure the function choice behavior into the settings object
+            # that will become part of the request to the AI service
+            settings.function_choice_behavior.configure(
+                kernel=kernel,
+                update_settings_callback=self._update_function_choice_settings_callback(),
+                settings=settings,
+            )
+
+        if (
+            settings.function_choice_behavior is None
+            or not settings.function_choice_behavior.auto_invoke_kernel_functions
+        ):
+            return await self._send_chat_request(chat_history, settings)
+
+        # Auto invoke loop
+        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
+            completions = await self._send_chat_request(chat_history, settings)
+            # Get the function call contents from the chat message. There is only one chat message,
+            # which should be checked in the `_verify_function_choice_settings` method.
+            function_calls = [item for item in completions[0].items if isinstance(item, FunctionCallContent)]
+            if (fc_count := len(function_calls)) == 0:
+                return completions
+
+            # Since we have a function call, add the assistant's tool call message to the history
+            chat_history.add_message(message=completions[0])
+
+            logger.info(f"processing {fc_count} tool calls in parallel.")
+
+            # This function either updates the chat history with the function call results
+            # or returns the context, with terminate set to True in which case the loop will
+            # break and the function calls are returned.
+            results = await asyncio.gather(
+                *[
+                    kernel.invoke_function_call(
+                        function_call=function_call,
+                        chat_history=chat_history,
+                        arguments=kwargs.get("arguments", None),
+                        function_call_count=fc_count,
+                        request_index=request_index,
+                        function_behavior=settings.function_choice_behavior,
+                    )
+                    for function_call in function_calls
+                ],
+            )
+
+            if any(result.terminate for result in results if result is not None):
+                return merge_function_results(chat_history.messages[-len(results) :])
+        else:
+            # Do a final call, without function calling when the max has been reached.
+            self._reset_function_choice_settings(settings)
+            return await self._send_chat_request(chat_history, settings)
 
     async def get_chat_message_content(
         self, chat_history: "ChatHistory", settings: "PromptExecutionSettings", **kwargs: Any
@@ -58,8 +211,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         # this should not happen, should error out before returning an empty list
         return None  # pragma: no cover
 
-    @abstractmethod
-    def get_streaming_chat_message_contents(
+    async def get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -76,7 +228,97 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         Yields:
             A stream representing the response(s) from the LLM.
         """
-        ...
+        # Create a copy of the settings to avoid modifying the original settings
+        settings = copy.deepcopy(settings)
+
+        if not self.SUPPORTS_FUNCTION_CALLING:
+            async for streaming_chat_message_contents in self._send_streaming_chat_request(chat_history, settings):
+                yield streaming_chat_message_contents
+            return
+
+        # For backwards compatibility we need to convert the `FunctionCallBehavior` to `FunctionChoiceBehavior`
+        # if this method is called with a `FunctionCallBehavior` object as part of the settings
+        if hasattr(settings, "function_call_behavior") and isinstance(
+            settings.function_call_behavior, FunctionCallBehavior
+        ):
+            settings.function_choice_behavior = FunctionChoiceBehavior.from_function_call_behavior(
+                settings.function_call_behavior
+            )
+
+        kernel = kwargs.get("kernel", None)
+        if settings.function_choice_behavior is not None:
+            if kernel is None:
+                raise ServiceInvalidExecutionSettingsError("The kernel is required for function calls.")
+            self._verify_function_choice_settings(settings)
+
+        if settings.function_choice_behavior and kernel:
+            # Configure the function choice behavior into the settings object
+            # that will become part of the request to the AI service
+            settings.function_choice_behavior.configure(
+                kernel=kernel,
+                update_settings_callback=self._update_function_choice_settings_callback(),
+                settings=settings,
+            )
+
+        if (
+            settings.function_choice_behavior is None
+            or not settings.function_choice_behavior.auto_invoke_kernel_functions
+        ):
+            async for streaming_chat_message_contents in self._send_streaming_chat_request(chat_history, settings):
+                yield streaming_chat_message_contents
+            return
+
+        # Auto invoke loop
+        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
+            # Hold the messages, if there are more than one response, it will not be used, so we flatten
+            all_messages: list["StreamingChatMessageContent"] = []
+            function_call_returned = False
+            async for messages in self._send_streaming_chat_request(chat_history, settings):
+                for msg in messages:
+                    if msg is not None:
+                        all_messages.append(msg)
+                        if any(isinstance(item, FunctionCallContent) for item in msg.items):
+                            function_call_returned = True
+                yield messages
+
+            if not function_call_returned:
+                return
+
+            # There is one FunctionCallContent response stream in the messages, combining now to create
+            # the full completion depending on the prompt, the message may contain both function call
+            # content and others
+            full_completion: StreamingChatMessageContent = reduce(lambda x, y: x + y, all_messages)
+            function_calls = [item for item in full_completion.items if isinstance(item, FunctionCallContent)]
+            chat_history.add_message(message=full_completion)
+
+            fc_count = len(function_calls)
+            logger.info(f"processing {fc_count} tool calls in parallel.")
+
+            # This function either updates the chat history with the function call results
+            # or returns the context, with terminate set to True in which case the loop will
+            # break and the function calls are returned.
+            results = await asyncio.gather(
+                *[
+                    kernel.invoke_function_call(
+                        function_call=function_call,
+                        chat_history=chat_history,
+                        arguments=kwargs.get("arguments", None),
+                        function_call_count=fc_count,
+                        request_index=request_index,
+                        function_behavior=settings.function_choice_behavior,
+                    )
+                    for function_call in function_calls
+                ],
+            )
+
+            if any(result.terminate for result in results if result is not None):
+                yield merge_function_results(chat_history.messages[-len(results) :])  # type: ignore
+                break
+        else:
+            # Do a final call, without function calling when the max has been reached.
+            self._reset_function_choice_settings(settings)
+            async for streaming_chat_message_contents in self._send_streaming_chat_request(chat_history, settings):
+                yield streaming_chat_message_contents
 
     async def get_streaming_chat_message_content(
         self,
@@ -103,6 +345,10 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             else:
                 # this should not happen, should error out before returning an empty list
                 yield None  # pragma: no cover
+
+    # endregion
+
+    # region internal handlers
 
     def _prepare_chat_history_for_request(
         self,
@@ -133,3 +379,5 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             for message in chat_history.messages
             if not isinstance(message, (AnnotationContent, FileReferenceContent))
         ]
+
+    # endregion

--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -71,31 +71,6 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         if False:
             yield
 
-    @abstractmethod
-    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
-        """Additional verification to validate settings for function choice behavior.
-
-        Args:
-            settings (PromptExecutionSettings): The settings to verify.
-        """
-        pass
-
-    @abstractmethod
-    def _update_function_choice_settings_callback(
-        self,
-    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
-        """Return the callback function to update the settings from a function call configuration."""
-        pass
-
-    @abstractmethod
-    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
-        """Reset the settings updated by `_update_function_choice_settings_callback`.
-
-        Args:
-            settings (PromptExecutionSettings): The prompt execution settings to reset.
-        """
-        ...
-
     # endregion
 
     # region Public methods
@@ -379,5 +354,35 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             for message in chat_history.messages
             if not isinstance(message, (AnnotationContent, FileReferenceContent))
         ]
+
+    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        """Additional verification to validate settings for function choice behavior.
+
+        Override this method to add additional verification for the settings.
+
+        Args:
+            settings (PromptExecutionSettings): The settings to verify.
+        """
+        return
+
+    def _update_function_choice_settings_callback(
+        self,
+    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
+        """Return the callback function to update the settings from a function call configuration.
+
+        Override this method to provide a custom callback function to
+        update the settings from a function call configuration.
+        """
+        return lambda configuration, settings, choice_type: None
+
+    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        """Reset the settings updated by `_update_function_choice_settings_callback`.
+
+        Override this method to reset the settings updated by `_update_function_choice_settings_callback`.
+
+        Args:
+            settings (PromptExecutionSettings): The prompt execution settings to reset.
+        """
+        return
 
     # endregion

--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -3,7 +3,7 @@
 import asyncio
 import copy
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import AsyncGenerator, Callable
 from functools import reduce
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -33,10 +33,9 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
     # Connectors that support function calling should set this to True
     SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = False
 
-    # region Abstract methods
+    # region Internal methods to be implemented by the derived classes
 
-    @abstractmethod
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -50,10 +49,9 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         Returns:
             chat_message_contents (list[ChatMessageContent]): The chat message contents representing the response(s).
         """
-        ...
+        raise NotImplementedError
 
-    @abstractmethod
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -67,6 +65,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         Yields:
             streaming_chat_message_contents (list[StreamingChatMessageContent]): The streaming chat message contents.
         """
+        raise NotImplementedError
         # Below is needed for mypy: https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
         if False:
             yield
@@ -96,7 +95,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         settings = copy.deepcopy(settings)
 
         if not self.SUPPORTS_FUNCTION_CALLING:
-            return await self._send_chat_request(chat_history, settings)
+            return await self._inner_get_chat_message_content(chat_history, settings)
 
         # For backwards compatibility we need to convert the `FunctionCallBehavior` to `FunctionChoiceBehavior`
         # if this method is called with a `FunctionCallBehavior` object as part of the settings
@@ -126,11 +125,11 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             settings.function_choice_behavior is None
             or not settings.function_choice_behavior.auto_invoke_kernel_functions
         ):
-            return await self._send_chat_request(chat_history, settings)
+            return await self._inner_get_chat_message_content(chat_history, settings)
 
         # Auto invoke loop
         for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            completions = await self._send_chat_request(chat_history, settings)
+            completions = await self._inner_get_chat_message_content(chat_history, settings)
             # Get the function call contents from the chat message. There is only one chat message,
             # which should be checked in the `_verify_function_choice_settings` method.
             function_calls = [item for item in completions[0].items if isinstance(item, FunctionCallContent)]
@@ -164,7 +163,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         else:
             # Do a final call, without function calling when the max has been reached.
             self._reset_function_choice_settings(settings)
-            return await self._send_chat_request(chat_history, settings)
+            return await self._inner_get_chat_message_content(chat_history, settings)
 
     async def get_chat_message_content(
         self, chat_history: "ChatHistory", settings: "PromptExecutionSettings", **kwargs: Any
@@ -207,7 +206,9 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         settings = copy.deepcopy(settings)
 
         if not self.SUPPORTS_FUNCTION_CALLING:
-            async for streaming_chat_message_contents in self._send_streaming_chat_request(chat_history, settings):
+            async for streaming_chat_message_contents in self._inner_get_streaming_chat_message_content(
+                chat_history, settings
+            ):
                 yield streaming_chat_message_contents
             return
 
@@ -239,7 +240,9 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             settings.function_choice_behavior is None
             or not settings.function_choice_behavior.auto_invoke_kernel_functions
         ):
-            async for streaming_chat_message_contents in self._send_streaming_chat_request(chat_history, settings):
+            async for streaming_chat_message_contents in self._inner_get_streaming_chat_message_content(
+                chat_history, settings
+            ):
                 yield streaming_chat_message_contents
             return
 
@@ -248,7 +251,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             # Hold the messages, if there are more than one response, it will not be used, so we flatten
             all_messages: list["StreamingChatMessageContent"] = []
             function_call_returned = False
-            async for messages in self._send_streaming_chat_request(chat_history, settings):
+            async for messages in self._inner_get_streaming_chat_message_content(chat_history, settings):
                 for msg in messages:
                     if msg is not None:
                         all_messages.append(msg)

--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -289,11 +289,6 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
             if any(result.terminate for result in results if result is not None):
                 yield merge_function_results(chat_history.messages[-len(results) :])  # type: ignore
                 break
-        else:
-            # Do a final call, without function calling when the max has been reached.
-            self._reset_function_choice_settings(settings)
-            async for streaming_chat_message_contents in self._send_streaming_chat_request(chat_history, settings):
-                yield streaming_chat_message_contents
 
     async def get_streaming_chat_message_content(
         self,

--- a/python/semantic_kernel/connectors/ai/function_calling_utils.py
+++ b/python/semantic_kernel/connectors/ai/function_calling_utils.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceType
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 def update_settings_from_function_call_configuration(
     function_choice_configuration: "FunctionCallChoiceConfiguration",
     settings: "PromptExecutionSettings",
-    type: str,
+    type: FunctionChoiceType,
 ) -> None:
     """Update the settings from a FunctionChoiceConfiguration."""
     if (

--- a/python/semantic_kernel/connectors/ai/function_calling_utils.py
+++ b/python/semantic_kernel/connectors/ai/function_calling_utils.py
@@ -3,14 +3,16 @@
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
-from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceType
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
 
 if TYPE_CHECKING:
-    from semantic_kernel.connectors.ai.function_choice_behavior import FunctionCallChoiceConfiguration
+    from semantic_kernel.connectors.ai.function_choice_behavior import (
+        FunctionCallChoiceConfiguration,
+        FunctionChoiceType,
+    )
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
     from semantic_kernel.functions.kernel_function_metadata import KernelFunctionMetadata
 
@@ -18,7 +20,7 @@ if TYPE_CHECKING:
 def update_settings_from_function_call_configuration(
     function_choice_configuration: "FunctionCallChoiceConfiguration",
     settings: "PromptExecutionSettings",
-    type: FunctionChoiceType,
+    type: "FunctionChoiceType",
 ) -> None:
     """Update the settings from a FunctionChoiceConfiguration."""
     if (

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -115,7 +115,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -140,7 +140,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -3,9 +3,8 @@
 
 import logging
 import sys
-from collections.abc import AsyncGenerator
-from functools import reduce
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncGenerator, Callable
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import google.generativeai as genai
 from google.generativeai import GenerativeModel
@@ -13,7 +12,8 @@ from google.generativeai.protos import Candidate, Content
 from google.generativeai.types import AsyncGenerateContentResponse, GenerateContentResponse, GenerationConfig
 from pydantic import ValidationError
 
-from semantic_kernel.connectors.ai.function_calling_utils import merge_function_results
+from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceType
 from semantic_kernel.connectors.ai.google.google_ai.google_ai_prompt_execution_settings import (
     GoogleAIChatPromptExecutionSettings,
 )
@@ -26,10 +26,8 @@ from semantic_kernel.connectors.ai.google.google_ai.services.utils import (
     update_settings_from_function_choice_configuration,
 )
 from semantic_kernel.connectors.ai.google.shared_utils import (
-    configure_function_choice_behavior,
     filter_system_message,
     format_gemini_function_name_to_kernel_function_fully_qualified_name,
-    invoke_function_calls,
 )
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.streaming_chat_message_content import ITEM_TYPES as STREAMING_ITEM_TYPES
@@ -38,9 +36,6 @@ from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.contents.utils.finish_reason import FinishReason
-from semantic_kernel.functions.kernel_arguments import KernelArguments
-from semantic_kernel.kernel import Kernel
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -64,6 +59,8 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
     """Google AI Chat Completion Client."""
+
+    SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -108,59 +105,23 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
             service_settings=google_ai_settings,
         )
 
-    # region Non-streaming
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_chat_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
-    async def get_chat_message_contents(
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return GoogleAIChatPromptExecutionSettings
+
+    @override
+    async def _send_chat_request(
         self,
-        chat_history: ChatHistory,
+        chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> list[ChatMessageContent]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+    ) -> list["ChatMessageContent"]:
+        if not isinstance(settings, GoogleAIChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, GoogleAIChatPromptExecutionSettings)  # nosec
 
-        kernel = kwargs.get("kernel")
-        if settings.function_choice_behavior is not None and (not kernel or not isinstance(kernel, Kernel)):
-            raise ServiceInvalidExecutionSettingsError("Kernel is required for auto invoking functions.")
-
-        if kernel and settings.function_choice_behavior:
-            configure_function_choice_behavior(settings, kernel, update_settings_from_function_choice_configuration)
-
-        if (
-            settings.function_choice_behavior is None
-            or not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            return await self._send_chat_request(chat_history, settings)
-
-        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            completions = await self._send_chat_request(chat_history, settings)
-            function_calls = [item for item in completions[0].items if isinstance(item, FunctionCallContent)]
-            if (fc_count := len(function_calls)) == 0:
-                return completions
-
-            chat_history.add_message(message=completions[0])
-
-            results = await invoke_function_calls(
-                function_calls=function_calls,
-                chat_history=chat_history,
-                kernel=kernel,  # type: ignore
-                arguments=kwargs.get("arguments", None),
-                function_call_count=fc_count,
-                request_index=request_index,
-                function_behavior=settings.function_choice_behavior,
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                return merge_function_results(chat_history.messages[-len(results) :])
-        else:
-            # do a final call without auto function calling
-            return await self._send_chat_request(chat_history, settings)
-
-    async def _send_chat_request(
-        self, chat_history: ChatHistory, settings: GoogleAIChatPromptExecutionSettings
-    ) -> list[ChatMessageContent]:
-        """Send a chat request to the Google AI service."""
         genai.configure(api_key=self.service_settings.api_key.get_secret_value())
         model = GenerativeModel(
             self.service_settings.gemini_model_id,
@@ -175,6 +136,60 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
         )
 
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]
+
+    @override
+    async def _send_streaming_chat_request(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
+        if not isinstance(settings, GoogleAIChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, GoogleAIChatPromptExecutionSettings)  # nosec
+
+        genai.configure(api_key=self.service_settings.api_key.get_secret_value())
+        model = GenerativeModel(
+            self.service_settings.gemini_model_id,
+            system_instruction=filter_system_message(chat_history),
+        )
+
+        response: AsyncGenerateContentResponse = await model.generate_content_async(
+            contents=self._prepare_chat_history_for_request(chat_history),
+            generation_config=GenerationConfig(**settings.prepare_settings_dict()),
+            tools=settings.tools,
+            tool_config=settings.tool_config,
+            stream=True,
+        )
+
+        async for chunk in response:
+            yield [self._create_streaming_chat_message_content(chunk, candidate) for candidate in chunk.candidates]
+
+    @override
+    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if not isinstance(settings, GoogleAIChatPromptExecutionSettings):
+            raise ServiceInvalidExecutionSettingsError("The settings must be an GoogleAIChatPromptExecutionSettings.")
+        if settings.candidate_count is not None and settings.candidate_count > 1:
+            raise ServiceInvalidExecutionSettingsError(
+                "Auto-invocation of tool calls may only be used with a "
+                "GoogleAIChatPromptExecutionSettings.candidate_count of 1."
+            )
+
+    @override
+    def _update_function_choice_settings_callback(
+        self,
+    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
+        return update_settings_from_function_choice_configuration
+
+    @override
+    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if hasattr(settings, "tool_config"):
+            delattr(settings, "tool_config")
+        if hasattr(settings, "tools"):
+            delattr(settings, "tools")
+
+    # endregion
+
+    # region Non-streaming
 
     def _create_chat_message_content(
         self, response: AsyncGenerateContentResponse, candidate: Candidate
@@ -220,109 +235,6 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
     # endregion
 
     # region Streaming
-    @override
-    async def get_streaming_chat_message_contents(
-        self,
-        chat_history: ChatHistory,
-        settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
-        assert isinstance(settings, GoogleAIChatPromptExecutionSettings)  # nosec
-
-        kernel = kwargs.get("kernel")
-        if settings.function_choice_behavior is not None and (not kernel or not isinstance(kernel, Kernel)):
-            raise ServiceInvalidExecutionSettingsError("Kernel is required for auto invoking functions.")
-
-        if kernel and settings.function_choice_behavior:
-            configure_function_choice_behavior(settings, kernel, update_settings_from_function_choice_configuration)
-
-        if (
-            settings.function_choice_behavior is None
-            or not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            # No auto invoke is required.
-            async_generator = self._send_chat_streaming_request(chat_history, settings)
-        else:
-            # Auto invoke is required.
-            async_generator = self._get_streaming_chat_message_contents_auto_invoke(
-                kernel,  # type: ignore
-                kwargs.get("arguments"),
-                chat_history,
-                settings,
-            )
-
-        async for messages in async_generator:
-            yield messages
-
-    async def _get_streaming_chat_message_contents_auto_invoke(
-        self,
-        kernel: Kernel,
-        arguments: KernelArguments | None,
-        chat_history: ChatHistory,
-        settings: GoogleAIChatPromptExecutionSettings,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Get streaming chat message contents from the Google AI service with auto invoking functions."""
-        if not settings.function_choice_behavior:
-            raise ServiceInvalidExecutionSettingsError(
-                "Function choice behavior is required for auto invoking functions."
-            )
-
-        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            all_messages: list[StreamingChatMessageContent] = []
-            function_call_returned = False
-            async for messages in self._send_chat_streaming_request(chat_history, settings):
-                for message in messages:
-                    if message:
-                        all_messages.append(message)
-                        if any(isinstance(item, FunctionCallContent) for item in message.items):
-                            function_call_returned = True
-                yield messages
-
-            if not function_call_returned:
-                # Response doesn't contain any function calls. No need to proceed to the next request.
-                return
-
-            full_completion: StreamingChatMessageContent = reduce(lambda x, y: x + y, all_messages)
-            function_calls = [item for item in full_completion.items if isinstance(item, FunctionCallContent)]
-            chat_history.add_message(message=full_completion)
-
-            results = await invoke_function_calls(
-                function_calls=function_calls,
-                chat_history=chat_history,
-                kernel=kernel,
-                arguments=arguments,
-                function_call_count=len(function_calls),
-                request_index=request_index,
-                function_behavior=settings.function_choice_behavior,
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                yield merge_function_results(chat_history.messages[-len(results) :])  # type: ignore
-                break
-
-    async def _send_chat_streaming_request(
-        self,
-        chat_history: ChatHistory,
-        settings: GoogleAIChatPromptExecutionSettings,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Send a streaming chat request to the Google AI service."""
-        genai.configure(api_key=self.service_settings.api_key.get_secret_value())
-        model = GenerativeModel(
-            self.service_settings.gemini_model_id,
-            system_instruction=filter_system_message(chat_history),
-        )
-
-        response: AsyncGenerateContentResponse = await model.generate_content_async(
-            contents=self._prepare_chat_history_for_request(chat_history),
-            generation_config=GenerationConfig(**settings.prepare_settings_dict()),
-            tools=settings.tools,
-            tool_config=settings.tool_config,
-            stream=True,
-        )
-
-        async for chunk in response:
-            yield [self._create_streaming_chat_message_content(chunk, candidate) for candidate in chunk.candidates]
 
     def _create_streaming_chat_message_content(
         self,
@@ -431,10 +343,3 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
             "safety_ratings": candidate.safety_ratings,
             "token_count": candidate.token_count,
         }
-
-    @override
-    def get_prompt_execution_settings_class(
-        self,
-    ) -> type["PromptExecutionSettings"]:
-        """Get the request settings class."""
-        return GoogleAIChatPromptExecutionSettings

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -36,6 +36,7 @@ from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.contents.utils.finish_reason import FinishReason
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -113,6 +114,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
         return GoogleAIChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -115,7 +115,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -140,7 +140,7 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_chat_completion.py
@@ -183,9 +183,9 @@ class GoogleAIChatCompletion(GoogleAIBase, ChatCompletionClientBase):
     @override
     def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
         if hasattr(settings, "tool_config"):
-            delattr(settings, "tool_config")
+            settings.tool_config = None
         if hasattr(settings, "tools"):
-            delattr(settings, "tools")
+            settings.tools = None
 
     @override
     def _prepare_chat_history_for_request(

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
@@ -15,6 +15,7 @@ from semantic_kernel.connectors.ai.google.google_ai.google_ai_prompt_execution_s
 )
 from semantic_kernel.connectors.ai.google.google_ai.services.google_ai_base import GoogleAIBase
 from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -84,6 +85,7 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
         return GoogleAITextPromptExecutionSettings
 
     @override
+    @trace_text_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
     async def _send_text_request(
         self,
         prompt: str,

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
@@ -15,7 +15,6 @@ from semantic_kernel.connectors.ai.google.google_ai.google_ai_prompt_execution_s
 )
 from semantic_kernel.connectors.ai.google.google_ai.services.google_ai_base import GoogleAIBase
 from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -77,21 +76,23 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
             service_settings=google_ai_settings,
         )
 
-    # region Non-streaming
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_text_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
-    async def get_text_contents(
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return GoogleAITextPromptExecutionSettings
+
+    @override
+    async def _send_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
     ) -> list[TextContent]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+        if not isinstance(settings, GoogleAITextPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, GoogleAITextPromptExecutionSettings)  # nosec
 
-        return await self._send_request(prompt, settings)
-
-    async def _send_request(self, prompt: str, settings: GoogleAITextPromptExecutionSettings) -> list[TextContent]:
-        """Send a text generation request to the Google AI service."""
         genai.configure(api_key=self.service_settings.api_key.get_secret_value())
         model = GenerativeModel(
             self.service_settings.gemini_model_id,
@@ -103,6 +104,32 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
         )
 
         return [self._create_text_content(response, candidate) for candidate in response.candidates]
+
+    @override
+    async def _send_streaming_text_request(
+        self,
+        prompt: str,
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list[StreamingTextContent], Any]:
+        if not isinstance(settings, GoogleAITextPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, GoogleAITextPromptExecutionSettings)  # nosec
+
+        genai.configure(api_key=self.service_settings.api_key.get_secret_value())
+        model = GenerativeModel(
+            self.service_settings.gemini_model_id,
+        )
+
+        response: AsyncGenerateContentResponse = await model.generate_content_async(
+            contents=prompt,
+            generation_config=GenerationConfig(**settings.prepare_settings_dict()),
+            stream=True,
+        )
+
+        async for chunk in response:
+            yield [self._create_streaming_text_content(chunk, candidate) for candidate in chunk.candidates]
+
+    # endregion
 
     def _create_text_content(self, response: AsyncGenerateContentResponse, candidate: Candidate) -> TextContent:
         """Create a text content object.
@@ -123,41 +150,6 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
             inner_content=response,
             metadata=response_metadata,
         )
-
-    # endregion
-
-    # region Streaming
-    @override
-    async def get_streaming_text_contents(
-        self,
-        prompt: str,
-        settings: "PromptExecutionSettings",
-    ) -> AsyncGenerator[list["StreamingTextContent"], Any]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
-        assert isinstance(settings, GoogleAITextPromptExecutionSettings)  # nosec
-
-        async_generator = self._send_streaming_request(prompt, settings)
-
-        async for text_contents in async_generator:
-            yield text_contents
-
-    async def _send_streaming_request(
-        self, prompt: str, settings: GoogleAITextPromptExecutionSettings
-    ) -> AsyncGenerator[list[StreamingTextContent], Any]:
-        """Send a text generation request to the Google AI service."""
-        genai.configure(api_key=self.service_settings.api_key.get_secret_value())
-        model = GenerativeModel(
-            self.service_settings.gemini_model_id,
-        )
-
-        response: AsyncGenerateContentResponse = await model.generate_content_async(
-            contents=prompt,
-            generation_config=GenerationConfig(**settings.prepare_settings_dict()),
-            stream=True,
-        )
-
-        async for chunk in response:
-            yield [self._create_streaming_text_content(chunk, candidate) for candidate in chunk.candidates]
 
     def _create_streaming_text_content(
         self, chunk: GenerateContentResponse, candidate: Candidate
@@ -181,8 +173,6 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
             inner_content=chunk,
             metadata=response_metadata,
         )
-
-    # endregion
 
     def _get_metadata_from_response(
         self,
@@ -216,10 +206,3 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
             "safety_ratings": candidate.safety_ratings,
             "token_count": candidate.token_count,
         }
-
-    @override
-    def get_prompt_execution_settings_class(
-        self,
-    ) -> type["PromptExecutionSettings"]:
-        """Get the request settings class."""
-        return GoogleAITextPromptExecutionSettings

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/google_ai_text_completion.py
@@ -86,7 +86,7 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
 
     @override
     @trace_text_completion(GoogleAIBase.MODEL_PROVIDER_NAME)
-    async def _send_text_request(
+    async def _inner_get_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -108,7 +108,7 @@ class GoogleAITextCompletion(GoogleAIBase, TextCompletionClientBase):
         return [self._create_text_content(response, candidate) for candidate in response.candidates]
 
     @override
-    async def _send_streaming_text_request(
+    async def _inner_get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/google/google_ai/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/google/google_ai/services/utils.py
@@ -16,6 +16,7 @@ from semantic_kernel.connectors.ai.google.shared_utils import (
     format_function_result_content_name_to_gemini_function_name,
     format_kernel_function_fully_qualified_name_to_gemini_function_name,
 )
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
@@ -149,10 +150,12 @@ def kernel_function_metadata_to_google_ai_function_call_format(metadata: KernelF
 
 def update_settings_from_function_choice_configuration(
     function_choice_configuration: FunctionCallChoiceConfiguration,
-    settings: GoogleAIChatPromptExecutionSettings,
+    settings: PromptExecutionSettings,
     type: FunctionChoiceType,
 ) -> None:
     """Update the settings from a FunctionChoiceConfiguration."""
+    assert isinstance(settings, GoogleAIChatPromptExecutionSettings)  # nosec
+
     if function_choice_configuration.available_functions:
         settings.tool_config = {
             "function_calling_config": {

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/utils.py
@@ -18,6 +18,7 @@ from semantic_kernel.connectors.ai.google.shared_utils import (
 from semantic_kernel.connectors.ai.google.vertex_ai.vertex_ai_prompt_execution_settings import (
     VertexAIChatPromptExecutionSettings,
 )
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
@@ -151,10 +152,12 @@ def kernel_function_metadata_to_vertex_ai_function_call_format(metadata: KernelF
 
 def update_settings_from_function_choice_configuration(
     function_choice_configuration: FunctionCallChoiceConfiguration,
-    settings: VertexAIChatPromptExecutionSettings,
+    settings: PromptExecutionSettings,
     type: FunctionChoiceType,
 ) -> None:
     """Update the settings from a FunctionChoiceConfiguration."""
+    assert isinstance(settings, VertexAIChatPromptExecutionSettings)  # nosec
+
     if function_choice_configuration.available_functions:
         settings.tool_config = ToolConfig(
             function_calling_config=ToolConfig.FunctionCallingConfig(

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -108,7 +108,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(VertexAIBase.MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -133,7 +133,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -177,9 +177,9 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
     @override
     def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
         if hasattr(settings, "tool_config"):
-            delattr(settings, "tool_config")
+            settings.tool_config = None
         if hasattr(settings, "tools"):
-            delattr(settings, "tools")
+            settings.tools = None
 
     @override
     def _prepare_chat_history_for_request(

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -9,6 +9,7 @@ from google.cloud.aiplatform_v1beta1.types.content import Content
 from pydantic import ValidationError
 from vertexai.generative_models import Candidate, GenerationResponse, GenerativeModel
 
+from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
 from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
 from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceType
 from semantic_kernel.connectors.ai.google.shared_utils import (
@@ -41,13 +42,12 @@ from semantic_kernel.exceptions.service_exceptions import (
     ServiceInitializationError,
     ServiceInvalidExecutionSettingsError,
 )
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
 else:
     from typing_extensions import override  # pragma: no cover
-
-from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
 
 
 class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
@@ -107,6 +107,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         return VertexAIChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(VertexAIBase.MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -1,21 +1,19 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import sys
-from collections.abc import AsyncGenerator, AsyncIterable
-from functools import reduce
-from typing import Any
+from collections.abc import AsyncGenerator, AsyncIterable, Callable
+from typing import Any, ClassVar
 
 import vertexai
 from google.cloud.aiplatform_v1beta1.types.content import Content
 from pydantic import ValidationError
 from vertexai.generative_models import Candidate, GenerationResponse, GenerativeModel
 
-from semantic_kernel.connectors.ai.function_calling_utils import merge_function_results
+from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceType
 from semantic_kernel.connectors.ai.google.shared_utils import (
-    configure_function_choice_behavior,
     filter_system_message,
     format_gemini_function_name_to_kernel_function_fully_qualified_name,
-    invoke_function_calls,
 )
 from semantic_kernel.connectors.ai.google.vertex_ai.services.utils import (
     finish_reason_from_vertex_ai_to_semantic_kernel,
@@ -43,9 +41,6 @@ from semantic_kernel.exceptions.service_exceptions import (
     ServiceInitializationError,
     ServiceInvalidExecutionSettingsError,
 )
-from semantic_kernel.functions.kernel_arguments import KernelArguments
-from semantic_kernel.kernel import Kernel
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -57,6 +52,8 @@ from semantic_kernel.connectors.ai.chat_completion_client_base import ChatComple
 
 class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
     """Google Vertex AI Chat Completion Service."""
+
+    SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -102,59 +99,23 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
             service_settings=vertex_ai_settings,
         )
 
-    # region Non-streaming
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_chat_completion(VertexAIBase.MODEL_PROVIDER_NAME)
-    async def get_chat_message_contents(
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return VertexAIChatPromptExecutionSettings
+
+    @override
+    async def _send_chat_request(
         self,
-        chat_history: ChatHistory,
+        chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> list[ChatMessageContent]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+    ) -> list["ChatMessageContent"]:
+        if not isinstance(settings, VertexAIChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, VertexAIChatPromptExecutionSettings)  # nosec
 
-        kernel = kwargs.get("kernel")
-        if settings.function_choice_behavior is not None and (not kernel or not isinstance(kernel, Kernel)):
-            raise ServiceInvalidExecutionSettingsError("Kernel is required for auto invoking functions.")
-
-        if kernel and settings.function_choice_behavior:
-            configure_function_choice_behavior(settings, kernel, update_settings_from_function_choice_configuration)
-
-        if (
-            settings.function_choice_behavior is None
-            or not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            return await self._send_chat_request(chat_history, settings)
-
-        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            completions = await self._send_chat_request(chat_history, settings)
-            function_calls = [item for item in completions[0].items if isinstance(item, FunctionCallContent)]
-            if (fc_count := len(function_calls)) == 0:
-                return completions
-
-            chat_history.add_message(message=completions[0])
-
-            results = await invoke_function_calls(
-                function_calls=function_calls,
-                chat_history=chat_history,
-                kernel=kernel,  # type: ignore
-                arguments=kwargs.get("arguments", None),
-                function_call_count=fc_count,
-                request_index=request_index,
-                function_behavior=settings.function_choice_behavior,
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                return merge_function_results(chat_history.messages[-len(results) :])
-        else:
-            # do a final call without auto function calling
-            return await self._send_chat_request(chat_history, settings)
-
-    async def _send_chat_request(
-        self, chat_history: ChatHistory, settings: VertexAIChatPromptExecutionSettings
-    ) -> list[ChatMessageContent]:
-        """Send a chat request to the Vertex AI service."""
         vertexai.init(project=self.service_settings.project_id, location=self.service_settings.region)
         model = GenerativeModel(
             self.service_settings.gemini_model_id,
@@ -169,6 +130,60 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         )
 
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]
+
+    @override
+    async def _send_streaming_chat_request(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
+        if not isinstance(settings, VertexAIChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, VertexAIChatPromptExecutionSettings)  # nosec
+
+        vertexai.init(project=self.service_settings.project_id, location=self.service_settings.region)
+        model = GenerativeModel(
+            self.service_settings.gemini_model_id,
+            system_instruction=filter_system_message(chat_history),
+        )
+
+        response: AsyncIterable[GenerationResponse] = await model.generate_content_async(
+            contents=self._prepare_chat_history_for_request(chat_history),
+            generation_config=settings.prepare_settings_dict(),
+            tools=settings.tools,
+            tool_config=settings.tool_config,
+            stream=True,
+        )
+
+        async for chunk in response:
+            yield [self._create_streaming_chat_message_content(chunk, candidate) for candidate in chunk.candidates]
+
+    @override
+    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if not isinstance(settings, VertexAIChatPromptExecutionSettings):
+            raise ServiceInvalidExecutionSettingsError("The settings must be an VertexAIChatPromptExecutionSettings.")
+        if settings.candidate_count is not None and settings.candidate_count > 1:
+            raise ServiceInvalidExecutionSettingsError(
+                "Auto-invocation of tool calls may only be used with a "
+                "VertexAIChatPromptExecutionSettings.candidate_count of 1."
+            )
+
+    @override
+    def _update_function_choice_settings_callback(
+        self,
+    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
+        return update_settings_from_function_choice_configuration
+
+    @override
+    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if hasattr(settings, "tool_config"):
+            delattr(settings, "tool_config")
+        if hasattr(settings, "tools"):
+            delattr(settings, "tools")
+
+    # endregion
+
+    # region Non-streaming
 
     def _create_chat_message_content(self, response: GenerationResponse, candidate: Candidate) -> ChatMessageContent:
         """Create a chat message content object.
@@ -213,109 +228,6 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
     # endregion
 
     # region Streaming
-    @override
-    async def get_streaming_chat_message_contents(
-        self,
-        chat_history: ChatHistory,
-        settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
-        assert isinstance(settings, VertexAIChatPromptExecutionSettings)  # nosec
-
-        kernel = kwargs.get("kernel")
-        if settings.function_choice_behavior is not None and (not kernel or not isinstance(kernel, Kernel)):
-            raise ServiceInvalidExecutionSettingsError("Kernel is required for auto invoking functions.")
-
-        if kernel and settings.function_choice_behavior:
-            configure_function_choice_behavior(settings, kernel, update_settings_from_function_choice_configuration)
-
-        if (
-            settings.function_choice_behavior is None
-            or not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            # No auto invoke is required.
-            async_generator = self._send_chat_streaming_request(chat_history, settings)
-        else:
-            # Auto invoke is required.
-            async_generator = self._get_streaming_chat_message_contents_auto_invoke(
-                kernel,  # type: ignore
-                kwargs.get("arguments"),
-                chat_history,
-                settings,
-            )
-
-        async for messages in async_generator:
-            yield messages
-
-    async def _get_streaming_chat_message_contents_auto_invoke(
-        self,
-        kernel: Kernel,
-        arguments: KernelArguments | None,
-        chat_history: ChatHistory,
-        settings: VertexAIChatPromptExecutionSettings,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Get streaming chat message contents from the Google AI service with auto invoking functions."""
-        if not settings.function_choice_behavior:
-            raise ServiceInvalidExecutionSettingsError(
-                "Function choice behavior is required for auto invoking functions."
-            )
-
-        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            all_messages: list[StreamingChatMessageContent] = []
-            function_call_returned = False
-            async for messages in self._send_chat_streaming_request(chat_history, settings):
-                for message in messages:
-                    if message:
-                        all_messages.append(message)
-                        if any(isinstance(item, FunctionCallContent) for item in message.items):
-                            function_call_returned = True
-                yield messages
-
-            if not function_call_returned:
-                # Response doesn't contain any function calls. No need to proceed to the next request.
-                return
-
-            full_completion: StreamingChatMessageContent = reduce(lambda x, y: x + y, all_messages)
-            function_calls = [item for item in full_completion.items if isinstance(item, FunctionCallContent)]
-            chat_history.add_message(message=full_completion)
-
-            results = await invoke_function_calls(
-                function_calls=function_calls,
-                chat_history=chat_history,
-                kernel=kernel,
-                arguments=arguments,
-                function_call_count=len(function_calls),
-                request_index=request_index,
-                function_behavior=settings.function_choice_behavior,
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                yield merge_function_results(chat_history.messages[-len(results) :])  # type: ignore
-                break
-
-    async def _send_chat_streaming_request(
-        self,
-        chat_history: ChatHistory,
-        settings: VertexAIChatPromptExecutionSettings,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Send a streaming chat request to the Vertex AI service."""
-        vertexai.init(project=self.service_settings.project_id, location=self.service_settings.region)
-        model = GenerativeModel(
-            self.service_settings.gemini_model_id,
-            system_instruction=filter_system_message(chat_history),
-        )
-
-        response: AsyncIterable[GenerationResponse] = await model.generate_content_async(
-            contents=self._prepare_chat_history_for_request(chat_history),
-            generation_config=settings.prepare_settings_dict(),
-            tools=settings.tools,
-            tool_config=settings.tool_config,
-            stream=True,
-        )
-
-        async for chunk in response:
-            yield [self._create_streaming_chat_message_content(chunk, candidate) for candidate in chunk.candidates]
 
     def _create_streaming_chat_message_content(
         self,
@@ -422,10 +334,3 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
             "finish_reason": candidate.finish_reason,
             "safety_ratings": candidate.safety_ratings,
         }
-
-    @override
-    def get_prompt_execution_settings_class(
-        self,
-    ) -> type["PromptExecutionSettings"]:
-        """Get the request settings class."""
-        return VertexAIChatPromptExecutionSettings

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -181,6 +181,29 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         if hasattr(settings, "tools"):
             delattr(settings, "tools")
 
+    @override
+    def _prepare_chat_history_for_request(
+        self,
+        chat_history: ChatHistory,
+        role_key: str = "role",
+        content_key: str = "content",
+    ) -> list[Content]:
+        chat_request_messages: list[Content] = []
+
+        for message in chat_history.messages:
+            if message.role == AuthorRole.SYSTEM:
+                # Skip system messages since they are not part of the chat request.
+                # System message will be provided as system_instruction in the model.
+                continue
+            if message.role == AuthorRole.USER:
+                chat_request_messages.append(Content(role="user", parts=format_user_message(message)))
+            elif message.role == AuthorRole.ASSISTANT:
+                chat_request_messages.append(Content(role="model", parts=format_assistant_message(message)))
+            elif message.role == AuthorRole.TOOL:
+                chat_request_messages.append(Content(role="function", parts=format_tool_message(message)))
+
+        return chat_request_messages
+
     # endregion
 
     # region Non-streaming
@@ -282,29 +305,6 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         )
 
     # endregion
-
-    @override
-    def _prepare_chat_history_for_request(
-        self,
-        chat_history: ChatHistory,
-        role_key: str = "role",
-        content_key: str = "content",
-    ) -> list[Content]:
-        chat_request_messages: list[Content] = []
-
-        for message in chat_history.messages:
-            if message.role == AuthorRole.SYSTEM:
-                # Skip system messages since they are not part of the chat request.
-                # System message will be provided as system_instruction in the model.
-                continue
-            if message.role == AuthorRole.USER:
-                chat_request_messages.append(Content(role="user", parts=format_user_message(message)))
-            elif message.role == AuthorRole.ASSISTANT:
-                chat_request_messages.append(Content(role="model", parts=format_assistant_message(message)))
-            elif message.role == AuthorRole.TOOL:
-                chat_request_messages.append(Content(role="function", parts=format_tool_message(message)))
-
-        return chat_request_messages
 
     def _get_metadata_from_response(self, response: GenerationResponse) -> dict[str, Any]:
         """Get metadata from the response.

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_chat_completion.py
@@ -108,7 +108,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(VertexAIBase.MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -133,7 +133,7 @@ class VertexAIChatCompletion(VertexAIBase, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, candidate) for candidate in response.candidates]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_text_completion.py
@@ -19,6 +19,7 @@ from semantic_kernel.connectors.ai.text_completion_client_base import TextComple
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -80,6 +81,7 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
         return VertexAITextPromptExecutionSettings
 
     @override
+    @trace_text_completion(VertexAIBase.MODEL_PROVIDER_NAME)
     async def _send_text_request(
         self,
         prompt: str,

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_text_completion.py
@@ -19,7 +19,6 @@ from semantic_kernel.connectors.ai.text_completion_client_base import TextComple
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -73,21 +72,23 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
             service_settings=vertex_ai_settings,
         )
 
-    # region Non-streaming
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_text_completion(VertexAIBase.MODEL_PROVIDER_NAME)
-    async def get_text_contents(
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return VertexAITextPromptExecutionSettings
+
+    @override
+    async def _send_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
     ) -> list[TextContent]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+        if not isinstance(settings, VertexAITextPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, VertexAITextPromptExecutionSettings)  # nosec
 
-        return await self._send_request(prompt, settings)
-
-    async def _send_request(self, prompt: str, settings: VertexAITextPromptExecutionSettings) -> list[TextContent]:
-        """Send a text generation request to the Vertex AI service."""
         vertexai.init(project=self.service_settings.project_id, location=self.service_settings.region)
         model = GenerativeModel(self.service_settings.gemini_model_id)
 
@@ -97,6 +98,30 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
         )
 
         return [self._create_text_content(response, candidate) for candidate in response.candidates]
+
+    @override
+    async def _send_streaming_text_request(
+        self,
+        prompt: str,
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list[StreamingTextContent], Any]:
+        if not isinstance(settings, VertexAITextPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, VertexAITextPromptExecutionSettings)  # nosec
+
+        vertexai.init(project=self.service_settings.project_id, location=self.service_settings.region)
+        model = GenerativeModel(self.service_settings.gemini_model_id)
+
+        response: AsyncIterable[GenerationResponse] = await model.generate_content_async(
+            contents=prompt,
+            generation_config=settings.prepare_settings_dict(),
+            stream=True,
+        )
+
+        async for chunk in response:
+            yield [self._create_streaming_text_content(chunk, candidate) for candidate in chunk.candidates]
+
+    # endregion
 
     def _create_text_content(self, response: GenerationResponse, candidate: Candidate) -> TextContent:
         """Create a text content object.
@@ -118,39 +143,6 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
             metadata=response_metadata,
         )
 
-    # endregion
-
-    # region Streaming
-    @override
-    async def get_streaming_text_contents(
-        self,
-        prompt: str,
-        settings: "PromptExecutionSettings",
-    ) -> AsyncGenerator[list["StreamingTextContent"], Any]:
-        settings = self.get_prompt_execution_settings_from_settings(settings)
-        assert isinstance(settings, VertexAITextPromptExecutionSettings)  # nosec
-
-        async_generator = self._send_streaming_request(prompt, settings)
-
-        async for text_contents in async_generator:
-            yield text_contents
-
-    async def _send_streaming_request(
-        self, prompt: str, settings: VertexAITextPromptExecutionSettings
-    ) -> AsyncGenerator[list[StreamingTextContent], Any]:
-        """Send a text generation request to the Vertex AI service."""
-        vertexai.init(project=self.service_settings.project_id, location=self.service_settings.region)
-        model = GenerativeModel(self.service_settings.gemini_model_id)
-
-        response: AsyncIterable[GenerationResponse] = await model.generate_content_async(
-            contents=prompt,
-            generation_config=settings.prepare_settings_dict(),
-            stream=True,
-        )
-
-        async for chunk in response:
-            yield [self._create_streaming_text_content(chunk, candidate) for candidate in chunk.candidates]
-
     def _create_streaming_text_content(self, chunk: GenerationResponse, candidate: Candidate) -> StreamingTextContent:
         """Create a streaming text content object.
 
@@ -171,8 +163,6 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
             inner_content=chunk,
             metadata=response_metadata,
         )
-
-    # endregion
 
     def _get_metadata_from_response(self, response: GenerationResponse) -> dict[str, Any]:
         """Get metadata from the response.
@@ -202,10 +192,3 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
             "finish_reason": candidate.finish_reason,
             "safety_ratings": candidate.safety_ratings,
         }
-
-    @override
-    def get_prompt_execution_settings_class(
-        self,
-    ) -> type["PromptExecutionSettings"]:
-        """Get the request settings class."""
-        return VertexAITextPromptExecutionSettings

--- a/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/google/vertex_ai/services/vertex_ai_text_completion.py
@@ -82,7 +82,7 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
 
     @override
     @trace_text_completion(VertexAIBase.MODEL_PROVIDER_NAME)
-    async def _send_text_request(
+    async def _inner_get_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -102,7 +102,7 @@ class VertexAITextCompletion(VertexAIBase, TextCompletionClientBase):
         return [self._create_text_content(response, candidate) for candidate in response.candidates]
 
     @override
-    async def _send_streaming_text_request(
+    async def _inner_get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
@@ -79,20 +79,19 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
             generator=generator,
         )
 
-    async def get_text_contents(
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
+    @override
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return HuggingFacePromptExecutionSettings
+
+    @override
+    async def _send_text_request(
         self,
         prompt: str,
-        settings: PromptExecutionSettings,
+        settings: "PromptExecutionSettings",
     ) -> list[TextContent]:
-        """This is the method that is called from the kernel to get a response from a text-optimized LLM.
-
-        Args:
-            prompt (str): The prompt to send to the LLM.
-            settings (HuggingFacePromptExecutionSettings): Settings for the request.
-
-        Returns:
-            List[TextContent]: A list of TextContent objects representing the response(s) from the LLM.
-        """
         if not isinstance(settings, HuggingFacePromptExecutionSettings):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, HuggingFacePromptExecutionSettings)  # nosec
@@ -101,41 +100,25 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
             results = self.generator(prompt, **settings.prepare_settings_dict())
         except Exception as e:
             raise ServiceResponseException("Hugging Face completion failed") from e
+
         if isinstance(results, list):
             return [self._create_text_content(results, result) for result in results]
         return [self._create_text_content(results, results)]
 
-    def _create_text_content(self, response: Any, candidate: dict[str, str]) -> TextContent:
-        return TextContent(
-            inner_content=response,
-            ai_model_id=self.ai_model_id,
-            text=candidate["summary_text" if self.task == "summarization" else "generated_text"],
-        )
-
-    async def get_streaming_text_contents(
+    @override
+    async def _send_streaming_text_request(
         self,
         prompt: str,
-        settings: PromptExecutionSettings,
+        settings: "PromptExecutionSettings",
     ) -> AsyncGenerator[list[StreamingTextContent], Any]:
-        """Streams a text completion using a Hugging Face model.
-
-        Note that this method does not support multiple responses.
-
-        Args:
-            prompt (str): Prompt to complete.
-            settings (HuggingFacePromptExecutionSettings): Request settings.
-
-        Yields:
-            List[StreamingTextContent]: List of StreamingTextContent objects.
-        """
         if not isinstance(settings, HuggingFacePromptExecutionSettings):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, HuggingFacePromptExecutionSettings)  # nosec
 
         if settings.num_return_sequences > 1:
             raise ServiceInvalidExecutionSettingsError(
-                "HuggingFace TextIteratorStreamer does not stream multiple responses in a parseable format. \
-                    If you need multiple responses, please use the complete method.",
+                "HuggingFace TextIteratorStreamer does not stream multiple responses in a parsable format."
+                " If you need multiple responses, please use the complete method.",
             )
         try:
             streamer = TextIteratorStreamer(AutoTokenizer.from_pretrained(self.ai_model_id))
@@ -156,7 +139,11 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
         except Exception as e:
             raise ServiceResponseException("Hugging Face completion failed") from e
 
-    @override
-    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
-        """Create a request settings object."""
-        return HuggingFacePromptExecutionSettings
+    # endregion
+
+    def _create_text_content(self, response: Any, candidate: dict[str, str]) -> TextContent:
+        return TextContent(
+            inner_content=response,
+            ai_model_id=self.ai_model_id,
+            text=candidate["summary_text" if self.task == "summarization" else "generated_text"],
+        )

--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
@@ -91,7 +91,7 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
 
     @override
     @trace_text_completion(MODEL_PROVIDER_NAME)
-    async def _send_text_request(
+    async def _inner_get_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -110,7 +110,7 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
         return [self._create_text_content(results, results)]
 
     @override
-    async def _send_streaming_text_request(
+    async def _inner_get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/hugging_face/services/hf_text_completion.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from collections.abc import AsyncGenerator
 from threading import Thread
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -20,12 +20,15 @@ from semantic_kernel.connectors.ai.text_completion_client_base import TextComple
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.exceptions import ServiceInvalidExecutionSettingsError, ServiceResponseException
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
 class HuggingFaceTextCompletion(TextCompletionClientBase):
     """Hugging Face text completion service."""
+
+    MODEL_PROVIDER_NAME: ClassVar[str] = "huggingface"
 
     task: Literal["summarization", "text-generation", "text2text-generation"]
     device: str
@@ -87,6 +90,7 @@ class HuggingFaceTextCompletion(TextCompletionClientBase):
         return HuggingFacePromptExecutionSettings
 
     @override
+    @trace_text_completion(MODEL_PROVIDER_NAME)
     async def _send_text_request(
         self,
         prompt: str,

--- a/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
@@ -105,7 +105,7 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(MistralAIBase.MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -129,7 +129,7 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
@@ -38,6 +38,7 @@ from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.contents.utils.finish_reason import FinishReason
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceResponseException
 from semantic_kernel.utils.experimental_decorator import experimental_class
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
         return MistralAIChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(MistralAIBase.MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, ClassVar
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -38,7 +38,6 @@ from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.contents.utils.finish_reason import FinishReason
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceResponseException
 from semantic_kernel.utils.experimental_decorator import experimental_class
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -47,9 +46,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
     """Mistral Chat completion class."""
 
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
-    total_tokens: int = 0
+    SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -97,33 +94,27 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
             ai_model_id=ai_model_id or mistralai_settings.chat_model_id,
         )
 
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_chat_completion(MistralAIBase.MODEL_PROVIDER_NAME)
-    async def get_chat_message_contents(
+    def get_prompt_execution_settings_class(self) -> "type[MistralAIChatPromptExecutionSettings]":
+        """Create a request settings object."""
+        return MistralAIChatPromptExecutionSettings
+
+    @override
+    async def _send_chat_request(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
     ) -> list["ChatMessageContent"]:
-        """Executes a chat completion request and returns the result.
-
-        Args:
-            chat_history (ChatHistory): The chat history to use for the chat completion.
-            settings (PromptExecutionSettings): The settings to use
-                for the chat completion request.
-            kwargs (Dict[str, Any]): The optional arguments.
-
-        Returns:
-            List[ChatMessageContent]: The completion result(s).
-        """
         if not isinstance(settings, MistralAIChatPromptExecutionSettings):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, MistralAIChatPromptExecutionSettings)  # nosec
 
-        if not settings.ai_model_id:
-            settings.ai_model_id = self.ai_model_id
-
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
         settings.messages = self._prepare_chat_history_for_request(chat_history)
+
         try:
             response = await self.async_client.chat(**settings.prepare_settings_dict())
         except Exception as ex:
@@ -132,36 +123,22 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
                 ex,
             ) from ex
 
-        self.store_usage(response)
         response_metadata = self._get_metadata_from_response(response)
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
-    async def get_streaming_chat_message_contents(
+    @override
+    async def _send_streaming_chat_request(
         self,
-        chat_history: ChatHistory,
-        settings: PromptExecutionSettings,
-        **kwargs: Any,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        """Executes a streaming chat completion request and returns the result.
-
-        Args:
-            chat_history (ChatHistory): The chat history to use for the chat completion.
-            settings (PromptExecutionSettings): The settings to use
-                for the chat completion request.
-            kwargs (Dict[str, Any]): The optional arguments.
-
-        Yields:
-            List[StreamingChatMessageContent]: A stream of
-                StreamingChatMessageContent when using Azure.
-        """
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
         if not isinstance(settings, MistralAIChatPromptExecutionSettings):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, MistralAIChatPromptExecutionSettings)  # nosec
 
-        if not settings.ai_model_id:
-            settings.ai_model_id = self.ai_model_id
-
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
         settings.messages = self._prepare_chat_history_for_request(chat_history)
+
         try:
             response = self.async_client.chat_stream(**settings.prepare_settings_dict())
         except Exception as ex:
@@ -176,6 +153,8 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
             yield [
                 self._create_streaming_chat_message_content(chunk, choice, chunk_metadata) for choice in chunk.choices
             ]
+
+    # endregion
 
     # region content conversion to SK
 
@@ -267,16 +246,3 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
         ]
 
     # endregion
-
-    def get_prompt_execution_settings_class(self) -> "type[MistralAIChatPromptExecutionSettings]":
-        """Create a request settings object."""
-        return MistralAIChatPromptExecutionSettings
-
-    def store_usage(self, response):
-        """Store the usage information from the response."""
-        if not isinstance(response, AsyncGenerator):
-            logger.info(f"MistralAI usage: {response.usage}")
-            self.prompt_tokens += response.usage.prompt_tokens
-            self.total_tokens += response.usage.total_tokens
-            if hasattr(response.usage, "completion_tokens"):
-                self.completion_tokens += response.usage.completion_tokens

--- a/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/mistral_ai/services/mistral_ai_chat_completion.py
@@ -105,7 +105,7 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(MistralAIBase.MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -129,7 +129,7 @@ class MistralAIChatCompletion(MistralAIBase, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -84,7 +84,7 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(OllamaBase.MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -118,7 +118,7 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
         ]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -22,6 +22,7 @@ from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceInvalidResponseError
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
@@ -82,6 +83,7 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
         return OllamaChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(OllamaBase.MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -84,7 +84,7 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(OllamaBase.MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -118,7 +118,7 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
         ]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -20,6 +20,7 @@ from semantic_kernel.connectors.ai.text_completion_client_base import TextComple
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceInvalidResponseError
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
@@ -77,6 +78,7 @@ class OllamaTextCompletion(OllamaBase, TextCompletionClientBase):
         return OllamaTextPromptExecutionSettings
 
     @override
+    @trace_text_completion(OllamaBase.MODEL_PROVIDER_NAME)
     async def _send_text_request(
         self,
         prompt: str,

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -20,7 +20,6 @@ from semantic_kernel.connectors.ai.text_completion_client_base import TextComple
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceInvalidResponseError
-from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
@@ -70,23 +69,22 @@ class OllamaTextCompletion(OllamaBase, TextCompletionClientBase):
             client=client or AsyncClient(host=ollama_settings.host),
         )
 
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
-    @trace_text_completion(OllamaBase.MODEL_PROVIDER_NAME)
-    async def get_text_contents(
+    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
+        return OllamaTextPromptExecutionSettings
+
+    @override
+    async def _send_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
     ) -> list[TextContent]:
-        """This is the method that is called from the kernel to get a response from a text-optimized LLM.
-
-        Args:
-            prompt (str): The prompt to send to the LLM.
-            settings (OllamaTextPromptExecutionSettings): Settings for the request.
-
-        Returns:
-            List[TextContent]: A list of TextContent objects representing the response(s) from the LLM.
-        """
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+        if not isinstance(settings, OllamaTextPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, OllamaTextPromptExecutionSettings)  # nosec
 
         response_object = await self.client.generate(
             model=self.ai_model_id,
@@ -105,24 +103,15 @@ class OllamaTextCompletion(OllamaBase, TextCompletionClientBase):
         text = inner_content["response"]
         return [TextContent(inner_content=inner_content, ai_model_id=self.ai_model_id, text=text)]
 
-    async def get_streaming_text_contents(
+    @override
+    async def _send_streaming_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
     ) -> AsyncGenerator[list[StreamingTextContent], Any]:
-        """Streams a text completion using an Ollama model.
-
-        Note that this method does not support multiple responses,
-        but the result will be a list anyway.
-
-        Args:
-            prompt (str): Prompt to complete.
-            settings (OllamaTextPromptExecutionSettings): Request settings.
-
-        Yields:
-            List[StreamingTextContent]: Completion result.
-        """
-        settings = self.get_prompt_execution_settings_from_settings(settings)
+        if not isinstance(settings, OllamaTextPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, OllamaTextPromptExecutionSettings)  # nosec
 
         response_object = await self.client.generate(
             model=self.ai_model_id,
@@ -144,7 +133,4 @@ class OllamaTextCompletion(OllamaBase, TextCompletionClientBase):
                 )
             ]
 
-    @override
-    def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
-        """Get the request settings class."""
-        return OllamaTextPromptExecutionSettings
+    # endregion

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_text_completion.py
@@ -79,7 +79,7 @@ class OllamaTextCompletion(OllamaBase, TextCompletionClientBase):
 
     @override
     @trace_text_completion(OllamaBase.MODEL_PROVIDER_NAME)
-    async def _send_text_request(
+    async def _inner_get_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -106,7 +106,7 @@ class OllamaTextCompletion(OllamaBase, TextCompletionClientBase):
         return [TextContent(inner_content=inner_content, ai_model_id=self.ai_model_id, text=text)]
 
     @override
-    async def _send_streaming_text_request(
+    async def _inner_get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_chat_completion
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -62,6 +63,7 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
         return OpenAIChatPromptExecutionSettings
 
     @override
+    @trace_chat_completion(MODEL_PROVIDER_NAME)
     async def _send_chat_request(
         self,
         chat_history: "ChatHistory",

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import asyncio
-import logging
 import sys
-from collections.abc import AsyncGenerator
-from functools import reduce
+from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from semantic_kernel.connectors.ai.function_call_choice_configuration import FunctionCallChoiceConfiguration
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -22,11 +22,8 @@ from typing_extensions import deprecated
 
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
 from semantic_kernel.connectors.ai.function_call_behavior import FunctionCallBehavior
-from semantic_kernel.connectors.ai.function_calling_utils import (
-    merge_function_results,
-    update_settings_from_function_call_configuration,
-)
-from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+from semantic_kernel.connectors.ai.function_calling_utils import update_settings_from_function_call_configuration
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior, FunctionChoiceType
 from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_prompt_execution_settings import (
     OpenAIChatPromptExecutionSettings,
 )
@@ -43,224 +40,60 @@ from semantic_kernel.exceptions import ServiceInvalidExecutionSettingsError, Ser
 from semantic_kernel.filters.auto_function_invocation.auto_function_invocation_context import (
     AutoFunctionInvocationContext,
 )
-from semantic_kernel.utils.telemetry.model_diagnostics import trace_chat_completion
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
     from semantic_kernel.functions.kernel_arguments import KernelArguments
     from semantic_kernel.kernel import Kernel
 
-logger: logging.Logger = logging.getLogger(__name__)
-
-
-class InvokeTermination(Exception):
-    """Exception for termination of function invocation."""
-
-    pass
-
 
 class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
     """OpenAI Chat completion class."""
 
     MODEL_PROVIDER_NAME: ClassVar[str] = "openai"
+    SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = True
 
     # region Overriding base class methods
     # most of the methods are overridden from the ChatCompletionClientBase class, otherwise it is mentioned
 
+    # Override from AIServiceClientBase
     @override
     def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
         return OpenAIChatPromptExecutionSettings
 
     @override
-    @trace_chat_completion(MODEL_PROVIDER_NAME)
-    async def get_chat_message_contents(
+    async def _send_chat_request(
         self,
-        chat_history: ChatHistory,
+        chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
     ) -> list["ChatMessageContent"]:
         if not isinstance(settings, OpenAIChatPromptExecutionSettings):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, OpenAIChatPromptExecutionSettings)  # nosec
 
-        # For backwards compatibility we need to convert the `FunctionCallBehavior` to `FunctionChoiceBehavior`
-        # if this method is called with a `FunctionCallBehavior` object as part of the settings
-        if hasattr(settings, "function_call_behavior") and isinstance(
-            settings.function_call_behavior, FunctionCallBehavior
-        ):
-            settings.function_choice_behavior = FunctionChoiceBehavior.from_function_call_behavior(
-                settings.function_call_behavior
-            )
+        settings.stream = False
+        settings.messages = self._prepare_chat_history_for_request(chat_history)
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
 
-        kernel = kwargs.get("kernel", None)
-        if settings.function_choice_behavior is not None:
-            if kernel is None:
-                raise ServiceInvalidExecutionSettingsError("The kernel is required for OpenAI tool calls.")
-            if settings.number_of_responses is not None and settings.number_of_responses > 1:
-                raise ServiceInvalidExecutionSettingsError(
-                    "Auto-invocation of tool calls may only be used with a "
-                    "OpenAIChatPromptExecutions.number_of_responses of 1."
-                )
-
-        # behavior for non-function calling or for enable, but not auto-invoke.
-        self._prepare_settings(settings, chat_history, stream_request=False, kernel=kernel)
-        if settings.function_choice_behavior is None or (
-            settings.function_choice_behavior and not settings.function_choice_behavior.auto_invoke_kernel_functions
-        ):
-            return await self._send_chat_request(settings)
-
-        # loop for auto-invoke function calls
-        for request_index in range(settings.function_choice_behavior.maximum_auto_invoke_attempts):
-            completions = await self._send_chat_request(settings)
-            # get the function call contents from the chat message, there is only one chat message
-            # this was checked earlier
-            function_calls = [item for item in completions[0].items if isinstance(item, FunctionCallContent)]
-            if (fc_count := len(function_calls)) == 0:
-                return completions
-
-            # Since we have a function call, add the assistant's tool call message to the history
-            chat_history.add_message(message=completions[0])
-
-            logger.info(f"processing {fc_count} tool calls in parallel.")
-
-            # this function either updates the chat history with the function call results
-            # or returns the context, with terminate set to True
-            # in which case the loop will break and the function calls are returned.
-            results = await asyncio.gather(
-                *[
-                    self._process_function_call(
-                        function_call=function_call,
-                        chat_history=chat_history,
-                        kernel=kernel,
-                        arguments=kwargs.get("arguments", None),
-                        function_call_count=fc_count,
-                        request_index=request_index,
-                        function_call_behavior=settings.function_choice_behavior,
-                    )
-                    for function_call in function_calls
-                ],
-            )
-
-            if any(result.terminate for result in results if result is not None):
-                return merge_function_results(chat_history.messages[-len(results) :])
-
-            self._update_settings(settings, chat_history, kernel=kernel)
-        else:
-            # do a final call, without function calling when the max has been reached.
-            settings.function_choice_behavior.auto_invoke_kernel_functions = False
-            return await self._send_chat_request(settings)
-
-    @override
-    async def get_streaming_chat_message_contents(
-        self,
-        chat_history: ChatHistory,
-        settings: "PromptExecutionSettings",
-        **kwargs: Any,
-    ) -> AsyncGenerator[list[StreamingChatMessageContent], Any]:
-        if not isinstance(settings, OpenAIChatPromptExecutionSettings):
-            settings = self.get_prompt_execution_settings_from_settings(settings)
-        assert isinstance(settings, OpenAIChatPromptExecutionSettings)  # nosec
-
-        # For backwards compatibility we need to convert the `FunctionCallBehavior` to `FunctionChoiceBehavior`
-        # if this method is called with a `FunctionCallBehavior` object as part of the settings
-        if hasattr(settings, "function_call_behavior") and isinstance(
-            settings.function_call_behavior, FunctionCallBehavior
-        ):
-            settings.function_choice_behavior = FunctionChoiceBehavior.from_function_call_behavior(
-                settings.function_call_behavior
-            )
-
-        kernel = kwargs.get("kernel", None)
-        if settings.function_choice_behavior is not None:
-            if kernel is None:
-                raise ServiceInvalidExecutionSettingsError("The kernel is required for OpenAI tool calls.")
-            if settings.number_of_responses is not None and settings.number_of_responses > 1:
-                raise ServiceInvalidExecutionSettingsError(
-                    "Auto-invocation of tool calls may only be used with a "
-                    "OpenAIChatPromptExecutions.number_of_responses of 1."
-                )
-
-        # Prepare settings for streaming requests
-        self._prepare_settings(settings, chat_history, stream_request=True, kernel=kernel)
-
-        request_attempts = (
-            settings.function_choice_behavior.maximum_auto_invoke_attempts
-            if (settings.function_choice_behavior and settings.function_choice_behavior.auto_invoke_kernel_functions)
-            else 1
-        )
-        # hold the messages, if there are more than one response, it will not be used, so we flatten
-        for request_index in range(request_attempts):
-            all_messages: list[StreamingChatMessageContent] = []
-            function_call_returned = False
-            async for messages in self._send_chat_stream_request(settings):
-                for msg in messages:
-                    if msg is not None:
-                        all_messages.append(msg)
-                        if any(isinstance(item, FunctionCallContent) for item in msg.items):
-                            function_call_returned = True
-                yield messages
-
-            if (
-                settings.function_choice_behavior is None
-                or (
-                    settings.function_choice_behavior
-                    and not settings.function_choice_behavior.auto_invoke_kernel_functions
-                )
-                or not function_call_returned
-            ):
-                # no need to process function calls
-                # note that we don't check the FinishReason and instead check whether there are any tool calls,
-                # as the service may return a FinishReason of "stop" even if there are tool calls to be made,
-                # in particular if a required tool is specified.
-                return
-
-            # there is one response stream in the messages, combining now to create the full completion
-            # depending on the prompt, the message may contain both function call content and others
-            full_completion: StreamingChatMessageContent = reduce(lambda x, y: x + y, all_messages)
-            function_calls = [item for item in full_completion.items if isinstance(item, FunctionCallContent)]
-            chat_history.add_message(message=full_completion)
-
-            fc_count = len(function_calls)
-            logger.info(f"processing {fc_count} tool calls in parallel.")
-
-            # this function either updates the chat history with the function call results
-            # or returns the context, with terminate set to True
-            # in which case the loop will break and the function calls are returned.
-            # Exceptions are not caught, that is up to the developer, can be done with a filter
-            results = await asyncio.gather(
-                *[
-                    self._process_function_call(
-                        function_call=function_call,
-                        chat_history=chat_history,
-                        kernel=kernel,
-                        arguments=kwargs.get("arguments", None),
-                        function_call_count=fc_count,
-                        request_index=request_index,
-                        function_call_behavior=settings.function_choice_behavior,
-                    )
-                    for function_call in function_calls
-                ],
-            )
-            if any(result.terminate for result in results if result is not None):
-                yield merge_function_results(chat_history.messages[-len(results) :])  # type: ignore
-                break
-
-            self._update_settings(settings, chat_history, kernel=kernel)
-
-    # endregion
-    # region internal handlers
-
-    async def _send_chat_request(self, settings: OpenAIChatPromptExecutionSettings) -> list["ChatMessageContent"]:
-        """Send the chat request."""
         response = await self._send_request(request_settings=settings)
         assert isinstance(response, ChatCompletion)  # nosec
         response_metadata = self._get_metadata_from_chat_response(response)
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
-    async def _send_chat_stream_request(
-        self, settings: OpenAIChatPromptExecutionSettings
-    ) -> AsyncGenerator[list["StreamingChatMessageContent"], None]:
-        """Send the chat stream request."""
+    @override
+    async def _send_streaming_chat_request(
+        self,
+        chat_history: "ChatHistory",
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
+        if not isinstance(settings, OpenAIChatPromptExecutionSettings):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
+        assert isinstance(settings, OpenAIChatPromptExecutionSettings)  # nosec
+
+        settings.stream = True
+        settings.messages = self._prepare_chat_history_for_request(chat_history)
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
+
         response = await self._send_request(request_settings=settings)
         if not isinstance(response, AsyncStream):
             raise ServiceInvalidResponseError("Expected an AsyncStream[ChatCompletionChunk] response.")
@@ -273,7 +106,31 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
                 self._create_streaming_chat_message_content(chunk, choice, chunk_metadata) for choice in chunk.choices
             ]
 
+    @override
+    def _verify_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if not isinstance(settings, OpenAIChatPromptExecutionSettings):
+            raise ServiceInvalidExecutionSettingsError("The settings must be an OpenAIChatPromptExecutionSettings.")
+        if settings.number_of_responses is not None and settings.number_of_responses > 1:
+            raise ServiceInvalidExecutionSettingsError(
+                "Auto-invocation of tool calls may only be used with a "
+                "OpenAIChatPromptExecutions.number_of_responses of 1."
+            )
+
+    @override
+    def _update_function_choice_settings_callback(
+        self,
+    ) -> Callable[[FunctionCallChoiceConfiguration, "PromptExecutionSettings", FunctionChoiceType], None]:
+        return update_settings_from_function_call_configuration
+
+    @override
+    def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
+        if hasattr(settings, "tool_choice"):
+            delattr(settings, "tool_choice")
+        if hasattr(settings, "tools"):
+            delattr(settings, "tools")
+
     # endregion
+
     # region content creation
 
     def _create_chat_message_content(
@@ -375,39 +232,8 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
         return []
 
     # endregion
-    # region request preparation
 
-    def _prepare_settings(
-        self,
-        settings: OpenAIChatPromptExecutionSettings,
-        chat_history: ChatHistory,
-        stream_request: bool = False,
-        kernel: "Kernel | None" = None,
-    ) -> None:
-        """Prepare the prompt execution settings for the chat request."""
-        settings.stream = stream_request
-        if not settings.ai_model_id:
-            settings.ai_model_id = self.ai_model_id
-        self._update_settings(settings=settings, chat_history=chat_history, kernel=kernel)
-
-    def _update_settings(
-        self,
-        settings: OpenAIChatPromptExecutionSettings,
-        chat_history: ChatHistory,
-        kernel: "Kernel | None" = None,
-    ) -> None:
-        """Update the settings with the chat history."""
-        settings.messages = self._prepare_chat_history_for_request(chat_history)
-        if settings.function_choice_behavior and kernel:
-            settings.function_choice_behavior.configure(
-                kernel=kernel,
-                update_settings_callback=update_settings_from_function_call_configuration,
-                settings=settings,
-            )
-
-    # endregion
     # region function calling
-
     @deprecated("Use `invoke_function_call` from the kernel instead with `FunctionChoiceBehavior`.")
     async def _process_function_call(
         self,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -64,7 +64,7 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(MODEL_PROVIDER_NAME)
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -83,7 +83,7 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -125,9 +125,9 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
     @override
     def _reset_function_choice_settings(self, settings: "PromptExecutionSettings") -> None:
         if hasattr(settings, "tool_choice"):
-            delattr(settings, "tool_choice")
+            settings.tool_choice = None
         if hasattr(settings, "tools"):
-            delattr(settings, "tools")
+            settings.tools = None
 
     # endregion
 

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_chat_completion_base.py
@@ -64,7 +64,7 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
 
     @override
     @trace_chat_completion(MODEL_PROVIDER_NAME)
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -83,7 +83,7 @@ class OpenAIChatCompletionBase(OpenAIHandler, ChatCompletionClientBase):
         return [self._create_chat_message_content(response, choice, response_metadata) for choice in response.choices]
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
@@ -26,6 +26,7 @@ from semantic_kernel.connectors.ai.open_ai.services.open_ai_handler import OpenA
 from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
+from semantic_kernel.utils.telemetry.model_diagnostics.decorators import trace_text_completion
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
@@ -46,6 +47,7 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
         return OpenAITextPromptExecutionSettings
 
     @override
+    @trace_text_completion(MODEL_PROVIDER_NAME)
     async def _send_text_request(
         self,
         prompt: str,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
@@ -26,7 +26,6 @@ from semantic_kernel.connectors.ai.open_ai.services.open_ai_handler import OpenA
 from semantic_kernel.connectors.ai.text_completion_client_base import TextCompletionClientBase
 from semantic_kernel.contents.streaming_text_content import StreamingTextContent
 from semantic_kernel.contents.text_content import TextContent
-from semantic_kernel.utils.telemetry.model_diagnostics import trace_text_completion
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
@@ -39,13 +38,15 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
 
     MODEL_PROVIDER_NAME: ClassVar[str] = "openai"
 
+    # region Overriding base class methods
+
+    # Override from AIServiceClientBase
     @override
     def get_prompt_execution_settings_class(self) -> type["PromptExecutionSettings"]:
         return OpenAITextPromptExecutionSettings
 
     @override
-    @trace_text_completion(MODEL_PROVIDER_NAME)
-    async def get_text_contents(
+    async def _send_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -53,19 +54,22 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
         if not isinstance(settings, (OpenAITextPromptExecutionSettings, OpenAIChatPromptExecutionSettings)):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, (OpenAITextPromptExecutionSettings, OpenAIChatPromptExecutionSettings))  # nosec
+
         if isinstance(settings, OpenAITextPromptExecutionSettings):
             settings.prompt = prompt
         else:
             settings.messages = [{"role": "user", "content": prompt}]
-        if settings.ai_model_id is None:
-            settings.ai_model_id = self.ai_model_id
+
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
+
         response = await self._send_request(request_settings=settings)
         assert isinstance(response, (TextCompletion, ChatCompletion))  # nosec
+
         metadata = self._get_metadata_from_text_response(response)
         return [self._create_text_content(response, choice, metadata) for choice in response.choices]
 
     @override
-    async def get_streaming_text_contents(
+    async def _send_streaming_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -81,16 +85,21 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
                 settings.messages = [{"role": "user", "content": prompt}]
             else:
                 settings.messages.append({"role": "user", "content": prompt})
-        settings.ai_model_id = self.ai_model_id
+
+        settings.ai_model_id = settings.ai_model_id or self.ai_model_id
         settings.stream = True
+
         response = await self._send_request(request_settings=settings)
         assert isinstance(response, AsyncStream)  # nosec
+
         async for chunk in response:
             if len(chunk.choices) == 0:
                 continue
             assert isinstance(chunk, (TextCompletion, ChatCompletionChunk))  # nosec
             chunk_metadata = self._get_metadata_from_text_response(chunk)
             yield [self._create_streaming_text_content(chunk, choice, chunk_metadata) for choice in chunk.choices]
+
+    # endregion
 
     def _create_text_content(
         self,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_text_completion_base.py
@@ -48,7 +48,7 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
 
     @override
     @trace_text_completion(MODEL_PROVIDER_NAME)
-    async def _send_text_request(
+    async def _inner_get_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -71,7 +71,7 @@ class OpenAITextCompletionBase(OpenAIHandler, TextCompletionClientBase):
         return [self._create_text_content(response, choice, metadata) for choice in response.choices]
 
     @override
-    async def _send_streaming_text_request(
+    async def _inner_get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/semantic_kernel/connectors/ai/text_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/text_completion_client_base.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import copy
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
@@ -14,7 +15,46 @@ if TYPE_CHECKING:
 class TextCompletionClientBase(AIServiceClientBase, ABC):
     """Base class for text completion AI services."""
 
+    # region Abstract methods
+
     @abstractmethod
+    async def _send_text_request(
+        self,
+        prompt: str,
+        settings: "PromptExecutionSettings",
+    ) -> list["TextContent"]:
+        """Send a text completion request to the AI service.
+
+        Args:
+            prompt (str): The prompt to send to the LLM.
+            settings (PromptExecutionSettings): Settings for the request.
+
+        Returns:
+            list[TextContent]: A string or list of strings representing the response(s) from the LLM.
+        """
+        ...
+
+    @abstractmethod
+    async def _send_streaming_text_request(
+        self,
+        prompt: str,
+        settings: "PromptExecutionSettings",
+    ) -> AsyncGenerator[list["StreamingTextContent"], Any]:
+        """Send a streaming text request to the AI service.
+
+        Args:
+            prompt (str): The prompt to send to the LLM.
+            settings (PromptExecutionSettings): Settings for the request.
+
+        Yields:
+            list[StreamingTextContent]: A stream representing the response(s) from the LLM.
+        """
+        # Below is needed for mypy: https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
+        if False:
+            yield
+
+    # endregion
+
     async def get_text_contents(
         self,
         prompt: str,
@@ -29,6 +69,10 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
         Returns:
             list[TextContent]: A string or list of strings representing the response(s) from the LLM.
         """
+        # Create a copy of the settings to avoid modifying the original settings
+        settings = copy.deepcopy(settings)
+
+        return await self._send_text_request(prompt, settings)
 
     async def get_text_content(self, prompt: str, settings: "PromptExecutionSettings") -> "TextContent | None":
         """This is the method that is called from the kernel to get a response from a text-optimized LLM.
@@ -46,8 +90,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
         # this should not happen, should error out before returning an empty list
         return None  # pragma: no cover
 
-    @abstractmethod
-    def get_streaming_text_contents(
+    async def get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -61,7 +104,11 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
         Yields:
             list[StreamingTextContent]: A stream representing the response(s) from the LLM.
         """
-        ...
+        # Create a copy of the settings to avoid modifying the original settings
+        settings = copy.deepcopy(settings)
+
+        async for contents in self._send_streaming_text_request(prompt, settings):
+            yield contents
 
     async def get_streaming_text_content(
         self, prompt: str, settings: "PromptExecutionSettings"

--- a/python/semantic_kernel/connectors/ai/text_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/text_completion_client_base.py
@@ -31,7 +31,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
         Returns:
             list[TextContent]: A string or list of strings representing the response(s) from the LLM.
         """
-        raise NotImplementedError
+        raise NotImplementedError("The _inner_get_text_contents method is not implemented.")
 
     async def _inner_get_streaming_text_contents(
         self,
@@ -48,7 +48,7 @@ class TextCompletionClientBase(AIServiceClientBase, ABC):
             list[StreamingTextContent]: A stream representing the response(s) from the LLM.
         """
         # Below is needed for mypy: https://mypy.readthedocs.io/en/stable/more_types.html#asynchronous-iterators
-        raise NotImplementedError
+        raise NotImplementedError("The _inner_get_streaming_text_contents method is not implemented.")
         if False:
             yield
 

--- a/python/semantic_kernel/utils/telemetry/model_diagnostics/decorators.py
+++ b/python/semantic_kernel/utils/telemetry/model_diagnostics/decorators.py
@@ -75,8 +75,12 @@ def trace_chat_completion(model_provider: str) -> Callable:
                 return await completion_func(*args, **kwargs)
 
             completion_service: ChatCompletionClientBase = args[0]
-            chat_history: ChatHistory = kwargs["chat_history"]
-            settings: PromptExecutionSettings = kwargs["settings"]
+            chat_history: ChatHistory = (
+                kwargs.get("chat_history") if kwargs.get("chat_history") is not None else args[1]
+            )
+            settings: PromptExecutionSettings = (
+                kwargs.get("settings") if kwargs.get("settings") is not None else args[2]
+            )
 
             with use_span(
                 _start_completion_activity(
@@ -113,8 +117,8 @@ def trace_text_completion(model_provider: str) -> Callable:
                 return await completion_func(*args, **kwargs)
 
             completion_service: TextCompletionClientBase = args[0]
-            prompt: str = kwargs["prompt"]
-            settings: PromptExecutionSettings = kwargs["settings"]
+            prompt: str = kwargs.get("prompt") if kwargs.get("prompt") is not None else args[1]
+            settings: PromptExecutionSettings = kwargs["settings"] if kwargs.get("settings") is not None else args[2]
 
             with use_span(
                 _start_completion_activity(

--- a/python/tests/unit/connectors/ollama/services/test_ollama_chat_completion.py
+++ b/python/tests/unit/connectors/ollama/services/test_ollama_chat_completion.py
@@ -4,10 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from semantic_kernel.connectors.ai.ollama.ollama_prompt_execution_settings import (
-    OllamaChatPromptExecutionSettings,
-    OllamaTextPromptExecutionSettings,
-)
+from semantic_kernel.connectors.ai.ollama.ollama_prompt_execution_settings import OllamaChatPromptExecutionSettings
 from semantic_kernel.connectors.ai.ollama.services.ollama_chat_completion import OllamaChatCompletion
 from semantic_kernel.exceptions.service_exceptions import ServiceInitializationError, ServiceInvalidResponseError
 
@@ -61,20 +58,13 @@ async def test_custom_host(
         OllamaChatPromptExecutionSettings(service_id=service_id, options=default_options),
     )
 
-    text_responses = await ollama.get_text_contents(
-        prompt,
-        OllamaTextPromptExecutionSettings(service_id=service_id, options=default_options),
-    )
-
     # Check that the client was initialized once with the correct host
     assert mock_client.call_count == 1
     mock_client.assert_called_with(host=host)
-    # Check that the chat client was called twice and the responses are correct
-    assert mock_chat_client.call_count == 2
+    # Check that the chat client was called once and the responses are correct
+    assert mock_chat_client.call_count == 1
     assert len(chat_responses) == 1
     assert chat_responses[0].content == "test_response"
-    assert len(text_responses) == 1
-    assert text_responses[0].text == "test_response"
 
 
 @pytest.mark.asyncio
@@ -104,18 +94,11 @@ async def test_custom_host_streaming(
         assert messages[0].role == "assistant"
         assert messages[0].content == "test_response"
 
-    async for messages in ollama.get_streaming_text_contents(
-        prompt,
-        OllamaTextPromptExecutionSettings(service_id=service_id, options=default_options),
-    ):
-        assert len(messages) == 1
-        assert messages[0].text == "test_response"
-
     # Check that the client was initialized once with the correct host
     assert mock_client.call_count == 1
     mock_client.assert_called_with(host=host)
-    # Check that the chat client was called twice and the responses are correct
-    assert mock_chat_client.call_count == 2
+    # Check that the chat client was called once
+    assert mock_chat_client.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -158,48 +141,6 @@ async def test_chat_completion_wrong_return_type(
         await ollama.get_chat_message_contents(
             chat_history,
             OllamaChatPromptExecutionSettings(service_id=service_id, options=default_options),
-        )
-
-
-@pytest.mark.asyncio
-@patch("ollama.AsyncClient.chat")
-async def test_text_completion(mock_chat_client, model_id, service_id, prompt, default_options):
-    """Test that the text completion service completes correctly."""
-    mock_chat_client.return_value = {"message": {"content": "test_response"}}
-    ollama = OllamaChatCompletion(ai_model_id=model_id)
-    response = await ollama.get_text_contents(
-        prompt=prompt,
-        settings=OllamaTextPromptExecutionSettings(service_id=service_id, options=default_options),
-    )
-
-    assert len(response) == 1
-    assert response[0].text == "test_response"
-    mock_chat_client.assert_called_once_with(
-        model=model_id,
-        messages=[{"role": "user", "content": prompt}],
-        options=default_options,
-        stream=False,
-    )
-
-
-@pytest.mark.asyncio
-@patch("ollama.AsyncClient.chat")
-async def test_text_completion_wrong_return_type(
-    mock_chat_client,
-    mock_streaming_chat_response,
-    model_id,
-    service_id,
-    chat_history,
-    default_options,
-):
-    """Test that the text completion service fails when the return type is incorrect."""
-    mock_chat_client.return_value = mock_streaming_chat_response  # should not be a streaming response
-
-    ollama = OllamaChatCompletion(ai_model_id=model_id)
-    with pytest.raises(ServiceInvalidResponseError):
-        await ollama.get_text_contents(
-            chat_history,
-            OllamaTextPromptExecutionSettings(service_id=service_id, options=default_options),
         )
 
 
@@ -254,60 +195,5 @@ async def test_streaming_chat_completion_wrong_return_type(
         async for _ in ollama.get_streaming_chat_message_contents(
             chat_history,
             OllamaChatPromptExecutionSettings(service_id=service_id, options=default_options),
-        ):
-            pass
-
-
-@pytest.mark.asyncio
-@patch("ollama.AsyncClient.chat")
-async def test_streaming_text_completion(
-    mock_chat_client,
-    mock_streaming_chat_response,
-    model_id,
-    service_id,
-    prompt,
-    default_options,
-):
-    """Test that the streaming text completion service completes correctly."""
-    mock_chat_client.return_value = mock_streaming_chat_response
-
-    ollama = OllamaChatCompletion(ai_model_id=model_id)
-    response = ollama.get_streaming_text_contents(
-        prompt,
-        OllamaTextPromptExecutionSettings(service_id=service_id, options=default_options),
-    )
-
-    responses = []
-    async for line in response:
-        if line:
-            assert line[0].text == "test_response"
-            responses.append(line[0].text)
-    assert len(responses) == 1
-
-    mock_chat_client.assert_called_once_with(
-        model=model_id,
-        messages=[{"role": "user", "content": prompt}],
-        options=default_options,
-        stream=True,
-    )
-
-
-@pytest.mark.asyncio
-@patch("ollama.AsyncClient.chat")
-async def test_streaming_text_completion_wrong_return_type(
-    mock_chat_client,
-    model_id,
-    service_id,
-    chat_history,
-    default_options,
-):
-    """Test that the text completion streaming service fails when the return type is incorrect."""
-    mock_chat_client.return_value = {"message": {"content": "test_response"}}  # should not be a non-streaming response
-
-    ollama = OllamaChatCompletion(ai_model_id=model_id)
-    with pytest.raises(ServiceInvalidResponseError):
-        async for _ in ollama.get_streaming_text_contents(
-            chat_history,
-            OllamaTextPromptExecutionSettings(service_id=service_id, options=default_options),
         ):
             pass

--- a/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
@@ -341,18 +341,16 @@ async def test_azure_on_your_data_string(
             message=ChatCompletionMessage(
                 content="test",
                 role="assistant",
-                context=json.dumps(
-                    {
-                        "citations": {
-                            "content": "test content",
-                            "title": "test title",
-                            "url": "test url",
-                            "filepath": "test filepath",
-                            "chunk_id": "test chunk_id",
-                        },
-                        "intent": "query used",
-                    }
-                ),
+                context=json.dumps({
+                    "citations": {
+                        "content": "test content",
+                        "title": "test title",
+                        "url": "test url",
+                        "filepath": "test filepath",
+                        "chunk_id": "test chunk_id",
+                    },
+                    "intent": "query used",
+                }),
             ),
             finish_reason="stop",
         )
@@ -742,7 +740,7 @@ async def test_no_kernel_provided_throws_error(
 
     with pytest.raises(
         ServiceInvalidExecutionSettingsError,
-        match="The kernel is required for OpenAI tool calls.",
+        match="The kernel is required for function calls.",
     ):
         await azure_chat_completion.get_chat_message_contents(
             chat_history=chat_history, settings=complete_prompt_execution_settings
@@ -769,7 +767,7 @@ async def test_auto_invoke_false_no_kernel_provided_throws_error(
 
     with pytest.raises(
         ServiceInvalidExecutionSettingsError,
-        match="The kernel is required for OpenAI tool calls.",
+        match="The kernel is required for function calls.",
     ):
         await azure_chat_completion.get_chat_message_contents(
             chat_history=chat_history, settings=complete_prompt_execution_settings

--- a/python/tests/unit/connectors/open_ai/services/test_open_ai_chat_completion_base.py
+++ b/python/tests/unit/connectors/open_ai/services/test_open_ai_chat_completion_base.py
@@ -17,9 +17,7 @@ from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoic
 from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_prompt_execution_settings import (
     OpenAIChatPromptExecutionSettings,
 )
-from semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion import (
-    OpenAIChatCompletion,
-)
+from semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion import OpenAIChatCompletion
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.contents import StreamingChatMessageContent
 from semantic_kernel.contents.chat_history import ChatHistory
@@ -176,7 +174,7 @@ async def test_cmc_function_call_behavior(
         service_id="test_service_id", function_call_behavior=FunctionCallBehavior.AutoInvokeKernelFunctions()
     )
     with patch(
-        "semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion_base.OpenAIChatCompletionBase._process_function_call",
+        "semantic_kernel.kernel.Kernel.invoke_function_call",
         new_callable=AsyncMock,
     ) as mock_process_function_call:
         openai_chat_completion = OpenAIChatCompletion()
@@ -227,7 +225,7 @@ async def test_cmc_function_choice_behavior(
         service_id="test_service_id", function_choice_behavior=FunctionChoiceBehavior.Auto()
     )
     with patch(
-        "semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion_base.OpenAIChatCompletionBase._process_function_call",
+        "semantic_kernel.kernel.Kernel.invoke_function_call",
         new_callable=AsyncMock,
     ) as mock_process_function_call:
         openai_chat_completion = OpenAIChatCompletion()

--- a/python/tests/unit/utils/model_diagnostics/conftest.py
+++ b/python/tests/unit/utils/model_diagnostics/conftest.py
@@ -53,20 +53,18 @@ class MockChatCompletion(ChatCompletionClientBase):
     MODEL_PROVIDER_NAME: ClassVar[str] = "mock"
 
     @override
-    async def get_chat_message_contents(
+    async def _send_chat_request(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
     ) -> list["ChatMessageContent"]:
         return []
 
     @override
-    async def get_streaming_chat_message_contents(
+    async def _send_streaming_chat_request(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
-        **kwargs: Any,
     ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
         yield []
 
@@ -75,7 +73,7 @@ class MockTextCompletion(TextCompletionClientBase):
     MODEL_PROVIDER_NAME: ClassVar[str] = "mock"
 
     @override
-    async def get_text_contents(
+    async def _send_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -83,7 +81,7 @@ class MockTextCompletion(TextCompletionClientBase):
         return []
 
     @override
-    async def get_streaming_text_contents(
+    async def _send_streaming_text_request(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/tests/unit/utils/model_diagnostics/conftest.py
+++ b/python/tests/unit/utils/model_diagnostics/conftest.py
@@ -53,7 +53,7 @@ class MockChatCompletion(ChatCompletionClientBase):
     MODEL_PROVIDER_NAME: ClassVar[str] = "mock"
 
     @override
-    async def _inner_get_chat_message_content(
+    async def _inner_get_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -61,7 +61,7 @@ class MockChatCompletion(ChatCompletionClientBase):
         return []
 
     @override
-    async def _inner_get_streaming_chat_message_content(
+    async def _inner_get_streaming_chat_message_contents(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",

--- a/python/tests/unit/utils/model_diagnostics/conftest.py
+++ b/python/tests/unit/utils/model_diagnostics/conftest.py
@@ -53,7 +53,7 @@ class MockChatCompletion(ChatCompletionClientBase):
     MODEL_PROVIDER_NAME: ClassVar[str] = "mock"
 
     @override
-    async def _send_chat_request(
+    async def _inner_get_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -61,7 +61,7 @@ class MockChatCompletion(ChatCompletionClientBase):
         return []
 
     @override
-    async def _send_streaming_chat_request(
+    async def _inner_get_streaming_chat_message_content(
         self,
         chat_history: "ChatHistory",
         settings: "PromptExecutionSettings",
@@ -73,7 +73,7 @@ class MockTextCompletion(TextCompletionClientBase):
     MODEL_PROVIDER_NAME: ClassVar[str] = "mock"
 
     @override
-    async def _send_text_request(
+    async def _inner_get_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",
@@ -81,7 +81,7 @@ class MockTextCompletion(TextCompletionClientBase):
         return []
 
     @override
-    async def _send_streaming_text_request(
+    async def _inner_get_streaming_text_contents(
         self,
         prompt: str,
         settings: "PromptExecutionSettings",

--- a/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
@@ -92,11 +92,11 @@ async def test_trace_chat_completion(
     # Setup
     chat_completion: ChatCompletionClientBase = MockChatCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockChatCompletion, "_send_chat_request", return_value=mock_response):
+    with patch.object(MockChatCompletion, "_inner_get_chat_message_content", return_value=mock_response):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockChatCompletion._send_chat_request = trace_chat_completion(MockChatCompletion.MODEL_PROVIDER_NAME)(
-            chat_completion._send_chat_request
-        )
+        MockChatCompletion._inner_get_chat_message_content = trace_chat_completion(
+            MockChatCompletion.MODEL_PROVIDER_NAME
+        )(chat_completion._inner_get_chat_message_content)
 
         results: list[ChatMessageContent] = await chat_completion.get_chat_message_contents(
             chat_history, execution_settings
@@ -156,11 +156,11 @@ async def test_trace_chat_completion_exception(
     # Setup
     chat_completion: ChatCompletionClientBase = MockChatCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockChatCompletion, "_send_chat_request", side_effect=ServiceResponseException()):
+    with patch.object(MockChatCompletion, "_inner_get_chat_message_content", side_effect=ServiceResponseException()):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockChatCompletion._send_chat_request = trace_chat_completion(MockChatCompletion.MODEL_PROVIDER_NAME)(
-            chat_completion._send_chat_request
-        )
+        MockChatCompletion._inner_get_chat_message_content = trace_chat_completion(
+            MockChatCompletion.MODEL_PROVIDER_NAME
+        )(chat_completion._inner_get_chat_message_content)
 
         with pytest.raises(ServiceResponseException):
             await chat_completion.get_chat_message_contents(chat_history, execution_settings)

--- a/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
@@ -92,11 +92,11 @@ async def test_trace_chat_completion(
     # Setup
     chat_completion: ChatCompletionClientBase = MockChatCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockChatCompletion, "_inner_get_chat_message_content", return_value=mock_response):
+    with patch.object(MockChatCompletion, "_inner_get_chat_message_contents", return_value=mock_response):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockChatCompletion._inner_get_chat_message_content = trace_chat_completion(
+        MockChatCompletion._inner_get_chat_message_contents = trace_chat_completion(
             MockChatCompletion.MODEL_PROVIDER_NAME
-        )(chat_completion._inner_get_chat_message_content)
+        )(chat_completion._inner_get_chat_message_contents)
 
         results: list[ChatMessageContent] = await chat_completion.get_chat_message_contents(
             chat_history, execution_settings
@@ -156,11 +156,11 @@ async def test_trace_chat_completion_exception(
     # Setup
     chat_completion: ChatCompletionClientBase = MockChatCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockChatCompletion, "_inner_get_chat_message_content", side_effect=ServiceResponseException()):
+    with patch.object(MockChatCompletion, "_inner_get_chat_message_contents", side_effect=ServiceResponseException()):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockChatCompletion._inner_get_chat_message_content = trace_chat_completion(
+        MockChatCompletion._inner_get_chat_message_contents = trace_chat_completion(
             MockChatCompletion.MODEL_PROVIDER_NAME
-        )(chat_completion._inner_get_chat_message_content)
+        )(chat_completion._inner_get_chat_message_contents)
 
         with pytest.raises(ServiceResponseException):
             await chat_completion.get_chat_message_contents(chat_history, execution_settings)

--- a/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
@@ -92,14 +92,14 @@ async def test_trace_chat_completion(
     # Setup
     chat_completion: ChatCompletionClientBase = MockChatCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockChatCompletion, "get_chat_message_contents", return_value=mock_response):
+    with patch.object(MockChatCompletion, "_send_chat_request", return_value=mock_response):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockChatCompletion.get_chat_message_contents = trace_chat_completion(MockChatCompletion.MODEL_PROVIDER_NAME)(
-            chat_completion.get_chat_message_contents
+        MockChatCompletion._send_chat_request = trace_chat_completion(MockChatCompletion.MODEL_PROVIDER_NAME)(
+            chat_completion._send_chat_request
         )
 
         results: list[ChatMessageContent] = await chat_completion.get_chat_message_contents(
-            chat_history=chat_history, settings=execution_settings
+            chat_history, execution_settings
         )
 
         assert results == mock_response
@@ -156,14 +156,14 @@ async def test_trace_chat_completion_exception(
     # Setup
     chat_completion: ChatCompletionClientBase = MockChatCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockChatCompletion, "get_chat_message_contents", side_effect=ServiceResponseException()):
+    with patch.object(MockChatCompletion, "_send_chat_request", side_effect=ServiceResponseException()):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockChatCompletion.get_chat_message_contents = trace_chat_completion(MockChatCompletion.MODEL_PROVIDER_NAME)(
-            chat_completion.get_chat_message_contents
+        MockChatCompletion._send_chat_request = trace_chat_completion(MockChatCompletion.MODEL_PROVIDER_NAME)(
+            chat_completion._send_chat_request
         )
 
         with pytest.raises(ServiceResponseException):
-            await chat_completion.get_chat_message_contents(chat_history=chat_history, settings=execution_settings)
+            await chat_completion.get_chat_message_contents(chat_history, execution_settings)
 
         exception = ServiceResponseException()
         mock_span.set_attribute.assert_any_call(gen_ai_attributes.ERROR_TYPE, str(type(exception)))

--- a/python/tests/unit/utils/model_diagnostics/test_trace_text_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_text_completion.py
@@ -76,10 +76,10 @@ async def test_trace_text_completion(
     # Setup
     text_completion: TextCompletionClientBase = MockTextCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockTextCompletion, "get_text_contents", return_value=mock_response):
+    with patch.object(MockTextCompletion, "_send_text_request", return_value=mock_response):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockTextCompletion.get_text_contents = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
-            text_completion.get_text_contents
+        MockTextCompletion._send_text_request = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
+            text_completion._send_text_request
         )
 
         results: list[ChatMessageContent] = await text_completion.get_text_contents(
@@ -134,10 +134,10 @@ async def test_trace_text_completion_exception(
     # Setup
     text_completion: TextCompletionClientBase = MockTextCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockTextCompletion, "get_text_contents", side_effect=ServiceResponseException()):
+    with patch.object(MockTextCompletion, "_send_text_request", side_effect=ServiceResponseException()):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockTextCompletion.get_text_contents = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
-            text_completion.get_text_contents
+        MockTextCompletion._send_text_request = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
+            text_completion._send_text_request
         )
 
         with pytest.raises(ServiceResponseException):

--- a/python/tests/unit/utils/model_diagnostics/test_trace_text_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_text_completion.py
@@ -76,10 +76,10 @@ async def test_trace_text_completion(
     # Setup
     text_completion: TextCompletionClientBase = MockTextCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockTextCompletion, "_send_text_request", return_value=mock_response):
+    with patch.object(MockTextCompletion, "_inner_get_text_contents", return_value=mock_response):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockTextCompletion._send_text_request = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
-            text_completion._send_text_request
+        MockTextCompletion._inner_get_text_contents = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
+            text_completion._inner_get_text_contents
         )
 
         results: list[ChatMessageContent] = await text_completion.get_text_contents(
@@ -134,10 +134,10 @@ async def test_trace_text_completion_exception(
     # Setup
     text_completion: TextCompletionClientBase = MockTextCompletion(ai_model_id="ai_model_id")
 
-    with patch.object(MockTextCompletion, "_send_text_request", side_effect=ServiceResponseException()):
+    with patch.object(MockTextCompletion, "_inner_get_text_contents", side_effect=ServiceResponseException()):
         # We need to reapply the decorator to the method since the mock will not have the decorator applied
-        MockTextCompletion._send_text_request = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
-            text_completion._send_text_request
+        MockTextCompletion._inner_get_text_contents = trace_text_completion(MockTextCompletion.MODEL_PROVIDER_NAME)(
+            text_completion._inner_get_text_contents
         )
 
         with pytest.raises(ServiceResponseException):


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This PR implements: https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0052-python-ai-connector-new-abstract-methods.md (PR: https://github.com/microsoft/semantic-kernel/pull/8430).

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Add abstract methods `_inner_get_chat_message_content` and `_inner_get_streaming_chat_message_content` to `ChatCompletionClientBase`.
2. Implement the abstractions in all chat completion connectors.
3. Add abstract methods `_inner_get_text_contents` and `_inner_get_streaming_text_contents` to `TextCompletionClientBase`.
4. Implement the abstractions in all text completion connectors.
5. Remove text completion APIs from `OllamaChatCompletion` (breaking changes).
> No breaking changes on other connectors except Ollama, and public APIs stay the same.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
