### PR TITLE
.Net: Add float64 support for redis vector search.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -353,7 +353,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
 
         if (vector is not ReadOnlyMemory<float> floatVector)
         {
-            throw new NotSupportedException($"The provided vector type {vector.GetType().Name} is not supported by the Azure AI Search connector.");
+            throw new NotSupportedException($"The provided vector type {vector.GetType().FullName} is not supported by the Azure AI Search connector.");
         }
 
         // Resolve options.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -458,7 +458,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
 
         if (vector is not ReadOnlyMemory<float> floatVector)
         {
-            throw new NotSupportedException($"The provided vector type {vector.GetType().Name} is not supported by the Qdrant connector.");
+            throw new NotSupportedException($"The provided vector type {vector.GetType().FullName} is not supported by the Qdrant connector.");
         }
 
         var internalOptions = options ?? Data.VectorSearchOptions.Default;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -387,15 +387,11 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
             throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
         }
 
-        if (vector is not ReadOnlyMemory<float> floatVector)
-        {
-            throw new NotSupportedException($"The provided vector type {vector.GetType().Name} is not supported by the Redis JSON connector.");
-        }
-
         var internalOptions = options ?? Data.VectorSearchOptions.Default;
 
         // Build query & search.
-        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVector, internalOptions, this._storagePropertyNames, this._firstVectorPropertyName, null);
+        byte[] vectorBytes = RedisVectorStoreCollectionSearchMapping.ValidateVectorAndConvertToBytes(vector, "JSON");
+        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(vectorBytes, internalOptions, this._storagePropertyNames, this._firstVectorPropertyName, null);
         var results = await this.RunOperationAsync(
             "FT.SEARCH",
             () => this._database

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
@@ -123,11 +123,12 @@ internal static class RedisVectorStoreCollectionCreateMapping
 
                 var storageName = storagePropertyNames[vectorProperty.DataModelPropertyName];
                 var indexKind = GetSDKIndexKind(vectorProperty);
-                var distanceAlgorithm = GetSDKDistanceAlgorithm(vectorProperty);
+                var vectorType = GetSDKVectorType(vectorProperty);
                 var dimensions = vectorProperty.Dimensions.Value.ToString(CultureInfo.InvariantCulture);
+                var distanceAlgorithm = GetSDKDistanceAlgorithm(vectorProperty);
                 schema.AddVectorField(new FieldName($"{fieldNamePrefix}{storageName}", storageName), indexKind, new Dictionary<string, object>()
                 {
-                    ["TYPE"] = "FLOAT32",
+                    ["TYPE"] = vectorType,
                     ["DIM"] = dimensions,
                     ["DISTANCE_METRIC"] = distanceAlgorithm
                 });
@@ -179,6 +180,24 @@ internal static class RedisVectorStoreCollectionCreateMapping
             DistanceFunction.DotProductSimilarity => "IP",
             DistanceFunction.EuclideanDistance => "L2",
             _ => throw new InvalidOperationException($"Distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' is not supported by the Redis VectorStore.")
+        };
+    }
+
+    /// <summary>
+    /// Get the vector type to pass to the SDK based on the data type of the vector property.
+    /// </summary>
+    /// <param name="vectorProperty">The vector property definition.</param>
+    /// <returns>The SDK required vector type.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the property data type is not supported by the connector.</exception>
+    public static string GetSDKVectorType(VectorStoreRecordVectorProperty vectorProperty)
+    {
+        return vectorProperty.PropertyType switch
+        {
+            Type t when t == typeof(ReadOnlyMemory<float>) => "FLOAT32",
+            Type t when t == typeof(ReadOnlyMemory<float>?) => "FLOAT32",
+            Type t when t == typeof(ReadOnlyMemory<double>) => "FLOAT64",
+            Type t when t == typeof(ReadOnlyMemory<double>?) => "FLOAT64",
+            _ => throw new InvalidOperationException($"Vector data type '{vectorProperty.PropertyType.FullName}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' is not supported by the Redis VectorStore.")
         };
     }
 

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
@@ -15,22 +15,48 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 internal static class RedisVectorStoreCollectionSearchMapping
 {
     /// <summary>
+    /// Validate that the given vector is one of the types supported by the Redis connector and convert it to a byte array.
+    /// </summary>
+    /// <typeparam name="TVector">The vector type.</typeparam>
+    /// <param name="vector">The vector to validate and convert.</param>
+    /// <param name="connectorTypeName">The type of connector, HashSet or JSON, to use for error reporting.</param>
+    /// <returns>The vector converted to a byte array.</returns>
+    /// <exception cref="NotSupportedException">Thrown if the vector type is not supported.</exception>
+    public static byte[] ValidateVectorAndConvertToBytes<TVector>(TVector vector, string connectorTypeName)
+    {
+        byte[] vectorBytes;
+        if (vector is ReadOnlyMemory<float> floatVector)
+        {
+            vectorBytes = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
+        }
+        else if (vector is ReadOnlyMemory<double> doubleVector)
+        {
+            vectorBytes = MemoryMarshal.AsBytes(doubleVector.Span).ToArray();
+        }
+        else
+        {
+            throw new NotSupportedException($"The provided vector type {vector?.GetType().FullName} is not supported by the Redis {connectorTypeName} connector.");
+        }
+
+        return vectorBytes;
+    }
+
+    /// <summary>
     /// Build a Redis <see cref="Query"/> object from the given vector and options.
     /// </summary>
-    /// <param name="floatVector">The vector to search the database with.</param>
+    /// <param name="vectorBytes">The vector to search the database with as a byte array.</param>
     /// <param name="options">The options to configure the behavior of the search.</param>
     /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
     /// <param name="firstVectorPropertyName">The name of the first vector property in the data model.</param>
     /// <param name="selectFields">The set of fields to limit the results to. Null for all.</param>
     /// <returns>The <see cref="Query"/>.</returns>
-    public static Query BuildQuery(ReadOnlyMemory<float> floatVector, VectorSearchOptions options, Dictionary<string, string> storagePropertyNames, string firstVectorPropertyName, string[]? selectFields)
+    public static Query BuildQuery(byte[] vectorBytes, VectorSearchOptions options, Dictionary<string, string> storagePropertyNames, string firstVectorPropertyName, string[]? selectFields)
     {
         // Resolve options.
         var vectorPropertyName = ResolveVectorFieldName(options.VectorFieldName, storagePropertyNames, firstVectorPropertyName);
 
         // Build search query.
         var filter = RedisVectorStoreCollectionSearchMapping.BuildFilter(options.Filter, storagePropertyNames);
-        var vectorBytes = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
         var query = new Query($"{filter}=>[KNN {options.Limit} @{vectorPropertyName} $embedding AS vector_score]")
             .AddParam("embedding", vectorBytes)
             .SetSortBy("vector_score")

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Microsoft.SemanticKernel.Data;
 using Xunit;
 
@@ -13,10 +14,55 @@ namespace Microsoft.SemanticKernel.Connectors.Redis.UnitTests;
 public class RedisVectorStoreCollectionSearchMappingTests
 {
     [Fact]
+    public void ValidateVectorAndConvertToBytesConvertsFloatVector()
+    {
+        // Arrange.
+        var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
+
+        // Act.
+        var byteArray = RedisVectorStoreCollectionSearchMapping.ValidateVectorAndConvertToBytes(floatVector, "Test");
+
+        // Assert.
+        Assert.NotNull(byteArray);
+        Assert.Equal(12, byteArray.Length);
+        Assert.Equal(new byte[12] { 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64 }, byteArray);
+    }
+
+    [Fact]
+    public void ValidateVectorAndConvertToBytesConvertsDoubleVector()
+    {
+        // Arrange.
+        var doubleVector = new ReadOnlyMemory<double>(new double[] { 1.0, 2.0, 3.0 });
+
+        // Act.
+        var byteArray = RedisVectorStoreCollectionSearchMapping.ValidateVectorAndConvertToBytes(doubleVector, "Test");
+
+        // Assert.
+        Assert.NotNull(byteArray);
+        Assert.Equal(24, byteArray.Length);
+        Assert.Equal(new byte[24] { 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 8, 64 }, byteArray);
+    }
+
+    [Fact]
+    public void ValidateVectorAndConvertToBytesThrowsForUnsupportedType()
+    {
+        // Arrange.
+        var unsupportedVector = new ReadOnlyMemory<int>(new int[] { 1, 2, 3 });
+
+        // Act & Assert.
+        var exception = Assert.Throws<NotSupportedException>(() =>
+        {
+            var byteArray = RedisVectorStoreCollectionSearchMapping.ValidateVectorAndConvertToBytes(unsupportedVector, "Test");
+        });
+        Assert.Equal("The provided vector type System.ReadOnlyMemory`1[[System.Int32, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]] is not supported by the Redis Test connector.", exception.Message);
+    }
+
+    [Fact]
     public void BuildQueryBuildsRedisQueryWithDefaults()
     {
         // Arrange.
         var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
+        var byteArray = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
         var storagePropertyNames = new Dictionary<string, string>()
         {
             { "Vector", "storage_Vector" },
@@ -24,7 +70,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
         var firstVectorPropertyName = "storage_Vector";
 
         // Act.
-        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVector, VectorSearchOptions.Default, storagePropertyNames, firstVectorPropertyName, null);
+        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(byteArray, VectorSearchOptions.Default, storagePropertyNames, firstVectorPropertyName, null);
 
         // Assert.
         Assert.NotNull(query);
@@ -39,6 +85,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
     {
         // Arrange.
         var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
+        var byteArray = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
         var vectorSearchOptions = new VectorSearchOptions { Limit = 5, Offset = 3, VectorFieldName = "Vector" };
         var storagePropertyNames = new Dictionary<string, string>()
         {
@@ -48,7 +95,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
         var selectFields = new string[] { "storage_Field1", "storage_Field2" };
 
         // Act.
-        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVector, vectorSearchOptions, storagePropertyNames, firstVectorPropertyName, selectFields);
+        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(byteArray, vectorSearchOptions, storagePropertyNames, firstVectorPropertyName, selectFields);
 
         // Assert.
         Assert.NotNull(query);
@@ -60,6 +107,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
     {
         // Arrange.
         var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
+        var byteArray = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
         var vectorSearchOptions = new VectorSearchOptions { VectorFieldName = "UnknownVector" };
         var storagePropertyNames = new Dictionary<string, string>()
         {
@@ -70,7 +118,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
         // Act & Assert.
         Assert.Throws<InvalidOperationException>(() =>
         {
-            var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(floatVector, vectorSearchOptions, storagePropertyNames, firstVectorPropertyName, null);
+            var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(byteArray, vectorSearchOptions, storagePropertyNames, firstVectorPropertyName, null);
         });
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -33,7 +33,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
     {
         // Arrange.
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, collectionName);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, collectionName);
 
         // Act.
         var actual = await sut.CollectionExistsAsync();
@@ -52,12 +52,12 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var collectionNamePostfix = useRecordDefinition ? "WithDefinition" : "WithType";
         var testCollectionName = $"hashsetcreatetest{collectionNamePostfix}";
 
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel>
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, testCollectionName, options);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, testCollectionName, options);
 
         // Act
         await sut.CreateCollectionAsync();
@@ -109,7 +109,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         createParams.AddPrefix(tempCollectionName);
         await fixture.Database.FT().CreateAsync(tempCollectionName, createParams, schema);
 
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, tempCollectionName);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, tempCollectionName);
 
         // Act
         await sut.DeleteCollectionAsync();
@@ -124,12 +124,12 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItCanUpsertDocumentToVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel>
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         var record = CreateTestHotel("HUpsert-2", 2);
 
         // Act.
@@ -157,12 +157,12 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItCanUpsertManyDocumentsToVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel>
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
         var results = sut.UpsertBatchAsync(
@@ -196,12 +196,12 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItCanGetDocumentFromVectorStoreAsync(bool includeVectors, bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel>
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act.
         var getResult = await sut.GetAsync("HBaseSet-1", new GetRecordOptions { IncludeVectors = includeVectors });
@@ -230,8 +230,8 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItCanGetManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act
         // Also include one non-existing key to test that the operation does not fail for these and returns only the found ones.
@@ -255,13 +255,13 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItCanRemoveDocumentFromVectorStoreAsync(bool useRecordDefinition)
     {
         // Arrange.
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel>
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             VectorStoreRecordDefinition = useRecordDefinition ? fixture.BasicVectorStoreRecordDefinition : null
         };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
-        var record = new BasicHotel
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
+        var record = new BasicFloat32Hotel
         {
             HotelId = "HRemove-1",
             HotelName = "Remove Test Hotel",
@@ -285,8 +285,8 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItCanRemoveManyDocumentsFromVectorStoreAsync()
     {
         // Arrange
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         await sut.UpsertAsync(CreateTestHotel("HRemoveMany-1", 1));
         await sut.UpsertAsync(CreateTestHotel("HRemoveMany-2", 2));
         await sut.UpsertAsync(CreateTestHotel("HRemoveMany-3", 3));
@@ -304,11 +304,11 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     [Theory(Skip = SkipReason)]
     [InlineData("hotelCode", true)]
     [InlineData("hotelName", false)]
-    public async Task ItCanSearchWithVectorAndFilterAsync(string filterType, bool includeVectors)
+    public async Task ItCanSearchWithFloat32VectorAndFilterAsync(string filterType, bool includeVectors)
     {
         // Arrange
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
         var vector = new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f });
         var filter = filterType == "equality" ? new VectorSearchFilter().EqualTo("HotelCode", 1) : new VectorSearchFilter().EqualTo("HotelName", "My Hotel 1");
 
@@ -340,12 +340,52 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         }
     }
 
+    [Theory(Skip = SkipReason)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItCanSearchWithFloat64VectorAsync(bool includeVectors)
+    {
+        // Arrange
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat64Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat64Hotel>(fixture.Database, TestCollectionName + "Float64", options);
+        await sut.CreateCollectionIfNotExistsAsync();
+        await sut.UpsertAsync(new BasicFloat64Hotel { HotelId = "HFloat64_1", HotelName = "1", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([1.0d, 1.1d, 1.2d, 1.3d]) });
+        await sut.UpsertAsync(new BasicFloat64Hotel { HotelId = "HFloat64_2", HotelName = "2", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([2.0d, 2.1d, 2.2d, 2.3d]) });
+        await sut.UpsertAsync(new BasicFloat64Hotel { HotelId = "HFloat64_3", HotelName = "3", Description = "Nice hotel", DescriptionEmbedding = new ReadOnlyMemory<double>([3.0d, 3.1d, 3.2d, 3.3d]) });
+
+        var vector = new ReadOnlyMemory<double>([2.0d, 2.1d, 2.2d, 2.3d]);
+
+        // Act
+        var actual = await sut.VectorizedSearchAsync(
+            vector,
+            new VectorSearchOptions
+            {
+                IncludeVectors = includeVectors,
+                Limit = 1
+            }).ToListAsync();
+
+        // Assert
+        Assert.Single(actual);
+        var searchResult = actual.First().Record;
+        Assert.Equal("HFloat64_2", searchResult?.HotelId);
+        Assert.Equal("2", searchResult?.HotelName);
+        Assert.Equal("Nice hotel", searchResult?.Description);
+        if (includeVectors)
+        {
+            Assert.Equal<double[]>([2.0d, 2.1d, 2.2d, 2.3d], searchResult?.DescriptionEmbedding?.ToArray());
+        }
+        else
+        {
+            Assert.Null(searchResult?.DescriptionEmbedding);
+        }
+    }
+
     [Fact(Skip = SkipReason)]
     public async Task ItReturnsNullWhenGettingNonExistentRecordAsync()
     {
         // Arrange
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel> { PrefixCollectionNameToKeyNames = true };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel> { PrefixCollectionNameToKeyNames = true };
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert
         Assert.Null(await sut.GetAsync("HBaseSet-5", new GetRecordOptions { IncludeVectors = true }));
@@ -355,12 +395,12 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     public async Task ItThrowsMappingExceptionForFailedMapperAsync()
     {
         // Arrange
-        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicHotel>
+        var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel>
         {
             PrefixCollectionNameToKeyNames = true,
             HashEntriesCustomMapper = new FailingMapper()
         };
-        var sut = new RedisHashSetVectorStoreRecordCollection<BasicHotel>(fixture.Database, TestCollectionName, options);
+        var sut = new RedisHashSetVectorStoreRecordCollection<BasicFloat32Hotel>(fixture.Database, TestCollectionName, options);
 
         // Act & Assert
         await Assert.ThrowsAsync<VectorStoreRecordMappingException>(async () => await sut.GetAsync("HBaseSet-1", new GetRecordOptions { IncludeVectors = true }));
@@ -378,8 +418,8 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var sut = new RedisHashSetVectorStoreRecordCollection<VectorStoreGenericDataModel<string>>(fixture.Database, TestCollectionName, options);
 
         // Act
-        var baseSetGetResult = await sut.GetAsync("BaseSet-1", new GetRecordOptions { IncludeVectors = true });
-        var upsertResult = await sut.UpsertAsync(new VectorStoreGenericDataModel<string>("GenericMapper-1")
+        var baseSetGetResult = await sut.GetAsync("HBaseSet-1", new GetRecordOptions { IncludeVectors = true });
+        var upsertResult = await sut.UpsertAsync(new VectorStoreGenericDataModel<string>("HGenericMapper-1")
         {
             Data =
             {
@@ -394,11 +434,11 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
                 { "DescriptionEmbedding", new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }) }
             }
         });
-        var localGetResult = await sut.GetAsync("GenericMapper-1", new GetRecordOptions { IncludeVectors = true });
+        var localGetResult = await sut.GetAsync("HGenericMapper-1", new GetRecordOptions { IncludeVectors = true });
 
         // Assert
         Assert.NotNull(baseSetGetResult);
-        Assert.Equal("BaseSet-1", baseSetGetResult.Key);
+        Assert.Equal("HBaseSet-1", baseSetGetResult.Key);
         Assert.Equal("My Hotel 1", baseSetGetResult.Data["HotelName"]);
         Assert.Equal(1, baseSetGetResult.Data["HotelCode"]);
         Assert.True((bool)baseSetGetResult.Data["ParkingIncluded"]!);
@@ -407,10 +447,10 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         Assert.NotNull(baseSetGetResult.Vectors["DescriptionEmbedding"]);
         Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)baseSetGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
 
-        Assert.Equal("GenericMapper-1", upsertResult);
+        Assert.Equal("HGenericMapper-1", upsertResult);
 
         Assert.NotNull(localGetResult);
-        Assert.Equal("GenericMapper-1", localGetResult.Key);
+        Assert.Equal("HGenericMapper-1", localGetResult.Key);
         Assert.Equal("Generic Mapper Hotel", localGetResult.Data["HotelName"]);
         Assert.Equal(40, localGetResult.Data["HotelCode"]);
         Assert.True((bool)localGetResult.Data["ParkingIncluded"]!);
@@ -419,9 +459,9 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)localGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
     }
 
-    private static BasicHotel CreateTestHotel(string hotelId, int hotelCode)
+    private static BasicFloat32Hotel CreateTestHotel(string hotelId, int hotelCode)
     {
-        var record = new BasicHotel
+        var record = new BasicFloat32Hotel
         {
             HotelId = hotelId,
             HotelName = $"My Hotel {hotelCode}",
@@ -434,14 +474,14 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         return record;
     }
 
-    private sealed class FailingMapper : IVectorStoreRecordMapper<BasicHotel, (string Key, HashEntry[] HashEntries)>
+    private sealed class FailingMapper : IVectorStoreRecordMapper<BasicFloat32Hotel, (string Key, HashEntry[] HashEntries)>
     {
-        public (string Key, HashEntry[] HashEntries) MapFromDataToStorageModel(BasicHotel dataModel)
+        public (string Key, HashEntry[] HashEntries) MapFromDataToStorageModel(BasicFloat32Hotel dataModel)
         {
             throw new NotImplementedException();
         }
 
-        public BasicHotel MapFromStorageToDataModel((string Key, HashEntry[] HashEntries) storageModel, StorageToDataModelMapperOptions options)
+        public BasicFloat32Hotel MapFromStorageToDataModel((string Key, HashEntry[] HashEntries) storageModel, StorageToDataModelMapperOptions options)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisVectorStoreFixture.cs
@@ -289,7 +289,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
     /// <summary>
     /// A test model for the vector store that only uses basic types as supported by HashSets Redis mode.
     /// </summary>
-    public class BasicHotel
+    public class BasicHotel<TVectorElement>
     {
         [VectorStoreRecordKey]
         public string HotelId { get; init; }
@@ -304,7 +304,7 @@ public class RedisVectorStoreFixture : IAsyncLifetime
         public string Description { get; init; }
 
         [VectorStoreRecordVector(4)]
-        public ReadOnlyMemory<float>? DescriptionEmbedding { get; init; }
+        public ReadOnlyMemory<TVectorElement>? DescriptionEmbedding { get; init; }
 
         [JsonPropertyName("parking_is_included")]
         [VectorStoreRecordData(StoragePropertyName = "parking_is_included")]
@@ -312,6 +312,20 @@ public class RedisVectorStoreFixture : IAsyncLifetime
 
         [VectorStoreRecordData]
         public double Rating { get; init; }
+    }
+
+    /// <summary>
+    /// A test model for the vector store that only uses basic types as supported by HashSets Redis mode.
+    /// </summary>
+    public class BasicFloat32Hotel : BasicHotel<float>
+    {
+    }
+
+    /// <summary>
+    /// A test model for the vector store that only uses basic types as supported by HashSets Redis mode.
+    /// </summary>
+    public class BasicFloat64Hotel : BasicHotel<double>
+    {
     }
 }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -227,7 +227,7 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, TRecord> : IVector
 
         if (vector is not ReadOnlyMemory<float> floatVector)
         {
-            throw new NotSupportedException($"The provided vector type {vector.GetType().Name} is not supported by the Qdrant connector.");
+            throw new NotSupportedException($"The provided vector type {vector.GetType().FullName} is not supported by the Qdrant connector.");
         }
 
         // Resolve options and get requested vector property or first as default.


### PR DESCRIPTION
### Motivation and Context

Redis supports float64 for vector storage, and the Redis connectors were supporting this as well, but not for search.

### Description

- Adding float64 support for Redis vector search with tests.
- Changed from suing name to fullname for outputting the vector type name since name doesn't include the generic type.

#8846

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
