### PR TITLE
.Net: Adding generic data model support for Redis

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetGenericDataModelMapper.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.SemanticKernel.Data;
+using StackExchange.Redis;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// A mapper that maps between the generic semantic kernel data model and the model that the data is stored in in Redis when using hash sets.
+/// </summary>
+internal class RedisHashSetGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, (string Key, HashEntry[] HashEntries)>
+{
+    /// <summary>A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</summary>
+    private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisHashSetGenericDataModelMapper"/> class.
+    /// </summary>
+    /// <param name="vectorStoreRecordDefinition">A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</param>
+    public RedisHashSetGenericDataModelMapper(VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    {
+        Verify.NotNull(vectorStoreRecordDefinition);
+
+        this._vectorStoreRecordDefinition = vectorStoreRecordDefinition;
+    }
+
+    /// <inheritdoc />
+    public (string Key, HashEntry[] HashEntries) MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)
+    {
+        var hashEntries = new List<HashEntry>();
+
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            var storagePropertyName = property.StoragePropertyName ?? property.DataModelPropertyName;
+            var sourceDictionary = property is VectorStoreRecordDataProperty ? dataModel.Data : dataModel.Vectors;
+
+            // Only map properties across that actually exist in the input.
+            if (sourceDictionary is null || !sourceDictionary.TryGetValue(property.DataModelPropertyName, out var sourceValue))
+            {
+                continue;
+            }
+
+            // Replicate null if the property exists but is null.
+            if (sourceValue is null)
+            {
+                hashEntries.Add(new HashEntry(storagePropertyName, RedisValue.Null));
+                continue;
+            }
+
+            // Map data Properties
+            if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                hashEntries.Add(new HashEntry(storagePropertyName, RedisValue.Unbox(sourceValue)));
+            }
+            // Map vector properties
+            else if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                if (sourceValue is ReadOnlyMemory<float> rom)
+                {
+                    hashEntries.Add(new HashEntry(storagePropertyName, RedisVectorStoreRecordFieldMapping.ConvertVectorToBytes(rom)));
+                }
+                else if (sourceValue is ReadOnlyMemory<double> rod)
+                {
+                    hashEntries.Add(new HashEntry(storagePropertyName, RedisVectorStoreRecordFieldMapping.ConvertVectorToBytes(rod)));
+                }
+                else
+                {
+                    throw new VectorStoreRecordMappingException($"Unsupported vector type {sourceValue.GetType().Name} found on property ${vectorProperty.DataModelPropertyName}. Only float and double vectors are supported.");
+                }
+            }
+        }
+
+        return (dataModel.Key, hashEntries.ToArray());
+    }
+
+    /// <inheritdoc />
+    public VectorStoreGenericDataModel<string> MapFromStorageToDataModel((string Key, HashEntry[] HashEntries) storageModel, StorageToDataModelMapperOptions options)
+    {
+        var dataModel = new VectorStoreGenericDataModel<string>(storageModel.Key);
+
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            var storagePropertyName = property.StoragePropertyName ?? property.DataModelPropertyName;
+            var targetDictionary = property is VectorStoreRecordDataProperty ? dataModel.Data : dataModel.Vectors;
+            var hashEntry = storageModel.HashEntries.FirstOrDefault(x => x.Name == storagePropertyName);
+
+            // Only map properties across that actually exist in the input.
+            if (!hashEntry.Name.HasValue)
+            {
+                continue;
+            }
+
+            // Replicate null if the property exists but is null.
+            if (hashEntry.Value.IsNull)
+            {
+                targetDictionary.Add(property.DataModelPropertyName, null);
+                continue;
+            }
+
+            // Map data Properties
+            if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                var typeOrNullableType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+                var convertedValue = Convert.ChangeType(hashEntry.Value, typeOrNullableType);
+                dataModel.Data.Add(dataProperty.DataModelPropertyName, convertedValue);
+            }
+            // Map vector properties
+            else if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                if (property.PropertyType == typeof(ReadOnlyMemory<float>) || property.PropertyType == typeof(ReadOnlyMemory<float>?))
+                {
+                    var array = MemoryMarshal.Cast<byte, float>((byte[])hashEntry.Value!).ToArray();
+                    dataModel.Vectors.Add(vectorProperty.DataModelPropertyName, new ReadOnlyMemory<float>(array));
+                }
+                else if (property.PropertyType == typeof(ReadOnlyMemory<double>) || property.PropertyType == typeof(ReadOnlyMemory<double>?))
+                {
+                    var array = MemoryMarshal.Cast<byte, double>((byte[])hashEntry.Value!).ToArray();
+                    dataModel.Vectors.Add(vectorProperty.DataModelPropertyName, new ReadOnlyMemory<double>(array));
+                }
+                else
+                {
+                    throw new VectorStoreRecordMappingException($"Unsupported vector type '{property.PropertyType.Name}' found on property '{property.DataModelPropertyName}'. Only float and double vectors are supported.");
+                }
+            }
+        }
+
+        return dataModel;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -118,10 +118,17 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         // Assign Mapper.
         if (this._options.HashEntriesCustomMapper is not null)
         {
+            // Custom Mapper.
             this._mapper = this._options.HashEntriesCustomMapper;
+        }
+        else if (typeof(TRecord) == typeof(VectorStoreGenericDataModel<string>))
+        {
+            // Generic data model mapper.
+            this._mapper = (IVectorStoreRecordMapper<TRecord, (string Key, HashEntry[] HashEntries)>)new RedisHashSetGenericDataModelMapper(this._vectorStoreRecordDefinition);
         }
         else
         {
+            // Default Mapper.
             this._mapper = new RedisHashSetVectorStoreRecordMapper<TRecord>(this._vectorStoreRecordDefinition, this._storagePropertyNames);
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
@@ -87,11 +87,11 @@ internal sealed class RedisHashSetVectorStoreRecordMapper<TConsumerDataModel> : 
                 // collection constructor to ensure that the model has no other vector types.
                 if (value is ReadOnlyMemory<float> rom)
                 {
-                    hashEntries.Add(new HashEntry(storageName, ConvertVectorToBytes(rom)));
+                    hashEntries.Add(new HashEntry(storageName, RedisVectorStoreRecordFieldMapping.ConvertVectorToBytes(rom)));
                 }
                 else if (value is ReadOnlyMemory<double> rod)
                 {
-                    hashEntries.Add(new HashEntry(storageName, ConvertVectorToBytes(rod)));
+                    hashEntries.Add(new HashEntry(storageName, RedisVectorStoreRecordFieldMapping.ConvertVectorToBytes(rod)));
                 }
             }
         }
