### PR TITLE
.Net: Disable failing integration tests

### DIFF
--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletion_AutoFunctionChoiceBehaviorTests.cs
@@ -208,7 +208,7 @@ public sealed class AzureOpenAIAutoFunctionChoiceBehaviorTests : BaseIntegration
         Assert.Contains("GetCurrentDate", invokedFunctions);
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to unblock PR pipeline.")]
     public async Task SpecifiedInCodeInstructsConnectorToInvokeKernelFunctionManuallyForStreamingAsync()
     {
         // Arrange

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_FunctionCallingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_FunctionCallingTests.cs
@@ -185,7 +185,7 @@ public sealed class OpenAIChatCompletionFunctionCallingTests : BaseIntegrationTe
         Assert.Contains("Transportation", result, StringComparison.InvariantCultureIgnoreCase);
     }
 
-    [Fact]
+    [Fact(Skip = "Temporarily disabled to unblock PR pipeline.")]
     public async Task ConnectorSpecificChatMessageContentClassesCanBeUsedForManualFunctionCallingAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context
Two integration tests keep failing during PR runs. This PR disables them to unblock other PRs while the root cause of the failure is being investigated.
