### PR TITLE
.Net Processes - Fluent edge building

### DIFF
--- a/dotnet/samples/GettingStartedWithProcesses/Step02/Step02_AccountOpening.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step02/Step02_AccountOpening.cs
@@ -57,19 +57,14 @@ public class Step02_AccountOpening(ITestOutputHelper output) : BaseTest(output, 
             .OnEvent(CommonEvents.AssistantResponseGenerated)
             .SendEventTo(new ProcessFunctionTargetBuilder(userInputStep, ScriptedUserInputStep.Functions.GetUserInput));
 
-        // When the newCustomerForm is completed, the information gets passed to the core system record creation step
+        // When the newCustomerForm is completed...
         newCustomerFormStep
             .OnEvent(AccountOpeningEvents.NewCustomerFormCompleted)
-            .SendEventTo(new ProcessFunctionTargetBuilder(customerCreditCheckStep, functionName: CreditScoreCheckStep.Functions.DetermineCreditScore, parameterName: "customerDetails"));
-
-        // When the newCustomerForm is completed, the information gets passed to the fraud detection step for validation
-        newCustomerFormStep
-            .OnEvent(AccountOpeningEvents.NewCustomerFormCompleted)
-            .SendEventTo(new ProcessFunctionTargetBuilder(fraudDetectionCheckStep, functionName: FraudDetectionStep.Functions.FraudDetectionCheck, parameterName: "customerDetails"));
-
-        // When the newCustomerForm is completed, the information gets passed to the core system record creation step
-        newCustomerFormStep
-            .OnEvent(AccountOpeningEvents.NewCustomerFormCompleted)
+            // The information gets passed to the core system record creation step
+            .SendEventTo(new ProcessFunctionTargetBuilder(customerCreditCheckStep, functionName: CreditScoreCheckStep.Functions.DetermineCreditScore, parameterName: "customerDetails"))
+            // The information gets passed to the fraud detection step for validation
+            .SendEventTo(new ProcessFunctionTargetBuilder(fraudDetectionCheckStep, functionName: FraudDetectionStep.Functions.FraudDetectionCheck, parameterName: "customerDetails"))
+            // The information gets passed to the core system record creation step
             .SendEventTo(new ProcessFunctionTargetBuilder(coreSystemRecordCreationStep, functionName: NewAccountStep.Functions.CreateNewAccount, parameterName: "customerDetails"));
 
         // When the newCustomerForm is completed, the user interaction transcript with the user is passed to the core system record creation step

--- a/dotnet/samples/GettingStartedWithProcesses/Step03/Processes/FishAndChipsProcess.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step03/Processes/FishAndChipsProcess.cs
@@ -30,10 +30,7 @@ public static class FishAndChipsProcess
 
         processBuilder
             .OnInputEvent(ProcessEvents.PrepareFishAndChips)
-            .SendEventTo(makeFriedFishStep.WhereInputEventIs(FriedFishProcess.ProcessEvents.PrepareFriedFish));
-
-        processBuilder
-            .OnInputEvent(ProcessEvents.PrepareFishAndChips)
+            .SendEventTo(makeFriedFishStep.WhereInputEventIs(FriedFishProcess.ProcessEvents.PrepareFriedFish))
             .SendEventTo(makePotatoFriesStep.WhereInputEventIs(PotatoFriesProcess.ProcessEvents.PreparePotatoFries));
 
         makeFriedFishStep

--- a/dotnet/src/Experimental/Process.Core/ProcessEdgeBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessEdgeBuilder.cs
@@ -17,7 +17,7 @@ public sealed class ProcessEdgeBuilder
     /// <summary>
     /// The source step of the edge.
     /// </summary>
-    internal ProcessStepBuilder Source { get; }
+    internal ProcessBuilder Source { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessEdgeBuilder"/> class.
@@ -33,10 +33,12 @@ public sealed class ProcessEdgeBuilder
     /// <summary>
     /// Sends the output of the source step to the specified target when the associated event fires.
     /// </summary>
-    public void SendEventTo(ProcessFunctionTargetBuilder target)
+    public ProcessEdgeBuilder SendEventTo(ProcessFunctionTargetBuilder target)
     {
         this.Target = target;
         ProcessStepEdgeBuilder edgeBuilder = new(this.Source, this.EventId) { Target = this.Target };
         this.Source.LinkTo(this.EventId, edgeBuilder);
+
+        return new ProcessEdgeBuilder(this.Source, this.EventId);
     }
 }

--- a/dotnet/src/Experimental/Process.Core/ProcessStepEdgeBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessStepEdgeBuilder.cs
@@ -50,7 +50,8 @@ public sealed class ProcessStepEdgeBuilder
     /// Signals that the output of the source step should be sent to the specified target when the associated event fires.
     /// </summary>
     /// <param name="target">The output target.</param>
-    public void SendEventTo(ProcessFunctionTargetBuilder target)
+    /// <returns>A fresh builder instance for fluid definition</returns>
+    public ProcessStepEdgeBuilder SendEventTo(ProcessFunctionTargetBuilder target)
     {
         if (this.Target is not null)
         {
@@ -59,6 +60,8 @@ public sealed class ProcessStepEdgeBuilder
 
         this.Target = target;
         this.Source.LinkTo(this.EventId, this);
+
+        return new ProcessStepEdgeBuilder(this.Source, this.EventId);
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.UnitTests/KernelProcessStateTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/KernelProcessStateTests.cs
@@ -3,7 +3,7 @@
 using System;
 using Xunit;
 
-namespace Microsoft.SemanticKernel.UnitTests;
+namespace Microsoft.SemanticKernel.Process.UnitTests;
 
 /// <summary>
 /// Unit testing of <see cref="KernelProcessState"/>.

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessBuilderTests.cs
@@ -2,7 +2,7 @@
 
 using Xunit;
 
-namespace Microsoft.SemanticKernel.UnitTests;
+namespace Microsoft.SemanticKernel.Process.UnitTests;
 
 /// <summary>
 /// Unit tests for the ProcessBuilder class.

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessEdgeBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessEdgeBuilderTests.cs
@@ -22,6 +22,66 @@ public class ProcessEdgeBuilderTests
         var edgeBuilder = new ProcessEdgeBuilder(processBuilder, "TestEvent");
 
         // Assert
-        Assert.NotNull(edgeBuilder);
+        Assert.StrictEqual(processBuilder, edgeBuilder.Source);
+        Assert.Equal("TestEvent", edgeBuilder.EventId);
+    }
+
+    /// <summary>
+    /// Verify initialization of <see cref="ProcessEdgeBuilder"/>.
+    /// </summary>
+    [Fact]
+    public void SendEventToShouldSetOutputTarget()
+    {
+        // Arrange
+        var processBuilder = new ProcessBuilder("TestProcess");
+        var source = new ProcessStepBuilder<TestStep>("TestStep");
+        var outputTarget = new ProcessFunctionTargetBuilder(source, "TestFunction");
+
+        // Act
+        var edgeBuilder = new ProcessEdgeBuilder(processBuilder, "TestEvent");
+        edgeBuilder.SendEventTo(outputTarget);
+
+        // Assert
+        Assert.Equal(outputTarget, edgeBuilder.Target);
+    }
+
+    /// <summary>
+    /// Verify initialization of <see cref="ProcessEdgeBuilder"/>.
+    /// </summary>
+    [Fact]
+    public void SendEventToShouldSetMultipleOutputTargets()
+    {
+        // Arrange
+        var processBuilder = new ProcessBuilder("TestProcess");
+        var outputTargetA = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<TestStep>("TestStep1"), "TestFunction");
+        var outputTargetB = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<TestStep>("TestStep2"), "TestFunction");
+
+        // Act
+        var edgeBuilder = new ProcessEdgeBuilder(processBuilder, "TestEvent");
+        var edgeBuilder2 = edgeBuilder.SendEventTo(outputTargetA);
+        edgeBuilder2.SendEventTo(outputTargetB);
+
+        // Assert
+        Assert.Equal(outputTargetA, edgeBuilder.Target);
+        Assert.Equal(outputTargetB, edgeBuilder2.Target);
+    }
+
+    /// <summary>
+    /// A class that represents a step for testing.
+    /// </summary>
+    private sealed class TestStep : KernelProcessStep
+    {
+        /// <summary>
+        /// The name of the step.
+        /// </summary>
+        public static string Name => "TestStep";
+
+        /// <summary>
+        /// A method that represents a function for testing.
+        /// </summary>
+        [KernelFunction]
+        public void TestFunction()
+        {
+        }
     }
 }

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessEdgeBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessEdgeBuilderTests.cs
@@ -2,7 +2,7 @@
 
 using Xunit;
 
