### PR TITLE
.Net: Advertise required functions in the first request to AI model only

### DIFF
--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_RequiredFunctionChoiceBehaviorTests.cs
@@ -31,6 +31,47 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
         this._chatCompletionService = this._kernel.GetRequiredService<IChatCompletionService>();
     }
 
+    //[Fact]
+    // This test should be uncommented when the solution to dynamically control list of functions to advertise to the model is implemented.
+    //public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string?>();
+
+    //    IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+    //    {
+    //        // Get all function names that have been invoked
+    //        var invokedFunctionNames = context.ChatHistory
+    //            .SelectMany(m => m.Items.OfType<FunctionResultContent>())
+    //            .Select(i => i.FunctionName);
+
+    //        invokedFunctions.AddRange(invokedFunctionNames);
+
+    //        if (invokedFunctionNames.Contains("GetCurrentDate"))
+    //        {
+    //            return []; // Don't advertise any more functions because the expected function has been invoked.
+    //        }
+
+    //        return context.Functions;
+    //    }
+
+    //    var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+
+    //    var chatHistory = new ChatHistory();
+    //    chatHistory.AddUserMessage("How many days until Christmas?");
+
+    //    // Act
+    //    var result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, settings, this._kernel);
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
     [Fact]
     public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
     {
@@ -39,24 +80,13 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
 
         var invokedFunctions = new List<string?>();
 
-        IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
         {
-            // Get all function names that have been invoked
-            var invokedFunctionNames = context.ChatHistory
-                .SelectMany(m => m.Items.OfType<FunctionResultContent>())
-                .Select(i => i.FunctionName);
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
 
-            invokedFunctions.AddRange(invokedFunctionNames);
-
-            if (invokedFunctionNames.Contains("GetCurrentDate"))
-            {
-                return []; // Don't advertise any more functions because the expected function has been invoked.
-            }
-
-            return context.Functions;
-        }
-
-        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+        var settings = new AzureOpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true) };
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("How many days until Christmas?");
@@ -71,41 +101,41 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
         Assert.Contains("GetCurrentDate", invokedFunctions);
     }
 
-    //[Fact]
-    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
-    //{
-    //    // Arrange
-    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+    [Fact]
+    public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
 
-    //    var invokedFunctions = new List<string>();
+        var invokedFunctions = new List<string>();
 
-    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
-    //    {
-    //        invokedFunctions.Add(context.Function.Name);
-    //        await next(context);
-    //    });
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
 
-    //    var promptTemplate = """"
-    //        template_format: semantic-kernel
-    //        template: How many days until Christmas?
-    //        execution_settings:
-    //          default:
-    //            temperature: 0.1
-    //            function_choice_behavior:
-    //              type: required
-    //        """";
+        var promptTemplate = """"
+            template_format: semantic-kernel
+            template: How many days until Christmas?
+            execution_settings:
+              default:
+                temperature: 0.1
+                function_choice_behavior:
+                  type: required
+            """";
 
-    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+        var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
 
-    //    // Act
-    //    var result = await this._kernel.InvokeAsync(promptFunction);
+        // Act
+        var result = await this._kernel.InvokeAsync(promptFunction);
 
-    //    // Assert
-    //    Assert.NotNull(result);
+        // Assert
+        Assert.NotNull(result);
 
-    //    Assert.Single(invokedFunctions);
-    //    Assert.Contains("GetCurrentDate", invokedFunctions);
-    //}
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
 
     [Fact]
     public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyAsync()
@@ -143,6 +173,52 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
         Assert.Equal("GetCurrentDate", functionCall.FunctionName);
     }
 
