### PR TITLE
.Net: Update samples to use new function calling model

### DIFF
--- a/dotnet/samples/Concepts/Agents/ChatCompletion_FunctionTermination.cs
+++ b/dotnet/samples/Concepts/Agents/ChatCompletion_FunctionTermination.cs
@@ -23,7 +23,7 @@ public class ChatCompletion_FunctionTermination(ITestOutputHelper output) : Base
             {
                 Instructions = "Answer questions about the menu.",
                 Kernel = CreateKernelWithFilter(),
-                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions }),
+                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
             };
 
         KernelPlugin plugin = KernelPluginFactory.CreateFromType<MenuPlugin>();
@@ -76,7 +76,7 @@ public class ChatCompletion_FunctionTermination(ITestOutputHelper output) : Base
             {
                 Instructions = "Answer questions about the menu.",
                 Kernel = CreateKernelWithFilter(),
-                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions }),
+                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
             };
 
         KernelPlugin plugin = KernelPluginFactory.CreateFromType<MenuPlugin>();

--- a/dotnet/samples/Concepts/Agents/ChatCompletion_Streaming.cs
+++ b/dotnet/samples/Concepts/Agents/ChatCompletion_Streaming.cs
@@ -49,7 +49,7 @@ public class ChatCompletion_Streaming(ITestOutputHelper output) : BaseAgentsTest
                 Name = "Host",
                 Instructions = MenuInstructions,
                 Kernel = this.CreateKernelWithChatCompletion(),
-                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions }),
+                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
             };
 
         // Initialize plugin and add to the agent's Kernel (same as direct Kernel usage).

--- a/dotnet/samples/Concepts/Agents/ComplexChat_NestedShopper.cs
+++ b/dotnet/samples/Concepts/Agents/ComplexChat_NestedShopper.cs
@@ -97,7 +97,7 @@ public class ComplexChat_NestedShopper(ITestOutputHelper output) : BaseAgentsTes
         Console.WriteLine($"! {Model}");
 
         OpenAIPromptExecutionSettings jsonSettings = new() { ResponseFormat = ChatResponseFormat.JsonObject };
