### PR TITLE
.Net: Rename a number of properties as agreed and remove dangerous default

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_Common.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_Common.cs
@@ -50,7 +50,7 @@ public class VectorStore_VectorSearch_MultiStore_Common(IVectorStore vectorStore
         // Search the collection using a vector search.
         var searchString = "What is an Application Programming Interface";
         var searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Limit = 1 }).ToListAsync();
+        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
 
         output.WriteLine("Search string: " + searchString);
         output.WriteLine("Result: " + searchResult.First().Record.Definition);
@@ -59,7 +59,7 @@ public class VectorStore_VectorSearch_MultiStore_Common(IVectorStore vectorStore
         // Search the collection using a vector search.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Limit = 1 }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
 
         output.WriteLine("Search string: " + searchString);
         output.WriteLine("Result: " + searchResult.First().Record.Definition);
@@ -69,7 +69,7 @@ public class VectorStore_VectorSearch_MultiStore_Common(IVectorStore vectorStore
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
         var filter = new VectorSearchFilter().EqualTo(nameof(Glossary<TKey>.Category), "External Definitions");
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Limit = 3, Filter = filter }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = filter }).ToListAsync();
 
         output.WriteLine("Search string: " + searchString);
         output.WriteLine("Number of results: " + searchResult.Count);

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiVector.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiVector.cs
@@ -56,8 +56,8 @@ public class VectorStore_VectorSearch_MultiVector(ITestOutputHelper output) : Ba
         var searchResult = await collection.VectorizedSearchAsync(
             searchVector, new()
             {
-                Limit = 1,
-                VectorFieldName = nameof(Product.DescriptionEmbedding)
+                Top = 1,
+                VectorPropertyName = nameof(Product.DescriptionEmbedding)
             }).ToListAsync();
 
         WriteLine("Search string: " + searchString);
@@ -72,8 +72,8 @@ public class VectorStore_VectorSearch_MultiVector(ITestOutputHelper output) : Ba
             searchVector,
             new()
             {
-                Limit = 1,
-                VectorFieldName = nameof(Product.FeatureListEmbedding)
+                Top = 1,
+                VectorPropertyName = nameof(Product.FeatureListEmbedding)
             }).ToListAsync();
 
         WriteLine("Search string: " + searchString);

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs
@@ -45,7 +45,7 @@ public class VectorStore_VectorSearch_Paging(ITestOutputHelper output) : BaseTes
         var moreResults = true;
         while (moreResults)
         {
-            // Get the next page of results by asking for 10 results, and using offset to skip the results from the previous pages.
+            // Get the next page of results by asking for 10 results, and using 'Skip' to skip the results from the previous pages.
             var currentPageResults = await collection.VectorizedSearchAsync(
                 searchVector,
                 new()

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs
@@ -50,8 +50,8 @@ public class VectorStore_VectorSearch_Paging(ITestOutputHelper output) : BaseTes
                 searchVector,
                 new()
                 {
-                    Limit = 10,
-                    Offset = page * 10
+                    Top = 10,
+                    Skip = page * 10
                 }).ToListAsync();
 
             // Print the results.

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Simple.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Simple.cs
@@ -48,7 +48,7 @@ public class VectorStore_VectorSearch_Simple(ITestOutputHelper output) : BaseTes
         // Search the collection using a vector search.
         var searchString = "What is an Application Programming Interface";
         var searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Limit = 1 }).ToListAsync();
+        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
         Console.WriteLine("Result: " + searchResult.First().Record.Definition);
@@ -57,7 +57,7 @@ public class VectorStore_VectorSearch_Simple(ITestOutputHelper output) : BaseTes
         // Search the collection using a vector search.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Limit = 1 }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
         Console.WriteLine("Result: " + searchResult.First().Record.Definition);
@@ -67,7 +67,7 @@ public class VectorStore_VectorSearch_Simple(ITestOutputHelper output) : BaseTes
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
         var filter = new VectorSearchFilter().EqualTo(nameof(Glossary.Category), "External Definitions");
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Limit = 3, Filter = filter }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = filter }).ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
         Console.WriteLine("Number of results: " + searchResult.Count);

--- a/dotnet/samples/Concepts/Memory/VolatileVectorStore_LoadData.cs
+++ b/dotnet/samples/Concepts/Memory/VolatileVectorStore_LoadData.cs
@@ -69,7 +69,7 @@ public class VolatileVectorStore_LoadData(ITestOutputHelper output) : BaseTest(o
             // Search the collection using a vector search.
             var searchString = "What is the Semantic Kernel?";
             var searchVector = await embeddingGenerationService.GenerateEmbeddingAsync(searchString);
-            var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Limit = 1 }).ToListAsync();
+            var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
 
             Console.WriteLine("Search string: " + searchString);
             Console.WriteLine("Result: " + searchResult.First().Record.Text);
@@ -113,7 +113,7 @@ public class VolatileVectorStore_LoadData(ITestOutputHelper output) : BaseTest(o
         // Search the collection using a vector search.
         var searchString = "What is the Semantic Kernel?";
         var searchVector = await embeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Limit = 1 }).ToListAsync();
+        var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
         Console.WriteLine("Result: " + searchResult.First().Record.Text);

--- a/dotnet/samples/Concepts/Search/Bing_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/Bing_TextSearch.cs
@@ -27,7 +27,7 @@ public class Bing_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search and return results as a string items
-        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Count = 4, Offset = 0 });
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 4, Skip = 0 });
         Console.WriteLine("--- String Results ---\n");
         await foreach (string result in stringResults.Results)
         {
@@ -36,7 +36,7 @@ public class Bing_TextSearch(ITestOutputHelper output) : BaseTest(output)
         }
 
         // Search and return results as TextSearchResult items
-        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Count = 4, Offset = 4 });
+        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Top = 4, Skip = 4 });
         Console.WriteLine("\n--- Text Search Results ---\n");
         await foreach (TextSearchResult result in textResults.Results)
         {
@@ -47,7 +47,7 @@ public class Bing_TextSearch(ITestOutputHelper output) : BaseTest(output)
         }
 
         // Search and return s results as BingWebPage items
-        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Count = 4, Offset = 8 });
+        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Top = 4, Skip = 8 });
         Console.WriteLine("\n--- Bing Web Page Results ---\n");
         await foreach (BingWebPage result in fullResults.Results)
         {
@@ -80,7 +80,7 @@ public class Bing_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search with TextSearchResult textResult type
-        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Count = 2, Offset = 0 });
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 2, Skip = 0 });
         Console.WriteLine("--- Serialized JSON Results ---");
         await foreach (string result in stringResults.Results)
         {
@@ -109,7 +109,7 @@ public class Bing_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search with TextSearchResult textResult type
-        TextSearchOptions searchOptions = new() { Count = 4, Offset = 0, Filter = new TextSearchFilter().Equality("site", "devblogs.microsoft.com") };
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality("site", "devblogs.microsoft.com") };
         KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, searchOptions);
         Console.WriteLine("--- Microsoft Developer Blogs Results ---");
         await foreach (TextSearchResult result in textResults.Results)

