### PR TITLE
.Net: Unit test for KernelJsonSchemaBuilder

### DIFF
--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/KernelJsonSchemaBuilderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/KernelJsonSchemaBuilderTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticKernel;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Utilities;
+
+public class KernelJsonSchemaBuilderTests
+{
+    [Fact]
+    public void ItShouldBuildJsonSchemaForPublicMembersOfTypesThatCanRepresentOtherTypesWithDefaultValuesInConstructor()
+    {
+        // Arrange & Act
+        var schema = KernelJsonSchemaBuilder.Build(null, typeof(ClassWithDefaultValuesInConstructorForTypesThatCanRepresentOtherTypes));
+
+        // Assert
+        Assert.NotNull(schema?.RootElement);
+    }
+
+#pragma warning disable CA1812 // Instantiated by reflection
+    private sealed class ClassWithDefaultValuesInConstructorForTypesThatCanRepresentOtherTypes
+    {
+        public ClassWithDefaultValuesInConstructorForTypesThatCanRepresentOtherTypes(object? content = null, KernelJsonSchema? schema = null)
+        {
+            this.Content = content;
+            this.Schema = schema;
+        }
+
+        public object? Content { get; set; }
+
+        public KernelJsonSchema? Schema { get; set; }
+    }
+#pragma warning restore CA1812 // Instantiated by reflection
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/KernelJsonSchemaBuilderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/KernelJsonSchemaBuilderTests.cs
@@ -8,7 +8,7 @@ namespace SemanticKernel.UnitTests.Utilities;
 public class KernelJsonSchemaBuilderTests
 {
     [Fact]
-    public void ItShouldBuildJsonSchemaForPublicMembersOfTypesThatCanRepresentOtherTypesWithDefaultValuesInConstructor()
+    public void ItShouldBuildJsonSchemaForTypesWithPublicMembersHavingTypesThatCanRepresentOtherTypesWithDefaultValuesInTheConstructor()
     {
         // Arrange & Act
         var schema = KernelJsonSchemaBuilder.Build(null, typeof(ClassWithDefaultValuesInConstructorForTypesThatCanRepresentOtherTypes));


### PR DESCRIPTION
Make sure the `KernelJsonSchemaBuilder` can build schemas for types having public properties of `object` or/and `KernelJsonSchema` types that have default values in the constructor. This test verifies that the fix https://github.com/microsoft/semantic-kernel/pull/8988 works and prevents future regressions of this scenario.