### PR TITLE
Python: Add a samples README and a demos README.

### DIFF
--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -5,5 +5,5 @@
 | [`getting_started`](./getting_started/CONFIGURING_THE_KERNEL.md)         | Take this step by step tutorial to get started with Semantic Kernel and get introduced to the key concepts.            |
 | [`getting_started_with_agents`](./getting_started_with_agents/README.md) | Take this step by step tutorial to get started with Semantic Kernel Agents and get introduced to the key concepts.     |
 | [`concepts`](./concepts/README.md)                                       | This section contains focused samples which illustrate all of the concepts included in Semantic Kernel.                |
-| [`demos`](./Demos/README.md)                                             | Look here to find a sample which demonstrate how to use many of Semantic Kernel features.                              |
+| [`demos`](./demos/README.md)                                             | Look here to find a sample which demonstrate how to use many of Semantic Kernel features.                              |
 | [`learn_resources`](./learn_resources/README.md)                         | Code snippets that are related to online documentation sources like Microsoft Learn, DevBlogs and others               |

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -1,0 +1,9 @@
+## Semantic Kernel Samples
+
+| Type                                                                     | Description                                                                                                            |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| [`getting_started`](./getting_started/CONFIGURING_THE_KERNEL.md)         | Take this step by step tutorial to get started with Semantic Kernel and get introduced to the key concepts.            |
+| [`getting_started_with_agents`](./getting_started_with_agents/README.md) | Take this step by step tutorial to get started with Semantic Kernel Agents and get introduced to the key concepts.     |
+| [`concepts`](./concepts/README.md)                                       | This section contains focused samples which illustrate all of the concepts included in Semantic Kernel.                |
+| [`demos`](./Demos/README.md)                                             | Look here to find a sample which demonstrate how to use many of Semantic Kernel features.                              |
+| [`learn_resources`](./learn_resources/README.md)                         | Code snippets that are related to online documentation sources like Microsoft Learn, DevBlogs and others               |

--- a/python/samples/demos/README.md
+++ b/python/samples/demos/README.md
@@ -1,0 +1,9 @@
+## Semantic Kernel Demo Applications
+
+Demonstration applications that leverage the usage of one or many SK features
+
+| Type              | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| assistants_group_chat | A sample Agent demo that shows a chat functionality with an OpenAI Assistant agent. |
+| booking_restaurant | A sample chat bot that leverages the Microsoft Graph and Bookings API as a Semantic Kernel plugin to make a fake booking at a restaurant. |
+| telemetry_with_application_insights | A sample project that shows how a Python application can be configured to send Semantic Kernel telemetry to Application Insights. |


### PR DESCRIPTION
### Motivation and Context

The Python samples folder is a lacking an overall README file covering what each samples folder does.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adds a samples README as well as a demos folder README.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