--- a/dotnet/samples/Concepts/Search/Google_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/Google_TextSearch.cs
@@ -26,7 +26,7 @@ public class Google_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search and return results as string items
-        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Count = 4, Offset = 0 });
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 4, Skip = 0 });
         Console.WriteLine("——— String Results ———\n");
         await foreach (string result in stringResults.Results)
         {
@@ -35,7 +35,7 @@ public class Google_TextSearch(ITestOutputHelper output) : BaseTest(output)
         }
 
         // Search and return results as TextSearchResult items
-        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Count = 4, Offset = 4 });
+        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Top = 4, Skip = 4 });
         Console.WriteLine("\n——— Text Search Results ———\n");
         await foreach (TextSearchResult result in textResults.Results)
         {
@@ -46,7 +46,7 @@ public class Google_TextSearch(ITestOutputHelper output) : BaseTest(output)
         }
 
         // Search and return results as Google.Apis.CustomSearchAPI.v1.Data.Result items
-        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Count = 4, Offset = 8 });
+        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Top = 4, Skip = 8 });
         Console.WriteLine("\n——— Google Web Page Results ———\n");
         await foreach (Google.Apis.CustomSearchAPI.v1.Data.Result result in fullResults.Results)
         {
@@ -74,7 +74,7 @@ public class Google_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search with TextSearchResult textResult type
-        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Count = 2, Offset = 0 });
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 2, Skip = 0 });
         Console.WriteLine("--- Serialized JSON Results ---");
         await foreach (string result in stringResults.Results)
         {
@@ -97,7 +97,7 @@ public class Google_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search with TextSearchResult textResult type
-        TextSearchOptions searchOptions = new() { Count = 4, Offset = 0, Filter = new TextSearchFilter().Equality("siteSearch", "devblogs.microsoft.com") };
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality("siteSearch", "devblogs.microsoft.com") };
         KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, searchOptions);
         Console.WriteLine("--- Microsoft Developer Blogs Results ---");
         await foreach (TextSearchResult result in textResults.Results)

--- a/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
@@ -65,7 +65,7 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
         var query = "What is the Semantic Kernel?";
 
         // Search and return results as a string items
-        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Count = 2, Offset = 0 });
+        KernelSearchResults<string> stringResults = await textSearch.SearchAsync(query, new() { Top = 2, Skip = 0 });
         Console.WriteLine("--- String Results ---\n");
         await foreach (string result in stringResults.Results)
         {
@@ -74,7 +74,7 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
         }
 
         // Search and return results as TextSearchResult items
-        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Count = 2, Offset = 0 });
+        KernelSearchResults<TextSearchResult> textResults = await textSearch.GetTextSearchResultsAsync(query, new() { Top = 2, Skip = 0 });
         Console.WriteLine("\n--- Text Search Results ---\n");
         await foreach (TextSearchResult result in textResults.Results)
         {
@@ -85,7 +85,7 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
         }
 
         // Search and returns results as DataModel items
-        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Count = 2, Offset = 0 });
+        KernelSearchResults<object> fullResults = await textSearch.GetSearchResultsAsync(query, new() { Top = 2, Skip = 0 });
         Console.WriteLine("\n--- DataModel Results ---\n");
         await foreach (DataModel result in fullResults.Results)
         {

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -573,10 +573,10 @@ public class AzureAISearchVectorStoreRecordCollectionTests
             new ReadOnlyMemory<float>(new float[4]),
             new()
             {
-                Limit = 5,
-                Offset = 3,
+                Top = 5,
+                Skip = 3,
                 Filter = filter,
-                VectorFieldName = nameof(MultiPropsModel.Vector1)
+                VectorPropertyName = nameof(MultiPropsModel.Vector1)
             },
             this._testCancellationToken).ToListAsync();
 
@@ -615,10 +615,10 @@ public class AzureAISearchVectorStoreRecordCollectionTests
             "search string",
             new()
             {
-                Limit = 5,
-                Offset = 3,
+                Top = 5,
+                Skip = 3,
                 Filter = filter,
-                VectorFieldName = nameof(MultiPropsModel.Vector1)
+                VectorPropertyName = nameof(MultiPropsModel.Vector1)
             },
             this._testCancellationToken).ToListAsync();
 

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -622,8 +622,8 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
         // Act
         var result = await sut.VectorizedSearchAsync(vector, new()
         {
-            VectorFieldName = vectorPropertyName,
-            Limit = actualLimit,
+            VectorPropertyName = vectorPropertyName,
+            Top = actualLimit,
         }).FirstOrDefaultAsync();
 
         // Assert
@@ -646,7 +646,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
             this._mockMongoDatabase.Object,
             "collection");
 
-        var options = new VectorSearchOptions { VectorFieldName = "non-existent-property" };
+        var options = new VectorSearchOptions { VectorPropertyName = "non-existent-property" };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), options).FirstOrDefaultAsync());

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -578,8 +578,8 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
     public async Task VectorizedSearchUsesValidQueryAsync(
         string? vectorPropertyName,
         string expectedVectorPropertyName,
-        int actualLimit,
-        int expectedLimit)
+        int actualTop,
+        int expectedTop)
     {
         // Arrange
         var vector = new ReadOnlyMemory<float>([1f, 2f, 3f]);
@@ -594,7 +594,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
                         {
                             { "vector", BsonArray.Create(vector.ToArray()) },
                             { "path", expectedVectorPropertyName },
-                            { "k", expectedLimit },
+                            { "k", expectedTop },
                         }
                     },
                     { "returnStoredSource", true }
@@ -623,7 +623,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
         var result = await sut.VectorizedSearchAsync(vector, new()
         {
             VectorPropertyName = vectorPropertyName,
-            Top = actualLimit,
+            Top = actualTop,
         }).FirstOrDefaultAsync();
 
         // Assert

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests.cs
@@ -42,7 +42,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
             .EqualTo("TestProperty2", "test-value-2")
             .AnyTagEqualTo("TestProperty3", "test-value-3");
 
