### PR TITLE
.Net: Remove class constraint for VectorStore records.

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStoreExtensions.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreExtensions.cs
@@ -17,14 +17,14 @@ internal static class VectorStoreExtensions
     /// </summary>
     /// <typeparam name="TKey">Type of the record key.</typeparam>
     /// <typeparam name="TRecord">Type of the record.</typeparam>
-    internal delegate TRecord CreateRecordFromString<TKey, TRecord>(string text, ReadOnlyMemory<float> vector) where TKey : notnull where TRecord : class;
+    internal delegate TRecord CreateRecordFromString<TKey, TRecord>(string text, ReadOnlyMemory<float> vector) where TKey : notnull;
 
     /// <summary>
     /// Delegate to create a record from a <see cref="TextSearchResult"/>.
     /// </summary>
     /// <typeparam name="TKey">Type of the record key.</typeparam>
     /// <typeparam name="TRecord">Type of the record.</typeparam>
-    internal delegate TRecord CreateRecordFromTextSearchResult<TKey, TRecord>(TextSearchResult searchResult, ReadOnlyMemory<float> vector) where TKey : notnull where TRecord : class;
+    internal delegate TRecord CreateRecordFromTextSearchResult<TKey, TRecord>(TextSearchResult searchResult, ReadOnlyMemory<float> vector) where TKey : notnull;
 
     /// <summary>
     /// Create a <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> from a list of strings by:
@@ -45,7 +45,6 @@ internal static class VectorStoreExtensions
         ITextEmbeddingGenerationService embeddingGenerationService,
         CreateRecordFromString<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         // Get and create collection if it doesn't exist.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);
@@ -81,7 +80,6 @@ internal static class VectorStoreExtensions
         ITextEmbeddingGenerationService embeddingGenerationService,
         CreateRecordFromTextSearchResult<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         // Get and create collection if it doesn't exist.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);

--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
@@ -2,6 +2,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Azure.Identity;
 using Memory.VectorStoreFixtures;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
@@ -58,7 +59,7 @@ public class VectorStore_DataIngestion_CustomMapper(ITestOutputHelper output, Ve
         var textEmbeddingGenerationService = new AzureOpenAITextEmbeddingGenerationService(
                 TestConfiguration.AzureOpenAIEmbeddings.DeploymentName,
                 TestConfiguration.AzureOpenAIEmbeddings.Endpoint,
-                TestConfiguration.AzureOpenAIEmbeddings.ApiKey);
+                new AzureCliCredential());
 
         // Initiate the docker container and construct the vector store using the custom factory for creating collections.
         await redisFixture.ManualInitializeAsync();
