### PR TITLE
.Net: VectorStore: Adding a generic data model and related azure ai search mapper.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchGenericDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchGenericDataModelMapperTests.cs
@@ -1,0 +1,232 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Connectors.AzureAISearch;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace SemanticKernel.Connectors.AzureAISearch.UnitTests;
+
+/// <summary>
+/// Tests for the <see cref="AzureAISearchGenericDataModelMapper"/> class.
+/// </summary>
+public class AzureAISearchGenericDataModelMapperTests
+{
+    private static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+            new VectorStoreRecordDataProperty("IntDataProp", typeof(int)),
+            new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+            new VectorStoreRecordDataProperty("LongDataProp", typeof(long)),
+            new VectorStoreRecordDataProperty("NullableLongDataProp", typeof(long?)),
+            new VectorStoreRecordDataProperty("FloatDataProp", typeof(float)),
+            new VectorStoreRecordDataProperty("NullableFloatDataProp", typeof(float?)),
+            new VectorStoreRecordDataProperty("DoubleDataProp", typeof(double)),
+            new VectorStoreRecordDataProperty("NullableDoubleDataProp", typeof(double?)),
+            new VectorStoreRecordDataProperty("BoolDataProp", typeof(bool)),
+            new VectorStoreRecordDataProperty("NullableBoolDataProp", typeof(bool?)),
+            new VectorStoreRecordDataProperty("DateTimeOffsetDataProp", typeof(DateTimeOffset)),
+            new VectorStoreRecordDataProperty("NullableDateTimeOffsetDataProp", typeof(DateTimeOffset?)),
+            new VectorStoreRecordDataProperty("TagListDataProp", typeof(string[])),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+        },
+    };
+
+    private static readonly float[] s_vector1 = new float[] { 1.0f, 2.0f, 3.0f };
+    private static readonly float[] s_vector2 = new float[] { 4.0f, 5.0f, 6.0f };
+    private static readonly string[] s_taglist = new string[] { "tag1", "tag2" };
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsAllSupportedTypes()
+    {
+        // Arrange
+        var mapper = new AzureAISearchGenericDataModelMapper(s_vectorStoreRecordDefinition);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringDataProp"] = "string",
+                ["IntDataProp"] = 1,
+                ["NullableIntDataProp"] = 2,
+                ["LongDataProp"] = 3L,
+                ["NullableLongDataProp"] = 4L,
+                ["FloatDataProp"] = 5.0f,
+                ["NullableFloatDataProp"] = 6.0f,
+                ["DoubleDataProp"] = 7.0,
+                ["NullableDoubleDataProp"] = 8.0,
+                ["BoolDataProp"] = true,
+                ["NullableBoolDataProp"] = false,
+                ["DateTimeOffsetDataProp"] = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                ["NullableDateTimeOffsetDataProp"] = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                ["TagListDataProp"] = s_taglist,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = new ReadOnlyMemory<float>(s_vector1),
+                ["NullableFloatVector"] = new ReadOnlyMemory<float>(s_vector2),
+            },
+        };
+
+        // Act
+        var storageModel = mapper.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", (string?)storageModel["Key"]);
+        Assert.Equal("string", (string?)storageModel["StringDataProp"]);
+        Assert.Equal(1, (int?)storageModel["IntDataProp"]);
+        Assert.Equal(2, (int?)storageModel["NullableIntDataProp"]);
+        Assert.Equal(3L, (long?)storageModel["LongDataProp"]);
+        Assert.Equal(4L, (long?)storageModel["NullableLongDataProp"]);
+        Assert.Equal(5.0f, (float?)storageModel["FloatDataProp"]);
+        Assert.Equal(6.0f, (float?)storageModel["NullableFloatDataProp"]);
+        Assert.Equal(7.0, (double?)storageModel["DoubleDataProp"]);
+        Assert.Equal(8.0, (double?)storageModel["NullableDoubleDataProp"]);
+        Assert.Equal(true, (bool?)storageModel["BoolDataProp"]);
+        Assert.Equal(false, (bool?)storageModel["NullableBoolDataProp"]);
+        Assert.Equal(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero), (DateTimeOffset?)storageModel["DateTimeOffsetDataProp"]);
+        Assert.Equal(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero), (DateTimeOffset?)storageModel["NullableDateTimeOffsetDataProp"]);
+        Assert.Equal(s_taglist, storageModel["TagListDataProp"]!.AsArray().Select(x => (string)x!).ToArray());
+        Assert.Equal(s_vector1, storageModel["FloatVector"]!.AsArray().Select(x => (float)x!).ToArray());
+        Assert.Equal(s_vector2, storageModel["NullableFloatVector"]!.AsArray().Select(x => (float)x!).ToArray());
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsNullValues()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+                new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+            },
+        };
+
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringDataProp"] = null,
+                ["NullableIntDataProp"] = null,
+            },
+            Vectors =
+            {
+                ["NullableFloatVector"] = null,
+            },
+        };
+
+        var mapper = new AzureAISearchGenericDataModelMapper(vectorStoreRecordDefinition);
+
+        // Act
+        var storageModel = mapper.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Null(storageModel["StringDataProp"]);
+        Assert.Null(storageModel["NullableIntDataProp"]);
+        Assert.Null(storageModel["NullableFloatVector"]);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsAllSupportedTypes()
+    {
+        // Arrange
+        var mapper = new AzureAISearchGenericDataModelMapper(s_vectorStoreRecordDefinition);
+        var storageModel = new JsonObject();
+        storageModel["Key"] = "key";
+        storageModel["StringDataProp"] = "string";
+        storageModel["IntDataProp"] = 1;
+        storageModel["NullableIntDataProp"] = 2;
+        storageModel["LongDataProp"] = 3L;
+        storageModel["NullableLongDataProp"] = 4L;
+        storageModel["FloatDataProp"] = 5.0f;
+        storageModel["NullableFloatDataProp"] = 6.0f;
+        storageModel["DoubleDataProp"] = 7.0;
+        storageModel["NullableDoubleDataProp"] = 8.0;
+        storageModel["BoolDataProp"] = true;
+        storageModel["NullableBoolDataProp"] = false;
+        storageModel["DateTimeOffsetDataProp"] = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        storageModel["NullableDateTimeOffsetDataProp"] = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        storageModel["TagListDataProp"] = new JsonArray { "tag1", "tag2" };
+        storageModel["FloatVector"] = new JsonArray { 1.0f, 2.0f, 3.0f };
+        storageModel["NullableFloatVector"] = new JsonArray { 4.0f, 5.0f, 6.0f };
+
+        // Act
+        var dataModel = mapper.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal("key", dataModel.Key);
+        Assert.Equal("string", dataModel.Data["StringDataProp"]);
+        Assert.Equal(1, dataModel.Data["IntDataProp"]);
+        Assert.Equal(2, dataModel.Data["NullableIntDataProp"]);
+        Assert.Equal(3L, dataModel.Data["LongDataProp"]);
+        Assert.Equal(4L, dataModel.Data["NullableLongDataProp"]);
+        Assert.Equal(5.0f, dataModel.Data["FloatDataProp"]);
+        Assert.Equal(6.0f, dataModel.Data["NullableFloatDataProp"]);
+        Assert.Equal(7.0, dataModel.Data["DoubleDataProp"]);
+        Assert.Equal(8.0, dataModel.Data["NullableDoubleDataProp"]);
+        Assert.Equal(true, dataModel.Data["BoolDataProp"]);
+        Assert.Equal(false, dataModel.Data["NullableBoolDataProp"]);
+        Assert.Equal(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero), dataModel.Data["DateTimeOffsetDataProp"]);
+        Assert.Equal(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero), dataModel.Data["NullableDateTimeOffsetDataProp"]);
+        Assert.Equal(s_taglist, dataModel.Data["TagListDataProp"]);
+        Assert.Equal(s_vector1, ((ReadOnlyMemory<float>)dataModel.Vectors["FloatVector"]!).ToArray());
+        Assert.Equal(s_vector2, ((ReadOnlyMemory<float>)dataModel.Vectors["NullableFloatVector"]!)!.ToArray());
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsNullValues()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+                new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+            },
+        };
+
+        var storageModel = new JsonObject();
+        storageModel["Key"] = "key";
+        storageModel["StringDataProp"] = null;
+        storageModel["NullableIntDataProp"] = null;
+        storageModel["NullableFloatVector"] = null;
+
+        var mapper = new AzureAISearchGenericDataModelMapper(vectorStoreRecordDefinition);
+
+        // Act
+        var dataModel = mapper.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal("key", dataModel.Key);
+        Assert.Null(dataModel.Data["StringDataProp"]);
+        Assert.Null(dataModel.Data["NullableIntDataProp"]);
+        Assert.Null(dataModel.Vectors["NullableFloatVector"]);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelThrowsForMissingKey()
+    {
+        // Arrange
+        var mapper = new AzureAISearchGenericDataModelMapper(s_vectorStoreRecordDefinition);
+        var storageModel = new JsonObject();
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() => mapper.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true }));
+
+        // Assert
+        Assert.Equal("The key property 'Key' is missing from the record retrieved from storage.", exception.Message);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// <summary>
 /// A mapper that maps between the generic semantic kernel data model and the model that the data is stored in in Azure AI Search.
 /// </summary>
