### PR TITLE
.Net:  Exception handling consistency for `FunctionCallContent` class.

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/FunctionCallContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/FunctionCallContent.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Represents a function call requested by LLM.
+/// Represents a function call requested by AI model.
 /// </summary>
 [Experimental("SKEXP0001")]
 public sealed class FunctionCallContent : KernelContent
@@ -40,7 +40,7 @@ public sealed class FunctionCallContent : KernelContent
     public KernelArguments? Arguments { get; }
 
     /// <summary>
-    /// The exception that occurred while mapping original LLM function call to the model class.
+    /// The exception that occurred while mapping original AI model function call to the model class.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Exception? Exception { get; init; }
@@ -75,7 +75,7 @@ public sealed class FunctionCallContent : KernelContent
 
         if (this.Exception is not null)
         {
-            return new FunctionResultContent(this, this.Exception.Message);
+            throw this.Exception;
         }
 
         if (kernel.Plugins.TryGetFunction(this.PluginName, this.FunctionName, out KernelFunction? function))

--- a/dotnet/src/SemanticKernel.UnitTests/Contents/FunctionCallContentTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Contents/FunctionCallContentTests.cs
@@ -70,11 +70,10 @@ public class FunctionCallContentTests
         };
 
         // Act
-        var resultContent = await sut.InvokeAsync(kernel);
+        var exception = await Assert.ThrowsAsync<JsonException>(() => sut.InvokeAsync(kernel));
 
         // Assert
-        Assert.NotNull(resultContent);
-        Assert.Equal("Error: Function call arguments were invalid JSON.", resultContent.Result);
+        Assert.Equal("Error: Function call arguments were invalid JSON.", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation and Context  
The `FunctionCallContent.InvokeAsync` method throws exceptions in two cases: if the function invocation fails or the function is not found. However, it does not throw exceptions captured in the `Exception` property that might occur while mapping the function call represented by the AI connector-specific function call model to the connector-agnostic `FunctionCallContent` model class.  
   
This introduces inconsistency in the way exceptions are handled by the `FunctionCallContent.InvokeAsync` method and may lead to intermittent failures in the calling code that are difficult to troubleshoot and identify the root cause of.

### Description
This PR throws the function call mapping exception captured by the `Exception` property.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile: