### PR TITLE
Add open ai support to RAG sample

### DIFF
--- a/dotnet/samples/Demos/VectorStoreRAG/Options/ApplicationConfig.cs
+++ b/dotnet/samples/Demos/VectorStoreRAG/Options/ApplicationConfig.cs
@@ -11,6 +11,8 @@ internal sealed class ApplicationConfig
 {
     private readonly AzureOpenAIConfig _azureOpenAIConfig;
     private readonly AzureOpenAIEmbeddingsConfig _azureOpenAIEmbeddingsConfig = new();
+    private readonly OpenAIConfig _openAIConfig = new();
+    private readonly OpenAIEmbeddingsConfig _openAIEmbeddingsConfig = new();
     private readonly RagConfig _ragConfig = new();
     private readonly AzureAISearchConfig _azureAISearchConfig = new();
     private readonly AzureCosmosDBConfig _azureCosmosDBMongoDBConfig = new();
@@ -28,6 +30,12 @@ internal sealed class ApplicationConfig
         configurationManager
             .GetRequiredSection($"AIServices:{AzureOpenAIEmbeddingsConfig.ConfigSectionName}")
             .Bind(this._azureOpenAIEmbeddingsConfig);
+        configurationManager
+            .GetRequiredSection($"AIServices:{OpenAIConfig.ConfigSectionName}")
+            .Bind(this._openAIConfig);
+        configurationManager
+            .GetRequiredSection($"AIServices:{OpenAIEmbeddingsConfig.ConfigSectionName}")
+            .Bind(this._openAIEmbeddingsConfig);
         configurationManager
             .GetRequiredSection(RagConfig.ConfigSectionName)
             .Bind(this._ragConfig);
@@ -54,6 +62,10 @@ internal sealed class ApplicationConfig
     public AzureOpenAIConfig AzureOpenAIConfig => this._azureOpenAIConfig;
 
     public AzureOpenAIEmbeddingsConfig AzureOpenAIEmbeddingsConfig => this._azureOpenAIEmbeddingsConfig;
+
+    public OpenAIConfig OpenAIConfig => this._openAIConfig;
+
+    public OpenAIEmbeddingsConfig OpenAIEmbeddingsConfig => this._openAIEmbeddingsConfig;
 
     public RagConfig RagConfig => this._ragConfig;
 

--- a/dotnet/samples/Demos/VectorStoreRAG/Options/OpenAIConfig.cs
+++ b/dotnet/samples/Demos/VectorStoreRAG/Options/OpenAIConfig.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace VectorStoreRAG.Options;
+
+/// <summary>
+/// OpenAI service settings.
+/// </summary>
+internal sealed class OpenAIConfig
+{
+    public const string ConfigSectionName = "OpenAI";
+
+    [Required]
+    public string ModelId { get; set; } = string.Empty;
+
+    [Required]
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/dotnet/samples/Demos/VectorStoreRAG/Options/OpenAIEmbeddingsConfig.cs
+++ b/dotnet/samples/Demos/VectorStoreRAG/Options/OpenAIEmbeddingsConfig.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace VectorStoreRAG.Options;
+
+/// <summary>
+/// OpenAI Embeddings service settings.
+/// </summary>
+internal sealed class OpenAIEmbeddingsConfig
+{
+    public const string ConfigSectionName = "OpenAIEmbeddings";
+
+    [Required]
+    public string ModelId { get; set; } = string.Empty;
+
+    [Required]
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/dotnet/samples/Demos/VectorStoreRAG/Options/RagConfig.cs
+++ b/dotnet/samples/Demos/VectorStoreRAG/Options/RagConfig.cs
@@ -12,13 +12,13 @@ internal sealed class RagConfig
     public const string ConfigSectionName = "Rag";
 
     [Required]
+    public string AIChatService { get; set; } = string.Empty;
+
+    [Required]
+    public string AIEmbeddingService { get; set; } = string.Empty;
+
+    [Required]
     public bool BuildCollection { get; set; } = true;
-
-    [Required]
-    public string[]? PdfFilePaths { get; set; }
-
-    [Required]
-    public string VectorStoreType { get; set; } = string.Empty;
 
     [Required]
     public string CollectionName { get; set; } = string.Empty;
@@ -28,4 +28,10 @@ internal sealed class RagConfig
 
     [Required]
     public int DataLoadingBetweenBatchDelayInMilliseconds { get; set; } = 0;
+
+    [Required]
+    public string[]? PdfFilePaths { get; set; }
+
+    [Required]
+    public string VectorStoreType { get; set; } = string.Empty;
 }

--- a/dotnet/samples/Demos/VectorStoreRAG/Program.cs
+++ b/dotnet/samples/Demos/VectorStoreRAG/Program.cs
@@ -26,15 +26,41 @@ builder.Services.AddKeyedSingleton("AppShutdown", appShutdownCancellationTokenSo
 
 // Register the kernel with the dependency injection container
 // and add Chat Completion and Text Embedding Generation services.
-var kernelBuilder = builder.Services.AddKernel()
-    .AddAzureOpenAIChatCompletion(
-        appConfig.AzureOpenAIConfig.ChatDeploymentName,
-        appConfig.AzureOpenAIConfig.Endpoint,
-        new AzureCliCredential())
-    .AddAzureOpenAITextEmbeddingGeneration(
-        appConfig.AzureOpenAIEmbeddingsConfig.DeploymentName,
-        appConfig.AzureOpenAIEmbeddingsConfig.Endpoint,
-        new AzureCliCredential());
+var kernelBuilder = builder.Services.AddKernel();
+
+switch (appConfig.RagConfig.AIChatService)
+{
+    case "AzureOpenAI":
+        kernelBuilder.AddAzureOpenAIChatCompletion(
+            appConfig.AzureOpenAIConfig.ChatDeploymentName,
+            appConfig.AzureOpenAIConfig.Endpoint,
+            new AzureCliCredential());
+        break;
+    case "OpenAI":
+        kernelBuilder.AddOpenAIChatCompletion(
+            appConfig.OpenAIConfig.ModelId,
+            appConfig.OpenAIConfig.ApiKey);
+        break;
+    default:
+        throw new NotSupportedException($"AI Chat Service type '{appConfig.RagConfig.AIChatService}' is not supported.");
+}
+
+switch (appConfig.RagConfig.AIEmbeddingService)
+{
+    case "AzureOpenAIEmbeddings":
+        kernelBuilder.AddAzureOpenAITextEmbeddingGeneration(
+            appConfig.AzureOpenAIEmbeddingsConfig.DeploymentName,
+            appConfig.AzureOpenAIEmbeddingsConfig.Endpoint,
+            new AzureCliCredential());
+        break;
+    case "OpenAIEmbeddings":
+        kernelBuilder.AddOpenAITextEmbeddingGeneration(
+            appConfig.OpenAIEmbeddingsConfig.ModelId,
+            appConfig.OpenAIEmbeddingsConfig.ApiKey);
+        break;
+    default:
+        throw new NotSupportedException($"AI Embedding Service type '{appConfig.RagConfig.AIEmbeddingService}' is not supported.");
+}
 
 // Add the configured vector store record collection type to the
 // dependency injection container.

--- a/dotnet/samples/Demos/VectorStoreRAG/README.md
+++ b/dotnet/samples/Demos/VectorStoreRAG/README.md
@@ -15,6 +15,12 @@ The sample can be configured in various ways:
    1. Qdrant
    1. Redis
    1. Weaviate
+1. You can choose your preferred AI Chat service by settings the `Rag:AIChatService` configuration setting in the `appsettings.json` file to one of the following values:
+   1. AzureOpenAI
+   1. OpenAI
+1. You can choose your preferred AI Embedding service by settings the `Rag:AIEmbeddingService` configuration setting in the `appsettings.json` file to one of the following values:
+   1. AzureOpenAIEmbeddings
+   1. OpenAIEmbeddings
 1. You can choose whether to load data into the vector store by setting the `Rag:BuildCollection` configuration setting in the `appsettings.json` file to `true`. If you set this to `false`, the sample will assume that data was already loaded previously and it will go straight into the chat experience.
 1. You can choose the name of the collection to use by setting the `Rag:CollectionName` configuration setting in the `appsettings.json` file.
 1. You can choose the pdf file to load into the vector store by setting the `Rag:PdfFilePaths` array in the `appsettings.json` file.
@@ -42,9 +48,9 @@ Why not try the semantic kernel documentation as your input.
 You can download it as a PDF from the https://learn.microsoft.com/en-us/semantic-kernel/overview/ page.
 See the Download PDF button at the bottom of the page.
 
-### Azure OpenAI
+### Azure OpenAI Chat Completion
 
-For Azure OpenAI, you need to add the following secrets:
+For Azure OpenAI Chat Completion, you need to add the following secrets:
 
 ```cli
 dotnet user-secrets set "AIServices:AzureOpenAI:Endpoint" "https://<yourservice>.openai.azure.com"
@@ -52,6 +58,15 @@ dotnet user-secrets set "AIServices:AzureOpenAI:ChatDeploymentName" "<your deplo
 ```
 
 Note that the code doesn't use an API Key to communicate with Azure Open AI, but rather an `AzureCliCredential` so no api key secret is required.
+
+### OpenAI Chat Completion
+
+For OpenAI Chat Completion, you need to add the following secrets:
+
+```cli
+dotnet user-secrets set "AIServices:OpenAI:ModelId" "<your model id>"
+dotnet user-secrets set "AIServices:OpenAI:ApiKey" "<your api key>"
+```
 
 ### Azure OpenAI Embeddings
 
@@ -63,6 +78,15 @@ dotnet user-secrets set "AIServices:AzureOpenAIEmbeddings:DeploymentName" "<your
 ```
 
 Note that the code doesn't use an API Key to communicate with Azure Open AI, but rather an `AzureCliCredential` so no api key secret is required.
+
+### OpenAI Embeddings
+
+For OpenAI Embeddings, you need to add the following secrets:
+
+```cli
+dotnet user-secrets set "AIServices:OpenAIEmbeddings:ModelId" "<your model id>"
+dotnet user-secrets set "AIServices:OpenAIEmbeddings:ApiKey" "<your api key>"
+```
 
 ### Azure AI Search
 

--- a/dotnet/samples/Demos/VectorStoreRAG/VectorStoreRAG.csproj
+++ b/dotnet/samples/Demos/VectorStoreRAG/VectorStoreRAG.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\Connectors\Connectors.OpenAI\Connectors.OpenAI.csproj" />
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.Memory.AzureAISearch\Connectors.Memory.AzureAISearch.csproj" />
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.Memory.AzureCosmosDBMongoDB\Connectors.Memory.AzureCosmosDBMongoDB.csproj" />
     <ProjectReference Include="..\..\..\src\Connectors\Connectors.Memory.AzureCosmosDBNoSQL\Connectors.Memory.AzureCosmosDBNoSQL.csproj" />

--- a/dotnet/samples/Demos/VectorStoreRAG/appsettings.json
+++ b/dotnet/samples/Demos/VectorStoreRAG/appsettings.json
@@ -12,6 +12,14 @@
     "AzureOpenAIEmbeddings": {
       "Endpoint": "",
       "DeploymentName": "text-embedding-ada-002"
+    },
+    "OpenAI": {
+      "ModelId": "gpt-4o",
+      "ApiKey": ""
+    },
+    "OpenAIEmbeddings": {
+      "ModelId": "text-embedding-3-small",
+      "ApiKey": ""
     }
   },
   "VectorStores": {
@@ -41,11 +49,13 @@
     }
   },
   "Rag": {
+    "AIChatService": "OpenAI",
+    "AIEmbeddingService": "OpenAIEmbeddings",
     "BuildCollection": true,
-    "PdfFilePaths": [ "sourcedocument.pdf" ],
-    "VectorStoreType": "InMemory",
     "CollectionName": "pdfcontent",
-    "DataLoadingBatchSize": 2,
-    "DataLoadingBetweenBatchDelayInMilliseconds": 1000
+    "DataLoadingBatchSize": 10,
+    "DataLoadingBetweenBatchDelayInMilliseconds": 1000,
+    "PdfFilePaths": [ "sourcedocument.pdf" ],
+    "VectorStoreType": "InMemory"
   }
 }


### PR DESCRIPTION
### Motivation and Context

It's nice to demonstrate being able to use different AI services and allowing users more choice when running the sample

### Description

- Add support for using open ai chat and embedding services in the rag sample

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