-public class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, JsonObject>
+internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, JsonObject>
 {
     /// <summary>A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</summary>
     private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
@@ -46,7 +46,7 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
             }
             else if (property is VectorStoreRecordDataProperty dataProperty)
             {
-                if (dataModel.Data != null)
+                if (dataModel.Data is not null)
                 {
                     var storagePropertyName = dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName;
                     var serializedJsonNode = JsonSerializer.SerializeToNode(dataModel.Data[dataProperty.DataModelPropertyName]);
@@ -55,7 +55,7 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
             }
             else if (property is VectorStoreRecordVectorProperty vectorProperty)
             {
-                if (dataModel.Vectors != null)
+                if (dataModel.Vectors is not null)
                 {
                     var storagePropertyName = vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName;
 
@@ -76,7 +76,7 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
         // Create variables to store the response properties.
         var dataProperties = new Dictionary<string, object?>();
         var vectorProperties = new Dictionary<string, object?>();
-        string key = string.Empty;
+        string? key = null;
 
         // Loop through all known properties and map each from json to the data type.
         foreach (var property in this._vectorStoreRecordDefinition.Properties)
@@ -85,7 +85,7 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
             {
                 var storagePropertyName = keyProperty.StoragePropertyName ?? keyProperty.DataModelPropertyName;
                 var value = storageModel[storagePropertyName];
-                if (value == null)
+                if (value is null)
                 {
                     throw new InvalidOperationException($"The key property '{storagePropertyName}' is missing from the record retrieved from storage.");
                 }
@@ -96,7 +96,7 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
             {
                 var storagePropertyName = dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName;
                 var value = storageModel[storagePropertyName];
-                if (value != null)
+                if (value is not null)
                 {
                     dataProperties.Add(dataProperty.DataModelPropertyName, GetDataPropertyValue(property.PropertyType, value));
                 }
@@ -109,7 +109,7 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
             {
                 var storagePropertyName = vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName;
                 var value = storageModel[storagePropertyName];
-                if (value != null)
+                if (value is not null)
                 {
                     ReadOnlyMemory<float> vector = value.AsArray().Select(x => (float)x!).ToArray();
                     vectorProperties.Add(vectorProperty.DataModelPropertyName, vector);
@@ -119,6 +119,11 @@ internal class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<Ve
                     vectorProperties.Add(vectorProperty.DataModelPropertyName, null);
                 }
             }
+        }
+
+        if (key is null)
+        {
+            throw new InvalidOperationException("No key property was found in the record retrieved from storage.");
         }
 
         return new VectorStoreGenericDataModel<string>(key) { Data = dataProperties, Vectors = vectorProperties };

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
+
+/// <summary>
+/// A mapper that maps between the generic semantic kernel data model and the model that the data is stored in in Azure AI Search.
+/// </summary>
+public class AzureAISearchGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, JsonObject>
+{
+    /// <summary>A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</summary>
+    private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureAISearchGenericDataModelMapper"/> class.
+    /// </summary>
+    /// <param name="vectorStoreRecordDefinition">A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</param>
+    public AzureAISearchGenericDataModelMapper(VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    {
+        Verify.NotNull(vectorStoreRecordDefinition);
+
+        this._vectorStoreRecordDefinition = vectorStoreRecordDefinition;
+    }
+
+    /// <inheritdoc />
+    public JsonObject MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)
+    {
+        Verify.NotNull(dataModel);
+
+        var storageJsonObject = new JsonObject();
+
+        // Loop through all known properties and map each from the data model json to the storage json.
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            if (property is VectorStoreRecordKeyProperty keyProperty)
+            {
+                var storagePropertyName = keyProperty.StoragePropertyName ?? keyProperty.DataModelPropertyName;
+                storageJsonObject.Add(storagePropertyName, dataModel.Key);
+            }
+            else if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                if (dataModel.Data != null)
+                {
+                    var storagePropertyName = dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName;
+                    var serializedJsonNode = JsonSerializer.SerializeToNode(dataModel.Data[dataProperty.DataModelPropertyName]);
+                    storageJsonObject.Add(storagePropertyName, serializedJsonNode);
+                }
+            }
+            else if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                if (dataModel.Vectors != null)
+                {
+                    var storagePropertyName = vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName;
+
+                    var serializedJsonNode = JsonSerializer.SerializeToNode(dataModel.Vectors[vectorProperty.DataModelPropertyName]);
+                    storageJsonObject.Add(storagePropertyName, serializedJsonNode);
+                }
+            }
+        }
+
+        return storageJsonObject;
+    }
+
+    /// <inheritdoc />
+    public VectorStoreGenericDataModel<string> MapFromStorageToDataModel(JsonObject storageModel, StorageToDataModelMapperOptions options)
+    {
+        Verify.NotNull(storageModel);
+
+        // Create variables to store the response properties.
+        var dataProperties = new Dictionary<string, object?>();
+        var vectorProperties = new Dictionary<string, object?>();
+        string key = string.Empty;
+
+        // Loop through all known properties and map each from json to the data type.
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            if (property is VectorStoreRecordKeyProperty keyProperty)
+            {
+                var storagePropertyName = keyProperty.StoragePropertyName ?? keyProperty.DataModelPropertyName;
+                var value = storageModel[storagePropertyName];
+                if (value == null)
+                {
+                    throw new InvalidOperationException($"The key property '{storagePropertyName}' is missing from the record retrieved from storage.");
+                }
+
+                key = (string)value!;
+            }
+            else if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                var storagePropertyName = dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName;
+                var value = storageModel[storagePropertyName];
+                if (value != null)
+                {
+                    dataProperties.Add(dataProperty.DataModelPropertyName, GetDataPropertyValue(property.PropertyType, value));
+                }
+                else
+                {
+                    dataProperties.Add(dataProperty.DataModelPropertyName, null);
+                }
+            }
+            else if (property is VectorStoreRecordVectorProperty vectorProperty && options.IncludeVectors)
+            {
+                var storagePropertyName = vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName;
+                var value = storageModel[storagePropertyName];
+                if (value != null)
+                {
+                    ReadOnlyMemory<float> vector = value.AsArray().Select(x => (float)x!).ToArray();
+                    vectorProperties.Add(vectorProperty.DataModelPropertyName, vector);
+                }
+                else
+                {
+                    vectorProperties.Add(vectorProperty.DataModelPropertyName, null);
+                }
+            }
+        }
+
+        return new VectorStoreGenericDataModel<string>(key) { Data = dataProperties, Vectors = vectorProperties };
+    }
+
+    /// <summary>
+    /// Get the value of the given json node as the given property type.
+    /// </summary>
+    /// <param name="propertyType">The type of property that is required.</param>
+    /// <param name="value">The json node containing the property value.</param>
+    /// <returns>The value of the json node as the required type.</returns>
+    private static object? GetDataPropertyValue(Type propertyType, JsonNode value)
+    {
+        if (propertyType == typeof(string))
+        {
+            return (string?)value.AsValue();
+        }
+
+        if (propertyType == typeof(int) || propertyType == typeof(int?))
+        {
+            return (int?)value.AsValue();
+        }
+
+        if (propertyType == typeof(long) || propertyType == typeof(long?))
+        {
+            return (long?)value.AsValue();
+        }
+
+        if (propertyType == typeof(float) || propertyType == typeof(float?))
+        {
+            return (float?)value.AsValue();
+        }
+
+        if (propertyType == typeof(double) || propertyType == typeof(double?))
+        {
+            return (double?)value.AsValue();
+        }
+
+        if (propertyType == typeof(bool) || propertyType == typeof(bool?))
+        {
+            return (bool?)value.AsValue();
+        }
+
+        if (propertyType == typeof(DateTimeOffset) || propertyType == typeof(DateTimeOffset?))
+        {
+            return value.GetValue<DateTimeOffset>();
+        }
+
+        if (typeof(IEnumerable).IsAssignableFrom(propertyType))
+        {
+            return value.Deserialize(propertyType);
+        }
+
+        return null;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -77,6 +77,9 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
     /// <summary>Optional configuration options for this class.</summary>
     private readonly AzureAISearchVectorStoreRecordCollectionOptions<TRecord> _options;
 
+    /// <summary>A mapper to use for converting between the data model and the Azure AI Search record.</summary>
+    private readonly IVectorStoreRecordMapper<TRecord, JsonObject>? _mapper;
+
     /// <summary>A definition of the current storage model.</summary>
     private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
 
@@ -102,6 +105,15 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         // Verify.
         Verify.NotNull(searchIndexClient);
         Verify.NotNullOrWhiteSpace(collectionName);
+        Verify.True(
+            !(typeof(TRecord).IsGenericType &&
+                typeof(TRecord).GetGenericTypeDefinition() == typeof(VectorStoreGenericDataModel<>) &&
+                typeof(TRecord).GetGenericArguments()[0] != typeof(string) &&
+                options?.JsonObjectCustomMapper is null),
+            $"A data model of VectorStoreGenericDataModel with a different key type than string, is not supported by the default mappers. Please provide your own mapper to map to your chosen key type.");
+        Verify.True(
+            !(typeof(TRecord) == typeof(VectorStoreGenericDataModel<string>) && options?.VectorStoreRecordDefinition is null),
+            $"A {nameof(VectorStoreRecordDefinition)} must be provided when using {nameof(VectorStoreGenericDataModel<string>)}.");
 
         // Assign.
         this._searchIndexClient = searchIndexClient;
@@ -125,6 +137,19 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
             .Concat([properties.KeyProperty])
             .Select(x => this._storagePropertyNames[x.DataModelPropertyName])
             .ToList();
+
+        // Resolve mapper.
+        // First, if someone has provided a custom mapper, use that.
+        // If they didn't provide a custom mapper, and the record type is the generic data model, use the built in mapper for that.
+        // Otherwise, don't set the mapper, and we'll default to just using Azure AI Search's built in json serialization and deserialization.
+        if (this._options.JsonObjectCustomMapper is not null)
+        {
+            this._mapper = this._options.JsonObjectCustomMapper;
+        }
+        else if (typeof(TRecord) == typeof(VectorStoreGenericDataModel<string>))
+        {
+            this._mapper = new AzureAISearchGenericDataModelMapper(this._vectorStoreRecordDefinition) as IVectorStoreRecordMapper<TRecord, JsonObject>;
+        }
     }
 
     /// <inheritdoc />