-        var searchOptions = new VectorSearchOptions { Filter = filter, Offset = 5, Limit = 10 };
+        var searchOptions = new VectorSearchOptions { Filter = filter, Skip = 5, Top = 10 };
 
         // Act
         var queryDefinition = AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.BuildSearchQuery(
@@ -85,7 +85,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
 
         var filter = new VectorSearchFilter().EqualTo("non-existent-property", "test-value-2");
 
-        var searchOptions = new VectorSearchOptions { Filter = filter, Offset = 5, Limit = 10 };
+        var searchOptions = new VectorSearchOptions { Filter = filter, Skip = 5, Top = 10 };
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() =>
@@ -106,7 +106,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
         var vectorPropertyName = "test_property_1";
         var fields = this._storagePropertyNames.Values.ToList();
 
-        var searchOptions = new VectorSearchOptions { Offset = 5, Limit = 10 };
+        var searchOptions = new VectorSearchOptions { Skip = 5, Top = 10 };
 
         // Act
         var queryDefinition = AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.BuildSearchQuery(
@@ -145,7 +145,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
 
         ((List<FilterClause>)filter.FilterClauses).Add(new UnsupportedFilterClause());
 
-        var searchOptions = new VectorSearchOptions { Filter = filter, Offset = 5, Limit = 10 };
+        var searchOptions = new VectorSearchOptions { Filter = filter, Skip = 5, Top = 10 };
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() =>

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -620,7 +620,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
             this._mockDatabase.Object,
             "collection");
 
-        var searchOptions = new VectorSearchOptions { VectorFieldName = "non-existent-property" };
+        var searchOptions = new VectorSearchOptions { VectorPropertyName = "non-existent-property" };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -65,6 +65,9 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         typeof(ReadOnlyMemory<float>?)
     ];
 
+    /// <summary>The default options for vector search.</summary>
+    private static readonly Data.VectorSearchOptions s_defaultVectorSearchOptions = new();
+
     /// <summary>Azure AI Search client that can be used to manage the list of indices in an Azure AI Search Service.</summary>
     private readonly SearchIndexClient _searchIndexClient;
 
@@ -350,20 +353,20 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         }
 
         // Resolve options.
-        var internalOptions = options ?? Data.VectorSearchOptions.Default;
-        string? vectorFieldName = this.ResolveVectorFieldName(internalOptions.VectorFieldName);
+        var internalOptions = options ?? s_defaultVectorSearchOptions;
+        string? vectorFieldName = this.ResolveVectorFieldName(internalOptions.VectorPropertyName);
 
         // Configure search settings.
         var vectorQueries = new List<VectorQuery>();
-        vectorQueries.Add(new VectorizedQuery(floatVector) { KNearestNeighborsCount = internalOptions.Limit, Fields = { vectorFieldName } });
+        vectorQueries.Add(new VectorizedQuery(floatVector) { KNearestNeighborsCount = internalOptions.Top, Fields = { vectorFieldName } });
         var filterString = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(internalOptions.Filter, this._storagePropertyNames);
 
         // Build search options.
         var searchOptions = new SearchOptions
         {
             VectorSearch = new(),
-            Size = internalOptions.Limit,
-            Skip = internalOptions.Offset,
+            Size = internalOptions.Top,
+            Skip = internalOptions.Skip,
             Filter = filterString,
         };
         searchOptions.VectorSearch.Queries.AddRange(vectorQueries);
@@ -388,20 +391,20 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
         }
 
         // Resolve options.
-        var internalOptions = options ?? Data.VectorSearchOptions.Default;
-        string? vectorFieldName = this.ResolveVectorFieldName(internalOptions.VectorFieldName);
+        var internalOptions = options ?? s_defaultVectorSearchOptions;
+        string? vectorFieldName = this.ResolveVectorFieldName(internalOptions.VectorPropertyName);
 
         // Configure search settings.
         var vectorQueries = new List<VectorQuery>();
-        vectorQueries.Add(new VectorizableTextQuery(searchText) { KNearestNeighborsCount = internalOptions.Limit, Fields = { vectorFieldName } });
+        vectorQueries.Add(new VectorizableTextQuery(searchText) { KNearestNeighborsCount = internalOptions.Top, Fields = { vectorFieldName } });
         var filterString = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(internalOptions.Filter, this._storagePropertyNames);
 
         // Build search options.
         var searchOptions = new SearchOptions
         {
             VectorSearch = new(),
-            Size = internalOptions.Limit,
-            Skip = internalOptions.Offset,
+            Size = internalOptions.Top,
+            Skip = internalOptions.Skip,
             Filter = filterString,
         };
         searchOptions.VectorSearch.Queries.AddRange(vectorQueries);

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.cs
@@ -59,8 +59,8 @@ internal static class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder
         var queryDefinition = new QueryDefinition(query);
 
         queryDefinition.WithParameter(VectorVariableName, vector);
-        queryDefinition.WithParameter(OffsetVariableName, searchOptions.Offset);
-        queryDefinition.WithParameter(LimitVariableName, searchOptions.Limit);
+        queryDefinition.WithParameter(OffsetVariableName, searchOptions.Skip);
+        queryDefinition.WithParameter(LimitVariableName, searchOptions.Top);
 
         if (filterQueryParameters is { Count: > 0 })
         {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -74,6 +74,9 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         typeof(ReadOnlyMemory<sbyte>?),
     ];
 
+    /// <summary>The default options for vector search.</summary>
+    private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
+
     /// <summary><see cref="Database"/> that can be used to manage the collections in Azure CosmosDB NoSQL.</summary>
     private readonly Database _database;
 
@@ -393,8 +396,8 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
                 $"Supported types are: {string.Join(", ", s_supportedVectorTypes.Select(l => l.FullName))}");
         }
 
-        var searchOptions = options ?? VectorSearchOptions.Default;
-        var vectorProperty = this.GetVectorPropertyForSearch(searchOptions.VectorFieldName);
+        var searchOptions = options ?? s_defaultVectorSearchOptions;
+        var vectorProperty = this.GetVectorPropertyForSearch(searchOptions.VectorPropertyName);
 
         if (vectorProperty is null)
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -29,6 +29,9 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
         typeof(Guid)
     ];
 
+    /// <summary>The default options for vector search.</summary>
+    private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
+
     /// <summary>The name of this database for telemetry purposes.</summary>
     private const string DatabaseName = "Qdrant";
 
@@ -463,7 +466,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
             throw new NotSupportedException($"The provided vector type {vector.GetType().FullName} is not supported by the Qdrant connector.");
         }
 
-        var internalOptions = options ?? Data.VectorSearchOptions.Default;
+        var internalOptions = options ?? s_defaultVectorSearchOptions;
 
         // Build filter object.
         var filter = QdrantVectorStoreCollectionSearchMapping.BuildFilter(internalOptions.Filter, this._storagePropertyNames);
@@ -472,7 +475,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
         string? vectorName = null;
         if (this._options.HasNamedVectors)
         {
-            vectorName = this.ResolveVectorFieldName(internalOptions.VectorFieldName);
+            vectorName = this.ResolveVectorFieldName(internalOptions.VectorPropertyName);
         }
 
         // Specify whether to include vectors in the search results.
@@ -492,8 +495,8 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
                 query: query,
                 usingVector: vectorName,
                 filter: filter,
-                limit: (ulong)internalOptions.Limit,
-                offset: (ulong)internalOptions.Offset,
+                limit: (ulong)internalOptions.Top,
+                offset: (ulong)internalOptions.Skip,
                 vectorsSelector: vectorsSelector,
                 cancellationToken: cancellationToken)).ConfigureAwait(false);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -61,6 +61,9 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         typeof(ReadOnlyMemory<double>?)
     ];
 