-namespace Microsoft.SemanticKernel.UnitTests;
+namespace Microsoft.SemanticKernel.Process.UnitTests;
 
 /// <summary>
 /// Unit testing of <see cref="ProcessEdgeBuilder"/>.

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace Microsoft.SemanticKernel.Tests;
+namespace Microsoft.SemanticKernel.Process.UnitTests;
 
 /// <summary>
 /// Unit tests for the <see cref="ProcessStepBuilder"/> class.

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepEdgeBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepEdgeBuilderTests.cs
@@ -36,9 +36,8 @@ public class ProcessStepEdgeBuilderTests
     {
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
-        var eventType = "Event1";
-        var builder = new ProcessStepEdgeBuilder(source, eventType);
-        var outputTarget = new ProcessFunctionTargetBuilder(source);
+        var builder = new ProcessStepEdgeBuilder(source, "Event1");
+        var outputTarget = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<KernelProcessStep>());
 
         // Act
         builder.SendEventTo(outputTarget);
@@ -55,19 +54,17 @@ public class ProcessStepEdgeBuilderTests
     {
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
-        var eventType = "Event1";
-        var builder = new ProcessStepEdgeBuilder(source, eventType);
-        var outputTargetA = new ProcessFunctionTargetBuilder(source);
-        var outputTargetB = new ProcessFunctionTargetBuilder(source);
+        var builder = new ProcessStepEdgeBuilder(source, "Event1");
+        var outputTargetA = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<TestStep>("StepA"));
+        var outputTargetB = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<TestStep>("StepB"));
 
         // Act
