### PR TITLE
Python: Support Sessions plugin auth token

### DIFF
--- a/python/samples/concepts/auto_function_calling/azure_python_code_interpreter_function_calling.py
+++ b/python/samples/concepts/auto_function_calling/azure_python_code_interpreter_function_calling.py
@@ -13,33 +13,6 @@ from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.functions.kernel_arguments import KernelArguments
 from semantic_kernel.kernel import Kernel
 
-# auth_token: AccessToken | None = None
-
-# ACA_TOKEN_ENDPOINT: str = "https://acasessions.io/.default"  # nosec
-
-
-# async def auth_callback() -> str:
-#     """Auth callback for the SessionsPythonTool.
-#     This is a sample auth callback that shows how to use Azure's DefaultAzureCredential
-#     to get an access token.
-#     """
-#     global auth_token
-#     current_utc_timestamp = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
-
-#     if not auth_token or auth_token.expires_on < current_utc_timestamp:
-#         credential = DefaultAzureCredential()
-
-#         try:
-#             auth_token = credential.get_token(ACA_TOKEN_ENDPOINT)
-#         except ClientAuthenticationError as cae:
-#             err_messages = getattr(cae, "messages", [])
-#             raise FunctionExecutionException(
-#                 f"Failed to retrieve the client auth token with messages: {' '.join(err_messages)}"
-#             ) from cae
-
-#     return auth_token.token
-
-
 kernel = Kernel()
 
 service_id = "sessions-tool"

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion.py
@@ -104,18 +104,13 @@ class AzureChatCompletion(AzureOpenAIConfigBase, OpenAIChatCompletionBase, OpenA
         if not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
             raise ServiceInitializationError("Please provide either api_key, ad_token or ad_token_provider")
 
-        # Similate that the API key isn't provided, so we use the AD token. This is for testing purposes.
-        # This is so we don't have to delete the key from GH secrets.
-        if azure_openai_settings.api_key is not None:
-            azure_openai_settings.api_key = None
-
         super().__init__(
             deployment_name=azure_openai_settings.chat_deployment_name,
             endpoint=azure_openai_settings.endpoint,
             base_url=azure_openai_settings.base_url,
             api_version=azure_openai_settings.api_version,
             service_id=service_id,
-            api_key=None,
+            api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
             ad_token=ad_token,
             ad_token_provider=ad_token_provider,
             default_headers=default_headers,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_text_completion.py
@@ -86,7 +86,7 @@ class AzureTextCompletion(AzureOpenAIConfigBase, OpenAITextCompletionBase):
             base_url=azure_openai_settings.base_url,
             api_version=azure_openai_settings.api_version,
             service_id=service_id,
-            api_key=None,  # Simulated, will revert
+            api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
             ad_token=ad_token,
             ad_token_provider=ad_token_provider,
             default_headers=default_headers,

--- a/python/semantic_kernel/core_plugins/sessions_python_tool/README.md
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/README.md
@@ -14,7 +14,10 @@ Next, as an environment variable or in the .env file, add the `poolManagementEnd
 https://eastus.acasessions.io/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/sessionPools/{{sessionPool}}/python/execute
 ```
 
-It is possible to add the code interpreter plugin as follows:
+You can also provide the the `ACA_TOKEN_ENDPOINT` if you want to override the default value of `https://acasessions.io/.default`. If this token endpoint doesn't need to be overriden, then it is
+not necessary to include this as an environment variable, in the .env file, or via the plugin's constructor. Please follow the [Azure Container Apps Documentation](https://learn.microsoft.com/en-us/azure/container-apps/sessions-code-interpreter) to review the proper role required to authenticate with the `DefaultAzureCredential`.
+
+Next, let's move on to implementing the plugin in code. It is possible to add the code interpreter plugin as follows:
 
 ```python
 kernel = Kernel()

--- a/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
@@ -81,6 +81,9 @@ class SessionsPythonTool(KernelBaseModel):
         """Generates a default authentication callback using the ACA settings."""
         token = aca_settings.get_sessions_auth_token()
 
+        if token is None:
+            raise FunctionInitializationError("Failed to retrieve the client auth token.")
+
         def auth_callback() -> str:
             """Retrieve the client auth token."""
             return token

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -234,6 +234,7 @@ def azure_openai_unit_test_env(monkeypatch, exclude_list, override_env_param_dic
         "AZURE_OPENAI_ENDPOINT": "https://test-endpoint.com",
         "AZURE_OPENAI_API_VERSION": "2023-03-15-preview",
         "AZURE_OPENAI_BASE_URL": "https://test_text_deployment.test-base-url.com",
+        "AZURE_OPENAI_TOKEN_ENDPOINT": "https://test-token-endpoint.com",
     }
 
     env_vars.update(override_env_param_dict)

--- a/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_chat_completion.py
@@ -92,14 +92,6 @@ def test_init_with_empty_deployment_name(azure_openai_unit_test_env) -> None:
         )
 
 
-@pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
-def test_init_with_empty_api_key(azure_openai_unit_test_env) -> None:
-    with pytest.raises(ServiceInitializationError):
-        AzureChatCompletion(
-            env_file_path="test.env",
-        )
-
-
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_BASE_URL"]], indirect=True)
 def test_init_with_empty_endpoint_and_base_url(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):

--- a/python/tests/unit/connectors/open_ai/services/test_azure_text_completion.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_text_completion.py
@@ -63,14 +63,6 @@ def test_init_with_empty_deployment_name(monkeypatch, azure_openai_unit_test_env
         )
 
 
-@pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
-def test_init_with_empty_api_key(azure_openai_unit_test_env) -> None:
-    with pytest.raises(ServiceInitializationError):
-        AzureTextCompletion(
-            env_file_path="test.env",
-        )
-
-
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_BASE_URL"]], indirect=True)
 def test_init_with_empty_endpoint_and_base_url(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):

--- a/python/tests/unit/connectors/open_ai/services/test_azure_text_embedding.py
+++ b/python/tests/unit/connectors/open_ai/services/test_azure_text_embedding.py
@@ -29,14 +29,6 @@ def test_azure_text_embedding_init_with_empty_deployment_name(azure_openai_unit_
         )
 
 
-@pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
-def test_azure_text_embedding_init_with_empty_api_key(azure_openai_unit_test_env) -> None:
-    with pytest.raises(ServiceInitializationError):
-        AzureTextEmbedding(
-            env_file_path="test.env",
-        )
-
-
 @pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_BASE_URL"]], indirect=True)
 def test_azure_text_embedding_init_with_empty_endpoint_and_base_url(azure_openai_unit_test_env) -> None:
     with pytest.raises(ServiceInitializationError):

--- a/python/tests/unit/core_plugins/test_sessions_python_plugin.py
+++ b/python/tests/unit/core_plugins/test_sessions_python_plugin.py
@@ -608,7 +608,7 @@ async def test_auth_token_fail(aca_python_sessions_unit_test_env):
 
     plugin = SessionsPythonTool(auth_callback=token_cb)
     with pytest.raises(
-        FunctionExecutionException, match="Failed to retrieve the client auth token with messages: Could not get token."
+        FunctionExecutionException, match="Failed to retrieve the client auth token with message: Could not get token."
     ):
         await plugin._ensure_auth_token()
 


### PR DESCRIPTION
### Motivation and Context

Move the sessions plugin to use the default token provider, which can be overridden by the user as needed.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Move the sessions plugin to use the default token provider, which can be overridden by the user as needed.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