@@ -316,7 +341,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         const string OperationName = "GetDocument";
 
         // Use the user provided mapper.
-        if (this._options.JsonObjectCustomMapper is not null)
+        if (this._mapper is not null)
         {
             var jsonObject = await this.RunOperationAsync(
                 OperationName,
@@ -331,7 +356,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
                 DatabaseName,
                 this._collectionName,
                 OperationName,
-                () => this._options.JsonObjectCustomMapper!.MapFromStorageToDataModel(jsonObject, new() { IncludeVectors = includeVectors }));
+                () => this._mapper!.MapFromStorageToDataModel(jsonObject, new() { IncludeVectors = includeVectors }));
         }
 
         // Use the built in Azure AI Search mapper.
@@ -355,13 +380,13 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         const string OperationName = "UploadDocuments";
 
         // Use the user provided mapper.
-        if (this._options.JsonObjectCustomMapper is not null)
+        if (this._mapper is not null)
         {
             var jsonObjects = VectorStoreErrorHandler.RunModelConversion(
                 DatabaseName,
                 this._collectionName,
                 OperationName,
-                () => records.Select(this._options.JsonObjectCustomMapper!.MapFromDataToStorageModel));
+                () => records.Select(this._mapper!.MapFromDataToStorageModel));
 
             return this.RunOperationAsync(
                 OperationName,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -110,7 +110,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
                 typeof(TRecord).GetGenericTypeDefinition() == typeof(VectorStoreGenericDataModel<>) &&
                 typeof(TRecord).GetGenericArguments()[0] != typeof(string) &&
                 options?.JsonObjectCustomMapper is null),