-        builder
-            .SendEventTo(outputTargetA)
-            .SendEventTo(outputTargetB);
+        var builder2 = builder.SendEventTo(outputTargetA);
+        builder2.SendEventTo(outputTargetB);
 
         // Assert
         Assert.Equal(outputTargetA, builder.Target); // Assuming GetOutputTarget() is a method to access _outputTarget
-        Assert.Equal(outputTargetB, builder.Target); // Assuming GetOutputTarget() is a method to access _outputTarget
+        Assert.Equal(outputTargetB, builder2.Target); // Assuming GetOutputTarget() is a method to access _outputTarget
     }
 
     /// <summary>
@@ -78,8 +75,7 @@ public class ProcessStepEdgeBuilderTests
     {
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
-        var eventType = "Event1";
-        var builder = new ProcessStepEdgeBuilder(source, eventType);
+        var builder = new ProcessStepEdgeBuilder(source, "Event1");
         var outputTarget1 = new ProcessFunctionTargetBuilder(source);
         var outputTarget2 = new ProcessFunctionTargetBuilder(source);
 
@@ -98,8 +94,7 @@ public class ProcessStepEdgeBuilderTests
     {
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
-        var eventType = "Event1";
-        var builder = new ProcessStepEdgeBuilder(source, eventType);
+        var builder = new ProcessStepEdgeBuilder(source, "Event1");
 
         // Act
         builder.StopProcess();
@@ -116,8 +111,7 @@ public class ProcessStepEdgeBuilderTests
     {
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
-        var eventType = "Event1";
-        var builder = new ProcessStepEdgeBuilder(source, eventType);
+        var builder = new ProcessStepEdgeBuilder(source, "Event1");
         var outputTarget = new ProcessFunctionTargetBuilder(source);
 
         // Act
@@ -135,8 +129,7 @@ public class ProcessStepEdgeBuilderTests
     {
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
-        var eventType = "Event1";
-        var builder = new ProcessStepEdgeBuilder(source, eventType);
+        var builder = new ProcessStepEdgeBuilder(source, "Event1");
         var outputTarget = new ProcessFunctionTargetBuilder(source);
         builder.SendEventTo(outputTarget);
 

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepEdgeBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepEdgeBuilderTests.cs
@@ -37,7 +37,7 @@ public class ProcessStepEdgeBuilderTests
         // Arrange
         var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
         var builder = new ProcessStepEdgeBuilder(source, "Event1");
-        var outputTarget = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<KernelProcessStep>());
+        var outputTarget = new ProcessFunctionTargetBuilder(new ProcessStepBuilder<TestStep>("OutputStep"));
 
         // Act
         builder.SendEventTo(outputTarget);

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepEdgeBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepEdgeBuilderTests.cs
@@ -3,7 +3,7 @@
 using System;
 using Xunit;
 
-namespace Microsoft.SemanticKernel.Tests;
+namespace Microsoft.SemanticKernel.Process.UnitTests;
 
 /// <summary>
 /// Unit tests for the <see cref="ProcessStepEdgeBuilder"/> class.
@@ -45,6 +45,29 @@ public class ProcessStepEdgeBuilderTests
 
         // Assert
         Assert.Equal(outputTarget, builder.Target); // Assuming GetOutputTarget() is a method to access _outputTarget
+    }
+
+    /// <summary>
+    /// Verify that the <see cref="ProcessStepEdgeBuilder.SendEventTo(ProcessFunctionTargetBuilder)"/> method sets chained output targets.
+    /// </summary>
+    [Fact]
+    public void SendEventToShouldSetMultipleOutputTargets()
+    {
+        // Arrange
+        var source = new ProcessStepBuilder<TestStep>(TestStep.Name);
+        var eventType = "Event1";
+        var builder = new ProcessStepEdgeBuilder(source, eventType);
+        var outputTargetA = new ProcessFunctionTargetBuilder(source);
+        var outputTargetB = new ProcessFunctionTargetBuilder(source);
+
+        // Act
+        builder
+            .SendEventTo(outputTargetA)
+            .SendEventTo(outputTargetB);
+
+        // Assert
+        Assert.Equal(outputTargetA, builder.Target); // Assuming GetOutputTarget() is a method to access _outputTarget
+        Assert.Equal(outputTargetB, builder.Target); // Assuming GetOutputTarget() is a method to access _outputTarget
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessTypeExtensionsTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessTypeExtensionsTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using Microsoft.SemanticKernel.Process;
 using Xunit;
 
-namespace Microsoft.SemanticKernel.Tests;
+namespace Microsoft.SemanticKernel.Process.UnitTests;
 
 /// <summary>
 /// Unit tests for the <see cref="ProcessTypeExtensions"/> class.


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Broadcasting the same event along multiple edges will likely be a common pattern (Estefanía and I both have utilized this pattern early).  A small tweak reduces the vebosity for this pattern.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Returning a cloned `ProcessStepEdgeBuilder` when invoking `ProcessStepEdgeBuilderSendEventTo`
- Added unit-test
- Normalized unit-tests namespaces
- Worst cases there's a tiny bit of additional memory pressure on GC for the final un-used builder: One object with two object references that can be addressed in gen-0 collection.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