@@ -155,15 +155,5 @@ internal sealed class RedisHashSetVectorStoreRecordMapper<TConsumerDataModel> : 
         jsonObject.Add(this._keyFieldJsonPropertyName, storageModel.Key);
 
         return JsonSerializer.Deserialize<TConsumerDataModel>(jsonObject)!;
-    }
-
-    private static byte[] ConvertVectorToBytes(ReadOnlyMemory<float> vector)
-    {
-        return MemoryMarshal.AsBytes(vector.Span).ToArray();
-    }
-
-    private static byte[] ConvertVectorToBytes(ReadOnlyMemory<double> vector)
-    {
-        return MemoryMarshal.AsBytes(vector.Span).ToArray();
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonGenericDataModelMapper.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Data;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// A mapper that maps between the generic semantic kernel data model and the model that the data is stored in in Redis when using JSON.
+/// </summary>
+internal class RedisJsonGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, (string Key, JsonNode Node)>
+{
+    /// <summary>A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</summary>
+    private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
+
+    /// <summary>The JSON serializer options to use when converting between the data model and the Redis record.</summary>
+    private readonly JsonSerializerOptions _jsonSerializerOptions;
+
+    /// <summary>A dictionary that maps from a property name to the storage name that should be used when serializing it to json for data and vector properties.</summary>
+    public readonly Dictionary<string, string> _storagePropertyNames;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisJsonGenericDataModelMapper"/> class.
+    /// </summary>
+    /// <param name="vectorStoreRecordDefinition">A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</param>
+    /// <param name="jsonSerializerOptions">The JSON serializer options to use when converting between the data model and the Redis record.</param>
+    public RedisJsonGenericDataModelMapper(
+        VectorStoreRecordDefinition vectorStoreRecordDefinition,
+        JsonSerializerOptions jsonSerializerOptions)
+    {
+        Verify.NotNull(vectorStoreRecordDefinition);
+        Verify.NotNull(jsonSerializerOptions);
+
+        this._vectorStoreRecordDefinition = vectorStoreRecordDefinition;
+        this._jsonSerializerOptions = jsonSerializerOptions;
+
+        // Create a dictionary that maps from the data model property name to the storage property name.
+        this._storagePropertyNames = vectorStoreRecordDefinition.Properties.Select(x =>
+        {
+            if (x.StoragePropertyName is not null)
+            {
+                return new KeyValuePair<string, string>(
+                    x.DataModelPropertyName,
+                    x.StoragePropertyName);
+            }
+
+            if (jsonSerializerOptions.PropertyNamingPolicy is not null)
+            {
+                return new KeyValuePair<string, string>(
+                    x.DataModelPropertyName,
+                    jsonSerializerOptions.PropertyNamingPolicy.ConvertName(x.DataModelPropertyName));
+            }
+
+            return new KeyValuePair<string, string>(
+                x.DataModelPropertyName,
+                x.DataModelPropertyName);
+        }).ToDictionary(x => x.Key, x => x.Value);
+    }
+
+    /// <inheritdoc />
+    public (string Key, JsonNode Node) MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)
+    {
+        var jsonObject = new JsonObject();
+
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            var storagePropertyName = this._storagePropertyNames[property.DataModelPropertyName];
+            var sourceDictionary = property is VectorStoreRecordDataProperty ? dataModel.Data : dataModel.Vectors;
+
+            // Only map properties across that actually exist in the input.
+            if (sourceDictionary is null || !sourceDictionary.TryGetValue(property.DataModelPropertyName, out var sourceValue))
+            {
+                continue;
+            }
+
+            // Replicate null if the property exists but is null.
+            if (sourceValue is null)
+            {
+                jsonObject.Add(storagePropertyName, null);
+                continue;
+            }
+
+            jsonObject.Add(storagePropertyName, JsonSerializer.SerializeToNode(sourceValue, property.PropertyType));
+        }
+
+        return (dataModel.Key, jsonObject);
+    }
+
+    /// <inheritdoc />
+    public VectorStoreGenericDataModel<string> MapFromStorageToDataModel((string Key, JsonNode Node) storageModel, StorageToDataModelMapperOptions options)
+    {
+        var dataModel = new VectorStoreGenericDataModel<string>(storageModel.Key);
+
+        // The redis result can be either a single object or an array with a single object in the case where we are doing an MGET.
+        JsonObject jsonObject;
+        if (storageModel.Node is JsonObject topLevelJsonObject)
+        {
+            jsonObject = topLevelJsonObject;
+        }
+        else if (storageModel.Node is JsonArray jsonArray && jsonArray.Count == 1 && jsonArray[0] is JsonObject arrayEntryJsonObject)
+        {
+            jsonObject = arrayEntryJsonObject;
+        }
+        else
+        {
+            throw new VectorStoreRecordMappingException($"Invalid data format for document with key '{storageModel.Key}'");
+        }
+
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            var storagePropertyName = this._storagePropertyNames[property.DataModelPropertyName];
+            var targetDictionary = property is VectorStoreRecordDataProperty ? dataModel.Data : dataModel.Vectors;
+
+            // Only map properties across that actually exist in the input.
+            if (!jsonObject.TryGetPropertyValue(storagePropertyName, out var sourceValue))
+            {
+                continue;
+            }
+
+            // Replicate null if the property exists but is null.
+            if (sourceValue is null)
+            {
+                targetDictionary.Add(property.DataModelPropertyName, null);
+                continue;
+            }
+
+            // Map data and vector values.
+            if (property is VectorStoreRecordDataProperty || property is VectorStoreRecordVectorProperty)
+            {
+                targetDictionary.Add(property.DataModelPropertyName, JsonSerializer.Deserialize(sourceValue, property.PropertyType));
+            }
+        }
+
+        return dataModel;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -106,10 +106,19 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         // Assign Mapper.
         if (this._options.JsonNodeCustomMapper is not null)
         {
+            // Custom Mapper.
             this._mapper = this._options.JsonNodeCustomMapper;
+        }
+        else if (typeof(TRecord) == typeof(VectorStoreGenericDataModel<string>))
+        {
+            // Generic data model mapper.
+            this._mapper = (IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)>)new RedisJsonGenericDataModelMapper(
+                this._vectorStoreRecordDefinition,
+                this._jsonSerializerOptions);
         }
         else
         {
+            // Default Mapper.
             this._mapper = new RedisJsonVectorStoreRecordMapper<TRecord>(keyJsonPropertyName, this._jsonSerializerOptions);
         }
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordFieldMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreRecordFieldMapping.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis;
+
+/// <summary>
+/// Contains helper methods for mapping fields to and from the format required by the Redis client sdk.
+/// </summary>
+internal static class RedisVectorStoreRecordFieldMapping
+{
+    /// <summary>
+    /// Convert a vector to a byte array as required by the Redis client sdk when using hashsets.
+    /// </summary>
+    /// <param name="vector">The vector to convert.</param>
+    /// <returns>The byte array.</returns>
+    public static byte[] ConvertVectorToBytes(ReadOnlyMemory<float> vector)
+    {
+        return MemoryMarshal.AsBytes(vector.Span).ToArray();
+    }
+
+    /// <summary>
+    /// Convert a vector to a byte array as required by the Redis client sdk when using hashsets.
+    /// </summary>
+    /// <param name="vector">The vector to convert.</param>
+    /// <returns>The byte array.</returns>
+    public static byte[] ConvertVectorToBytes(ReadOnlyMemory<double> vector)
+    {
+        return MemoryMarshal.AsBytes(vector.Span).ToArray();
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetGenericDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetGenericDataModelMapperTests.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Data;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisHashSetGenericDataModelMapper"/> class.
+/// </summary>
+public class RedisHashSetGenericDataModelMapperTests
+{
+    private static readonly float[] s_floatVector = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
+    private static readonly double[] s_doubleVector = new double[] { 5.0d, 6.0d, 7.0d, 8.0d };
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsAllSupportedTypes()
+    {
+        // Arrange.
+        var sut = new RedisHashSetGenericDataModelMapper(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringData"] = "data 1",
+                ["IntData"] = 1,
+                ["UIntData"] = 2u,
+                ["LongData"] = 3L,
+                ["ULongData"] = 4ul,
+                ["DoubleData"] = 5.5d,
+                ["FloatData"] = 6.6f,
+                ["BoolData"] = true,
+                ["NullableIntData"] = 7,
+                ["NullableUIntData"] = 8u,
+                ["NullableLongData"] = 9L,
+                ["NullableULongData"] = 10ul,
+                ["NullableDoubleData"] = 11.1d,
+                ["NullableFloatData"] = 12.2f,
+                ["NullableBoolData"] = false,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = new ReadOnlyMemory<float>(s_floatVector),
+                ["DoubleVector"] = new ReadOnlyMemory<double>(s_doubleVector),
+            },
+        };
+
+        // Act.
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel.Key);
+        RedisHashSetVectorStoreMappingTestHelpers.VerifyHashSet(storageModel.HashEntries);
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsNullValues()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringData", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntData", typeof(int?)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>?)),
+            },
+        };
+
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringData"] = null,
+                ["NullableIntData"] = null,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = null,
+            },
+        };
+
+        var sut = new RedisHashSetGenericDataModelMapper(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition);
+
+        // Act
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel.Key);
+
+        Assert.Equal("storage_string_data", storageModel.HashEntries[0].Name.ToString());
+        Assert.True(storageModel.HashEntries[0].Value.IsNull);
+
+        Assert.Equal("NullableIntData", storageModel.HashEntries[1].Name.ToString());
+        Assert.True(storageModel.HashEntries[1].Value.IsNull);
+
+        Assert.Equal("FloatVector", storageModel.HashEntries[2].Name.ToString());
+        Assert.True(storageModel.HashEntries[2].Value.IsNull);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsAllSupportedTypes()
+    {
+        // Arrange.
+        var hashSet = RedisHashSetVectorStoreMappingTestHelpers.CreateHashSet();
+
+        var sut = new RedisHashSetGenericDataModelMapper(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition);
+
+        // Act.
+        var dataModel = sut.MapFromStorageToDataModel(("key", hashSet), new() { IncludeVectors = true });
+
+        // Assert.
+        Assert.Equal("key", dataModel.Key);
+        Assert.Equal("data 1", dataModel.Data["StringData"]);
+        Assert.Equal(1, dataModel.Data["IntData"]);
+        Assert.Equal(2u, dataModel.Data["UIntData"]);
+        Assert.Equal(3L, dataModel.Data["LongData"]);
+        Assert.Equal(4ul, dataModel.Data["ULongData"]);
+        Assert.Equal(5.5d, dataModel.Data["DoubleData"]);
+        Assert.Equal(6.6f, dataModel.Data["FloatData"]);
+        Assert.True((bool)dataModel.Data["BoolData"]!);
+        Assert.Equal(7, dataModel.Data["NullableIntData"]);
+        Assert.Equal(8u, dataModel.Data["NullableUIntData"]);
+        Assert.Equal(9L, dataModel.Data["NullableLongData"]);
+        Assert.Equal(10ul, dataModel.Data["NullableULongData"]);
+        Assert.Equal(11.1d, dataModel.Data["NullableDoubleData"]);
+        Assert.Equal(12.2f, dataModel.Data["NullableFloatData"]);
+        Assert.False((bool)dataModel.Data["NullableBoolData"]!);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, ((ReadOnlyMemory<float>)dataModel.Vectors["FloatVector"]!).ToArray());
+        Assert.Equal(new double[] { 5, 6, 7, 8 }, ((ReadOnlyMemory<double>)dataModel.Vectors["DoubleVector"]!).ToArray());
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsNullValues()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringData", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntData", typeof(int?)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>?)),
+            },
+        };
+
+        var hashSet = new HashEntry[]
+        {
+            new("storage_string_data", RedisValue.Null),
+            new("NullableIntData", RedisValue.Null),
+            new("FloatVector", RedisValue.Null),
+        };
+
+        var sut = new RedisHashSetGenericDataModelMapper(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition);
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(("key", hashSet), new() { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal("key", dataModel.Key);
+        Assert.Null(dataModel.Data["StringData"]);
+        Assert.Null(dataModel.Data["NullableIntData"]);
+        Assert.Null(dataModel.Vectors["FloatVector"]);
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelSkipsMissingProperties()
+    {
+        // Arrange.
+        var sut = new RedisHashSetGenericDataModelMapper(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data = { },
+            Vectors = { },
+        };
+
+        // Act.
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel.Key);
+        Assert.Empty(storageModel.HashEntries);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelSkipsMissingProperties()
+    {
+        // Arrange.
+        var hashSet = Array.Empty<HashEntry>();
+
+        var sut = new RedisHashSetGenericDataModelMapper(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition);
+
+        // Act.
+        var dataModel = sut.MapFromStorageToDataModel(("key", hashSet), new() { IncludeVectors = true });
+
+        // Assert.
+        Assert.Equal("key", dataModel.Key);
+        Assert.Empty(dataModel.Data);
+        Assert.Empty(dataModel.Vectors);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreMappingTestHelpers.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreMappingTestHelpers.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.SemanticKernel.Data;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains helper methods and data for testing the mapping of records between storage and data models.
+/// These helpers are shared between the different mapping tests.
+/// </summary>
+internal static class RedisHashSetVectorStoreMappingTestHelpers
+{
+    public static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>()
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("StringData", typeof(string)) { StoragePropertyName = "storage_string_data" },
+            new VectorStoreRecordDataProperty("IntData", typeof(int)),
+            new VectorStoreRecordDataProperty("UIntData", typeof(uint)),
+            new VectorStoreRecordDataProperty("LongData", typeof(long)),
+            new VectorStoreRecordDataProperty("ULongData", typeof(ulong)),
+            new VectorStoreRecordDataProperty("DoubleData", typeof(double)),
+            new VectorStoreRecordDataProperty("FloatData", typeof(float)),
+            new VectorStoreRecordDataProperty("BoolData", typeof(bool)),
+            new VectorStoreRecordDataProperty("NullableIntData", typeof(int?)),
+            new VectorStoreRecordDataProperty("NullableUIntData", typeof(uint?)),
+            new VectorStoreRecordDataProperty("NullableLongData", typeof(long?)),
+            new VectorStoreRecordDataProperty("NullableULongData", typeof(ulong?)),
+            new VectorStoreRecordDataProperty("NullableDoubleData", typeof(double?)),
+            new VectorStoreRecordDataProperty("NullableFloatData", typeof(float?)),
+            new VectorStoreRecordDataProperty("NullableBoolData", typeof(bool?)),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            new VectorStoreRecordVectorProperty("DoubleVector", typeof(ReadOnlyMemory<double>)),
+        }
+    };
+
+    public static HashEntry[] CreateHashSet()
+    {
+        var hashSet = new HashEntry[17];
+        hashSet[0] = new HashEntry("storage_string_data", "data 1");
+        hashSet[1] = new HashEntry("IntData", 1);
+        hashSet[2] = new HashEntry("UIntData", 2);
+        hashSet[3] = new HashEntry("LongData", 3);
+        hashSet[4] = new HashEntry("ULongData", 4);
+        hashSet[5] = new HashEntry("DoubleData", 5.5);
+        hashSet[6] = new HashEntry("FloatData", 6.6);
+        hashSet[7] = new HashEntry("BoolData", true);
+        hashSet[8] = new HashEntry("NullableIntData", 7);
+        hashSet[9] = new HashEntry("NullableUIntData", 8);
+        hashSet[10] = new HashEntry("NullableLongData", 9);
+        hashSet[11] = new HashEntry("NullableULongData", 10);
+        hashSet[12] = new HashEntry("NullableDoubleData", 11.1);
+        hashSet[13] = new HashEntry("NullableFloatData", 12.2);
+        hashSet[14] = new HashEntry("NullableBoolData", false);
+        hashSet[15] = new HashEntry("FloatVector", MemoryMarshal.AsBytes(new ReadOnlySpan<float>(new float[] { 1, 2, 3, 4 })).ToArray());
+        hashSet[16] = new HashEntry("DoubleVector", MemoryMarshal.AsBytes(new ReadOnlySpan<double>(new double[] { 5, 6, 7, 8 })).ToArray());
+        return hashSet;
+    }
+
+    public static void VerifyHashSet(HashEntry[] hashEntries)
+    {
+        Assert.Equal("storage_string_data", hashEntries[0].Name.ToString());
+        Assert.Equal("data 1", hashEntries[0].Value.ToString());
+
+        Assert.Equal("IntData", hashEntries[1].Name.ToString());
+        Assert.Equal(1, (int)hashEntries[1].Value);
+
+        Assert.Equal("UIntData", hashEntries[2].Name.ToString());
+        Assert.Equal(2u, (uint)hashEntries[2].Value);
+
+        Assert.Equal("LongData", hashEntries[3].Name.ToString());
+        Assert.Equal(3, (long)hashEntries[3].Value);
+
+        Assert.Equal("ULongData", hashEntries[4].Name.ToString());
+        Assert.Equal(4ul, (ulong)hashEntries[4].Value);
+
+        Assert.Equal("DoubleData", hashEntries[5].Name.ToString());
+        Assert.Equal(5.5d, (double)hashEntries[5].Value);
+
+        Assert.Equal("FloatData", hashEntries[6].Name.ToString());
+        Assert.Equal(6.6f, (float)hashEntries[6].Value);
+
+        Assert.Equal("BoolData", hashEntries[7].Name.ToString());
+        Assert.True((bool)hashEntries[7].Value);
+
+        Assert.Equal("NullableIntData", hashEntries[8].Name.ToString());
+        Assert.Equal(7, (int)hashEntries[8].Value);
+
+        Assert.Equal("NullableUIntData", hashEntries[9].Name.ToString());
+        Assert.Equal(8u, (uint)hashEntries[9].Value);
+
+        Assert.Equal("NullableLongData", hashEntries[10].Name.ToString());
+        Assert.Equal(9, (long)hashEntries[10].Value);
+
+        Assert.Equal("NullableULongData", hashEntries[11].Name.ToString());
+        Assert.Equal(10ul, (ulong)hashEntries[11].Value);
+
+        Assert.Equal("NullableDoubleData", hashEntries[12].Name.ToString());
+        Assert.Equal(11.1d, (double)hashEntries[12].Value);
+
+        Assert.Equal("NullableFloatData", hashEntries[13].Name.ToString());
+        Assert.Equal(12.2f, (float)hashEntries[13].Value);
+
+        Assert.Equal("NullableBoolData", hashEntries[14].Name.ToString());
+        Assert.False((bool)hashEntries[14].Value);
+
+        Assert.Equal("FloatVector", hashEntries[15].Name.ToString());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, MemoryMarshal.Cast<byte, float>((byte[])hashEntries[15].Value!).ToArray());
+
+        Assert.Equal("DoubleVector", hashEntries[16].Name.ToString());
+        Assert.Equal(new double[] { 5, 6, 7, 8 }, MemoryMarshal.Cast<byte, double>((byte[])hashEntries[16].Value!).ToArray());
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordMapperTests.cs
@@ -2,10 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using Microsoft.SemanticKernel.Connectors.Redis;
+using Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
 using Microsoft.SemanticKernel.Data;
-using StackExchange.Redis;
 using Xunit;
 
 namespace SemanticKernel.Connectors.Redis.UnitTests;
@@ -19,7 +18,7 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
     public void MapsAllFieldsFromDataToStorageModel()
     {
         // Arrange.
-        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(s_vectorStoreRecordDefinition, s_storagePropertyNames);
+        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition, s_storagePropertyNames);
 
         // Act.
         var actual = sut.MapFromDataToStorageModel(CreateModel("test key"));
@@ -27,67 +26,17 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
         // Assert.
         Assert.NotNull(actual.HashEntries);
         Assert.Equal("test key", actual.Key);
-
-        Assert.Equal("storage_string_data", actual.HashEntries[0].Name.ToString());
-        Assert.Equal("data 1", actual.HashEntries[0].Value.ToString());
-
-        Assert.Equal("IntData", actual.HashEntries[1].Name.ToString());
-        Assert.Equal(1, (int)actual.HashEntries[1].Value);
-
-        Assert.Equal("UIntData", actual.HashEntries[2].Name.ToString());
-        Assert.Equal(2u, (uint)actual.HashEntries[2].Value);
-
-        Assert.Equal("LongData", actual.HashEntries[3].Name.ToString());
-        Assert.Equal(3, (long)actual.HashEntries[3].Value);
-
-        Assert.Equal("ULongData", actual.HashEntries[4].Name.ToString());
-        Assert.Equal(4ul, (ulong)actual.HashEntries[4].Value);
-
-        Assert.Equal("DoubleData", actual.HashEntries[5].Name.ToString());
-        Assert.Equal(5.5d, (double)actual.HashEntries[5].Value);
-
-        Assert.Equal("FloatData", actual.HashEntries[6].Name.ToString());
-        Assert.Equal(6.6f, (float)actual.HashEntries[6].Value);
-
-        Assert.Equal("BoolData", actual.HashEntries[7].Name.ToString());
-        Assert.True((bool)actual.HashEntries[7].Value);
-
-        Assert.Equal("NullableIntData", actual.HashEntries[8].Name.ToString());
-        Assert.Equal(7, (int)actual.HashEntries[8].Value);
-
-        Assert.Equal("NullableUIntData", actual.HashEntries[9].Name.ToString());
-        Assert.Equal(8u, (uint)actual.HashEntries[9].Value);
-
-        Assert.Equal("NullableLongData", actual.HashEntries[10].Name.ToString());
-        Assert.Equal(9, (long)actual.HashEntries[10].Value);
-
-        Assert.Equal("NullableULongData", actual.HashEntries[11].Name.ToString());
-        Assert.Equal(10ul, (ulong)actual.HashEntries[11].Value);
-
-        Assert.Equal("NullableDoubleData", actual.HashEntries[12].Name.ToString());
-        Assert.Equal(11.1d, (double)actual.HashEntries[12].Value);
-
-        Assert.Equal("NullableFloatData", actual.HashEntries[13].Name.ToString());
-        Assert.Equal(12.2f, (float)actual.HashEntries[13].Value);
-
-        Assert.Equal("NullableBoolData", actual.HashEntries[14].Name.ToString());
-        Assert.False((bool)actual.HashEntries[14].Value);
-
-        Assert.Equal("FloatVector", actual.HashEntries[15].Name.ToString());
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, MemoryMarshal.Cast<byte, float>((byte[])actual.HashEntries[15].Value!).ToArray());
-
-        Assert.Equal("DoubleVector", actual.HashEntries[16].Name.ToString());
-        Assert.Equal(new double[] { 5, 6, 7, 8 }, MemoryMarshal.Cast<byte, double>((byte[])actual.HashEntries[16].Value!).ToArray());
+        RedisHashSetVectorStoreMappingTestHelpers.VerifyHashSet(actual.HashEntries);
     }
 
     [Fact]
     public void MapsAllFieldsFromStorageToDataModel()
     {
         // Arrange.
-        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(s_vectorStoreRecordDefinition, s_storagePropertyNames);
+        var sut = new RedisHashSetVectorStoreRecordMapper<AllTypesModel>(RedisHashSetVectorStoreMappingTestHelpers.s_vectorStoreRecordDefinition, s_storagePropertyNames);
 
         // Act.
-        var actual = sut.MapFromStorageToDataModel(("test key", CreateHashSet()), new() { IncludeVectors = true });
+        var actual = sut.MapFromStorageToDataModel(("test key", RedisHashSetVectorStoreMappingTestHelpers.CreateHashSet()), new() { IncludeVectors = true });
 
         // Assert.
         Assert.NotNull(actual);
@@ -138,29 +87,6 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
         };
     }
 