-            $"A data model of VectorStoreGenericDataModel with a different key type than string, is not supported by the default mappers. Please provide your own mapper to map to your chosen key type.");
+            "A data model of VectorStoreGenericDataModel with a different key type than string, is not supported by the default mappers. Please provide your own mapper to map to your chosen key type.");
         Verify.True(
             !(typeof(TRecord) == typeof(VectorStoreGenericDataModel<string>) && options?.VectorStoreRecordDefinition is null),
             $"A {nameof(VectorStoreRecordDefinition)} must be provided when using {nameof(VectorStoreGenericDataModel<string>)}.");

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreFixture.cs
@@ -58,9 +58,9 @@ public class AzureAISearchVectorStoreFixture : IAsyncLifetime
                 new VectorStoreRecordDataProperty("Description", typeof(string)),
                 new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4 },
                 new VectorStoreRecordDataProperty("Tags", typeof(string[])) { IsFilterable = true },
-                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool?)) { IsFilterable = true },
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool?)) { IsFilterable = true, StoragePropertyName = "parking_is_included" },
                 new VectorStoreRecordDataProperty("LastRenovationDate", typeof(DateTimeOffset?)) { IsFilterable = true },
-                new VectorStoreRecordDataProperty("Rating", typeof(float?))
+                new VectorStoreRecordDataProperty("Rating", typeof(double?))
             }
         };
     }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -314,7 +314,6 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         // Arrange
         var options = new AzureAISearchVectorStoreRecordCollectionOptions<VectorStoreGenericDataModel<string>>
         {
-            JsonObjectCustomMapper = new AzureAISearchGenericDataModelMapper(fixture.VectorStoreRecordDefinition),
             VectorStoreRecordDefinition = fixture.VectorStoreRecordDefinition
         };
         var sut = new AzureAISearchVectorStoreRecordCollection<VectorStoreGenericDataModel<string>>(fixture.SearchIndexClient, fixture.TestIndexName, options);

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -308,6 +308,60 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
     }
 
