### PR TITLE
.Net: Mark new Native-AOT API as experimental

### DIFF
--- a/dotnet/docs/EXPERIMENTS.md
+++ b/dotnet/docs/EXPERIMENTS.md
@@ -24,6 +24,7 @@ You can use the following diagnostic IDs to ignore warnings or errors for a part
 | SKEXP0080 | Processes |
 | SKEXP0100 | Advanced Semantic Kernel features |
 | SKEXP0110 | Semantic Kernel Agents |
+| SKEXP0120 | Native-AOT |
 
 ## Experimental Features Tracking
 
@@ -83,3 +84,5 @@ You can use the following diagnostic IDs to ignore warnings or errors for a part
 | SKEXP0101 | Experiment with Flow Orchestration |
 | | | | | | | |
 | SKEXP0110 | Agent Framework |
+| | | | | | | |
+| SKEXP0120 | Native-AOT |

--- a/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Connectors.UnitTests.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1806,CA1869,CA1861,IDE0300,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1806,CA1869,CA1861,IDE0300,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050,SKEXP0120</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
@@ -33,12 +33,9 @@ internal static class KernelJsonSchemaBuilder
     [RequiresDynamicCode("Uses reflection to generate JSON schema, making it incompatible with AOT scenarios.")]
     public static KernelJsonSchema Build(Type type, string? description = null, JsonSchemaMapperConfiguration? configuration = null)
     {
-#pragma warning disable SKEXP0120
         return Build(type, GetDefaultOptions(), description, configuration);
-#pragma warning restore SKEXP0120
     }
 
-    [Experimental("SKEXP0120")]
     public static KernelJsonSchema Build(
         Type type,
         JsonSerializerOptions options,

--- a/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
+++ b/dotnet/src/InternalUtilities/src/Schema/KernelJsonSchemaBuilder.cs
@@ -33,9 +33,12 @@ internal static class KernelJsonSchemaBuilder
     [RequiresDynamicCode("Uses reflection to generate JSON schema, making it incompatible with AOT scenarios.")]
     public static KernelJsonSchema Build(Type type, string? description = null, JsonSchemaMapperConfiguration? configuration = null)
     {
+#pragma warning disable SKEXP0120
         return Build(type, GetDefaultOptions(), description, configuration);
+#pragma warning restore SKEXP0120
     }
 
+    [Experimental("SKEXP0120")]
     public static KernelJsonSchema Build(
         Type type,
         JsonSerializerOptions options,

--- a/dotnet/src/SemanticKernel.Abstractions/Contents/FunctionCallContentBuilder.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/FunctionCallContentBuilder.cs
@@ -34,6 +34,7 @@ public sealed class FunctionCallContentBuilder
     /// Creates a new instance of the <see cref="FunctionCallContentBuilder"/> class.
     /// </summary>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for deserializing function arguments.</param>
+    [Experimental("SKEXP0120")]
     public FunctionCallContentBuilder(JsonSerializerOptions jsonSerializerOptions)
     {
         this._jsonSerializerOptions = jsonSerializerOptions;

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelParameterMetadata.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelParameterMetadata.cs
@@ -37,6 +37,7 @@ public sealed class KernelParameterMetadata
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
     /// <exception cref="ArgumentNullException">The <paramref name="name"/> was null.</exception>
     /// <exception cref="ArgumentException">The <paramref name="name"/> was empty or composed entirely of whitespace.</exception>
+    [Experimental("SKEXP0120")]
     public KernelParameterMetadata(string name, JsonSerializerOptions jsonSerializerOptions)
     {
         this.Name = name;
@@ -65,6 +66,7 @@ public sealed class KernelParameterMetadata
     /// <param name="metadata">The metadata to copy.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
     /// <remarks>This creates a shallow clone of <paramref name="metadata"/>.</remarks>
+    [Experimental("SKEXP0120")]
     public KernelParameterMetadata(KernelParameterMetadata metadata, JsonSerializerOptions jsonSerializerOptions)
     {
         Verify.NotNull(metadata);

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelReturnParameterMetadata.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelReturnParameterMetadata.cs
@@ -40,6 +40,7 @@ public sealed class KernelReturnParameterMetadata
 
     /// <summary>Initializes the <see cref="KernelReturnParameterMetadata"/>.</summary>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
+    [Experimental("SKEXP0120")]
     public KernelReturnParameterMetadata(JsonSerializerOptions jsonSerializerOptions)
     {
         this._jsonSerializerOptions = jsonSerializerOptions;
@@ -59,6 +60,7 @@ public sealed class KernelReturnParameterMetadata
     /// <summary>Initializes a <see cref="KernelReturnParameterMetadata"/> as a copy of another <see cref="KernelReturnParameterMetadata"/>.</summary>
     /// <param name="metadata">The metadata to copy.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
+    [Experimental("SKEXP0120")]
     public KernelReturnParameterMetadata(KernelReturnParameterMetadata metadata, JsonSerializerOptions jsonSerializerOptions)
     {
         this._description = metadata._description;

--- a/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/PromptTemplate/PromptTemplateConfig.cs
@@ -75,6 +75,7 @@ public sealed class PromptTemplateConfig
     /// <exception cref="ArgumentException"><paramref name="json"/> is an invalid JSON representation of a <see cref="PromptTemplateConfig"/>.</exception>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "This method is AOT safe.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "This method is AOT safe.")]
+    [Experimental("SKEXP0120")]
     public static PromptTemplateConfig FromJson(string json, JsonSerializerOptions jsonSerializerOptions)
     {
         return FromJsonInternal(json, jsonSerializerOptions);

--- a/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
+++ b/dotnet/src/SemanticKernel.Abstractions/SemanticKernel.Abstractions.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Microsoft.SemanticKernel.Abstractions</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001,SKEXP0120</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFactory.cs
@@ -50,6 +50,7 @@ public static class KernelFunctionFactory
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         Delegate method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -80,6 +81,7 @@ public static class KernelFunctionFactory
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         Delegate method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -123,6 +125,7 @@ public static class KernelFunctionFactory
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -159,6 +162,7 @@ public static class KernelFunctionFactory
     /// <param name="target">The target object for the <paramref name="method"/> if it represents an instance method. This should be null if and only if <paramref name="method"/> is a static method.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -217,6 +221,7 @@ public static class KernelFunctionFactory
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         string promptTemplate,
         JsonSerializerOptions jsonSerializerOptions,
@@ -277,6 +282,7 @@ public static class KernelFunctionFactory
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         string promptTemplate,
         JsonSerializerOptions jsonSerializerOptions,
@@ -316,6 +322,7 @@ public static class KernelFunctionFactory
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         PromptTemplateConfig promptConfig,
         JsonSerializerOptions jsonSerializerOptions,
@@ -344,6 +351,7 @@ public static class KernelFunctionFactory
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         IPromptTemplate promptTemplate,
         PromptTemplateConfig promptConfig,

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -78,6 +78,7 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -150,6 +151,7 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="target">The target object for the <paramref name="method"/> if it represents an instance method. This should be null if and only if <paramref name="method"/> is a static method.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -89,6 +89,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <param name="promptTemplateFactory">Optional: Prompt template factory</param>
     /// <param name="loggerFactory">Logger factory</param>
     /// <returns>A function ready to use</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         string promptTemplate,
         JsonSerializerOptions jsonSerializerOptions,
@@ -161,6 +162,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <param name="promptTemplateFactory">Optional: Prompt template factory</param>
     /// <param name="loggerFactory">Logger factory</param>
     /// <returns>A function ready to use</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         PromptTemplateConfig promptConfig,
         JsonSerializerOptions jsonSerializerOptions,
@@ -207,6 +209,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="loggerFactory">Logger factory</param>
     /// <returns>A function ready to use</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         IPromptTemplate promptTemplate,
         PromptTemplateConfig promptConfig,

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelPluginFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelPluginFactory.cs
@@ -55,6 +55,7 @@ public static partial class KernelPluginFactory
     /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
     /// Attributed methods must all have different names; overloads are not supported.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateFromType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(JsonSerializerOptions jsonSerializerOptions, string? pluginName = null, IServiceProvider? serviceProvider = null)
     {
         serviceProvider ??= EmptyServiceProvider.Instance;
@@ -93,6 +94,7 @@ public static partial class KernelPluginFactory
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "This method is AOT save.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "This method is AOT safe.")]
+    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateFromObject(object target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null, ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(jsonSerializerOptions);

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -57,6 +57,7 @@ public static class KernelExtensions
     /// <param name="parameters">Optional parameter descriptions. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromMethod(
         this Kernel kernel,
         Delegate method,
@@ -114,6 +115,7 @@ public static class KernelExtensions
     /// <param name="parameters">Optional parameter descriptions. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromMethod(
         this Kernel kernel,
         MethodInfo method,
@@ -187,6 +189,7 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromPrompt(
         this Kernel kernel,
         string promptTemplate,
@@ -264,6 +267,7 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromPrompt(
         this Kernel kernel,
         string promptTemplate,
@@ -322,6 +326,7 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromPrompt(
         this Kernel kernel,
         PromptTemplateConfig promptConfig,
@@ -368,6 +373,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin CreatePluginFromType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this Kernel kernel, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         Verify.NotNull(kernel);
@@ -409,6 +415,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin CreatePluginFromObject(this Kernel kernel, object target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         Verify.NotNull(kernel);
@@ -481,6 +488,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin ImportPluginFromType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this Kernel kernel, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         KernelPlugin plugin = CreatePluginFromType<T>(kernel, jsonSerializerOptions, pluginName);
@@ -524,6 +532,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin AddFromType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this ICollection<KernelPlugin> plugins, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null, IServiceProvider? serviceProvider = null)
     {
         Verify.NotNull(plugins);
@@ -567,6 +576,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static IKernelBuilderPlugins AddFromType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IKernelBuilderPlugins plugins, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         Verify.NotNull(plugins);
@@ -624,6 +634,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin ImportPluginFromObject(this Kernel kernel, object target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         KernelPlugin plugin = CreatePluginFromObject(kernel, target, jsonSerializerOptions, pluginName);
@@ -667,6 +678,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin AddFromObject(this ICollection<KernelPlugin> plugins, object target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null, IServiceProvider? serviceProvider = null)
     {
         Verify.NotNull(plugins);
@@ -710,6 +722,7 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static IKernelBuilderPlugins AddFromObject(this IKernelBuilderPlugins plugins, object target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         Verify.NotNull(plugins);
@@ -898,6 +911,7 @@ public static class KernelExtensions
     /// <returns>A <see cref="KernelPlugin"/> containing prompt functions created from the specified directory.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "This method is AOT save.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "This method is AOT safe.")]
+    [Experimental("SKEXP0120")]
     public static KernelPlugin CreatePluginFromPromptDirectory(
         this Kernel kernel,
         string pluginDirectory,
@@ -1073,6 +1087,7 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>A <see cref="KernelPlugin"/> containing prompt functions created from the specified directory.</returns>
+    [Experimental("SKEXP0120")]
     public static KernelPlugin ImportPluginFromPromptDirectory(
         this Kernel kernel,
         string pluginDirectory,
@@ -1178,6 +1193,7 @@ public static class KernelExtensions
     /// <returns>The same instance as <paramref name="plugins"/>.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "This method is AOT save.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "This method is AOT safe.")]
+    [Experimental("SKEXP0120")]
     public static IKernelBuilderPlugins AddFromPromptDirectory(
         this IKernelBuilderPlugins plugins,
         string pluginDirectory,
@@ -1256,6 +1272,7 @@ public static class KernelExtensions
     /// <exception cref="KernelFunction">The function failed to invoke successfully.</exception>
     /// <exception cref="KernelFunctionCanceledException">The <see cref="KernelFunction"/>'s invocation was canceled.</exception>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    [Experimental("SKEXP0120")]
     public static Task<FunctionResult> InvokePromptAsync(
         this Kernel kernel,
         JsonSerializerOptions jsonSerializerOptions,
@@ -1339,6 +1356,7 @@ public static class KernelExtensions
     /// <exception cref="ArgumentException"><paramref name="promptTemplate"/> is empty or composed entirely of whitespace.</exception>
     /// <exception cref="KernelFunction">The function failed to invoke successfully.</exception>
     /// <exception cref="KernelFunctionCanceledException">The <see cref="KernelFunction"/>'s invocation was canceled.</exception>
+    [Experimental("SKEXP0120")]
     public static Task<T?> InvokePromptAsync<T>(
         this Kernel kernel,
         JsonSerializerOptions jsonSerializerOptions,
@@ -1464,6 +1482,7 @@ public static class KernelExtensions
     /// The function will not be invoked until an enumerator is retrieved from the returned <see cref="IAsyncEnumerable{T}"/>
     /// and its iteration initiated via an initial call to <see cref="IAsyncEnumerator{T}.MoveNextAsync"/>.
     /// </remarks>
+    [Experimental("SKEXP0120")]
     public static IAsyncEnumerable<StreamingKernelContent> InvokePromptStreamingAsync(
         this Kernel kernel,
         JsonSerializerOptions jsonSerializerOptions,
@@ -1553,6 +1572,7 @@ public static class KernelExtensions
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "This method is AOT save.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "This method is AOT save.")]
+    [Experimental("SKEXP0120")]
     public static IAsyncEnumerable<T> InvokePromptStreamingAsync<T>(
         this Kernel kernel,
         JsonSerializerOptions jsonSerializerOptions,

--- a/dotnet/src/SemanticKernel.Core/SemanticKernel.Core.csproj
+++ b/dotnet/src/SemanticKernel.Core/SemanticKernel.Core.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001,SKEXP0120</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>    <!-- ;net48 -->
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0050,SKEXP0110,IDE1006</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0050,SKEXP0110,IDE1006, SKEXP0120</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation, Context and Description
This PR adds a new experimental category and annotates all new Native-AOT API with the Experimental attribute.
