### PR TITLE
Python: Fix openai assistant function calling bug

### DIFF
--- a/python/samples/getting_started_with_agents/step2_plugins.py
+++ b/python/samples/getting_started_with_agents/step2_plugins.py
@@ -5,9 +5,11 @@ from typing import Annotated
 
 from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
-from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion import OpenAIChatCompletion
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.core_plugins.math_plugin import MathPlugin
+from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel import Kernel
 
@@ -72,13 +74,14 @@ async def main():
 
     # Add the OpenAIChatCompletion AI Service to the Kernel
     service_id = "agent"
-    kernel.add_service(AzureChatCompletion(service_id=service_id))
+    kernel.add_service(OpenAIChatCompletion(service_id=service_id))
 
     settings = kernel.get_prompt_execution_settings_from_service_id(service_id=service_id)
     # Configure the function choice behavior to auto invoke kernel functions
     settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
 
-    kernel.add_plugin(plugin=MenuPlugin(), plugin_name="menu")
+    kernel.add_plugin(MathPlugin(), plugin_name="math")
+    kernel.add_plugin(TimePlugin(), plugin_name="time")
 
     # Create the agent
     agent = ChatCompletionAgent(
@@ -89,10 +92,10 @@ async def main():
     chat = ChatHistory()
 
     # Respond to user input
-    await invoke_agent(agent, "Hello", chat)
-    await invoke_agent(agent, "What is the special soup?", chat)
-    await invoke_agent(agent, "What is the special drink?", chat)
-    await invoke_agent(agent, "Thank you", chat)
+    await invoke_agent(agent, "What is the current hour added to 10?", chat)
+    # await invoke_agent(agent, "What is the special soup?", chat)
+    # await invoke_agent(agent, "What is the special drink?", chat)
+    # await invoke_agent(agent, "Thank you", chat)
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started_with_agents/step2_plugins.py
+++ b/python/samples/getting_started_with_agents/step2_plugins.py
@@ -5,11 +5,9 @@ from typing import Annotated
 
 from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
-from semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion import OpenAIChatCompletion
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.core_plugins.math_plugin import MathPlugin
-from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel import Kernel
 
@@ -72,16 +70,14 @@ async def main():
     # Create the instance of the Kernel
     kernel = Kernel()
 
-    # Add the OpenAIChatCompletion AI Service to the Kernel
     service_id = "agent"
-    kernel.add_service(OpenAIChatCompletion(service_id=service_id))
+    kernel.add_service(AzureChatCompletion(service_id=service_id))
 
     settings = kernel.get_prompt_execution_settings_from_service_id(service_id=service_id)
     # Configure the function choice behavior to auto invoke kernel functions
     settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
 
-    kernel.add_plugin(MathPlugin(), plugin_name="math")
-    kernel.add_plugin(TimePlugin(), plugin_name="time")
+    kernel.add_plugin(MenuPlugin(), plugin_name="menu")
 
     # Create the agent
     agent = ChatCompletionAgent(
@@ -92,10 +88,10 @@ async def main():
     chat = ChatHistory()
 
     # Respond to user input
-    await invoke_agent(agent, "What is the current hour added to 10?", chat)
-    # await invoke_agent(agent, "What is the special soup?", chat)
-    # await invoke_agent(agent, "What is the special drink?", chat)
-    # await invoke_agent(agent, "Thank you", chat)
+    await invoke_agent(agent, "Hello", chat)
+    await invoke_agent(agent, "What is the special soup?", chat)
+    await invoke_agent(agent, "What is the special drink?", chat)
+    await invoke_agent(agent, "Thank you", chat)
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started_with_agents/step7_assistant.py
+++ b/python/samples/getting_started_with_agents/step7_assistant.py
@@ -59,7 +59,7 @@ async def main():
     kernel = Kernel()
 
     # Add the sample plugin to the kernel
-    kernel.add_plugin(plugin=MenuPlugin(), name="menu")
+    kernel.add_plugin(plugin=MenuPlugin(), plugin_name="menu")
 
     # Create the OpenAI Assistant Agent
     service_id = "agent"

--- a/python/samples/getting_started_with_agents/step7_assistant.py
+++ b/python/samples/getting_started_with_agents/step7_assistant.py
@@ -5,6 +5,8 @@ from typing import Annotated
 from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.core_plugins.math_plugin import MathPlugin
+from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel import Kernel
 
@@ -20,7 +22,7 @@ HOST_NAME = "Host"
 HOST_INSTRUCTIONS = "Answer questions about the menu."
 
 # Note: you may toggle this to switch between AzureOpenAI and OpenAI
-use_azure_openai = True
+use_azure_openai = False
 
 
 # Define a sample plugin for the sample
@@ -59,7 +61,8 @@ async def main():
     kernel = Kernel()
 
     # Add the sample plugin to the kernel
-    kernel.add_plugin(plugin=MenuPlugin(), plugin_name="menu")
+    kernel.add_plugin(MathPlugin(), plugin_name="math")
+    kernel.add_plugin(TimePlugin(), plugin_name="time")
 
     # Create the OpenAI Assistant Agent
     service_id = "agent"
@@ -75,10 +78,7 @@ async def main():
     thread_id = await agent.create_thread()
 
     try:
-        await invoke_agent(agent, thread_id=thread_id, input="Hello")
-        await invoke_agent(agent, thread_id=thread_id, input="What is the special soup?")
-        await invoke_agent(agent, thread_id=thread_id, input="What is the special drink?")
-        await invoke_agent(agent, thread_id=thread_id, input="Thank you")
+        await invoke_agent(agent, thread_id=thread_id, input="What is 10+10 and 10-10?")
     finally:
         await agent.delete_thread(thread_id)
         await agent.delete()

--- a/python/samples/getting_started_with_agents/step7_assistant.py
+++ b/python/samples/getting_started_with_agents/step7_assistant.py
@@ -5,8 +5,6 @@ from typing import Annotated
 from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.core_plugins.math_plugin import MathPlugin
-from semantic_kernel.core_plugins.time_plugin import TimePlugin
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel import Kernel
 
@@ -61,8 +59,7 @@ async def main():
     kernel = Kernel()
 
     # Add the sample plugin to the kernel
-    kernel.add_plugin(MathPlugin(), plugin_name="math")
-    kernel.add_plugin(TimePlugin(), plugin_name="time")
+    kernel.add_plugin(plugin=MenuPlugin(), name="menu")
 
     # Create the OpenAI Assistant Agent
     service_id = "agent"
@@ -78,7 +75,10 @@ async def main():
     thread_id = await agent.create_thread()
 
     try:
-        await invoke_agent(agent, thread_id=thread_id, input="What is 10+10 and 10-10?")
+        await invoke_agent(agent, thread_id=thread_id, input="Hello")
+        await invoke_agent(agent, thread_id=thread_id, input="What is the special soup?")
+        await invoke_agent(agent, thread_id=thread_id, input="What is the special drink?")
+        await invoke_agent(agent, thread_id=thread_id, input="Thank you")
     finally:
         await agent.delete_thread(thread_id)
         await agent.delete()

--- a/python/tests/unit/agents/test_open_ai_assistant_base.py
+++ b/python/tests/unit/agents/test_open_ai_assistant_base.py
@@ -965,8 +965,8 @@ def test_format_tool_outputs(azure_openai_assistant_agent, openai_unit_test_env)
     frc = FunctionResultContent.from_function_call_content_and_result(fcc, 123, {"test2": "test2"})
     chat_history.add_message(message=frc.to_chat_message_content())
 
-    tool_outputs = azure_openai_assistant_agent._format_tool_outputs(chat_history)
-    assert tool_outputs[0] == {"tool_call_id": "test", "output": 123}
+    tool_outputs = azure_openai_assistant_agent._format_tool_outputs([fcc], chat_history)
+    assert tool_outputs[0] == {"tool_call_id": "test", "output": "123"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation and Context

We weren't properly handling the available FunctionResultContent in an OpenAI assistant if multiple tool calls were included in the chat history. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix this issue by making sure we use the `function call contents` list as the source of truth (the model is expecting that we return the tool call ids that were sent). We then use these function call content ids to grab the corresponding function result content from the chat history and this is sent back to the model.
- Fixes #8701 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
