### PR TITLE
.Net: WIP Allow override connector modelId when a different is provided in the ExecutionSettings.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAIChatCompletionService.cs
@@ -24,7 +24,7 @@ public sealed class AzureOpenAIChatCompletionService : IChatCompletionService, I
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureOpenAIChatCompletionService"/> class.
     /// </summary>
-    /// <param name="deploymentName">Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
+    /// <param name="deploymentName">Default Azure OpenAI deployment name, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
     /// <param name="endpoint">Azure OpenAI deployment URL, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="apiKey">Azure OpenAI API key, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="modelId">Azure OpenAI model id, see https://learn.microsoft.com/azure/cognitive-services/openai/how-to/create-resource</param>
@@ -86,17 +86,22 @@ public sealed class AzureOpenAIChatCompletionService : IChatCompletionService, I
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(ChatHistory chatHistory, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null, CancellationToken cancellationToken = default)
-        => this._client.GetChatMessageContentsAsync(this._client.DeploymentName, chatHistory, executionSettings, kernel, cancellationToken);
+        => this._client.GetChatMessageContentsAsync(this.GetModelId(executionSettings), chatHistory, executionSettings, kernel, cancellationToken);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(ChatHistory chatHistory, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null, CancellationToken cancellationToken = default)
-        => this._client.GetStreamingChatMessageContentsAsync(this._client.DeploymentName, chatHistory, executionSettings, kernel, cancellationToken);
+        => this._client.GetStreamingChatMessageContentsAsync(this.GetModelId(executionSettings), chatHistory, executionSettings, kernel, cancellationToken);
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<TextContent>> GetTextContentsAsync(string prompt, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null, CancellationToken cancellationToken = default)
-        => this._client.GetChatAsTextContentsAsync(this._client.DeploymentName, prompt, executionSettings, kernel, cancellationToken);
+        => this._client.GetChatAsTextContentsAsync(this.GetModelId(executionSettings), prompt, executionSettings, kernel, cancellationToken);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<StreamingTextContent> GetStreamingTextContentsAsync(string prompt, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null, CancellationToken cancellationToken = default)
-        => this._client.GetChatAsTextStreamingContentsAsync(this._client.DeploymentName, prompt, executionSettings, kernel, cancellationToken);
+        => this._client.GetChatAsTextStreamingContentsAsync(this.GetModelId(executionSettings), prompt, executionSettings, kernel, cancellationToken);
+
+    private string GetModelId(PromptExecutionSettings? executionSettings)
+        => string.IsNullOrWhiteSpace(executionSettings?.ModelId)
+            ? this._client.DeploymentName
+            : executionSettings!.ModelId!;
 }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Settings/AzureOpenAIPromptExecutionSettings.cs
@@ -17,6 +17,19 @@ namespace Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 public sealed class AzureOpenAIPromptExecutionSettings : OpenAIPromptExecutionSettings
 {
     /// <summary>
+    /// The name of the deployment to use for the completion request.
+    /// </summary>
+    /// <remarks>
+    /// Azure API's doesn't make a distinction between the modelId and the deploymentName.
+    /// </remarks>
+    [Experimental("SKEXP0010")]
+    public string? DeploymentName
+    {
+        get => this.ModelId;
+        set => this.ModelId = value;
+    }
+
+    /// <summary>
     /// An abstraction of additional settings for chat completion, see https://learn.microsoft.com/en-us/dotnet/api/azure.ai.openai.azurechatextensionsoptions.
     /// This property is compatible only with Azure OpenAI.
     /// </summary>
@@ -103,6 +116,7 @@ public sealed class AzureOpenAIPromptExecutionSettings : OpenAIPromptExecutionSe
     #region private ================================================================================
 
     private AzureChatDataSource? _azureChatDataSource;
+    private string? _deploymentName;
 
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIChatCompletionService.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Services/OpenAIChatCompletionService.cs
@@ -27,7 +27,7 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
     /// <summary>
     /// Create an instance of the OpenAI chat completion connector
     /// </summary>
-    /// <param name="modelId">Model name</param>
+    /// <param name="modelId">Default model identifier</param>
     /// <param name="apiKey">OpenAI API Key</param>
     /// <param name="organization">OpenAI Organization Id (usually optional)</param>
     /// <param name="httpClient">Custom <see cref="HttpClient"/> for HTTP requests.</param>
@@ -52,7 +52,7 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
     /// <summary>
     /// Create an instance of the Custom Message API OpenAI chat completion connector
     /// </summary>
-    /// <param name="modelId">Model name</param>
+    /// <param name="modelId">Default model identifier</param>
     /// <param name="endpoint">Custom Message API compatible endpoint</param>
     /// <param name="apiKey">OpenAI API Key</param>
     /// <param name="organization">OpenAI Organization Id (usually optional)</param>
@@ -102,7 +102,12 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,
         CancellationToken cancellationToken = default)
-        => this._client.GetChatMessageContentsAsync(this._client.ModelId, chatHistory, executionSettings, kernel, cancellationToken);
+        => this._client.GetChatMessageContentsAsync(
+            this.GetModelId(executionSettings),
+            chatHistory,
+            executionSettings,
+            kernel,
+            cancellationToken);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(
@@ -110,7 +115,12 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,
         CancellationToken cancellationToken = default)
-        => this._client.GetStreamingChatMessageContentsAsync(this._client.ModelId, chatHistory, executionSettings, kernel, cancellationToken);
+        => this._client.GetStreamingChatMessageContentsAsync(
+            this.GetModelId(executionSettings),
+            chatHistory,
+            executionSettings,
+            kernel,
+            cancellationToken);
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<TextContent>> GetTextContentsAsync(
@@ -118,7 +128,12 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,
         CancellationToken cancellationToken = default)
-        => this._client.GetChatAsTextContentsAsync(this._client.ModelId, prompt, executionSettings, kernel, cancellationToken);
+        => this._client.GetChatAsTextContentsAsync(
+            this.GetModelId(executionSettings),
+            prompt,
+            executionSettings,
+            kernel,
+            cancellationToken);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<StreamingTextContent> GetStreamingTextContentsAsync(
@@ -126,5 +141,13 @@ public sealed class OpenAIChatCompletionService : IChatCompletionService, ITextG
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,
         CancellationToken cancellationToken = default)
-        => this._client.GetChatAsTextStreamingContentsAsync(this._client.ModelId, prompt, executionSettings, kernel, cancellationToken);
+        => this._client.GetChatAsTextStreamingContentsAsync(
+            this.GetModelId(executionSettings),
+            prompt,
+            executionSettings,
+            kernel,
+            cancellationToken);
+
+    private string GetModelId(PromptExecutionSettings? executionSettings)
+        => string.IsNullOrWhiteSpace(executionSettings?.ModelId) ? this._client.ModelId : executionSettings!.ModelId!;
 }


### PR DESCRIPTION
## Motivation and Problem

This PR fixes the problem where we are ignoring the `PromptExecutionSettings.ModelId` property when this is different from the the model the service was initialized.

This change now allows you to override the model per-request basis.

Fixes #4359 
Fixes #7104

- #4359
- #7104
