### PR TITLE
.Net: Add response container type for vector search results.

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_Common.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_Common.cs
@@ -50,33 +50,36 @@ public class VectorStore_VectorSearch_MultiStore_Common(IVectorStore vectorStore
         // Search the collection using a vector search.
         var searchString = "What is an Application Programming Interface";
         var searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
+        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+        var resultRecords = await searchResult.Results.ToListAsync();
 
         output.WriteLine("Search string: " + searchString);
-        output.WriteLine("Result: " + searchResult.First().Record.Definition);
+        output.WriteLine("Result: " + resultRecords.First().Record.Definition);
         output.WriteLine();
 
         // Search the collection using a vector search.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+        resultRecords = await searchResult.Results.ToListAsync();
 
         output.WriteLine("Search string: " + searchString);
-        output.WriteLine("Result: " + searchResult.First().Record.Definition);
+        output.WriteLine("Result: " + resultRecords.First().Record.Definition);
         output.WriteLine();
 
         // Search the collection using a vector search with pre-filtering.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
         var filter = new VectorSearchFilter().EqualTo(nameof(Glossary<TKey>.Category), "External Definitions");
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = filter }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = filter });
+        resultRecords = await searchResult.Results.ToListAsync();
 
         output.WriteLine("Search string: " + searchString);
-        output.WriteLine("Number of results: " + searchResult.Count);
-        output.WriteLine("Result 1 Score: " + searchResult[0].Score);
-        output.WriteLine("Result 1: " + searchResult[0].Record.Definition);
-        output.WriteLine("Result 2 Score: " + searchResult[1].Score);
-        output.WriteLine("Result 2: " + searchResult[1].Record.Definition);
+        output.WriteLine("Number of results: " + resultRecords.Count);
+        output.WriteLine("Result 1 Score: " + resultRecords[0].Score);
+        output.WriteLine("Result 1: " + resultRecords[0].Record.Definition);
+        output.WriteLine("Result 2 Score: " + resultRecords[1].Score);
+        output.WriteLine("Result 2: " + resultRecords[1].Record.Definition);
     }
 
     /// <summary>

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiVector.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiVector.cs
@@ -58,11 +58,12 @@ public class VectorStore_VectorSearch_MultiVector(ITestOutputHelper output) : Ba
             {
                 Top = 1,
                 VectorPropertyName = nameof(Product.DescriptionEmbedding)
-            }).ToListAsync();
+            });
+        var resultRecords = await searchResult.Results.ToListAsync();
 
         WriteLine("Search string: " + searchString);
-        WriteLine("Result: " + searchResult.First().Record.Description);
-        WriteLine("Score: " + searchResult.First().Score);
+        WriteLine("Result: " + resultRecords.First().Record.Description);
+        WriteLine("Score: " + resultRecords.First().Score);
         WriteLine();
 
         // Search the store using the feature list embedding.
@@ -74,11 +75,12 @@ public class VectorStore_VectorSearch_MultiVector(ITestOutputHelper output) : Ba
             {
                 Top = 1,
                 VectorPropertyName = nameof(Product.FeatureListEmbedding)
-            }).ToListAsync();
+            });
+        resultRecords = await searchResult.Results.ToListAsync();
 
         WriteLine("Search string: " + searchString);
-        WriteLine("Result: " + searchResult.First().Record.Description);
-        WriteLine("Score: " + searchResult.First().Score);
+        WriteLine("Result: " + resultRecords.First().Record.Description);
+        WriteLine("Score: " + resultRecords.First().Score);
         WriteLine();
     }
 

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs
@@ -52,16 +52,18 @@ public class VectorStore_VectorSearch_Paging(ITestOutputHelper output) : BaseTes
                 {
                     Top = 10,
                     Skip = page * 10
-                }).ToListAsync();
+                });
 
             // Print the results.
-            foreach (var result in currentPageResults)
+            var pageCount = 0;
+            await foreach (var result in currentPageResults.Results)
             {
                 Console.WriteLine($"Key: {result.Record.Key}, Text: {result.Record.Text}");
+                pageCount++;
             }
 
             // Stop when we got back less than the requested number of results.
