### PR TITLE
.Net: Add SK user agent string for Azure Cosmos DB NoSQL and MongoDB.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBKernelBuilderExtensionsTests.cs
@@ -23,14 +23,7 @@ public sealed class AzureCosmosDBMongoDBKernelBuilderExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        var mongoClientSettings = new MongoClientSettings();
-        var mongoClient = new Mock<IMongoClient>();
-        var databaseMock = new Mock<IMongoDatabase>();
-
-        mongoClient.SetupGet(c => c.Settings).Returns(mongoClientSettings);
-        databaseMock.SetupGet(d => d.Client).Returns(mongoClient.Object);
-
-        this._kernelBuilder.Services.AddSingleton<IMongoDatabase>(databaseMock.Object);
+        this._kernelBuilder.Services.AddSingleton<IMongoDatabase>(Mock.Of<IMongoDatabase>());
 
         // Act
         this._kernelBuilder.AddAzureCosmosDBMongoDBVectorStore();
@@ -41,7 +34,6 @@ public sealed class AzureCosmosDBMongoDBKernelBuilderExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBMongoDBVectorStore>(vectorStore);
-        Assert.Equal(HttpHeaderConstant.Values.UserAgent, mongoClientSettings.ApplicationName);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBServiceCollectionExtensionsTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Http;
 using MongoDB.Driver;
 using Moq;
 using Xunit;
@@ -21,7 +23,14 @@ public sealed class AzureCosmosDBMongoDBServiceCollectionExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        this._serviceCollection.AddSingleton<IMongoDatabase>(Mock.Of<IMongoDatabase>());
+        var mongoClientSettings = new MongoClientSettings();
+        var mongoClient = new Mock<IMongoClient>();
+        var databaseMock = new Mock<IMongoDatabase>();
+
+        mongoClient.SetupGet(c => c.Settings).Returns(mongoClientSettings);
+        databaseMock.SetupGet(d => d.Client).Returns(mongoClient.Object);
+
+        this._serviceCollection.AddSingleton<IMongoDatabase>(databaseMock.Object);
 
         // Act
         this._serviceCollection.AddAzureCosmosDBMongoDBVectorStore();
@@ -32,5 +41,23 @@ public sealed class AzureCosmosDBMongoDBServiceCollectionExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBMongoDBVectorStore>(vectorStore);
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, mongoClientSettings.ApplicationName);
+    }
+
+    [Fact]
+    public void AddVectorStoreWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._serviceCollection.AddAzureCosmosDBMongoDBVectorStore("mongodb://localhost:27017", "mydb");
+
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
+
+        // Assert
+        Assert.NotNull(vectorStore);
+        Assert.IsType<AzureCosmosDBMongoDBVectorStore>(vectorStore);
+
+        var database = (IMongoDatabase)vectorStore.GetType().GetField("_mongoDatabase", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.Settings.ApplicationName);
     }
 }

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBServiceCollectionExtensionsTests.cs
@@ -23,14 +23,7 @@ public sealed class AzureCosmosDBMongoDBServiceCollectionExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        var mongoClientSettings = new MongoClientSettings();
-        var mongoClient = new Mock<IMongoClient>();
-        var databaseMock = new Mock<IMongoDatabase>();
-
-        mongoClient.SetupGet(c => c.Settings).Returns(mongoClientSettings);
-        databaseMock.SetupGet(d => d.Client).Returns(mongoClient.Object);
-
-        this._serviceCollection.AddSingleton<IMongoDatabase>(databaseMock.Object);
+        this._serviceCollection.AddSingleton<IMongoDatabase>(Mock.Of<IMongoDatabase>());
 
         // Act
         this._serviceCollection.AddAzureCosmosDBMongoDBVectorStore();