+    /// <summary>The default options for vector search.</summary>
+    private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
+
     /// <summary>The Redis database to read/write records from.</summary>
     private readonly IDatabase _database;
 
@@ -351,7 +354,7 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
             throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
         }
 
-        var internalOptions = options ?? Data.VectorSearchOptions.Default;
+        var internalOptions = options ?? s_defaultVectorSearchOptions;
 
         // Build query & search.
         var selectFields = internalOptions.IncludeVectors ? null : this._dataStoragePropertyNames;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -44,6 +44,9 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         typeof(ReadOnlyMemory<double>?)
     ];
 
+    /// <summary>The default options for vector search.</summary>
+    private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
+
     /// <summary>The Redis database to read/write records from.</summary>
     private readonly IDatabase _database;
 
@@ -389,7 +392,7 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
             throw new InvalidOperationException("The collection does not have any vector fields, so vector search is not possible.");
         }
 
-        var internalOptions = options ?? Data.VectorSearchOptions.Default;
+        var internalOptions = options ?? s_defaultVectorSearchOptions;
 
         // Build query & search.
         byte[] vectorBytes = RedisVectorStoreCollectionSearchMapping.ValidateVectorAndConvertToBytes(vector, "JSON");

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
@@ -53,15 +53,15 @@ internal static class RedisVectorStoreCollectionSearchMapping
     public static Query BuildQuery(byte[] vectorBytes, VectorSearchOptions options, Dictionary<string, string> storagePropertyNames, string firstVectorPropertyName, string[]? selectFields)
     {
         // Resolve options.
-        var vectorPropertyName = ResolveVectorFieldName(options.VectorFieldName, storagePropertyNames, firstVectorPropertyName);
+        var vectorPropertyName = ResolveVectorFieldName(options.VectorPropertyName, storagePropertyNames, firstVectorPropertyName);
 
         // Build search query.
-        var redisLimit = options.Limit + options.Offset;
+        var redisLimit = options.Top + options.Skip;
         var filter = RedisVectorStoreCollectionSearchMapping.BuildFilter(options.Filter, storagePropertyNames);
         var query = new Query($"{filter}=>[KNN {redisLimit} @{vectorPropertyName} $embedding AS vector_score]")
             .AddParam("embedding", vectorBytes)
             .SetSortBy("vector_score")
-            .Limit(options.Offset, redisLimit)
+            .Limit(options.Skip, redisLimit)
             .SetWithScores(true)
             .Dialect(2);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -83,6 +83,9 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
         }
     };
 
+    /// <summary>The default options for vector search.</summary>
+    private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
+
     /// <summary><see cref="HttpClient"/> that is used to interact with Weaviate API.</summary>
     private readonly HttpClient _httpClient;
 
@@ -385,8 +388,8 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
                 $"Supported types are: {string.Join(", ", s_supportedVectorTypes.Select(l => l.FullName))}");
         }
 
-        var searchOptions = options ?? VectorSearchOptions.Default;
-        var vectorProperty = this.GetVectorPropertyForSearch(searchOptions.VectorFieldName);
+        var searchOptions = options ?? s_defaultVectorSearchOptions;
+        var vectorProperty = this.GetVectorPropertyForSearch(searchOptions.VectorPropertyName);
 
         if (vectorProperty is null)
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionQueryBuilder.cs
@@ -44,8 +44,8 @@ internal static class WeaviateVectorStoreRecordCollectionQueryBuilder
         {
           Get {
             {{collectionName}} (
-              limit: {{searchOptions.Limit}}
-              offset: {{searchOptions.Offset}}
+              limit: {{searchOptions.Top}}
+              offset: {{searchOptions.Skip}}
               {{filter}}
               nearVector: {
                 targetVectors: ["{{vectorPropertyName}}"]

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -563,7 +563,7 @@ public class QdrantVectorStoreRecordCollectionTests
         // Act.
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new[] { 1f, 2f, 3f, 4f }),
-            new() { IncludeVectors = true, Filter = filter, Limit = 5, Offset = 2 },
+            new() { IncludeVectors = true, Filter = filter, Top = 5, Skip = 2 },
             this._testCancellationToken).ToListAsync();
 
         // Assert.

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -449,8 +449,8 @@ public class RedisHashSetVectorStoreRecordCollectionTests
             {
                 IncludeVectors = includeVectors,
                 Filter = filter,
-                Limit = 5,
-                Offset = 2
+                Top = 5,
+                Skip = 2
             }).ToListAsync();
 
         // Assert.

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -464,8 +464,8 @@ public class RedisJsonVectorStoreRecordCollectionTests
             {
                 IncludeVectors = true,
                 Filter = filter,
-                Limit = 5,
-                Offset = 2
+                Top = 5,
+                Skip = 2
             }).ToListAsync();
 
         // Assert.

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
@@ -70,7 +70,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
         var firstVectorPropertyName = "storage_Vector";
 
         // Act.
-        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(byteArray, VectorSearchOptions.Default, storagePropertyNames, firstVectorPropertyName, null);
+        var query = RedisVectorStoreCollectionSearchMapping.BuildQuery(byteArray, new VectorSearchOptions(), storagePropertyNames, firstVectorPropertyName, null);
 
         // Assert.
         Assert.NotNull(query);
@@ -86,7 +86,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
         // Arrange.
         var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
         var byteArray = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