-            moreResults = currentPageResults.Count == 10;
+            moreResults = pageCount == 10;
             page++;
         }
     }

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Simple.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Simple.cs
@@ -48,33 +48,36 @@ public class VectorStore_VectorSearch_Simple(ITestOutputHelper output) : BaseTes
         // Search the collection using a vector search.
         var searchString = "What is an Application Programming Interface";
         var searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
+        var searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+        var resultRecords = await searchResult.Results.ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
-        Console.WriteLine("Result: " + searchResult.First().Record.Definition);
+        Console.WriteLine("Result: " + resultRecords.First().Record.Definition);
         Console.WriteLine();
 
         // Search the collection using a vector search.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+        resultRecords = await searchResult.Results.ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
-        Console.WriteLine("Result: " + searchResult.First().Record.Definition);
+        Console.WriteLine("Result: " + resultRecords.First().Record.Definition);
         Console.WriteLine();
 
         // Search the collection using a vector search with pre-filtering.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
         var filter = new VectorSearchFilter().EqualTo(nameof(Glossary.Category), "External Definitions");
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = filter }).ToListAsync();
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = filter });
+        resultRecords = await searchResult.Results.ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
-        Console.WriteLine("Number of results: " + searchResult.Count);
-        Console.WriteLine("Result 1 Score: " + searchResult[0].Score);
-        Console.WriteLine("Result 1: " + searchResult[0].Record.Definition);
-        Console.WriteLine("Result 2 Score: " + searchResult[1].Score);
-        Console.WriteLine("Result 2: " + searchResult[1].Record.Definition);
+        Console.WriteLine("Number of results: " + resultRecords.Count);
+        Console.WriteLine("Result 1 Score: " + resultRecords[0].Score);
+        Console.WriteLine("Result 1: " + resultRecords[0].Record.Definition);
+        Console.WriteLine("Result 2 Score: " + resultRecords[1].Score);
+        Console.WriteLine("Result 2: " + resultRecords[1].Record.Definition);
     }
 
     /// <summary>

--- a/dotnet/samples/Concepts/Memory/VolatileVectorStore_LoadData.cs
+++ b/dotnet/samples/Concepts/Memory/VolatileVectorStore_LoadData.cs
@@ -69,10 +69,11 @@ public class VolatileVectorStore_LoadData(ITestOutputHelper output) : BaseTest(o
             // Search the collection using a vector search.
             var searchString = "What is the Semantic Kernel?";
             var searchVector = await embeddingGenerationService.GenerateEmbeddingAsync(searchString);
-            var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
+            var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+            var resultRecords = await searchResult.Results.ToListAsync();
 
             Console.WriteLine("Search string: " + searchString);
-            Console.WriteLine("Result: " + searchResult.First().Record.Text);
+            Console.WriteLine("Result: " + resultRecords.First().Record.Text);
             Console.WriteLine();
         }
     }
@@ -113,10 +114,11 @@ public class VolatileVectorStore_LoadData(ITestOutputHelper output) : BaseTest(o
         // Search the collection using a vector search.
         var searchString = "What is the Semantic Kernel?";
         var searchVector = await embeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync();
+        var searchResult = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+        var resultRecords = await searchResult.Results.ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);
-        Console.WriteLine("Result: " + searchResult.First().Record.Text);
+        Console.WriteLine("Result: " + resultRecords.First().Record.Text);
         Console.WriteLine();
     }
 

--- a/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-using System.Runtime.CompilerServices;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Data;
 using Microsoft.SemanticKernel.Embeddings;
@@ -178,14 +177,11 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
         where TRecord : class
     {
         /// <inheritdoc/>
-        public async IAsyncEnumerable<VectorSearchResult<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
         {
             var vectorizedQuery = await textEmbeddingGeneration!.GenerateEmbeddingAsync(searchText, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            await foreach (var result in vectorizedSearch.VectorizedSearchAsync(vectorizedQuery, options, cancellationToken))
-            {
-                yield return result;
-            }
+            return await vectorizedSearch.VectorizedSearchAsync(vectorizedQuery, options, cancellationToken);
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -578,7 +578,7 @@ public class AzureAISearchVectorStoreRecordCollectionTests
                 Filter = filter,
                 VectorPropertyName = nameof(MultiPropsModel.Vector1)
             },
-            this._testCancellationToken).ToListAsync();
+            this._testCancellationToken);
 
         // Assert.
         this._searchClientMock.Verify(
@@ -620,7 +620,7 @@ public class AzureAISearchVectorStoreRecordCollectionTests
                 Filter = filter,
                 VectorPropertyName = nameof(MultiPropsModel.Vector1)
             },
