### PR TITLE
.Net: Fix typo for DefaultSummarizationPrompt

### DIFF
--- a/dotnet/src/Agents/Core/History/ChatHistorySummarizationReducer.cs
+++ b/dotnet/src/Agents/Core/History/ChatHistorySummarizationReducer.cs
@@ -29,7 +29,7 @@ public class ChatHistorySummarizationReducer : IChatHistoryReducer
     /// </summary>
     public const string DefaultSummarizationPrompt =
         """
-        Provide a concise and complete summarizion of the entire dialog that does not exceed 5 sentences
+        Provide a concise and complete summarization of the entire dialog that does not exceed 5 sentences
 
         This summary must always:
         - Consider both user and assistant interactions


### PR DESCRIPTION
### Motivation and Context

This PR fixes the incorrect spelling of **"summarization"** in `DefaultSummarizationPrompt` of `ChatHistorySummarizationReducer` class

### Description

Fixes #8545 

### Contribution Checklist


- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
