### PR TITLE
.Net: Add DI registration helpers for collections and search

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchKernelBuilderExtensionsTests.cs
@@ -58,11 +58,69 @@ public class AzureAISearchKernelBuilderExtensionsTests
         this.AssertVectorStoreCreated();
     }
 
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        this._kernelBuilder.Services.AddSingleton<SearchIndexClient>(Mock.Of<SearchIndexClient>());
+
+        // Act.
+        this._kernelBuilder.AddAzureAISearchVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithUriAndCredsRegistersClass()
+    {
+        // Act.
+        this._kernelBuilder.AddAzureAISearchVectorStoreRecordCollection<TestRecord>("testcollection", new Uri("https://localhost"), new AzureKeyCredential("fakeKey"));
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithUriAndTokenCredsRegistersClass()
+    {
+        // Act.
+        this._kernelBuilder.AddAzureAISearchVectorStoreRecordCollection<TestRecord>("testcollection", new Uri("https://localhost"), Mock.Of<TokenCredential>());
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
     private void AssertVectorStoreCreated()
     {
         var kernel = this._kernelBuilder.Build();
         var vectorStore = kernel.Services.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureAISearchVectorStore>(vectorStore);
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var kernel = this._kernelBuilder.Build();
+
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = kernel.Services.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+
+        var vectorizableSearch = kernel.Services.GetRequiredService<IVectorizableTextSearch<TestRecord>>();
+        Assert.NotNull(vectorizableSearch);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<TestRecord>>(vectorizableSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
     }
 }

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchServiceCollectionExtensionsTests.cs
@@ -58,11 +58,69 @@ public class AzureAISearchServiceCollectionExtensionsTests
         this.AssertVectorStoreCreated();
     }
 
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        this._serviceCollection.AddSingleton<SearchIndexClient>(Mock.Of<SearchIndexClient>());
+
+        // Act.
+        this._serviceCollection.AddAzureAISearchVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithUriAndCredsRegistersClass()
+    {
+        // Act.
+        this._serviceCollection.AddAzureAISearchVectorStoreRecordCollection<TestRecord>("testcollection", new Uri("https://localhost"), new AzureKeyCredential("fakeKey"));
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithUriAndTokenCredsRegistersClass()
+    {
+        // Act.
+        this._serviceCollection.AddAzureAISearchVectorStoreRecordCollection<TestRecord>("testcollection", new Uri("https://localhost"), Mock.Of<TokenCredential>());
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
     private void AssertVectorStoreCreated()
     {
         var serviceProvider = this._serviceCollection.BuildServiceProvider();
         var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<AzureAISearchVectorStore>(vectorStore);
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+
+        var vectorizableSearch = serviceProvider.GetRequiredService<IVectorizableTextSearch<TestRecord>>();
+        Assert.NotNull(vectorizableSearch);
+        Assert.IsType<AzureAISearchVectorStoreRecordCollection<TestRecord>>(vectorizableSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
     }
 }

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBServiceCollectionExtensionsTests.cs
@@ -52,4 +52,48 @@ public sealed class AzureCosmosDBMongoDBServiceCollectionExtensionsTests
         var database = (IMongoDatabase)vectorStore.GetType().GetField("_mongoDatabase", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
         Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.Settings.ApplicationName);
     }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange
+        this._serviceCollection.AddSingleton<IMongoDatabase>(Mock.Of<IMongoDatabase>());
+
+        // Act
+        this._serviceCollection.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._serviceCollection.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TestRecord>("testcollection", "mongodb://localhost:27017", "mydb");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<AzureCosmosDBMongoDBVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<AzureCosmosDBMongoDBVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLKernelBuilderExtensionsTests.cs
@@ -51,4 +51,47 @@ public sealed class AzureCosmosDBNoSQLKernelBuilderExtensionsTests
         var database = (Database)vectorStore.GetType().GetField("_database", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
         Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.ClientOptions.ApplicationName);
     }
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange
+        this._kernelBuilder.Services.AddSingleton<Database>(Mock.Of<Database>());
+
+        // Act
+        this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._kernelBuilder.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>("testcollection", "AccountEndpoint=https://test.documents.azure.com:443/;AccountKey=mock;", "mydb");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var kernel = this._kernelBuilder.Build();
+
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<AzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = kernel.Services.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<AzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLServiceCollectionExtensionsTests.cs
@@ -51,4 +51,48 @@ public sealed class AzureCosmosDBNoSQLServiceCollectionExtensionsTests
         var database = (Database)vectorStore.GetType().GetField("_database", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
         Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.ClientOptions.ApplicationName);
     }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange
+        this._serviceCollection.AddSingleton<Database>(Mock.Of<Database>());
+
+        // Act
+        this._serviceCollection.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._serviceCollection.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>("testcollection", "AccountEndpoint=https://test.documents.azure.com:443/;AccountKey=mock;", "mydb");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<AzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<AzureCosmosDBNoSQLVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
@@ -56,4 +56,75 @@ public static class AzureAISearchKernelBuilderExtensions
         builder.Services.AddAzureAISearchVectorStore(endpoint, credential, options, serviceId);
         return builder;
     }
+
+    /// <summary>
+    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// specified service ID and where <see cref="SearchIndexClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IKernelBuilder AddAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="TokenCredential"/> and the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IKernelBuilder AddAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        Uri endpoint,
+        TokenCredential tokenCredential,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, endpoint, tokenCredential, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/> and the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IKernelBuilder AddAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        Uri endpoint,
+        AzureKeyCredential credential,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, endpoint, credential, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
@@ -66,7 +66,7 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    /// <returns>The service collection.</returns>
+    /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddAzureAISearchVectorStoreRecordCollection<TRecord>(
         this IKernelBuilder builder,
         string collectionName,
@@ -89,7 +89,7 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    /// <returns>The service collection.</returns>
+    /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddAzureAISearchVectorStoreRecordCollection<TRecord>(
         this IKernelBuilder builder,
         string collectionName,
@@ -114,7 +114,7 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    /// <returns>The service collection.</returns>
+    /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddAzureAISearchVectorStoreRecordCollection<TRecord>(
         this IKernelBuilder builder,
         string collectionName,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Text.Json;
 using Azure;
 using Azure.Core;
 using Azure.Core.Serialization;
@@ -63,15 +64,7 @@ public static class AzureAISearchServiceCollectionExtensions
             (sp, obj) =>
             {
                 var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreOptions>();
-
-                // Build options for the Azure AI Search client and construct it.
-                var searchClientOptions = new SearchClientOptions();
-                searchClientOptions.Diagnostics.ApplicationId = HttpHeaderConstant.Values.UserAgent;
-                if (selectedOptions?.JsonSerializerOptions != null)
-                {
-                    searchClientOptions.Serializer = new JsonObjectSerializer(selectedOptions.JsonSerializerOptions);
-                }
-
+                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
                 var searchIndexClient = new SearchIndexClient(endpoint, tokenCredential, searchClientOptions);
 
                 // Construct the vector store.
@@ -102,15 +95,7 @@ public static class AzureAISearchServiceCollectionExtensions
             (sp, obj) =>
             {
                 var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreOptions>();
-
-                // Build options for the Azure AI Search client and construct it.
-                var searchClientOptions = new SearchClientOptions();
-                searchClientOptions.Diagnostics.ApplicationId = HttpHeaderConstant.Values.UserAgent;
-                if (selectedOptions?.JsonSerializerOptions != null)
-                {
-                    searchClientOptions.Serializer = new JsonObjectSerializer(selectedOptions.JsonSerializerOptions);
-                }
-
+                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
                 var searchIndexClient = new SearchIndexClient(endpoint, credential, searchClientOptions);
 
                 // Construct the vector store.
@@ -120,5 +105,184 @@ public static class AzureAISearchServiceCollectionExtensions
             });
 
         return services;
+    }
+
+    /// <summary>
+    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// specified service ID and where <see cref="SearchIndexClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        // If we are not constructing the SearchIndexClient, add the IVectorStore as transient, since we
+        // cannot make assumptions about how SearchIndexClient is being managed.
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var searchIndexClient = sp.GetRequiredService<SearchIndexClient>();
+                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new AzureAISearchVectorStoreRecordCollection<TRecord>(
+                    searchIndexClient,
+                    collectionName,
+                    selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+        AddVectorizableTextSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="TokenCredential"/> and the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        Uri endpoint,
+        TokenCredential tokenCredential,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        Verify.NotNull(endpoint);
+        Verify.NotNull(tokenCredential);
+
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
+                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
+                var searchIndexClient = new SearchIndexClient(endpoint, tokenCredential, searchClientOptions);
+
+                // Construct the vector store.
+                return new AzureAISearchVectorStoreRecordCollection<TRecord>(
+                    searchIndexClient,
+                    collectionName,
+                    selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+        AddVectorizableTextSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/> and the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        Uri endpoint,
+        AzureKeyCredential credential,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        Verify.NotNull(endpoint);
+        Verify.NotNull(credential);
+
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
+                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
+                var searchIndexClient = new SearchIndexClient(endpoint, credential, searchClientOptions);
+
+                // Construct the vector store.
+                return new AzureAISearchVectorStoreRecordCollection<TRecord>(
+                    searchIndexClient,
+                    collectionName,
+                    selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+        AddVectorizableTextSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
+            });
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizableTextSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizableTextSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizableTextSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return (sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId) as IVectorizableTextSearch<TRecord>)!;
+            });
+    }
+
+    /// <summary>
+    /// Build a <see cref="SearchClientOptions"/> instance, using the provided <see cref="JsonSerializerOptions"/> if it's not null and add the SK user agent string.
+    /// </summary>
+    /// <param name="jsonSerializerOptions">Optional <see cref="JsonSerializerOptions"/> to add to the options if provided.</param>
+    /// <returns>The <see cref="SearchClientOptions"/>.</returns>
+    private static SearchClientOptions BuildSearchClientOptions(JsonSerializerOptions? jsonSerializerOptions)
+    {
+        var searchClientOptions = new SearchClientOptions();
+        searchClientOptions.Diagnostics.ApplicationId = HttpHeaderConstant.Values.UserAgent;
+        if (jsonSerializerOptions != null)
+        {
+            searchClientOptions.Serializer = new JsonObjectSerializer(jsonSerializerOptions);
+        }
+
+        return searchClientOptions;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBKernelBuilderExtensions.cs
@@ -48,4 +48,50 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         builder.Services.AddAzureCosmosDBMongoDBVectorStore(connectionString, databaseName, options, serviceId);
         return builder;
     }
