### PR TITLE
.NET: Processes support for sub-processes

### DIFF
--- a/dotnet/samples/GettingStartedWithProcesses/Step01/Step01_Processes.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step01/Step01_Processes.cs
@@ -38,7 +38,7 @@ public class Step01_Processes(ITestOutputHelper output) : BaseTest(output, redir
 
         // Define the behavior when the process receives an external event
         process
-            .OnExternalEvent(ChatBotEvents.StartProcess)
+            .OnInputEvent(ChatBotEvents.StartProcess)
             .SendEventTo(new ProcessFunctionTargetBuilder(introStep));
 
         // When the intro is complete, notify the userInput step

--- a/dotnet/samples/GettingStartedWithProcesses/Step01/Step01_Processes.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step01/Step01_Processes.cs
@@ -46,9 +46,9 @@ public class Step01_Processes(ITestOutputHelper output) : BaseTest(output, redir
             .OnFunctionResult(nameof(IntroStep.PrintIntroMessage))
             .SendEventTo(new ProcessFunctionTargetBuilder(userInputStep));
 
-        // When the userInput step emits an exit event, send it to the end steprt
+        // When the userInput step emits an exit event, send it to the end step
         userInputStep
-            .OnFunctionResult("GetUserInput")
+            .OnEvent(ChatBotEvents.Exit)
             .StopProcess();
 
         // When the userInput step emits a user input event, send it to the assistantResponse step

--- a/dotnet/samples/GettingStartedWithProcesses/Step02/Step02_AccountOpening.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step02/Step02_AccountOpening.cs
@@ -30,7 +30,7 @@ public class Step02_AccountOpening(ITestOutputHelper output) : BaseTest(output, 
         var crmRecordStep = process.AddStepFromType<CRMRecordCreationStep>();
         var welcomePacketStep = process.AddStepFromType<WelcomePacketStep>();
 
-        process.OnExternalEvent(AccountOpeningEvents.StartProcess)
+        process.OnInputEvent(AccountOpeningEvents.StartProcess)
             .SendEventTo(new ProcessFunctionTargetBuilder(newCustomerFormStep, CompleteNewCustomerFormStep.Functions.NewAccountWelcome));
 
         // When the welcome message is generated, send message to displayAssistantMessageStep

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessEvent.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessEvent.cs
@@ -16,4 +16,9 @@ public sealed record KernelProcessEvent
     /// An optional data payload associated with the event.
     /// </summary>
     public object? Data { get; set; }
+
+    /// <summary>
+    /// The visibility of the event. Defaults to <see cref="KernelProcessEventVisibility.Internal"/>.
+    /// </summary>
+    public KernelProcessEventVisibility Visibility { get; set; } = KernelProcessEventVisibility.Internal;
 }

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessEventVisibility.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessEventVisibility.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// An enumeration representing the visibility of a <see cref="KernelProcessEvent"/>. This is used to determine
+/// if the event is kept within the process it's emitted in, or exposed to external processes and systems.
+/// </summary>
+public enum KernelProcessEventVisibility
+{
+    /// <summary>
+    /// The event is only visible to steps within the same process.
+    /// </summary>
+    Internal,
+
+    /// <summary>
+    /// The event is visible inside the process as well as outside the process. This is useful
+    /// when the event is intended to be consumed by other processes or external systems.
+    /// </summary>
+    Public
+}

--- a/dotnet/src/Experimental/Process.Abstractions/KernelProcessFunctionTarget.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/KernelProcessFunctionTarget.cs
@@ -10,7 +10,7 @@ public record KernelProcessFunctionTarget
     /// <summary>
     /// Creates an instance of the <see cref="KernelProcessFunctionTarget"/> class.
     /// </summary>
-    public KernelProcessFunctionTarget(string stepId, string functionName, string? parameterName = null)
+    public KernelProcessFunctionTarget(string stepId, string functionName, string? parameterName = null, string? targetEventId = null)
     {
         Verify.NotNullOrWhiteSpace(stepId);
         Verify.NotNullOrWhiteSpace(functionName);
@@ -18,6 +18,7 @@ public record KernelProcessFunctionTarget
         this.StepId = stepId;
         this.FunctionName = functionName;
         this.ParameterName = parameterName;
+        this.TargetEventId = targetEventId;
     }
 
     /// <summary>
@@ -34,4 +35,9 @@ public record KernelProcessFunctionTarget
     /// The name of the parameter to target. This may be null if the function has no parameters.
     /// </summary>
     public string? ParameterName { get; init; }
+
+    /// <summary>
+    /// The unique identifier for the event to target. This may be null if the target is not a sub-process.
+    /// </summary>
+    public string? TargetEventId { get; init; }
 }

--- a/dotnet/src/Experimental/Process.Core/Internal/EndStep.cs
+++ b/dotnet/src/Experimental/Process.Core/Internal/EndStep.cs
@@ -34,12 +34,6 @@ internal sealed class EndStep : ProcessStepBuilder
     {
     }
 
-    internal override string GetScopedEventId(string eventId)
-    {
-        // No event scoping for the end step.
-        return eventId;
-    }
-
     internal override Dictionary<string, KernelFunctionMetadata> GetFunctionMetadataMap()
     {
         // The end step has no functions.

--- a/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
@@ -133,7 +133,7 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     /// </summary>
     /// <param name="eventId">The Id of the external event.</param>
     /// <returns>An instance of <see cref="ProcessStepEdgeBuilder"/></returns>
-    public ProcessEdgeBuilder OnExternalEvent(string eventId)
+    public ProcessEdgeBuilder OnInputEvent(string eventId)
     {
         return new ProcessEdgeBuilder(this, eventId);
     }
@@ -144,7 +144,7 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     /// <param name="eventId">The Id of the event</param>
     /// <returns>An instance of <see cref="ProcessFunctionTargetBuilder"/></returns>
     /// <exception cref="KernelException"></exception>
-    public ProcessFunctionTargetBuilder GetTargetForExternalEvent(string eventId)
+    public ProcessFunctionTargetBuilder WhereInputEventIs(string eventId)
     {
         Verify.NotNullOrWhiteSpace(eventId);
 

--- a/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
@@ -11,9 +11,19 @@ namespace Microsoft.SemanticKernel;
 /// </summary>
 public sealed class ProcessBuilder : ProcessStepBuilder
 {
-    private readonly List<ProcessStepBuilder> _steps;
-    private readonly List<ProcessStepBuilder> _entrySteps;
-    private readonly Dictionary<string, ProcessStepBuilder> _stepsMap;
+    /// <summary>The collection of steps within this process.</summary>
+    private readonly List<ProcessStepBuilder> _steps = [];
+
+    /// <summary>The collection of entry steps within this process.</summary>
+    private readonly List<ProcessStepBuilder> _entrySteps = [];
+
+    /// <summary>Maps external event Ids to the target entry step for the event.</summary>
+    private readonly Dictionary<string, ProcessFunctionTargetBuilder> _externalEventTargetMap = [];
+
+    /// <summary>
+    /// A boolean indicating if the current process is a step within another process.
+    /// </summary>
+    internal bool HasParentProcess { get; set; }
 
     /// <summary>
     /// Used to resolve the target function and parameter for a given optional function name and parameter name.
@@ -56,16 +66,13 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     /// <inheritdoc/>
     internal override void LinkTo(string eventId, ProcessStepEdgeBuilder edgeBuilder)
     {
+        Verify.NotNull(edgeBuilder?.Source, nameof(edgeBuilder.Source));
+        Verify.NotNull(edgeBuilder?.Target, nameof(edgeBuilder.Target));
+
         // Keep track of the entry point steps
         this._entrySteps.Add(edgeBuilder.Source);
+        this._externalEventTargetMap[eventId] = edgeBuilder.Target;
         base.LinkTo(eventId, edgeBuilder);
-    }
-
-    /// <inheritdoc/>
-    internal override string GetScopedEventId(string eventId)
-    {
-        // The event id is scoped to the process name
-        return $"{this.Name}.{eventId}";
     }
 
     /// <inheritdoc/>
@@ -104,7 +111,6 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     {
         var stepBuilder = new ProcessStepBuilder<TStep>(name);
         this._steps.Add(stepBuilder);
-        this._stepsMap[stepBuilder.Name] = stepBuilder;
 
         return stepBuilder;
     }
@@ -114,15 +120,10 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     /// </summary>
     /// <param name="kernelProcess">The process to add as a step.</param>
     /// <returns>An instance of <see cref="ProcessStepBuilder"/></returns>
-    public ProcessStepBuilder AddStepFromProcess(ProcessBuilder kernelProcess)
+    public ProcessBuilder AddStepFromProcess(ProcessBuilder kernelProcess)
     {
-        // TODO: Could this method be converted to an "AddStepFromObject" method takes an
-        // instance of ProcessStepBase and adds it to the process?
-        // This would work for processes.
-        // This would benefit steps because the initial value of state could be captured?
-
+        kernelProcess.HasParentProcess = true;
         this._steps.Add(kernelProcess);
-        this._stepsMap[kernelProcess.Name] = kernelProcess;
         return kernelProcess;
     }
 
@@ -135,6 +136,26 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     public ProcessEdgeBuilder OnExternalEvent(string eventId)
     {
         return new ProcessEdgeBuilder(this, eventId);
+    }
+
+    /// <summary>
+    /// Retrieves the target for a given external event. The step associated with the target is the process itself (this).
+    /// </summary>
+    /// <param name="eventId">The Id of the event</param>
+    /// <returns>An instance of <see cref="ProcessFunctionTargetBuilder"/></returns>
+    /// <exception cref="KernelException"></exception>
+    public ProcessFunctionTargetBuilder GetTargetForExternalEvent(string eventId)
+    {
+        Verify.NotNullOrWhiteSpace(eventId);
+
+        if (!this._externalEventTargetMap.TryGetValue(eventId, out var target))
+        {
+            throw new KernelException($"The process named '{this.Name}' does not expose an event with Id '{eventId}'.");
+        }
+
+        // Targets for external events on a process should be scoped to the process iteself rather than the step inside the process.
+        var processTarget = target with { Step = this, TargetEventId = eventId };
+        return processTarget;
     }
 
     /// <summary>
@@ -151,7 +172,7 @@ public sealed class ProcessBuilder : ProcessStepBuilder
         var builtSteps = this._steps.Select(step => step.BuildStep()).ToList();
 
         // Create the process
-        var state = new KernelProcessState(this.Name);
+        var state = new KernelProcessState(this.Name, id: this.HasParentProcess ? this.Id : null);
         var process = new KernelProcess(state, builtSteps, builtEdges);
         return process;
     }
@@ -163,9 +184,6 @@ public sealed class ProcessBuilder : ProcessStepBuilder
     public ProcessBuilder(string name)
         : base(name)
     {
-        this._steps = [];
-        this._entrySteps = [];
-        this._stepsMap = [];
     }
 
     #endregion

--- a/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessBuilder.cs
@@ -153,7 +153,7 @@ public sealed class ProcessBuilder : ProcessStepBuilder
             throw new KernelException($"The process named '{this.Name}' does not expose an event with Id '{eventId}'.");
         }
 
-        // Targets for external events on a process should be scoped to the process iteself rather than the step inside the process.
+        // Targets for external events on a process should be scoped to the process itself rather than the step inside the process.
         var processTarget = target with { Step = this, TargetEventId = eventId };
         return processTarget;
     }

--- a/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessFunctionTargetBuilder.cs
@@ -5,7 +5,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Provides functionality for incrementally defining a process function target.
 /// </summary>
-public sealed class ProcessFunctionTargetBuilder
+public sealed record ProcessFunctionTargetBuilder
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessFunctionTargetBuilder"/> class.
@@ -41,7 +41,7 @@ public sealed class ProcessFunctionTargetBuilder
     internal KernelProcessFunctionTarget Build()
     {
         Verify.NotNull(this.Step.Id);
-        return new KernelProcessFunctionTarget(this.Step.Id, this.FunctionName, this.ParameterName);
+        return new KernelProcessFunctionTarget(this.Step.Id, this.FunctionName, this.ParameterName, this.TargetEventId);
     }
 
     /// <summary>
@@ -58,4 +58,9 @@ public sealed class ProcessFunctionTargetBuilder
     /// The name of the parameter to target. This may be null if the function has no parameters.
     /// </summary>
     public string? ParameterName { get; init; }
+
+    /// <summary>
+    /// The unique identifier for the event to target. This may be null if the target is not a sub-process.
+    /// </summary>
+    public string? TargetEventId { get; init; }
 }

--- a/dotnet/src/Experimental/Process.Core/ProcessStepEdgeBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessStepEdgeBuilder.cs
@@ -49,15 +49,15 @@ public sealed class ProcessStepEdgeBuilder
     /// <summary>
     /// Signals that the output of the source step should be sent to the specified target when the associated event fires.
     /// </summary>
-    /// <param name="outputTarget">The output target.</param>
-    public void SendEventTo(ProcessFunctionTargetBuilder outputTarget)
+    /// <param name="target">The output target.</param>
+    public void SendEventTo(ProcessFunctionTargetBuilder target)
     {
         if (this.Target is not null)
         {
             throw new InvalidOperationException("An output target has already been set.");
         }
 
-        this.Target = outputTarget;
+        this.Target = target;
         this.Source.LinkTo(this.EventId, this);
     }
 

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalEvent.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalEvent.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Process;
+
+/// <summary>
+/// A wrapper around <see cref="KernelProcessEvent"/> that helps to manage the namespace of the event.
+/// </summary>
+internal record LocalEvent
+{
+    /// <summary>
+    /// The inner <see cref="KernelProcessEvent"/> that this <see cref="LocalEvent"/> wraps.
+    /// </summary>
+    private KernelProcessEvent InnerEvent { get; init; }
+
+    /// <summary>
+    /// The namespace of the event.
+    /// </summary>
+    internal string? Namespace { get; init; }
+
+    /// <summary>
+    /// The Id of the event.
+    /// </summary>
+    internal string Id => $"{this.Namespace}.{this.InnerEvent.Id}";
+
+    /// <summary>
+    /// The data of the event.
+    /// </summary>
+    internal object? Data => this.InnerEvent.Data;
+
+    /// <summary>
+    /// The visibility of the event.
+    /// </summary>
+    internal KernelProcessEventVisibility Visibility => this.InnerEvent.Visibility;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalEvent"/> class.
+    /// </summary>
+    /// <param name="eventNamespace">The namespace of the event.</param>
+    /// <param name="innerEvent">The instance of <see cref="KernelProcessEvent"/> that this <see cref="LocalEvent"/> came from.</param>
+    internal LocalEvent(string? eventNamespace, KernelProcessEvent innerEvent)
+    {
+        this.Namespace = eventNamespace;
+        this.InnerEvent = innerEvent;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="LocalEvent"/> from a <see cref="KernelProcessEvent"/>.
+    /// </summary>
+    /// <param name="kernelProcessEvent">The <see cref="KernelProcessEvent"/></param>
+    /// <param name="Namespace">The namespace of the event.</param>
+    /// <returns>An instance of <see cref="LocalEvent"/></returns>
+    internal static LocalEvent FromKernelProcessEvent(KernelProcessEvent kernelProcessEvent, string Namespace) => new(Namespace, kernelProcessEvent);
+}

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalKernelProcessContext.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalKernelProcessContext.cs
@@ -47,6 +47,12 @@ public sealed class LocalKernelProcessContext : IDisposable
     public async Task StopAsync() => await this._localProcess.StopAsync().ConfigureAwait(false);
 
     /// <summary>
+    /// Gets a snapshot of the current state of the process.
+    /// </summary>
+    /// <returns>A <see cref="Task{T}"/> where T is <see cref="KernelProcess"/></returns>
+    public async Task<KernelProcess> GetStateAsync() => await this._localProcess.GetProcessInfoAsync().ConfigureAwait(false);
+
+    /// <summary>
     /// Disposes of the resources used by the process.
     /// </summary>
     public void Dispose() => this._localProcess?.Dispose();

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalMessage.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalMessage.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel;
 /// <param name="destinationId">The destination identifier of the message.</param>
 /// <param name="functionName">The name of the function associated with the message.</param>
 /// <param name="values">The dictionary of values associated with the message.</param>
-internal class LocalMessage(string sourceId, string destinationId, string functionName, Dictionary<string, object?> values)
+internal record LocalMessage(string sourceId, string destinationId, string functionName, Dictionary<string, object?> values)
 {
     /// <summary>
     /// Gets the source identifier of the message.
@@ -34,4 +34,14 @@ internal class LocalMessage(string sourceId, string destinationId, string functi
     /// Gets the dictionary of values associated with the message.
     /// </summary>
     public Dictionary<string, object?> Values { get; } = values;
+
+    /// <summary>
+    /// The Id of the target event. This may be null if the message is not targeting a sub-process.
+    /// </summary>
+    public string? TargetEventId { get; init; }
+
+    /// <summary>
+    /// The data associated with the target event. This may be null if the message is not targeting a sub-process.
+    /// </summary>
+    public object? TargetEventData { get; init; }
 }

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalMessageFactory.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalMessageFactory.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.SemanticKernel.Process;
+
+/// <summary>
+/// A factory class for creating <see cref="LocalMessage"/> instances.
+/// </summary>
+internal static class LocalMessageFactory
+{
+    /// <summary>
+    /// Creates a new <see cref="LocalMessage"/> instance from a <see cref="KernelProcessEdge"/> and a data object.
+    /// </summary>
+    /// <param name="edge">An instance of <see cref="KernelProcessEdge"/></param>
+    /// <param name="data">A data object.</param>
+    /// <returns>An instance of <see cref="LocalMessage"/></returns>
+    internal static LocalMessage CreateFromEdge(KernelProcessEdge edge, object? data)
+    {
+        var target = edge.OutputTarget;
+        Dictionary<string, object?> parameterValue = [];
+        if (!string.IsNullOrWhiteSpace(target.ParameterName))
+        {
+            parameterValue.Add(target.ParameterName!, data);
+        }
+
+        LocalMessage newMessage = new(edge.SourceStepId, target.StepId, target.FunctionName, parameterValue)
+        {
+            TargetEventId = target.TargetEventId,
+            TargetEventData = data
+        };
+
+        return newMessage;
+    }
+}

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
@@ -8,6 +8,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Process;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.SemanticKernel;
@@ -18,6 +19,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     private readonly JoinableTaskFactory _joinableTaskFactory;
     private readonly JoinableTaskContext _joinableTaskContext;
     private readonly Channel<KernelProcessEvent> _externalEventChannel;
+    private readonly Queue<KernelProcessEvent> _eventQueue = new();
     private readonly Lazy<ValueTask> _initializeTask;
 
     internal readonly List<KernelProcessStepInfo> _stepsInfos;
@@ -25,7 +27,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     internal readonly KernelProcess _process;
     internal readonly Kernel _kernel;
 
-    private readonly ILogger? _logger;
+    private readonly ILogger _logger;
     private JoinableTask? _processTask;
     private CancellationTokenSource? _processCancelSource;
 
@@ -125,6 +127,88 @@ internal sealed class LocalProcess : LocalStep, IDisposable
         await this._externalEventChannel.Writer.WriteAsync(processEvent).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Gets the process information.
+    /// </summary>
+    /// <returns>An instance of <see cref="KernelProcess"/></returns>
+    internal async Task<KernelProcess> GetProcessInfoAsync()
+    {
+        return await this.ToKernelProcessAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles a <see cref="LocalMessage"/> that has been sent to the process. This happens only in the case
+    /// of a process (this one) running as a step within another process (this one's parent). In this case the
+    /// entire sub-process should be executed within a single superstep.
+    /// </summary>
+    /// <param name="message">The message to process.</param>
+    /// <returns>A <see cref="Task"/></returns>
+    /// <exception cref="KernelException"></exception>
+    internal override async Task HandleMessageAsync(LocalMessage message)
+    {
+        if (string.IsNullOrWhiteSpace(message.TargetEventId))
+        {
+            string errorMessage = "Internal Process Error: The target event id must be specified when sending a message to a step.";
+            this._logger.LogError("{ErrorMessage}", errorMessage);
+            throw new KernelException(errorMessage);
+        }
+
+        string eventId = message.TargetEventId!;
+        if (this._outputEdges!.TryGetValue(eventId, out List<KernelProcessEdge>? edges) && edges is not null)
+        {
+            foreach (var edge in edges)
+            {
+                // Create the external event that will be used to start the nested process. Since this event came
+                // from outside this processes, we set the visibility to internal so that it's not emitted back out again.
+                var nestedEvent = new KernelProcessEvent() { Id = eventId, Data = message.TargetEventData, Visibility = KernelProcessEventVisibility.Internal };
+
+                // Run the nested process completely within a single superstep.
+                await this.RunOnceAsync(nestedEvent, this._kernel).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the process information.
+    /// </summary>
+    /// <returns>An instance of <see cref="KernelProcess"/></returns>
+    internal async Task<KernelProcess> GetProcessInfoAsync()
+    {
+        return await this.ToKernelProcessAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles a <see cref="LocalMessage"/> that has been sent to the process. This happens only in the case
+    /// of a process (this one) running as a step within another process (this one's parent). In this case the
+    /// entire sub-process should be executed within a single superstep.
+    /// </summary>
+    /// <param name="message">The message to process.</param>
+    /// <returns>A <see cref="Task"/></returns>
+    /// <exception cref="KernelException"></exception>
+    internal override async Task HandleMessageAsync(LocalMessage message)
+    {
+        if (string.IsNullOrWhiteSpace(message.TargetEventId))
+        {
+            string errorMessage = "Internal Process Error: The target event id must be specified when sending a message to a step.";
+            this._logger.LogError("{ErrorMessage}", errorMessage);
+            throw new KernelException(errorMessage);
+        }
+
+        string eventId = message.TargetEventId!;
+        if (this._outputEdges!.TryGetValue(eventId, out List<KernelProcessEdge>? edges) && edges is not null)
+        {
+            foreach (var edge in edges)
+            {
+                // Create the external event that will be used to start the nested process. Since this event came
+                // from outside this processes, we set the visibility to internal so that it's not emitted back out again.
+                var nestedEvent = new KernelProcessEvent() { Id = eventId, Data = message.TargetEventData, Visibility = KernelProcessEventVisibility.Internal };
+
+                // Run the nested process completely within a single superstep.
+                await this.RunOnceAsync(nestedEvent, this._kernel).ConfigureAwait(false);
+            }
+        }
+    }
+
     #region Private Methods
 
     /// <summary>
@@ -158,6 +242,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
                     parentProcessId: this.Id,
                     loggerFactory: this.LoggerFactory);
 
+                //await process.StartAsync(kernel: this._kernel, keepAlive: true).ConfigureAwait(false);
                 localStep = process;
             }
             else
@@ -179,17 +264,41 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     }
 
     /// <summary>
-    /// Executes the process asynchronously until one of the following conditions is met:
-    /// - The process has been cancelled.
-    /// - The process has hit the specified limit of supersteps.
-    /// - There are no more messages to be process AND <paramref name="keepAlive"/> is false. No more messages means that
-    /// none of the steps in this process emitted any events in the last superstep, indicating that they have finished processing.
+    /// Initializes this process as a step within another process.
     /// </summary>
-    /// <param name="kernel">An options override of the process level kernel.</param>
-    /// <param name="maxSupersteps">The maximum number of supersteps that this process can execute. Defaults to 100.</param>
-    /// <param name="keepAlive">If true, the process will continue running after internal events have stopped. This allows the process to wait for external events.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
-    /// <returns></returns>
+    /// <returns>A <see cref="ValueTask"/></returns>
+    /// <exception cref="KernelException"></exception>
+    protected override ValueTask InitializeStepAsync()
+    {
+        // The process does not need any further initialization as it's already been initialized.
+        // Override the base method to prevent it from being called.
+        return default;
+    }
+
+    /// <summary>
+    /// Initializes this process as a step within another process.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/></returns>
+    /// <exception cref="KernelException"></exception>
+    protected override ValueTask InitializeStepAsync()
+    {
+        // The process does not need any further initialization as it's already been initialized.
+        // Override the base method to prevent it from being called.
+        return default;
+    }
+
+    /// <summary>
+    /// Emits an event from the step.
+    /// </summary>
+    /// <param name="processEvent">The event to emit.</param>
+    /// <returns>A <see cref="ValueTask"/></returns>
+    public override ValueTask EmitEventAsync(KernelProcessEvent processEvent)
+    {
+        var scopedEvent = processEvent with { Id = this.StepScopedEventId(processEvent.Id!) };
+        this._eventQueue.Enqueue(scopedEvent);
+        return default;
+    }
+
     private async Task Internal_ExecuteAsync(Kernel? kernel = null, int maxSupersteps = 100, bool keepAlive = true, CancellationToken cancellationToken = default)
     {
         Kernel localKernel = kernel ?? this._kernel;
@@ -275,14 +384,8 @@ internal sealed class LocalProcess : LocalStep, IDisposable
             {
                 foreach (var edge in edges)
                 {
-                    Dictionary<string, object?> parameterValue = new();
-                    if (!string.IsNullOrWhiteSpace(edge.OutputTarget.ParameterName))
-                    {
-                        parameterValue.Add(edge.OutputTarget.ParameterName!, externalEvent.Data);
-                    }
-
-                    LocalMessage newMessage = new(edge.SourceStepId, edge.OutputTarget.StepId, edge.OutputTarget.FunctionName, parameterValue);
-                    messageChannel.Enqueue(newMessage);
+                    LocalMessage message = LocalMessageFactory.CreateFromEdge(edge, externalEvent.Data);
+                    messageChannel.Enqueue(message);
                 }
             }
         }
@@ -299,19 +402,42 @@ internal sealed class LocalProcess : LocalStep, IDisposable
         var allStepEvents = step.GetAllEvents();
         foreach (var stepEvent in allStepEvents)
         {
+            // Emit the event out of the process (this one) if it's visibility is public.
+            if (stepEvent.Visibility == KernelProcessEventVisibility.Public)
+            {
+                base.EmitEvent(stepEvent);
+            }
+
+            // Get the edges for the event and queue up the messages to be sent to the next steps.
             foreach (var edge in step.GetEdgeForEvent(stepEvent.Id!))
             {
-                var target = edge.OutputTarget;
-                Dictionary<string, object?> parameterValue = new();
-                if (!string.IsNullOrWhiteSpace(target.ParameterName))
-                {
-                    parameterValue.Add(target.ParameterName!, stepEvent.Data);
-                }
-
-                LocalMessage newMessage = new(edge.SourceStepId, target.StepId, target.FunctionName, parameterValue);
-                messageChannel.Enqueue(newMessage);
+                LocalMessage message = LocalMessageFactory.CreateFromEdge(edge, stepEvent.Data);
+                messageChannel.Enqueue(message);
             }
         }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="KernelProcess"/> from the current <see cref="LocalProcess"/>.
+    /// </summary>
+    /// <returns>An instance of <see cref="KernelProcess"/></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    private async Task<KernelProcess> ToKernelProcessAsync()
+    {
+        var processState = new KernelProcessState(this.Name, this.Id);
+        var stepTasks = this._steps.Select(step => step.ToKernelProcessStepInfoAsync()).ToList();
+        var steps = await Task.WhenAll(stepTasks).ConfigureAwait(false);
+        return new KernelProcess(processState, steps, this._outputEdges);
+    }
+
+    /// <summary>
+    /// When the process is used as a step within another process, this method will be called
+    /// rather than ToKernelProcessAsync when extracting the state.
+    /// </summary>
+    /// <returns>A <see cref="Task{T}"/> where T is <see cref="KernelProcess"/></returns>
+    internal override async Task<KernelProcessStepInfo> ToKernelProcessStepInfoAsync()
+    {
+        return await this.ToKernelProcessAsync().ConfigureAwait(false);
     }
 
     #endregion

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.Process;
 
 namespace Microsoft.SemanticKernel;
 
@@ -20,19 +21,21 @@ internal class LocalStep : KernelProcessMessageChannel
     /// The generic state type for a process step.
     /// </summary>
     private static readonly Type s_genericType = typeof(KernelProcessStep<>);
-    private Dictionary<string, Dictionary<string, object?>?>? _inputs;
-    private Dictionary<string, Dictionary<string, object?>?>? _initialInputs;
 
-    private readonly Dictionary<string, KernelFunction> _functions = [];
     private readonly Kernel _kernel;
-    private readonly Queue<KernelProcessEvent> _eventQueue = new();
+    private readonly Queue<LocalEvent> _outgoingEventQueue = new();
     private readonly Lazy<ValueTask> _initializeTask;
     private readonly KernelProcessStepInfo _stepInfo;
+    private readonly string _eventNamespace;
     private readonly ILogger? _logger;
 
+    protected KernelProcessStepState _stepState;
+    protected Dictionary<string, Dictionary<string, object?>?>? _inputs = [];
+    protected Dictionary<string, Dictionary<string, object?>?>? _initialInputs = [];
+    protected readonly Dictionary<string, KernelFunction> _functions = [];
     protected readonly string? ParentProcessId;
     protected readonly ILoggerFactory? LoggerFactory;
-    protected Dictionary<string, List<KernelProcessEdge>>? _outputEdges;
+    protected Dictionary<string, List<KernelProcessEdge>> _outputEdges;
 
     /// <summary>
     /// Represents a step in a process that is running in-process.
@@ -57,9 +60,11 @@ internal class LocalStep : KernelProcessMessageChannel
         this.LoggerFactory = loggerFactory;
         this._kernel = kernel;
         this._stepInfo = stepInfo;
+        this._stepState = stepInfo.State;
         this._initializeTask = new Lazy<ValueTask>(this.InitializeStepAsync);
         this._logger = this.LoggerFactory?.CreateLogger(this._stepInfo.InnerStepType) ?? new NullLogger<LocalStep>();
         this._outputEdges = this._stepInfo.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
+        this._eventNamespace = $"{this._stepInfo.State.Name}_{this._stepInfo.State.Id}";
     }
 
     /// <summary>
@@ -76,10 +81,10 @@ internal class LocalStep : KernelProcessMessageChannel
     /// Retrieves all events that have been emitted by this step in the previous superstep.
     /// </summary>
     /// <returns>An <see cref="IEnumerable{T}"/> where T is <see cref="KernelProcessEvent"/></returns>
-    internal IEnumerable<KernelProcessEvent> GetAllEvents()
+    internal IEnumerable<LocalEvent> GetAllEvents()
     {
-        var allEvents = this._eventQueue.ToArray();
-        this._eventQueue.Clear();
+        var allEvents = this._outgoingEventQueue.ToArray();
+        this._outgoingEventQueue.Clear();
         return allEvents;
     }
 
@@ -110,21 +115,8 @@ internal class LocalStep : KernelProcessMessageChannel
     /// <returns>A <see cref="ValueTask"/></returns>
     public override ValueTask EmitEventAsync(KernelProcessEvent processEvent)
     {
-        var scopedEvent = processEvent with { Id = this.StepScopedEventId(processEvent.Id!) };
-        this._eventQueue.Enqueue(scopedEvent);
+        this.EmitEvent(LocalEvent.FromKernelProcessEvent(processEvent, this._eventNamespace));
         return default;
-    }
-
-    /// <summary>
-    /// Invokes the provides function with the provided kernel and arguments.
-    /// </summary>
-    /// <param name="function">The function to invoke.</param>
-    /// <param name="kernel">The kernel to use for invocation.</param>
-    /// <param name="arguments">The arguments to invoke with.</param>
-    /// <returns>A <see cref="Task"/> containing the result of the function invocation.</returns>
-    private Task<FunctionResult> InvokeFunction(KernelFunction function, Kernel kernel, KernelArguments arguments)
-    {
-        return kernel.InvokeAsync(function, arguments: arguments);
     }
 
     /// <summary>
@@ -133,8 +125,10 @@ internal class LocalStep : KernelProcessMessageChannel
     /// <param name="message">The message to process.</param>
     /// <returns>A <see cref="Task"/></returns>
     /// <exception cref="KernelException"></exception>
-    internal async Task HandleMessageAsync(LocalMessage message)
+    internal virtual async Task HandleMessageAsync(LocalMessage message)
     {
+        Verify.NotNull(message);
+
         // Lazy one-time initialization of the step before processing a message
         await this._initializeTask.Value.ConfigureAwait(false);
 
@@ -220,7 +214,7 @@ internal class LocalStep : KernelProcessMessageChannel
     /// </summary>
     /// <returns>A <see cref="ValueTask"/></returns>
     /// <exception cref="KernelException"></exception>
-    private async ValueTask InitializeStepAsync()
+    protected virtual async ValueTask InitializeStepAsync()
     {
         // Instantiate an instance of the inner step object
         KernelProcessStep stepInstance = (KernelProcessStep)ActivatorUtilities.CreateInstance(this._kernel.Services, this._stepInfo.InnerStepType);
@@ -247,13 +241,17 @@ internal class LocalStep : KernelProcessMessageChannel
             var userStateType = genericStepType.GetGenericArguments()[0];
             if (userStateType is null)
             {
-                throw new KernelException("The generic type argument for the KernelProcessStep subclass could not be determined.");
+                var errorMessage = "The generic type argument for the KernelProcessStep subclass could not be determined.";
+                this._logger?.LogError("{ErrorMessage}", errorMessage);
+                throw new KernelException(errorMessage);
             }
 
             stateType = typeof(KernelProcessStepState<>).MakeGenericType(userStateType);
             if (stateType is null)
             {
-                throw new KernelException("The generic type argument for the KernelProcessStep subclass could not be determined.");
+                var errorMessage = "The generic type argument for the KernelProcessStep subclass could not be determined.";
+                this._logger?.LogError("{ErrorMessage}", errorMessage);
+                throw new KernelException(errorMessage);
             }
 
             stateObject = (KernelProcessStepState?)Activator.CreateInstance(stateType, this.Name, this.Id);
@@ -267,16 +265,21 @@ internal class LocalStep : KernelProcessMessageChannel
 
         if (stateObject is null)
         {
-            throw new KernelException("The state object for the KernelProcessStep could not be created.");
+            var errorMessage = "The state object for the KernelProcessStep could not be created.";
+            this._logger?.LogError("{ErrorMessage}", errorMessage);
+            throw new KernelException(errorMessage);
         }
 
         MethodInfo? methodInfo = this._stepInfo.InnerStepType.GetMethod(nameof(KernelProcessStep.ActivateAsync), [stateType]);
 
         if (methodInfo is null)
         {
-            throw new KernelException("The ActivateAsync method for the KernelProcessStep could not be found.");
+            var errorMessage = "The ActivateAsync method for the KernelProcessStep could not be found.";
+            this._logger?.LogError("{ErrorMessage}", errorMessage);
+            throw new KernelException(errorMessage);
         }
 
+        this._stepState = stateObject;
         methodInfo.Invoke(stepInstance, [stateObject]);
         await stepInstance.ActivateAsync(stateObject).ConfigureAwait(false);
     }
@@ -292,7 +295,9 @@ internal class LocalStep : KernelProcessMessageChannel
     {
         if (this._functions is null)
         {
-            throw new InvalidOperationException("The step has not been initialized.");
+            var errorMessage = "Internal Error: The step has not been initialized.";
+            this._logger?.LogError("{ErrorMessage}", errorMessage);
+            throw new KernelException(errorMessage);
         }
 
         Dictionary<string, Dictionary<string, object?>?> inputs = new();
@@ -301,6 +306,14 @@ internal class LocalStep : KernelProcessMessageChannel
             inputs[kvp.Key] = new();
             foreach (var param in kvp.Value.Metadata.Parameters)
             {
+                // Optional parameters are should not be added to the input dictionary.
+                if (!param.IsRequired)
+                {
+                    continue;
+                }
+
+                // Parameters of type KernelProcessStepContext are injected by the process
+                // and are instanciated here.
                 if (param.ParameterType == typeof(KernelProcessStepContext))
                 {
                     inputs[kvp.Key]![param.Name] = new KernelProcessStepContext(this);
@@ -340,12 +353,60 @@ internal class LocalStep : KernelProcessMessageChannel
     }
 
     /// <summary>
-    /// Generates a scoped event Id for the step.
+    /// Invokes the provides function with the provided kernel and arguments.
     /// </summary>
-    /// <param name="eventId">The current Id of the event.</param>
-    /// <returns>A <see cref="string"/> with the scoped Id.</returns>
-    private string StepScopedEventId(string eventId)
+    /// <param name="function">The function to invoke.</param>
+    /// <param name="kernel">The kernel to use for invocation.</param>
+    /// <param name="arguments">The arguments to invoke with.</param>
+    /// <returns>A <see cref="Task"/> containing the result of the function invocation.</returns>
+    private Task<FunctionResult> InvokeFunction(KernelFunction function, Kernel kernel, KernelArguments arguments)
     {
-        return $"{this.Name}_{this.Id}.{eventId}";
+        return kernel.InvokeAsync(function, arguments: arguments);
+    }
+
+    /// <summary>
+    /// Extracts the current state of the step and returns it as a <see cref="KernelProcessStepInfo"/>.
+    /// </summary>
+    /// <returns>An instance of <see cref="KernelProcessStepInfo"/></returns>
+    internal virtual async Task<KernelProcessStepInfo> ToKernelProcessStepInfoAsync()
+    {
+        // Lazy one-time initialization of the step before extracting state information.
+        // This allows state information to be extracted even if the step has not been activated.
+        await this._initializeTask.Value.ConfigureAwait(false);
+
+        var stepInfo = new KernelProcessStepInfo(this._stepInfo.InnerStepType, this._stepState!, this._outputEdges);
+        return stepInfo;
+    }
+
+    /// <summary>
+    /// Emits an event from the step.
+    /// </summary>
+    /// <param name="localEvent">The event to emit.</param>
+    protected void EmitEvent(LocalEvent localEvent)
+    {
+        var scopedEvent = this.ScopedEvent(localEvent);
+        this._outgoingEventQueue.Enqueue(scopedEvent);
+    }
+
+    /// <summary>
+    /// Generates a scoped event for the step.
+    /// </summary>
+    /// <param name="localEvent">The event.</param>
+    /// <returns>A <see cref="LocalEvent"/> with the correctly scoped namespace.</returns>
+    protected LocalEvent ScopedEvent(LocalEvent localEvent)
+    {
+        Verify.NotNull(localEvent);
+        return localEvent with { Namespace = $"{this.Name}_{this.Id}" };
+    }
+
+    /// <summary>
+    /// Generates a scoped event for the step.
+    /// </summary>
+    /// <param name="processEvent">The event.</param>
+    /// <returns>A <see cref="LocalEvent"/> with the correctly scoped namespace.</returns>
+    protected LocalEvent ScopedEvent(KernelProcessEvent processEvent)
+    {
+        Verify.NotNull(processEvent);
+        return LocalEvent.FromKernelProcessEvent(processEvent, $"{this.Name}_{this.Id}");
     }
 }

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
@@ -313,7 +313,7 @@ internal class LocalStep : KernelProcessMessageChannel
                 }
 
                 // Parameters of type KernelProcessStepContext are injected by the process
-                // and are instanciated here.
+                // and are instantiated here.
                 if (param.ParameterType == typeof(KernelProcessStepContext))
                 {
                     inputs[kvp.Key]![param.Name] = new KernelProcessStepContext(this);

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessBuilderTests.cs
@@ -73,7 +73,7 @@ public class ProcessBuilderTests
         var processBuilder = new ProcessBuilder(ProcessName);
 
         // Act
-        var edgeBuilder = processBuilder.OnExternalEvent(EventId);
+        var edgeBuilder = processBuilder.OnInputEvent(EventId);
 
         // Assert
         Assert.NotNull(edgeBuilder);

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
@@ -218,11 +218,6 @@ public class ProcessStepBuilderTests
             return new KernelProcessStepInfo(typeof(TestProcessStepBuilder), new KernelProcessStepState(this.Name, this.Id), []);
         }
 
-        internal override string GetScopedEventId(string eventId)
-        {
-            return $"TestScope.{eventId}";
-        }
-
         internal override Dictionary<string, KernelFunctionMetadata> GetFunctionMetadataMap()
         {
             return new Dictionary<string, KernelFunctionMetadata>();

--- a/dotnet/src/IntegrationTests/IntegrationTests.csproj
+++ b/dotnet/src/IntegrationTests/IntegrationTests.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0040,SKEXP0050,SKEXP0060,SKEXP0070,SKEXP0110</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0040,SKEXP0050,SKEXP0060,SKEXP0070,SKEXP0080,SKEXP0110</NoWarn>
     <UserSecretsId>b7762d10-e29b-4bb1-8b74-b6d69a667dd4</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
@@ -87,6 +87,9 @@
     <ProjectReference Include="..\Connectors\Connectors.Memory.Postgres\Connectors.Memory.Postgres.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Memory.SqlServer\Connectors.Memory.SqlServer.csproj" />
     <ProjectReference Include="..\Connectors\Connectors.Memory.Weaviate\Connectors.Memory.Weaviate.csproj" />
+    <ProjectReference Include="..\Experimental\Process.Abstractions\Process.Abstractions.csproj" />
+    <ProjectReference Include="..\Experimental\Process.Core\Process.Core.csproj" />
+    <ProjectReference Include="..\Experimental\Process.LocalRuntime\Process.LocalRuntime.csproj" />
     <ProjectReference Include="..\Extensions\PromptTemplates.Handlebars\PromptTemplates.Handlebars.csproj" />
     <ProjectReference Include="..\Functions\Functions.Yaml\Functions.Yaml.csproj" />
     <ProjectReference Include="..\Planners\Planners.Handlebars\Planners.Handlebars.csproj" />

--- a/dotnet/src/IntegrationTests/Processes/ProcessTests.cs
+++ b/dotnet/src/IntegrationTests/Processes/ProcessTests.cs
@@ -37,8 +37,8 @@ public sealed class ProcessTests
 
         // Act
         string testInput = "Test";
-        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartProcess, Data = testInput });
-        var processInfo = await procesHandle.GetStateAsync();
+        var processHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartProcess, Data = testInput });
+        var processInfo = await processHandle.GetStateAsync();
 
         // Assert
         var repeatStepState = processInfo.Steps.Where(s => s.State.Name == nameof(RepeatStep)).FirstOrDefault()?.State as KernelProcessStepState<StepState>;
@@ -77,8 +77,8 @@ public sealed class ProcessTests
 
         // Act
         string testInput = "Test";
-        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartProcess, Data = testInput });
-        var processInfo = await procesHandle.GetStateAsync();
+        var processHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartProcess, Data = testInput });
+        var processInfo = await processHandle.GetStateAsync();
 
         // Assert
         var innerProcess = processInfo.Steps.Where(s => s.State.Name == "Inner").Single() as KernelProcess;
@@ -123,8 +123,8 @@ public sealed class ProcessTests
 
         // Act
         string testInput = "Test";
-        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartInnerProcess, Data = testInput });
-        var processInfo = await procesHandle.GetStateAsync();
+        var processHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartInnerProcess, Data = testInput });
+        var processInfo = await processHandle.GetStateAsync();
 
         // Assert
         var repeatStepState = processInfo.Steps.Where(s => s.State.Name == nameof(RepeatStep)).FirstOrDefault()?.State as KernelProcessStepState<StepState>;
@@ -167,8 +167,8 @@ public sealed class ProcessTests
 
         // Act
         string testInput = "Test";
-        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartInnerProcess, Data = testInput });
-        var processInfo = await procesHandle.GetStateAsync();
+        var processHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartInnerProcess, Data = testInput });
+        var processInfo = await processHandle.GetStateAsync();
 
         // Assert
         var repeatStepState = processInfo.Steps.Where(s => s.State.Name == nameof(RepeatStep)).FirstOrDefault()?.State as KernelProcessStepState<StepState>;

--- a/dotnet/src/IntegrationTests/Processes/ProcessTests.cs
+++ b/dotnet/src/IntegrationTests/Processes/ProcessTests.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using SemanticKernel.IntegrationTests.Agents;
+using SemanticKernel.IntegrationTests.TestSettings;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Processes;
+public sealed class ProcessTests
+{
+    private readonly IKernelBuilder _kernelBuilder = Kernel.CreateBuilder();
+    private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
+            .AddJsonFile(path: "testsettings.json", optional: true, reloadOnChange: true)
+            .AddJsonFile(path: "testsettings.development.json", optional: true, reloadOnChange: true)
+            .AddEnvironmentVariables()
+            .AddUserSecrets<OpenAIAssistantAgentTests>()
+            .Build();
+
+    /// <summary>
+    /// Tests a simple linear process with two steps and no sub processes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/></returns>
+    [Fact]
+    public async Task LinearProcessAsync()
+    {
+        // Arrange
+        OpenAIConfiguration configuration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>()!;
+        this._kernelBuilder.AddOpenAIChatCompletion(
+            modelId: configuration.ModelId!,
+            apiKey: configuration.ApiKey);
+
+        Kernel kernel = this._kernelBuilder.Build();
+        var process = this.CreateLinearProcess("Simple").Build();
+
+        // Act
+        string testInput = "Test";
+        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartProcess, Data = testInput });
+        var processInfo = await procesHandle.GetStateAsync();
+
+        // Assert
+        var repeatStepState = processInfo.Steps.Where(s => s.State.Name == nameof(RepeatStep)).FirstOrDefault()?.State as KernelProcessStepState<StepState>;
+        Assert.NotNull(repeatStepState?.State);
+        Assert.Equal(string.Join(" ", Enumerable.Repeat(testInput, 2)), repeatStepState.State.LastMessage);
+    }
+
+    /// <summary>
+    /// Tests a process with three steps where the third step is a nested process. Events from the outer process
+    /// are routed to the inner process.
+    /// </summary>
+    /// <returns>A <see cref="Task"/></returns>
+    [Fact]
+    public async Task NestedProcessOuterToInnerWorksAsync()
+    {
+        // Arrange
+        OpenAIConfiguration configuration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>()!;
+        this._kernelBuilder.AddOpenAIChatCompletion(
+            modelId: configuration.ModelId!,
+            apiKey: configuration.ApiKey);
+
+        Kernel kernel = this._kernelBuilder.Build();
+
+        // Create the outer process
+        var processBuilder = this.CreateLinearProcess("Outer");
+
+        // Create the inner process and add it as a step to the outer process
+        var nestedProcessStep = processBuilder.AddStepFromProcess(this.CreateLinearProcess("Inner"));
+
+        // Route the last step of the outer process to trigger the external event that starts the inner process
+        processBuilder.Steps[1].OnEvent(ProcessTestsEvents.OutputReadyInternal)
+            .SendEventTo(nestedProcessStep.GetTargetForExternalEvent(ProcessTestsEvents.StartProcess));
+
+        // Build the outer process
+        var process = processBuilder.Build();
+
+        // Act
+        string testInput = "Test";
+        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartProcess, Data = testInput });
+        var processInfo = await procesHandle.GetStateAsync();
+
+        // Assert
+        var innerProcess = processInfo.Steps.Where(s => s.State.Name == "Inner").Single() as KernelProcess;
+        Assert.NotNull(innerProcess);
+        var repeatStepState = innerProcess.Steps.Where(s => s.State.Name == nameof(RepeatStep)).Single().State as KernelProcessStepState<StepState>;
+        Assert.NotNull(repeatStepState?.State);
+        Assert.Equal(string.Join(" ", Enumerable.Repeat(testInput, 4)), repeatStepState.State.LastMessage);
+    }
+
+    /// <summary>
+    /// Tests a process with three steps where the third step is a nested process. Events from the inner process
+    /// are routed to the outer process.
+    /// </summary>
+    /// <returns>A <see cref="Task"/></returns>
+    [Fact]
+    public async Task NestedProcessInnerToOuterWorksWithPublicEventAsync()
+    {
+        // Arrange
+        OpenAIConfiguration configuration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>()!;
+        this._kernelBuilder.AddOpenAIChatCompletion(
+            modelId: configuration.ModelId!,
+            apiKey: configuration.ApiKey);
+
+        Kernel kernel = this._kernelBuilder.Build();
+
+        // Create the outer process
+        var processBuilder = this.CreateLinearProcess("Outer");
+
+        // Create the inner process and add it as a step to the outer process
+        var nestedProcessStep = processBuilder.AddStepFromProcess(this.CreateLinearProcess("Inner"));
+
+        // Add a new external event to start the outer process and handoff to the inner process directly
+        processBuilder.OnExternalEvent(ProcessTestsEvents.StartInnerProcess)
+            .SendEventTo(nestedProcessStep.GetTargetForExternalEvent(ProcessTestsEvents.StartProcess));
+
+        // Route the last step of the inner process to trigger the echo step of the outer process
+        nestedProcessStep.OnEvent(ProcessTestsEvents.OutputReadyPublic)
+            .SendEventTo(new ProcessFunctionTargetBuilder(processBuilder.Steps[0]));
+
+        // Build the outer process
+        var process = processBuilder.Build();
+
+        // Act
+        string testInput = "Test";
+        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartInnerProcess, Data = testInput });
+        var processInfo = await procesHandle.GetStateAsync();
+
+        // Assert
+        var repeatStepState = processInfo.Steps.Where(s => s.State.Name == nameof(RepeatStep)).FirstOrDefault()?.State as KernelProcessStepState<StepState>;
+        Assert.NotNull(repeatStepState?.State);
+        Assert.Equal(string.Join(" ", Enumerable.Repeat(testInput, 4)), repeatStepState.State.LastMessage);
+    }
+
+    /// <summary>
+    /// Tests a process with three steps where the third step is a nested process. Events from the inner process
+    /// are routed to the outer process.
+    /// </summary>
+    /// <returns>A <see cref="Task"/></returns>
+    [Fact]
+    public async Task NestedProcessInnerToOuterDoesNotWorkWithInternalEventAsync()
+    {
+        // Arrange
+        OpenAIConfiguration configuration = this._configuration.GetSection("OpenAI").Get<OpenAIConfiguration>()!;
+        this._kernelBuilder.AddOpenAIChatCompletion(
+            modelId: configuration.ModelId!,
+            apiKey: configuration.ApiKey);
+
+        Kernel kernel = this._kernelBuilder.Build();
+
+        // Create the outer process
+        var processBuilder = this.CreateLinearProcess("Outer");
+
+        // Create the inner process and add it as a step to the outer process
+        var nestedProcessStep = processBuilder.AddStepFromProcess(this.CreateLinearProcess("Inner"));
+
+        // Add a new external event to start the outer process and handoff to the inner process directly
+        processBuilder.OnExternalEvent(ProcessTestsEvents.StartInnerProcess)
+            .SendEventTo(nestedProcessStep.GetTargetForExternalEvent(ProcessTestsEvents.StartProcess));
+
+        // Route the last step of the inner process to trigger the echo step of the outer process
+        nestedProcessStep.OnEvent(ProcessTestsEvents.OutputReadyInternal)
+            .SendEventTo(new ProcessFunctionTargetBuilder(processBuilder.Steps[0]));
+
+        // Build the outer process
+        var process = processBuilder.Build();
+
+        // Act
+        string testInput = "Test";
+        var procesHandle = await process.StartAsync(kernel, new() { Id = ProcessTestsEvents.StartInnerProcess, Data = testInput });
+        var processInfo = await procesHandle.GetStateAsync();
+
+        // Assert
+        var repeatStepState = processInfo.Steps.Where(s => s.State.Name == nameof(RepeatStep)).FirstOrDefault()?.State as KernelProcessStepState<StepState>;
+        Assert.NotNull(repeatStepState);
+        Assert.Null(repeatStepState.State?.LastMessage);
+    }
+
+    /// <summary>
+    /// Creates a simple linear process with two steps.
+    /// </summary>
+    private ProcessBuilder CreateLinearProcess(string name)
+    {
+        var processBuilder = new ProcessBuilder(name);
+        var echoStep = processBuilder.AddStepFromType<EchoStep>();
+        var repeatStep = processBuilder.AddStepFromType<RepeatStep>();
+
+        processBuilder.OnExternalEvent(ProcessTestsEvents.StartProcess)
+            .SendEventTo(new ProcessFunctionTargetBuilder(echoStep));
+
+        echoStep.OnFunctionResult(nameof(EchoStep.Echo))
+            .SendEventTo(new ProcessFunctionTargetBuilder(repeatStep, parameterName: "message"));
+
+        return processBuilder;
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    // These classes are dynamically instantiated by the processes used in tests.
+
+    /// <summary>
+    /// A step that echos its input.
+    /// </summary>
+    private sealed class EchoStep : KernelProcessStep
+    {
+        [KernelFunction]
+        public string Echo(string message) => message;
+    }
+
+    /// <summary>
+    /// A step that repeats its input.
+    /// </summary>
+    private sealed class RepeatStep : KernelProcessStep<StepState>
+    {
+        private readonly StepState _state = new();
+
+        public override ValueTask ActivateAsync(KernelProcessStepState<StepState> state)
+        {
+            state.State ??= this._state;
+
+            return default;
+        }
+
+        [KernelFunction]
+        public async Task RepeatAsync(string message, KernelProcessStepContext context, int count = 2)
+        {
+            var output = string.Join(" ", Enumerable.Repeat(message, count));
+            this._state.LastMessage = output;
+
+            // Emit the OnReady event with a public visibility and an internal visibility to aid in testing
+            await context.EmitEventAsync(new() { Id = ProcessTestsEvents.OutputReadyPublic, Data = output, Visibility = KernelProcessEventVisibility.Public });
+            await context.EmitEventAsync(new() { Id = ProcessTestsEvents.OutputReadyInternal, Data = output, Visibility = KernelProcessEventVisibility.Internal });
+        }
+    }
+
+    /// <summary>
+    /// The state object for the repeat step.
+    /// </summary>
+    private sealed record StepState
+    {
+        public string? LastMessage { get; set; }
+    }
+
+    /// <summary>
+    /// A class that defines the events that can be emitted by the chat bot process. This is
+    /// not required but used to ensure that the event names are consistent.
+    /// </summary>
+    private static class ProcessTestsEvents
+    {
+        public const string StartProcess = "StartProcess";
+        public const string StartInnerProcess = "StartInnerProcess";
+        public const string OutputReadyPublic = "OutputReadyPublic";
+        public const string OutputReadyInternal = "OutputReadyInternal";
+    }
+
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+}

--- a/dotnet/src/IntegrationTests/Processes/ProcessTests.cs
+++ b/dotnet/src/IntegrationTests/Processes/ProcessTests.cs
@@ -70,7 +70,7 @@ public sealed class ProcessTests
 
         // Route the last step of the outer process to trigger the external event that starts the inner process
         processBuilder.Steps[1].OnEvent(ProcessTestsEvents.OutputReadyInternal)
-            .SendEventTo(nestedProcessStep.GetTargetForExternalEvent(ProcessTestsEvents.StartProcess));
+            .SendEventTo(nestedProcessStep.WhereInputEventIs(ProcessTestsEvents.StartProcess));
 
         // Build the outer process
         var process = processBuilder.Build();
@@ -111,8 +111,8 @@ public sealed class ProcessTests
         var nestedProcessStep = processBuilder.AddStepFromProcess(this.CreateLinearProcess("Inner"));
 
         // Add a new external event to start the outer process and handoff to the inner process directly
-        processBuilder.OnExternalEvent(ProcessTestsEvents.StartInnerProcess)
-            .SendEventTo(nestedProcessStep.GetTargetForExternalEvent(ProcessTestsEvents.StartProcess));
+        processBuilder.OnInputEvent(ProcessTestsEvents.StartInnerProcess)
+            .SendEventTo(nestedProcessStep.WhereInputEventIs(ProcessTestsEvents.StartProcess));
 
         // Route the last step of the inner process to trigger the echo step of the outer process
         nestedProcessStep.OnEvent(ProcessTestsEvents.OutputReadyPublic)
@@ -155,8 +155,8 @@ public sealed class ProcessTests
         var nestedProcessStep = processBuilder.AddStepFromProcess(this.CreateLinearProcess("Inner"));
 
         // Add a new external event to start the outer process and handoff to the inner process directly
-        processBuilder.OnExternalEvent(ProcessTestsEvents.StartInnerProcess)
-            .SendEventTo(nestedProcessStep.GetTargetForExternalEvent(ProcessTestsEvents.StartProcess));
+        processBuilder.OnInputEvent(ProcessTestsEvents.StartInnerProcess)
+            .SendEventTo(nestedProcessStep.WhereInputEventIs(ProcessTestsEvents.StartProcess));
 
         // Route the last step of the inner process to trigger the echo step of the outer process
         nestedProcessStep.OnEvent(ProcessTestsEvents.OutputReadyInternal)
@@ -185,7 +185,7 @@ public sealed class ProcessTests
         var echoStep = processBuilder.AddStepFromType<EchoStep>();
         var repeatStep = processBuilder.AddStepFromType<RepeatStep>();
 
-        processBuilder.OnExternalEvent(ProcessTestsEvents.StartProcess)
+        processBuilder.OnInputEvent(ProcessTestsEvents.StartProcess)
             .SendEventTo(new ProcessFunctionTargetBuilder(echoStep));
 
         echoStep.OnFunctionResult(nameof(EchoStep.Echo))


### PR DESCRIPTION
### Description

#### Enables use of sub-processes by adding a process to another process as a step.

##### Event bubbling and visibility:
This PR adds the concept of visibility to events within a process. There are two options, `Internal` which keeps the event within the process it's fired in, and `Public` which allows the event to bubble out of the process to parent processes or external systems. Events default to `Internal`. This allows a parent process to receive events that originate from within a sub-process.

##### Targets for process' external events:
Processes now expose targets for their external events. When a processes defines a route for an external event by calling `processBuilder.OnExternalEvent(...)...`, the target for this event can now be retrieved by calling `process.GetTargetForExternalEvent(...)`. This allows a parent process to route a step event to the specified entry event of the sub-process.

#### Retrieve state of a running or completed process
The `*KernelProcessContext` now exposes  a `GetStateAsync` method that allows the state of the process to be retrieved on a started process. 

Closes #9097 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
