### PR TITLE
.Net: Support OpenAI 2.0.0-beta.12 and Azure OpenAI 2.0.0-beta.6

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -6,10 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.1" />
-    <PackageVersion Include="OpenAI" Version="2.0.0-beta.11" />
-    <PackageVersion Include="System.ClientModel" Version="1.1.0-beta.7" />
+    <PackageVersion Include="OpenAI" Version="[2.0.0-beta.12]" />
     <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.0.0-beta.5" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="[2.0.0-beta.6]" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.6.0" />
@@ -141,6 +140,6 @@
     <!-- OnnxRuntimeGenAI -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.4.0" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.4.0" />
-	  <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.4.0"/>
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.4.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/samples/Concepts/Agents/ComplexChat_NestedShopper.cs
+++ b/dotnet/samples/Concepts/Agents/ComplexChat_NestedShopper.cs
@@ -96,7 +96,7 @@ public class ComplexChat_NestedShopper(ITestOutputHelper output) : BaseAgentsTes
     {
         Console.WriteLine($"! {Model}");
 
-        OpenAIPromptExecutionSettings jsonSettings = new() { ResponseFormat = ChatResponseFormat.JsonObject };
+        OpenAIPromptExecutionSettings jsonSettings = new() { ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat() };
         OpenAIPromptExecutionSettings autoInvokeSettings = new() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() };
 
         ChatCompletionAgent internalLeaderAgent = CreateAgent(InternalLeaderName, InternalLeaderInstructions);

--- a/dotnet/samples/Concepts/ChatCompletion/AzureOpenAI_CustomClient.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/AzureOpenAI_CustomClient.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ClientModel;
 using System.ClientModel.Primitives;
 using Azure.AI.OpenAI;
 using Microsoft.SemanticKernel;
@@ -29,7 +30,7 @@ public sealed class AzureOpenAI_CustomClient(ITestOutputHelper output) : BaseTes
             RetryPolicy = new ClientRetryPolicy()
         };
 
-        var customClient = new AzureOpenAIClient(new Uri(TestConfiguration.AzureOpenAI.Endpoint), TestConfiguration.AzureOpenAI.ApiKey, clientOptions);
+        var customClient = new AzureOpenAIClient(new Uri(TestConfiguration.AzureOpenAI.Endpoint), new ApiKeyCredential(TestConfiguration.AzureOpenAI.ApiKey), clientOptions);
 
         var kernel = Kernel.CreateBuilder()
             .AddAzureOpenAIChatCompletion(TestConfiguration.AzureOpenAI.ChatDeploymentName, customClient)

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletion.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletion.cs
@@ -150,9 +150,9 @@ public class OpenAI_ChatCompletion(ITestOutputHelper output) : BaseTest(output)
         Console.WriteLine($"Created At: {innerContent.CreatedAt}");
 
         Console.WriteLine($"Finish reason: {innerContent.FinishReason}");
-        Console.WriteLine($"Input tokens usage: {innerContent.Usage.InputTokens}");
-        Console.WriteLine($"Output tokens usage: {innerContent.Usage.OutputTokens}");
-        Console.WriteLine($"Total tokens usage: {innerContent.Usage.TotalTokens}");
+        Console.WriteLine($"Input tokens usage: {innerContent.Usage.InputTokenCount}");
+        Console.WriteLine($"Output tokens usage: {innerContent.Usage.OutputTokenCount}");
+        Console.WriteLine($"Total tokens usage: {innerContent.Usage.TotalTokenCount}");
         Console.WriteLine($"Refusal: {innerContent.Refusal} ");
         Console.WriteLine($"Id: {innerContent.Id}");
         Console.WriteLine($"System fingerprint: {innerContent.SystemFingerprint}");

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionStreaming.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_ChatCompletionStreaming.cs
@@ -293,7 +293,7 @@ public class OpenAI_ChatCompletionStreaming(ITestOutputHelper output) : BaseTest
             {
                 Console.WriteLine($"   Image uri: {contentUpdate.ImageUri}");
                 Console.WriteLine($"   Image media type: {contentUpdate.ImageBytesMediaType}");
-                Console.WriteLine($"   Image detail: {contentUpdate.ImageDetail}");
+                Console.WriteLine($"   Image detail: {contentUpdate.ImageDetailLevel}");
                 Console.WriteLine($"   Image bytes: {contentUpdate.ImageBytes}");
                 Console.WriteLine("   =======");
             }
@@ -345,9 +345,9 @@ public class OpenAI_ChatCompletionStreaming(ITestOutputHelper output) : BaseTest
         /// The last message in the chunk is a <see cref="ChatDoneResponseStream"/> type with additional metadata.
         if (streamChunk.Usage is not null)
         {
-            Console.WriteLine($"Usage input tokens: {streamChunk.Usage.InputTokens}");
-            Console.WriteLine($"Usage output tokens: {streamChunk.Usage.OutputTokens}");
-            Console.WriteLine($"Usage total tokens: {streamChunk.Usage.TotalTokens}");
+            Console.WriteLine($"Usage input tokens: {streamChunk.Usage.InputTokenCount}");
+            Console.WriteLine($"Usage output tokens: {streamChunk.Usage.OutputTokenCount}");
+            Console.WriteLine($"Usage total tokens: {streamChunk.Usage.TotalTokenCount}");
         }
         Console.WriteLine("------------------------");
     }

--- a/dotnet/samples/Concepts/ChatCompletion/OpenAI_StructuredOutputs.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/OpenAI_StructuredOutputs.cs
@@ -41,7 +41,7 @@ public class OpenAI_StructuredOutputs(ITestOutputHelper output) : BaseTest(outpu
 
         // Initialize ChatResponseFormat object with JSON schema of desired response format.
         ChatResponseFormat chatResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-            name: "movie_result",
+            jsonSchemaFormatName: "movie_result",
             jsonSchema: BinaryData.FromString("""
                 {
                     "type": "object",
@@ -67,7 +67,7 @@ public class OpenAI_StructuredOutputs(ITestOutputHelper output) : BaseTest(outpu
                     "additionalProperties": false
                 }
                 """),
-            strictSchemaEnabled: true);
+            jsonSchemaIsStrict: true);
 
         // Specify response format by setting ChatResponseFormat object in prompt execution settings.
         var executionSettings = new OpenAIPromptExecutionSettings

--- a/dotnet/samples/Concepts/Functions/FunctionResult_StronglyTyped.cs
+++ b/dotnet/samples/Concepts/Functions/FunctionResult_StronglyTyped.cs
@@ -82,9 +82,9 @@ public class FunctionResult_StronglyTyped(ITestOutputHelper output) : BaseTest(o
             var usage = FunctionResult.Metadata?["Usage"] as ChatTokenUsage;
 
             return new TokenCounts(
-                completionTokens: usage?.OutputTokens ?? 0,
-                promptTokens: usage?.InputTokens ?? 0,
-                totalTokens: usage?.TotalTokens ?? 0);
+                completionTokens: usage?.OutputTokenCount ?? 0,
+                promptTokens: usage?.InputTokenCount ?? 0,
+                totalTokens: usage?.TotalTokenCount ?? 0);
         }
 
         private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()

