### PR TITLE
Improve mapping efficiency for Qdrant by removing JSON intermediary.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantGenericDataModelMapper.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 
@@ -189,34 +187,9 @@ internal class QdrantGenericDataModelMapper : IVectorStoreRecordMapper<VectorSto
                     // Shortcut any null handling here so we don't have to check for it for each case.
                     dataProperties[dataProperty.DataModelPropertyName] = null;
                 }
-                else if (typeof(IEnumerable).IsAssignableFrom(dataProperty.PropertyType))
-                {
-                    // Using json deserialization to convert lists back into the correct enumerable type.
-                    // There are many different possible enumerable types and this makes it easy to
-                    // support all that System.Text.Json supports.
-                    var jsonNode = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValueToJsonNode(propertyValue);
-                    var targetObject = jsonNode.Deserialize(dataProperty.PropertyType);
-                    dataProperties[dataProperty.DataModelPropertyName] = targetObject;
-                }
-                else if (dataProperty.PropertyType == typeof(int) || dataProperty.PropertyType == typeof(int?))
-                {
-                    // The Qdrant sdk only returns long values for integers, so we need to convert them
-                    // manually to the type of our data model.
-                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValue(propertyValue);
-                    convertedValue = Convert.ToInt32(convertedValue);
-                    dataProperties[dataProperty.DataModelPropertyName] = convertedValue;
-                }
-                else if (dataProperty.PropertyType == typeof(float) || dataProperty.PropertyType == typeof(float?))
-                {
-                    // The Qdrant sdk only returns double values for floats, so we need to convert them
-                    // manually to the type of our data model.
-                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValue(propertyValue);
-                    convertedValue = Convert.ToSingle(convertedValue);
-                    dataProperties[dataProperty.DataModelPropertyName] = convertedValue;
-                }
                 else
                 {
-                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValue(propertyValue);
+                    var convertedValue = QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValueToNativeType(propertyValue, dataProperty.PropertyType);
                     dataProperties[dataProperty.DataModelPropertyName] = convertedValue;
                 }
             }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordFieldMapping.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Nodes;
 using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 
@@ -46,40 +45,28 @@ internal static class QdrantVectorStoreRecordFieldMapping
     /// Convert the given <paramref name="payloadValue"/> to the correct native type based on its properties.
     /// </summary>
     /// <param name="payloadValue">The value to convert to a native type.</param>
+    /// <param name="targetType">The target type to convert the value to.</param>
     /// <returns>The converted native value.</returns>
     /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
