### PR TITLE
.Net: Add vectorless search to record collection interface.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreCollectionSearchMappingTests.cs
@@ -21,7 +21,7 @@ public class AzureAISearchVectorStoreCollectionSearchMappingTests
         var filter = new VectorSearchFilter().EqualTo(fieldName, fieldValue!);
 
         // Act.
-        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter, new Dictionary<string, string> { { fieldName, "storage_" + fieldName } });
+        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter.FilterClauses, new Dictionary<string, string> { { fieldName, "storage_" + fieldName } });
 
         // Assert.
         Assert.Equal(expected, actual);
@@ -34,7 +34,7 @@ public class AzureAISearchVectorStoreCollectionSearchMappingTests
         var filter = new VectorSearchFilter().AnyTagEqualTo("Tags", "mytag");
 
         // Act.
-        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter, new Dictionary<string, string> { { "Tags", "storage_tags" } });
+        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter.FilterClauses, new Dictionary<string, string> { { "Tags", "storage_tags" } });
 
         // Assert.
         Assert.Equal("storage_tags/any(t: t eq 'mytag')", actual);
@@ -47,7 +47,7 @@ public class AzureAISearchVectorStoreCollectionSearchMappingTests
         var filter = new VectorSearchFilter().EqualTo("intField", 5).AnyTagEqualTo("Tags", "mytag");
 
         // Act.
-        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter, new Dictionary<string, string> { { "Tags", "storage_tags" }, { "intField", "storage_intField" } });
+        var actual = AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(filter.FilterClauses, new Dictionary<string, string> { { "Tags", "storage_tags" }, { "intField", "storage_intField" } });
 
         // Assert.
         Assert.Equal("storage_intField eq 5 and storage_tags/any(t: t eq 'mytag')", actual);
@@ -57,8 +57,8 @@ public class AzureAISearchVectorStoreCollectionSearchMappingTests
     public void BuildFilterStringThrowsForUnknownPropertyName()
     {
         // Act and assert.
-        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(new VectorSearchFilter().EqualTo("unknown", "value"), new Dictionary<string, string>()));
-        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(new VectorSearchFilter().AnyTagEqualTo("unknown", "value"), new Dictionary<string, string>()));
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(new VectorSearchFilter().EqualTo("unknown", "value").FilterClauses, new Dictionary<string, string>()));
+        Assert.Throws<InvalidOperationException>(() => AzureAISearchVectorStoreCollectionSearchMapping.BuildFilterString(new VectorSearchFilter().AnyTagEqualTo("unknown", "value").FilterClauses, new Dictionary<string, string>()));
     }
 
     public static IEnumerable<object[]> DataTypeMappingOptions()

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreCollectionSearchMapping.cs
@@ -15,17 +15,17 @@ internal static class AzureAISearchVectorStoreCollectionSearchMapping
     /// <summary>
     /// Build an OData filter string from the provided <see cref="VectorSearchFilter"/>.
     /// </summary>
-    /// <param name="basicVectorSearchFilter">The <see cref="VectorSearchFilter"/> to build an OData filter string from.</param>
+    /// <param name="filterClausees">The <see cref="FilterClause"/> objects to build an OData filter string from.</param>
     /// <param name="storagePropertyNames">A mapping of data model property names to the names under which they are stored.</param>
     /// <returns>The OData filter string.</returns>
     /// <exception cref="InvalidOperationException">Thrown when a provided filter value is not supported.</exception>