--- a/dotnet/samples/Concepts/Planners/AutoFunctionCallingPlanning.cs
+++ b/dotnet/samples/Concepts/Planners/AutoFunctionCallingPlanning.cs
@@ -331,7 +331,7 @@ public class AutoFunctionCallingPlanning(ITestOutputHelper output) : BaseTest(ou
                 usage is ChatTokenUsage completionsUsage &&
                 completionsUsage is not null)
             {
-                tokens += completionsUsage.TotalTokens;
+                tokens += completionsUsage.TotalTokenCount;
             }
         }
 

--- a/dotnet/samples/GettingStartedWithAgents/Step11_AssistantTool_FileSearch.cs
+++ b/dotnet/samples/GettingStartedWithAgents/Step11_AssistantTool_FileSearch.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents.OpenAI;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -39,7 +40,7 @@ public class Step11_AssistantTool_FileSearch(ITestOutputHelper output) : BaseAge
             await vectorStoreClient.CreateVectorStoreAsync(
                 new VectorStoreCreationOptions()
                 {
-                    FileIds = [fileInfo.Id],
+                    FileIds = { fileInfo.Id },
                     Metadata = { { AssistantSampleMetadataKey, bool.TrueString } }
                 });
 

--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
-using System.ClientModel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -11,7 +10,6 @@ using System.Threading.Tasks;
 using Azure;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.ChatCompletion;
-using OpenAI;
 using OpenAI.Assistants;
 
 namespace Microsoft.SemanticKernel.Agents.OpenAI.Internal;

--- a/dotnet/src/Agents/OpenAI/Internal/AssistantToolResourcesFactory.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantToolResourcesFactory.cs
@@ -26,24 +26,23 @@ internal static class AssistantToolResourcesFactory
 
         if (hasVectorStore || hasCodeInterpreterFiles)
         {
-            toolResources =
-                new ToolResources()
+            var fileSearch = hasVectorStore
+                ? new FileSearchToolResources
                 {
-                    FileSearch =
-                        hasVectorStore ?
-                            new FileSearchToolResources()
-                            {
-                                VectorStoreIds = [vectorStoreId!],
-                            } :
-                            null,
-                    CodeInterpreter =
-                        hasCodeInterpreterFiles ?
-                            new CodeInterpreterToolResources()
-                            {
-                                FileIds = (IList<string>)codeInterpreterFileIds!,
-                            } :
-                            null,
-                };
+                    VectorStoreIds = { vectorStoreId! }
+                }
+                : null;
+
+            var codeInterpreter = hasCodeInterpreterFiles
+                ? new CodeInterpreterToolResources()
+                : null;
+
+            codeInterpreter?.FileIds.AddRange(codeInterpreterFileIds!);
+            toolResources = new ToolResources
+            {
+                FileSearch = fileSearch,
+                CodeInterpreter = codeInterpreter
+            };
         }
 
         return toolResources;

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-using System.ClientModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Agents.OpenAI.Internal;
 using Microsoft.SemanticKernel.ChatCompletion;
-using OpenAI;
 using OpenAI.Assistants;
 using OpenAI.Files;
 

--- a/dotnet/src/Agents/OpenAI/OpenAIClientProvider.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIClientProvider.cs
@@ -79,7 +79,7 @@ public sealed class OpenAIClientProvider
     public static OpenAIClientProvider ForOpenAI(Uri? endpoint = null, HttpClient? httpClient = null)
     {
         OpenAIClientOptions clientOptions = CreateOpenAIClientOptions(endpoint, httpClient);
-        return new(new OpenAIClient(SingleSpaceKey, clientOptions), CreateConfigurationKeys(endpoint, httpClient));
+        return new(new OpenAIClient(new ApiKeyCredential(SingleSpaceKey), clientOptions), CreateConfigurationKeys(endpoint, httpClient));
     }
 
     /// <summary>

--- a/dotnet/src/Agents/UnitTests/OpenAI/OpenAIAssistantAgentTests.cs
+++ b/dotnet/src/Agents/UnitTests/OpenAI/OpenAIAssistantAgentTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
+using System.ClientModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -883,8 +884,8 @@ public sealed class OpenAIAssistantAgentTests : IDisposable
 
     private OpenAIClientProvider CreateTestConfiguration(bool targetAzure = false)
         => targetAzure ?
-            OpenAIClientProvider.ForAzureOpenAI(apiKey: "fakekey", endpoint: new Uri("https://localhost"), this._httpClient) :
-            OpenAIClientProvider.ForOpenAI(apiKey: "fakekey", endpoint: null, this._httpClient);
+            OpenAIClientProvider.ForAzureOpenAI(apiKey: new ApiKeyCredential("fakekey"), endpoint: new Uri("https://localhost"), this._httpClient) :
+            OpenAIClientProvider.ForOpenAI(apiKey: new ApiKeyCredential("fakekey"), endpoint: null, this._httpClient);
 
     private void SetupResponse(HttpStatusCode statusCode, string content) =>
         this._messageHandlerStub.SetupResponses(statusCode, content);

--- a/dotnet/src/Agents/UnitTests/OpenAI/OpenAIClientProviderTests.cs
+++ b/dotnet/src/Agents/UnitTests/OpenAI/OpenAIClientProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
+using System.ClientModel;
 using System.Net.Http;
 using Azure.Core;
 using Microsoft.SemanticKernel.Agents.OpenAI;