+    //[Fact]
+    //This test should be uncommented when the solution to dynamically control list of functions to advertise to the model is implemented.
+    //public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    //{
+    //    // Arrange
+    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+
+    //    var invokedFunctions = new List<string?>();
+
+    //    IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+    //    {
+    //        // Get all function names that have been invoked
+    //        var invokedFunctionNames = context.ChatHistory
+    //            .SelectMany(m => m.Items.OfType<FunctionResultContent>())
+    //            .Select(i => i.FunctionName);
+
+    //        invokedFunctions.AddRange(invokedFunctionNames);
+
+    //        if (invokedFunctionNames.Contains("GetCurrentDate"))
+    //        {
+    //            return []; // Don't advertise any more functions because the expected function has been invoked.
+    //        }
+
+    //        return context.Functions;
+    //    }
+
+    //    var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+
+    //    var chatHistory = new ChatHistory();
+    //    chatHistory.AddUserMessage("How many days until Christmas?");
+
+    //    string result = "";
+
+    //    // Act
+    //    await foreach (var content in this._chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory, settings, this._kernel))
+    //    {
+    //        result += content;
+    //    }
+
+    //    // Assert
+    //    Assert.NotNull(result);
+
+    //    Assert.Single(invokedFunctions);
+    //    Assert.Contains("GetCurrentDate", invokedFunctions);
+    //}
+
     [Fact]
     public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
     {
@@ -151,24 +227,13 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
 
         var invokedFunctions = new List<string?>();
 
-        IReadOnlyList<KernelFunction>? SelectFunctions(FunctionChoiceBehaviorFunctionsSelectorContext context)
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
         {
-            // Get all function names that have been invoked
-            var invokedFunctionNames = context.ChatHistory
-                .SelectMany(m => m.Items.OfType<FunctionResultContent>())
-                .Select(i => i.FunctionName);
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
 
-            invokedFunctions.AddRange(invokedFunctionNames);
-
-            if (invokedFunctionNames.Contains("GetCurrentDate"))
-            {
-                return []; // Don't advertise any more functions because the expected function has been invoked.
-            }
-
-            return context.Functions;
-        }
-
-        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: SelectFunctions) };
+        var settings = new AzureOpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true) };
 
         var chatHistory = new ChatHistory();
         chatHistory.AddUserMessage("How many days until Christmas?");
@@ -188,46 +253,46 @@ public sealed class AzureOpenAIRequiredFunctionChoiceBehaviorTests : BaseIntegra
         Assert.Contains("GetCurrentDate", invokedFunctions);
     }
 
-    //[Fact]
-    //public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
-    //{
-    //    // Arrange
-    //    this._kernel.ImportPluginFromType<DateTimeUtils>();
+    [Fact]
+    public async Task SpecifiedInPromptInstructsConnectorToInvokeKernelFunctionAutomaticallyForStreamingAsync()
+    {
+        // Arrange
+        this._kernel.ImportPluginFromType<DateTimeUtils>();
 
-    //    var invokedFunctions = new List<string>();
+        var invokedFunctions = new List<string>();
 
-    //    this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
-    //    {
-    //        invokedFunctions.Add(context.Function.Name);
-    //        await next(context);
-    //    });
+        this._autoFunctionInvocationFilter.RegisterFunctionInvocationHandler(async (context, next) =>
+        {
+            invokedFunctions.Add(context.Function.Name);
+            await next(context);
+        });
 
-    //    var promptTemplate = """"
-    //        template_format: semantic-kernel
-    //        template: How many days until Christmas?
-    //        execution_settings:
-    //          default:
-    //            temperature: 0.1
-    //            function_choice_behavior:
-    //              type: required
-    //        """";
+        var promptTemplate = """"
+            template_format: semantic-kernel
+            template: How many days until Christmas?
+            execution_settings:
+              default:
+                temperature: 0.1
+                function_choice_behavior:
+                  type: required
+            """";
 
-    //    var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
+        var promptFunction = KernelFunctionYaml.FromPromptYaml(promptTemplate);
 
-    //    string result = "";
+        string result = "";
 
-    //    // Act
-    //    await foreach (string c in promptFunction.InvokeStreamingAsync<string>(this._kernel))
-    //    {
-    //        result += c;
-    //    }
+        // Act
+        await foreach (string c in promptFunction.InvokeStreamingAsync<string>(this._kernel))
+        {
+            result += c;
+        }
 
-    //    // Assert
-    //    Assert.NotNull(result);
+        // Assert
+        Assert.NotNull(result);
 
-    //    Assert.Single(invokedFunctions);
-    //    Assert.Contains("GetCurrentDate", invokedFunctions);
-    //}
+        Assert.Single(invokedFunctions);
+        Assert.Contains("GetCurrentDate", invokedFunctions);
+    }
 
     [Fact]
     public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyForStreamingAsync()

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehavior.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -69,7 +68,7 @@ public abstract class FunctionChoiceBehavior
 
     /// <summary>
     /// Gets an instance of the <see cref="FunctionChoiceBehavior"/> that provides either all of the <see cref="Kernel"/>'s plugins' functions to the AI model to call or specific ones.
