### PR TITLE
.Net: Fixing subprocess triggered by multiple inputs unexpected behavior bug 

### DIFF
--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
@@ -155,15 +155,12 @@ internal sealed class LocalProcess : LocalStep, IDisposable
         string eventId = message.TargetEventId!;
         if (this._outputEdges!.TryGetValue(eventId, out List<KernelProcessEdge>? edges) && edges is not null)
         {
-            foreach (var edge in edges)
-            {
-                // Create the external event that will be used to start the nested process. Since this event came
-                // from outside this processes, we set the visibility to internal so that it's not emitted back out again.
-                var nestedEvent = new KernelProcessEvent() { Id = eventId, Data = message.TargetEventData, Visibility = KernelProcessEventVisibility.Internal };
+            // Create the external event that will be used to start the nested process. Since this event came
+            // from outside this processes, we set the visibility to internal so that it's not emitted back out again.
+            var nestedEvent = new KernelProcessEvent() { Id = eventId, Data = message.TargetEventData, Visibility = KernelProcessEventVisibility.Internal };
 
-                // Run the nested process completely within a single superstep.
-                await this.RunOnceAsync(nestedEvent, this._kernel).ConfigureAwait(false);
-            }
+            // Run the nested process completely within a single superstep.
+            await this.RunOnceAsync(nestedEvent, this._kernel).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
### Description

Fixing subprocesses bug where subprocess has getting triggered multiple times if having more than one external input event trigger.

Adding UTs to validate

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