@@ -21,7 +22,7 @@ public class OpenAIClientProviderTests
     public void VerifyOpenAIClientProviderTargetAzureByKey()
     {
         // Act
-        OpenAIClientProvider provider = OpenAIClientProvider.ForAzureOpenAI("key", new Uri("https://localhost"));
+        OpenAIClientProvider provider = OpenAIClientProvider.ForAzureOpenAI(new ApiKeyCredential("key"), new Uri("https://localhost"));
 
         // Assert
         Assert.NotNull(provider.Client);
@@ -67,7 +68,7 @@ public class OpenAIClientProviderTests
     public void VerifyOpenAIClientProviderTargetOpenAIByKey(string key, string? endpoint)
     {
         // Act
-        OpenAIClientProvider provider = OpenAIClientProvider.ForOpenAI(key, endpoint != null ? new Uri(endpoint) : null);
+        OpenAIClientProvider provider = OpenAIClientProvider.ForOpenAI(new ApiKeyCredential(key), endpoint != null ? new Uri(endpoint) : null);
 
         // Assert
         Assert.NotNull(provider.Client);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIKernelBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using Azure.AI.OpenAI;
 using Azure.Core;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,7 +32,7 @@ public sealed class AzureOpenAIKernelBuilderExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("http://localhost"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://localhost"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton(client);
@@ -67,7 +68,7 @@ public sealed class AzureOpenAIKernelBuilderExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("http://localhost"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://localhost"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton<AzureOpenAIClient>(client);
@@ -121,7 +122,7 @@ public sealed class AzureOpenAIKernelBuilderExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("http://localhost"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://localhost"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton<AzureOpenAIClient>(client);
@@ -155,7 +156,7 @@ public sealed class AzureOpenAIKernelBuilderExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("https://endpoint"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://endpoint"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton<AzureOpenAIClient>(client);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Extensions/AzureOpenAIServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using Azure.AI.OpenAI;
 using Azure.Core;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,7 +32,7 @@ public sealed class AzureOpenAIServiceCollectionExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("http://localhost"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://localhost"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton(client);
@@ -67,7 +68,7 @@ public sealed class AzureOpenAIServiceCollectionExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("http://localhost"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://localhost"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton<AzureOpenAIClient>(client);
@@ -121,7 +122,7 @@ public sealed class AzureOpenAIServiceCollectionExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("http://localhost"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://localhost"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton<AzureOpenAIClient>(client);
@@ -155,7 +156,7 @@ public sealed class AzureOpenAIServiceCollectionExtensionsTests
     {
         // Arrange
         var credentials = DelegatedTokenCredential.Create((_, _) => new AccessToken());
-        var client = new AzureOpenAIClient(new Uri("https://endpoint"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://endpoint"), new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton<AzureOpenAIClient>(client);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIAudioToTextServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -68,7 +69,7 @@ public sealed class AzureOpenAIAudioToTextServiceTests : IDisposable
     public void ConstructorWithOpenAIClientWorksCorrectly(bool includeLoggerFactory)
     {
         // Arrange & Act
-        var client = new AzureOpenAIClient(new Uri("http://host"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://host"), new ApiKeyCredential("key"));
         var service = includeLoggerFactory ?
             new AzureOpenAIAudioToTextService("deployment", client, "model-id", loggerFactory: this._mockLoggerFactory.Object) :
             new AzureOpenAIAudioToTextService("deployment", client, "model-id");
@@ -83,11 +84,11 @@ public sealed class AzureOpenAIAudioToTextServiceTests : IDisposable
     {
         // Act & Assert
         Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService(" ", "http://host", "apikey"));
-        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService(" ", azureOpenAIClient: new(new Uri("http://host"), "apikey")));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService(" ", azureOpenAIClient: new(new Uri("http://host"), new ApiKeyCredential("apikey"))));
         Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService("", "http://host", "apikey"));
-        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService("", azureOpenAIClient: new(new Uri("http://host"), "apikey")));
+        Assert.Throws<ArgumentException>(() => new AzureOpenAIAudioToTextService("", azureOpenAIClient: new(new Uri("http://host"), new ApiKeyCredential("apikey"))));
         Assert.Throws<ArgumentNullException>(() => new AzureOpenAIAudioToTextService(null!, "http://host", "apikey"));
-        Assert.Throws<ArgumentNullException>(() => new AzureOpenAIAudioToTextService(null!, azureOpenAIClient: new(new Uri("http://host"), "apikey")));
+        Assert.Throws<ArgumentNullException>(() => new AzureOpenAIAudioToTextService(null!, azureOpenAIClient: new(new Uri("http://host"), new ApiKeyCredential("apikey"))));
     }
 
     [Theory]

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -82,7 +83,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
     public void ConstructorWithOpenAIClientWorksCorrectly(bool includeLoggerFactory)
     {
         // Arrange & Act
-        var client = new AzureOpenAIClient(new Uri("http://host"), "key");
+        var client = new AzureOpenAIClient(new Uri("http://host"), new ApiKeyCredential("apikey"));
         var service = includeLoggerFactory ?
             new AzureOpenAIChatCompletionService("deployment", client, "model-id", loggerFactory: this._mockLoggerFactory.Object) :
             new AzureOpenAIChatCompletionService("deployment", client, "model-id");
@@ -114,9 +115,9 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var usage = result[0].Metadata?["Usage"] as ChatTokenUsage;
 
         Assert.NotNull(usage);
-        Assert.Equal(55, usage.InputTokens);
-        Assert.Equal(100, usage.OutputTokens);
-        Assert.Equal(155, usage.TotalTokens);
+        Assert.Equal(55, usage.InputTokenCount);
+        Assert.Equal(100, usage.OutputTokenCount);
+        Assert.Equal(155, usage.TotalTokenCount);
     }
 
     [Fact]
@@ -265,9 +266,9 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         var usage = result[0].Metadata?["Usage"] as ChatTokenUsage;
 
         Assert.NotNull(usage);
-        Assert.Equal(55, usage.InputTokens);
-        Assert.Equal(100, usage.OutputTokens);
-        Assert.Equal(155, usage.TotalTokens);
+        Assert.Equal(55, usage.InputTokenCount);
+        Assert.Equal(100, usage.OutputTokenCount);
+        Assert.Equal(155, usage.TotalTokenCount);
 
         Assert.Equal("Stop", result[0].Metadata?["FinishReason"]);
     }
@@ -449,7 +450,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         Assert.IsType<StreamingChatCompletionUpdate>(message.InnerContent);
         var update = (StreamingChatCompletionUpdate)message.InnerContent;
-        var promptResults = update.GetContentFilterResultForPrompt();
+        var promptResults = update.GetRequestContentFilterResult();
         Assert.Equal(ContentFilterSeverity.Safe, promptResults.Hate.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, promptResults.Sexual.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, promptResults.Violence.Severity);
@@ -471,7 +472,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         Assert.IsType<StreamingChatCompletionUpdate>(message.InnerContent);
         update = (StreamingChatCompletionUpdate)message.InnerContent;
 
-        var filterResults = update.GetContentFilterResultForResponse();
+        var filterResults = update.GetResponseContentFilterResult();
         Assert.Equal(ContentFilterSeverity.Safe, filterResults.Hate.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, filterResults.Sexual.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, filterResults.SelfHarm.Severity);
@@ -482,7 +483,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         Assert.IsType<StreamingChatCompletionUpdate>(message.InnerContent);
         update = (StreamingChatCompletionUpdate)message.InnerContent;
-        filterResults = update.GetContentFilterResultForResponse();
+        filterResults = update.GetResponseContentFilterResult();
         Assert.False(filterResults.ProtectedMaterialCode.Detected);
         Assert.False(filterResults.ProtectedMaterialText.Detected);
 #pragma warning restore AOAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -595,7 +596,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         Assert.IsType<StreamingChatCompletionUpdate>(message.InnerContent);
         var update = (StreamingChatCompletionUpdate)message.InnerContent;
 #pragma warning disable AOAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var promptResults = update.GetContentFilterResultForPrompt();
+        var promptResults = update.GetRequestContentFilterResult();
         Assert.Equal(ContentFilterSeverity.Safe, promptResults.Hate.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, promptResults.Sexual.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, promptResults.Violence.Severity);
@@ -626,7 +627,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         Assert.IsType<StreamingChatCompletionUpdate>(message.InnerContent);
         update = (StreamingChatCompletionUpdate)message.InnerContent;
 
-        var filterResults = update.GetContentFilterResultForResponse();
+        var filterResults = update.GetResponseContentFilterResult();
         Assert.Equal(ContentFilterSeverity.Safe, filterResults.Hate.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, filterResults.Sexual.Severity);
         Assert.Equal(ContentFilterSeverity.Safe, filterResults.SelfHarm.Severity);
@@ -637,7 +638,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
 
         Assert.IsType<StreamingChatCompletionUpdate>(message.InnerContent);
         update = (StreamingChatCompletionUpdate)message.InnerContent;
-        filterResults = update.GetContentFilterResultForResponse();
+        filterResults = update.GetResponseContentFilterResult();
         Assert.False(filterResults.ProtectedMaterialCode.Detected);
         Assert.False(filterResults.ProtectedMaterialText.Detected);
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToImageServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAITextToImageServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
@@ -51,7 +52,7 @@ public sealed class AzureOpenAITextToImageServiceTests : IDisposable
         Assert.Equal("model", sut.Attributes[AIServiceExtensions.ModelIdKey]);
 
         // Case #3
-        sut = new AzureOpenAITextToImageService("deployment", new AzureOpenAIClient(new Uri("https://api-host/"), "api-key"), "model", loggerFactory: this._mockLoggerFactory.Object);
+        sut = new AzureOpenAITextToImageService("deployment", new AzureOpenAIClient(new Uri("https://api-host/"), new ApiKeyCredential("api-key")), "model", loggerFactory: this._mockLoggerFactory.Object);
         Assert.Equal("deployment", sut.Attributes[AzureClientCore.DeploymentNameKey]);
         Assert.Equal("model", sut.Attributes[AIServiceExtensions.ModelIdKey]);
     }

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.ChatCompletion.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Diagnostics;
-using Azure.AI.OpenAI;
+using Azure.AI.OpenAI.Chat;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Diagnostics;
@@ -38,7 +38,7 @@ internal partial class AzureClientCore
 
         var options = new ChatCompletionOptions
         {
-            MaxTokens = executionSettings.MaxTokens,
+            MaxOutputTokenCount = executionSettings.MaxTokens,
             Temperature = (float?)executionSettings.Temperature,
             TopP = (float?)executionSettings.TopP,
             FrequencyPenalty = (float?)executionSettings.FrequencyPenalty,

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Net.Http;
 using System.Threading;
@@ -57,7 +58,7 @@ internal partial class AzureClientCore : ClientCore
         this.Logger = logger ?? NullLogger.Instance;
         this.DeploymentName = deploymentName;
         this.Endpoint = new Uri(endpoint);
-        this.Client = new AzureOpenAIClient(this.Endpoint, apiKey, options);
+        this.Client = new AzureOpenAIClient(this.Endpoint, new ApiKeyCredential(apiKey), options);
         this.FunctionCallsProcessor = new FunctionCallsProcessor(this.Logger);
 
         this.AddAttribute(DeploymentNameKey, deploymentName);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToAudioService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToAudioService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
@@ -61,7 +62,7 @@ public sealed class AzureOpenAITextToAudioService : ITextToAudioService
             httpClient,
             AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview); // https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#text-to-speech
 
-        var azureOpenAIClient = new AzureOpenAIClient(new Uri(url), apiKey, options);
+        var azureOpenAIClient = new AzureOpenAIClient(new Uri(url), new ApiKeyCredential(apiKey), options);
 
         this._client = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(typeof(AzureOpenAITextToAudioService)));
 

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToImageService.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Services/AzureOpenAITextToImageService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
@@ -56,7 +57,7 @@ public class AzureOpenAITextToImageService : ITextToImageService
             httpClient,
             AzureOpenAIClientOptions.ServiceVersion.V2024_05_01_Preview); // DALL-E 3 is supported in the latest API releases - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#image-generation
 
-        var azureOpenAIClient = new AzureOpenAIClient(new Uri(connectorEndpoint), apiKey, options);
+        var azureOpenAIClient = new AzureOpenAIClient(new Uri(connectorEndpoint), new ApiKeyCredential(apiKey), options);
 
         this._client = new(deploymentName, azureOpenAIClient, loggerFactory?.CreateLogger(this.GetType()));
 

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Core/ClientCoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Core/ClientCoreTests.cs
@@ -24,7 +24,7 @@ public partial class ClientCoreTests
     {
         // Act
         var logger = new Mock<ILogger<ClientCoreTests>>().Object;
-        var openAIClient = new OpenAIClient("key");
+        var openAIClient = new OpenAIClient(new ApiKeyCredential("key"));
 
         var clientCoreModelConstructor = new ClientCore("model1", "apiKey");
         var clientCoreOpenAIClientConstructor = new ClientCore("model1", openAIClient, logger: logger);
@@ -145,7 +145,7 @@ public partial class ClientCoreTests
         var clientCore = new ClientCore(
             modelId: "model",
             openAIClient: new OpenAIClient(
-                "test",
+                new ApiKeyCredential("test"),
                 new OpenAIClientOptions()
                 {
                     Transport = new HttpClientPipelineTransport(client),
@@ -197,7 +197,7 @@ public partial class ClientCoreTests
 
         // Act
         var clientCore = new ClientCore(expectedModelId, "apikey");
-        var clientCoreBreakingGlass = new ClientCore(expectedModelId, new OpenAIClient(" "));
+        var clientCoreBreakingGlass = new ClientCore(expectedModelId, new OpenAIClient(new ApiKeyCredential(" ")));
 
         // Assert
         Assert.True(clientCore.Attributes.ContainsKey(AIServiceExtensions.ModelIdKey));

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Core/OpenAIWithDataStreamingChatMessageContentTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Core/OpenAIWithDataStreamingChatMessageContentTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
@@ -34,7 +35,7 @@ public sealed class OpenAIStreamingChatMessageContentTests
         };
 
         using var httpClient = new HttpClient(messageHandlerStub);
-        var openAIClient = new OpenAIClient("key", new() { Transport = new HttpClientPipelineTransport(httpClient) });
+        var openAIClient = new OpenAIClient(new ApiKeyCredential("key"), new() { Transport = new HttpClientPipelineTransport(httpClient) });
 
         // Act & Assert
         var enumerator = openAIClient.GetChatClient("modelId").CompleteChatStreamingAsync("Test message").GetAsyncEnumerator();

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/KernelBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AudioToText;
@@ -40,7 +41,7 @@ public class KernelBuilderExtensionsTests
         var sut = Kernel.CreateBuilder();
 
         // Act
-        var service = sut.AddOpenAITextEmbeddingGeneration("model", new OpenAIClient("key"))
+        var service = sut.AddOpenAITextEmbeddingGeneration("model", new OpenAIClient(new ApiKeyCredential("key")))
             .Build()
             .GetRequiredService<ITextEmbeddingGenerationService>();
 
@@ -100,7 +101,7 @@ public class KernelBuilderExtensionsTests
         var sut = Kernel.CreateBuilder();
 
         // Act
-        var service = sut.AddOpenAIAudioToText("model", new OpenAIClient("key"))
+        var service = sut.AddOpenAIAudioToText("model", new OpenAIClient(new ApiKeyCredential("key")))
             .Build()
             .GetRequiredService<IAudioToTextService>();
 
@@ -129,7 +130,7 @@ public class KernelBuilderExtensionsTests
     public void KernelBuilderAddOpenAIChatCompletionAddsValidService(InitializationType type)
     {
         // Arrange
-        var client = new OpenAIClient("key");
+        var client = new OpenAIClient(new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton(client);

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.AudioToText;
@@ -27,7 +28,7 @@ public class ServiceCollectionExtensionsTests
     public void ItCanAddChatCompletionService(InitializationType type)
     {
         // Arrange
-        var client = new OpenAIClient("key");
+        var client = new OpenAIClient(new ApiKeyCredential("key"));
         var builder = Kernel.CreateBuilder();
 
         builder.Services.AddSingleton(client);
@@ -73,7 +74,7 @@ public class ServiceCollectionExtensionsTests
         var sut = new ServiceCollection();
 
         // Act
-        var service = sut.AddOpenAITextEmbeddingGeneration("model", new OpenAIClient("key"))
+        var service = sut.AddOpenAITextEmbeddingGeneration("model", new OpenAIClient(new ApiKeyCredential("key")))
             .BuildServiceProvider()
             .GetRequiredService<ITextEmbeddingGenerationService>();
 
@@ -133,7 +134,7 @@ public class ServiceCollectionExtensionsTests
         var sut = new ServiceCollection();
 
         // Act
-        var service = sut.AddOpenAIAudioToText("model", new OpenAIClient("key"))
+        var service = sut.AddOpenAIAudioToText("model", new OpenAIClient(new ApiKeyCredential("key")))
             .BuildServiceProvider()
             .GetRequiredService<IAudioToTextService>();
 

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIAudioToTextServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -48,11 +49,11 @@ public sealed class OpenAIAudioToTextServiceTests : IDisposable
     {
         // Act & Assert
         Assert.Throws<ArgumentException>(() => new OpenAIAudioToTextService(" ", "apikey"));
-        Assert.Throws<ArgumentException>(() => new OpenAIAudioToTextService(" ", openAIClient: new("apikey")));
+        Assert.Throws<ArgumentException>(() => new OpenAIAudioToTextService(" ", openAIClient: new(new ApiKeyCredential("apikey"))));
         Assert.Throws<ArgumentException>(() => new OpenAIAudioToTextService("", "apikey"));
-        Assert.Throws<ArgumentException>(() => new OpenAIAudioToTextService("", openAIClient: new("apikey")));
+        Assert.Throws<ArgumentException>(() => new OpenAIAudioToTextService("", openAIClient: new(new ApiKeyCredential("apikey"))));
         Assert.Throws<ArgumentNullException>(() => new OpenAIAudioToTextService(null!, "apikey"));
-        Assert.Throws<ArgumentNullException>(() => new OpenAIAudioToTextService(null!, openAIClient: new("apikey")));
+        Assert.Throws<ArgumentNullException>(() => new OpenAIAudioToTextService(null!, openAIClient: new(new ApiKeyCredential("apikey"))));
     }
 
     [Theory]
@@ -61,7 +62,7 @@ public sealed class OpenAIAudioToTextServiceTests : IDisposable
     public void ConstructorWithOpenAIClientWorksCorrectly(bool includeLoggerFactory)
     {
         // Arrange & Act
-        var client = new OpenAIClient("key");
+        var client = new OpenAIClient(new ApiKeyCredential("key"));
         var service = includeLoggerFactory ?
             new OpenAIAudioToTextService("model-id", client, loggerFactory: this._mockLoggerFactory.Object) :
             new OpenAIAudioToTextService("model-id", client);

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.ClientModel;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -153,7 +154,7 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     public void ConstructorWithOpenAIClientWorksCorrectly(bool includeLoggerFactory)
     {
         // Arrange & Act
-        var client = new OpenAIClient("key");
+        var client = new OpenAIClient(new ApiKeyCredential("key"));
         var service = includeLoggerFactory ?
             new OpenAIChatCompletionService("model-id", client, loggerFactory: this._mockLoggerFactory.Object) :
             new OpenAIChatCompletionService("model-id", client);
@@ -829,7 +830,7 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
                 format = JsonSerializer.Deserialize<JsonElement>(formatValue);
                 break;
             case "ChatResponseFormat":
-                format = formatValue == "text" ? ChatResponseFormat.Text : ChatResponseFormat.JsonObject;
+                format = formatValue == "text" ? ChatResponseFormat.CreateTextFormat() : ChatResponseFormat.CreateJsonObjectFormat();
                 break;
         }
 
@@ -1039,7 +1040,7 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     {
         // Arrange
         object responseFormat = typedResponseFormat ? typeof(MathReasoning) : ChatResponseFormat.CreateJsonSchemaFormat(
-            name: "MathReasoning",
+            jsonSchemaFormatName: "MathReasoning",
             jsonSchema: BinaryData.FromString("""
                 {
                     "type": "object",
@@ -1062,7 +1063,7 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
                     "additionalProperties": false
                 }
                 """),
-            strictSchemaEnabled: true);
+            jsonSchemaIsStrict: true);
 
         var executionSettings = new OpenAIPromptExecutionSettings { ResponseFormat = responseFormat };
 

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAITextEmbeddingGenerationServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAITextEmbeddingGenerationServiceTests.cs
@@ -41,11 +41,11 @@ public class OpenAITextEmbeddingGenerationServiceTests
     {
         // Act & Assert
         Assert.Throws<ArgumentException>(() => new OpenAITextEmbeddingGenerationService(" ", "apikey"));
-        Assert.Throws<ArgumentException>(() => new OpenAITextEmbeddingGenerationService(" ", openAIClient: new("apikey")));
+        Assert.Throws<ArgumentException>(() => new OpenAITextEmbeddingGenerationService(" ", openAIClient: new(new ApiKeyCredential("apikey"))));
         Assert.Throws<ArgumentException>(() => new OpenAITextEmbeddingGenerationService("", "apikey"));
-        Assert.Throws<ArgumentException>(() => new OpenAITextEmbeddingGenerationService("", openAIClient: new("apikey")));
+        Assert.Throws<ArgumentException>(() => new OpenAITextEmbeddingGenerationService("", openAIClient: new(new ApiKeyCredential("apikey"))));
         Assert.Throws<ArgumentNullException>(() => new OpenAITextEmbeddingGenerationService(null!, "apikey"));
-        Assert.Throws<ArgumentNullException>(() => new OpenAITextEmbeddingGenerationService(null!, openAIClient: new("apikey")));
+        Assert.Throws<ArgumentNullException>(() => new OpenAITextEmbeddingGenerationService(null!, openAIClient: new(new ApiKeyCredential("apikey"))));
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/ToolCallBehaviorTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/ToolCallBehaviorTests.cs
@@ -106,7 +106,7 @@ public sealed class ToolCallBehaviorTests
         var options = kernelFunctions.ConfigureOptions(kernel);
 
         // Assert
-        Assert.Equal(ChatToolChoice.Auto, options.Choice);
+        Assert.Equal(ChatToolChoice.CreateAutoChoice(), options.Choice);
 
         this.AssertTools(options.Tools);
     }
@@ -167,7 +167,7 @@ public sealed class ToolCallBehaviorTests
         var options = enabledFunctions.ConfigureOptions(kernel);
 
         // Assert
-        Assert.Equal(ChatToolChoice.Auto, options.Choice);
+        Assert.Equal(ChatToolChoice.CreateAutoChoice(), options.Choice);
 
         this.AssertTools(options.Tools);
     }

--- a/dotnet/src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj
@@ -37,6 +37,5 @@
 
   <ItemGroup>
     <PackageReference Include="OpenAI" />
-    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -181,14 +181,15 @@ internal partial class ClientCore
                         // Capture available metadata even if the operation failed.
                         activity
                             .SetResponseId(chatCompletion.Id)
-                            .SetPromptTokenUsage(chatCompletion.Usage.InputTokens)
-                            .SetCompletionTokenUsage(chatCompletion.Usage.OutputTokens);
+                            .SetPromptTokenUsage(chatCompletion.Usage.InputTokenCount)
+                            .SetCompletionTokenUsage(chatCompletion.Usage.OutputTokenCount);
                     }
+
                     throw;
                 }
 
                 chatMessageContent = this.CreateChatMessageContent(chatCompletion, targetModel);
-                activity?.SetCompletionResponse([chatMessageContent], chatCompletion.Usage.InputTokens, chatCompletion.Usage.OutputTokens);
+                activity?.SetCompletionResponse([chatMessageContent], chatCompletion.Usage.InputTokenCount, chatCompletion.Usage.OutputTokenCount);
             }
 
             // If we don't want to attempt to invoke any functions or there is nothing to call, just return the result.
@@ -454,7 +455,7 @@ internal partial class ClientCore
     {
         var options = new ChatCompletionOptions
         {
-            MaxTokens = executionSettings.MaxTokens,
+            MaxOutputTokenCount = executionSettings.MaxTokens,
             Temperature = (float?)executionSettings.Temperature,
             TopP = (float?)executionSettings.TopP,
             FrequencyPenalty = (float?)executionSettings.FrequencyPenalty,
@@ -519,11 +520,12 @@ internal partial class ClientCore
                 switch (formatString)
                 {
                     case "json_object":
-                        return ChatResponseFormat.JsonObject;
+                        return ChatResponseFormat.CreateJsonObjectFormat();
 
                     case "text":
-                        return ChatResponseFormat.Text;
+                        return ChatResponseFormat.CreateTextFormat();
                 }
+
                 break;
 
             case JsonElement formatElement:
@@ -535,12 +537,13 @@ internal partial class ClientCore
                     switch (formatString)
                     {
                         case "json_object":
-                            return ChatResponseFormat.JsonObject;
+                            return ChatResponseFormat.CreateJsonObjectFormat();
 
                         case "text":
-                            return ChatResponseFormat.Text;
+                            return ChatResponseFormat.CreateTextFormat();
                     }
                 }
+
                 break;
             case Type formatObjectType:
                 return GetJsonSchemaResponseFormat(formatObjectType);
@@ -554,14 +557,12 @@ internal partial class ClientCore
     /// </summary>
     private static ChatResponseFormat GetJsonSchemaResponseFormat(Type formatObjectType)
     {
-        var type = formatObjectType.IsGenericType && formatObjectType.GetGenericTypeDefinition() == typeof(Nullable<>) ?
-            Nullable.GetUnderlyingType(formatObjectType)! :
-            formatObjectType;
+        var type = formatObjectType.IsGenericType && formatObjectType.GetGenericTypeDefinition() == typeof(Nullable<>) ? Nullable.GetUnderlyingType(formatObjectType)! : formatObjectType;
 
         var schema = KernelJsonSchemaBuilder.Build(options: null, type, configuration: s_jsonSchemaMapperConfiguration);
         var schemaBinaryData = BinaryData.FromString(schema.ToString());
 
-        return ChatResponseFormat.CreateJsonSchemaFormat(type.Name, schemaBinaryData, strictSchemaEnabled: true);
+        return ChatResponseFormat.CreateJsonSchemaFormat(type.Name, schemaBinaryData, jsonSchemaIsStrict: true);
     }
 
     /// <summary>Checks if a tool call is for a function that was defined.</summary>
@@ -678,13 +679,16 @@ internal partial class ClientCore
                 return [new UserChatMessage(textContent.Text) { ParticipantName = message.AuthorName }];
             }
 
-            return [new UserChatMessage(message.Items.Select(static (KernelContent item) => (ChatMessageContentPart)(item switch
-            {
-                TextContent textContent => ChatMessageContentPart.CreateTextMessageContentPart(textContent.Text),
-                ImageContent imageContent => GetImageContentItem(imageContent),
-                _ => throw new NotSupportedException($"Unsupported chat message content type '{item.GetType()}'.")
-            })))
-            { ParticipantName = message.AuthorName }];
+            return
+            [
+                new UserChatMessage(message.Items.Select(static (KernelContent item) => item switch
+                    {
+                        TextContent textContent => ChatMessageContentPart.CreateTextPart(textContent.Text),
+                        ImageContent imageContent => GetImageContentItem(imageContent),
+                        _ => throw new NotSupportedException($"Unsupported chat message content type '{item.GetType()}'.")
+                    }))
+                    { ParticipantName = message.AuthorName }
+            ];
         }
 
         if (message.Role == AuthorRole.Assistant)
@@ -752,7 +756,7 @@ internal partial class ClientCore
                 return [new AssistantChatMessage(message.Content) { ParticipantName = message.AuthorName }];
             }
 
-            return [new AssistantChatMessage(toolCalls, message.Content) { ParticipantName = message.AuthorName }];
+            return [new AssistantChatMessage(toolCalls) { ParticipantName = message.AuthorName, Content = { message.Content } }];
         }
 
         throw new NotSupportedException($"Role {message.Role} is not supported.");
@@ -762,12 +766,12 @@ internal partial class ClientCore
     {
         if (imageContent.Data is { IsEmpty: false } data)
         {
-            return ChatMessageContentPart.CreateImageMessageContentPart(BinaryData.FromBytes(data), imageContent.MimeType);
+            return ChatMessageContentPart.CreateImagePart(BinaryData.FromBytes(data), imageContent.MimeType);
         }
 
         if (imageContent.Uri is not null)
         {
-            return ChatMessageContentPart.CreateImageMessageContentPart(imageContent.Uri);
+            return ChatMessageContentPart.CreateImagePart(imageContent.Uri);
         }
 
         throw new ArgumentException($"{nameof(ImageContent)} must have either Data or a Uri.");
@@ -875,12 +879,12 @@ internal partial class ClientCore
         {
             this.Logger.LogInformation(
                 "Prompt tokens: {InputTokens}. Completion tokens: {OutputTokens}. Total tokens: {TotalTokens}.",
-                usage.InputTokens, usage.OutputTokens, usage.TotalTokens);
+                usage.InputTokenCount, usage.OutputTokenCount, usage.TotalTokenCount);
         }
 
-        s_promptTokensCounter.Add(usage.InputTokens);
-        s_completionTokensCounter.Add(usage.OutputTokens);
-        s_totalTokensCounter.Add(usage.TotalTokens);
+        s_promptTokensCounter.Add(usage.InputTokenCount);
+        s_completionTokensCounter.Add(usage.OutputTokenCount);
+        s_totalTokensCounter.Add(usage.TotalTokenCount);
     }
 
     private ToolCallingConfig GetFunctionCallingConfiguration(Kernel? kernel, OpenAIPromptExecutionSettings executionSettings, ChatHistory chatHistory, int requestIndex)
@@ -931,7 +935,7 @@ internal partial class ClientCore
 
         return new ToolCallingConfig(
             Tools: tools ?? [s_nonInvocableFunctionTool],
-            Choice: choice ?? ChatToolChoice.None,
+            Choice: choice ?? ChatToolChoice.CreateNoneChoice(),
             AutoInvoke: autoInvoke,
             AllowAnyRequestedKernelFunction: allowAnyRequestedKernelFunction,
             Options: options);
@@ -973,15 +977,15 @@ internal partial class ClientCore
         {
             if (config.Choice == FunctionChoice.Auto)
             {
-                toolChoice = ChatToolChoice.Auto;
+                toolChoice = ChatToolChoice.CreateAutoChoice();
             }
             else if (config.Choice == FunctionChoice.Required)
             {
-                toolChoice = ChatToolChoice.Required;
+                toolChoice = ChatToolChoice.CreateRequiredChoice();
             }
             else if (config.Choice == FunctionChoice.None)
             {
-                toolChoice = ChatToolChoice.None;
+                toolChoice = ChatToolChoice.CreateNoneChoice();
             }
             else
             {

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.Embeddings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.Embeddings.cs
@@ -49,7 +49,7 @@ internal partial class ClientCore
 
             for (var i = 0; i < embeddings.Count; i++)
             {
-                result.Add(embeddings[i].Vector);
+                result.Add(embeddings[i].ToFloats());
             }
         }
 

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.cs
@@ -132,7 +132,7 @@ internal partial class ClientCore
             this.AddAttribute(ClientCore.OrganizationKey, organizationId);
         }
 
-        this.Client = new OpenAIClient(apiKey!, options);
+        this.Client = new OpenAIClient(new ApiKeyCredential(apiKey!), options);
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/ToolCallBehavior.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/ToolCallBehavior.cs
@@ -146,7 +146,7 @@ public abstract class ToolCallBehavior
                 IList<KernelFunctionMetadata> functions = kernel.Plugins.GetFunctionsMetadata();
                 if (functions.Count > 0)
                 {
-                    choice = ChatToolChoice.Auto;
+                    choice = ChatToolChoice.CreateAutoChoice();
                     tools = [];
                     for (int i = 0; i < functions.Count; i++)
                     {
@@ -206,7 +206,7 @@ public abstract class ToolCallBehavior
                     throw new KernelException($"Auto-invocation with {nameof(EnabledFunctions)} is not supported when no kernel is provided.");
                 }
 
-                choice = ChatToolChoice.Auto;
+                choice = ChatToolChoice.CreateAutoChoice();
                 tools = [];
                 for (int i = 0; i < openAIFunctions.Length; i++)
                 {
@@ -241,7 +241,7 @@ public abstract class ToolCallBehavior
         {
             this._function = function;
             this._tool = function.ToFunctionDefinition();
-            this._choice = new ChatToolChoice(this._tool);
+            this._choice = ChatToolChoice.CreateFunctionChoice(this._tool.FunctionName);
         }
 
         public override string ToString() => $"{nameof(RequiredFunction)}(autoInvoke:{this.MaximumAutoInvokeAttempts != 0}): {this._tool.FunctionName}";

--- a/dotnet/src/IntegrationTests/Agents/MixedAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/MixedAgentTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
+using System.ClientModel;
 using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
@@ -42,7 +43,7 @@ public sealed class MixedAgentTests
         // Arrange, Act & Assert
         await this.VerifyAgentExecutionAsync(
             this.CreateChatCompletionKernel(openAISettings),
-            OpenAIClientProvider.ForOpenAI(openAISettings.ApiKey),
+            OpenAIClientProvider.ForOpenAI(new ApiKeyCredential(openAISettings.ApiKey)),
             openAISettings.ChatModelId!,
             useNewFunctionCallingModel);
     }

--- a/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
+using System.ClientModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
@@ -39,7 +40,7 @@ public sealed class OpenAIAssistantAgentTests
         Assert.NotNull(openAISettings);
 
         await this.ExecuteAgentAsync(
-            OpenAIClientProvider.ForOpenAI(openAISettings.ApiKey),
+            OpenAIClientProvider.ForOpenAI(new ApiKeyCredential(openAISettings.ApiKey)),
             openAISettings.ChatModelId!,
             input,
             expectedAnswerContains);
@@ -75,7 +76,7 @@ public sealed class OpenAIAssistantAgentTests
         Assert.NotNull(openAISettings);
 
         await this.ExecuteStreamingAgentAsync(
-            OpenAIClientProvider.ForOpenAI(openAISettings.ApiKey),
+            OpenAIClientProvider.ForOpenAI(new ApiKeyCredential(openAISettings.ApiKey)),
             openAISettings.ModelId,
             input,
             expectedAnswerContains);

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionNonStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionNonStreamingTests.cs
@@ -79,7 +79,7 @@ public sealed class AzureOpenAIChatCompletionNonStreamingTests : BaseIntegration
         Assert.Equal("Stop", finishReason);
 
         Assert.True(result.Metadata.TryGetValue("ContentTokenLogProbabilities", out object? logProbabilityInfo));
-        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityInfo>)!);
+        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityDetails>)!);
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public sealed class AzureOpenAIChatCompletionNonStreamingTests : BaseIntegration
         Assert.Equal("Stop", finishReason);
 
         Assert.True(result.Metadata.TryGetValue("ContentTokenLogProbabilities", out object? logProbabilityInfo));
-        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityInfo>)!);
+        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityDetails>)!);
     }
 
     #region internals