-        var vectorSearchOptions = new VectorSearchOptions { Limit = 5, Offset = 3, VectorFieldName = "Vector" };
+        var vectorSearchOptions = new VectorSearchOptions { Top = 5, Skip = 3, VectorPropertyName = "Vector" };
         var storagePropertyNames = new Dictionary<string, string>()
         {
             { "Vector", "storage_Vector" },
@@ -108,7 +108,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
         // Arrange.
         var floatVector = new ReadOnlyMemory<float>(new float[] { 1.0f, 2.0f, 3.0f });
         var byteArray = MemoryMarshal.AsBytes(floatVector.Span).ToArray();
-        var vectorSearchOptions = new VectorSearchOptions { VectorFieldName = "UnknownVector" };
+        var vectorSearchOptions = new VectorSearchOptions { VectorPropertyName = "UnknownVector" };
         var storagePropertyNames = new Dictionary<string, string>()
         {
             { "Vector", "storage_Vector" },

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionQueryBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionQueryBuilderTests.cs
@@ -74,9 +74,9 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
 
         var searchOptions = new VectorSearchOptions
         {
-            Offset = 2,
-            Limit = 3,
-            VectorFieldName = "DescriptionEmbedding"
+            Skip = 2,
+            Top = 3,
+            VectorPropertyName = "DescriptionEmbedding"
         };
 
         // Act
@@ -104,9 +104,9 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
         // Arrange
         var searchOptions = new VectorSearchOptions
         {
-            Offset = 2,
-            Limit = 3,
-            VectorFieldName = "DescriptionEmbedding",
+            Skip = 2,
+            Top = 3,
+            VectorPropertyName = "DescriptionEmbedding",
             IncludeVectors = true
         };
 
@@ -135,9 +135,9 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
 
         var searchOptions = new VectorSearchOptions
         {
-            Offset = 2,
-            Limit = 3,
-            VectorFieldName = "DescriptionEmbedding",
+            Skip = 2,
+            Top = 3,
+            VectorPropertyName = "DescriptionEmbedding",
             Filter = new VectorSearchFilter()
                 .EqualTo("HotelName", "Test Name")
                 .AnyTagEqualTo("Tags", "t1")
@@ -166,9 +166,9 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
         // Arrange
         var searchOptions = new VectorSearchOptions
         {
-            Offset = 2,
-            Limit = 3,
-            VectorFieldName = "DescriptionEmbedding",
+            Skip = 2,
+            Top = 3,
+            VectorPropertyName = "DescriptionEmbedding",
             Filter = new VectorSearchFilter().EqualTo("HotelName", new TestFilterValue())
         };
 
@@ -191,9 +191,9 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
         // Arrange
         var searchOptions = new VectorSearchOptions
         {
-            Offset = 2,
-            Limit = 3,
-            VectorFieldName = "DescriptionEmbedding",
+            Skip = 2,
+            Top = 3,
+            VectorPropertyName = "DescriptionEmbedding",
             Filter = new VectorSearchFilter().EqualTo("NonExistentProperty", "value")
         };
 

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionTests.cs
@@ -529,7 +529,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests : IDisposable
         // Arrange
         var sut = new WeaviateVectorStoreRecordCollection<WeaviateHotel>(this._mockHttpClient, "Collection");
 
-        var searchOptions = new VectorSearchOptions { VectorFieldName = "non-existent-property" };
+        var searchOptions = new VectorSearchOptions { VectorPropertyName = "non-existent-property" };
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -342,7 +342,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
             new()
             {
                 IncludeVectors = includeVectors,
-                VectorFieldName = "DescriptionEmbedding",
+                VectorPropertyName = "DescriptionEmbedding",
                 Filter = filter,
             });
 
@@ -381,7 +381,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
             "A hotel with great views.",
             new()
             {
-                VectorFieldName = "DescriptionEmbedding",
+                VectorPropertyName = "DescriptionEmbedding",
                 Filter = filter,
             });
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -373,8 +373,8 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         // Act
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Limit = 2,
-            Offset = 2
+            Top = 2,
+            Skip = 2
         }).ToListAsync();
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -305,8 +305,8 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests(AzureCosm
         // Act
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Limit = 2,
-            Offset = 2
+            Top = 2,
+            Skip = 2
         }).ToListAsync();
 
         // Assert
@@ -339,7 +339,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests(AzureCosm
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Filter = filter,
-            Limit = 4,
+            Top = 4,
         }).ToListAsync();
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -341,7 +341,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
     }
 
     [Fact(Skip = SkipReason)]
-    public async Task ItCanSearchWithFloat32VectorAndLimitOffsetAsync()
+    public async Task ItCanSearchWithFloat32VectorAndTopSkipAsync()
     {
         // Arrange
         var options = new RedisHashSetVectorStoreRecordCollectionOptions<BasicFloat32Hotel> { PrefixCollectionNameToKeyNames = true };

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -359,8 +359,8 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             vector,
             new VectorSearchOptions
             {
-                Limit = 3,
-                Offset = 2
+                Top = 3,
+                Skip = 2
             }).ToListAsync();
 
         // Assert
@@ -389,7 +389,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             new VectorSearchOptions
             {
                 IncludeVectors = includeVectors,
-                Limit = 1
+                Top = 1
             }).ToListAsync();
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -365,7 +365,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
     }
 
     [Fact(Skip = SkipReason)]
-    public async Task ItCanSearchWithFloat32VectorAndLimitOffsetAsync()
+    public async Task ItCanSearchWithFloat32VectorAndTopSkipAsync()
     {
         // Arrange
         var options = new RedisJsonVectorStoreRecordCollectionOptions<BasicFloat32Hotel> { PrefixCollectionNameToKeyNames = true };

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -383,8 +383,8 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             vector,
             new VectorSearchOptions
             {
-                Limit = 3,
-                Offset = 2
+                Top = 3,
+                Skip = 2
             }).ToListAsync();
 
         // Assert
@@ -413,7 +413,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
             new VectorSearchOptions
             {
                 IncludeVectors = includeVectors,
-                Limit = 1
+                Top = 1
             }).ToListAsync();
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
@@ -263,8 +263,8 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         // Act
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Limit = 2,
-            Offset = 2
+            Top = 2,
+            Skip = 2
         }).ToListAsync();
 
         // Assert
@@ -297,7 +297,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Filter = filter,
-            Limit = 4,
+            Top = 4,
         }).ToListAsync();
 
         // Assert
@@ -341,7 +341,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([40f, 40f, 40f, 40f]), new()
         {
             Filter = filter,
-            Limit = 4,
+            Top = 4,
         }).ToListAsync();
 
         // Assert

--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/Bing/BingTextSearchTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/Bing/BingTextSearchTests.cs
@@ -35,7 +35,7 @@ public sealed class BingTextSearchTests : IDisposable
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient });
 
         // Act
-        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -59,7 +59,7 @@ public sealed class BingTextSearchTests : IDisposable
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient });
 
         // Act
-        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -85,7 +85,7 @@ public sealed class BingTextSearchTests : IDisposable
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient });
 
         // Act
-        KernelSearchResults<object> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<object> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -113,7 +113,7 @@ public sealed class BingTextSearchTests : IDisposable
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient, StringMapper = new TestTextSearchStringMapper() });
 
         // Act
-        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -139,7 +139,7 @@ public sealed class BingTextSearchTests : IDisposable
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient, ResultMapper = new TestTextSearchResultMapper() });
 
         // Act
-        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -191,7 +191,7 @@ public sealed class BingTextSearchTests : IDisposable
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient });
 
         // Act
-        TextSearchOptions searchOptions = new() { Count = 4, Offset = 0, Filter = new TextSearchFilter().Equality(paramName, paramValue) };
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality(paramName, paramValue) };
         KernelSearchResults<object> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", searchOptions);
 
         // Assert
@@ -206,7 +206,7 @@ public sealed class BingTextSearchTests : IDisposable
     {
         // Arrange
         this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterDevBlogsResponseJson));
-        TextSearchOptions searchOptions = new() { Count = 4, Offset = 0, Filter = new TextSearchFilter().Equality("fooBar", "Baz") };
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality("fooBar", "Baz") };
 
         // Create an ITextSearch instance using Bing search
         var textSearch = new BingTextSearch(apiKey: "ApiKey", options: new() { HttpClient = this._httpClient });

