### PR TITLE
.Net: Added default index kind and distance function for Azure CosmosDB MongoDB connector

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConstants.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConstants.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 
@@ -10,6 +11,12 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// </summary>
 internal static class AzureCosmosDBMongoDBConstants
 {
+    /// <summary>Default index kind for vector search.</summary>
+    internal const string DefaultIndexKind = IndexKind.IvfFlat;
+
+    /// <summary>Default distance function for vector search.</summary>
+    internal const string DefaultDistanceFunction = DistanceFunction.CosineDistance;
+
     /// <summary>Reserved key property name in Azure CosmosDB MongoDB.</summary>
     internal const string MongoReservedKeyPropertyName = "_id";
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping.cs
@@ -112,7 +112,9 @@ internal static class AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping
     /// </summary>
     private static string GetIndexKind(string? indexKind, string vectorPropertyName)
     {
-        return indexKind switch
+        var vectorPropertyIndexKind = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetVectorPropertyIndexKind(indexKind);
+
+        return vectorPropertyIndexKind switch
         {
             IndexKind.Hnsw => "vector-hnsw",
             IndexKind.IvfFlat => "vector-ivf",
@@ -125,7 +127,9 @@ internal static class AzureCosmosDBMongoDBVectorStoreCollectionCreateMapping
     /// </summary>
     private static string GetDistanceFunction(string? distanceFunction, string vectorPropertyName)
     {
-        return distanceFunction switch
+        var vectorPropertyDistanceFunction = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetVectorPropertyDistanceFunction(distanceFunction);
+
+        return vectorPropertyDistanceFunction switch
         {
             DistanceFunction.CosineDistance => "COS",
             DistanceFunction.DotProductSimilarity => "IP",

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.cs
@@ -13,6 +13,12 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// </summary>
 internal static class AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping
 {
+    /// <summary>Returns index kind specified on vector property or default <see cref="AzureCosmosDBMongoDBConstants.DefaultIndexKind"/>.</summary>
+    public static string GetVectorPropertyIndexKind(string? indexKind) => !string.IsNullOrWhiteSpace(indexKind) ? indexKind! : AzureCosmosDBMongoDBConstants.DefaultIndexKind;
+
+    /// <summary>Returns distance function specified on vector property or default <see cref="AzureCosmosDBMongoDBConstants.DefaultDistanceFunction"/>.</summary>
+    public static string GetVectorPropertyDistanceFunction(string? distanceFunction) => !string.IsNullOrWhiteSpace(distanceFunction) ? distanceFunction! : AzureCosmosDBMongoDBConstants.DefaultDistanceFunction;
+
     /// <summary>
     /// Build Azure CosmosDB MongoDB filter from the provided <see cref="VectorSearchFilter"/>.
     /// </summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -280,7 +280,9 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : I
         // to perform skip logic locally, since skip option is not part of API. 
         var itemsAmount = searchOptions.Skip + searchOptions.Top;
 
-        var searchQuery = vectorProperty.IndexKind switch
+        var vectorPropertyIndexKind = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetVectorPropertyIndexKind(vectorProperty.IndexKind);
+
+        var searchQuery = vectorPropertyIndexKind switch
         {
             IndexKind.Hnsw => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.GetSearchQueryForHnswIndex(
                 vectorArray,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Default index kind and distance function should be used when this information is not specified by the user in vector store record definition.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