-            this._testCancellationToken).ToListAsync();
+            this._testCancellationToken);
 
         // Assert.
         this._searchClientMock.Verify(

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -560,13 +560,13 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
         // Act & Assert
         if (exceptionExpected)
         {
-            await Assert.ThrowsAsync<NotSupportedException>(async () => await sut.VectorizedSearchAsync(vector).ToListAsync());
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await sut.VectorizedSearchAsync(vector));
         }
         else
         {
-            var result = await sut.VectorizedSearchAsync(vector).FirstOrDefaultAsync();
+            var actual = await sut.VectorizedSearchAsync(vector);
 
-            Assert.NotNull(result);
+            Assert.NotNull(actual);
         }
     }
 
@@ -620,14 +620,14 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
             "collection");
 
         // Act
-        var result = await sut.VectorizedSearchAsync(vector, new()
+        var actual = await sut.VectorizedSearchAsync(vector, new()
         {
             VectorPropertyName = vectorPropertyName,
             Top = actualTop,
-        }).FirstOrDefaultAsync();
+        });
 
         // Assert
-        Assert.NotNull(result);
+        Assert.NotNull(await actual.Results.FirstOrDefaultAsync());
 
         this._mockMongoCollection.Verify(l => l.AggregateAsync(
             It.Is<PipelineDefinition<BsonDocument, BsonDocument>>(pipeline =>
@@ -649,7 +649,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
         var options = new VectorSearchOptions { VectorPropertyName = "non-existent-property" };
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), options).FirstOrDefaultAsync());
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await (await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), options)).Results.FirstOrDefaultAsync());
     }
 
     [Fact]
@@ -663,9 +663,10 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
             "collection");
 
         // Act
-        var result = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f])).FirstOrDefaultAsync();
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]));
 
         // Assert
+        var result = await actual.Results.FirstOrDefaultAsync();
         Assert.NotNull(result);
         Assert.Equal("key", result.Record.HotelId);
         Assert.Equal("Test Name", result.Record.HotelName);

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -588,8 +588,9 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
             "collection");
 
         // Act
-        var results = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f])).ToListAsync();
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]));
 
+        var results = await actual.Results.ToListAsync();
         var result = results[0];
 
         // Assert
@@ -609,7 +610,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
 
         // Act & Assert
         await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            await sut.VectorizedSearchAsync(new List<double>([1, 2, 3])).ToListAsync());
+            await (await sut.VectorizedSearchAsync(new List<double>([1, 2, 3]))).Results.ToListAsync());
     }
 
     [Fact]
@@ -624,7 +625,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), searchOptions).ToListAsync());
+            await (await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), searchOptions)).Results.ToListAsync());
     }
 
     public static TheoryData<List<string>, string, bool> CollectionExistsData => new()

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -11,7 +11,6 @@ using Microsoft.SemanticKernel.Data;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
-using MongoDB.Driver.Search;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -236,7 +236,7 @@ public sealed class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
-    public IAsyncEnumerable<VectorSearchResult<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -564,7 +564,7 @@ public class QdrantVectorStoreRecordCollectionTests
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new[] { 1f, 2f, 3f, 4f }),
             new() { IncludeVectors = true, Filter = filter, Top = 5, Skip = 2 },
-            this._testCancellationToken).ToListAsync();
+            this._testCancellationToken);
 
         // Assert.
         this._qdrantClientMock
@@ -588,12 +588,13 @@ public class QdrantVectorStoreRecordCollectionTests
                     this._testCancellationToken),
                 Times.Once);
 