-    /// This behavior forces the model to always call one or more functions.
+    /// This behavior forces the model to call the provided functions. SK connectors will invoke a requested function or multiple requested functions if the model requests multiple ones in one request, while handling the first request, and stop advertising the functions for the following requests to prevent the model from repeatedly calling the same function(s).
     /// </summary>
     /// <param name="functions">
     /// Functions to provide to the model. If null, all of the <see cref="Kernel"/>'s plugins' functions are provided to the model.
@@ -78,22 +77,11 @@ public abstract class FunctionChoiceBehavior
     /// <param name="autoInvoke">
     /// Indicates whether the functions should be automatically invoked by AI connectors.
     /// </param>
-    /// <param name="functionsSelector">
-    /// The callback function allows customization of function selection.
-    /// It accepts functions, chat history, and an optional kernel, and returns a list of functions to be used by the AI model.
-    /// This should be supplied to prevent the AI model from repeatedly calling functions even when the prompt has already been answered.
-    /// For example, if the AI model is prompted to calculate the sum of two numbers, 2 and 3, and is provided with the 'Add' function,
-    /// the model will keep calling the 'Add' function even if the sum - 5 - is already calculated, until the 'Add' function is no longer provided to the model.
-    /// In this example, the function selector can analyze chat history and decide not to advertise the 'Add' function anymore.
-    /// </param>
     /// <param name="options">The behavior options.</param>
     /// <returns>An instance of one of the <see cref="FunctionChoiceBehavior"/>.</returns>