-        OpenAIPromptExecutionSettings autoInvokeSettings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings autoInvokeSettings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         ChatCompletionAgent internalLeaderAgent = CreateAgent(InternalLeaderName, InternalLeaderInstructions);
         ChatCompletionAgent internalGiftIdeaAgent = CreateAgent(InternalGiftIdeaAgentName, InternalGiftIdeaAgentInstructions);

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionStreaming.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionStreaming.cs
@@ -96,7 +96,7 @@ public class OpenAI_ChatCompletionStreaming(ITestOutputHelper output) : BaseTest
         ]);
 
         // Create execution settings with manual function calling
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.EnableKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
 
         // Create chat history with initial user question
         ChatHistory chatHistory = new();

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_FunctionCalling.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_FunctionCalling.cs
@@ -19,7 +19,7 @@ public sealed class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(
         const string ChatPrompt = """
             <message role="user">What is the weather like in Paris?</message>
         """;
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var chatSemanticFunction = kernel.CreateFunctionFromPrompt(
             ChatPrompt, executionSettings);
         var chatPromptResult = await kernel.InvokeAsync(chatSemanticFunction);
@@ -39,7 +39,7 @@ public sealed class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(
         {
             new ChatMessageContent(AuthorRole.User, "What is the weather like in Paris?")
         };
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result1 = await service.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
         chatHistory.Add(result1);
 
@@ -60,7 +60,7 @@ public sealed class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(
         const string ChatPrompt = """
             <message role="user">Book a holiday for me from 6th June 2025 to 20th June 2025?</message>
         """;
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var chatSemanticFunction = kernel.CreateFunctionFromPrompt(
             ChatPrompt, executionSettings);
         var chatPromptResult = await kernel.InvokeAsync(chatSemanticFunction);
@@ -79,7 +79,7 @@ public sealed class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(
         const string ChatPrompt = """
             <message role="user">Turn on the light?</message>
         """;
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var chatSemanticFunction = kernel.CreateFunctionFromPrompt(
             ChatPrompt, executionSettings);
         var chatPromptResult = await kernel.InvokeAsync(chatSemanticFunction);

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_ReasonedFunctionCalling.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_ReasonedFunctionCalling.cs
@@ -31,7 +31,7 @@ public sealed class OpenAI_ReasonedFunctionCalling(ITestOutputHelper output) : B
         {
             new ChatMessageContent(AuthorRole.User, "What is the weather like in Paris?")
         };
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result1 = await service.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
         chatHistory.Add(result1);
         Console.WriteLine(result1);
@@ -57,7 +57,7 @@ public sealed class OpenAI_ReasonedFunctionCalling(ITestOutputHelper output) : B
         {
             new ChatMessageContent(AuthorRole.User, "What is the weather like in Paris?")
         };
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result = await service.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
         chatHistory.Add(result);
         Console.WriteLine(result);
@@ -78,7 +78,7 @@ public sealed class OpenAI_ReasonedFunctionCalling(ITestOutputHelper output) : B
         string chatPrompt = """
             <message role="user">What is the weather like in Paris?</message>
             """;
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result = await kernel.InvokePromptAsync(chatPrompt, new(executionSettings));
         Console.WriteLine(result);
     }
@@ -100,7 +100,7 @@ public sealed class OpenAI_ReasonedFunctionCalling(ITestOutputHelper output) : B
         {
             new ChatMessageContent(AuthorRole.User, "What is the weather like in Paris?")
         };
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result = await service.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
         chatHistory.Add(result);
         Console.WriteLine(result);
@@ -124,7 +124,7 @@ public sealed class OpenAI_ReasonedFunctionCalling(ITestOutputHelper output) : B
         {
             new ChatMessageContent(AuthorRole.User, "What is the weather like in Paris?")
         };
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result = await service.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
         chatHistory.Add(result);
         Console.WriteLine(result);
@@ -193,7 +193,7 @@ public sealed class OpenAI_ReasonedFunctionCalling(ITestOutputHelper output) : B
             {
                 new ChatMessageContent(AuthorRole.User, $"Provide an explanation why these functions: {string.Join(',', functionNames)} need to be called to answer this query: {message.Content}")
             };
-            var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.EnableKernelFunctions };
+            var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
             var result = await service.GetChatMessageContentAsync(chatHistory, executionSettings, context.Kernel);
             this._output.WriteLine(result);
 

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_RepeatedFunctionCalling.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_RepeatedFunctionCalling.cs
@@ -28,7 +28,7 @@ public sealed class OpenAI_RepeatedFunctionCalling(ITestOutputHelper output) : B
         {
             new ChatMessageContent(AuthorRole.User, "What is the weather like in Boston?")
         };
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         var result1 = await service.GetChatMessageContentAsync(chatHistory, executionSettings, kernel);
         chatHistory.Add(result1);
         Console.WriteLine(result1);

--- a/dotnet/samples/Concepts/Filtering/AutoFunctionInvocationFiltering.cs
+++ b/dotnet/samples/Concepts/Filtering/AutoFunctionInvocationFiltering.cs
@@ -29,7 +29,7 @@ public class AutoFunctionInvocationFiltering(ITestOutputHelper output) : BaseTes
 
         var executionSettings = new OpenAIPromptExecutionSettings
         {
-            ToolCallBehavior = ToolCallBehavior.RequireFunction(function.Metadata.ToOpenAIFunction(), autoInvoke: true)
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Required([function], autoInvoke: true)
         };
 
         var result = await kernel.InvokePromptAsync("Invoke provided function and return result", new(executionSettings));
@@ -76,7 +76,7 @@ public class AutoFunctionInvocationFiltering(ITestOutputHelper output) : BaseTes
 
         var executionSettings = new OpenAIPromptExecutionSettings
         {
-            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
         };
 
         await foreach (var chunk in kernel.InvokePromptStreamingAsync("Check current UTC time and return current weather in Boston city.", new(executionSettings)))

--- a/dotnet/samples/Concepts/Filtering/TelemetryWithFilters.cs
+++ b/dotnet/samples/Concepts/Filtering/TelemetryWithFilters.cs
@@ -57,7 +57,7 @@ public class TelemetryWithFilters(ITestOutputHelper output) : BaseTest(output)
         // Enable automatic function calling.
         var executionSettings = new OpenAIPromptExecutionSettings
         {
-            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
             ModelId = "gpt-4"
         };
 

--- a/dotnet/samples/Concepts/FunctionCalling/OpenAI_FunctionCalling.cs
+++ b/dotnet/samples/Concepts/FunctionCalling/OpenAI_FunctionCalling.cs
@@ -37,7 +37,7 @@ public class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
 
         Kernel kernel = CreateKernel();
 
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         Console.WriteLine(await kernel.InvokePromptAsync("Given the current time of day and weather, what is the likely color of the sky in Boston?", new(settings)));
     }
@@ -52,7 +52,7 @@ public class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
 
         Kernel kernel = CreateKernel();
 
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         await foreach (StreamingKernelContent update in kernel.InvokePromptStreamingAsync("Given the current time of day and weather, what is the likely color of the sky in Boston?", new(settings)))
         {
@@ -74,7 +74,7 @@ public class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
         IChatCompletionService chat = kernel.GetRequiredService<IChatCompletionService>();
 
         // Configure the chat service to enable manual function calling
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.EnableKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
 
         // Create chat history with the initial user message
         ChatHistory chatHistory = new();
@@ -137,7 +137,7 @@ public class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
         IChatCompletionService chat = kernel.GetRequiredService<IChatCompletionService>();
 
         // Configure the chat service to enable manual function calling
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.EnableKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
 
         // Create chat history with the initial user message
         ChatHistory chatHistory = new();
@@ -204,7 +204,7 @@ public class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
 
         IChatCompletionService chat = kernel.GetRequiredService<IChatCompletionService>();
 
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.EnableKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) };
 
         ChatHistory chatHistory = new();
         chatHistory.AddUserMessage("Given the current time of day and weather, what is the likely color of the sky in Boston?");
