### PR TITLE
.Net: Adding Qdrant generic data model mapper.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantGenericDataModelMapper.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.SemanticKernel.Data;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// A mapper that maps between the generic semantic kernel data model and the model that the data is stored in in Qdrant.
+/// </summary>
+internal class QdrantGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<ulong>, PointStruct>, IVectorStoreRecordMapper<VectorStoreGenericDataModel<Guid>, PointStruct>
+{
+    /// <summary>A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</summary>
+    private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
+
+    /// <summary>A value indicating whether the vectors in the store are named, or whether there is just a single unnamed vector per qdrant point.</summary>
+    private readonly bool _hasNamedVectors;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QdrantGenericDataModelMapper"/> class.
+    /// </summary>
+    /// <param name="vectorStoreRecordDefinition">The record definition that defines the schema of the record type.</param>
+    /// <param name="hasNamedVectors">A value indicating whether the vectors in the store are named, or whether there is just a single unnamed vector per qdrant point.</param>
+    public QdrantGenericDataModelMapper(
+        VectorStoreRecordDefinition vectorStoreRecordDefinition,
+        bool hasNamedVectors)
+    {
+        Verify.NotNull(vectorStoreRecordDefinition);
+
+        // Validate property types.
+        var properties = VectorStoreRecordPropertyReader.SplitDefinitionAndVerify("VectorStoreGenericDataModel", vectorStoreRecordDefinition, supportsMultipleVectors: hasNamedVectors, requiresAtLeastOneVector: !hasNamedVectors);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.DataProperties, QdrantVectorStoreRecordFieldMapping.s_supportedDataTypes, "Data", supportEnumerable: true);
+        VectorStoreRecordPropertyReader.VerifyPropertyTypes(properties.VectorProperties, QdrantVectorStoreRecordFieldMapping.s_supportedVectorTypes, "Vector");
+
+        // Assign.
+        this._vectorStoreRecordDefinition = vectorStoreRecordDefinition;
+        this._hasNamedVectors = hasNamedVectors;
+    }
+
+    /// <inheritdoc />
+    public PointStruct MapFromDataToStorageModel(VectorStoreGenericDataModel<ulong> dataModel)
+    {
+        // Create point.
+        var pointStruct = new PointStruct
+        {
+            Id = new PointId { Num = dataModel.Key },
+            Vectors = new Vectors(),
+            Payload = { },
+        };
+
+        // Loop through all properties and map each from the data model to the storage model.
+        MapProperties(
+            this._vectorStoreRecordDefinition.Properties,
+            dataModel.Data,
+            dataModel.Vectors,
+            pointStruct,
+            this._hasNamedVectors);
+
+        return pointStruct;
+    }
+
+    /// <inheritdoc />
+    public VectorStoreGenericDataModel<ulong> MapFromStorageToDataModel(PointStruct storageModel, StorageToDataModelMapperOptions options)
+    {
+        var dataModel = new VectorStoreGenericDataModel<ulong>(storageModel.Id.Num);
+        MapProperties(this._vectorStoreRecordDefinition.Properties, storageModel, dataModel.Data, dataModel.Vectors, this._hasNamedVectors);
+        return dataModel;
+    }
+
+    /// <inheritdoc />
+    PointStruct IVectorStoreRecordMapper<VectorStoreGenericDataModel<Guid>, PointStruct>.MapFromDataToStorageModel(VectorStoreGenericDataModel<Guid> dataModel)
+    {
+        // Create point.
+        var pointStruct = new PointStruct
+        {
+            Id = new PointId { Uuid = dataModel.Key.ToString("D") },
+            Vectors = new Vectors(),
+            Payload = { },
+        };
+
+        // Loop through all properties and map each from the data model to the storage model.
+        MapProperties(
+            this._vectorStoreRecordDefinition.Properties,
+            dataModel.Data,
+            dataModel.Vectors,
+            pointStruct,
+            this._hasNamedVectors);
+
+        return pointStruct;
+    }
+
+    /// <inheritdoc />
+    VectorStoreGenericDataModel<Guid> IVectorStoreRecordMapper<VectorStoreGenericDataModel<Guid>, PointStruct>.MapFromStorageToDataModel(PointStruct storageModel, StorageToDataModelMapperOptions options)
+    {
+        var dataModel = new VectorStoreGenericDataModel<Guid>(new Guid(storageModel.Id.Uuid));
+        MapProperties(this._vectorStoreRecordDefinition.Properties, storageModel, dataModel.Data, dataModel.Vectors, this._hasNamedVectors);
+        return dataModel;
+    }
+
+    /// <summary>
+    /// Map the payload and vector properties from the data model to the qdrant storage model.
+    /// </summary>
+    /// <param name="properties">The list of properties to map.</param>
+    /// <param name="dataProperties">The payload properties on the data model.</param>
+    /// <param name="vectorProperties">The vector properties on the data model.</param>
+    /// <param name="pointStruct">The storage model to map to.</param>
+    /// <param name="hasNamedVectors">A value indicating whether qdrant is using named vectors for this collection.</param>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown if a vector on the data model is not a supported type.</exception>
+    private static void MapProperties(IEnumerable<VectorStoreRecordProperty> properties, Dictionary<string, object?> dataProperties, Dictionary<string, object?> vectorProperties, PointStruct pointStruct, bool hasNamedVectors)
+    {
+        if (hasNamedVectors)
+        {
+            pointStruct.Vectors.Vectors_ = new NamedVectors();
+        }
+
+        foreach (var property in properties)
+        {
+            if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                var storagePropertyName = dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName;
+
+                // Just skip this property if it's not in the data model.
+                if (!dataProperties.TryGetValue(dataProperty.DataModelPropertyName, out var propertyValue))
+                {
+                    continue;
+                }
+
+                // Map.
+                pointStruct.Payload.Add(storagePropertyName, QdrantVectorStoreRecordFieldMapping.ConvertToGrpcFieldValue(propertyValue));
+            }
+            else if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                var storagePropertyName = vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName;
+
+                // Just skip this property if it's not in the data model.
+                if (!vectorProperties.TryGetValue(vectorProperty.DataModelPropertyName, out var vector))
+                {
+                    continue;
+                }
+
+                // Validate.
+                if (vector is not ReadOnlyMemory<float> floatROM)
+                {
+                    throw new VectorStoreRecordMappingException($"Vector property '{vectorProperty.DataModelPropertyName}' on provided record of type {nameof(VectorStoreGenericDataModel<ulong>)} must be of type ReadOnlyMemory<float> and not null.");
+                }
+
+                // Map.
+                if (hasNamedVectors)
+                {
+                    pointStruct.Vectors.Vectors_.Vectors.Add(storagePropertyName, floatROM.ToArray());
+                }
+                else
+                {
+                    pointStruct.Vectors.Vector = floatROM.ToArray();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Map the payload and vector properties from the qdrant storage model to the data model.
+    /// </summary>
+    /// <param name="properties">The list of properties to map.</param>
+    /// <param name="storageModel">The storage model to map from.</param>
+    /// <param name="dataProperties">The payload properties on the data model.</param>
+    /// <param name="vectorProperties">The vector properties on the data model.</param>
+    /// <param name="hasNamedVectors">A value indicating whether qdrant is using named vectors for this collection.</param>
+    public static void MapProperties(IEnumerable<VectorStoreRecordProperty> properties, PointStruct storageModel, Dictionary<string, object?> dataProperties, Dictionary<string, object?> vectorProperties, bool hasNamedVectors)
+    {
+        foreach (var property in properties)
+        {
+            if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                var storagePropertyName = dataProperty.StoragePropertyName ?? dataProperty.DataModelPropertyName;
+
+                // Just skip this property if it's not in the storage model.
+                if (!storageModel.Payload.TryGetValue(storagePropertyName, out var propertyValue))
+                {
+                    continue;
+                }
+
+                if (propertyValue.HasNullValue)
+                {
+                    // Shortcut any null handling here so we don't have to check for it for each case.
+                    dataProperties[dataProperty.DataModelPropertyName] = null;
+                }
+                else if (typeof(IEnumerable).IsAssignableFrom(dataProperty.PropertyType))
+                {
+                    // Using json deserialization to convert lists back into the correct enumerable type.
+                    // There are many different possible enumerable types and this makes it easy to
+                    // support all that System.Text.Json supports.
+                    var jsonNode = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValueToJsonNode(propertyValue);
+                    var targetObject = jsonNode.Deserialize(dataProperty.PropertyType);
+                    dataProperties[dataProperty.DataModelPropertyName] = targetObject;
+                }
+                else if (dataProperty.PropertyType == typeof(int) || dataProperty.PropertyType == typeof(int?))
+                {
+                    // The Qdrant sdk only returns long values for integers, so we need to convert them
+                    // manually to the type of our data model.
+                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValue(propertyValue);
+                    convertedValue = Convert.ToInt32(convertedValue);
+                    dataProperties[dataProperty.DataModelPropertyName] = convertedValue;
+                }
+                else if (dataProperty.PropertyType == typeof(float) || dataProperty.PropertyType == typeof(float?))
+                {
+                    // The Qdrant sdk only returns double values for floats, so we need to convert them
+                    // manually to the type of our data model.
+                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValue(propertyValue);
+                    convertedValue = Convert.ToSingle(convertedValue);
+                    dataProperties[dataProperty.DataModelPropertyName] = convertedValue;
+                }
+                else
+                {
+                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValue(propertyValue);
+                    dataProperties[dataProperty.DataModelPropertyName] = convertedValue;
+                }
+            }
+            else if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                Vector? vector;
+                if (hasNamedVectors)
+                {
+                    var storagePropertyName = vectorProperty.StoragePropertyName ?? vectorProperty.DataModelPropertyName;
+
+                    // Just skip this property if it's not in the storage model.
+                    if (!storageModel.Vectors.Vectors_.Vectors.TryGetValue(storagePropertyName, out vector))
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    vector = storageModel.Vectors.Vector;
+                }
+
+                vectorProperties[vectorProperty.DataModelPropertyName] = new ReadOnlyMemory<float>(vector.Data.ToArray());
+            }
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -102,6 +102,13 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
             // Custom Mapper.
             this._mapper = this._options.PointStructCustomMapper;
         }
+        else if (typeof(TRecord) == typeof(VectorStoreGenericDataModel<ulong>) || typeof(TRecord) == typeof(VectorStoreGenericDataModel<Guid>))
+        {
+            // Generic data model mapper.
+            this._mapper = (IVectorStoreRecordMapper<TRecord, PointStruct>)new QdrantGenericDataModelMapper(
+                this._vectorStoreRecordDefinition,
+                this._options.HasNamedVectors);
+        }
         else
         {
             // Default Mapper.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 using Qdrant.Client.Grpc;
 using Microsoft.SemanticKernel.Data;
-using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Qdrant.Client.Grpc;
+using Microsoft.SemanticKernel.Data;
+using System;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant;
+
+/// <summary>
+/// Contains helper methods for mapping fields to and from the format required by the Qdrant client sdk.
+/// </summary>
+internal static class QdrantVectorStoreRecordFieldMapping
+{
+    /// <summary>A set of types that data properties on the provided model may have.</summary>
+    public static readonly HashSet<Type> s_supportedDataTypes =
+    [
+        typeof(string),
+        typeof(int),
+        typeof(long),
+        typeof(double),
+        typeof(float),
+        typeof(bool),
+        typeof(int?),
+        typeof(long?),
+        typeof(double?),
+        typeof(float?),
+        typeof(bool?)
+    ];
+
+    /// <summary>A set of types that vectors on the provided model may have.</summary>
+    /// <remarks>
+    /// While qdrant supports float32 and uint64, the api only supports float64, therefore
+    /// any float32 vectors will be converted to float64 before being sent to qdrant.
+    /// </remarks>
+    public static readonly HashSet<Type> s_supportedVectorTypes =
+    [
+        typeof(ReadOnlyMemory<float>),
+        typeof(ReadOnlyMemory<float>?),
+        typeof(ReadOnlyMemory<double>),
+        typeof(ReadOnlyMemory<double>?)
+    ];
+
+    /// <summary>
+    /// Convert the given <paramref name="payloadValue"/> to the correct native type based on its properties.
+    /// </summary>
+    /// <param name="payloadValue">The value to convert to a native type.</param>
+    /// <returns>The converted native value.</returns>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
+    public static JsonNode? ConvertFromGrpcFieldValueToJsonNode(Value payloadValue)
+    {
+        return payloadValue.KindCase switch
+        {
+            Value.KindOneofCase.NullValue => null,
+            Value.KindOneofCase.IntegerValue => JsonValue.Create(payloadValue.IntegerValue),
+            Value.KindOneofCase.StringValue => JsonValue.Create(payloadValue.StringValue),
+            Value.KindOneofCase.DoubleValue => JsonValue.Create(payloadValue.DoubleValue),
+            Value.KindOneofCase.BoolValue => JsonValue.Create(payloadValue.BoolValue),
+            Value.KindOneofCase.ListValue => new JsonArray(payloadValue.ListValue.Values.Select(x => ConvertFromGrpcFieldValueToJsonNode(x)).ToArray()),
+            Value.KindOneofCase.StructValue => new JsonObject(payloadValue.StructValue.Fields.ToDictionary(x => x.Key, x => ConvertFromGrpcFieldValueToJsonNode(x.Value))),
+            _ => throw new VectorStoreRecordMappingException($"Unsupported grpc value kind {payloadValue.KindCase}."),
+        };
+    }
+
+    /// <summary>
+    /// Convert the given <paramref name="payloadValue"/> to the correct native type based on its properties.
+    /// </summary>
+    /// <param name="payloadValue">The value to convert to a native type.</param>
+    /// <returns>The converted native value.</returns>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
+    public static object? ConvertFromGrpcFieldValue(Value payloadValue)
+    {
+        return payloadValue.KindCase switch
+        {
+            Value.KindOneofCase.NullValue => null,
+            Value.KindOneofCase.IntegerValue => payloadValue.IntegerValue,
+            Value.KindOneofCase.StringValue => payloadValue.StringValue,
+            Value.KindOneofCase.DoubleValue => payloadValue.DoubleValue,
+            Value.KindOneofCase.BoolValue => payloadValue.BoolValue,
+            Value.KindOneofCase.ListValue => payloadValue.ListValue.Values.Select(x => ConvertFromGrpcFieldValue(x)).ToArray(),
+            Value.KindOneofCase.StructValue => payloadValue.StructValue.Fields.ToDictionary(x => x.Key, x => ConvertFromGrpcFieldValue(x.Value)),
+            _ => throw new VectorStoreRecordMappingException($"Unsupported grpc value kind {payloadValue.KindCase}."),
+        };
+    }
+
+    /// <summary>
+    /// Convert the given <paramref name="sourceValue"/> to a <see cref="Value"/> object that can be stored in Qdrant.
+    /// </summary>
+    /// <param name="sourceValue">The object to convert.</param>
+    /// <returns>The converted Qdrant value.</returns>
+    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
+    public static Value ConvertToGrpcFieldValue(object? sourceValue)
+    {
+        var value = new Value();
+        if (sourceValue is null)
+        {
+            value.NullValue = NullValue.NullValue;
+        }
+        else if (sourceValue is int intValue)
+        {
+            value.IntegerValue = intValue;
+        }
+        else if (sourceValue is long longValue)
+        {
+            value.IntegerValue = longValue;
+        }
+        else if (sourceValue is string stringValue)
+        {
+            value.StringValue = stringValue;
+        }
+        else if (sourceValue is float floatValue)
+        {
+            value.DoubleValue = floatValue;
+        }
+        else if (sourceValue is double doubleValue)
+        {
+            value.DoubleValue = doubleValue;
+        }
+        else if (sourceValue is bool boolValue)
+        {
+            value.BoolValue = boolValue;
+        }
+        else if (sourceValue is IEnumerable<int> ||
+            sourceValue is IEnumerable<long> ||
+            sourceValue is IEnumerable<string> ||
+            sourceValue is IEnumerable<float> ||
+            sourceValue is IEnumerable<double> ||
+            sourceValue is IEnumerable<bool>)
+        {
+            var listValue = sourceValue as IEnumerable;
+            value.ListValue = new ListValue();
+            foreach (var item in listValue!)
+            {
+                value.ListValue.Values.Add(ConvertToGrpcFieldValue(item));
+            }
+        }
+        else
+        {
+            throw new VectorStoreRecordMappingException($"Unsupported source value type {sourceValue?.GetType().FullName}.");
+        }
+
+        return value;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
@@ -5,8 +5,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
-using Qdrant.Client.Grpc;
 using Microsoft.SemanticKernel.Data;
+using Qdrant.Client.Grpc;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantGenericDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantGenericDataModelMapperTests.cs
@@ -1,0 +1,398 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SemanticKernel.Data;
+using Qdrant.Client.Grpc;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Qdrant.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="QdrantGenericDataModelMapper"/> class.
+/// </summary>
+public class QdrantGenericDataModelMapperTests
+{
+    private static readonly VectorStoreRecordDefinition s_singleVectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+            new VectorStoreRecordDataProperty("IntDataProp", typeof(int)),
+            new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+            new VectorStoreRecordDataProperty("LongDataProp", typeof(long)),
+            new VectorStoreRecordDataProperty("NullableLongDataProp", typeof(long?)),
+            new VectorStoreRecordDataProperty("FloatDataProp", typeof(float)),
+            new VectorStoreRecordDataProperty("NullableFloatDataProp", typeof(float?)),
+            new VectorStoreRecordDataProperty("DoubleDataProp", typeof(double)),
+            new VectorStoreRecordDataProperty("NullableDoubleDataProp", typeof(double?)),
+            new VectorStoreRecordDataProperty("BoolDataProp", typeof(bool)),
+            new VectorStoreRecordDataProperty("NullableBoolDataProp", typeof(bool?)),
+            new VectorStoreRecordDataProperty("TagListDataProp", typeof(string[])),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+        },
+    };
+
+    private static readonly VectorStoreRecordDefinition s_multiVectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+            new VectorStoreRecordDataProperty("IntDataProp", typeof(int)),
+            new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+            new VectorStoreRecordDataProperty("LongDataProp", typeof(long)),
+            new VectorStoreRecordDataProperty("NullableLongDataProp", typeof(long?)),
+            new VectorStoreRecordDataProperty("FloatDataProp", typeof(float)),
+            new VectorStoreRecordDataProperty("NullableFloatDataProp", typeof(float?)),
+            new VectorStoreRecordDataProperty("DoubleDataProp", typeof(double)),
+            new VectorStoreRecordDataProperty("NullableDoubleDataProp", typeof(double?)),
+            new VectorStoreRecordDataProperty("BoolDataProp", typeof(bool)),
+            new VectorStoreRecordDataProperty("NullableBoolDataProp", typeof(bool?)),
+            new VectorStoreRecordDataProperty("TagListDataProp", typeof(string[])),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+        },
+    };
+
+    private static readonly float[] s_vector1 = new float[] { 1.0f, 2.0f, 3.0f };
+    private static readonly float[] s_vector2 = new float[] { 4.0f, 5.0f, 6.0f };
+    private static readonly string[] s_taglist = new string[] { "tag1", "tag2" };
+    private const string TestGuidKeyString = "11111111-1111-1111-1111-111111111111";
+    private static readonly Guid s_testGuidKey = Guid.Parse(TestGuidKeyString);
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapFromDataToStorageModelMapsAllSupportedTypes(bool hasNamedVectors)
+    {
+        // Arrange.
+        var sut = new QdrantGenericDataModelMapper(hasNamedVectors ? s_multiVectorStoreRecordDefinition : s_singleVectorStoreRecordDefinition, hasNamedVectors);
+        var dataModel = new VectorStoreGenericDataModel<ulong>(1ul)
+        {
+            Data =
+            {
+                ["StringDataProp"] = "string",
+                ["IntDataProp"] = 1,
+                ["NullableIntDataProp"] = 2,
+                ["LongDataProp"] = 3L,
+                ["NullableLongDataProp"] = 4L,
+                ["FloatDataProp"] = 5.0f,
+                ["NullableFloatDataProp"] = 6.0f,
+                ["DoubleDataProp"] = 7.0,
+                ["NullableDoubleDataProp"] = 8.0,
+                ["BoolDataProp"] = true,
+                ["NullableBoolDataProp"] = false,
+                ["TagListDataProp"] = s_taglist,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = new ReadOnlyMemory<float>(s_vector1),
+            },
+        };
+
+        if (hasNamedVectors)
+        {
+            dataModel.Vectors.Add("NullableFloatVector", new ReadOnlyMemory<float>(s_vector2));
+        }
+
+        // Act.
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal(1ul, storageModel.Id.Num);
+        Assert.Equal("string", (string?)storageModel.Payload["StringDataProp"].StringValue);
+        Assert.Equal(1, (int?)storageModel.Payload["IntDataProp"].IntegerValue);
+        Assert.Equal(2, (int?)storageModel.Payload["NullableIntDataProp"].IntegerValue);
+        Assert.Equal(3L, (long?)storageModel.Payload["LongDataProp"].IntegerValue);
+        Assert.Equal(4L, (long?)storageModel.Payload["NullableLongDataProp"].IntegerValue);
+        Assert.Equal(5.0f, (float?)storageModel.Payload["FloatDataProp"].DoubleValue);
+        Assert.Equal(6.0f, (float?)storageModel.Payload["NullableFloatDataProp"].DoubleValue);
+        Assert.Equal(7.0, (double?)storageModel.Payload["DoubleDataProp"].DoubleValue);
+        Assert.Equal(8.0, (double?)storageModel.Payload["NullableDoubleDataProp"].DoubleValue);
+        Assert.Equal(true, (bool?)storageModel.Payload["BoolDataProp"].BoolValue);
+        Assert.Equal(false, (bool?)storageModel.Payload["NullableBoolDataProp"].BoolValue);
+        Assert.Equal(s_taglist, storageModel.Payload["TagListDataProp"].ListValue.Values.Select(x => x.StringValue).ToArray());
+
+        if (hasNamedVectors)
+        {
+            Assert.Equal(s_vector1, storageModel.Vectors.Vectors_.Vectors["FloatVector"].Data.ToArray());
+            Assert.Equal(s_vector2, storageModel.Vectors.Vectors_.Vectors["NullableFloatVector"].Data.ToArray());
+        }
+        else
+        {
+            Assert.Equal(s_vector1, storageModel.Vectors.Vector.Data.ToArray());
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapFromDataToStorageModelMapsNullValues(bool hasNamedVectors)
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(Guid)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+                new VectorStoreRecordDataProperty("NullableTagListDataProp", typeof(string[])),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var dataModel = new VectorStoreGenericDataModel<Guid>(s_testGuidKey)
+        {
+            Data =
+            {
+                ["StringDataProp"] = null,
+                ["NullableIntDataProp"] = null,
+                ["NullableTagListDataProp"] = null,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = new ReadOnlyMemory<float>(s_vector1),
+            },
+        };
+
+        var sut = (IVectorStoreRecordMapper<VectorStoreGenericDataModel<Guid>, PointStruct>)new QdrantGenericDataModelMapper(vectorStoreRecordDefinition, hasNamedVectors);
+
+        // Act
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal(TestGuidKeyString, storageModel.Id.Uuid);
+        Assert.True(storageModel.Payload["StringDataProp"].HasNullValue);
+        Assert.True(storageModel.Payload["NullableIntDataProp"].HasNullValue);
+        Assert.True(storageModel.Payload["NullableTagListDataProp"].HasNullValue);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapFromStorageToDataModelMapsAllSupportedTypes(bool hasNamedVectors)
+    {
+        // Arrange
+        var sut = new QdrantGenericDataModelMapper(hasNamedVectors ? s_multiVectorStoreRecordDefinition : s_singleVectorStoreRecordDefinition, hasNamedVectors);
+        var storageModel = new PointStruct()
+        {
+            Id = new PointId() { Num = 1 },
+            Payload =
+            {
+                ["StringDataProp"] = new Value() { StringValue = "string" },
+                ["IntDataProp"] = new Value() { IntegerValue = 1 },
+                ["NullableIntDataProp"] = new Value() { IntegerValue = 2 },
+                ["LongDataProp"] = new Value() { IntegerValue = 3 },
+                ["NullableLongDataProp"] = new Value() { IntegerValue = 4 },
+                ["FloatDataProp"] = new Value() { DoubleValue = 5.0 },
+                ["NullableFloatDataProp"] = new Value() { DoubleValue = 6.0 },
+                ["DoubleDataProp"] = new Value() { DoubleValue = 7.0 },
+                ["NullableDoubleDataProp"] = new Value() { DoubleValue = 8.0 },
+                ["BoolDataProp"] = new Value() { BoolValue = true },
+                ["NullableBoolDataProp"] = new Value() { BoolValue = false },
+                ["TagListDataProp"] = new Value()
+                {
+                    ListValue = new ListValue()
+                    {
+                        Values =
+                        {
+                            new Value() { StringValue = "tag1" },
+                            new Value() { StringValue = "tag2" },
+                        },
+                    },
+                },
+            },
+            Vectors = new Vectors()
+        };
+
+        if (hasNamedVectors)
+        {
+            storageModel.Vectors.Vectors_ = new NamedVectors();
+            storageModel.Vectors.Vectors_.Vectors.Add("FloatVector", new Vector() { Data = { 1.0f, 2.0f, 3.0f } });
+            storageModel.Vectors.Vectors_.Vectors.Add("NullableFloatVector", new Vector() { Data = { 4.0f, 5.0f, 6.0f } });
+        }
+        else
+        {
+            storageModel.Vectors.Vector = new Vector() { Data = { 1.0f, 2.0f, 3.0f } };
+        }
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions());
+
+        // Assert
+        Assert.Equal(1ul, dataModel.Key);
+        Assert.Equal("string", (string?)dataModel.Data["StringDataProp"]);
+        Assert.Equal(1, (int?)dataModel.Data["IntDataProp"]);
+        Assert.Equal(2, (int?)dataModel.Data["NullableIntDataProp"]);
+        Assert.Equal(3L, (long?)dataModel.Data["LongDataProp"]);
+        Assert.Equal(4L, (long?)dataModel.Data["NullableLongDataProp"]);
+        Assert.Equal(5.0f, (float?)dataModel.Data["FloatDataProp"]);
+        Assert.Equal(6.0f, (float?)dataModel.Data["NullableFloatDataProp"]);
+        Assert.Equal(7.0, (double?)dataModel.Data["DoubleDataProp"]);
+        Assert.Equal(8.0, (double?)dataModel.Data["NullableDoubleDataProp"]);
+        Assert.Equal(true, (bool?)dataModel.Data["BoolDataProp"]);
+        Assert.Equal(false, (bool?)dataModel.Data["NullableBoolDataProp"]);
+        Assert.Equal(s_taglist, (string[]?)dataModel.Data["TagListDataProp"]);
+
+        if (hasNamedVectors)
+        {
+            Assert.Equal(s_vector1, ((ReadOnlyMemory<float>?)dataModel.Vectors["FloatVector"])!.Value.ToArray());
+            Assert.Equal(s_vector2, ((ReadOnlyMemory<float>?)dataModel.Vectors["NullableFloatVector"])!.Value.ToArray());
+        }
+        else
+        {
+            Assert.Equal(s_vector1, ((ReadOnlyMemory<float>?)dataModel.Vectors["FloatVector"])!.Value.ToArray());
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MapFromStorageToDataModelMapsNullValues(bool hasNamedVectors)
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(Guid)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+                new VectorStoreRecordDataProperty("NullableTagListDataProp", typeof(string[])),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var storageModel = new PointStruct()
+        {
+            Id = new PointId() { Uuid = TestGuidKeyString },
+            Payload =
+            {
+                ["StringDataProp"] = new Value() { NullValue = new NullValue() },
+                ["NullableIntDataProp"] = new Value() { NullValue = new NullValue() },
+                ["NullableTagListDataProp"] = new Value() { NullValue = new NullValue() },
+            },
+            Vectors = new Vectors()
+        };
+
+        if (hasNamedVectors)
+        {
+            storageModel.Vectors.Vectors_ = new NamedVectors();
+            storageModel.Vectors.Vectors_.Vectors.Add("FloatVector", new Vector() { Data = { 1.0f, 2.0f, 3.0f } });
+        }
+        else
+        {
+            storageModel.Vectors.Vector = new Vector() { Data = { 1.0f, 2.0f, 3.0f } };
+        }
+
+        var sut = (IVectorStoreRecordMapper<VectorStoreGenericDataModel<Guid>, PointStruct>)new QdrantGenericDataModelMapper(vectorStoreRecordDefinition, hasNamedVectors);
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions());
+
+        // Assert
+        Assert.Equal(s_testGuidKey, dataModel.Key);
+        Assert.Null(dataModel.Data["StringDataProp"]);
+        Assert.Null(dataModel.Data["NullableIntDataProp"]);
+        Assert.Null(dataModel.Data["NullableTagListDataProp"]);
+        Assert.Equal(s_vector1, ((ReadOnlyMemory<float>?)dataModel.Vectors["FloatVector"])!.Value.ToArray());
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelThrowsForInvalidVectorType()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(ulong)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var sut = new QdrantGenericDataModelMapper(vectorStoreRecordDefinition, false);
+
+        var dataModel = new VectorStoreGenericDataModel<ulong>(1ul)
+        {
+            Vectors =
+            {
+                ["FloatVector"] = "not a vector",
+            },
+        };
+
+        // Act
+        var exception = Assert.Throws<VectorStoreRecordMappingException>(() => sut.MapFromDataToStorageModel(dataModel));
+
+        // Assert
+        Assert.Equal("Vector property 'FloatVector' on provided record of type VectorStoreGenericDataModel must be of type ReadOnlyMemory<float> and not null.", exception.Message);
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelSkipsMissingProperties()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(ulong)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var sut = new QdrantGenericDataModelMapper(vectorStoreRecordDefinition, false);
+
+        var dataModel = new VectorStoreGenericDataModel<ulong>(1ul)
+        {
+            Vectors = { ["FloatVector"] = new ReadOnlyMemory<float>(s_vector1) },
+        };
+
+        // Act
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal(1ul, storageModel.Id.Num);
+        Assert.False(storageModel.Payload.ContainsKey("StringDataProp"));
+        Assert.Equal(s_vector1, storageModel.Vectors.Vector.Data.ToArray());
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelSkipsMissingProperties()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(ulong)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var sut = new QdrantGenericDataModelMapper(vectorStoreRecordDefinition, false);
+
+        var storageModel = new PointStruct()
+        {
+            Id = new PointId() { Num = 1 },
+            Vectors = new Vectors()
+            {
+                Vector = new Vector() { Data = { 1.0f, 2.0f, 3.0f } }
+            },
+        };
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(storageModel, new() { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal(1ul, dataModel.Key);
+        Assert.False(dataModel.Data.ContainsKey("StringDataProp"));
+        Assert.Equal(s_vector1, ((ReadOnlyMemory<float>?)dataModel.Vectors["FloatVector"])!.Value.ToArray());
+    }
+}


### PR DESCRIPTION
### Motivation and Context

To allow use of the vector store abstractions without needing to define your own data type, we are adding a generic data type and mappers that can work with it.

### Description

- Separate field mapping functions into a separate class for Qdrant, so that it can be reused across mappers.
- Adding a mapper for the generic data type for Qdrant
- Adding some small improvements to Azure AI Search's mapper.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