-        Assert.Single(actual);
-        Assert.Equal(testRecordKey, actual.First().Record.Key);
-        Assert.Equal("data 1", actual.First().Record.OriginalNameData);
-        Assert.Equal("data 1", actual.First().Record.Data);
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector!.Value.ToArray());
-        Assert.Equal(0.5f, actual.First().Score);
+        var results = await actual.Results.ToListAsync();
+        Assert.Single(results);
+        Assert.Equal(testRecordKey, results.First().Record.Key);
+        Assert.Equal("data 1", results.First().Record.OriginalNameData);
+        Assert.Equal("data 1", results.First().Record.Data);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, results.First().Record.Vector!.Value.ToArray());
+        Assert.Equal(0.5f, results.First().Score);
     }
 
     private void SetupRetrieveMock(List<RetrievedPoint> retrievedPoints)

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -451,7 +451,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
                 Filter = filter,
                 Top = 5,
                 Skip = 2
-            }).ToListAsync();
+            });
 
         // Assert.
         var expectedArgsPart1 = new object[]
@@ -490,18 +490,19 @@ public class RedisHashSetVectorStoreRecordCollectionTests
                     It.Is<object[]>(x => x.Where(y => !(y is byte[])).SequenceEqual(expectedArgs.Where(y => !(y is byte[]))))),
                 Times.Once);
 
-        Assert.Single(actual);
-        Assert.Equal(TestRecordKey1, actual.First().Record.Key);
-        Assert.Equal(0.5d, actual.First().Score);
-        Assert.Equal("original data 1", actual.First().Record.OriginalNameData);
-        Assert.Equal("data 1", actual.First().Record.Data);
+        var results = await actual.Results.ToListAsync();
+        Assert.Single(results);
+        Assert.Equal(TestRecordKey1, results.First().Record.Key);
+        Assert.Equal(0.5d, results.First().Score);
+        Assert.Equal("original data 1", results.First().Record.OriginalNameData);
+        Assert.Equal("data 1", results.First().Record.Data);
         if (includeVectors)
         {
-            Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector!.Value.ToArray());
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, results.First().Record.Vector!.Value.ToArray());
         }
         else
         {
-            Assert.False(actual.First().Record.Vector.HasValue);
+            Assert.False(results.First().Record.Vector.HasValue);
         }
     }
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -466,7 +466,7 @@ public class RedisJsonVectorStoreRecordCollectionTests
                 Filter = filter,
                 Top = 5,
                 Skip = 2
-            }).ToListAsync();
+            });
 
         // Assert.
         var expectedArgs = new object[]
@@ -493,13 +493,14 @@ public class RedisJsonVectorStoreRecordCollectionTests
                     It.Is<object[]>(x => x.Where(y => !(y is byte[])).SequenceEqual(expectedArgs.Where(y => !(y is byte[]))))),
                 Times.Once);
 
-        Assert.Single(actual);
-        Assert.Equal(TestRecordKey1, actual.First().Record.Key);
-        Assert.Equal(0.5d, actual.First().Score);
-        Assert.Equal("data 1", actual.First().Record.Data1);
-        Assert.Equal("data 2", actual.First().Record.Data2);
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector1!.Value.ToArray());
-        Assert.Equal(new float[] { 1, 2, 3, 4 }, actual.First().Record.Vector2!.Value.ToArray());
+        var results = await actual.Results.ToListAsync();
+        Assert.Single(results);
+        Assert.Equal(TestRecordKey1, results.First().Record.Key);
+        Assert.Equal(0.5d, results.First().Score);
+        Assert.Equal("data 1", results.First().Record.Data1);
+        Assert.Equal("data 2", results.First().Record.Data2);
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, results.First().Record.Vector1!.Value.ToArray());
+        Assert.Equal(new float[] { 1, 2, 3, 4 }, results.First().Record.Vector2!.Value.ToArray());
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionTests.cs
@@ -479,12 +479,13 @@ public sealed class WeaviateVectorStoreRecordCollectionTests : IDisposable
         var sut = new WeaviateVectorStoreRecordCollection<WeaviateHotel>(this._mockHttpClient, CollectionName);
 
         // Act