-    public static FunctionChoiceBehavior Required(
-        IEnumerable<KernelFunction>? functions = null,
-        bool autoInvoke = true, Func<FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList<KernelFunction>?>? functionsSelector = null,
-        FunctionChoiceBehaviorOptions? options = null)
+    public static FunctionChoiceBehavior Required(IEnumerable<KernelFunction>? functions = null, bool autoInvoke = true, FunctionChoiceBehaviorOptions? options = null)
     {
-        return new RequiredFunctionChoiceBehavior(functions, autoInvoke, functionsSelector, options);
+        return new RequiredFunctionChoiceBehavior(functions, autoInvoke, null, options);
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehavior.cs
@@ -79,6 +79,18 @@ internal sealed class RequiredFunctionChoiceBehavior : FunctionChoiceBehavior
     /// <inheritdoc />
     public override FunctionChoiceBehaviorConfiguration GetConfiguration(FunctionChoiceBehaviorConfigurationContext context)
     {
+        // Stop advertising functions after the first request to prevent the AI model from repeatedly calling the same function.
+        // This is a temporary solution which will be removed after we have a way to dynamically control list of functions to advertise to the model.
+        if (context.RequestSequenceIndex >= 1)
+        {
+            return new FunctionChoiceBehaviorConfiguration(this.Options ?? DefaultOptions)
+            {
+                Choice = FunctionChoice.Required,
+                Functions = null,
+                AutoInvoke = this._autoInvoke,
+            };
+        }
+
         var functions = base.GetFunctions(this.Functions, context.Kernel, this._autoInvoke);
 
         IReadOnlyList<KernelFunction>? selectedFunctions = null;

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -77,7 +77,7 @@ public class PromptExecutionSettings
     /// </item>
     /// <item>
     /// To force the model to always call one or more functions set the property to an instance returned
-    /// by the <see cref="FunctionChoiceBehavior.Required(IEnumerable{KernelFunction}?, bool, Func{FunctionChoiceBehaviorFunctionsSelectorContext, IReadOnlyList{KernelFunction}?}?, FunctionChoiceBehaviorOptions?)"/> method.
+    /// by the <see cref="FunctionChoiceBehavior.Required(IEnumerable{KernelFunction}?, bool, FunctionChoiceBehaviorOptions?)"/> method.
     /// </item>
     /// <item>
     /// To instruct the model to not call any functions and only generate a user-facing message, set the property to an instance returned

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SemanticKernel;
 using Xunit;
@@ -186,50 +185,52 @@ public sealed class FunctionChoiceBehaviorTests
         Assert.True(config.AutoInvoke);
     }
 
-    [Fact]
-    public void RequiredFunctionChoiceShouldReturnNoFunctionAsSpecifiedByFunctionsSelector()
-    {
-        // Arrange
-        var plugin = GetTestPlugin();
-        this._kernel.Plugins.Add(plugin);
+    //[Fact]
+    //This test should be uncommented when the solution to dynamically control list of functions to advertise to the model is implemented.
+    //public void RequiredFunctionChoiceShouldReturnNoFunctionAsSpecifiedByFunctionsSelector()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
 
-        static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
-        {
-            return [];
-        }
+    //    static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
+    //    {
+    //        return [];
+    //    }
 
-        // Act
-        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
+    //    var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
-        // Assert
-        Assert.NotNull(config.Functions);
-        Assert.Empty(config.Functions);
-    }
+    //    // Assert
+    //    Assert.NotNull(config.Functions);
+    //    Assert.Empty(config.Functions);
+    //}
 
-    [Fact]
-    public void RequiredFunctionChoiceShouldReturnFunctionsAsSpecifiedByFunctionsSelector()
-    {
-        // Arrange
-        var plugin = GetTestPlugin();
-        this._kernel.Plugins.Add(plugin);
+    //[Fact]
+    //This test should be uncommented when the solution to dynamically control the list of functions to advertise to the model is implemented.
+    //public void RequiredFunctionChoiceShouldReturnFunctionsAsSpecifiedByFunctionsSelector()
+    //{
+    //    // Arrange
+    //    var plugin = GetTestPlugin();
+    //    this._kernel.Plugins.Add(plugin);
 
-        static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
-        {
-            return context.Functions!.Where(f => f.Name == "Function1").ToList();
-        }
+    //    static IReadOnlyList<KernelFunction>? FunctionsSelector(FunctionChoiceBehaviorFunctionsSelectorContext context)
+    //    {
+    //        return context.Functions!.Where(f => f.Name == "Function1").ToList();
+    //    }
 
-        // Act
-        var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
+    //    // Act
+    //    var choiceBehavior = FunctionChoiceBehavior.Required(autoInvoke: true, functionsSelector: FunctionsSelector);
 
-        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
+    //    var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel });
 
-        // Assert
-        Assert.NotNull(config?.Functions);
-        Assert.Single(config.Functions);
-        Assert.Equal("Function1", config.Functions[0].Name);
-    }
+    //    // Assert
+    //    Assert.NotNull(config?.Functions);
+    //    Assert.Single(config.Functions);
+    //    Assert.Equal("Function1", config.Functions[0].Name);
+    //}
 
     [Fact]
     public void RequiredFunctionChoiceShouldAllowManualInvocation()

--- a/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/FunctionChoiceBehaviors/RequiredFunctionChoiceBehaviorTests.cs
@@ -128,6 +128,38 @@ public sealed class RequiredFunctionChoiceBehaviorTests
         Assert.Contains(config.Functions, f => f.Name == "Function3");
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(100)]
+    public void ItShouldAdvertiseFunctionsForTheFirstRequestOnly(int requestSequenceIndex)
+    {
+        // Arrange
+        var plugin = GetTestPlugin();
+        this._kernel.Plugins.Add(plugin);
+
+        // Act
+        var choiceBehavior = new RequiredFunctionChoiceBehavior(functions: [plugin.ElementAt(0), plugin.ElementAt(1)]);
+
+        var config = choiceBehavior.GetConfiguration(new(chatHistory: []) { Kernel = this._kernel, RequestSequenceIndex = requestSequenceIndex });
+
+        // Assert
+        Assert.NotNull(config);
+
+        if (requestSequenceIndex == 0)
+        {
+            Assert.NotNull(config.Functions);
+            Assert.Equal(2, config.Functions.Count);
+            Assert.Contains(config.Functions, f => f.Name == "Function1");
+            Assert.Contains(config.Functions, f => f.Name == "Function2");
+        }
+        else
+        {
+            Assert.Null(config.Functions);
+        }
+    }
+
     [Fact]
     public void ItShouldAllowAutoInvocationByDefault()
     {


### PR DESCRIPTION
### Motivation and Context
To fully finalize the new function-calling model, we need a mechanism to prevent endless invocation of **required** functions by AI models. Until this mechanism is in place, and to expedite the release of the new function-calling model, it makes sense to align its behavior with that of the current model. Specifically, required functions should be advertised only in the initial request to the model and not in subsequent requests, to prevent endless function calls by the model.

### Description
This PR modifies the `RequiredFunctionChoiceBehavior` class to advertise functions only in the first request to the model and not in subsequent requests of the same interaction with AI connector.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: