### PR TITLE
.Net: Add attributes to add to a model which can be converted to a TextSearchResult

### DIFF
--- a/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
@@ -49,14 +49,12 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
             vectorStore, collectionName, lines, textEmbeddingGeneration, CreateRecord);
 
         // Create a text search instance using the volatile vector store.
-        var stringMapper = new DataModelTextSearchStringMapper();
-        var resultMapper = new DataModelTextSearchResultMapper();
-        var textSearch = new VectorStoreTextSearch<DataModel>(vectorizedSearch, textEmbeddingGeneration, stringMapper, resultMapper);
+        var textSearch = new VectorStoreTextSearch<DataModel>(vectorizedSearch, textEmbeddingGeneration);
         await ExecuteSearchesAsync(textSearch);
 
         // Create a text search instance using a vectorized search wrapper around the volatile vector store.
         IVectorizableTextSearch<DataModel> vectorizableTextSearch = new VectorizedSearchWrapper<DataModel>(vectorizedSearch, textEmbeddingGeneration);
-        textSearch = new VectorStoreTextSearch<DataModel>(vectorizableTextSearch, stringMapper, resultMapper);
+        textSearch = new VectorStoreTextSearch<DataModel>(vectorizableTextSearch);
         await ExecuteSearchesAsync(textSearch);
     }
 
@@ -93,38 +91,6 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
             Console.WriteLine($"Text:        {result.Text}");
             Console.WriteLine($"Embedding:   {result.Embedding.Length}");
             WriteHorizontalRule();
-        }
-    }
-
-    /// <summary>
-    /// String mapper which converts a DataModel to a string.
-    /// </summary>
-    private sealed class DataModelTextSearchStringMapper : ITextSearchStringMapper
-    {
-        /// <inheritdoc />
-        public string MapFromResultToString(object result)
-        {
-            if (result is DataModel dataModel)
-            {
-                return dataModel.Text;
-            }
-            throw new ArgumentException("Invalid result type.");
-        }
-    }
-
-    /// <summary>
-    /// Result mapper which converts a DataModel to a TextSearchResult.
-    /// </summary>
-    private sealed class DataModelTextSearchResultMapper : ITextSearchResultMapper
-    {
-        /// <inheritdoc />
-        public TextSearchResult MapFromResultToTextSearchResult(object result)
-        {
-            if (result is DataModel dataModel)
-            {
-                return new TextSearchResult(name: dataModel.Key.ToString(), value: dataModel.Text);
-            }
-            throw new ArgumentException("Invalid result type.");
         }
     }
 
