### PR TITLE
.Net: Suppress moq warning after taking package updates.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -556,7 +556,9 @@ public class AzureAISearchVectorStoreRecordCollectionTests
     public async Task CanSearchWithVectorAndFilterAsync()
     {
         // Arrange.
+#pragma warning disable Moq1002 // Could not find a matching constructor for arguments: SearchResults has an internal parameterless constructor.
         var searchResultsMock = Mock.Of<SearchResults<MultiPropsModel>>();
+#pragma warning restore Moq1002 // Could not find a matching constructor for arguments: SearchResults has an internal parameterless constructor.
         this._searchClientMock
             .Setup(x => x.SearchAsync<MultiPropsModel>(null, It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResultsMock, Mock.Of<Response>()));
@@ -596,7 +598,9 @@ public class AzureAISearchVectorStoreRecordCollectionTests
     public async Task CanSearchWithTextAndFilterAsync()
     {
         // Arrange.
+#pragma warning disable Moq1002 // Could not find a matching constructor for arguments: SearchResults has an internal parameterless constructor.
         var searchResultsMock = Mock.Of<SearchResults<MultiPropsModel>>();
+#pragma warning restore Moq1002 // Could not find a matching constructor for arguments: SearchResults has an internal parameterless constructor.
         this._searchClientMock
             .Setup(x => x.SearchAsync<MultiPropsModel>(null, It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResultsMock, Mock.Of<Response>()));


### PR DESCRIPTION
### Motivation and Context

After merging the latest changes from main, we have a moq warning about not finding a constructor for a type.
There is an internal parameterless constructor though.

### Description

Suppressing the warning, since tests still work as expected.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
