### PR TITLE
.Net: Switch to using AzureCliCredential

### DIFF
--- a/dotnet/src/IntegrationTests/Agents/ChatCompletionAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/ChatCompletionAgentTests.cs
@@ -44,7 +44,7 @@ public sealed class ChatCompletionAgentTests()
         this._kernelBuilder.AddAzureOpenAIChatCompletion(
             deploymentName: configuration.ChatDeploymentName!,
             endpoint: configuration.Endpoint,
-            credentials: new DefaultAzureCredential());
+            credentials: new AzureCliCredential());
 
         if (useAutoFunctionTermination)
         {

--- a/dotnet/src/IntegrationTests/Agents/MixedAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/MixedAgentTests.cs
@@ -56,7 +56,7 @@ public sealed class MixedAgentTests
         // Arrange, Act & Assert
         await this.VerifyAgentExecutionAsync(
             this.CreateChatCompletionKernel(azureOpenAISettings),
-            OpenAIClientProvider.ForAzureOpenAI(new DefaultAzureCredential(), new Uri(azureOpenAISettings.Endpoint)),
+            OpenAIClientProvider.ForAzureOpenAI(new AzureCliCredential(), new Uri(azureOpenAISettings.Endpoint)),
             azureOpenAISettings.ChatDeploymentName!);
     }
 
@@ -123,7 +123,7 @@ public sealed class MixedAgentTests
         kernelBuilder.AddAzureOpenAIChatCompletion(
             deploymentName: configuration.ChatDeploymentName!,
             endpoint: configuration.Endpoint,
-            credentials: new DefaultAzureCredential());
+            credentials: new AzureCliCredential());
 
         return kernelBuilder.Build();
     }

--- a/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
@@ -55,7 +55,7 @@ public sealed class OpenAIAssistantAgentTests
         Assert.NotNull(azureOpenAIConfiguration);
 
         await this.ExecuteAgentAsync(
-            OpenAIClientProvider.ForAzureOpenAI(new DefaultAzureCredential(), new Uri(azureOpenAIConfiguration.Endpoint)),
+            OpenAIClientProvider.ForAzureOpenAI(new AzureCliCredential(), new Uri(azureOpenAIConfiguration.Endpoint)),
             azureOpenAIConfiguration.ChatDeploymentName!,
             input,
             expectedAnswerContains);

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIAudioToTextTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIAudioToTextTests.cs
@@ -36,7 +36,7 @@ public sealed class AzureOpenAIAudioToTextTests()
             .AddAzureOpenAIAudioToText(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
-                credentials: new DefaultAzureCredential())
+                credentials: new AzureCliCredential())
             .Build();
 
         var service = kernel.GetRequiredService<IAudioToTextService>();

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionFunctionCallingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionFunctionCallingTests.cs
@@ -874,7 +874,7 @@ public sealed class AzureOpenAIChatCompletionFunctionCallingTests : BaseIntegrat
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            credentials: new DefaultAzureCredential());
+            credentials: new AzureCliCredential());
 
         var kernel = kernelBuilder.Build();
 

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionNonStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionNonStreamingTests.cs
@@ -156,7 +156,7 @@ public sealed class AzureOpenAIChatCompletionNonStreamingTests : BaseIntegration
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            credentials: new DefaultAzureCredential());
+            credentials: new AzureCliCredential());
 
         return kernelBuilder.Build();
     }

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionStreamingTests.cs
@@ -157,7 +157,7 @@ public sealed class AzureOpenAIChatCompletionStreamingTests : BaseIntegrationTes
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            credentials: new DefaultAzureCredential());
+            credentials: new AzureCliCredential());
 
         return kernelBuilder.Build();
     }

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionTests.cs
@@ -242,7 +242,7 @@ public sealed class AzureOpenAIChatCompletionTests : BaseIntegrationTest
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            credentials: new DefaultAzureCredential(),
+            credentials: new AzureCliCredential(),
             serviceId: azureOpenAIConfiguration.ServiceId,
             httpClient: httpClient);
 

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextEmbeddingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextEmbeddingTests.cs
@@ -27,7 +27,7 @@ public sealed class AzureOpenAITextEmbeddingTests
         var embeddingGenerator = new AzureOpenAITextEmbeddingGenerationService(
             deploymentName: this._azureOpenAIConfiguration.DeploymentName,
             endpoint: this._azureOpenAIConfiguration.Endpoint,
-            credential: new DefaultAzureCredential());
+            credential: new AzureCliCredential());
 
         // Act
         var singleResult = await embeddingGenerator.GenerateEmbeddingAsync(testInputString);
@@ -49,7 +49,7 @@ public sealed class AzureOpenAITextEmbeddingTests
         var embeddingGenerator = new AzureOpenAITextEmbeddingGenerationService(
             deploymentName: "text-embedding-3-large",
             endpoint: this._azureOpenAIConfiguration.Endpoint,
-            credential: new DefaultAzureCredential(),
+            credential: new AzureCliCredential(),
             dimensions: dimensions);
 
         // Act

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToAudioTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToAudioTests.cs
@@ -30,7 +30,7 @@ public sealed class AzureOpenAITextToAudioTests
             .AddAzureOpenAITextToAudio(
                 deploymentName: azureOpenAIConfiguration.DeploymentName,
                 endpoint: azureOpenAIConfiguration.Endpoint,
-                credential: new DefaultAzureCredential())
+                credential: new AzureCliCredential())
             .Build();
 
         var service = kernel.GetRequiredService<ITextToAudioService>();

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToImageTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAITextToImageTests.cs
@@ -30,7 +30,7 @@ public sealed class AzureOpenAITextToImageTests
             .AddAzureOpenAITextToImage(
                 deploymentName: configuration.DeploymentName,
                 endpoint: configuration.Endpoint,
-                credentials: new DefaultAzureCredential())
+                credentials: new AzureCliCredential())
             .Build();
 
         var service = kernel.GetRequiredService<ITextToImageService>();

--- a/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
+++ b/dotnet/src/IntegrationTests/Planners/Handlebars/HandlebarsPlannerTests.cs
@@ -118,7 +118,7 @@ public sealed class HandlebarsPlannerTests
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName!,
             modelId: azureOpenAIConfiguration.ChatModelId,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            credentials: new DefaultAzureCredential());
+            credentials: new AzureCliCredential());
 
         if (useEmbeddings)
         {
@@ -126,7 +126,7 @@ public sealed class HandlebarsPlannerTests
                 deploymentName: azureOpenAIEmbeddingsConfiguration.DeploymentName,
                 modelId: azureOpenAIEmbeddingsConfiguration.EmbeddingModelId,
                 endpoint: azureOpenAIEmbeddingsConfiguration.Endpoint,
-                credential: new DefaultAzureCredential());
+                credential: new AzureCliCredential());
         }
 
         return builder.Build();

--- a/dotnet/src/IntegrationTests/PromptTests.cs
+++ b/dotnet/src/IntegrationTests/PromptTests.cs
@@ -83,7 +83,7 @@ public sealed class PromptTests : IDisposable
         kernelBuilder.AddAzureOpenAIChatCompletion(
             deploymentName: azureOpenAIConfiguration.ChatDeploymentName,
             endpoint: azureOpenAIConfiguration.Endpoint,
-            credentials: new DefaultAzureCredential(),
+            credentials: new AzureCliCredential(),
             serviceId: azureOpenAIConfiguration.ServiceId);
     }
     #endregion


### PR DESCRIPTION
### Motivation and Context

`DefaultAzureCredential` attempts multiple strategies but we can start by just relying on Azure Cli login.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
