### PR TITLE
.Net: Remove float64 from supported vectors for Qdrant.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
@@ -39,9 +39,7 @@ internal static class QdrantVectorStoreRecordFieldMapping
     public static readonly HashSet<Type> s_supportedVectorTypes =
     [
         typeof(ReadOnlyMemory<float>),
-        typeof(ReadOnlyMemory<float>?),
-        typeof(ReadOnlyMemory<double>),
-        typeof(ReadOnlyMemory<double>?)
+        typeof(ReadOnlyMemory<float>?)
     ];
 
     /// <summary>


### PR DESCRIPTION
### Description

Qdrant supports UInt8, Float16 and Float32, but the SDK only supports Float32, so removing Float64 from supported list and keeping only Float32.

See https://qdrant.tech/documentation/concepts/vectors/

#8623

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