--- a/dotnet/src/Plugins/Plugins.UnitTests/Web/Google/GoogleTextSearchTests.cs
+++ b/dotnet/src/Plugins/Plugins.UnitTests/Web/Google/GoogleTextSearchTests.cs
@@ -38,7 +38,7 @@ public sealed class GoogleTextSearchTests : IDisposable
             searchEngineId: "SearchEngineId");
 
         // Act
-        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Count = 4, Offset = 0 });
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -64,7 +64,7 @@ public sealed class GoogleTextSearchTests : IDisposable
             searchEngineId: "SearchEngineId");
 
         // Act
-        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -92,7 +92,7 @@ public sealed class GoogleTextSearchTests : IDisposable
             searchEngineId: "SearchEngineId");
 
         // Act
-        KernelSearchResults<object> results = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 10, Offset = 0 });
+        KernelSearchResults<object> results = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 10, Skip = 0 });
 
         // Assert
         Assert.NotNull(results);
@@ -123,7 +123,7 @@ public sealed class GoogleTextSearchTests : IDisposable
             options: new() { StringMapper = new TestTextSearchStringMapper() });
 
         // Act
-        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Count = 4, Offset = 0 });
+        KernelSearchResults<string> result = await textSearch.SearchAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -152,7 +152,7 @@ public sealed class GoogleTextSearchTests : IDisposable
             options: new() { ResultMapper = new TestTextSearchResultMapper() });
 
         // Act
-        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 4, Offset = 0 });
+        KernelSearchResults<TextSearchResult> result = await textSearch.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 4, Skip = 0 });
 
         // Assert
         Assert.NotNull(result);
@@ -193,7 +193,7 @@ public sealed class GoogleTextSearchTests : IDisposable
             searchEngineId: "SearchEngineId");
 
         // Act
-        TextSearchOptions searchOptions = new() { Count = 4, Offset = 0, Filter = new TextSearchFilter().Equality(paramName, paramValue) };
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality(paramName, paramValue) };
         KernelSearchResults<object> result = await textSearch.GetSearchResultsAsync("What is the Semantic Kernel?", searchOptions);
 
         // Assert
