### PR TITLE
Python: Improve exception log message in streaming content merge item list

### DIFF
--- a/python/semantic_kernel/contents/streaming_content_mixin.py
+++ b/python/semantic_kernel/contents/streaming_content_mixin.py
@@ -49,10 +49,11 @@ class StreamingContentMixin(KernelBaseModel, ABC):
                             new_item = item + other_item  # type: ignore
                             new_items_list[id] = new_item
                             added = True
-                        except (ValueError, ContentAdditionException):
-                            logger.warning("Could not add item %s to %s. Skipping...", other_item, item)
+                        except (ValueError, ContentAdditionException) as ex:
+                            logger.debug(f"Could not add item {other_item} to {item}.", exc_info=ex)
                             continue
                 if not added:
+                    logger.debug(f"Could not add item {other_item} to any item in the list. Adding it as a new item.")
                     new_items_list.append(other_item)
 
         return new_items_list


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Exceptions are expected to happen when merging the item lists from two chat streaming contents. When all attempts fail, the new item will simply be added to the end of the list.

The `WARN` log level is too high for this event.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Reduce the log level of the event to `DEBUG`.
2. Add an additional log message for the event when all attempts have failed.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