-        var results = await sut.VectorizedSearchAsync(vector, new()
+        var actual = await sut.VectorizedSearchAsync(vector, new()
         {
             IncludeVectors = includeVectors
-        }).ToListAsync();
+        });
 
         // Assert
+        var results = await actual.Results.ToListAsync();
         Assert.Single(results);
 
         var score = results[0].Score;
@@ -520,7 +521,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests : IDisposable
 
         // Act & Assert
         await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            await sut.VectorizedSearchAsync(new List<double>([1, 2, 3])).ToListAsync());
+            await (await sut.VectorizedSearchAsync(new List<double>([1, 2, 3]))).Results.ToListAsync());
     }
 
     [Fact]
@@ -533,7 +534,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests : IDisposable
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), searchOptions).ToListAsync());
+            await (await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), searchOptions)).Results.ToListAsync());
     }
 
     public void Dispose()

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -342,9 +342,10 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f])).ToListAsync();
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]));
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId).ToList();
 
         Assert.Equal("key1", ids[0]);
@@ -372,13 +373,14 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Top = 2,
             Skip = 2
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId).ToList();
 
         Assert.Equal("key3", ids[0]);
@@ -404,12 +406,13 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Filter = new VectorSearchFilter().EqualTo(nameof(AzureCosmosDBMongoDBHotel.HotelName), "My Hotel key2")
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId).ToList();
 
         Assert.Equal("key2", ids[0]);

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -274,9 +274,10 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests(AzureCosm
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f])).ToListAsync();
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]));
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId).ToList();
 
         Assert.Equal("key1", ids[0]);
@@ -304,13 +305,14 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests(AzureCosm
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Top = 2,
             Skip = 2
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId).ToList();
 
         Assert.Equal("key3", ids[0]);
@@ -337,13 +339,14 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests(AzureCosm
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Filter = filter,
             Top = 4,
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var actualIds = searchResults.Select(l => l.Record.HotelId).ToList();
 
         Assert.Equal(expectedIds, actualIds);

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
@@ -224,12 +224,13 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             IncludeVectors = includeVectors
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId.ToString()).ToList();
 
         Assert.Equal("11111111-1111-1111-1111-111111111111", ids[0]);
@@ -261,13 +262,14 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Top = 2,
             Skip = 2
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var ids = searchResults.Select(l => l.Record.HotelId.ToString()).ToList();
 
         Assert.Equal("33333333-3333-3333-3333-333333333333", ids[0]);
@@ -294,13 +296,14 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
             Filter = filter,
             Top = 4,
-        }).ToListAsync();
+        });
 
         // Assert
+        var searchResults = await actual.Results.ToListAsync();
         var actualIds = searchResults.Select(l => l.Record.HotelId.ToString()).ToList();
 
         Assert.Equal(expectedIds, actualIds);
@@ -338,14 +341,14 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         await sut.UpsertBatchAsync([hotel4, hotel2, hotel5, hotel3, hotel1]).ToListAsync();
 
         // Act
-        var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([40f, 40f, 40f, 40f]), new()
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([40f, 40f, 40f, 40f]), new()
         {
             Filter = filter,
             Top = 4,
-        }).ToListAsync();
+        });
 
         // Assert
-
+        var searchResults = await actual.Results.ToListAsync();
         var actualIds = searchResults.Select(l => l.Record.HotelId.ToString()).ToList();
 
         Assert.Single(actualIds);

