### PR TITLE
.Net: [Feature branch] Added support for Filter and Offset parameters in Azure CosmosDB MongoDB vector search

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBHotelModel.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBHotelModel.cs
@@ -14,7 +14,7 @@ public class AzureCosmosDBMongoDBHotelModel(string hotelId)
     public string HotelId { get; init; } = hotelId;
 
     /// <summary>A string metadata field.</summary>
-    [VectorStoreRecordData]
+    [VectorStoreRecordData(IsFilterable = true)]
     public string? HotelName { get; set; }
 
     /// <summary>An int metadata field.</summary>

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreCollectionSearchMappingTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
+using Microsoft.SemanticKernel.Data;
+using MongoDB.Bson;
+using Xunit;
+
+namespace SemanticKernel.Connectors.AzureCosmosDBMongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping"/> class.
+/// </summary>
+public sealed class AzureCosmosDBMongoDBVectorStoreCollectionSearchMappingTests
+{
+    private readonly Dictionary<string, string> _storagePropertyNames = new()
+    {
+        ["Property1"] = "property_1",
+        ["Property2"] = "property_2",
+    };
+
+    [Fact]
+    public void BuildFilterWithNullVectorSearchFilterReturnsNull()
+    {
+        // Arrange
+        VectorSearchFilter? vectorSearchFilter = null;
+
+        // Act
+        var filter = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames);
+
+        // Assert
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildFilterWithoutFilterClausesReturnsNull()
+    {
+        // Arrange
+        VectorSearchFilter vectorSearchFilter = new();
+
+        // Act
+        var filter = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames);
+
+        // Assert
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildFilterThrowsExceptionWithUnsupportedFilterClause()
+    {
+        // Arrange
+        var vectorSearchFilter = new VectorSearchFilter().AnyTagEqualTo("NonExistentProperty", "TestValue");
+
+        // Act & Assert
+        Assert.Throws<NotSupportedException>(() => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames));
+    }
+
+    [Fact]
+    public void BuildFilterThrowsExceptionWithNonExistentPropertyName()
+    {
+        // Arrange
+        var vectorSearchFilter = new VectorSearchFilter().EqualTo("NonExistentProperty", "TestValue");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames));
+    }
+
+    [Fact]
+    public void BuildFilterThrowsExceptionWithMultipleFilterClausesOfSameType()
+    {
+        // Arrange
+        var vectorSearchFilter = new VectorSearchFilter()
+            .EqualTo("Property1", "TestValue1")
+            .EqualTo("Property1", "TestValue2");
+
+        // Act & Assert
+        Assert.Throws<NotSupportedException>(() => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames));
+    }
+
+    [Fact]
+    public void BuilderFilterByDefaultReturnsValidFilter()
+    {
+        // Arrange
+        var expectedFilter = new BsonDocument() { ["property_1"] = new BsonDocument() { ["$eq"] = "TestValue1" } };
+        var vectorSearchFilter = new VectorSearchFilter().EqualTo("Property1", "TestValue1");
+
+        // Act
+        var filter = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames);
+
+        Assert.Equal(filter.ToJson(), expectedFilter.ToJson());
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -107,7 +107,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
         // Arrange
         const string CollectionName = "collection";
 
-        List<BsonDocument> indexes = indexExists ? [new BsonDocument { ["name"] = "DescriptionEmbedding_" }] : [];
+        List<BsonDocument> indexes = indexExists ? [new BsonDocument { ["name"] = "DescriptionEmbedding_" }, new BsonDocument { ["name"] = "HotelName_" }] : [];
 
         var mockIndexCursor = new Mock<IAsyncCursor<BsonDocument>>();
         mockIndexCursor
@@ -144,7 +144,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
             It.Is<BsonDocumentCommand<BsonDocument>>(command =>
                 command.Document["createIndexes"] == CollectionName &&
                 command.Document["indexes"].GetType() == typeof(BsonArray) &&
-                ((BsonArray)command.Document["indexes"]).Count == 1),
+                ((BsonArray)command.Document["indexes"]).Count == 2),
             It.IsAny<ReadPreference>(),
             It.IsAny<CancellationToken>()), Times.Exactly(actualIndexCreations));
     }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.SemanticKernel.Data;
