### PR TITLE
.Net: Refactored step inheritance to make this less confusing.

### DIFF
--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcess.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcess.cs
@@ -7,28 +7,25 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// A serializable representation of a Process.
 /// </summary>
-public sealed class KernelProcess : KernelProcessStep<KernelProcessState>
+public sealed class KernelProcess : KernelProcessStepInfo
 {
     /// <summary>
     /// The collection of Steps in the Process.
     /// </summary>
-    public IList<KernelProcessStepBase> Steps { get; }
+    public IList<KernelProcessStepInfo> Steps { get; }
 
     /// <summary>
     /// Creates a new instance of the <see cref="KernelProcess"/> class.
     /// </summary>
     /// <param name="name">The human friendly name of the Process.</param>
     /// <param name="steps">The steps of the process.</param>
-    public KernelProcess(string name, IList<KernelProcessStepBase> steps)
+    public KernelProcess(string name, IList<KernelProcessStepInfo> steps)
+        : base(typeof(KernelProcess), new KernelProcessState() { Name = name }, [])
     {
         Verify.NotNull(steps);
         Verify.NotNullOrWhiteSpace(name);
 
         this.Steps = [];
         this.Steps.AddRange(steps);
-        this.State.State = new KernelProcessState
-        {
-            Name = name
-        };
     }
 }

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessStep.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessStep.cs
@@ -1,95 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
-/// Base implementation of a Step in a Process.
-/// </summary>
-public class KernelProcessStepBase
-{
-    /// <summary>
-    /// A mapping of output edges from the Step using the .
-    /// </summary>
-    private readonly Dictionary<string, List<KernelProcessEdge>> _outputEdges;
-
-    /// <summary>
-    /// The state object of type TState.
-    /// </summary>
-    internal KernelProcessStepState State { get; init; }
-
-    /// <summary>
-    /// A read-only collection of event Ids that this Step can emit.
-    /// </summary>
-    protected IReadOnlyCollection<string> EventIds => this._outputEdges.Keys.ToArray();
-
-    /// <summary>
-    /// Retrieves the output edges for a given event Id. Returns an empty list if the event Id is not found.
-    /// </summary>
-    /// <param name="eventId">The Id of an event.</param>
-    /// <returns>An <see cref="IReadOnlyCollection{T}"/> where T is <see cref="KernelProcessEdge"/></returns>
-    protected IReadOnlyCollection<KernelProcessEdge> GetOutputEdges(string eventId)
-    {
-        if (this._outputEdges.TryGetValue(eventId, out List<KernelProcessEdge>? edges))
-        {
-            return edges.AsReadOnly();
-        }
-
-        return [];
-    }
-
-    /// <summary>
-    /// Called when the Step is activated.
-    /// </summary>
-    /// <param name="state">An instance of the state that holds state data for the step.</param>
-    /// <returns>An instance of <see cref="ValueTask"/></returns>
-    internal virtual ValueTask _ActivateAsync(KernelProcessStepState state)
-    {
-        return default;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="KernelProcessStepBase"/> class.
-    /// </summary>
-    public KernelProcessStepBase(KernelProcessStepState state, Dictionary<string, List<KernelProcessEdge>> edges)
-    {
-        Verify.NotNull(state);
-        Verify.NotNull(edges);
-
-        this.State = state;
-        this._outputEdges = edges;
-    }
-}
-
-/// <summary>
 /// Process Step. Derive from this class to create a new Step for a Process.
 /// </summary>
-public class KernelProcessStep : KernelProcessStepBase
+public class KernelProcessStep
 {
-    /// <inheritdoc/>
-    internal override ValueTask _ActivateAsync(KernelProcessStepState state)
-    {
-        Verify.NotNull(state);
-        return this.ActivateAsync(state);
-    }
-
     /// <inheritdoc/>
     public virtual ValueTask ActivateAsync(KernelProcessStepState state)
     {
         return default;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="KernelProcessStep"/> class.
-    /// </summary>
-    /// <param name="state">An instance that derives from <see cref="KernelProcessStepState"/></param>
-    /// <param name="edges">The output edges.</param>
-    protected KernelProcessStep(KernelProcessStepState? state = null, Dictionary<string, List<KernelProcessEdge>>? edges = null)
-        : base(state ?? new(), edges ?? [])
-    {
     }
 }
 
@@ -97,38 +20,11 @@ public class KernelProcessStep : KernelProcessStepBase
 /// Process Step. Derive from this class to create a new Step with user-defined state of type TState for a Process.
 /// </summary>
 /// <typeparam name="TState">An instance of TState used for user-defined state.</typeparam>
-public class KernelProcessStep<TState> : KernelProcessStepBase where TState : class, new()
+public class KernelProcessStep<TState> : KernelProcessStep where TState : class, new()
 {
-    internal new ProcessStepState<TState> State => base.State as ProcessStepState<TState> ?? new();
-
     /// <inheritdoc/>
-    internal override ValueTask _ActivateAsync(KernelProcessStepState state)
+    public virtual ValueTask ActivateAsync(KernelProcessStepState<TState> state)
     {
-        var genericState = state as ProcessStepState<TState>;
-        Verify.NotNull(genericState);
-
-        // initialize the state if it is null
-        if (genericState.State is null)
-        {
-            genericState.State = new TState();
-        }
-
-        return this.ActivateAsync(genericState);
-    }
-
-    /// <inheritdoc/>
-    public virtual ValueTask ActivateAsync(ProcessStepState<TState> state)
-    {
-        return this._ActivateAsync(state);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="KernelProcessStep"/> class.
-    /// </summary>
-    /// <param name="state">The state associated with this step.</param>
-    /// <param name="edges">The output edges.</param>
-    public KernelProcessStep(ProcessStepState<TState>? state = null, Dictionary<string, List<KernelProcessEdge>>? edges = null)
-        : base(state ?? new(), edges ?? [])
-    {
+        return default;
     }
 }

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessStepInfo.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessStepInfo.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Contains information about a Step in a Process including it's state and edges.
+/// </summary>
+public class KernelProcessStepInfo
+{
+    /// <summary>
+    /// A mapping of output edges from the Step using the .
+    /// </summary>
+    private readonly Dictionary<string, List<KernelProcessEdge>> _outputEdges;
+
+    /// <summary>
+    /// The type of the inner step.
+    /// </summary>
+    internal Type InnerStepType { get; }
+
+    /// <summary>
+    /// A read-only collection of event Ids that this Step can emit.
+    /// </summary>
+    public IReadOnlyCollection<string> EventIds => this._outputEdges.Keys.ToArray();
+
+    /// <summary>
+    /// The state of the Step.
+    /// </summary>
+    public KernelProcessStepState State { get; }
+
+    /// <summary>
+    /// Retrieves the output edges for a given event Id. Returns an empty list if the event Id is not found.
+    /// </summary>
+    /// <param name="eventId">The Id of an event.</param>
+    /// <returns>An <see cref="IReadOnlyCollection{T}"/> where T is <see cref="KernelProcessEdge"/></returns>
+    protected IReadOnlyCollection<KernelProcessEdge> GetOutputEdges(string eventId)
+    {
+        if (this._outputEdges.TryGetValue(eventId, out List<KernelProcessEdge>? edges))
+        {
+            return edges.AsReadOnly();
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KernelProcessStepInfo"/> class.
+    /// </summary>
+    public KernelProcessStepInfo(Type innerStepType, KernelProcessStepState state, Dictionary<string, List<KernelProcessEdge>> edges)
+    {
+        Verify.NotNull(innerStepType);
+        Verify.NotNull(edges);
+        Verify.NotNull(state);
+
+        this.InnerStepType = innerStepType;
+        this._outputEdges = edges;
+        this.State = state;
+    }
+}

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessStepState.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessStepState.cs
@@ -6,7 +6,6 @@ namespace Microsoft.SemanticKernel;
 /// Represents the state of an individual step in a process.
 /// </summary>
 public class KernelProcessStepState
-
 {
     /// <summary>
     /// The identifier of the Step which is required to be unique within an instance of a Process.
@@ -19,16 +18,38 @@ public class KernelProcessStepState
     /// when the Step is added to a Process, the name will be derived from the steps .NET type.
     /// </summary>
     public string? Name { get; init; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KernelProcessStepState"/> class.
+    /// </summary>
+    /// <param name="id">The Id of the associated <see cref="KernelProcessStep"/></param>
+    /// <param name="name">The name of the associated <see cref="KernelProcessStep"/></param>
+    public KernelProcessStepState(string? id = null, string? name = null)
+    {
+        this.Id = id;
+        this.Name = name;
+    }
 }
 
 /// <summary>
 /// Represents the state of an individual step in a process that includes a user-defined state object.
 /// </summary>
 /// <typeparam name="TState">The type of the user-defined state.</typeparam>
-public sealed class ProcessStepState<TState> : KernelProcessStepState where TState : class, new()
+public sealed class KernelProcessStepState<TState> : KernelProcessStepState where TState : class, new()
 {
     /// <summary>
     /// The user-defined state object associated with the Step.
     /// </summary>
-    public TState? State { get; internal set; }
+    public TState? State { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KernelProcessStepState"/> class.
+    /// </summary>
+    /// <param name="id">The Id of the associated <see cref="KernelProcessStep"/></param>
+    /// <param name="name">The name of the associated <see cref="KernelProcessStep"/></param>
+    public KernelProcessStepState(string? id = null, string? name = null)
+    {
+        this.Id = id;
+        this.Name = name;
+    }
 }


### PR DESCRIPTION
### Description

Refactored `KernelProcessStep` to simplify things by braking the inheritance from `KernelProcessStepBase`. `KernelProcessStepBase` has been changed to `KernelProcessStepInfo` and now keeps track of metadata about a step without being in the inheritance chain.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
