### PR TITLE
.Net: Enable the GoogleTextSearchTests

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -134,6 +134,8 @@ jobs:
           AzureOpenAITextToImage__Endpoint: ${{ secrets.AZUREOPENAITEXTTOIMAGE__ENDPOINT }}
           AzureOpenAITextToImage__DeploymentName: ${{ vars.AZUREOPENAITEXTTOIMAGE__DEPLOYMENTNAME }}
           Bing__ApiKey: ${{ secrets.BING__APIKEY }}
+          Google__SearchEngineId: ${{ secrets.GOOGLE__SEARCHENGINEID }}
+          Google__ApiKey: ${{ secrets.GOOGLE__APIKEY }}
           OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
           OpenAI__ChatModelId: ${{ vars.OPENAI__CHATMODELID }}
           AzureAIInference__ApiKey: ${{ secrets.AZUREAIINFERENCE__APIKEY }}

--- a/dotnet/src/IntegrationTests/Plugins/Web/Google/GoogleTextSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Plugins/Web/Google/GoogleTextSearchTests.cs
@@ -14,57 +14,13 @@ namespace SemanticKernel.IntegrationTests.Plugins.Web.Google;
 /// </summary>
 public class GoogleTextSearchTests : BaseTextSearchTests
 {
-    // If null, all tests will be enabled
-    private const string SkipReason = "Failing in integration test pipeline so disabling while investigating a fix (issue 9168)";
-
-    [Fact(Skip = SkipReason)]
-    public override async Task CanSearchAsync()
-    {
-        await base.CanSearchAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task CanGetTextSearchResultsAsync()
-    {
-        await base.CanGetTextSearchResultsAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task CanGetSearchResultsAsync()
-    {
-        await base.CanGetSearchResultsAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task UsingTextSearchWithAFilterAsync()
-    {
-        await base.UsingTextSearchWithAFilterAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task FunctionCallingUsingCreateWithSearchAsync()
-    {
-        await base.FunctionCallingUsingCreateWithSearchAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task FunctionCallingUsingCreateWithGetSearchResultsAsync()
-    {
-        await base.FunctionCallingUsingCreateWithGetSearchResultsAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task FunctionCallingUsingGetTextSearchResultsAsync()
-    {
-        await base.FunctionCallingUsingGetTextSearchResultsAsync();
-    }
-
     /// <inheritdoc/>
     public override Task<ITextSearch> CreateTextSearchAsync()
     {
         var configuration = this.Configuration.GetSection("Google").Get<GoogleConfiguration>();
         Assert.NotNull(configuration);
         Assert.NotNull(configuration.ApiKey);
+        Assert.NotNull(configuration.SearchEngineId);
 
         return Task.FromResult<ITextSearch>(new GoogleTextSearch(
             initializer: new() { ApiKey = configuration.ApiKey },


### PR DESCRIPTION
### Motivation and Context

- `GoogleTextSearchTests` are currently disabled, removing the code which disables them.
- Adding the configuration to run integration tests using Google Web Search.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