+
+    /// <summary>
+    /// Register an Azure CosmosDB MongoDB <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB MongoDB <see cref="IMongoDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register an Azure CosmosDB MongoDB <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB MongoDB <see cref="IMongoDatabase"/> is constructed using the provided <paramref name="connectionString"/> and <paramref name="databaseName"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="connectionString">Connection string required to connect to Azure CosmosDB MongoDB.</param>
+    /// <param name="databaseName">Database name for Azure CosmosDB MongoDB.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        string connectionString,
+        string databaseName,
+        AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(collectionName, connectionString, databaseName, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
@@ -77,4 +77,94 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Register an Azure CosmosDB MongoDB <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB MongoDB <see cref="IMongoDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = sp.GetRequiredService<IMongoDatabase>();
+                var selectedOptions = options ?? sp.GetService<AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register an Azure CosmosDB MongoDB <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB MongoDB <see cref="IMongoDatabase"/> is constructed using the provided <paramref name="connectionString"/> and <paramref name="databaseName"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="connectionString">Connection string required to connect to Azure CosmosDB MongoDB.</param>
+    /// <param name="databaseName">Database name for Azure CosmosDB MongoDB.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string connectionString,
+        string databaseName,
+        AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var settings = MongoClientSettings.FromConnectionString(connectionString);
+                settings.ApplicationName = HttpHeaderConstant.Values.UserAgent;
+
+                var mongoClient = new MongoClient(settings);
+                var database = mongoClient.GetDatabase(databaseName);
+
+                var selectedOptions = options ?? sp.GetService<AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
+            });
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKernelBuilderExtensions.cs
@@ -53,4 +53,50 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Register an Azure CosmosDB NoSQL <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB NoSQL <see cref="Database"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register an Azure CosmosDB NoSQL <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB NoSQL <see cref="Database"/> is constructed using the provided <paramref name="connectionString"/> and <paramref name="databaseName"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="connectionString">Connection string required to connect to Azure CosmosDB NoSQL.</param>
+    /// <param name="databaseName">Database name for Azure CosmosDB NoSQL.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        string connectionString,
+        string databaseName,
+        AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(collectionName, connectionString, databaseName, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
@@ -78,4 +78,95 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Register an Azure CosmosDB NoSQL <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB NoSQL <see cref="Database"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the colelction.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = sp.GetRequiredService<Database>();
+                var selectedOptions = options ?? sp.GetService<AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register an Azure CosmosDB NoSQL <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Azure CosmosDB NoSQL <see cref="Database"/> is constructed using the provided <paramref name="connectionString"/> and <paramref name="databaseName"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="connectionString">Connection string required to connect to Azure CosmosDB NoSQL.</param>
+    /// <param name="databaseName">Database name for Azure CosmosDB NoSQL.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string connectionString,
+        string databaseName,
+        AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var cosmosClient = new CosmosClient(connectionString, new()
+                {
+                    ApplicationName = HttpHeaderConstant.Values.UserAgent,
+                    UseSystemTextJsonSerializerWithOptions = options?.JsonSerializerOptions ?? JsonSerializerOptions.Default,
+                });
+
+                var database = cosmosClient.GetDatabase(databaseName);
+                var selectedOptions = options ?? sp.GetService<AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
+            });
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
@@ -85,7 +85,7 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
     /// </summary>
     /// <typeparam name="TRecord">The type of the record.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