@@ -41,7 +34,6 @@ public sealed class AzureCosmosDBMongoDBServiceCollectionExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBMongoDBVectorStore>(vectorStore);
-        Assert.Equal(HttpHeaderConstant.Values.UserAgent, mongoClientSettings.ApplicationName);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
@@ -23,14 +23,7 @@ public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        var cosmosClientOptions = new CosmosClientOptions();
-        var cosmosClientMock = new Mock<CosmosClient>();
-        var databaseMock = new Mock<Database>();
-
-        cosmosClientMock.SetupGet(c => c.ClientOptions).Returns(cosmosClientOptions);
-        databaseMock.SetupGet(d => d.Client).Returns(cosmosClientMock.Object);
-
-        this._kernelBuilder.Services.AddSingleton<Database>(databaseMock.Object);
+        this._kernelBuilder.Services.AddSingleton<Database>(Mock.Of<Database>());
 
         // Act
         this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStore();
@@ -41,7 +34,6 @@ public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBNoSQLVectorStore>(vectorStore);
-        Assert.Equal(HttpHeaderConstant.Values.UserAgent, cosmosClientOptions.ApplicationName);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Reflection;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Http;
 using Moq;
 using Xunit;
 
@@ -21,7 +23,14 @@ public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        this._kernelBuilder.Services.AddSingleton<Database>(Mock.Of<Database>());
+        var cosmosClientOptions = new CosmosClientOptions();
+        var cosmosClientMock = new Mock<CosmosClient>();
+        var databaseMock = new Mock<Database>();
+
+        cosmosClientMock.SetupGet(c => c.ClientOptions).Returns(cosmosClientOptions);
+        databaseMock.SetupGet(d => d.Client).Returns(cosmosClientMock.Object);
+
+        this._kernelBuilder.Services.AddSingleton<Database>(databaseMock.Object);
 
         // Act
         this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStore();
@@ -32,5 +41,22 @@ public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBNoSQLVectorStore>(vectorStore);
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, cosmosClientOptions.ApplicationName);
+    }
+
+    [Fact]
+    public void AddVectorStoreWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStore("AccountEndpoint=https://test.documents.azure.com:443/;AccountKey=mock;", "mydb");
+
+        var kernel = this._kernelBuilder.Build();
+        var vectorStore = kernel.Services.GetRequiredService<IVectorStore>();
+
+        // Assert
+        Assert.NotNull(vectorStore);
+        Assert.IsType<AzureCosmosDBNoSQLVectorStore>(vectorStore);
+        var database = (Database)vectorStore.GetType().GetField("_database", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.ClientOptions.ApplicationName);
     }
 }

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
@@ -23,14 +23,7 @@ public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        var cosmosClientOptions = new CosmosClientOptions();
-        var cosmosClientMock = new Mock<CosmosClient>();
-        var databaseMock = new Mock<Database>();
-
-        cosmosClientMock.SetupGet(c => c.ClientOptions).Returns(cosmosClientOptions);
-        databaseMock.SetupGet(d => d.Client).Returns(cosmosClientMock.Object);
-
-        this._serviceCollection.AddSingleton<Database>(databaseMock.Object);
+        this._serviceCollection.AddSingleton<Database>(Mock.Of<Database>());
 
         // Act
         this._serviceCollection.AddAzureCosmosDBNoSQLVectorStore();
@@ -41,7 +34,6 @@ public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBNoSQLVectorStore>(vectorStore);
-        Assert.Equal(HttpHeaderConstant.Values.UserAgent, cosmosClientOptions.ApplicationName);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Reflection;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Http;
 using Moq;
 using Xunit;
 
@@ -21,7 +23,14 @@ public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
     public void AddVectorStoreRegistersClass()
     {
         // Arrange
-        this._serviceCollection.AddSingleton<Database>(Mock.Of<Database>());
+        var cosmosClientOptions = new CosmosClientOptions();
+        var cosmosClientMock = new Mock<CosmosClient>();
+        var databaseMock = new Mock<Database>();
+
+        cosmosClientMock.SetupGet(c => c.ClientOptions).Returns(cosmosClientOptions);
+        databaseMock.SetupGet(d => d.Client).Returns(cosmosClientMock.Object);
+
+        this._serviceCollection.AddSingleton<Database>(databaseMock.Object);
 
         // Act
         this._serviceCollection.AddAzureCosmosDBNoSQLVectorStore();
@@ -32,5 +41,22 @@ public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureCosmosDBNoSQLVectorStore>(vectorStore);
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, cosmosClientOptions.ApplicationName);
+    }
+
+    [Fact]
+    public void AddVectorStoreWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._serviceCollection.AddAzureCosmosDBNoSQLVectorStore("AccountEndpoint=https://test.documents.azure.com:443/;AccountKey=mock;", "mydb");
+
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
+
+        // Assert
+        Assert.NotNull(vectorStore);
+        Assert.IsType<AzureCosmosDBNoSQLVectorStore>(vectorStore);
+        var database = (Database)vectorStore.GetType().GetField("_database", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.ClientOptions.ApplicationName);
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
@@ -35,12 +35,6 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
                 var database = sp.GetRequiredService<IMongoDatabase>();
                 var selectedOptions = options ?? sp.GetService<AzureCosmosDBMongoDBVectorStoreOptions>();
 
