### PR TITLE
.Net: Net: Bump System.Text.Json away from vulnerable package 8.0.4

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="OllamaSharp" Version="3.0.10" />
     <!-- Tokenizers -->
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24378.1" />


### PR DESCRIPTION
### Motivation and Context

System.Text.Json Version 8.0.4 is [flagged as vulnerable](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) and needs to be updated.