@@ -209,7 +209,7 @@ public sealed class GoogleTextSearchTests : IDisposable
     {
         // Arrange
         this._messageHandlerStub.AddJsonResponse(File.ReadAllText(SiteFilterDevBlogsResponseJson));
-        TextSearchOptions searchOptions = new() { Count = 4, Offset = 0, Filter = new TextSearchFilter().Equality("fooBar", "Baz") };
+        TextSearchOptions searchOptions = new() { Top = 4, Skip = 0, Filter = new TextSearchFilter().Equality("fooBar", "Baz") };
 
         using var textSearch = new GoogleTextSearch(
             initializer: new() { ApiKey = "ApiKey", HttpClientFactory = this._clientFactory },

--- a/dotnet/src/Plugins/Plugins.Web/Bing/BingTextSearch.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Bing/BingTextSearch.cs
@@ -120,8 +120,8 @@ public sealed class BingTextSearch : ITextSearch
     /// <returns>A <see cref="HttpResponseMessage"/> representing the response from the request.</returns>
     private async Task<HttpResponseMessage> SendGetRequestAsync(string query, TextSearchOptions searchOptions, CancellationToken cancellationToken = default)
     {
-        var count = searchOptions.Count;
-        var offset = searchOptions.Offset;
+        var count = searchOptions.Top;
+        var offset = searchOptions.Skip;
 
         if (count is <= 0 or > 50)
         {
@@ -278,7 +278,7 @@ public sealed class BingTextSearch : ITextSearch
             }
         }
 
-        fullQuery.Append($"&count={searchOptions.Count}&offset={searchOptions.Offset}{queryParams}");
+        fullQuery.Append($"&count={searchOptions.Top}&offset={searchOptions.Skip}{queryParams}");
 
         return fullQuery.ToString();
     }

--- a/dotnet/src/Plugins/Plugins.Web/Bing/BingTextSearch.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Bing/BingTextSearch.cs
@@ -120,10 +120,7 @@ public sealed class BingTextSearch : ITextSearch
     /// <returns>A <see cref="HttpResponseMessage"/> representing the response from the request.</returns>
     private async Task<HttpResponseMessage> SendGetRequestAsync(string query, TextSearchOptions searchOptions, CancellationToken cancellationToken = default)
     {
-        var count = searchOptions.Top;
-        var offset = searchOptions.Skip;
-
-        if (count is <= 0 or > 50)
+        if (searchOptions.Top is <= 0 or > 50)
         {
             throw new ArgumentOutOfRangeException(nameof(searchOptions), searchOptions, $"{nameof(searchOptions)} count value must be greater than 0 and have a maximum value of 50.");
         }

--- a/dotnet/src/Plugins/Plugins.Web/Google/GoogleTextSearch.cs
+++ b/dotnet/src/Plugins/Plugins.Web/Google/GoogleTextSearch.cs
@@ -135,8 +135,8 @@ public sealed class GoogleTextSearch : ITextSearch, IDisposable
     /// <exception cref="NotSupportedException"></exception>
     private async Task<global::Google.Apis.CustomSearchAPI.v1.Data.Search> ExecuteSearchAsync(string query, TextSearchOptions searchOptions, CancellationToken cancellationToken)
     {
-        var count = searchOptions.Count;
-        var offset = searchOptions.Offset;
+        var count = searchOptions.Top;
+        var offset = searchOptions.Skip;
 
         if (count is <= 0 or > MaxCount)
         {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchOptions.cs
@@ -12,7 +12,7 @@ public sealed class TextSearchOptions
     /// <summary>
     /// Default number of search results to return.
     /// </summary>
-    public static readonly int DefaultCount = 5;
+    public static readonly int DefaultTop = 5;
 
     /// <summary>
     /// Flag indicating the total count should be included in the results.
@@ -31,10 +31,10 @@ public sealed class TextSearchOptions
     /// <summary>
     /// Number of search results to return.
     /// </summary>
-    public int Count { get; init; } = DefaultCount;
+    public int Top { get; init; } = DefaultTop;
 
     /// <summary>
     /// The index of the first result to return.
     /// </summary>
-    public int Offset { get; init; } = 0;
+    public int Skip { get; init; } = 0;
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchFilter.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchFilter.cs
@@ -49,30 +49,30 @@ public sealed class VectorSearchFilter
     /// <summary>
     /// Add an equal to clause to the filter options.
     /// </summary>
-    /// <param name="field">Name of the field.</param>
-    /// <param name="value">Value of the field</param>
+    /// <param name="propertyName">Name of the property to check against. Use the name of the property from your data model or as provided in the record definition.</param>
+    /// <param name="value">Value that the property should match.</param>
     /// <returns><see cref="VectorSearchFilter"/> instance to allow fluent configuration.</returns>
     /// <remarks>
-    /// This clause will check if a field is equal to a specific value.
+    /// This clause will check if a property is equal to a specific value.
     /// </remarks>
-    public VectorSearchFilter EqualTo(string field, object value)
+    public VectorSearchFilter EqualTo(string propertyName, object value)
     {
-        this._filterClauses.Add(new EqualToFilterClause(field, value));
+        this._filterClauses.Add(new EqualToFilterClause(propertyName, value));
         return this;
     }
 
     /// <summary>
     /// Add an any tag equal to clause to the filter options.
     /// </summary>
-    /// <param name="field">Name of the field consisting of a list of values.</param>
+    /// <param name="propertyName">Name of the property consisting of a list of values to check against. Use the name of the property from your data model or as provided in the record definition.</param>
     /// <param name="value">Value that the list should contain.</param>
     /// <returns><see cref="VectorSearchFilter"/> instance to allow fluent configuration.</returns>
     /// <remarks>
-    /// This clause will check if a field consisting of a list of values contains a specific value.
+    /// This clause will check if a property consisting of a list of values contains a specific value.
     /// </remarks>
-    public VectorSearchFilter AnyTagEqualTo(string field, string value)
+    public VectorSearchFilter AnyTagEqualTo(string propertyName, string value)
     {
-        this._filterClauses.Add(new AnyTagEqualToFilterClause(field, value));
+        this._filterClauses.Add(new AnyTagEqualToFilterClause(propertyName, value));
         return this;
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchOptions.cs
@@ -11,30 +11,26 @@ namespace Microsoft.SemanticKernel.Data;
 public class VectorSearchOptions
 {
     /// <summary>
-    /// Gets the default options for vector search.
-    /// </summary>
-    public static VectorSearchOptions Default { get; } = new VectorSearchOptions();
-
-    /// <summary>
     /// Gets or sets a search filter to use before doing the vector search.
     /// </summary>
     public VectorSearchFilter? Filter { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the vector field to search.
-    /// If not provided will default to the first vector field in the schema.
+    /// Gets or sets the name of the vector property to search on.
+    /// Use the name of the vector property from your data model or as provided in the record definition.
+    /// If not provided will default to the first vector property in the schema.
     /// </summary>
-    public string? VectorFieldName { get; init; }
+    public string? VectorPropertyName { get; init; }
 
     /// <summary>
     /// Gets or sets the maximum number of results to return.
     /// </summary>
-    public int Limit { get; init; } = 3;
+    public int Top { get; init; } = 3;
 
     /// <summary>
-    /// Gets or sets the number of results to skip before returning results.
+    /// Gets or sets the number of results to skip before returning results, i.e. the index of the first result to return.
     /// </summary>
-    public int Offset { get; init; } = 0;
+    public int Skip { get; init; } = 0;
 
     /// <summary>
     /// Gets or sets a value indicating whether to include vectors in the retrieval result.

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -118,8 +118,8 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
         var vectorSearchOptions = new VectorSearchOptions
         {
             Filter = searchOptions.Filter?.FilterClauses is not null ? new VectorSearchFilter(searchOptions.Filter.FilterClauses) : null,
-            Offset = searchOptions.Offset,
-            Limit = searchOptions.Count,
+            Skip = searchOptions.Skip,
+            Top = searchOptions.Top,
         };
 
         if (this._vectorizedSearch is not null)

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearchExtensions.cs
@@ -95,8 +95,8 @@ public static class TextSearchExtensions
 
             searchOptions ??= new()
             {
-                Count = GetArgumentValue(arguments, parameters, "count", 2),
-                Offset = GetArgumentValue(arguments, parameters, "skip", 0),
+                Top = GetArgumentValue(arguments, parameters, "count", 2),
+                Skip = GetArgumentValue(arguments, parameters, "skip", 0),
                 Filter = CreateBasicFilter(options, arguments)
             };
 
@@ -132,8 +132,8 @@ public static class TextSearchExtensions
 
             searchOptions ??= new()
             {
-                Count = GetArgumentValue(arguments, parameters, "count", 2),
-                Offset = GetArgumentValue(arguments, parameters, "skip", 0),
+                Top = GetArgumentValue(arguments, parameters, "count", 2),
+                Skip = GetArgumentValue(arguments, parameters, "skip", 0),
                 Filter = CreateBasicFilter(options, arguments)
             };
 
@@ -168,8 +168,8 @@ public static class TextSearchExtensions
 
             searchOptions ??= new()
             {
-                Count = GetArgumentValue(arguments, parameters, "count", 2),
-                Offset = GetArgumentValue(arguments, parameters, "skip", 0),
+                Top = GetArgumentValue(arguments, parameters, "count", 2),
+                Skip = GetArgumentValue(arguments, parameters, "skip", 0),
                 Filter = CreateBasicFilter(options, arguments)
             };
 

--- a/dotnet/src/SemanticKernel.UnitTests/Data/MockTextSearch.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/MockTextSearch.cs
@@ -15,7 +15,7 @@ internal sealed class MockTextSearch(int count = 3, long totalCount = 30) : ITex
     /// <inheritdoc/>
     public Task<KernelSearchResults<object>> GetSearchResultsAsync(string query, TextSearchOptions? searchOptions = null, CancellationToken cancellationToken = default)
     {
-        int count = searchOptions?.Count ?? this._count;
+        int count = searchOptions?.Top ?? this._count;
         var results = Enumerable.Range(1, count).Select(i => new MySearchResult($"Name {i}", $"Result {i}", $"http://example.com/page{i}")).ToList();
         long? totalCount = searchOptions?.IncludeTotalCount ?? false ? this._totalCount : null;
         return Task.FromResult(new KernelSearchResults<object>(results.ToAsyncEnumerable<object>(), totalCount));
@@ -24,7 +24,7 @@ internal sealed class MockTextSearch(int count = 3, long totalCount = 30) : ITex
     /// <inheritdoc/>
     public Task<KernelSearchResults<TextSearchResult>> GetTextSearchResultsAsync(string query, TextSearchOptions? searchOptions = null, CancellationToken cancellationToken = default)
     {
-        int count = searchOptions?.Count ?? this._count;
+        int count = searchOptions?.Top ?? this._count;
         var results = Enumerable.Range(1, count).Select(i => new TextSearchResult($"Name {i}", $"Result {i}", $"http://example.com/page{i}")).ToList();
         long? totalCount = searchOptions?.IncludeTotalCount ?? false ? this._totalCount : null;
         return Task.FromResult(new KernelSearchResults<TextSearchResult>(results.ToAsyncEnumerable(), totalCount));
@@ -33,7 +33,7 @@ internal sealed class MockTextSearch(int count = 3, long totalCount = 30) : ITex
     /// <inheritdoc/>
     public Task<KernelSearchResults<string>> SearchAsync(string query, TextSearchOptions? searchOptions = null, CancellationToken cancellationToken = default)
     {
-        int count = searchOptions?.Count ?? this._count;
+        int count = searchOptions?.Top ?? this._count;
         var results = Enumerable.Range(1, count).Select(i => $"Result {i}").ToList();
         long? totalCount = searchOptions?.IncludeTotalCount ?? false ? this._totalCount : null;
         return Task.FromResult(new KernelSearchResults<string>(results.ToAsyncEnumerable(), totalCount));

--- a/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchExtensionsTests.cs
@@ -35,9 +35,9 @@ public class TextSearchExtensionsTests
 
     public static TheoryData<KernelFunction, int> FunctionsWithCount => new()
        {
-            { TextSearch.CreateSearch(searchOptions: new() { Count = 10 }), 10 },
-            { TextSearch.CreateGetTextSearchResults(searchOptions: new() { Count = 10 }), 10 },
-            { TextSearch.CreateGetSearchResults(searchOptions: new() { Count = 10 }), 10 },
+            { TextSearch.CreateSearch(searchOptions: new() { Top = 10 }), 10 },
+            { TextSearch.CreateGetTextSearchResults(searchOptions: new() { Top = 10 }), 10 },
+            { TextSearch.CreateGetSearchResults(searchOptions: new() { Top = 10 }), 10 },
        };
 
     [Theory]

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTests.cs
@@ -53,7 +53,7 @@ public class VectorStoreTextSearchTests
         var sut = await CreateVectorStoreTextSearchFromVectorizedSearchAsync();
 
         // Act.
-        KernelSearchResults<string> searchResults = await sut.SearchAsync("What is the Semantic Kernel?", new() { Count = 2, Offset = 0 });
+        KernelSearchResults<string> searchResults = await sut.SearchAsync("What is the Semantic Kernel?", new() { Top = 2, Skip = 0 });
         var results = await ToListAsync(searchResults.Results);
 
         Assert.Equal(2, results.Count);
@@ -66,7 +66,7 @@ public class VectorStoreTextSearchTests
         var sut = await CreateVectorStoreTextSearchFromVectorizedSearchAsync();
 
         // Act.
-        KernelSearchResults<TextSearchResult> searchResults = await sut.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 2, Offset = 0 });
+        KernelSearchResults<TextSearchResult> searchResults = await sut.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 2, Skip = 0 });
         var results = await ToListAsync(searchResults.Results);
 
         Assert.Equal(2, results.Count);
@@ -79,7 +79,7 @@ public class VectorStoreTextSearchTests
         var sut = await CreateVectorStoreTextSearchFromVectorizedSearchAsync();
 
         // Act.
-        KernelSearchResults<object> searchResults = await sut.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 2, Offset = 0 });
+        KernelSearchResults<object> searchResults = await sut.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 2, Skip = 0 });
         var results = await ToListAsync(searchResults.Results);
 
         Assert.Equal(2, results.Count);
@@ -92,7 +92,7 @@ public class VectorStoreTextSearchTests
         var sut = await CreateVectorStoreTextSearchFromVectorizableTextSearchAsync();
 
         // Act.
-        KernelSearchResults<string> searchResults = await sut.SearchAsync("What is the Semantic Kernel?", new() { Count = 2, Offset = 0 });
+        KernelSearchResults<string> searchResults = await sut.SearchAsync("What is the Semantic Kernel?", new() { Top = 2, Skip = 0 });
         var results = await ToListAsync(searchResults.Results);
 
         Assert.Equal(2, results.Count);
@@ -105,7 +105,7 @@ public class VectorStoreTextSearchTests
         var sut = await CreateVectorStoreTextSearchFromVectorizableTextSearchAsync();
 
         // Act.
-        KernelSearchResults<TextSearchResult> searchResults = await sut.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 2, Offset = 0 });
+        KernelSearchResults<TextSearchResult> searchResults = await sut.GetTextSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 2, Skip = 0 });
         var results = await ToListAsync(searchResults.Results);
 
         Assert.Equal(2, results.Count);