-    private static HashEntry[] CreateHashSet()
-    {
-        var hashSet = new HashEntry[17];
-        hashSet[0] = new HashEntry("storage_string_data", "data 1");
-        hashSet[1] = new HashEntry("IntData", 1);
-        hashSet[2] = new HashEntry("UIntData", 2);
-        hashSet[3] = new HashEntry("LongData", 3);
-        hashSet[4] = new HashEntry("ULongData", 4);
-        hashSet[5] = new HashEntry("DoubleData", 5.5);
-        hashSet[6] = new HashEntry("FloatData", 6.6);
-        hashSet[7] = new HashEntry("BoolData", true);
-        hashSet[8] = new HashEntry("NullableIntData", 7);
-        hashSet[9] = new HashEntry("NullableUIntData", 8);
-        hashSet[10] = new HashEntry("NullableLongData", 9);
-        hashSet[11] = new HashEntry("NullableULongData", 10);
-        hashSet[12] = new HashEntry("NullableDoubleData", 11.1);
-        hashSet[13] = new HashEntry("NullableFloatData", 12.2);
-        hashSet[14] = new HashEntry("NullableBoolData", false);
-        hashSet[15] = new HashEntry("FloatVector", MemoryMarshal.AsBytes(new ReadOnlySpan<float>(new float[] { 1, 2, 3, 4 })).ToArray());
-        hashSet[16] = new HashEntry("DoubleVector", MemoryMarshal.AsBytes(new ReadOnlySpan<double>(new double[] { 5, 6, 7, 8 })).ToArray());
-        return hashSet;
-    }
-
     private static readonly Dictionary<string, string> s_storagePropertyNames = new()
     {
         ["StringData"] = "storage_string_data",
@@ -180,31 +106,6 @@ public sealed class RedisHashSetVectorStoreRecordMapperTests
         ["NullableBoolData"] = "NullableBoolData",
         ["FloatVector"] = "FloatVector",
         ["DoubleVector"] = "DoubleVector",
-    };
-
-    private static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
-    {
-        Properties = new List<VectorStoreRecordProperty>()
-        {
-            new VectorStoreRecordKeyProperty("Key", typeof(string)),
-            new VectorStoreRecordDataProperty("StringData", typeof(string)),
-            new VectorStoreRecordDataProperty("IntData", typeof(int)),
-            new VectorStoreRecordDataProperty("UIntData", typeof(uint)),
-            new VectorStoreRecordDataProperty("LongData", typeof(long)),
-            new VectorStoreRecordDataProperty("ULongData", typeof(ulong)),
-            new VectorStoreRecordDataProperty("DoubleData", typeof(double)),
-            new VectorStoreRecordDataProperty("FloatData", typeof(float)),
-            new VectorStoreRecordDataProperty("BoolData", typeof(bool)),
-            new VectorStoreRecordDataProperty("NullableIntData", typeof(int?)),
-            new VectorStoreRecordDataProperty("NullableUIntData", typeof(uint?)),
-            new VectorStoreRecordDataProperty("NullableLongData", typeof(long?)),
-            new VectorStoreRecordDataProperty("NullableULongData", typeof(ulong?)),
-            new VectorStoreRecordDataProperty("NullableDoubleData", typeof(double?)),
-            new VectorStoreRecordDataProperty("NullableFloatData", typeof(float?)),
-            new VectorStoreRecordDataProperty("NullableBoolData", typeof(bool?)),
-            new VectorStoreRecordVectorProperty("FloatVector", typeof(float)),
-            new VectorStoreRecordVectorProperty("DoubleVector", typeof(double)),
-        }
     };
 
     private sealed class AllTypesModel

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonGenericDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonGenericDataModelMapperTests.cs
@@ -178,7 +178,7 @@ public class RedisJsonGenericDataModelMapperTests
         Assert.Empty(dataModel.Vectors);
     }
 