-                // Set the user agent string on the client (if not already set)
-                if (database.Client.Settings.ApplicationName == null)
-                {
-                    database.Client.Settings.ApplicationName = HttpHeaderConstant.Values.UserAgent;
-                }
-
                 return new AzureCosmosDBMongoDBVectorStore(database, options);
             });
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Http;
 using MongoDB.Driver;
 
 namespace Microsoft.SemanticKernel;
@@ -34,6 +35,12 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
                 var database = sp.GetRequiredService<IMongoDatabase>();
                 var selectedOptions = options ?? sp.GetService<AzureCosmosDBMongoDBVectorStoreOptions>();
 
+                // Set the user agent string on the client (if not already set)
+                if (database.Client.Settings.ApplicationName == null)
+                {
+                    database.Client.Settings.ApplicationName = HttpHeaderConstant.Values.UserAgent;
+                }
+
                 return new AzureCosmosDBMongoDBVectorStore(database, options);
             });
 
@@ -64,6 +71,8 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
             (sp, obj) =>
             {
                 var settings = MongoClientSettings.FromConnectionString(connectionString);
+                settings.ApplicationName = HttpHeaderConstant.Values.UserAgent;
+
                 var mongoClient = new MongoClient(settings);
                 var database = mongoClient.GetDatabase(databaseName);
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
@@ -36,12 +36,6 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
                 var database = sp.GetRequiredService<Database>();
                 var selectedOptions = options ?? sp.GetService<AzureCosmosDBNoSQLVectorStoreOptions>();
 
-                // Set the user agent string on the client (if not already set)
-                if (database.Client.ClientOptions.ApplicationName == null)
-                {
-                    database.Client.ClientOptions.ApplicationName = HttpHeaderConstant.Values.UserAgent;
-                }
-
                 return new AzureCosmosDBNoSQLVectorStore(database, options);
             });
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 using Microsoft.SemanticKernel.Data;
+using Microsoft.SemanticKernel.Http;
 
 namespace Microsoft.SemanticKernel;
 
@@ -34,6 +35,13 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
             {
                 var database = sp.GetRequiredService<Database>();
                 var selectedOptions = options ?? sp.GetService<AzureCosmosDBNoSQLVectorStoreOptions>();
+
+                // Set the user agent string on the client (if not already set)
+                if (database.Client.ClientOptions.ApplicationName == null)
+                {
+                    database.Client.ClientOptions.ApplicationName = HttpHeaderConstant.Values.UserAgent;
+                }
+
                 return new AzureCosmosDBNoSQLVectorStore(database, options);
             });
 
@@ -64,11 +72,13 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
             {
                 var cosmosClient = new CosmosClient(connectionString, new()
                 {
+                    ApplicationName = HttpHeaderConstant.Values.UserAgent,
                     Serializer = new CosmosSystemTextJsonSerializer(options?.JsonSerializerOptions ?? JsonSerializerOptions.Default)
                 });
 
                 var database = cosmosClient.GetDatabase(databaseName);
                 var selectedOptions = options ?? sp.GetService<AzureCosmosDBNoSQLVectorStoreOptions>();
+
                 return new AzureCosmosDBNoSQLVectorStore(database, options);
             });
 


### PR DESCRIPTION
### Motivation and Context

Set a default user agent string of semantic kernel for Azure Cosmos DB NoSQL and MongoDB.

#7580 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
