### PR TITLE
.Net: Enable the InMemoryTextSearchTests

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -124,6 +124,8 @@ jobs:
           OpenAIAudioToText__ModelId: ${{ vars.OPENAIAUDIOTOTEXT__MODELID }}
           OpenAITextToImage__ApiKey: ${{ secrets.OPENAITEXTTOIMAGE__APIKEY }}
           OpenAITextToImage__ModelId: ${{ vars.OPENAITEXTTOIMAGE__MODELID }}
+          OpenAIEmbeddings__ApiKey: ${{ secrets.OPENAIEMBEDDINGS__APIKEY }}
+          OpenAIEmbeddings__ModelId: ${{ vars.OPENAIEMBEDDINGS__MODELID }}
           AzureOpenAITextToAudio__ApiKey: ${{ secrets.AZUREOPENAITEXTTOAUDIO__APIKEY }}
           AzureOpenAITextToAudio__Endpoint: ${{ secrets.AZUREOPENAITEXTTOAUDIO__ENDPOINT }}
           AzureOpenAITextToAudio__DeploymentName: ${{ vars.AZUREOPENAITEXTTOAUDIO__DEPLOYMENTNAME }}

--- a/dotnet/src/IntegrationTests/Data/InMemoryVectorStoreTextSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Data/InMemoryVectorStoreTextSearchTests.cs
@@ -16,51 +16,6 @@ namespace SemanticKernel.IntegrationTests.Data;
 /// </summary>
 public class InMemoryVectorStoreTextSearchTests : BaseVectorStoreTextSearchTests
 {
-    // If null, all tests will be enabled
-    private const string SkipReason = "Failing in integration test pipeline so disabling while investigating a fix (issue 9168)";
-
-    [Fact(Skip = SkipReason)]
-    public override async Task CanSearchAsync()
-    {
-        await base.CanSearchAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task CanGetTextSearchResultsAsync()
-    {
-        await base.CanGetTextSearchResultsAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task CanGetSearchResultsAsync()
-    {
-        await base.CanGetSearchResultsAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task UsingTextSearchWithAFilterAsync()
-    {
-        await base.UsingTextSearchWithAFilterAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task FunctionCallingUsingCreateWithSearchAsync()
-    {
-        await base.FunctionCallingUsingCreateWithSearchAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task FunctionCallingUsingCreateWithGetSearchResultsAsync()
-    {
-        await base.FunctionCallingUsingCreateWithGetSearchResultsAsync();
-    }
-
-    [Fact(Skip = SkipReason)]
-    public override async Task FunctionCallingUsingGetTextSearchResultsAsync()
-    {
-        await base.FunctionCallingUsingGetTextSearchResultsAsync();
-    }
-
     /// <inheritdoc/>
     public async override Task<ITextSearch> CreateTextSearchAsync()
     {


### PR DESCRIPTION
### Motivation and Context

`InMemoryTextSearchTests` are currently disabled, removing the code which disables them.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