+    [Fact(Skip = SkipReason)]
+    public async Task ItCanUpsertAndRetrieveUsingTheGenericMapperAsync()
+    {
+        // Arrange
+        var options = new AzureAISearchVectorStoreRecordCollectionOptions<VectorStoreGenericDataModel<string>>
+        {
+            JsonObjectCustomMapper = new AzureAISearchGenericDataModelMapper(fixture.VectorStoreRecordDefinition),
+            VectorStoreRecordDefinition = fixture.VectorStoreRecordDefinition
+        };
+        var sut = new AzureAISearchVectorStoreRecordCollection<VectorStoreGenericDataModel<string>>(fixture.SearchIndexClient, fixture.TestIndexName, options);
+
+        // Act
+        var baseSetGetResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true });
+        var upsertResult = await sut.UpsertAsync(new VectorStoreGenericDataModel<string>("GenericMapper-1")
+        {
+            Data =
+            {
+                { "HotelName", "Generic Mapper Hotel" },
+                { "Description", "This is a generic mapper hotel" },
+                { "Tags", new string[] { "generic" } },
+                { "ParkingIncluded", false },
+                { "LastRenovationDate", new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero) },
+                { "Rating", 3.6d }
+            },
+            Vectors =
+            {
+                { "DescriptionEmbedding", new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }) }
+            }
+        });
+        var localGetResult = await sut.GetAsync("GenericMapper-1", new GetRecordOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.NotNull(baseSetGetResult);
+        Assert.Equal("Hotel 1", baseSetGetResult.Data["HotelName"]);
+        Assert.Equal("This is a great hotel", baseSetGetResult.Data["Description"]);
+        Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, baseSetGetResult.Data["Tags"]);
+        Assert.False((bool?)baseSetGetResult.Data["ParkingIncluded"]);
+        Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), baseSetGetResult.Data["LastRenovationDate"]);
+        Assert.Equal(3.6d, baseSetGetResult.Data["Rating"]);
+        Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)baseSetGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
+
+        Assert.NotNull(upsertResult);
+        Assert.Equal("GenericMapper-1", upsertResult);
+
+        Assert.NotNull(localGetResult);
+        Assert.Equal("Generic Mapper Hotel", localGetResult.Data["HotelName"]);
+        Assert.Equal("This is a generic mapper hotel", localGetResult.Data["Description"]);
+        Assert.Equal(new[] { "generic" }, localGetResult.Data["Tags"]);
+        Assert.False((bool?)localGetResult.Data["ParkingIncluded"]);
+        Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), localGetResult.Data["LastRenovationDate"]);
+        Assert.Equal(3.6d, localGetResult.Data["Rating"]);
+        Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)localGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
+    }
+
     private static Hotel CreateTestHotel(string hotelId) => new()
     {
         HotelId = hotelId,

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreGenericDataModel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreGenericDataModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// </summary>
 /// <typeparam name="TKey">The data type of the record key.</typeparam>
 /// <param name="key">The key of the record.</param>
+[Experimental("SKEXP0001")]
 public sealed class VectorStoreGenericDataModel<TKey>(TKey key)
     where TKey : notnull
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreGenericDataModel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreGenericDataModel.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// A generic data model that can be used to store and retrieve any data from a vector store.
+/// </summary>
+/// <typeparam name="TKey">The data type of the record key.</typeparam>
+/// <param name="key">The key of the record.</param>
+public sealed class VectorStoreGenericDataModel<TKey>(TKey key)
+    where TKey : notnull
+{
+    /// <summary>
+    /// Gets or sets the key of the record.
+    /// </summary>
+    public TKey Key { get; set; } = key;
+
+    /// <summary>
+    /// Gets or sets a dictionary of data items stored in the record.
+    /// </summary>
+    /// <remarks>
+    /// This dictionary contains all fields that are not vectors.
+    /// </remarks>
+    public Dictionary<string, object?> Data { get; init; } = new();
+
+    /// <summary>
+    /// Gets or sets a dictionary of vectors stored in the record.
+    /// </summary>
+    public Dictionary<string, object?> Vectors { get; init; } = new();
+}


### PR DESCRIPTION
### Motivation and Context

For cases where a developer is defining a schema using configuration, it's useful to have a generic data model that can be used with any data source.  A separate definition can be supplied in this case, that defines the schema, and this can look different to the data model.

### Description

- Adding a generic data model for any vector store records
- Adding a mapping for Azure AI Search that uses the definition to map from the database record to the generic data model.

#8536 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
