### PR TITLE
Python: Fix issue with default opentelemetry metric in pydantic base model

### DIFF
--- a/python/semantic_kernel/functions/kernel_function.py
+++ b/python/semantic_kernel/functions/kernel_function.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from opentelemetry import metrics, trace
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+from pydantic import Field
 
 from semantic_kernel.filters.filter_types import FilterTypes
 from semantic_kernel.filters.functions.function_invocation_context import FunctionInvocationContext
@@ -52,6 +53,22 @@ TEMPLATE_FORMAT_MAP = {
 }
 
 
+def _create_function_duration_histogram():
+    return meter.create_histogram(
+        "semantic_kernel.function.invocation.duration",
+        unit="s",
+        description="Measures the duration of a function's execution",
+    )
+
+
+def _create_function_streaming_duration_histogram():
+    return meter.create_histogram(
+        "semantic_kernel.function.streaming.duration",
+        unit="s",
+        description="Measures the duration of a function's streaming execution",
+    )
+
+
 class KernelFunction(KernelBaseModel):
     """Semantic Kernel function.
 
@@ -75,15 +92,9 @@ class KernelFunction(KernelBaseModel):
 
     metadata: KernelFunctionMetadata
 
-    invocation_duration_histogram: metrics.Histogram = meter.create_histogram(
-        "semantic_kernel.function.invocation.duration",
-        unit="s",
-        description="Measures the duration of a function's execution",
-    )
-    streaming_duration_histogram: metrics.Histogram = meter.create_histogram(
-        "semantic_kernel.function.streaming.duration",
-        unit="s",
-        description="Measures the duration of a function's streaming execution",
+    invocation_duration_histogram: metrics.Histogram = Field(default_factory=_create_function_duration_histogram)
+    streaming_duration_histogram: metrics.Histogram = Field(
+        default_factory=_create_function_streaming_duration_histogram
     )
 
     @classmethod


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
- This is fixing an issue with the default opentelemery metric in KernelFunction. This issue is with SemanticKernel version >= 1.8
causing 
`TypeError: cannot pickle '_thread.RLock' object`
when importing SemanticKernel

- This is blocking us from updating to the latest SemanticKernel version.

It is difficult to reproduce outside my application code. But is seems to be the same issue mentioned in 
#9057 and #9012 

changing to a Field with a default factory solve the issue.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Updating the default metrics value to use a Field with a default_factory

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