-    public static JsonNode? ConvertFromGrpcFieldValueToJsonNode(Value payloadValue)
+    public static object? ConvertFromGrpcFieldValueToNativeType(Value payloadValue, Type targetType)
     {
         return payloadValue.KindCase switch
         {
             Value.KindOneofCase.NullValue => null,
-            Value.KindOneofCase.IntegerValue => JsonValue.Create(payloadValue.IntegerValue),
-            Value.KindOneofCase.StringValue => JsonValue.Create(payloadValue.StringValue),
-            Value.KindOneofCase.DoubleValue => JsonValue.Create(payloadValue.DoubleValue),
-            Value.KindOneofCase.BoolValue => JsonValue.Create(payloadValue.BoolValue),
-            Value.KindOneofCase.ListValue => new JsonArray(payloadValue.ListValue.Values.Select(x => ConvertFromGrpcFieldValueToJsonNode(x)).ToArray()),
-            Value.KindOneofCase.StructValue => new JsonObject(payloadValue.StructValue.Fields.ToDictionary(x => x.Key, x => ConvertFromGrpcFieldValueToJsonNode(x.Value))),
-            _ => throw new VectorStoreRecordMappingException($"Unsupported grpc value kind {payloadValue.KindCase}."),
-        };
-    }
-
-    /// <summary>
-    /// Convert the given <paramref name="payloadValue"/> to the correct native type based on its properties.
-    /// </summary>
-    /// <param name="payloadValue">The value to convert to a native type.</param>
-    /// <returns>The converted native value.</returns>
-    /// <exception cref="VectorStoreRecordMappingException">Thrown when an unsupported type is encountered.</exception>
-    public static object? ConvertFromGrpcFieldValue(Value payloadValue)
-    {
-        return payloadValue.KindCase switch
-        {
-            Value.KindOneofCase.NullValue => null,
-            Value.KindOneofCase.IntegerValue => payloadValue.IntegerValue,
+            Value.KindOneofCase.IntegerValue =>
+                targetType == typeof(int) || targetType == typeof(int?) ?
+                (object)(int)payloadValue.IntegerValue :
+                (object)payloadValue.IntegerValue,
             Value.KindOneofCase.StringValue => payloadValue.StringValue,
-            Value.KindOneofCase.DoubleValue => payloadValue.DoubleValue,
+            Value.KindOneofCase.DoubleValue =>
+                targetType == typeof(float) || targetType == typeof(float?) ?
+                (object)(float)payloadValue.DoubleValue :
+                (object)payloadValue.DoubleValue,
             Value.KindOneofCase.BoolValue => payloadValue.BoolValue,
-            Value.KindOneofCase.ListValue => payloadValue.ListValue.Values.Select(x => ConvertFromGrpcFieldValue(x)).ToArray(),
-            Value.KindOneofCase.StructValue => payloadValue.StructValue.Fields.ToDictionary(x => x.Key, x => ConvertFromGrpcFieldValue(x.Value)),
+            Value.KindOneofCase.ListValue => VectorStoreRecordMapping.CreateEnumerable(
+                payloadValue.ListValue.Values.Select(
+                    x => ConvertFromGrpcFieldValueToNativeType(x, VectorStoreRecordPropertyReader.GetCollectionElementType(targetType))),
+                targetType),
             _ => throw new VectorStoreRecordMappingException($"Unsupported grpc value kind {payloadValue.KindCase}."),
         };
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Microsoft.SemanticKernel.Data;
 using Qdrant.Client.Grpc;
 
@@ -18,6 +17,9 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, PointStruct>
     where TRecord : class
 {
+    /// <summary>The public parameterless constructor for the current data model.</summary>
+    private readonly ConstructorInfo _constructorInfo;
+
     /// <summary>A property info object that points at the key property for the current model, allowing easy reading and writing of this property.</summary>
     private readonly PropertyInfo _keyPropertyInfo;
 
@@ -51,6 +53,7 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
         Verify.NotNull(storagePropertyNames);
 
         // Validate property types.
+        this._constructorInfo = VectorStoreRecordPropertyReader.GetParameterlessConstructor(typeof(TRecord));
         var propertiesInfo = VectorStoreRecordPropertyReader.FindProperties(typeof(TRecord), vectorStoreRecordDefinition, supportsMultipleVectors: hasNamedVectors);
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.DataProperties, QdrantVectorStoreRecordFieldMapping.s_supportedDataTypes, "Data", supportEnumerable: true);
         VectorStoreRecordPropertyReader.VerifyPropertyTypes(propertiesInfo.VectorProperties, QdrantVectorStoreRecordFieldMapping.s_supportedVectorTypes, "Vector");
@@ -139,50 +142,54 @@ internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecor
     public TRecord MapFromStorageToDataModel(PointStruct storageModel, StorageToDataModelMapperOptions options)
     {
         // Get the key property name and value.
-        var keyJsonName = this._jsonPropertyNames[this._keyPropertyInfo.Name];
-        var keyPropertyValue = storageModel.Id.HasNum ? storageModel.Id.Num as object : storageModel.Id.Uuid as object;
+        var keyPropertyValue = storageModel.Id.HasNum ? storageModel.Id.Num as object : new Guid(storageModel.Id.Uuid) as object;
 
-        // Create a json object to represent the point.
-        var outputJsonObject = new JsonObject
-        {
-            { keyJsonName, JsonValue.Create(keyPropertyValue) },
-        };
+        // Construct the output record.
+        var outputRecord = (TRecord)this._constructorInfo.Invoke(null);
 
-        // Add each vector property if embeddings are included in the point.
+        // Set Key.
+        var keyPropertyInfoWithValue = new KeyValuePair<PropertyInfo, object?>(
+                this._keyPropertyInfo,
+                keyPropertyValue);
+        VectorStoreRecordMapping.SetPropertiesOnRecord(
+            outputRecord,
+            [keyPropertyInfoWithValue]);
+
+        // Set each vector property if embeddings are included in the point.
         if (options?.IncludeVectors is true)
         {
-            foreach (var vectorProperty in this._vectorPropertiesInfo)
+            if (this._hasNamedVectors)
             {
-                var propertyName = this._storagePropertyNames[vectorProperty.Name];
-                var jsonName = this._jsonPropertyNames[vectorProperty.Name];
-
-                if (this._hasNamedVectors)
-                {
-                    if (storageModel.Vectors.Vectors_.Vectors.TryGetValue(propertyName, out var vector))
-                    {
-                        outputJsonObject.Add(jsonName, new JsonArray(vector.Data.Select(x => JsonValue.Create(x)).ToArray()));
-                    }
-                }
-                else
-                {
-                    outputJsonObject.Add(jsonName, new JsonArray(storageModel.Vectors.Vector.Data.Select(x => JsonValue.Create(x)).ToArray()));
-                }
+                var propertiesInfoWithValues = VectorStoreRecordMapping.BuildPropertiesInfoWithValues(
+                    this._vectorPropertiesInfo,
+                    this._storagePropertyNames,
+                    storageModel.Vectors.Vectors_.Vectors,
+                    (Vector vector, Type targetType) => new ReadOnlyMemory<float>(vector.Data.ToArray()));
+                VectorStoreRecordMapping.SetPropertiesOnRecord(outputRecord, propertiesInfoWithValues);
+            }
+            else
+            {
+                var propertyInfoWithValue = new KeyValuePair<PropertyInfo, object?>(
+                        this._vectorPropertiesInfo[0],
+                        new ReadOnlyMemory<float>(storageModel.Vectors.Vector.Data.ToArray()));
+                VectorStoreRecordMapping.SetPropertiesOnRecord(
+                    outputRecord,
+                    [propertyInfoWithValue]);
             }
         }
 
-        // Add each data property.
+        // Set each data property.
         foreach (var dataProperty in this._dataPropertiesInfo)
         {
-            var propertyName = this._storagePropertyNames[dataProperty.Name];
-            var jsonName = this._jsonPropertyNames[dataProperty.Name];
-
-            if (storageModel.Payload.TryGetValue(propertyName, out var value))
-            {
-                outputJsonObject.Add(jsonName, QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValueToJsonNode(value));
-            }
+            var propertiesInfoWithValues = VectorStoreRecordMapping.BuildPropertiesInfoWithValues(
+                this._dataPropertiesInfo,
+                this._storagePropertyNames,
+                storageModel.Payload,
+                (Value grpcValue, Type targetType) =>
+                    QdrantVectorStoreRecordFieldMapping.ConvertFromGrpcFieldValueToNativeType(grpcValue, targetType));
+            VectorStoreRecordMapping.SetPropertiesOnRecord(outputRecord, propertiesInfoWithValues);
         }
 
-        // Convert from json object to the target data model.
-        return JsonSerializer.Deserialize<TRecord>(outputJsonObject)!;
+        return outputRecord;
     }
 }

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordMapping.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordMapping.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Contains helper methods to map between storage and data models.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class VectorStoreRecordMapping
+{
+    /// <summary>
+    /// Build a list of properties with their values from the given data model properties and storage values.
+    /// </summary>
+    /// <typeparam name="TStorageType">The type of the storage proeprties.</typeparam>
+    /// <param name="dataModelPropertiesInfo"><see cref="PropertyInfo"/> objects listing the properties on the data model to get values for.</param>
+    /// <param name="dataModelToStorageNameMapping">Storage property names keyed by data property names.</param>
+    /// <param name="storageValues">A dictionary of storage values by storage property name.</param>
+    /// <param name="storageValueConverter">An optional function to convert the storage property values to data property values.</param>
+    /// <returns>The list of data property ojects and their values.</returns>
+    public static IEnumerable<KeyValuePair<PropertyInfo, object?>> BuildPropertiesInfoWithValues<TStorageType>(
+        IEnumerable<PropertyInfo> dataModelPropertiesInfo,
+        IDictionary<string, string> dataModelToStorageNameMapping,
+        IDictionary<string, TStorageType> storageValues,
+        Func<TStorageType, Type, object?>? storageValueConverter = null)
+    {
+        foreach (var propertyInfo in dataModelPropertiesInfo)
+        {
+            if (dataModelToStorageNameMapping.TryGetValue(propertyInfo.Name, out var storageName) &&
+                storageValues.TryGetValue(storageName, out var storageValue))
+            {
+                if (storageValueConverter is not null)
+                {
+                    var convertedStorageValue = storageValueConverter(storageValue, propertyInfo.PropertyType);
+                    yield return new KeyValuePair<PropertyInfo, object?>(propertyInfo, convertedStorageValue);
+                }
+                else
+                {
+                    yield return new KeyValuePair<PropertyInfo, object?>(propertyInfo, (object?)storageValue);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Set the given list of properties with their values on the given object.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the target object.</typeparam>
+    /// <param name="record">The target object to set the property values on.</param>
+    /// <param name="propertiesInfoWithValues">A list of properties and their values to set.</param>
+    public static void SetPropertiesOnRecord<TRecord>(
+        TRecord record,
+        IEnumerable<KeyValuePair<PropertyInfo, object?>> propertiesInfoWithValues)
+            where TRecord : class
+    {
+        foreach (var propertyInfoWithValue in propertiesInfoWithValues)
+        {
+            propertyInfoWithValue.Key.SetValue(record, propertyInfoWithValue.Value);
+        }
+    }
+
+    /// <summary>
+    /// Create an enumerable of the required type from the input enumerable.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the input enumerable.</typeparam>
+    /// <param name="input">The input enumerable to convert.</param>
+    /// <param name="requiredEnumerable">The type to convert to.</param>
+    /// <returns>The new enumerable in the required type.</returns>
+    /// <exception cref="NotSupportedException">Thrown when a target type is requested that is not supported.</exception>
+    public static object? CreateEnumerable<T>(IEnumerable<T> input, Type requiredEnumerable)
+    {
+        if (input is null)
+        {
+            return null;
+        }
+
+        if (requiredEnumerable.IsArray)
+        {
+            if (requiredEnumerable.HasElementType)
+            {
+                var elementType = requiredEnumerable.GetElementType();
+
+                var arrayList = new ArrayList();
+                foreach (var item in input)
+                {
+                    arrayList.Add(item);
+                }
+                return arrayList.ToArray(elementType!);
+            }
+
+            return input.ToArray();
+        }
+
+        if (requiredEnumerable.IsGenericType)
+        {
+            var genericTypeDefinition = requiredEnumerable.GetGenericTypeDefinition();
+            if (genericTypeDefinition == typeof(ICollection<>) ||
+                genericTypeDefinition == typeof(IEnumerable<>) ||
+                genericTypeDefinition == typeof(IList<>) ||
+                genericTypeDefinition == typeof(IReadOnlyCollection<>) ||
+                genericTypeDefinition == typeof(IReadOnlyList<>))
+            {
+                var genericMemberType = requiredEnumerable.GetGenericArguments()[0];
+                var listType = typeof(List<>).MakeGenericType(genericMemberType);
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(genericMemberType);
+                var constructor = listType.GetConstructor([enumerableType]);
+                return constructor!.Invoke([input]);
+            }
+        }
+
+        if (requiredEnumerable == typeof(IEnumerable))
+        {
+            return input;
+        }
+
+        if (typeof(IList).IsAssignableFrom(requiredEnumerable))
+        {
+            var publicParameterlessConstructor = requiredEnumerable.GetConstructor([]);
+            if (publicParameterlessConstructor is not null)
+            {
+                var list = (IList)publicParameterlessConstructor.Invoke(null);
+                foreach (var item in input)
+                {
+                    list.Add(item);
+                }
+                return list;
+            }
+        }
+
+        throw new NotSupportedException($"Type {requiredEnumerable.FullName} is not supported.");
+    }
+}

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordMappingTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordMappingTests.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.SemanticKernel.Data;
+using Xunit;
+
+namespace SemanticKernel.UnitTests.Data;
+
+public class VectorStoreRecordMappingTests
+{
+    [Fact]
+    public void BuildPropertiesInfoWithValuesShouldBuildPropertiesInfo()
+    {
+        // Arrange.
+        var dataModelPropertiesInfo = new[]
+        {
+            typeof(DataModel).GetProperty(nameof(DataModel.Key))!,
+            typeof(DataModel).GetProperty(nameof(DataModel.Data))!
+        };
+        var dataModelToStorageNameMapping = new Dictionary<string, string>
+        {
+            { nameof(DataModel.Key), "key" },
+            { nameof(DataModel.Data), "data" },
+        };
+        var storageValues = new Dictionary<string, string>
+        {
+            { "key", "key value" },
+            { "data", "data value" },
+        };
+
+        // Act.
+        var propertiesInfoWithValues = VectorStoreRecordMapping.BuildPropertiesInfoWithValues(
+            dataModelPropertiesInfo,
+            dataModelToStorageNameMapping,
+            storageValues);
+
+        // Assert.
+        var propertiesInfoWithValuesArray = propertiesInfoWithValues.ToArray();
+        Assert.Equal(2, propertiesInfoWithValuesArray.Length);
+        Assert.Equal(dataModelPropertiesInfo[0], propertiesInfoWithValuesArray[0].Key);
+        Assert.Equal("key value", propertiesInfoWithValuesArray[0].Value);
+        Assert.Equal(dataModelPropertiesInfo[1], propertiesInfoWithValuesArray[1].Key);
+        Assert.Equal("data value", propertiesInfoWithValuesArray[1].Value);
+    }
+
+    [Fact]
+    public void BuildPropertiesInfoWithValuesShouldUseValueMapperIfProvided()
+    {
+        // Arrange.
+        var dataModelPropertiesInfo = new[]
+        {
+            typeof(DataModel).GetProperty(nameof(DataModel.Key))!,
+            typeof(DataModel).GetProperty(nameof(DataModel.Data))!
+        };
+        var dataModelToStorageNameMapping = new Dictionary<string, string>
+        {
+            { nameof(DataModel.Key), "key" },
+            { nameof(DataModel.Data), "data" },
+        };
+        var storageValues = new Dictionary<string, int>
+        {
+            { "key", 10 },
+            { "data", 20 },
+        };
+
+        // Act.
+        var propertiesInfoWithValues = VectorStoreRecordMapping.BuildPropertiesInfoWithValues(
+            dataModelPropertiesInfo,
+            dataModelToStorageNameMapping,
+            storageValues,
+            (int value, Type type) => value.ToString());
+
+        // Assert.
+        var propertiesInfoWithValuesArray = propertiesInfoWithValues.ToArray();
+        Assert.Equal(2, propertiesInfoWithValuesArray.Length);
+        Assert.Equal(dataModelPropertiesInfo[0], propertiesInfoWithValuesArray[0].Key);
+        Assert.Equal("10", propertiesInfoWithValuesArray[0].Value);
+        Assert.Equal(dataModelPropertiesInfo[1], propertiesInfoWithValuesArray[1].Key);
+        Assert.Equal("20", propertiesInfoWithValuesArray[1].Value);
+    }
+
+    [Fact]
+    public void SetPropertiesOnRecordShouldSetProperties()
+    {
+        // Arrange.
+        var record = new DataModel();
+
+        // Act.
+        VectorStoreRecordMapping.SetPropertiesOnRecord(record, new[]
+        {
+            new KeyValuePair<PropertyInfo, object?>(typeof(DataModel).GetProperty(nameof(DataModel.Key))!, "key value"),
+            new KeyValuePair<PropertyInfo, object?>(typeof(DataModel).GetProperty(nameof(DataModel.Data))!, "data value"),
+        });
+
+        // Assert.
+        Assert.Equal("key value", record.Key);
+        Assert.Equal("data value", record.Data);
+    }
+
+    [Theory]
+    [InlineData(typeof(List<string>))]
+    [InlineData(typeof(ICollection<string>))]
+    [InlineData(typeof(IEnumerable<string>))]
+    [InlineData(typeof(IList<string>))]
+    [InlineData(typeof(IReadOnlyCollection<string>))]
+    [InlineData(typeof(IReadOnlyList<string>))]
+    [InlineData(typeof(string[]))]
+    [InlineData(typeof(IEnumerable))]
+    [InlineData(typeof(ArrayList))]
+    public void CreateEnumerableCanCreateEnumerablesOfAllRequiredTypes(Type expectedType)
+    {
+        // Arrange.
+        IEnumerable<string> input = new List<string> { "one", "two", "three", "four" };
+
+        // Act.
+        var actual = VectorStoreRecordMapping.CreateEnumerable(input, expectedType);
+
+        // Assert.
+        Assert.True(expectedType.IsAssignableFrom(actual!.GetType()));
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(HashSet<string>))]
+    [InlineData(typeof(ISet<string>))]
+    [InlineData(typeof(Dictionary<string, string>))]
+    [InlineData(typeof(Stack<string>))]
+    [InlineData(typeof(Queue<string>))]
+    public void CreateEnumerableThrowsForUnsupportedType(Type expectedType)
+    {
+        // Arrange.
+        IEnumerable<string> input = new List<string> { "one", "two", "three", "four" };
+
+        // Act & Assert.
+        Assert.Throws<NotSupportedException>(() => VectorStoreRecordMapping.CreateEnumerable(input, expectedType));
+    }
+
+    private sealed class DataModel
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Data { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
### Motivation and Context

In order to maximize support for custom and list types originally we were using JSON as an intermediary
when mapping from the storage model to the data model.  This PR removes this intermediary while still supporting
a large number of types.

### Description

- Add more fine grained checks for specific supported enumerable types.
- Add code to construct the supported enumerable types.
- Replace mapping that uses json intermediary with direct conversion.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