-    private class ComplexObject
+    private sealed class ComplexObject
     {
         public string Prop1 { get; set; } = string.Empty;
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonGenericDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonGenericDataModelMapperTests.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
+
+/// <summary>
+/// Contains tests for the <see cref="RedisJsonGenericDataModelMapper"/> class.
+/// </summary>
+public class RedisJsonGenericDataModelMapperTests
+{
+    private static readonly float[] s_floatVector = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
+
+    private static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>()
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("StringData", typeof(string)) { StoragePropertyName = "storage_string_data" },
+            new VectorStoreRecordDataProperty("IntData", typeof(int)),
+            new VectorStoreRecordDataProperty("NullableIntData", typeof(int?)),
+            new VectorStoreRecordDataProperty("ComplexObjectData", typeof(ComplexObject)),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+        }
+    };
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsAllSupportedTypes()
+    {
+        // Arrange.
+        var sut = new RedisJsonGenericDataModelMapper(s_vectorStoreRecordDefinition, JsonSerializerOptions.Default);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringData"] = "data 1",
+                ["IntData"] = 1,
+                ["NullableIntData"] = 2,
+                ["ComplexObjectData"] = new ComplexObject { Prop1 = "prop 1", Prop2 = "prop 2" },
+            },
+            Vectors =
+            {
+                ["FloatVector"] = new ReadOnlyMemory<float>(s_floatVector),
+            },
+        };
+
+        // Act.
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel.Key);
+        Assert.Equal("data 1", (string)storageModel.Node["storage_string_data"]!);
+        Assert.Equal(1, (int)storageModel.Node["IntData"]!);
+        Assert.Equal(2, (int?)storageModel.Node["NullableIntData"]!);
+        Assert.Equal("prop 1", (string)storageModel.Node["ComplexObjectData"]!.AsObject()["Prop1"]!);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, storageModel.Node["FloatVector"]?.AsArray().GetValues<float>().ToArray());
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsNullValues()
+    {
+        // Arrange.
+        var sut = new RedisJsonGenericDataModelMapper(s_vectorStoreRecordDefinition, JsonSerializerOptions.Default);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringData"] = null,
+                ["IntData"] = null,
+                ["NullableIntData"] = null,
+                ["ComplexObjectData"] = null,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = null,
+            },
+        };
+
+        // Act.
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel.Key);
+        Assert.Null(storageModel.Node["storage_string_data"]);
+        Assert.Null(storageModel.Node["IntData"]);
+        Assert.Null(storageModel.Node["NullableIntData"]);
+        Assert.Null(storageModel.Node["ComplexObjectData"]);
+        Assert.Null(storageModel.Node["FloatVector"]);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsAllSupportedTypes()
+    {
+        // Arrange.
+        var sut = new RedisJsonGenericDataModelMapper(s_vectorStoreRecordDefinition, JsonSerializerOptions.Default);
+        var storageModel = new JsonObject();
+        storageModel.Add("storage_string_data", "data 1");
+        storageModel.Add("IntData", 1);
+        storageModel.Add("NullableIntData", 2);
+        storageModel.Add("ComplexObjectData", new JsonObject(new KeyValuePair<string, JsonNode?>[] { new("Prop1", JsonValue.Create("prop 1")), new("Prop2", JsonValue.Create("prop 2")) }));
+        storageModel.Add("FloatVector", new JsonArray(new[] { 1, 2, 3, 4 }.Select(x => JsonValue.Create(x)).ToArray()));
+
+        // Act.
+        var dataModel = sut.MapFromStorageToDataModel(("key", storageModel), new() { IncludeVectors = true });
+
+        // Assert.
+        Assert.Equal("key", dataModel.Key);
+        Assert.Equal("data 1", dataModel.Data["StringData"]);
+        Assert.Equal(1, dataModel.Data["IntData"]);
+        Assert.Equal(2, dataModel.Data["NullableIntData"]);
+        Assert.Equal("prop 1", ((ComplexObject)dataModel.Data["ComplexObjectData"]!).Prop1);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, ((ReadOnlyMemory<float>)dataModel.Vectors["FloatVector"]!).ToArray());
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsNullValues()
+    {
+        // Arrange.
+        var sut = new RedisJsonGenericDataModelMapper(s_vectorStoreRecordDefinition, JsonSerializerOptions.Default);
+        var storageModel = new JsonObject();
+        storageModel.Add("storage_string_data", null);
+        storageModel.Add("IntData", null);
+        storageModel.Add("NullableIntData", null);
+        storageModel.Add("ComplexObjectData", null);
+        storageModel.Add("FloatVector", null);
+
+        // Act.
+        var dataModel = sut.MapFromStorageToDataModel(("key", storageModel), new() { IncludeVectors = true });
+
+        // Assert.
+        Assert.Equal("key", dataModel.Key);
+        Assert.Null(dataModel.Data["StringData"]);
+        Assert.Null(dataModel.Data["IntData"]);
+        Assert.Null(dataModel.Data["NullableIntData"]);
+        Assert.Null(dataModel.Data["ComplexObjectData"]);
+        Assert.Null(dataModel.Vectors["FloatVector"]);
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelSkipsMissingProperties()
+    {
+        // Arrange.
+        var sut = new RedisJsonGenericDataModelMapper(s_vectorStoreRecordDefinition, JsonSerializerOptions.Default);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data = { },
+            Vectors = { },
+        };
+
+        // Act.
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel.Key);
+        Assert.Empty(storageModel.Node.AsObject());
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelSkipsMissingProperties()
+    {
+        // Arrange.
+        var storageModel = new JsonObject();
+
+        var sut = new RedisJsonGenericDataModelMapper(s_vectorStoreRecordDefinition, JsonSerializerOptions.Default);
+
+        // Act.
+        var dataModel = sut.MapFromStorageToDataModel(("key", storageModel), new() { IncludeVectors = true });
+
+        // Assert.
+        Assert.Equal("key", dataModel.Key);
+        Assert.Empty(dataModel.Data);
+        Assert.Empty(dataModel.Vectors);
+    }
+
+    private class ComplexObject
+    {
+        public string Prop1 { get; set; } = string.Empty;
+
+        public string Prop2 { get; set; } = string.Empty;
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -339,6 +339,71 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true }));
     }
 