--- a/dotnet/src/IntegrationTests/Data/BaseVectorStoreTextSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Data/BaseVectorStoreTextSearchTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -104,14 +103,11 @@ public abstract class BaseVectorStoreTextSearchTests : BaseTextSearchTests
         where TRecord : class
     {
         /// <inheritdoc/>
-        public async IAsyncEnumerable<VectorSearchResult<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
         {
             var vectorizedQuery = await textEmbeddingGeneration!.GenerateEmbeddingAsync(searchText, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            await foreach (var result in vectorizedSearch.VectorizedSearchAsync(vectorizedQuery, options, cancellationToken))
-            {
-                yield return result;
-            }
+            return await vectorizedSearch.VectorizedSearchAsync(vectorizedQuery, options, cancellationToken);
         }
     }
 

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizableTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizableTextSearch.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -19,7 +19,7 @@ public interface IVectorizableTextSearch<TRecord>
     /// <param name="options">The options that control the behavior of the search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The records found by the vector search, including their result scores.</returns>
-    IAsyncEnumerable<VectorSearchResult<TRecord>> VectorizableTextSearchAsync(
+    Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(
         string searchText,
         VectorSearchOptions? options = default,
         CancellationToken cancellationToken = default);

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizableTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizableTextSearch.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// Contains a method for doing a vector search using text that will be vectorized downstream.
 /// </summary>
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+[Experimental("SKEXP0001")]
 public interface IVectorizableTextSearch<TRecord>
     where TRecord : class
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizedSearch.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizedSearch.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -20,7 +20,7 @@ public interface IVectorizedSearch<TRecord>
     /// <param name="options">The options that control the behavior of the search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The records found by the vector search, including their result scores.</returns>
-    IAsyncEnumerable<VectorSearchResult<TRecord>> VectorizedSearchAsync<TVector>(
+    Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         VectorSearchOptions? options = default,
         CancellationToken cancellationToken = default);

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizedSearch.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/IVectorizedSearch.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// Contains a method for doing a vector search using a vector.
 /// </summary>
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+[Experimental("SKEXP0001")]
 public interface IVectorizedSearch<TRecord>
     where TRecord : class
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchOptions.cs
@@ -36,4 +36,14 @@ public class VectorSearchOptions
     /// Gets or sets a value indicating whether to include vectors in the retrieval result.
     /// </summary>
     public bool IncludeVectors { get; init; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the total count should be included in the results.
+    /// </summary>
+    /// <remarks>
+    /// Default value is false.
+    /// Not all vector search implementations will support this option in which case the total
+    /// count will be null even if requested via this option.
+    /// </remarks>
+    public bool IncludeTotalCount { get; init; } = false;
 }

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchResults.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchResults.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Contains the full list of search results for a vector search operation with metadata.
+/// </summary>
+/// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+/// <param name="results">The list of records returned by the search operation.</param>
+public class VectorSearchResults<TRecord>(IAsyncEnumerable<VectorSearchResult<TRecord>> results)
+    where TRecord : class
+{
+    /// <summary>
+    /// The total count of results found by the search operation, or null
+    /// if the count was not requested or cannot be computed.
+    /// </summary>
+    /// <remarks>
+    /// This value represents the total number of results that are available for the current query and not the number of results being returned.
+    /// </remarks>
+    public long? TotalCount { get; init; }
+
+    /// <summary>
+    /// The metadata associated with the content.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?>? Metadata { get; init; }
+
+    /// <summary>
+    /// The search results.
+    /// </summary>
+    public IAsyncEnumerable<VectorSearchResult<TRecord>> Results { get; } = results;
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchResults.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorSearch/VectorSearchResults.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// </summary>
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
 /// <param name="results">The list of records returned by the search operation.</param>
+[Experimental("SKEXP0001")]
 public class VectorSearchResults<TRecord>(IAsyncEnumerable<VectorSearchResult<TRecord>> results)
     where TRecord : class
 {

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -126,14 +125,10 @@ public class VectorStoreTextSearchTestBase
         where TRecord : class
     {
         /// <inheritdoc/>
-        public async IAsyncEnumerable<VectorSearchResult<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
         {
             var vectorizedQuery = await textEmbeddingGeneration!.GenerateEmbeddingAsync(searchText, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            await foreach (var result in vectorizedSearch.VectorizedSearchAsync(vectorizedQuery, options, cancellationToken))
-            {
-                yield return result;
-            }
+            return await vectorizedSearch.VectorizedSearchAsync(vectorizedQuery, options, cancellationToken);
         }
     }
 


### PR DESCRIPTION
### Motivation and Context

We currently only return a list of results from vector search, but returning an object that can have additional metadata will help to be more future proof if we need to add more metadata or response information.

#9066

### Description

- Adding a response object for vector search.
- Update all implementations of the interface to use the new response type.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