-    /// <param name="collectionName">The name of the colelction.</param>
+    /// <param name="collectionName">The name of the collection.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>Service collection.</returns>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -47,7 +47,7 @@ public static class PineconeKernelBuilderExtensions
     /// <param name="collectionName">The name of the collection that this <see cref="PineconeVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    /// <returns>The service collection.</returns>
+    /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddPineconeVectorStoreRecordCollection<TRecord>(
         this IKernelBuilder builder,
         string collectionName,
@@ -69,7 +69,7 @@ public static class PineconeKernelBuilderExtensions
     /// <param name="apiKey">The api key for Pinecone.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    /// <returns>The service collection.</returns>
+    /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddPineconeVectorStoreRecordCollection<TRecord>(
         this IKernelBuilder builder,
         string collectionName,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -37,4 +37,48 @@ public static class PineconeKernelBuilderExtensions
         builder.Services.AddPineconeVectorStore(apiKey, options, serviceId);
         return builder;
     }
+
+    /// <summary>
+    /// Register a Pinecone <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the
+    /// specified service ID and where <see cref="Sdk.PineconeClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="PineconeVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IKernelBuilder AddPineconeVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        builder.Services.AddPineconeVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a Pinecone <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the
+    /// provided <see cref="Sdk.PineconeClient"/> and the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="PineconeVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="apiKey">The api key for Pinecone.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IKernelBuilder AddPineconeVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        string apiKey,
+        PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        builder.Services.AddPineconeVectorStoreRecordCollection<TRecord>(collectionName, apiKey, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
@@ -62,4 +62,95 @@ public static class PineconeServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Register a Pinecone <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the
+    /// specified service ID and where <see cref="Sdk.PineconeClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="PineconeVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddPineconeVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        // If we are not constructing the PineconeClient, add the IVectorStore as transient, since we
+        // cannot make assumptions about how PineconeClient is being managed.
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var pineconeClient = sp.GetRequiredService<Sdk.PineconeClient>();
+                var selectedOptions = options ?? sp.GetService<PineconeVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new PineconeVectorStoreRecordCollection<TRecord>(
+                    pineconeClient,
+                    collectionName,
+                    selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a Pinecone <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the
+    /// provided <see cref="Sdk.PineconeClient"/> and the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="PineconeVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="apiKey">The api key for Pinecone.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddPineconeVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string apiKey,
+        PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+            where TRecord : class
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var pineconeClient = new Sdk.PineconeClient(apiKey);
+                var selectedOptions = options ?? sp.GetService<PineconeVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new PineconeVectorStoreRecordCollection<TRecord>(
+                    pineconeClient,
+                    collectionName,
+                    selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
+            });
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
@@ -39,4 +39,58 @@ public static class QdrantKernelBuilderExtensions
         builder.Services.AddQdrantVectorStore(host, port, https, apiKey, options, serviceId);
         return builder;
     }
+
+    /// <summary>
+    /// Register a Qdrant <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Qdrant <see cref="QdrantClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddQdrantVectorStoreRecordCollection<TKey, TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TKey : notnull
+        where TRecord : class
+    {
+        builder.Services.AddQdrantVectorStoreRecordCollection<TKey, TRecord>(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a Qdrant <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Qdrant <see cref="QdrantClient"/> is constructed using the provided parameters.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="host">The Qdrant service host name.</param>
+    /// <param name="port">The Qdrant service port.</param>
+    /// <param name="https">A value indicating whether to use HTTPS for communicating with Qdrant.</param>
+    /// <param name="apiKey">The Qdrant service API key.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddQdrantVectorStoreRecordCollection<TKey, TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        string host,
+        int port = 6334,
+        bool https = false,
+        string? apiKey = default,
+        QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TKey : notnull
+        where TRecord : class
+    {
+        builder.Services.AddQdrantVectorStoreRecordCollection<TKey, TRecord>(collectionName, host, port, https, apiKey, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
@@ -64,4 +64,99 @@ public static class QdrantServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Register a Qdrant <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Qdrant <see cref="QdrantClient"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddQdrantVectorStoreRecordCollection<TKey, TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TKey : notnull
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<TKey, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var qdrantClient = sp.GetRequiredService<QdrantClient>();
+                var selectedOptions = options ?? sp.GetService<QdrantVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return (new QdrantVectorStoreRecordCollection<TRecord>(qdrantClient, collectionName, selectedOptions) as IVectorStoreRecordCollection<TKey, TRecord>)!;
+            });
+
+        AddVectorizedSearch<TKey, TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a Qdrant <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the Qdrant <see cref="QdrantClient"/> is constructed using the provided parameters.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="host">The Qdrant service host name.</param>
+    /// <param name="port">The Qdrant service port.</param>
+    /// <param name="https">A value indicating whether to use HTTPS for communicating with Qdrant.</param>
+    /// <param name="apiKey">The Qdrant service API key.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddQdrantVectorStoreRecordCollection<TKey, TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string host,
+        int port = 6334,
+        bool https = false,
+        string? apiKey = default,
+        QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TKey : notnull
+        where TRecord : class
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<TKey, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var qdrantClient = new QdrantClient(host, port, https, apiKey);
+                var selectedOptions = options ?? sp.GetService<QdrantVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return (new QdrantVectorStoreRecordCollection<TRecord>(qdrantClient, collectionName, selectedOptions) as IVectorStoreRecordCollection<TKey, TRecord>)!;
+            });
+
+        AddVectorizedSearch<TKey, TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TKey, TRecord>(IServiceCollection services, string? serviceId)
+        where TKey : notnull
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<TKey, TRecord>>(serviceId);
+            });
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
@@ -37,4 +37,92 @@ public static class RedisKernelBuilderExtensions
         builder.Services.AddRedisVectorStore(redisConnectionConfiguration, options, serviceId);
         return builder;
     }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddRedisHashSetVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddRedisHashSetVectorStoreRecordCollection(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is constructed using the provided <paramref name="redisConnectionConfiguration"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="redisConnectionConfiguration">The Redis connection configuration string.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddRedisHashSetVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        string redisConnectionConfiguration,
+        RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddRedisHashSetVectorStoreRecordCollection(collectionName, redisConnectionConfiguration, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddRedisJsonVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddRedisJsonVectorStoreRecordCollection(collectionName, options, serviceId);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is constructed using the provided <paramref name="redisConnectionConfiguration"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="redisConnectionConfiguration">The Redis connection configuration string.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddRedisJsonVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        string redisConnectionConfiguration,
+        RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddRedisJsonVectorStoreRecordCollection(collectionName, redisConnectionConfiguration, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisServiceCollectionExtensions.cs
@@ -64,4 +64,153 @@ public static class RedisServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddRedisHashSetVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = sp.GetRequiredService<IDatabase>();
+                var selectedOptions = options ?? sp.GetService<RedisHashSetVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new RedisHashSetVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is constructed using the provided <paramref name="redisConnectionConfiguration"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="redisConnectionConfiguration">The Redis connection configuration string.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddRedisHashSetVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string redisConnectionConfiguration,
+        RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = ConnectionMultiplexer.Connect(redisConnectionConfiguration).GetDatabase();
+                var selectedOptions = options ?? sp.GetService<RedisHashSetVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new RedisHashSetVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddRedisJsonVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = sp.GetRequiredService<IDatabase>();
+                var selectedOptions = options ?? sp.GetService<RedisJsonVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new RedisJsonVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a Redis <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the specified service ID
+    /// and where the Redis <see cref="IDatabase"/> is constructed using the provided <paramref name="redisConnectionConfiguration"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="redisConnectionConfiguration">The Redis connection configuration string.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddRedisJsonVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string redisConnectionConfiguration,
+        RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = ConnectionMultiplexer.Connect(redisConnectionConfiguration).GetDatabase();
+                var selectedOptions = options ?? sp.GetService<RedisJsonVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new RedisJsonVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
+            });
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
@@ -32,4 +32,30 @@ public static class WeaviateKernelBuilderExtensions
         builder.Services.AddWeaviateVectorStore(httpClient, options, serviceId);
         return builder;
     }
