### PR TITLE
Python: Azure identity needs to be a default dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "pydantic-settings ~= 2.0",
     "defusedxml ~= 0.7",
 
+    # azure identity
+    "azure-identity ~= 1.13",
+
     # embeddings
     "numpy >= 1.25.0; python_version < '3.12'",
     "numpy >= 1.26.0; python_version >= '3.12'",


### PR DESCRIPTION
### Motivation and Context

After introducing entra auth as an option for AzureChatCompletion and AzureAI Inference, we need to make sure that the azure-identity library is installed by default as a dependency.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

install azure-identity as a default dependency so that AzureChatCompletion doesn't break.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
