### PR TITLE
.Net Agents - Fixed Assistant Function-Call Message Role

### DIFF
--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -733,7 +733,7 @@ internal static class AssistantThreadActions
 
     private static ChatMessageContent GenerateFunctionCallContent(string agentName, IList<FunctionCallContent> functionCalls)
     {
-        ChatMessageContent functionCallContent = new(AuthorRole.Tool, content: null)
+        ChatMessageContent functionCallContent = new(AuthorRole.Assistant, content: null)
         {
             AuthorName = agentName
         };

--- a/dotnet/src/IntegrationTests/Agents/MixedAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/MixedAgentTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ClientModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Identity;
@@ -81,25 +82,28 @@ public sealed class MixedAgentTests
             new OpenAIPromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() } :
             new OpenAIPromptExecutionSettings() { ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions };
 
-        // Configure chat agent with the plugin.
+        // Chat agent doesn't need plug-in since it has access to the shared function result.
         ChatCompletionAgent chatAgent =
             new()
             {
+                Name = "Chat",
                 Kernel = chatCompletionKernel,
                 Instructions = "Answer questions about the menu.",
                 Arguments = new(executionSettings),
             };
         chatAgent.Kernel.Plugins.Add(plugin);
 
-        // Assistant doesn't need plug-in since it has access to the shared function result.
+        // Configure assistant agent with the plugin.
         OpenAIAssistantAgent assistantAgent =
             await OpenAIAssistantAgent.CreateAsync(
                 config,
                 new(modelName)
                 {
+                    Name = "Assistant",
                     Instructions = "Answer questions about the menu."
                 },
                 new Kernel());
+        assistantAgent.Kernel.Plugins.Add(plugin);
 
         // Act & Assert
         try
@@ -127,6 +131,27 @@ public sealed class MixedAgentTests
 
         // Assert
         Assert.Contains(expected, builder.ToString(), StringComparison.OrdinalIgnoreCase);
+        await foreach (var message in chat.GetChatMessagesAsync())
+        {
+            AssertMessageValid(message);
+        }
+    }
+
+    private static void AssertMessageValid(ChatMessageContent message)
+    {
+        if (message.Items.OfType<FunctionResultContent>().Any())
+        {
+            Assert.Equal(AuthorRole.Tool, message.Role);
+            return;
+        }
+
+        if (message.Items.OfType<FunctionCallContent>().Any())
+        {
+            Assert.Equal(AuthorRole.Assistant, message.Role);
+            return;
+        }
+
+        Assert.Equal(string.IsNullOrEmpty(message.AuthorName) ? AuthorRole.User : AuthorRole.Assistant, message.Role);
     }
 
     private Kernel CreateChatCompletionKernel(AzureOpenAIConfiguration configuration)

--- a/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/OpenAIAssistantAgentTests.cs
@@ -135,6 +135,10 @@ public sealed class OpenAIAssistantAgentTests
 
             // Assert
             Assert.Contains(expected, builder.ToString(), StringComparison.OrdinalIgnoreCase);
+            await foreach (var message in chat.GetChatMessagesAsync())
+            {
+                AssertMessageValid(message);
+            }
         }
         finally
         {
@@ -177,6 +181,23 @@ public sealed class OpenAIAssistantAgentTests
         ChatMessageContent[] history = await chat.GetChatMessagesAsync().ToArrayAsync();
         Assert.Contains(expected, builder.ToString(), StringComparison.OrdinalIgnoreCase);
         Assert.Contains(expected, history.First().Content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AssertMessageValid(ChatMessageContent message)
+    {
+        if (message.Items.OfType<FunctionResultContent>().Any())
+        {
+            Assert.Equal(AuthorRole.Tool, message.Role);
+            return;
+        }
+
+        if (message.Items.OfType<FunctionCallContent>().Any())
+        {
+            Assert.Equal(AuthorRole.Assistant, message.Role);
+            return;
+        }
+
+        Assert.Equal(string.IsNullOrEmpty(message.AuthorName) ? AuthorRole.User : AuthorRole.Assistant, message.Role);
     }
 
     public sealed class MenuPlugin


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Fixes: https://github.com/microsoft/semantic-kernel/issues/9245

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Assistant incorrectly assigning `Tool` role to function-call _and_ function-result.  Function-call should be `Assistant`.

Added validation in integration tests.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