+
+    /// <summary>
+    /// Register a Weaviate <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="builder">The builder to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="httpClient">
+    /// <see cref="HttpClient"/> that is used to interact with Weaviate API.
+    /// <see cref="HttpClient.BaseAddress"/> should point to remote or local cluster and API key can be configured via <see cref="HttpClient.DefaultRequestHeaders"/>.
+    /// It's also possible to provide these parameters via <see cref="WeaviateVectorStoreOptions"/>.
+    /// </param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>The kernel builder.</returns>
+    public static IKernelBuilder AddWeaviateVectorStoreRecordCollection<TRecord>(
+        this IKernelBuilder builder,
+        string collectionName,
+        HttpClient? httpClient = default,
+        WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        builder.Services.AddWeaviateVectorStoreRecordCollection(collectionName, httpClient, options, serviceId);
+        return builder;
+    }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel.Connectors.Weaviate;
@@ -41,5 +42,59 @@ public static class WeaviateServiceCollectionExtensions
             });
 
         return services;
+    }
+
+    /// <summary>
+    /// Register a Weaviate <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="httpClient">
+    /// <see cref="HttpClient"/> that is used to interact with Weaviate API.
+    /// <see cref="HttpClient.BaseAddress"/> should point to remote or local cluster and API key can be configured via <see cref="HttpClient.DefaultRequestHeaders"/>.
+    /// It's also possible to provide these parameters via <see cref="WeaviateVectorStoreOptions"/>.
+    /// </param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddWeaviateVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        HttpClient? httpClient = default,
+        WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<Guid, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var selectedHttpClient = HttpClientProvider.GetHttpClient(httpClient, sp);
+                var selectedOptions = options ?? sp.GetService<WeaviateVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new WeaviateVectorStoreRecordCollection<TRecord>(selectedHttpClient, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+        where TRecord : class
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<Guid, TRecord>>(serviceId);
+            });
     }
 }

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantKernelBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
@@ -61,5 +62,63 @@ public class QdrantKernelBuilderExtensionsTests
         var vectorStore = kernel.Services.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<QdrantVectorStore>(vectorStore);
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        using var qdrantClient = new QdrantClient("localhost");
+        this._kernelBuilder.Services.AddSingleton<QdrantClient>(qdrantClient);
+
+        // Act.
+        this._kernelBuilder.AddQdrantVectorStoreRecordCollection<ulong, TestRecord>("testcollection");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithHostAndPortAndCredsRegistersClass()
+    {
+        // Act.
+        this._kernelBuilder.AddQdrantVectorStoreRecordCollection<ulong, TestRecord>("testcollection", "localhost", 8080, true, "apikey");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithHostRegistersClass()
+    {
+        // Act.
+        this._kernelBuilder.AddQdrantVectorStoreRecordCollection<ulong, TestRecord>("testcollection", "localhost");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var kernel = this._kernelBuilder.Build();
+
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<ulong, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<QdrantVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = kernel.Services.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<QdrantVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public ulong Id { get; set; }
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float> Vector { get; set; }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
@@ -55,11 +56,69 @@ public class QdrantServiceCollectionExtensionsTests
         this.AssertVectorStoreCreated();
     }
 
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        using var qdrantClient = new QdrantClient("localhost");
+        this._serviceCollection.AddSingleton<QdrantClient>(qdrantClient);
+
+        // Act.
+        this._serviceCollection.AddQdrantVectorStoreRecordCollection<ulong, TestRecord>("testcollection");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithHostAndPortAndCredsRegistersClass()
+    {
+        // Act.
+        this._serviceCollection.AddQdrantVectorStoreRecordCollection<ulong, TestRecord>("testcollection", "localhost", 8080, true, "apikey");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithHostRegistersClass()
+    {
+        // Act.
+        this._serviceCollection.AddQdrantVectorStoreRecordCollection<ulong, TestRecord>("testcollection", "localhost");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
     private void AssertVectorStoreCreated()
     {
         var serviceProvider = this._serviceCollection.BuildServiceProvider();
         var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<QdrantVectorStore>(vectorStore);
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<ulong, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<QdrantVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<QdrantVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public ulong Id { get; set; }
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float> Vector { get; set; }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisKernelBuilderExtensionsTests.cs
@@ -35,11 +35,61 @@ public class RedisKernelBuilderExtensionsTests
         this.AssertVectorStoreCreated();
     }
 
+    [Fact]
+    public void AddRedisHashSetVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        this._kernelBuilder.Services.AddSingleton<IDatabase>(Mock.Of<IDatabase>());
+
+        // Act.
+        this._kernelBuilder.AddRedisHashSetVectorStoreRecordCollection<TestRecord>("testCollection");
+
+        // Assert.
+        this.AssertHashSetVectorStoreRecordCollectionCreated<TestRecord>();
+    }
+
+    [Fact]
+    public void AddRedisJsonVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        this._kernelBuilder.Services.AddSingleton<IDatabase>(Mock.Of<IDatabase>());
+
+        // Act.
+        this._kernelBuilder.AddRedisJsonVectorStoreRecordCollection<TestRecord>("testCollection");
+
+        // Assert.
+        this.AssertJsonVectorStoreRecordCollectionCreated<TestRecord>();
+    }
+
     private void AssertVectorStoreCreated()
     {
         var kernel = this._kernelBuilder.Build();
         var vectorStore = kernel.Services.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<RedisVectorStore>(vectorStore);
+    }
+
+    private void AssertHashSetVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    {
+        var kernel = this._kernelBuilder.Build();
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<RedisHashSetVectorStoreRecordCollection<TRecord>>(collection);
+    }
+
+    private void AssertJsonVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    {
+        var kernel = this._kernelBuilder.Build();
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<RedisJsonVectorStoreRecordCollection<TRecord>>(collection);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisServiceCollectionExtensionsTests.cs
@@ -35,11 +35,61 @@ public class RedisServiceCollectionExtensionsTests
         this.AssertVectorStoreCreated();
     }
 
+    [Fact]
+    public void AddRedisHashSetVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        this._serviceCollection.AddSingleton<IDatabase>(Mock.Of<IDatabase>());
+
+        // Act.
+        this._serviceCollection.AddRedisHashSetVectorStoreRecordCollection<TestRecord>("testCollection");
+
+        // Assert.
+        this.AssertHashSetVectorStoreRecordCollectionCreated<TestRecord>();
+    }
+
+    [Fact]
+    public void AddRedisJsonVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        this._serviceCollection.AddSingleton<IDatabase>(Mock.Of<IDatabase>());
+
+        // Act.
+        this._serviceCollection.AddRedisJsonVectorStoreRecordCollection<TestRecord>("testCollection");
+
+        // Assert.
+        this.AssertJsonVectorStoreRecordCollectionCreated<TestRecord>();
+    }
+
     private void AssertVectorStoreCreated()
     {
         var serviceProvider = this._serviceCollection.BuildServiceProvider();
         var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<RedisVectorStore>(vectorStore);
+    }
+
+    private void AssertHashSetVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<RedisHashSetVectorStoreRecordCollection<TRecord>>(collection);
+    }
+
+    private void AssertJsonVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<RedisJsonVectorStoreRecordCollection<TRecord>>(collection);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
     }
 }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeKernelBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -45,11 +46,59 @@ public class PineconeKernelBuilderExtensionsTests
         this.AssertVectorStoreCreated();
     }
 
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        using var client = new Sdk.PineconeClient("fake api key");
+        this._kernelBuilder.Services.AddSingleton<Sdk.PineconeClient>(client);
+
+        // Act.
+        this._kernelBuilder.AddPineconeVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithApiKeyRegistersClass()
+    {
+        // Act.
+        this._kernelBuilder.AddPineconeVectorStoreRecordCollection<TestRecord>("testcollection", "fake api key");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
     private void AssertVectorStoreCreated()
     {
         var kernel = this._kernelBuilder.Build();
         var vectorStore = kernel.Services.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<PineconeVectorStore>(vectorStore);
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var kernel = this._kernelBuilder.Build();
+
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<PineconeVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = kernel.Services.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<PineconeVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float> Vector { get; set; }
     }
 }

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Pinecone/PineconeServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -44,6 +45,29 @@ public class PineconeServiceCollectionExtensionsTests
         // Assert.
         this.AssertVectorStoreCreated();
     }
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange.
+        using var client = new Sdk.PineconeClient("fake api key");
+        this._serviceCollection.AddSingleton<Sdk.PineconeClient>(client);
+
+        // Act.
+        this._serviceCollection.AddPineconeVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithApiKeyRegistersClass()
+    {
+        // Act.
+        this._serviceCollection.AddPineconeVectorStoreRecordCollection<TestRecord>("testcollection", "fake api key");
+
+        // Assert.
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
 
     private void AssertVectorStoreCreated()
     {
@@ -51,5 +75,29 @@ public class PineconeServiceCollectionExtensionsTests
         var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
         Assert.NotNull(vectorStore);
         Assert.IsType<PineconeVectorStore>(vectorStore);
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<PineconeVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<PineconeVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
+
+        [VectorStoreRecordVector(4)]
+        public ReadOnlyMemory<float> Vector { get; set; }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateKernelBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
@@ -32,5 +33,35 @@ public sealed class WeaviateKernelBuilderExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<WeaviateVectorStore>(vectorStore);
+    }
+
+    [Fact]
+    public void AddWeaviateVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange
+        using var httpClient = new HttpClient() { BaseAddress = new Uri("http://localhost") };
+        this._kernelBuilder.Services.AddSingleton<HttpClient>(httpClient);
+
+        // Act
+        this._kernelBuilder.AddWeaviateVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        var kernel = this._kernelBuilder.Build();
+
+        // Assert
+        var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<Guid, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<WeaviateVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = kernel.Services.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<WeaviateVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public Guid Id { get; set; }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
@@ -32,5 +33,40 @@ public sealed class WeaviateServiceCollectionExtensionsTests
         // Assert
         Assert.NotNull(vectorStore);
         Assert.IsType<WeaviateVectorStore>(vectorStore);
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange
+        using var httpClient = new HttpClient() { BaseAddress = new Uri("http://localhost") };
+        this._serviceCollection.AddSingleton<HttpClient>(httpClient);
+
+        // Act
+        this._serviceCollection.AddWeaviateVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<Guid, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<WeaviateVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<WeaviateVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public Guid Id { get; set; }
     }
 }


### PR DESCRIPTION
### Motivation and Context

If someone wants to consume just the IVectorizedSearch interface from DI it's useful to have helpers to allow easy registration of collections for these.

#8974

### Description

- Adding a DI helper for each collection type to register the collection interface and all search interfaces on it.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
