### PR TITLE
.Net: Switch redis hashset vectorstore prefix default to true

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollectionOptions.cs
@@ -13,13 +13,13 @@ public sealed class RedisHashSetVectorStoreRecordCollectionOptions<TRecord>
 {
     /// <summary>
     /// Gets or sets a value indicating whether the collection name should be prefixed to the
-    /// key names before reading or writing to the Redis store. Default is false.
+    /// key names before reading or writing to the Redis store. Default is true.
     /// </summary>
     /// <remarks>
     /// For a record to be indexed by a specific Redis index, the key name must be prefixed with the matching prefix configured on the Redis index.
     /// You can either pass in keys that are already prefixed, or set this option to true to have the collection name prefixed to the key names automatically.
     /// </remarks>
-    public bool PrefixCollectionNameToKeyNames { get; init; } = false;
+    public bool PrefixCollectionNameToKeyNames { get; init; } = true;
 
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Redis record.


### PR DESCRIPTION
### Motivation and Context

The prefix setting automatically prefixes the collection name onto the record ids on upsert / read.
Using a prefix is required for records to be added to an index.
Users can have this setting off and pass in their own prefix directly or have it on and get the collection name prefixed
The plan was to set this to true by default because it'll just work for users, instead of them having to do something special, and they can switch this off if they want to do their own thing. It's true by default for the JSON implementation but this was missed for the Hashset implementation.

### Description

- Changing this setting to true by default to match the JSON Connector.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