+using MongoDB.Bson;
+
+namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
+
+/// <summary>
+/// Contains mapping helpers to use when creating a collection in Azure CosmosDB MongoDB.
+/// </summary>
+internal static class AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping
+{
+    /// <summary>
+    /// Returns an array of indexes to create for vector properties.
+    /// </summary>
+    /// <param name="vectorProperties">Collection of vector properties for index creation.</param>
+    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the storage name.</param>
+    /// <param name="uniqueIndexes">Collection of unique existing indexes to avoid creating duplicates.</param>
+    /// <param name="numLists">Number of clusters that the inverted file (IVF) index uses to group the vector data.</param>
+    /// <param name="efConstruction">The size of the dynamic candidate list for constructing the graph.</param>
+    public static BsonArray GetVectorIndexes(
+        List<VectorStoreRecordVectorProperty> vectorProperties,
+        Dictionary<string, string> storagePropertyNames,
+        HashSet<string?> uniqueIndexes,
+        int numLists,
+        int efConstruction)
+    {
+        var indexArray = new BsonArray();
+
+        // Create separate index for each vector property
+        foreach (var property in vectorProperties)
+        {
+            // Use index name same as vector property name with underscore
+            var vectorPropertyName = storagePropertyNames[property.DataModelPropertyName];
+            var indexName = $"{vectorPropertyName}_";
+
+            // If index already exists, proceed to the next vector property
+            if (uniqueIndexes.Contains(indexName))
+            {
+                continue;
+            }
+
+            // Otherwise, create a new index
+            var searchOptions = new BsonDocument
+            {
+                { "kind", GetIndexKind(property.IndexKind, vectorPropertyName) },
+                { "numLists", numLists },
+                { "similarity", GetDistanceFunction(property.DistanceFunction, vectorPropertyName) },
+                { "dimensions", property.Dimensions },
+                { "efConstruction", efConstruction }
+            };
+
+            var indexDocument = new BsonDocument
+            {
+                ["name"] = indexName,
+                ["key"] = new BsonDocument { [vectorPropertyName] = "cosmosSearch" },
+                ["cosmosSearchOptions"] = searchOptions
+            };
+
+            indexArray.Add(indexDocument);
+        }
+
+        return indexArray;
+    }
+
+    /// <summary>
+    /// Returns an array of indexes to create for filterable data properties.
+    /// </summary>
+    /// <param name="dataProperties">Collection of data properties for index creation.</param>
+    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the storage name.</param>
+    /// <param name="uniqueIndexes">Collection of unique existing indexes to avoid creating duplicates.</param>
+    public static BsonArray GetFilterableDataIndexes(
+        List<VectorStoreRecordDataProperty> dataProperties,
+        Dictionary<string, string> storagePropertyNames,
+        HashSet<string?> uniqueIndexes)
+    {
+        var indexArray = new BsonArray();
+
+        // Create separate index for each data property
+        foreach (var property in dataProperties)
+        {
+            if (property.IsFilterable)
+            {
+                // Use index name same as data property name with underscore
+                var dataPropertyName = storagePropertyNames[property.DataModelPropertyName];
+                var indexName = $"{dataPropertyName}_";
+
+                // If index already exists, proceed to the next data property
+                if (uniqueIndexes.Contains(indexName))
+                {
+                    continue;
+                }
+
+                // Otherwise, create a new index
+                var indexDocument = new BsonDocument
+                {
+                    ["name"] = indexName,
+                    ["key"] = new BsonDocument { [dataPropertyName] = 1 }
+                };
+
+                indexArray.Add(indexDocument);
+            }
+        }
+
+        return indexArray;
+    }
+
+    /// <summary>
+    /// More information about Azure CosmosDB for MongoDB index kinds here: <see href="https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search" />.
+    /// </summary>
+    private static string GetIndexKind(string? indexKind, string vectorPropertyName)
+    {
+        return indexKind switch
+        {
+            IndexKind.Hnsw => "vector-hnsw",
+            IndexKind.IvfFlat => "vector-ivf",
+            _ => throw new InvalidOperationException($"Index kind '{indexKind}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorPropertyName}' is not supported by the Azure CosmosDB for MongoDB VectorStore.")
+        };
+    }
+
+    /// <summary>
+    /// More information about Azure CosmosDB for MongoDB distance functions here: <see href="https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search" />.
+    /// </summary>
+    private static string GetDistanceFunction(string? distanceFunction, string vectorPropertyName)
+    {
+        return distanceFunction switch
+        {
+            DistanceFunction.CosineDistance => "COS",
+            DistanceFunction.DotProductSimilarity => "IP",
+            DistanceFunction.EuclideanDistance => "L2",
+            _ => throw new InvalidOperationException($"Distance function '{distanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorPropertyName}' is not supported by the Azure CosmosDB for MongoDB VectorStore.")
+        };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
@@ -52,7 +52,7 @@ internal static class AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping
                 throw new NotSupportedException(
                     $"Unsupported filter clause type '{filterClause.GetType().Name}'. " +
                     $"Supported filter clause types are: {string.Join(", ", [
-                        typeof(EqualToFilterClause).FullName])}");
+                        nameof(EqualToFilterClause)])}");
             }
 
             if (!storagePropertyNames.TryGetValue(propertyName, out var storagePropertyName))

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.SemanticKernel.Data;
 using MongoDB.Bson;
 
