### PR TITLE
.Net Agents - Make `messages` parameter optional for `OpenAIAssistantAgent.InvokeStreamingAsync`

### DIFF
--- a/dotnet/samples/Concepts/Agents/OpenAIAssistant_Streaming.cs
+++ b/dotnet/samples/Concepts/Agents/OpenAIAssistant_Streaming.cs
@@ -83,7 +83,7 @@ public class OpenAIAssistant_Streaming(ITestOutputHelper output) : BaseAgentsTes
         ChatHistory history = [];
 
         bool isFirst = false;
-        await foreach (StreamingChatMessageContent response in agent.InvokeStreamingAsync(threadId, history))
+        await foreach (StreamingChatMessageContent response in agent.InvokeStreamingAsync(threadId, messages: history))
         {
             if (string.IsNullOrEmpty(response.Content))
             {

--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -348,7 +348,7 @@ internal static class AssistantThreadActions
         OpenAIAssistantAgent agent,
         AssistantClient client,
         string threadId,
-        IList<ChatMessageContent> messages,
+        IList<ChatMessageContent>? messages,
         OpenAIAssistantInvocationOptions? invocationOptions,
         ILogger logger,
         Kernel kernel,
@@ -413,7 +413,7 @@ internal static class AssistantThreadActions
                 if (functionCalls.Length > 0)
                 {
                     // Emit function-call content
-                    messages.Add(GenerateFunctionCallContent(agent.GetName(), functionCalls));
+                    messages?.Add(GenerateFunctionCallContent(agent.GetName(), functionCalls));
 
                     // Invoke functions for each tool-step
                     IEnumerable<Task<FunctionResultContent>> functionResultTasks = ExecuteFunctionSteps(agent, functionCalls, cancellationToken);
@@ -425,7 +425,7 @@ internal static class AssistantThreadActions
                     ToolOutput[] toolOutputs = GenerateToolOutputs(functionResults);
                     asyncUpdates = client.SubmitToolOutputsToRunStreamingAsync(run, toolOutputs);
 
-                    messages.Add(GenerateFunctionResultsContent(agent.GetName(), functionResults));
+                    messages?.Add(GenerateFunctionResultsContent(agent.GetName(), functionResults));
                 }
             }
 
@@ -440,7 +440,7 @@ internal static class AssistantThreadActions
                     if (message != null)
                     {
                         ChatMessageContent content = GenerateMessageContent(agent.GetName(), message);
-                        messages.Add(content);
+                        messages?.Add(content);
                     }
                 }
 

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -298,9 +298,9 @@ public sealed class OpenAIAssistantAgent : KernelAgent
     /// Invoke the assistant on the specified thread.
     /// </summary>
     /// <param name="threadId">The thread identifier</param>
-    /// <param name="messages">The receiver for the completed messages generated</param>
     /// <param name="arguments">Optional arguments to pass to the agents's invocation, including any <see cref="PromptExecutionSettings"/>.</param>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use by the agent.</param>
+    /// <param name="messages">Optional receiver of the completed messages generated</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Asynchronous enumeration of messages.</returns>
     /// <remarks>
@@ -308,20 +308,20 @@ public sealed class OpenAIAssistantAgent : KernelAgent
     /// </remarks>
     public IAsyncEnumerable<StreamingChatMessageContent> InvokeStreamingAsync(
         string threadId,
-        ChatHistory messages,
         KernelArguments? arguments = null,
         Kernel? kernel = null,
+        ChatHistory? messages = null,
         CancellationToken cancellationToken = default)
-            => this.InvokeStreamingAsync(threadId, messages, options: null, arguments, kernel, cancellationToken);
+            => this.InvokeStreamingAsync(threadId, options: null, arguments, kernel, messages, cancellationToken);
 
     /// <summary>
     /// Invoke the assistant on the specified thread.
     /// </summary>
     /// <param name="threadId">The thread identifier</param>
-    /// <param name="messages">The receiver for the completed messages generated</param>
     /// <param name="options">Optional invocation options</param>
     /// <param name="arguments">Optional arguments to pass to the agents's invocation, including any <see cref="PromptExecutionSettings"/>.</param>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use by the agent.</param>
+    /// <param name="messages">Optional receiver of the completed messages generated</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Asynchronous enumeration of messages.</returns>
     /// <remarks>
@@ -329,10 +329,10 @@ public sealed class OpenAIAssistantAgent : KernelAgent
     /// </remarks>
     public IAsyncEnumerable<StreamingChatMessageContent> InvokeStreamingAsync(
         string threadId,
-        ChatHistory messages,
         OpenAIAssistantInvocationOptions? options,
         KernelArguments? arguments = null,
         Kernel? kernel = null,
+        ChatHistory? messages = null,
         CancellationToken cancellationToken = default)
     {
         this.ThrowIfDeleted();


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Customer input identified that `messages` parameter may not always be required by the caller.

Fixes: https://github.com/microsoft/semantic-kernel/issues/8857

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Providing the complete messages is a convenience and shouldn't be required.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
