### PR TITLE
.Net: Add delegates for the string and result mappers

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchResultMapper.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchResultMapper.cs
@@ -18,3 +18,24 @@ public interface ITextSearchResultMapper
     /// <returns>A <see cref="TextSearchResult" /> instance.</returns>
     TextSearchResult MapFromResultToTextSearchResult(object result);
 }
+
+/// <summary>
+/// Delegate to map from an <see cref="object"/> which represents a result value associated with a <see cref="ITextSearch" /> implementation
+/// to a a <see cref="TextSearchResult" /> instance.
+/// </summary>
+/// <param name="result">The result value to map.</param>
+/// <returns>A <see cref="TextSearchResult" /> instance.</returns>
+public delegate TextSearchResult MapFromResultToTextSearchResult(object result);
+
+/// <summary>
+/// Default implementation of <see cref="ITextSearchResultMapper" /> that use the <see cref="MapFromResultToTextSearchResult" /> delegate.
+/// </summary>
+/// <param name="mapFromResultToTextSearchResult">MapFromResultToTextSearchResult delegate</param>
+public class TextSearchResultMapper(MapFromResultToTextSearchResult mapFromResultToTextSearchResult) : ITextSearchResultMapper
+{
+    /// <inheritdoc />
+    public TextSearchResult MapFromResultToTextSearchResult(object result)
+    {
+        return mapFromResultToTextSearchResult(result);
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchStringMapper.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchStringMapper.cs
@@ -18,3 +18,24 @@ public interface ITextSearchStringMapper
     /// <returns>A string value.</returns>
     string MapFromResultToString(object result);
 }
+
+/// <summary>
+/// Delegate to map from an <see cref="object"/> which represents a result value associated with a <see cref="ITextSearch" /> implementation
+/// to a a <see cref="string" /> instance.
+/// </summary>
+/// <param name="result">The result value to map.</param>
+/// <returns>A string value.</returns>
+public delegate string MapFromResultToString(object result);
+
+/// <summary>
+/// Default implementation of <see cref="ITextSearchStringMapper" /> that use the <see cref="MapFromResultToString" /> delegate.
+/// </summary>
+/// <param name="mapFromResultToString">MapFromResultToString delegate</param>
+public class TextSearchStringMapper(MapFromResultToString mapFromResultToString) : ITextSearchStringMapper
+{
+    /// <inheritdoc />
+    public string MapFromResultToString(object result)
+    {
+        return mapFromResultToString(result);
+    }
+}

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -24,6 +24,31 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
     /// </summary>
     /// <param name="vectorizedSearch"><see cref="IVectorizedSearch{TRecord}"/> instance used to perform the search.</param>
     /// <param name="textEmbeddingGeneration"><see cref="ITextEmbeddingGenerationService"/> instance used to create a vector from the text query.</param>
+    /// <param name="stringMapper"><see cref="MapFromResultToString" /> instance that can map a TRecord to a <see cref="string"/></param>
+    /// <param name="resultMapper"><see cref="MapFromResultToTextSearchResult" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
+    /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
+    public VectorStoreTextSearch(
+        IVectorizedSearch<TRecord> vectorizedSearch,
+        ITextEmbeddingGenerationService textEmbeddingGeneration,
+        MapFromResultToString stringMapper,
+        MapFromResultToTextSearchResult resultMapper,
+        VectorStoreTextSearchOptions? options = null) :
+        this(
+            vectorizedSearch,
+            textEmbeddingGeneration,
+            new TextSearchStringMapper(stringMapper),
+            new TextSearchResultMapper(resultMapper),
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Create an instance of the <see cref="VectorStoreTextSearch{TRecord}"/> with the
+    /// provided <see cref="IVectorizedSearch{TRecord}"/> for performing searches and
+    /// <see cref="ITextEmbeddingGenerationService"/> for generating vectors from the text search query.
+    /// </summary>
+    /// <param name="vectorizedSearch"><see cref="IVectorizedSearch{TRecord}"/> instance used to perform the search.</param>
+    /// <param name="textEmbeddingGeneration"><see cref="ITextEmbeddingGenerationService"/> instance used to create a vector from the text query.</param>
     /// <param name="stringMapper"><see cref="ITextSearchStringMapper" /> instance that can map a TRecord to a <see cref="string"/></param>
     /// <param name="resultMapper"><see cref="ITextSearchResultMapper" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
     /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
@@ -43,6 +68,28 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
         this._textEmbeddingGeneration = textEmbeddingGeneration;
         this._stringMapper = stringMapper;
         this._resultMapper = resultMapper;
+    }
+
+    /// <summary>
+    /// Create an instance of the <see cref="VectorStoreTextSearch{TRecord}"/> with the
+    /// provided <see cref="IVectorizableTextSearch{TRecord}"/> for performing searches and
+    /// <see cref="ITextEmbeddingGenerationService"/> for generating vectors from the text search query.
+    /// </summary>
+    /// <param name="vectorizableTextSearch"><see cref="IVectorizableTextSearch{TRecord}"/> instance used to perform the text search.</param>
+    /// <param name="stringMapper"><see cref="MapFromResultToString" /> instance that can map a TRecord to a <see cref="string"/></param>
+    /// <param name="resultMapper"><see cref="MapFromResultToTextSearchResult" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
+    /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
+    public VectorStoreTextSearch(
+        IVectorizableTextSearch<TRecord> vectorizableTextSearch,
+        MapFromResultToString stringMapper,
+        MapFromResultToTextSearchResult resultMapper,
+        VectorStoreTextSearchOptions? options = null) :
+        this(
+            vectorizableTextSearch,
+            new TextSearchStringMapper(stringMapper),
+            new TextSearchResultMapper(resultMapper),
+            options)
+    {
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

Related to #6725 

Implementation of `ITextSearchStringMapper` in core where we can just pass a lambda

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