-    public static string BuildFilterString(VectorSearchFilter? basicVectorSearchFilter, IReadOnlyDictionary<string, string> storagePropertyNames)
+    public static string BuildFilterString(IEnumerable<FilterClause>? filterClausees, IReadOnlyDictionary<string, string> storagePropertyNames)
     {
         var filterString = string.Empty;
-        if (basicVectorSearchFilter?.FilterClauses is not null)
+        if (filterClausees is not null)
         {
             // Map Equality clauses.
-            var filterStrings = basicVectorSearchFilter?.FilterClauses.OfType<EqualToFilterClause>().Select(x =>
+            var filterStrings = filterClausees.OfType<EqualToFilterClause>().Select(x =>
             {
                 string storageFieldName = GetStoragePropertyName(storagePropertyNames, x.FieldName);
 
@@ -46,7 +46,7 @@ internal static class AzureAISearchVectorStoreCollectionSearchMapping
             });
 
             // Map tag contains clauses.
-            var tagListContainsStrings = basicVectorSearchFilter?.FilterClauses
+            var tagListContainsStrings = filterClausees
                 .OfType<AnyTagEqualToFilterClause>()
                 .Select(x =>
                 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -244,6 +244,18 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : I
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // TODO: Switch to non-vector search to improve performance.
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         VectorSearchOptions? options = null,

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -362,6 +362,18 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // TODO: Switch to non-vector search to improve performance.
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         VectorSearchOptions? options = null,

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreCollectionSearchMapping.cs
@@ -91,13 +91,13 @@ internal static class InMemoryVectorStoreCollectionSearchMapping
     /// <summary>
     /// Filter the provided records using the provided filter definition.
     /// </summary>
-    /// <param name="filter">The filter definition to filter the <paramref name="records"/> with.</param>
+    /// <param name="filterClauses">The filter clauses to filter the <paramref name="records"/> with.</param>
     /// <param name="records">The records to filter.</param>
     /// <returns>The filtered records.</returns>
     /// <exception cref="InvalidOperationException">Thrown when an unsupported filter clause is encountered.</exception>
-    public static IEnumerable<object> FilterRecords(VectorSearchFilter? filter, IEnumerable<object> records)
+    public static IEnumerable<object> FilterRecords(IEnumerable<FilterClause>? filterClauses, IEnumerable<object> records)
     {
-        if (filter == null)
+        if (filterClauses == null)
         {
             return records;
         }
@@ -109,7 +109,7 @@ internal static class InMemoryVectorStoreCollectionSearchMapping
             // Run each filter clause against the record, and AND the results together.
             // Break if any clause returns false, since we are doing an AND and no need
             // to check any further clauses.
-            foreach (var clause in filter.FilterClauses)
+            foreach (var clause in filterClauses)
             {
                 if (clause is EqualToFilterClause equalToFilter)
                 {

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -210,6 +210,26 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
 
     /// <inheritdoc />
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously - Need to satisfy the interface which returns IAsyncEnumerable
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+#pragma warning restore CS1998
+    {
+        var internalOptions = options ?? new VectorlessSearchOptions();
+
+        var filteredRecords = InMemoryVectorStoreCollectionSearchMapping.FilterRecords(internalOptions.Filter?.FilterClauses, this.GetCollectionDictionary().Values);
+
+        long? count = null;
+        if (internalOptions.IncludeTotalCount)
+        {
+            count = filteredRecords.Count();
+        }
+
+        var resultsPage = filteredRecords.Skip(internalOptions.Skip).Take(internalOptions.Top);
+
+        return new VectorlessSearchResults<TRecord>(resultsPage.Cast<TRecord>().ToAsyncEnumerable()) { TotalCount = count };
+    }
+
+    /// <inheritdoc />
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously - Need to satisfy the interface which returns IAsyncEnumerable
     public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
 #pragma warning restore CS1998
     {
@@ -235,7 +255,7 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
         }
 
         // Filter records using the provided filter before doing the vector comparison.
-        var filteredRecords = InMemoryVectorStoreCollectionSearchMapping.FilterRecords(internalOptions.Filter, this.GetCollectionDictionary().Values);
+        var filteredRecords = InMemoryVectorStoreCollectionSearchMapping.FilterRecords(internalOptions.Filter?.FilterClauses, this.GetCollectionDictionary().Values);
 
         // Compare each vector in the filtered results with the provided vector.
         var results = filteredRecords.Select<object, (object record, float score)?>((record) =>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -235,6 +235,17 @@ public sealed class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -444,6 +444,17 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRec
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(vector);

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -330,6 +330,18 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // TODO: Switch to non-vector search to improve performance.
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(vector);

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -374,6 +374,18 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // TODO: Switch to non-vector search to improve performance.
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(vector);

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -336,6 +336,17 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
+    public async Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(VectorlessSearchOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var dimensions = this._propertyReader.VectorProperty?.Dimensions ?? throw new InvalidOperationException("The collection does not have any vector properties, so simulated vectorless search is not possible.");
+        var vectorSearchResults = await this.VectorizedSearchAsync(
+            new ReadOnlyMemory<float>(new float[dimensions]),
+            VectorSearchOptions.FromVectorlessSearchOptions(options),
+            cancellationToken).ConfigureAwait(false);
+        return VectorStoreSearchResultMapping.ConvertToVectorlessSearchResults(vectorSearchResults, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
         TVector vector,
         VectorSearchOptions? options = null,

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchOptions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchOptions.cs
@@ -43,4 +43,27 @@ public class VectorSearchOptions
     /// count will be null even if requested via this option.
     /// </remarks>
     public bool IncludeTotalCount { get; init; } = false;
+
+    /// <summary>
+    /// Create a new <see cref="VectorSearchOptions"/> instance from a <see cref="VectorlessSearchOptions"/> instance
+    /// by copying all matching properties.
+    /// </summary>
+    /// <param name="options">The <see cref="VectorlessSearchOptions"/> instance to create the <see cref="VectorSearchOptions"/> instance from.</param>
+    /// <returns>The new <see cref="VectorSearchOptions"/> instance.</returns>
+    public static VectorSearchOptions FromVectorlessSearchOptions(VectorlessSearchOptions? options)
+    {
+        if (options is null)
+        {
+            return new VectorSearchOptions();
+        }
+
+        return new VectorSearchOptions()
+        {
+            Filter = options.Filter is not null ? new VectorSearchFilter(options.Filter.FilterClauses) : null,
+            Top = options.Top,
+            Skip = options.Skip,
+            IncludeVectors = options.IncludeVectors,
+            IncludeTotalCount = options.IncludeTotalCount
+        };
+    }
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordCollection.cs
@@ -124,4 +124,18 @@ public interface IVectorStoreRecordCollection<TKey, TRecord> : IVectorizedSearch
     /// <exception cref="VectorStoreOperationException">Throw when the command fails to execute for any reason.</exception>
     /// <exception cref="VectorStoreRecordMappingException">Throw when mapping between the storage model and record data model fails.</exception>
     IAsyncEnumerable<TKey> UpsertBatchAsync(IEnumerable<TRecord> records, UpsertRecordOptions? options = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Search the vector store for records that match the given options.
+    /// </summary>
+    /// <remarks>
+    /// This is a regular search, without using a search vector, however for some vector stores, it may internally use
+    /// an artificial vector to perform the search, since not all vector stores support searching without a vector.
+    /// </remarks>
+    /// <param name="options">The options that control the behavior of the search.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The records found by the vector search, including their result scores.</returns>
+    Task<VectorlessSearchResults<TRecord>> VectorlessSearchAsync(
+        VectorlessSearchOptions? options = default,
+        CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorlessSearchFilter.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorlessSearchFilter.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Used to provide filtering when doing searches without vectors.
+/// </summary>
+/// <remarks>
+/// A filter has a collection of <see cref="FilterClause"/>s that can be used
+/// to request that the underlying service filter the search results.
+/// All clauses are combined with and.
+/// </remarks>
+public sealed class VectorlessSearchFilter
+{
+    /// <summary>The filter clauses to and together.</summary>
+    private readonly List<FilterClause> _filterClauses = [];
+
+    /// <summary>Gets the default search filter.</summary>
+    public static VectorlessSearchFilter Default { get; } = new VectorlessSearchFilter();
+
+    /// <summary>
+    /// The filter clauses to and together.
+    /// </summary>
+    public IEnumerable<FilterClause> FilterClauses => this._filterClauses;
+
+    /// <summary>
+    /// Create an instance of <see cref="VectorlessSearchFilter"/>
+    /// </summary>
+    public VectorlessSearchFilter()
+    {
+    }
+
+    /// <summary>
+    /// Create an instance of <see cref="VectorlessSearchFilter"/> with the provided <see cref="FilterClause"/>s.
+    /// <param name="filterClauses">The <see cref="FilterClause"/> instances to use</param>
+    /// </summary>
+    public VectorlessSearchFilter(IEnumerable<FilterClause> filterClauses)
+    {
+        if (filterClauses == null)
+        {
+            throw new ArgumentNullException(nameof(filterClauses));
+        }
+
+        this._filterClauses.AddRange(filterClauses);
+    }
+
+    /// <summary>
+    /// Add an equal to clause to the filter options.
+    /// </summary>
+    /// <param name="propertyName">Name of the property to check against. Use the name of the property from your data model or as provided in the record definition.</param>
+    /// <param name="value">Value that the property should match.</param>
+    /// <returns><see cref="VectorlessSearchFilter"/> instance to allow fluent configuration.</returns>
+    /// <remarks>
+    /// This clause will check if a property is equal to a specific value.
+    /// </remarks>
+    public VectorlessSearchFilter EqualTo(string propertyName, object value)
+    {
+        this._filterClauses.Add(new EqualToFilterClause(propertyName, value));
+        return this;
+    }
+
+    /// <summary>
+    /// Add an any tag equal to clause to the filter options.
+    /// </summary>
+    /// <param name="propertyName">Name of the property consisting of a list of values to check against. Use the name of the property from your data model or as provided in the record definition.</param>
+    /// <param name="value">Value that the list should contain.</param>
+    /// <returns><see cref="VectorlessSearchFilter"/> instance to allow fluent configuration.</returns>
+    /// <remarks>
+    /// This clause will check if a property consisting of a list of values contains a specific value.
+    /// </remarks>
+    public VectorlessSearchFilter AnyTagEqualTo(string propertyName, string value)
+    {
+        this._filterClauses.Add(new AnyTagEqualToFilterClause(propertyName, value));
+        return this;
+    }
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorlessSearchOptions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorlessSearchOptions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Options for searching the vector store without a search vector as input.
+/// </summary>
+public class VectorlessSearchOptions
+{
+    /// <summary>
+    /// Gets or sets a search filter to filter the records in the store with during the search.
+    /// </summary>
+    public VectorlessSearchFilter? Filter { get; init; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of results to return.
+    /// </summary>
+    public int Top { get; init; } = 3;
+
+    /// <summary>
+    /// Gets or sets the number of results to skip before returning results, i.e. the index of the first result to return.
+    /// </summary>
+    public int Skip { get; init; } = 0;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include vectors in the retrieval result.
+    /// </summary>
+    public bool IncludeVectors { get; init; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the total count should be included in the results.
+    /// </summary>
+    /// <remarks>
+    /// Default value is false.
+    /// Not all vector stores will support this option in which case the total
+    /// count will be null even if requested via this option.
+    /// </remarks>
+    public bool IncludeTotalCount { get; init; } = false;
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorlessSearchResults.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/VectorlessSearchResults.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Contains the full list of search results for a vectorless search operation with metadata.
+/// </summary>
+/// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+/// <param name="results">The list of records returned by the search operation.</param>
+public class VectorlessSearchResults<TRecord>(IAsyncEnumerable<TRecord> results)
+{
+    /// <summary>
+    /// The total count of results found by the search operation, or null
+    /// if the count was not requested or cannot be computed.
+    /// </summary>
+    /// <remarks>
+    /// This value represents the total number of results that are available for the current query and not the number of results being returned.
+    /// </remarks>
+    public long? TotalCount { get; init; }
+
+    /// <summary>
+    /// The metadata associated with the content.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?>? Metadata { get; init; }
+
+    /// <summary>
+    /// The search results.
+    /// </summary>
+    public IAsyncEnumerable<TRecord> Results { get; } = results;
+}

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreSearchResultMapping.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreSearchResultMapping.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Contains helpers for reading vector store model properties and their attributes.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class VectorStoreSearchResultMapping
+{
+    /// <summary>
+    /// Convert the given <see cref="VectorSearchResults{TRecord}"/> to a <see cref="VectorlessSearchResults{TRecord}"/> instance.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the returned data model.</typeparam>
+    /// <param name="vectorSearchResults">The <see cref="VectorSearchResults{TRecord}"/> to convert.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The converted <see cref="VectorlessSearchResults{TRecord}"/> instance.</returns>
+    public static VectorlessSearchResults<TRecord> ConvertToVectorlessSearchResults<TRecord>(
+        VectorSearchResults<TRecord> vectorSearchResults,
+        CancellationToken cancellationToken)
+    {
+        var convertedItems = ConvertToRecordOnlyEnumerableAsync(vectorSearchResults.Results, cancellationToken);
+
+        return new VectorlessSearchResults<TRecord>(convertedItems)
+        {
+            TotalCount = vectorSearchResults.TotalCount,
+            Metadata = vectorSearchResults.Metadata,
+        };
+    }
+
+    /// <summary>
+    /// Convert the given list of vector search results to a list containing only the records.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the returned data model.</typeparam>
+    /// <param name="vectorSearchResults">The vector search results to convert.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The converted records.</returns>
+    private static async IAsyncEnumerable<TRecord> ConvertToRecordOnlyEnumerableAsync<TRecord>(
+        IAsyncEnumerable<VectorSearchResult<TRecord>> vectorSearchResults,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var result in vectorSearchResults.ConfigureAwait(false))
+        {
+            yield return result.Record;
+        }
+    }
+}

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreCollectionSearchMapping.cs
@@ -92,13 +92,13 @@ internal static class VolatileVectorStoreCollectionSearchMapping
     /// <summary>
     /// Filter the provided records using the provided filter definition.
     /// </summary>
-    /// <param name="filter">The filter definition to filter the <paramref name="records"/> with.</param>
+    /// <param name="filterClauses">The filter clauses to filter the <paramref name="records"/> with.</param>
     /// <param name="records">The records to filter.</param>
     /// <returns>The filtered records.</returns>
     /// <exception cref="InvalidOperationException">Thrown when an unsupported filter clause is encountered.</exception>
-    public static IEnumerable<object> FilterRecords(VectorSearchFilter? filter, IEnumerable<object> records)
+    public static IEnumerable<object> FilterRecords(IEnumerable<FilterClause>? filterClauses, IEnumerable<object> records)
     {
-        if (filter == null)
+        if (filterClauses == null)
         {
             return records;
         }
@@ -110,7 +110,7 @@ internal static class VolatileVectorStoreCollectionSearchMapping
             // Run each filter clause against the record, and AND the results together.
             // Break if any clause returns false, since we are doing an AND and no need
             // to check any further clauses.
-            foreach (var clause in filter.FilterClauses)
+            foreach (var clause in filterClauses)
             {
                 if (clause is EqualToFilterClause equalToFilter)
                 {


### PR DESCRIPTION
### Motivation and Context

Many of the databases that implement the vector store abstractions support search without vectors.
It is possible to search the database with a zero value vector anyway, but doing vector comparisons
without needing to is inefficient.

### Description

- Adding a vectorless search method to the collection interface with implementations.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