@@ -199,9 +165,11 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
     private sealed class DataModel
     {
         [VectorStoreRecordKey]
+        [TextSearchResultName]
         public Guid Key { get; init; }
 
         [VectorStoreRecordData]
+        [TextSearchResultValue]
         public string Text { get; init; }
 
         [VectorStoreRecordVector(1536)]

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultLinkAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultLinkAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Attribute to mark a property on a record class as the link to the source data.
+/// </summary>
+/// <remarks>
+/// The characteristics defined here will influence how the property is treated when converting a record to a <see cref="TextSearchResult"/>.
+/// </remarks>
+[Experimental("SKEXP0001")]
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class TextSearchResultLinkAttribute : Attribute
+{
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultNameAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultNameAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Attribute to mark a property on a record class as the name of the source data.
+/// </summary>
+/// <remarks>
+/// The characteristics defined here will influence how the property is treated when converting a record to a <see cref="TextSearchResult"/>.
+/// </remarks>
+[Experimental("SKEXP0001")]
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class TextSearchResultNameAttribute : Attribute
+{
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultPropertyReader.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultPropertyReader.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.SemanticKernel.Data.TextSearch;
+internal sealed class TextSearchResultPropertyReader
+{
+    /// <summary>The <see cref="Type"/> of the data model.</summary>
+    private readonly Type _dataModelType;
+
+    /// <summary>The <see cref="PropertyInfo"/> of the name property.</summary>
+    private readonly PropertyInfo? _nameProperty;
+
+    /// <summary>The <see cref="PropertyInfo"/> of the value property.</summary>
+    private readonly PropertyInfo? _valueProperty;
+
+    /// <summary>The <see cref="PropertyInfo"/> of the link property.</summary>
+    private readonly PropertyInfo? _linkProperty;
+
+    public TextSearchResultPropertyReader(Type dataModelType)
+    {
+        this._dataModelType = dataModelType;
+
+        var (NameProperty, ValueProperty, LinkProperty) = FindPropertiesInfo(dataModelType);
+        this._nameProperty = NameProperty;
+        this._valueProperty = ValueProperty;
+        this._linkProperty = LinkProperty;
+    }
+
+    /// <summary>
+    /// Get the name property value of the data model.
+    /// </summary>
+    /// <param name="dataModel">The data model instance.</param>
+    public string? GetName(object dataModel)
+    {
+        return this._nameProperty?.GetValue(dataModel)?.ToString();
+    }
+
+    /// <summary>
+    /// Get the value property value of the data model.
+    /// </summary>
+    /// <param name="dataModel">The data model instance.</param>
+    public string? GetValue(object dataModel)
+    {
+        return this._valueProperty?.GetValue(dataModel)?.ToString();
+    }
+
+    /// <summary>
+    /// Get the link property value of the data model.
+    /// </summary>
+    /// <param name="dataModel">The data model instance.</param>
+    public string? GetLink(object dataModel)
+    {
+        return this._linkProperty?.GetValue(dataModel)?.ToString();
+    }
+
+    /// <summary>
+    /// Find the properties with <see cref="TextSearchResultNameAttribute"/>, <see cref="TextSearchResultValueAttribute"/> and <see cref="TextSearchResultLinkAttribute"/> attributes
+    /// </summary>
+    /// <param name="type">The data model to find the properties on.</param>
+    /// <returns>The properties.</returns>
+    private static (PropertyInfo? NameProperty, PropertyInfo? ValueProperty, PropertyInfo? LinkProperty) FindPropertiesInfo(Type type)
+    {
+        PropertyInfo? nameProperty = null;
+        PropertyInfo? valueProperty = null;
+        PropertyInfo? linkProperty = null;
+
+        foreach (var property in type.GetProperties())
+        {
+            // Get name property.
+            if (property.GetCustomAttribute<TextSearchResultNameAttribute>() is not null)
+            {
+                nameProperty = property;
+            }
+
+            // Get value property.
+            if (property.GetCustomAttribute<TextSearchResultValueAttribute>() is not null)
+            {
+                valueProperty = property;
+            }
+
+            // Get link property.
+            if (property.GetCustomAttribute<TextSearchResultLinkAttribute>() is not null)
+            {
+                linkProperty = property;
+            }
+        }
+
+        return (nameProperty, valueProperty, linkProperty);
+    }
+}

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultValueAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultValueAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Attribute to mark a property on a record class as the value of the source data.
+/// </summary>
+/// <remarks>
+/// The characteristics defined here will influence how the property is treated when converting a record to a <see cref="TextSearchResult"/>.
+/// </remarks>
+[Experimental("SKEXP0001")]
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class TextSearchResultValueAttribute : Attribute
+{
+}

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchResultPropertyReader.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchResultPropertyReader.cs
@@ -3,7 +3,11 @@
 using System;
 using System.Reflection;
 
-namespace Microsoft.SemanticKernel.Data.TextSearch;
+namespace Microsoft.SemanticKernel.Data;
+
+/// <summary>
+/// Contains helpers for reading <see cref="TextSearchResult" /> attributes.
+/// </summary>
 internal sealed class TextSearchResultPropertyReader
 {
     /// <summary>The <see cref="Type"/> of the data model.</summary>
@@ -18,6 +22,10 @@ internal sealed class TextSearchResultPropertyReader
     /// <summary>The <see cref="PropertyInfo"/> of the link property.</summary>
     private readonly PropertyInfo? _linkProperty;
 
+    /// <summary>
+    /// Create a new instance of <see cref="TextSearchResultPropertyReader"/>.
+    /// </summary>
+    /// <param name="dataModelType">Type of the data model.</param>
     public TextSearchResultPropertyReader(Type dataModelType)
     {
         this._dataModelType = dataModelType;
@@ -71,18 +79,30 @@ internal sealed class TextSearchResultPropertyReader
             // Get name property.
             if (property.GetCustomAttribute<TextSearchResultNameAttribute>() is not null)
             {
+                if (nameProperty is not null)
+                {
+                    throw new InvalidOperationException($"Multiple properties with {nameof(TextSearchResultNameAttribute)} found on {type}.");
+                }
                 nameProperty = property;
             }
 
             // Get value property.
             if (property.GetCustomAttribute<TextSearchResultValueAttribute>() is not null)
             {
+                if (valueProperty is not null)
+                {
+                    throw new InvalidOperationException($"Multiple properties with {nameof(TextSearchResultValueAttribute)} found on {type}.");
+                }
                 valueProperty = property;
             }
 
             // Get link property.
             if (property.GetCustomAttribute<TextSearchResultLinkAttribute>() is not null)
             {
+                if (linkProperty is not null)
+                {
+                    throw new InvalidOperationException($"Multiple properties with {nameof(TextSearchResultLinkAttribute)} found on {type}.");
+                }
                 linkProperty = property;
             }
         }

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -160,7 +160,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
     /// </summary>
     private TextSearchResultMapper CreateTextSearchResultMapper()
     {
-        TextSearchResult MapFromResultToTextSearchResult(object result)
+        return new TextSearchResultMapper(result =>
         {
             if (typeof(TRecord) != result.GetType())
             {
@@ -171,9 +171,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
                 name: this._propertyReader.Value.GetName(result),
                 value: this._propertyReader.Value.GetValue(result),
                 link: this._propertyReader.Value.GetLink(result));
-        };
-
-        return new TextSearchResultMapper(MapFromResultToTextSearchResult);
+        });
     }
 
     /// <summary>
@@ -181,7 +179,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
     /// </summary>
     private TextSearchStringMapper CreateTextSearchStringMapper()
     {
-        string MapFromResultToString(object result)
+        return new TextSearchStringMapper(result =>
         {
             if (typeof(TRecord) != result.GetType())
             {
@@ -190,8 +188,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
             var value = this._propertyReader.Value.GetValue(result);
             return (string?)value ?? throw new InvalidOperationException("Value property cannot be null.");
-        };
-        return new TextSearchStringMapper(MapFromResultToString);
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

Add attributes to add to a model which can be converted to a TextSearchResult.
This allows a `VectorStoreTextSearch` to be created without the need to provide mappers.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
