### PR TITLE
.Net Processes - Expose OnError Event Handling

### DIFF
--- a/dotnet/src/Experimental/Process.Core/ProcessStepBuilder.cs
+++ b/dotnet/src/Experimental/Process.Core/ProcessStepBuilder.cs
@@ -46,6 +46,16 @@ public abstract class ProcessStepBuilder
         return this.OnEvent($"{functionName}.OnResult");
     }
 
+    /// <summary>
+    /// Define the behavior of the step when the specified function has thrown an exception.
+    /// </summary>
+    /// <param name="functionName">The name of the function of interest.</param>
+    /// <returns>An instance of <see cref="ProcessStepEdgeBuilder"/>.</returns>
+    public ProcessStepEdgeBuilder OnFunctionError(string functionName)
+    {
+        return this.OnEvent($"{functionName}.OnError");
+    }
+
     #endregion
 
     /// <summary>The namespace for events that are scoped to this step.</summary>

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
@@ -197,7 +197,7 @@ internal class LocalStep : KernelProcessMessageChannel
         {
             this._logger?.LogError("Error in Step {StepName}: {ErrorMessage}", this.Name, ex.Message);
             eventName = $"{targetFunction}.OnError";
-            eventValue = ex.Message;
+            eventValue = ex;
         }
         finally
         {

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -63,7 +62,7 @@ public class ProcessStepBuilderTests
         // Assert
         Assert.NotNull(edgeBuilder);
         Assert.IsType<ProcessStepEdgeBuilder>(edgeBuilder);
-        Assert.EndsWith(".OnResult", edgeBuilder.EventId);
+        Assert.EndsWith("TestFunction.OnResult", edgeBuilder.EventId);
     }
 
     /// <summary>
@@ -81,7 +80,7 @@ public class ProcessStepBuilderTests
         // Assert
         Assert.NotNull(edgeBuilder);
         Assert.IsType<ProcessStepEdgeBuilder>(edgeBuilder);
-        Assert.EndsWith(".OnError", edgeBuilder.EventId);
+        Assert.EndsWith("TestFunction.OnError", edgeBuilder.EventId);
     }
 
     /// <summary>

--- a/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/ProcessStepBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -43,6 +44,8 @@ public class ProcessStepBuilderTests
 
         // Assert
         Assert.NotNull(edgeBuilder);
+        Assert.IsType<ProcessStepEdgeBuilder>(edgeBuilder);
+        Assert.EndsWith("TestEvent", edgeBuilder.EventId);
     }
 
     /// <summary>
@@ -59,6 +62,26 @@ public class ProcessStepBuilderTests
 
         // Assert
         Assert.NotNull(edgeBuilder);
+        Assert.IsType<ProcessStepEdgeBuilder>(edgeBuilder);
+        Assert.EndsWith(".OnResult", edgeBuilder.EventId);
+    }
+
+    /// <summary>
+    /// Verify that the <see cref="ProcessStepBuilder.OnFunctionResult(string)"/> method returns a <see cref="ProcessStepEdgeBuilder"/>.
+    /// </summary>
+    [Fact]
+    public void OnFunctionErrorShouldReturnProcessStepEdgeBuilder()
+    {
+        // Arrange
+        var stepBuilder = new TestProcessStepBuilder("TestStep");
+
+        // Act
+        var edgeBuilder = stepBuilder.OnFunctionError("TestFunction");
+
+        // Assert
+        Assert.NotNull(edgeBuilder);
+        Assert.IsType<ProcessStepEdgeBuilder>(edgeBuilder);
+        Assert.EndsWith(".OnError", edgeBuilder.EventId);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Introduce support for `.OnError` with parity to `.OnResult`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Developer shouldn't need to guess at naming convention for error handling.
- Passing full exception, not just message.

> I'd really like to see ability to define process-level error handling

> I like the `OnError` approach, but there are still a lot of cases where the _Process_ just stops w/o any information...this doesn't affect those cases and I'm not actively looking (I have seen quite a few actionable messages, however, which is great!)

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