@@ -135,7 +136,6 @@ public class VectorStore_DataIngestion_CustomMapper(ITestOutputHelper output, Ve
     {
         public IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IDatabase database, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
             where TKey : notnull
-            where TRecord : class
         {
             // If the record definition is the glossary definition and the record type is the generic data model, inject the custom mapper into the collection options.
             if (vectorStoreRecordDefinition == s_glossaryDefinition && typeof(TRecord) == typeof(GenericDataModel))

--- a/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
+++ b/dotnet/samples/Concepts/Search/VectorStore_TextSearch.cs
@@ -101,7 +101,7 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
     /// </summary>
     /// <typeparam name="TKey">Type of the record key.</typeparam>
     /// <typeparam name="TRecord">Type of the record.</typeparam>
-    internal delegate TRecord CreateRecord<TKey, TRecord>(string text, ReadOnlyMemory<float> vector) where TKey : notnull where TRecord : class;
+    internal delegate TRecord CreateRecord<TKey, TRecord>(string text, ReadOnlyMemory<float> vector) where TKey : notnull;
 
     /// <summary>
     /// Create a <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> from a list of strings by:
@@ -122,7 +122,6 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
         ITextEmbeddingGenerationService embeddingGenerationService,
         CreateRecord<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         // Get and create collection if it doesn't exist.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);
@@ -143,7 +142,6 @@ public class VectorStore_TextSearch(ITestOutputHelper output) : BaseTest(output)
     /// Decorator for a <see cref="IVectorizedSearch{TRecord}"/> that generates embeddings for text search queries.
     /// </summary>
     private sealed class VectorizedSearchWrapper<TRecord>(IVectorizedSearch<TRecord> vectorizedSearch, ITextEmbeddingGenerationService textEmbeddingGeneration) : IVectorizableTextSearch<TRecord>
-        where TRecord : class
     {
         /// <inheritdoc/>
         public async Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/samples/GettingStartedWithTextSearch/InMemoryVectorStoreFixture.cs
+++ b/dotnet/samples/GettingStartedWithTextSearch/InMemoryVectorStoreFixture.cs
@@ -98,7 +98,7 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
     /// </summary>
     /// <typeparam name="TKey">Type of the record key.</typeparam>
     /// <typeparam name="TRecord">Type of the record.</typeparam>
-    internal delegate TRecord CreateRecord<TKey, TRecord>(int index, string text, ReadOnlyMemory<float> vector) where TKey : notnull where TRecord : class;
+    internal delegate TRecord CreateRecord<TKey, TRecord>(int index, string text, ReadOnlyMemory<float> vector) where TKey : notnull;
 
     /// <summary>
     /// Create a <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> from a list of strings by:
@@ -113,7 +113,6 @@ public class InMemoryVectorStoreFixture : IAsyncLifetime
         string[] entries,
         CreateRecord<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         // Get and create collection if it doesn't exist.
         var collection = this.InMemoryVectorStore.GetCollection<TKey, TRecord>(this.CollectionName);

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
@@ -72,7 +72,6 @@ public static class AzureAISearchKernelBuilderExtensions
         string collectionName,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
         return builder;
@@ -97,7 +96,6 @@ public static class AzureAISearchKernelBuilderExtensions
         TokenCredential tokenCredential,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, endpoint, tokenCredential, options, serviceId);
         return builder;
@@ -122,7 +120,6 @@ public static class AzureAISearchKernelBuilderExtensions
         AzureKeyCredential credential,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, endpoint, credential, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
@@ -122,7 +122,6 @@ public static class AzureAISearchServiceCollectionExtensions
         string collectionName,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         // If we are not constructing the SearchIndexClient, add the IVectorStore as transient, since we
         // cannot make assumptions about how SearchIndexClient is being managed.
@@ -163,7 +162,6 @@ public static class AzureAISearchServiceCollectionExtensions
         TokenCredential tokenCredential,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(tokenCredential);
@@ -207,7 +205,6 @@ public static class AzureAISearchServiceCollectionExtensions
         AzureKeyCredential credential,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(credential);
@@ -239,7 +236,6 @@ public static class AzureAISearchServiceCollectionExtensions
     /// <param name="services">The service collection to register on.</param>
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStore.cs
@@ -44,7 +44,6 @@ public sealed class AzureAISearchVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -25,7 +25,6 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IVectorizableTextSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-    where TRecord : class
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
     private const string DatabaseName = "AzureAISearch";
@@ -424,7 +423,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorS
 
             if (jsonObject is null)
             {
-                return null;
+                return default;
             }
 
             return VectorStoreErrorHandler.RunModelConversion(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollectionOptions.cs
@@ -11,7 +11,6 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// Options when creating a <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public sealed class AzureAISearchVectorStoreRecordCollectionOptions<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Azure AI Search record.

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/IAzureAISearchVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/IAzureAISearchVectorStoreRecordCollectionFactory.cs
@@ -20,6 +20,5 @@ public interface IAzureAISearchVectorStoreRecordCollectionFactory
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
     IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(SearchIndexClient searchIndexClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBKernelBuilderExtensions.cs
@@ -64,7 +64,6 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         string collectionName,
         AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
         return builder;
@@ -89,7 +88,6 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         string databaseName,
         AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(collectionName, connectionString, databaseName, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBServiceCollectionExtensions.cs
@@ -93,7 +93,6 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
         string collectionName,
         AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -129,7 +128,6 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
         string databaseName,
         AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -158,7 +156,6 @@ public static class AzureCosmosDBMongoDBServiceCollectionExtensions
     /// <param name="services">The service collection to register on.</param>
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStore.cs
@@ -39,7 +39,6 @@ public sealed class AzureCosmosDBMongoDBVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord> where TRecord : class
+public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -157,7 +157,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : I
 
         if (record is null)
         {
-            return null;
+            return default;
         }
 
         return VectorStoreErrorHandler.RunModelConversion(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Options when creating a <see cref="AzureCosmosDBMongoDBVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
-public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord> where TRecord : class
+public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>
 {
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Azure CosmosDB MongoDB BSON object.

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordMapper.cs
@@ -11,7 +11,6 @@ using MongoDB.Bson.Serialization.Conventions;
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 
 internal sealed class AzureCosmosDBMongoDBVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, BsonDocument>
-    where TRecord : class
 {
     /// <summary>A key property info of the data model.</summary>
     private readonly PropertyInfo _keyProperty;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/IAzureCosmosDBMongoDBVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/IAzureCosmosDBMongoDBVectorStoreRecordCollectionFactory.cs
@@ -20,6 +20,5 @@ public interface IAzureCosmosDBMongoDBVectorStoreRecordCollectionFactory
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
     IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IMongoDatabase mongoDatabase, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKernelBuilderExtensions.cs
@@ -69,7 +69,6 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
         string collectionName,
         AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
         return builder;
@@ -94,7 +93,6 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
         string databaseName,
         AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(collectionName, connectionString, databaseName, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLServiceCollectionExtensions.cs
@@ -94,7 +94,6 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
         string collectionName,
         AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -130,7 +129,6 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
         string databaseName,
         AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -160,7 +158,6 @@ public static class AzureCosmosDBNoSQLServiceCollectionExtensions
     /// <param name="services">The service collection to register on.</param>
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStore.cs
@@ -39,7 +39,6 @@ public sealed class AzureCosmosDBNoSQLVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(string) && typeof(TKey) != typeof(AzureCosmosDBNoSQLCompositeKey))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -25,7 +25,6 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<string, TRecord>,
     IVectorStoreRecordCollection<AzureCosmosDBNoSQLCompositeKey, TRecord>
-    where TRecord : class
 #pragma warning restore CA1711 // Identifiers should not have incorrect
 {
     /// <summary>The name of this database for telemetry purposes.</summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// <summary>
 /// Options when creating a <see cref="AzureCosmosDBNoSQLVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
-public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord> where TRecord : class
+public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>
 {
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Azure CosmosDB NoSQL record.

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordMapper.cs
@@ -12,7 +12,6 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
 internal sealed class AzureCosmosDBNoSQLVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, JsonObject>
-    where TRecord : class
 {
     /// <summary>The JSON serializer options to use when converting between the data model and the Azure CosmosDB NoSQL record.</summary>
     private readonly JsonSerializerOptions _jsonSerializerOptions;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/IAzureCosmosDBNoSQLVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/IAzureCosmosDBNoSQLVectorStoreRecordCollectionFactory.cs
@@ -23,6 +23,5 @@ public interface IAzureCosmosDBNoSQLVectorStoreRecordCollectionFactory
         Database database,
         string name,
         VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryKernelBuilderExtensions.cs
@@ -38,7 +38,6 @@ public static class InMemoryKernelBuilderExtensions
         InMemoryVectorStoreRecordCollectionOptions<TKey, TRecord>? options = default,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         builder.Services.AddInMemoryVectorStoreRecordCollection<TKey, TRecord>(collectionName, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryServiceCollectionExtensions.cs
@@ -42,7 +42,6 @@ public static class InMemoryServiceCollectionExtensions
         InMemoryVectorStoreRecordCollectionOptions<TKey, TRecord>? options = default,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<TKey, TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
@@ -40,7 +40,6 @@ public sealed class InMemoryVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (this._internalCollectionTypes.TryGetValue(name, out var existingCollectionDataType) && existingCollectionDataType != typeof(TRecord))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreExtensions.cs
@@ -32,7 +32,6 @@ public static class InMemoryVectorStoreExtensions
         Stream stream,
         JsonSerializerOptions? jsonSerializerOptions = null)
         where TKey : notnull
-        where TRecord : class
     {
         // Get collection and verify that it exists.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);
@@ -60,7 +59,6 @@ public static class InMemoryVectorStoreExtensions
         this InMemoryVectorStore vectorStore,
         Stream stream)
         where TKey : notnull
-        where TRecord : class
     {
         IVectorStoreRecordCollection<TKey, TRecord>? collection = null;
 
@@ -92,7 +90,6 @@ public static class InMemoryVectorStoreExtensions
     /// <summary>Model class used when storing a <see cref="InMemoryVectorStoreRecordCollection{TKey, TRecord}" />.</summary>
     private sealed class InMemoryRecordCollection<TKey, TRecord>(string name, IDictionary<TKey, TRecord> records)
         where TKey : notnull
-        where TRecord : class
     {
         public string Name { get; init; } = name;
         public IDictionary<TKey, TRecord> Records { get; init; } = records;

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreKeyResolver.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreKeyResolver.cs
@@ -8,5 +8,4 @@ namespace Microsoft.SemanticKernel.Connectors.InMemory;
 /// <param name="record">The record to look up the key for.</param>
 /// <returns>The record key.</returns>
 public delegate TKey? InMemoryVectorStoreKeyResolver<TKey, TRecord>(TRecord record)
-    where TKey : notnull
-    where TRecord : class;
+    where TKey : notnull;

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -20,7 +20,6 @@ namespace Microsoft.SemanticKernel.Connectors.InMemory;
 public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TKey : notnull
-    where TRecord : class
 {
     /// <summary>A set of types that vectors on the provided model may have.</summary>
     private static readonly HashSet<Type> s_supportedVectorTypes =
@@ -145,10 +144,10 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
 
         if (collectionDictionary.TryGetValue(key, out var record))
         {
-            return Task.FromResult<TRecord?>(record as TRecord);
+            return Task.FromResult<TRecord?>((TRecord?)record);
         }
 
-        return Task.FromResult<TRecord?>(null);
+        return Task.FromResult<TRecord?>(default);
     }
 
     /// <inheritdoc />
@@ -190,6 +189,8 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
     /// <inheritdoc />
     public Task<TKey> UpsertAsync(TRecord record, UpsertRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
+        Verify.NotNull(record);
+
         var collectionDictionary = this.GetCollectionDictionary();
 
         var key = (TKey)this._keyResolver(record)!;

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollectionOptions.cs
@@ -11,7 +11,6 @@ namespace Microsoft.SemanticKernel.Connectors.InMemory;
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data on the collection that this options will be used with.</typeparam>
 public sealed class InMemoryVectorStoreRecordCollectionOptions<TKey, TRecord>
     where TKey : notnull
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets an optional record definition that defines the schema of the record type.

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreVectorResolver.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreVectorResolver.cs
@@ -8,5 +8,4 @@ namespace Microsoft.SemanticKernel.Connectors.InMemory;
 /// <param name="vectorName">The name of the vector to find.</param>
 /// <param name="record">The record that contains the vector to look up.</param>
 /// <returns>The named vector from the record.</returns>
-public delegate object? InMemoryVectorStoreVectorResolver<TRecord>(string vectorName, TRecord record)
-    where TRecord : class;
+public delegate object? InMemoryVectorStoreVectorResolver<TRecord>(string vectorName, TRecord record);

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeVectorStoreRecordCollectionFactory.cs
@@ -20,6 +20,5 @@ public interface IPineconeVectorStoreRecordCollectionFactory
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
     IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(Sdk.PineconeClient pineconeClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -53,7 +53,6 @@ public static class PineconeKernelBuilderExtensions
         string collectionName,
         PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         builder.Services.AddPineconeVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
         return builder;
@@ -76,7 +75,6 @@ public static class PineconeKernelBuilderExtensions
         string apiKey,
         PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         builder.Services.AddPineconeVectorStoreRecordCollection<TRecord>(collectionName, apiKey, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeServiceCollectionExtensions.cs
@@ -78,7 +78,6 @@ public static class PineconeServiceCollectionExtensions
         string collectionName,
         PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         // If we are not constructing the PineconeClient, add the IVectorStore as transient, since we
         // cannot make assumptions about how PineconeClient is being managed.
@@ -117,7 +116,6 @@ public static class PineconeServiceCollectionExtensions
         string apiKey,
         PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-            where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -144,7 +142,6 @@ public static class PineconeServiceCollectionExtensions
     /// <param name="services">The service collection to register on.</param>
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStore.cs
@@ -41,7 +41,6 @@ public sealed class PineconeVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -20,7 +20,6 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public sealed class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-    where TRecord : class
 {
     private const string DatabaseName = "Pinecone";
     private const string CreateCollectionName = "CreateCollection";

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollectionOptions.cs
@@ -9,7 +9,6 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Options when creating a <see cref="PineconeVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public sealed class PineconeVectorStoreRecordCollectionOptions<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Pinecone vector.

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
@@ -13,7 +13,6 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
 internal sealed class PineconeVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, Vector>
-    where TRecord : class
 {
     /// <summary>A set of types that a key on the provided model may have.</summary>
     private static readonly HashSet<Type> s_supportedKeyTypes = [typeof(string)];

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorStoreRecordCollectionFactory.cs
@@ -20,6 +20,5 @@ public interface IQdrantVectorStoreRecordCollectionFactory
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
     IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(QdrantClient qdrantClient, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
@@ -57,7 +57,6 @@ public static class QdrantKernelBuilderExtensions
         QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         builder.Services.AddQdrantVectorStoreRecordCollection<TKey, TRecord>(collectionName, options, serviceId);
         return builder;
@@ -88,7 +87,6 @@ public static class QdrantKernelBuilderExtensions
         QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         builder.Services.AddQdrantVectorStoreRecordCollection<TKey, TRecord>(collectionName, host, port, https, apiKey, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantServiceCollectionExtensions.cs
@@ -82,7 +82,6 @@ public static class QdrantServiceCollectionExtensions
         QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorStoreRecordCollection<TKey, TRecord>>(
             serviceId,
@@ -124,7 +123,6 @@ public static class QdrantServiceCollectionExtensions
         QdrantVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<TKey, TRecord>>(
             serviceId,
@@ -150,7 +148,6 @@ public static class QdrantServiceCollectionExtensions
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TKey, TRecord>(IServiceCollection services, string? serviceId)
         where TKey : notnull
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -53,7 +53,6 @@ public sealed class QdrantVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(ulong) && typeof(TKey) != typeof(Guid))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
@@ -85,7 +85,6 @@ internal static class QdrantVectorStoreCollectionSearchMapping
     /// <param name="operationName">The type of database operation being run.</param>
     /// <returns>The mapped <see cref="VectorSearchResult{TRecord}"/>.</returns>
     public static VectorSearchResult<TRecord> MapScoredPointToVectorSearchResult<TRecord>(ScoredPoint point, IVectorStoreRecordMapper<TRecord, PointStruct> mapper, bool includeVectors, string databaseSystemName, string collectionName, string operationName)
-        where TRecord : class
     {
         // Since the mapper doesn't know about scored points, we need to convert the scored point to a point struct first.
         var pointStruct = new PointStruct

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -20,7 +20,6 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<ulong, TRecord>, IVectorStoreRecordCollection<Guid, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-    where TRecord : class
 {
     /// <summary>A set of types that a key on the provided model may have.</summary>
     private static readonly HashSet<Type> s_supportedKeyTypes =

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollectionOptions.cs
@@ -9,7 +9,6 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// Options when creating a <see cref="QdrantVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public sealed class QdrantVectorStoreRecordCollectionOptions<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets a value indicating whether the vectors in the store are named and multiple vectors are supported, or whether there is just a single unnamed vector per qdrant point.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -12,7 +12,6 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
 internal sealed class QdrantVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, PointStruct>
-    where TRecord : class
 {
     /// <summary>A helper to access property information for the current data model and record definition.</summary>
     private readonly VectorStoreRecordPropertyReader _propertyReader;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/IRedisVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/IRedisVectorStoreRecordCollectionFactory.cs
@@ -20,6 +20,5 @@ public interface IRedisVectorStoreRecordCollectionFactory
     /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
     /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
     IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IDatabase database, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -21,7 +21,6 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-    where TRecord : class
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
     private const string DatabaseName = "Redis";
@@ -233,7 +232,7 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         // Return null if we found nothing.
         if (retrievedHashEntries == null || retrievedHashEntries.Length == 0)
         {
-            return null;
+            return default;
         }
 
         // Convert to the caller's data model.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollectionOptions.cs
@@ -9,7 +9,6 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// Options when creating a <see cref="RedisHashSetVectorStoreRecordCollectionOptions{TRecord}"/>.
 /// </summary>
 public sealed class RedisHashSetVectorStoreRecordCollectionOptions<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets a value indicating whether the collection name should be prefixed to the

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
@@ -14,7 +14,6 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// </summary>
 /// <typeparam name="TConsumerDataModel">The consumer data model to map to or from.</typeparam>
 internal sealed class RedisHashSetVectorStoreRecordMapper<TConsumerDataModel> : IVectorStoreRecordMapper<TConsumerDataModel, (string Key, HashEntry[] HashEntries)>
-    where TConsumerDataModel : class
 {
     /// <summary>A helper to access property information for the current data model and record definition.</summary>
     private readonly VectorStoreRecordPropertyReader _propertyReader;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -24,7 +24,6 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-    where TRecord : class
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
     private const string DatabaseName = "Redis";
@@ -206,7 +205,7 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         // Check if the key was found before trying to parse the result.
         if (redisResult.IsNull || redisResult is null)
         {
-            return null;
+            return default;
         }
 
         // Check if the value contained any JSON text before trying to parse the result.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollectionOptions.cs
@@ -10,7 +10,6 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// Options when creating a <see cref="RedisJsonVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
 public sealed class RedisJsonVectorStoreRecordCollectionOptions<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets a value indicating whether the collection name should be prefixed to the

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
@@ -11,7 +11,6 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// </summary>
 /// <typeparam name="TConsumerDataModel">The consumer data model to map to or from.</typeparam>
 internal sealed class RedisJsonVectorStoreRecordMapper<TConsumerDataModel> : IVectorStoreRecordMapper<TConsumerDataModel, (string Key, JsonNode Node)>
-    where TConsumerDataModel : class
 {
     /// <summary>The name of the temporary json property that the key field will be serialized / parsed from.</summary>
     private readonly string _keyFieldJsonPropertyName;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
@@ -53,7 +53,6 @@ public static class RedisKernelBuilderExtensions
         string collectionName,
         RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddRedisHashSetVectorStoreRecordCollection(collectionName, options, serviceId);
         return builder;
@@ -76,7 +75,6 @@ public static class RedisKernelBuilderExtensions
         string redisConnectionConfiguration,
         RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddRedisHashSetVectorStoreRecordCollection(collectionName, redisConnectionConfiguration, options, serviceId);
         return builder;
@@ -97,7 +95,6 @@ public static class RedisKernelBuilderExtensions
         string collectionName,
         RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddRedisJsonVectorStoreRecordCollection(collectionName, options, serviceId);
         return builder;
@@ -120,7 +117,6 @@ public static class RedisKernelBuilderExtensions
         string redisConnectionConfiguration,
         RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddRedisJsonVectorStoreRecordCollection(collectionName, redisConnectionConfiguration, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisServiceCollectionExtensions.cs
@@ -80,7 +80,6 @@ public static class RedisServiceCollectionExtensions
         string collectionName,
         RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -114,7 +113,6 @@ public static class RedisServiceCollectionExtensions
         string redisConnectionConfiguration,
         RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -146,7 +144,6 @@ public static class RedisServiceCollectionExtensions
         string collectionName,
         RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -180,7 +177,6 @@ public static class RedisServiceCollectionExtensions
         string redisConnectionConfiguration,
         RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
             serviceId,
@@ -204,7 +200,6 @@ public static class RedisServiceCollectionExtensions
     /// <param name="services">The service collection to register on.</param>
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStore.cs
@@ -43,7 +43,6 @@ public sealed class RedisVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(string))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/IWeaviateVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/IWeaviateVectorStoreRecordCollectionFactory.cs
@@ -23,6 +23,5 @@ public interface IWeaviateVectorStoreRecordCollectionFactory
         HttpClient httpClient,
         string name,
         VectorStoreRecordDefinition? vectorStoreRecordDefinition)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
@@ -53,7 +53,6 @@ public static class WeaviateKernelBuilderExtensions
         HttpClient? httpClient = default,
         WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddWeaviateVectorStoreRecordCollection(collectionName, httpClient, options, serviceId);
         return builder;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateServiceCollectionExtensions.cs
@@ -64,7 +64,6 @@ public static class WeaviateServiceCollectionExtensions
         HttpClient? httpClient = default,
         WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorStoreRecordCollection<Guid, TRecord>>(
             serviceId,
@@ -88,7 +87,6 @@ public static class WeaviateServiceCollectionExtensions
     /// <param name="services">The service collection to register on.</param>
     /// <param name="serviceId">The service id that the registrations should use.</param>
     private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-        where TRecord : class
     {
         services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
             serviceId,

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStore.cs
@@ -45,7 +45,6 @@ public sealed class WeaviateVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (typeof(TKey) != typeof(Guid))
         {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<Guid, TRecord> where TRecord : class
+public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<Guid, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -264,7 +264,7 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
 
             if (jsonObject is null)
             {
-                return null;
+                return default;
             }
 
             return VectorStoreErrorHandler.RunModelConversion(

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// <summary>
 /// Options when creating a <see cref="WeaviateVectorStoreRecordCollection{TRecord}"/>.
 /// </summary>
-public sealed class WeaviateVectorStoreRecordCollectionOptions<TRecord> where TRecord : class
+public sealed class WeaviateVectorStoreRecordCollectionOptions<TRecord>
 {
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and Weaviate record.

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordMapper.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.VectorData;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-internal sealed class WeaviateVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, JsonObject> where TRecord : class
+internal sealed class WeaviateVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, JsonObject>
 {
     private readonly string _collectionName;
 

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisKernelBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisKernelBuilderExtensionsTests.cs
@@ -69,7 +69,7 @@ public class RedisKernelBuilderExtensionsTests
         Assert.IsType<RedisVectorStore>(vectorStore);
     }
 
-    private void AssertHashSetVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    private void AssertHashSetVectorStoreRecordCollectionCreated<TRecord>()
     {
         var kernel = this._kernelBuilder.Build();
         var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();
@@ -77,7 +77,7 @@ public class RedisKernelBuilderExtensionsTests
         Assert.IsType<RedisHashSetVectorStoreRecordCollection<TRecord>>(collection);
     }
 
-    private void AssertJsonVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    private void AssertJsonVectorStoreRecordCollectionCreated<TRecord>()
     {
         var kernel = this._kernelBuilder.Build();
         var collection = kernel.Services.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisServiceCollectionExtensionsTests.cs
@@ -69,7 +69,7 @@ public class RedisServiceCollectionExtensionsTests
         Assert.IsType<RedisVectorStore>(vectorStore);
     }
 
-    private void AssertHashSetVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    private void AssertHashSetVectorStoreRecordCollectionCreated<TRecord>()
     {
         var serviceProvider = this._serviceCollection.BuildServiceProvider();
         var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();
@@ -77,7 +77,7 @@ public class RedisServiceCollectionExtensionsTests
         Assert.IsType<RedisHashSetVectorStoreRecordCollection<TRecord>>(collection);
     }
 
-    private void AssertJsonVectorStoreRecordCollectionCreated<TRecord>() where TRecord : class
+    private void AssertJsonVectorStoreRecordCollectionCreated<TRecord>()
     {
         var serviceProvider = this._serviceCollection.BuildServiceProvider();
         var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TRecord>>();

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorizableTextSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorizableTextSearch.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Extensions.VectorData;
 /// </summary>
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
 public interface IVectorizableTextSearch<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Search the vector store for records that match the given text and filter. The text string will be vectorized downstream and used for the vector search.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorizedSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IVectorizedSearch.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Extensions.VectorData;
 /// </summary>
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
 public interface IVectorizedSearch<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Search the vector store for records that match the given embedding and filter.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchResult.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchResult.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Extensions.VectorData;
 /// </summary>
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
 public sealed class VectorSearchResult<TRecord>
-    where TRecord : class
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="VectorSearchResult{TRecord}"/> class.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchResults.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchResults.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Extensions.VectorData;
 /// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
 /// <param name="results">The list of records returned by the search operation.</param>
 public class VectorSearchResults<TRecord>(IAsyncEnumerable<VectorSearchResult<TRecord>> results)
-    where TRecord : class
 {
     /// <summary>
     /// The total count of results found by the search operation, or null

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
@@ -29,8 +29,7 @@ public interface IVectorStore
     /// <seealso cref="VectorStoreRecordDataAttribute"/>
     /// <seealso cref="VectorStoreRecordVectorAttribute"/>
     IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
-        where TKey : notnull
-        where TRecord : class;
+        where TKey : notnull;
 
     /// <summary>
     /// Retrieve the names of all the collections in the vector store.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordCollection.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Extensions.VectorData;
 public interface IVectorStoreRecordCollection<TKey, TRecord> : IVectorizedSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TKey : notnull
-    where TRecord : class
 {
     /// <summary>
     /// Gets the name of the collection.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordMapper.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Extensions.VectorData;
 /// <typeparam name="TRecordDataModel">The consumer record data model to map to or from.</typeparam>
 /// <typeparam name="TStorageModel">The storage model to map to or from.</typeparam>
 public interface IVectorStoreRecordMapper<TRecordDataModel, TStorageModel>
-    where TRecordDataModel : class
 {
     /// <summary>
     /// Map from the consumer record data model to the storage model.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreTests.cs
@@ -48,7 +48,6 @@ public class PineconeVectorStoreTests(PineconeVectorStoreFixture fixture) : ICla
             string name,
             VectorStoreRecordDefinition? vectorStoreRecordDefinition)
             where TKey : notnull
-            where TRecord : class
         {
             if (typeof(TKey) != typeof(string))
             {

--- a/dotnet/src/IntegrationTests/Data/BaseVectorStoreTextSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Data/BaseVectorStoreTextSearchTests.cs
@@ -41,7 +41,6 @@ public abstract class BaseVectorStoreTextSearchTests : BaseTextSearchTests
         ITextEmbeddingGenerationService embeddingGenerationService,
         CreateRecordFromString<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         var lines = await File.ReadAllLinesAsync("./TestData/semantic-kernel-info.txt");
 
@@ -101,7 +100,6 @@ public abstract class BaseVectorStoreTextSearchTests : BaseTextSearchTests
     /// Decorator for a <see cref="IVectorizedSearch{TRecord}"/> that generates embeddings for text search queries.
     /// </summary>
     protected sealed class VectorizedSearchWrapper<TRecord>(IVectorizedSearch<TRecord> vectorizedSearch, ITextEmbeddingGenerationService textEmbeddingGeneration) : IVectorizableTextSearch<TRecord>
-        where TRecord : class
     {
         /// <inheritdoc/>
         public async Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)

--- a/dotnet/src/IntegrationTests/Data/VectorStoreExtensions.cs
+++ b/dotnet/src/IntegrationTests/Data/VectorStoreExtensions.cs
@@ -20,14 +20,14 @@ public static class VectorStoreExtensions
     /// </summary>
     /// <typeparam name="TKey">Type of the record key.</typeparam>
     /// <typeparam name="TRecord">Type of the record.</typeparam>
-    public delegate TRecord CreateRecordFromString<TKey, TRecord>(int index, string text, ReadOnlyMemory<float> vector) where TKey : notnull where TRecord : class;
+    public delegate TRecord CreateRecordFromString<TKey, TRecord>(int index, string text, ReadOnlyMemory<float> vector) where TKey : notnull;
 
     /// <summary>
     /// Delegate to create a record from a <see cref="TextSearchResult"/>.
     /// </summary>
     /// <typeparam name="TKey">Type of the record key.</typeparam>
     /// <typeparam name="TRecord">Type of the record.</typeparam>
-    public delegate TRecord CreateRecordFromTextSearchResult<TKey, TRecord>(TextSearchResult searchResult, ReadOnlyMemory<float> vector) where TKey : notnull where TRecord : class;
+    public delegate TRecord CreateRecordFromTextSearchResult<TKey, TRecord>(TextSearchResult searchResult, ReadOnlyMemory<float> vector) where TKey : notnull;
 
     /// <summary>
     /// Create a <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> from a list of strings by:
@@ -48,7 +48,6 @@ public static class VectorStoreExtensions
         ITextEmbeddingGenerationService embeddingGenerationService,
         CreateRecordFromString<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         // Get and create collection if it doesn't exist.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);
@@ -84,7 +83,6 @@ public static class VectorStoreExtensions
         ITextEmbeddingGenerationService embeddingGenerationService,
         CreateRecordFromTextSearchResult<TKey, TRecord> createRecord)
         where TKey : notnull
-        where TRecord : class
     {
         // Get and create collection if it doesn't exist.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordMapping.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordMapping.cs
@@ -33,7 +33,6 @@ internal static class VectorStoreRecordMapping
         IReadOnlyDictionary<string, string> dataModelToStorageNameMapping,
         IReadOnlyDictionary<string, TStorageType> storageValues,
         Func<TStorageType, Type, object?>? storageValueConverter = null)
-            where TRecord : class
     {
         var propertiesInfoWithValues = BuildPropertiesInfoWithValues(
             dataModelPropertiesInfo,
@@ -86,7 +85,6 @@ internal static class VectorStoreRecordMapping
     public static void SetPropertiesOnRecord<TRecord>(
         TRecord record,
         IEnumerable<KeyValuePair<PropertyInfo, object?>> propertiesInfoWithValues)
-            where TRecord : class
     {
         foreach (var propertyInfoWithValue in propertiesInfoWithValues)
         {

--- a/dotnet/src/SemanticKernel.Core/Data/KernelBuilderExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/KernelBuilderExtensions.cs
@@ -44,7 +44,6 @@ public static class KernelBuilderExtensions
         VectorStoreTextSearchOptions? options = null,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         builder.Services.AddVolatileVectorStoreTextSearch<TKey, TRecord>(collectionName, stringMapper, resultMapper, options, serviceId);
         return builder;
@@ -68,7 +67,6 @@ public static class KernelBuilderExtensions
         VectorStoreTextSearchOptions? options = null,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         builder.AddVolatileVectorStoreTextSearch<TKey, TRecord>(
             collectionName,

--- a/dotnet/src/SemanticKernel.Core/Data/ServiceCollectionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/ServiceCollectionExtensions.cs
@@ -47,7 +47,6 @@ public static class ServiceCollectionExtensions
         VectorStoreTextSearchOptions? options = null,
         string? serviceId = default)
         where TKey : notnull
-        where TRecord : class
     {
         // If we are not constructing the dependent services, add the VectorStoreTextSearch as transient, since we
         // cannot make assumptions about how dependent services are being managed.

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchKernelBuilderExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchKernelBuilderExtensions.cs
@@ -23,7 +23,6 @@ public static class TextSearchKernelBuilderExtensions
         ITextSearchResultMapper? resultMapper = null,
         VectorStoreTextSearchOptions? options = null,
         string? serviceId = default)
-        where TRecord : class
     {
         builder.Services.AddVectorStoreTextSearch<TRecord>(stringMapper, resultMapper, options, serviceId);
         return builder;

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchServiceCollectionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchServiceCollectionExtensions.cs
@@ -27,7 +27,6 @@ public static class TextSearchServiceCollectionExtensions
         ITextSearchResultMapper? resultMapper = null,
         VectorStoreTextSearchOptions? options = null,
         string? serviceId = default)
-        where TRecord : class
     {
         // If we are not constructing the dependent services, add the VectorStoreTextSearch as transient, since we
         // cannot make assumptions about how dependent services are being managed.

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -230,7 +230,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
         await foreach (var result in searchResponse.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            if (result.Record != null)
+            if (result.Record is not null)
             {
                 yield return result.Record;
                 await Task.Yield();
@@ -252,7 +252,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
         await foreach (var result in searchResponse.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            if (result.Record != null)
+            if (result.Record is not null)
             {
                 yield return this._resultMapper.MapFromResultToTextSearchResult(result.Record);
                 await Task.Yield();
@@ -274,7 +274,7 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
         await foreach (var result in searchResponse.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            if (result.Record != null)
+            if (result.Record is not null)
             {
                 yield return this._stringMapper.MapFromResultToString(result.Record);
                 await Task.Yield();

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -17,7 +17,6 @@ namespace Microsoft.SemanticKernel.Data;
 [Experimental("SKEXP0001")]
 public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
-    where TRecord : class
 {
     /// <summary>
     /// Create an instance of the <see cref="VectorStoreTextSearch{TRecord}"/> with the
@@ -231,8 +230,11 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
         await foreach (var result in searchResponse.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            yield return result.Record;
-            await Task.Yield();
+            if (result.Record != null)
+            {
+                yield return result.Record;
+                await Task.Yield();
+            }
         }
     }
 
@@ -250,8 +252,11 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
         await foreach (var result in searchResponse.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            yield return this._resultMapper.MapFromResultToTextSearchResult(result.Record);
-            await Task.Yield();
+            if (result.Record != null)
+            {
+                yield return this._resultMapper.MapFromResultToTextSearchResult(result.Record);
+                await Task.Yield();
+            }
         }
     }
 
@@ -269,8 +274,11 @@ public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
 
         await foreach (var result in searchResponse.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            yield return this._stringMapper.MapFromResultToString(result.Record);
-            await Task.Yield();
+            if (result.Record != null)
+            {
+                yield return this._stringMapper.MapFromResultToString(result.Record);
+                await Task.Yield();
+            }
         }
     }
 

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
@@ -41,7 +41,6 @@ public sealed class VolatileVectorStore : IVectorStore
     /// <inheritdoc />
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
-        where TRecord : class
     {
         if (this._internalCollectionTypes.TryGetValue(name, out var existingCollectionDataType) && existingCollectionDataType != typeof(TRecord))
         {

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreExtensions.cs
@@ -33,7 +33,6 @@ public static class VolatileVectorStoreExtensions
         Stream stream,
         JsonSerializerOptions? jsonSerializerOptions = null)
         where TKey : notnull
-        where TRecord : class
     {
         // Get collection and verify that it exists.
         var collection = vectorStore.GetCollection<TKey, TRecord>(collectionName);
@@ -61,7 +60,6 @@ public static class VolatileVectorStoreExtensions
         this VolatileVectorStore vectorStore,
         Stream stream)
         where TKey : notnull
-        where TRecord : class
     {
         IVectorStoreRecordCollection<TKey, TRecord>? collection = null;
 
@@ -93,7 +91,6 @@ public static class VolatileVectorStoreExtensions
     /// <summary>Model class used when storing a <see cref="VolatileVectorStoreRecordCollection{TKey, TRecord}" />.</summary>
     private sealed class VolatileRecordCollection<TKey, TRecord>(string name, IDictionary<TKey, TRecord> records)
         where TKey : notnull
-        where TRecord : class
     {
         public string Name { get; init; } = name;
         public IDictionary<TKey, TRecord> Records { get; init; } = records;

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreKeyResolver.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreKeyResolver.cs
@@ -11,5 +11,4 @@ namespace Microsoft.SemanticKernel.Data;
 /// <returns>The record key.</returns>
 [Obsolete("This has been replaced by InMemoryVectorStoreKeyResolver in the Microsoft.SemanticKernel.Connectors.InMemory nuget package.")]
 public delegate TKey? VolatileVectorStoreKeyResolver<TKey, TRecord>(TRecord record)
-    where TKey : notnull
-    where TRecord : class;
+    where TKey : notnull;

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -21,7 +21,6 @@ namespace Microsoft.SemanticKernel.Data;
 public sealed class VolatileVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TKey : notnull
-    where TRecord : class
 {
     /// <summary>A set of types that vectors on the provided model may have.</summary>
     private static readonly HashSet<Type> s_supportedVectorTypes =
@@ -146,10 +145,10 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, TRecord> : IVector
 
         if (collectionDictionary.TryGetValue(key, out var record))
         {
-            return Task.FromResult<TRecord?>(record as TRecord);
+            return Task.FromResult<TRecord?>((TRecord?)record);
         }
 
-        return Task.FromResult<TRecord?>(null);
+        return Task.FromResult<TRecord?>(default);
     }
 
     /// <inheritdoc />
@@ -191,6 +190,8 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, TRecord> : IVector
     /// <inheritdoc />
     public Task<TKey> UpsertAsync(TRecord record, UpsertRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
+        Verify.NotNull(record);
+
         var collectionDictionary = this.GetCollectionDictionary();
 
         var key = (TKey)this._keyResolver(record)!;

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollectionOptions.cs
@@ -13,7 +13,6 @@ namespace Microsoft.SemanticKernel.Data;
 [Obsolete("This has been replaced by InMemoryVectorStoreRecordCollectionOptions in the Microsoft.SemanticKernel.Connectors.InMemory nuget package.")]
 public sealed class VolatileVectorStoreRecordCollectionOptions<TKey, TRecord>
     where TKey : notnull
-    where TRecord : class
 {
     /// <summary>
     /// Gets or sets an optional record definition that defines the schema of the record type.

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreVectorResolver.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreVectorResolver.cs
@@ -11,5 +11,4 @@ namespace Microsoft.SemanticKernel.Data;
 /// <param name="record">The record that contains the vector to look up.</param>
 /// <returns>The named vector from the record.</returns>
 [Obsolete("This has been replaced by InMemoryVectorStoreVectorResolver in the Microsoft.SemanticKernel.Connectors.InMemory nuget package.")]
-public delegate object? VolatileVectorStoreVectorResolver<TRecord>(string vectorName, TRecord record)
-    where TRecord : class;
+public delegate object? VolatileVectorStoreVectorResolver<TRecord>(string vectorName, TRecord record);

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreTextSearchTestBase.cs
@@ -124,7 +124,6 @@ public class VectorStoreTextSearchTestBase
     /// Decorator for a <see cref="IVectorizedSearch{TRecord}"/> that generates embeddings for text search queries.
     /// </summary>
     public sealed class VectorizedSearchWrapper<TRecord>(IVectorizedSearch<TRecord> vectorizedSearch, ITextEmbeddingGenerationService textEmbeddingGeneration) : IVectorizableTextSearch<TRecord>
-        where TRecord : class
     {
         /// <inheritdoc/>
         public async Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
### Description

- Removing class constraint on TRecord generic parameter for VectorStore.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