@@ -10,27 +13,100 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// </summary>
 internal static class AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping
 {
+    /// <summary>
+    /// Build Azure CosmosDB MongoDB filter from the provided <see cref="VectorSearchFilter"/>.
+    /// </summary>
+    /// <param name="vectorSearchFilter">The <see cref="VectorSearchFilter"/> to build Azure CosmosDB MongoDB filter from.</param>
+    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the storage name.</param>
+    /// <exception cref="NotSupportedException">Thrown when the provided filter type is unsupported.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when property name specified in filter doesn't exist.</exception>
+    public static BsonDocument? BuildFilter(
+        VectorSearchFilter? vectorSearchFilter,
+        Dictionary<string, string> storagePropertyNames)
+    {
+        const string EqualOperator = "$eq";
+
+        var filterClauses = vectorSearchFilter?.FilterClauses.ToList();
+
+        if (filterClauses is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var filter = new BsonDocument();
+
+        foreach (var filterClause in filterClauses)
+        {
+            string propertyName;
+            BsonValue propertyValue;
+            string filterOperator;
+
+            if (filterClause is EqualToFilterClause equalToFilterClause)
+            {
+                propertyName = equalToFilterClause.FieldName;
+                propertyValue = BsonValue.Create(equalToFilterClause.Value);
+                filterOperator = EqualOperator;
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    $"Unsupported filter clause type '{filterClause.GetType().Name}'. " +
+                    $"Supported filter clause types are: {string.Join(", ", [
+                        typeof(EqualToFilterClause).FullName])}");
+            }
+
+            if (!storagePropertyNames.TryGetValue(propertyName, out var storagePropertyName))
+            {
+                throw new InvalidOperationException($"Property name '{propertyName}' provided as part of the filter clause is not a valid property name.");
+            }
+
+            if (filter.Contains(storagePropertyName))
+            {
+                if (filter[storagePropertyName] is BsonDocument document && document.Contains(filterOperator))
+                {
+                    throw new NotSupportedException(
+                        $"Filter with operator '{filterOperator}' is already added to '{propertyName}' property. " +
+                        "Multiple filters of the same type in the same property are not supported.");
+                }
+
+                filter[storagePropertyName][filterOperator] = propertyValue;
+            }
+            else
+            {
+                filter[storagePropertyName] = new BsonDocument() { [filterOperator] = propertyValue };
+            }
+        }
+
+        return filter;
+    }
+
     /// <summary>Returns search part of the search query for <see cref="IndexKind.Hnsw"/> index kind.</summary>
     public static BsonDocument GetSearchQueryForHnswIndex<TVector>(
         TVector vector,
         string vectorPropertyName,
         int limit,
-        int efSearch)
+        int efSearch,
+        BsonDocument? filter)
     {
+        var searchQuery = new BsonDocument
+        {
+            { "vector", BsonArray.Create(vector) },
+            { "path", vectorPropertyName },
+            { "k", limit },
+            { "efSearch", efSearch }
+        };
+
+        if (filter is not null)
+        {
+            searchQuery["filter"] = filter;
+        }
+
         return new BsonDocument
         {
             { "$search",
                 new BsonDocument
                 {
-                    { "cosmosSearch",
-                        new BsonDocument
-                        {
-                            { "vector", BsonArray.Create(vector) },
-                            { "path", vectorPropertyName },
-                            { "k", limit },
-                            { "efSearch", efSearch }
-                        }
-                    }
+                    { "cosmosSearch", searchQuery }
                 }
             }
         };
@@ -40,21 +116,27 @@ internal static class AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping
     public static BsonDocument GetSearchQueryForIvfIndex<TVector>(
         TVector vector,
         string vectorPropertyName,
-        int limit)
+        int limit,
+        BsonDocument? filter)
     {
+        var searchQuery = new BsonDocument
+        {
+            { "vector", BsonArray.Create(vector) },
+            { "path", vectorPropertyName },
+            { "k", limit },
+        };
+
+        if (filter is not null)
+        {
+            searchQuery["filter"] = filter;
+        }
+
         return new BsonDocument
         {
             { "$search",
                 new BsonDocument
                 {
-                    { "cosmosSearch",
-                        new BsonDocument
-                        {
-                            { "vector", BsonArray.Create(vector) },
-                            { "path", vectorPropertyName },
-                            { "k", limit },
-                        }
-                    },
+                    { "cosmosSearch", searchQuery },
                     { "returnStoredSource", true }
                 }
             }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Contains mapping helpers to use when searching for documents using Azure CosmosDB MongoDB.
 /// </summary>
-internal sealed class AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping
+internal static class AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping
 {
     /// <summary>Returns search part of the search query for <see cref="IndexKind.Hnsw"/> index kind.</summary>
     public static BsonDocument GetSearchQueryForHnswIndex<TVector>(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -292,14 +292,27 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : I
 
         var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
 
+        var filter = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(
+            searchOptions.Filter,
+            this._storagePropertyNames);
+
         // Constructing a query to fetch "offset + limit" total items
         // to perform offset logic locally, since offset parameter is not part of API. 
         var itemsAmount = searchOptions.Offset + searchOptions.Limit;
 
         var searchQuery = vectorProperty.IndexKind switch
         {
-            IndexKind.Hnsw => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetSearchQueryForHnswIndex(vectorArray, vectorPropertyName, itemsAmount, this._options.EfSearch),
-            IndexKind.IvfFlat => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetSearchQueryForIvfIndex(vectorArray, vectorPropertyName, itemsAmount),
+            IndexKind.Hnsw => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetSearchQueryForHnswIndex(
+                vectorArray,
+                vectorPropertyName,
+                itemsAmount,
+                this._options.EfSearch,
+                filter),
+            IndexKind.IvfFlat => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetSearchQueryForIvfIndex(
+                vectorArray,
+                vectorPropertyName,
+                itemsAmount,
+                filter),
             _ => throw new InvalidOperationException(
                 $"Index kind '{vectorProperty.IndexKind}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorPropertyName}' is not supported by the Azure CosmosDB for MongoDB VectorStore. " +
                 $"Supported index kinds are: {string.Join(", ", [IndexKind.Hnsw, IndexKind.IvfFlat])}")

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -55,7 +55,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : I
     /// <summary>Collection of record vector properties.</summary>
     private readonly List<VectorStoreRecordVectorProperty> _vectorProperties;
 
-    /// <summary>Collection of record vector properties.</summary>
+    /// <summary>Collection of record data properties.</summary>
     private readonly List<VectorStoreRecordDataProperty> _dataProperties;
 
     /// <summary>First vector property for the collections that this class is used with.</summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions.cs
@@ -38,7 +38,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TReco
     /// maximum value is 1000). Higher ef_construction will result in better index quality and higher accuracy, but it will
     /// also increase the time required to build the index. EfConstruction has to be at least 2 * m
     /// </summary>
-    public int? EfConstruction { get; set; } = null;
+    public int EfConstruction { get; set; } = 64;
 
     /// <summary>
     /// The size of the dynamic candidate list for search (40 by default). A higher value provides better recall at

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordMapper.cs
@@ -7,6 +7,7 @@ using Microsoft.SemanticKernel.Data;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Conventions;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 
@@ -67,6 +68,16 @@ internal sealed class AzureCosmosDBMongoDBVectorStoreRecordMapper<TRecord> : IVe
 
         this._keyPropertyName = keyPropertyName;
         this._keyProperty = keyProperty;
+
+        var conventionPack = new ConventionPack
+        {
+            new IgnoreExtraElementsConvention(ignoreExtraElements: true)
+        };
+
+        ConventionRegistry.Register(
+            nameof(AzureCosmosDBMongoDBVectorStoreRecordMapper<TRecord>),
+            conventionPack,
+            type => type == typeof(TRecord));
     }
 
     public BsonDocument MapFromDataToStorageModel(TRecord dataModel)

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreFixture.cs
@@ -88,7 +88,7 @@ public class AzureCosmosDBMongoDBVectorStoreFixture : IAsyncLifetime
         public string HotelId { get; init; }
 
         /// <summary>A string metadata field.</summary>
-        [VectorStoreRecordData]
+        [VectorStoreRecordData(IsFilterable = true)]
         public string? HotelName { get; set; }
 
         /// <summary>An int metadata field.</summary>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreFixture.cs
@@ -69,9 +69,14 @@ public class AzureCosmosDBMongoDBVectorStoreFixture : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        foreach (var collection in this._testCollections)
+        var cursor = await this.MongoDatabase.ListCollectionNamesAsync();
+
+        while (await cursor.MoveNextAsync().ConfigureAwait(false))
         {
-            await this.MongoDatabase.DropCollectionAsync(collection);
+            foreach (var collection in cursor.Current)
+            {
+                await this.MongoDatabase.DropCollectionAsync(collection);
+            }
         }
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -326,7 +326,7 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
     }
 
     [Fact(Skip = SkipReason)]
-    public async Task VectorizedSearchWorksCorrectlyAsync()
+    public async Task VectorizedSearchReturnsValidResultsByDefaultAsync()
     {
         // Arrange
         var hotel1 = this.CreateTestHotel(hotelId: "key1", embedding: new[] { 30f, 31f, 32f, 33f });
@@ -353,8 +353,38 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         Assert.DoesNotContain("key4", ids);
 
         Assert.Equal(1, searchResults.First(l => l.Record.HotelId == "key1").Score);
+    }
 
-        await sut.DeleteCollectionAsync();
+    [Fact(Skip = SkipReason)]
+    public async Task VectorizedSearchReturnsValidResultsWithOffsetAsync()
+    {
+        // Arrange
+        var hotel1 = this.CreateTestHotel(hotelId: "key1", embedding: new[] { 30f, 31f, 32f, 33f });
+        var hotel2 = this.CreateTestHotel(hotelId: "key2", embedding: new[] { 31f, 32f, 33f, 34f });
+        var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
+        var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
+
+        var sut = new AzureCosmosDBMongoDBVectorStoreRecordCollection<AzureCosmosDBMongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+
+        await sut.CreateCollectionIfNotExistsAsync();
+
+        await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
+
+        // Act
+        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        {
+            Limit = 2,
+            Offset = 2
+        }).ToListAsync();
+
+        // Assert
+        var ids = searchResults.Select(l => l.Record.HotelId).ToList();
+
+        Assert.Equal("key3", ids[0]);
+        Assert.Equal("key4", ids[1]);
+
+        Assert.DoesNotContain("key1", ids);
+        Assert.DoesNotContain("key2", ids);
     }
 
     #region private

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -387,6 +387,37 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         Assert.DoesNotContain("key2", ids);
     }
 
+    [Fact(Skip = SkipReason)]
+    public async Task VectorizedSearchReturnsValidResultsWithFilterAsync()
+    {
+        // Arrange
+        var hotel1 = this.CreateTestHotel(hotelId: "key1", embedding: new[] { 30f, 31f, 32f, 33f });
+        var hotel2 = this.CreateTestHotel(hotelId: "key2", embedding: new[] { 31f, 32f, 33f, 34f });
+        var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
+        var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
+
+        var sut = new AzureCosmosDBMongoDBVectorStoreRecordCollection<AzureCosmosDBMongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+
+        await sut.CreateCollectionIfNotExistsAsync();
+
+        await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
+
+        // Act
+        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        {
+            Filter = new VectorSearchFilter().EqualTo(nameof(AzureCosmosDBMongoDBHotel.HotelName), "My Hotel key2")
+        }).ToListAsync();
+
+        // Assert
+        var ids = searchResults.Select(l => l.Record.HotelId).ToList();
+
+        Assert.Equal("key2", ids[0]);
+
+        Assert.DoesNotContain("key1", ids);
+        Assert.DoesNotContain("key3", ids);
+        Assert.DoesNotContain("key4", ids);
+    }
+
     #region private
 
     private AzureCosmosDBMongoDBHotel CreateTestHotel(string hotelId, ReadOnlyMemory<float>? embedding = null)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

- Added support for `Filter` parameter using `$eq` filter operator in vector search.
- Added support for `Offset` parameter in vector search. Since `Offset` doesn't exist in Azure CosmosDB MongoDB vector search API, it's currently implemented locally by fetching `Limit + Offset` items and returning last `Limit` items.
- Added unit and integration tests.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
