### PR TITLE
.Net: Ollama Image To Text Service via Vision Model

### DIFF
--- a/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Extensions/OllamaServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Ollama;
 using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.Http;
+using Microsoft.SemanticKernel.ImageToText;
 using Microsoft.SemanticKernel.TextGeneration;
 using OllamaSharp;
 
@@ -234,6 +235,83 @@ public static class OllamaServiceCollectionExtensions
 
         return services.AddKeyedSingleton<ITextEmbeddingGenerationService>(serviceId, (serviceProvider, _) =>
             new OllamaTextEmbeddingGenerationService(
+                modelId: modelId,
+                ollamaClient: ollamaClient,
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
+    }
+
+    #endregion
+
+    #region Image To Text
+
+    /// <summary>
+    /// Add Ollama Image To Text services to the specified service collection.
+    /// </summary>
+    /// <param name="services">The target service collection.</param>
+    /// <param name="modelId">The model for Vision.</param>
+    /// <param name="endpoint">The endpoint to Ollama hosted service.</param>
+    /// <param name="serviceId">Optional service ID.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddOllamaImageToText(
+        this IServiceCollection services,
+        string modelId,
+        Uri endpoint,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+
+        services.AddKeyedSingleton<IImageToTextService>(serviceId, (serviceProvider, _) =>
+            new OllamaImageToTextService(
+                modelId: modelId,
+                endpoint: endpoint,
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Add Ollama Image To Text services to the specified service collection.
+    /// </summary>
+    /// <param name="services">The target service collection.</param>
+    /// <param name="modelId">The model for Vision.</param>
+    /// <param name="httpClient">Optional custom HttpClient, picked from ServiceCollection if not provided.</param>
+    /// <param name="serviceId">Optional service ID.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddOllamaImageToText(
+        this IServiceCollection services,
+        string modelId,
+        HttpClient? httpClient = null,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+
+        services.AddKeyedSingleton<IImageToTextService>(serviceId, (serviceProvider, _) =>
+            new OllamaImageToTextService(
+                modelId: modelId,
+                httpClient: HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Add Ollama Image To Text service to the kernel builder.
+    /// </summary>
+    /// <param name="services">The target service collection.</param>
+    /// <param name="modelId">The model for Vision.</param>
+    /// <param name="ollamaClient">The Ollama Sharp library client.</param>
+    /// <param name="serviceId">The optional service ID.</param>
+    /// <returns>The updated kernel builder.</returns>
+    public static IServiceCollection AddOllamaImageToText(
+        this IServiceCollection services,
+        string modelId,
+        OllamaApiClient ollamaClient,
+        string? serviceId = null)
+    {
+        Verify.NotNull(services);
+
+        return services.AddKeyedSingleton<IImageToTextService>(serviceId, (serviceProvider, _) =>
+            new OllamaImageToTextService(
                 modelId: modelId,
                 ollamaClient: ollamaClient,
                 loggerFactory: serviceProvider.GetService<ILoggerFactory>()));

--- a/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaImageToTextService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaImageToTextService.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.Ollama.Core;
+using Microsoft.SemanticKernel.ImageToText;
+using OllamaSharp;
+using OllamaSharp.Models.Chat;
+
+namespace Microsoft.SemanticKernel.Connectors.Ollama;
+/// <summary>
+/// Ollama Image To Text Service via Vision Model
+/// </summary>
+public sealed class OllamaImageToTextService : ServiceBase, IImageToTextService
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OllamaImageToTextService"/> class.
+    /// </summary>
+    /// <param name="modelId">The hosted model.</param>
+    /// <param name="endpoint">The endpoint including the port where Ollama server is hosted</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public OllamaImageToTextService(
+        string modelId,
+        Uri endpoint,
+        ILoggerFactory? loggerFactory = null)
+        : base(modelId, endpoint, null, loggerFactory)
+    {
+        Verify.NotNull(endpoint);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OllamaImageToTextService"/> class.
+    /// </summary>
+    /// <param name="modelId">The hosted model.</param>
+    /// <param name="httpClient">HTTP client to be used for communication with the Ollama API.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public OllamaImageToTextService(
+        string modelId,
+        HttpClient httpClient,
+        ILoggerFactory? loggerFactory = null)
+        : base(modelId, null, httpClient, loggerFactory)
+    {
+        Verify.NotNull(httpClient);
+        Verify.NotNull(httpClient.BaseAddress);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OllamaImageToTextService"/> class.
+    /// </summary>
+    /// <param name="modelId">The hosted model.</param>
+    /// <param name="ollamaClient">The Ollama API client.</param>
+    /// <param name="loggerFactory">Optional logger factory to be used for logging.</param>
+    public OllamaImageToTextService(
+        string modelId,
+        OllamaApiClient ollamaClient,
+        ILoggerFactory? loggerFactory = null)
+        : base(modelId, ollamaClient, loggerFactory)
+    {
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, object?> Attributes => this.AttributesInternal;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<TextContent>> GetTextContentsAsync(ImageContent content, PromptExecutionSettings? executionSettings = null, Kernel? kernel = null, CancellationToken cancellationToken = default)
+    {
+        var settings = OllamaPromptExecutionSettings.FromExecutionSettings(executionSettings);
+        var request = CreateChatRequest(content, settings, this._client.SelectedModel);
+
+        List<TextContent> textContents = [];
+
+        await foreach (var stream in this._client.Chat(request, cancellationToken).ConfigureAwait(false))
+        {
+            textContents.Add(new(stream?.Message.Content));
+        }
+
+        return textContents;
+    }
+
+    private static ChatRequest CreateChatRequest(ImageContent content, OllamaPromptExecutionSettings settings, string selectedModel)
+    {
+        List<Message> messages = [];
+        messages.Add(new Message { Role = ChatRole.User, Content = "Describe this image:", Images = [content.DataUri!.Split(';')[1].Replace("base64,", "")] });
+
+        var request = new ChatRequest
+        {
+            Options = new()
+            {
+                Temperature = settings.Temperature,
+                TopP = settings.TopP,
+                TopK = settings.TopK,
+                Stop = settings.Stop?.ToArray()
+            },
+            Messages = messages,
+            Model = selectedModel,
+            Stream = true
+        };
+
+        return request;
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Ollama 支持视觉模型，例如：LLaVA 和MiniCPM-V等，可用于实现图片转文本服务。而Connectors.Ollama缺失这方面的功能，故想补上OllamaImageToTextService。

---

Ollama supports visual models, such as LLaVA and MiniCPM-V, which can be used to implement image-to-text services. Connectors.Ollama lacks this functionality, so I want to add OllamaImageToTextService.

### Description

```cs
var imageBinary = File.ReadAllBytes(file.LocalFile!.FullName);
imageContent = new ImageContent(imageBinary, file.ContentType);
var service = Kernel.GetRequiredService<IImageToTextService>();
var textContents = await service.GetTextContentsAsync(imageContent);
```
<img width="1884" alt="微信图片_20240922154314" src="https://github.com/user-attachments/assets/a3880d26-d099-4f9d-be6a-5b82bc9be01b">

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