--- a/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/AzureOpenAI/AzureOpenAIChatCompletionTests.cs
@@ -210,7 +210,7 @@ public sealed class AzureOpenAIChatCompletionTests : BaseIntegrationTest
         // Act
         var result = await kernel.InvokePromptAsync("Hi, can you help me today?", new(settings));
 
-        var logProbabilityInfo = result.Metadata?["ContentTokenLogProbabilities"] as IReadOnlyList<ChatTokenLogProbabilityInfo>;
+        var logProbabilityInfo = result.Metadata?["ContentTokenLogProbabilities"] as IReadOnlyList<ChatTokenLogProbabilityDetails>;
 
         // Assert
         Assert.NotNull(logProbabilityInfo);

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletionTests.cs
@@ -28,7 +28,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     //[Fact(Skip = "Skipping while we investigate issue with GitHub actions.")]
     public async Task ItCanUseOpenAiChatForTextGenerationAsync()
     {
-        // 
+        //
         var kernel = this.CreateAndInitializeKernel();
 
         var func = kernel.CreateFunctionFromPrompt(
@@ -47,7 +47,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [Fact]
     public async Task OpenAIStreamingTestAsync()
     {
-        // 
+        //
         var kernel = this.CreateAndInitializeKernel();
 
         var plugins = TestHelpers.ImportSamplePlugins(kernel, "ChatPlugin");
@@ -69,7 +69,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [Fact]
     public async Task OpenAIHttpRetryPolicyTestAsync()
     {
-        // 
+        //
         List<HttpStatusCode?> statusCodes = [];
 
         var openAIConfiguration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
@@ -113,7 +113,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [Fact]
     public async Task OpenAIShouldReturnMetadataAsync()
     {
-        // 
+        //
         var kernel = this.CreateAndInitializeKernel();
 
         var plugins = TestHelpers.ImportSamplePlugins(kernel, "FunPlugin");
@@ -143,7 +143,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [InlineData("\r\n")]
     public async Task CompletionWithDifferentLineEndingsAsync(string lineEnding)
     {
-        // 
+        //
         var prompt =
             "Given a json input and a request. Apply the request on the json input and return the result. " +
             $"Put the result in between <result></result> tags{lineEnding}" +
@@ -163,7 +163,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [Fact]
     public async Task ChatSystemPromptIsNotIgnoredAsync()
     {
-        // 
+        //
         var kernel = this.CreateAndInitializeKernel();
 
         var settings = new OpenAIPromptExecutionSettings { ChatSystemPrompt = "Reply \"I don't know\" to every question." };
@@ -178,7 +178,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [Fact]
     public async Task SemanticKernelVersionHeaderIsSentAsync()
     {
-        // 
+        //
         using var defaultHandler = new HttpClientHandler();
         using var httpHeaderHandler = new HttpHeaderHandler(defaultHandler);
         using var httpClient = new HttpClient(httpHeaderHandler);
@@ -201,7 +201,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
     [InlineData(true, 5)]
     public async Task LogProbsDataIsReturnedWhenRequestedAsync(bool? logprobs, int? topLogprobs)
     {
-        // 
+        //
         var settings = new OpenAIPromptExecutionSettings { Logprobs = logprobs, TopLogprobs = topLogprobs };
 
         var kernel = this.CreateAndInitializeKernel();
@@ -209,7 +209,7 @@ public sealed class OpenAIChatCompletionTests : BaseIntegrationTest
         // Act
         var result = await kernel.InvokePromptAsync("Hi, can you help me today?", new(settings));
 
-        var logProbabilityInfo = result.Metadata?["ContentTokenLogProbabilities"] as IReadOnlyList<ChatTokenLogProbabilityInfo>;
+        var logProbabilityInfo = result.Metadata?["ContentTokenLogProbabilities"] as IReadOnlyList<ChatTokenLogProbabilityDetails>;
 
         // Assert
         Assert.NotNull(logProbabilityInfo);

--- a/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_NonStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/OpenAI/OpenAIChatCompletion_NonStreamingTests.cs
@@ -78,7 +78,7 @@ public sealed class OpenAIChatCompletionNonStreamingTests : BaseIntegrationTest
         Assert.Equal("Stop", finishReason);
 
         Assert.True(result.Metadata.TryGetValue("ContentTokenLogProbabilities", out object? logProbabilityInfo));
-        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityInfo>)!);
+        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityDetails>)!);
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public sealed class OpenAIChatCompletionNonStreamingTests : BaseIntegrationTest
         Assert.Equal("Stop", finishReason);
 
         Assert.True(result.Metadata.TryGetValue("ContentTokenLogProbabilities", out object? logProbabilityInfo));
-        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityInfo>)!);
+        Assert.Empty((logProbabilityInfo as IReadOnlyList<ChatTokenLogProbabilityDetails>)!);
     }
 
     #region internals

--- a/dotnet/src/InternalUtilities/samples/AgentUtilities/BaseAgentsTest.cs
+++ b/dotnet/src/InternalUtilities/samples/AgentUtilities/BaseAgentsTest.cs
@@ -1,4 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ClientModel;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Microsoft.SemanticKernel;
@@ -36,8 +38,8 @@ public abstract class BaseAgentsTest(ITestOutputHelper output) : BaseTest(output
     protected OpenAIClientProvider GetClientProvider()
         =>
             this.UseOpenAIConfig ?
-                OpenAIClientProvider.ForOpenAI(this.ApiKey) :
-                OpenAIClientProvider.ForAzureOpenAI(this.ApiKey, new Uri(this.Endpoint!));
+                OpenAIClientProvider.ForOpenAI(new ApiKeyCredential(this.ApiKey)) :
+                OpenAIClientProvider.ForAzureOpenAI(new ApiKeyCredential(this.ApiKey), new Uri(this.Endpoint!));
 
     /// <summary>
     /// Common method to write formatted agent chat content to the console.

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Memory.Data" />
-    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation and Context

New beta releases of the OpenAI and Azure OpenAI packages are available, with breaking changes within those libraries and System.ClientModel. This change allows the repository and downstream customers to use the latest features from these libraries. It also pins the beta versions of these libraries, preventing issues similar to those raised in [#8956](https://github.com/microsoft/semantic-kernel/issues/8956) and [#8525](https://github.com/microsoft/semantic-kernel/issues/8525), reducing noise for maintainers.

### Description

- Pins OpenAI and Azure OpenAI packages to fixed beta releases so that the NuGet constraint is now `==` rather than `>=`, avoiding issues with beta releases and breaking changes.
- Removes the explicit dependency on `System.ClientModel`, as the GA `v1.1.0` release is now required by the OpenAI libraries and introduces additional breaking changes compared to `beta-7`.
- Updates code to handle the removal of an implicit operator from `beta-7`, which means strings cannot be passed into method signatures requiring `ApiKeyCredential`. Instead of changing the API surface to accept strings, `ApiKeyCredential` objects are created where needed, as downstream users will also need to do. This approach keeps the API design consistent and avoids exposing a "stringly" typed API.
- Updated breaking change calls with corresponding new property and method names. Code was updated where needed to pass in `ApiKeyCredentials` instead of string keys.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings.
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, except for `ItShouldDisableAutoInvocationIfMaximumInflightAutoInvocationLimitReachedAsync`, which is failing due to a pre-existing stack overflow issue also present in `main`.
- [x] No explicit breaking changes in this PR, but downstream users may need to address breaking changes in `ApiKeyCredential` from `System.ClientModel`.