+    [Fact(Skip = SkipReason)]
+    public async Task ItCanUpsertAndRetrieveUsingTheGenericMapperAsync()
+    {
+        // Arrange
+        var options = new RedisJsonVectorStoreRecordCollectionOptions<VectorStoreGenericDataModel<string>>
+        {
+            PrefixCollectionNameToKeyNames = true,
+            VectorStoreRecordDefinition = fixture.VectorStoreRecordDefinition
+        };
+        var sut = new RedisJsonVectorStoreRecordCollection<VectorStoreGenericDataModel<string>>(fixture.Database, TestCollectionName, options);
+
+        // Act
+        var baseSetGetResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true });
+        var upsertResult = await sut.UpsertAsync(new VectorStoreGenericDataModel<string>("GenericMapper-1")
+        {
+            Data =
+            {
+                { "HotelName", "Generic Mapper Hotel" },
+                { "HotelCode", 1 },
+                { "Tags", new[] { "generic 1", "generic 2" } },
+                { "FTSTags", new[] { "generic 1", "generic 2" } },
+                { "ParkingIncluded", true },
+                { "LastRenovationDate", new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero) },
+                { "Rating", 3.6 },
+                { "Address", new HotelAddress { City = "Seattle", Country = "USA" } },
+                { "Description", "This is a generic mapper hotel" },
+                { "DescriptionEmbedding", new[] { 30f, 31f, 32f, 33f } }
+            },
+            Vectors =
+            {
+                { "DescriptionEmbedding", new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }) }
+            }
+        });
+        var localGetResult = await sut.GetAsync("GenericMapper-1", new GetRecordOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.NotNull(baseSetGetResult);
+        Assert.Equal("BaseSet-1", baseSetGetResult.Key);
+        Assert.Equal("My Hotel 1", baseSetGetResult.Data["HotelName"]);
+        Assert.Equal(1, baseSetGetResult.Data["HotelCode"]);
+        Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, baseSetGetResult.Data["Tags"]);
+        Assert.Equal(new[] { "pool", "air conditioning", "concierge" }, baseSetGetResult.Data["FTSTags"]);
+        Assert.True((bool)baseSetGetResult.Data["ParkingIncluded"]!);
+        Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), baseSetGetResult.Data["LastRenovationDate"]);
+        Assert.Equal(3.6, baseSetGetResult.Data["Rating"]);
+        Assert.Equal("Seattle", ((HotelAddress)baseSetGetResult.Data["Address"]!).City);
+        Assert.Equal("This is a great hotel.", baseSetGetResult.Data["Description"]);
+        Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)baseSetGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
+
+        Assert.Equal("GenericMapper-1", upsertResult);
+
+        Assert.NotNull(localGetResult);
+        Assert.Equal("GenericMapper-1", localGetResult.Key);
+        Assert.Equal("Generic Mapper Hotel", localGetResult.Data["HotelName"]);
+        Assert.Equal(1, localGetResult.Data["HotelCode"]);
+        Assert.Equal(new[] { "generic 1", "generic 2" }, localGetResult.Data["Tags"]);
+        Assert.Equal(new[] { "generic 1", "generic 2" }, localGetResult.Data["FTSTags"]);
+        Assert.True((bool)localGetResult.Data["ParkingIncluded"]!);
+        Assert.Equal(new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.Zero), localGetResult.Data["LastRenovationDate"]);
+        Assert.Equal(3.6d, localGetResult.Data["Rating"]);
+        Assert.Equal("Seattle", ((HotelAddress)localGetResult.Data["Address"]!).City);
+        Assert.Equal("This is a generic mapper hotel", localGetResult.Data["Description"]);
+        Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)localGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
+    }
+
     private static Hotel CreateTestHotel(string hotelId, int hotelCode)
     {
         var address = new HotelAddress { City = "Seattle", Country = "USA" };


### PR DESCRIPTION
### Motivation and Context

In some cases users may not want to define their own data model, e.g. where the database schema is driven from configuration.
To support this we allow a generic data model which uses object dictionaries for most of the fields, but this requires custom mapping, since each field from storage has to be mapped specifically into the right dictionary.

### Description

- Adding support to Redis for using a generic data model where schema is determined from the record definition.
- Adding unit tests / integration tests
- Refactoring some of the existing unit tests to reuse test code.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