@@ -118,7 +118,7 @@ public class VectorStoreTextSearchTests
         var sut = await CreateVectorStoreTextSearchFromVectorizableTextSearchAsync();
 
         // Act.
-        KernelSearchResults<object> searchResults = await sut.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Count = 2, Offset = 0 });
+        KernelSearchResults<object> searchResults = await sut.GetSearchResultsAsync("What is the Semantic Kernel?", new() { Top = 2, Skip = 0 });
         var results = await ToListAsync(searchResults.Results);
 
         Assert.Equal(2, results.Count);
@@ -137,15 +137,15 @@ public class VectorStoreTextSearchTests
         // Act.
         KernelSearchResults<object> evenSearchResults = await sut.GetSearchResultsAsync("What is the Semantic Kernel?", new()
         {
-            Count = 2,
-            Offset = 0,
+            Top = 2,
+            Skip = 0,
             Filter = evenFilter
         });
         var evenResults = await ToListAsync(evenSearchResults.Results);
         KernelSearchResults<object> oddSearchResults = await sut.GetSearchResultsAsync("What is the Semantic Kernel?", new()
         {
-            Count = 2,
-            Offset = 0,
+            Top = 2,
+            Skip = 0,
             Filter = oddFilter
         });
         var oddResults = await ToListAsync(oddSearchResults.Results);

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -430,12 +430,12 @@ public class VolatileVectorStoreRecordCollectionTests
         // Assert
         Assert.NotNull(actual);
 
-        // Assert that limit was respected
+        // Assert that top was respected
         Assert.Equal(10, actual.Count);
         var actualIds = actual.Select(r => r.Record.Key).ToList();
         for (int i = 0; i < 10; i++)
         {
-            // Assert that offset was respected
+            // Assert that skip was respected
             Assert.Contains(i + 10, actualIds);
             if (i <= 4)
             {

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -424,7 +424,7 @@ public class VolatileVectorStoreRecordCollectionTests
         // Act
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new float[] { 1, 1, 1, 1 }),
-            new VectorSearchOptions { IncludeVectors = true, Limit = 10, Offset = 10 },
+            new VectorSearchOptions { IncludeVectors = true, Top = 10, Skip = 10 },
             this._testCancellationToken).ToListAsync();
 
         // Assert
@@ -498,7 +498,7 @@ public class VolatileVectorStoreRecordCollectionTests
         // Act
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>([1, 1, 1, 1]),
-            new VectorSearchOptions { IncludeVectors = true, VectorFieldName = "Vector" },
+            new VectorSearchOptions { IncludeVectors = true, VectorPropertyName = "Vector" },
             this._testCancellationToken).ToListAsync();
 
         // Assert


### PR DESCRIPTION
### Motivation and Context

We agreed to use OData terminology for the vector search abstractions where possible.

#8952

### Description

- Renaming options related to paging to Top and Skip.
- Renaming VectorFieldName => VectorPropertyName to indicate that it should be the name of the data model property.
- Removing default vector search options property since it can be changed globally.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