@@ -254,7 +254,7 @@ public class OpenAI_FunctionCalling(ITestOutputHelper output) : BaseTest(output)
 
         Kernel kernel = CreateKernel();
 
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         IChatCompletionService chat = kernel.GetRequiredService<IChatCompletionService>();
         ChatHistory chatHistory = new();
         int iteration = 0;

--- a/dotnet/samples/Concepts/Planners/AutoFunctionCallingPlanning.cs
+++ b/dotnet/samples/Concepts/Planners/AutoFunctionCallingPlanning.cs
@@ -54,7 +54,7 @@ public class AutoFunctionCallingPlanning(ITestOutputHelper output) : BaseTest(ou
         // 1.2 Plan execution using Auto Function Calling.
         var functionCallingChatHistory = new ChatHistory();
         var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         functionCallingChatHistory.AddUserMessage(Goal);
 
@@ -88,7 +88,7 @@ public class AutoFunctionCallingPlanning(ITestOutputHelper output) : BaseTest(ou
     {
         var kernel = GetKernel();
 
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         // If result is the only thing that is needed without generated plan, it's possible to create and execute a plan using Kernel object.
         var kernelResult = await kernel.InvokePromptAsync(Goal, new(executionSettings));
@@ -119,7 +119,7 @@ public class AutoFunctionCallingPlanning(ITestOutputHelper output) : BaseTest(ou
     {
         var kernel = GetKernel(enableLogging: true);
 
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         var result = await kernel.InvokePromptAsync(Goal, new(executionSettings));
 
@@ -161,7 +161,7 @@ public class AutoFunctionCallingPlanning(ITestOutputHelper output) : BaseTest(ou
     public async Task PlanCachingForReusabilityAsync()
     {
         var kernel = GetKernel();
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         // Wrap chat completion service from Kernel in caching decorator.
         var chatCompletionService = new CachedChatCompletionService(kernel.GetRequiredService<IChatCompletionService>());
@@ -204,7 +204,7 @@ public class AutoFunctionCallingPlanning(ITestOutputHelper output) : BaseTest(ou
 
         kernel.FunctionInvocationFilters.Add(new PlanExecutionFilter());
 
-        var executionSettings = new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        var executionSettings = new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         var result = await kernel.InvokePromptAsync(Goal, new(executionSettings));
 

--- a/dotnet/samples/Concepts/Plugins/TransformPlugin.cs
+++ b/dotnet/samples/Concepts/Plugins/TransformPlugin.cs
@@ -92,7 +92,7 @@ public sealed class TransformPlugin(ITestOutputHelper output) : BaseTest(output)
         Kernel kernel = kernelBuilder.Build();
 
         // Invoke the kernel with a prompt and allow the AI to automatically invoke functions
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         Console.WriteLine(await kernel.InvokePromptAsync("What is my favourite color?", new(settings)));
 
         // Example response
@@ -121,7 +121,7 @@ public sealed class TransformPlugin(ITestOutputHelper output) : BaseTest(output)
         Kernel kernel = kernelBuilder.Build();
 
         // Invoke the kernel with a prompt and allow the AI to automatically invoke functions
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         Console.WriteLine(await kernel.InvokePromptAsync("What is my favourite color?", new(settings)));
         Console.WriteLine(await kernel.InvokePromptAsync("What is my favourite cold-blooded animal?", new(settings)));
         Console.WriteLine(await kernel.InvokePromptAsync("What is my favourite marine animal?", new(settings)));

--- a/dotnet/samples/Demos/BookingRestaurant/BookingRestaurant.csproj
+++ b/dotnet/samples/Demos/BookingRestaurant/BookingRestaurant.csproj
@@ -6,7 +6,7 @@
     <RootNamespace></RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);CA2007;VSTHRD111</NoWarn>
+    <NoWarn>$(NoWarn);CA2007;VSTHRD111;SKEXP0001</NoWarn>
     <UserSecretsId>c478d0b2-7145-4d1a-9600-3130c04085cd</UserSecretsId>
   </PropertyGroup>
 

--- a/dotnet/samples/Demos/BookingRestaurant/Program.cs
+++ b/dotnet/samples/Demos/BookingRestaurant/Program.cs
@@ -106,7 +106,7 @@ while (true)
     // Enable auto function calling
     var executionSettings = new OpenAIPromptExecutionSettings
     {
-        ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
     };
 
     // Get the result from the AI

--- a/dotnet/samples/Demos/CodeInterpreterPlugin/CodeInterpreterPlugin.csproj
+++ b/dotnet/samples/Demos/CodeInterpreterPlugin/CodeInterpreterPlugin.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
   </PropertyGroup>
 

--- a/dotnet/samples/Demos/CodeInterpreterPlugin/Program.cs
+++ b/dotnet/samples/Demos/CodeInterpreterPlugin/Program.cs
@@ -97,7 +97,7 @@ while (true)
     fullAssistantContent.Clear();
     await foreach (var content in chatCompletion.GetStreamingChatMessageContentsAsync(
         chatHistory,
-        new OpenAIPromptExecutionSettings { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions },
+        new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() },
         kernel)
         .ConfigureAwait(false))
     {

--- a/dotnet/samples/Demos/CreateChatGptPlugin/Solution/CreateChatGptPlugin.csproj
+++ b/dotnet/samples/Demos/CreateChatGptPlugin/Solution/CreateChatGptPlugin.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <NoWarn>$(NoWarn);SKEXP0040</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0040;SKEXP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/Demos/CreateChatGptPlugin/Solution/Program.cs
+++ b/dotnet/samples/Demos/CreateChatGptPlugin/Solution/Program.cs
@@ -34,7 +34,7 @@ while (true)
     // Enable auto function calling
     OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
     {
-        ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
     };
 
     // Get the response from the AI

--- a/dotnet/samples/Demos/FunctionInvocationApproval/Program.cs
+++ b/dotnet/samples/Demos/FunctionInvocationApproval/Program.cs
@@ -37,7 +37,7 @@ internal sealed class Program
         var executionSettings = new OpenAIPromptExecutionSettings
         {
             Temperature = 0,
-            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
         };
 
         // Initialize kernel arguments.

--- a/dotnet/samples/Demos/HomeAutomation/HomeAutomation.csproj
+++ b/dotnet/samples/Demos/HomeAutomation/HomeAutomation.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-    <NoWarn>$(NoWarn);CA2007,CA2208,CS1591,IDE0009,IDE0055,IDE0073,VSTHRD111</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA2208,CS1591,IDE0009,IDE0055,IDE0073,VSTHRD111,SKEXP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/Demos/HomeAutomation/Worker.cs
+++ b/dotnet/samples/Demos/HomeAutomation/Worker.cs
@@ -26,7 +26,7 @@ internal sealed class Worker(
         // Enable auto function calling
         OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
         {
-            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
         };
 
         Console.WriteLine("Ask questions or give instructions to the copilot such as:\n" +

--- a/dotnet/samples/Demos/StepwisePlannerMigration/Controllers/AutoFunctionCallingController.cs
+++ b/dotnet/samples/Demos/StepwisePlannerMigration/Controllers/AutoFunctionCallingController.cs
@@ -48,7 +48,7 @@ public class AutoFunctionCallingController : ControllerBase
         ChatHistory chatHistory = [];
         chatHistory.AddUserMessage(request.Goal);
 
-        OpenAIPromptExecutionSettings executionSettings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings executionSettings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, executionSettings, this._kernel);
 
@@ -62,7 +62,7 @@ public class AutoFunctionCallingController : ControllerBase
     [HttpPost, Route("execute-new-plan")]
     public async Task<IActionResult> ExecuteNewPlanAsync(PlanRequest request)
     {
-        OpenAIPromptExecutionSettings executionSettings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings executionSettings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         FunctionResult result = await this._kernel.InvokePromptAsync(request.Goal, new(executionSettings));
 
@@ -77,7 +77,7 @@ public class AutoFunctionCallingController : ControllerBase
     public async Task<IActionResult> ExecuteExistingPlanAsync()
     {
         ChatHistory chatHistory = this._planProvider.GetPlan("auto-function-calling-plan.json");
-        OpenAIPromptExecutionSettings executionSettings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings executionSettings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         ChatMessageContent result = await this._chatCompletionService.GetChatMessageContentAsync(chatHistory, executionSettings, this._kernel);
 

--- a/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/Program.cs
@@ -323,7 +323,7 @@ public sealed class Program
                         AzureOpenAIServiceKey => new OpenAIPromptExecutionSettings()
                         {
                             Temperature = 0,
-                            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+                            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
                         },
                         GoogleAIGeminiServiceKey => new GeminiPromptExecutionSettings()
                         {

--- a/dotnet/samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj
+++ b/dotnet/samples/Demos/TelemetryWithAppInsights/TelemetryWithAppInsights.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress: "Declare types in namespaces", "Require ConfigureAwait" -->
-    <NoWarn>$(NoWarn);CA1024;CA1050;CA1707;CA2007;CS1591;VSTHRD111,SKEXP0050,SKEXP0060,SKEXP0070</NoWarn>
+    <NoWarn>$(NoWarn);CA1024;CA1050;CA1707;CA2007;CS1591;VSTHRD111,SKEXP0050,SKEXP0060,SKEXP0070,SKEXP0001</NoWarn>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
   </PropertyGroup>
 

--- a/dotnet/samples/Demos/TimePlugin/Program.cs
+++ b/dotnet/samples/Demos/TimePlugin/Program.cs
@@ -31,7 +31,7 @@ var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
 // Enable auto function calling
 OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
 {
-    ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
 };
 
 Console.WriteLine("Ask questions to use the Time Plugin such as:\n" +

--- a/dotnet/samples/Demos/TimePlugin/TimePlugin.csproj
+++ b/dotnet/samples/Demos/TimePlugin/TimePlugin.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
+    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/GettingStarted/Step2_Add_Plugins.cs
+++ b/dotnet/samples/GettingStarted/Step2_Add_Plugins.cs
@@ -35,7 +35,7 @@ public sealed class Step2_Add_Plugins(ITestOutputHelper output) : BaseTest(outpu
         Console.WriteLine(await kernel.InvokePromptAsync("The current time is {{TimeInformation.GetCurrentUtcTime}}. How many days until Christmas?"));
 
         // Example 3. Invoke the kernel with a prompt and allow the AI to automatically invoke functions
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas? Explain your thinking.", new(settings)));
 
         // Example 4. Invoke the kernel with a prompt and allow the AI to automatically invoke functions that use enumerations

--- a/dotnet/samples/GettingStarted/Step7_Observability.cs
+++ b/dotnet/samples/GettingStarted/Step7_Observability.cs
@@ -33,7 +33,7 @@ public sealed class Step7_Observability(ITestOutputHelper output) : BaseTest(out
         kernel.PromptRenderFilters.Add(new MyPromptFilter(this.Output));
 
         // Invoke the kernel with a prompt and allow the AI to automatically invoke functions
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas? Explain your thinking.", new(settings)));
     }
 
@@ -88,7 +88,7 @@ public sealed class Step7_Observability(ITestOutputHelper output) : BaseTest(out
         kernel.FunctionInvoked += MyInvokedHandler;
 
         // Invoke the kernel with a prompt and allow the AI to automatically invoke functions
-        OpenAIPromptExecutionSettings settings = new() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
+        OpenAIPromptExecutionSettings settings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
         Console.WriteLine(await kernel.InvokePromptAsync("How many days until Christmas? Explain your thinking.", new(settings)));
     }
 

--- a/dotnet/samples/GettingStartedWithAgents/Step02_Plugins.cs
+++ b/dotnet/samples/GettingStartedWithAgents/Step02_Plugins.cs
@@ -26,7 +26,7 @@ public class Step02_Plugins(ITestOutputHelper output) : BaseAgentsTest(output)
                 Instructions = HostInstructions,
                 Name = HostName,
                 Kernel = this.CreateKernelWithChatCompletion(),
-                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions }),
+                Arguments = new KernelArguments(new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
             };
 
         // Initialize plugin and add to the agent's Kernel (same as direct Kernel usage).

--- a/dotnet/samples/LearnResources/MicrosoftLearn/CreatingFunctions.cs
+++ b/dotnet/samples/LearnResources/MicrosoftLearn/CreatingFunctions.cs
@@ -62,7 +62,7 @@ public class CreatingFunctions(ITestOutputHelper output) : LearnBaseTest(["What 
             // Enable auto function calling
             OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
             {
-                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
             };
 
             // Get the response from the AI

--- a/dotnet/samples/LearnResources/MicrosoftLearn/Planner.cs
+++ b/dotnet/samples/LearnResources/MicrosoftLearn/Planner.cs
@@ -56,7 +56,7 @@ public class Planner(ITestOutputHelper output) : LearnBaseTest(output)
             // Enable auto function calling
             OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
             {
-                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
             };
 
             // Get the response from the AI

--- a/dotnet/samples/LearnResources/MicrosoftLearn/Plugin.cs
+++ b/dotnet/samples/LearnResources/MicrosoftLearn/Plugin.cs
@@ -59,7 +59,7 @@ public class Plugin(ITestOutputHelper output) : LearnBaseTest([
             // Enable auto function calling
             OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
             {
-                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
             };
 
             // Get the response from the AI

--- a/dotnet/src/Agents/Core/ChatCompletionAgent.cs
+++ b/dotnet/src/Agents/Core/ChatCompletionAgent.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Agents;
 /// A <see cref="KernelAgent"/> specialization based on <see cref="IChatCompletionService"/>.
 /// </summary>
 /// <remarks>
-/// NOTE: Enable OpenAIPromptExecutionSettings.ToolCallBehavior for agent plugins.
+/// NOTE: Enable OpenAIPromptExecutionSettings.FunctionChoiceBehavior for agent plugins.
 /// (<see cref="ChatHistoryKernelAgent.Arguments"/>)
 /// </remarks>
 public sealed class ChatCompletionAgent : ChatHistoryKernelAgent

--- a/dotnet/src/Agents/Core/ChatHistoryKernelAgent.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryKernelAgent.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Agents;
 /// A <see cref="KernelAgent"/> specialization bound to a <see cref="ChatHistoryChannel"/>.
 /// </summary>
 /// <remarks>
-/// NOTE: Enable OpenAIPromptExecutionSettings.ToolCallBehavior for agent plugins.
+/// NOTE: Enable OpenAIPromptExecutionSettings.FunctionChoiceBehavior for agent plugins.
 /// (<see cref="ChatHistoryKernelAgent.Arguments"/>)
 /// </remarks>
 public abstract class ChatHistoryKernelAgent : KernelAgent

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -577,13 +577,13 @@ internal partial class ClientCore
 
         foreach (var message in chatHistory)
         {
-            messages.AddRange(CreateRequestMessages(message, executionSettings.ToolCallBehavior));
+            messages.AddRange(CreateRequestMessages(message));
         }
 
         return messages;
     }
 
-    private static List<ChatMessage> CreateRequestMessages(ChatMessageContent message, ToolCallBehavior? toolCallBehavior)
+    private static List<ChatMessage> CreateRequestMessages(ChatMessageContent message)
     {
         if (message.Role == AuthorRole.System)
         {


### PR DESCRIPTION
### Motivation and Context
With the upcoming release of the new function calling model, we need to update all the samples that use the current model to use the new one so that new SK consumers start using it until all required assets - blog posts and official documentation are in place.

### Description
This PR updates all the samples and demo apps to use the new function calling model instead of the current one. Additionally, it removes an unused parameter from one of the methods of the OpenAIConnector and updates the FunctionCallingStepwisePlanner code to avoid using the obsolete ToolCallResultSerializerOptions property that does not exist in the new model.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: