### PR TITLE
Remove notnull constraint from generic data model

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreGenericDataModel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/VectorStoreGenericDataModel.cs
@@ -12,7 +12,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// <param name="key">The key of the record.</param>
 [Experimental("SKEXP0001")]
 public sealed class VectorStoreGenericDataModel<TKey>(TKey key)
-    where TKey : notnull
 {
     /// <summary>
     /// Gets or sets the key of the record.


### PR DESCRIPTION
### Motivation and Context

Some databases allow us to generate keys on the server, so when doing an upsert, a key doesn't have to be specified on the record.
This means that the key on the record should be nullable to enable this functionliaty.

### Description

- Removing the notnull constraint from the generic data model to support this scenario.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
