### PR TITLE
.Net: Set dll version number for vectordata.abstractions.

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.24.0</VersionPrefix>
+    <VersionPrefix>1.24.1</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
 

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorData.Abstractions.csproj
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorData.Abstractions.csproj
@@ -10,6 +10,7 @@
 
   <PropertyGroup>
     <PackageVersion>9.0.0-preview.1.24515.1</PackageVersion>
+    <AssemblyVersion>9.0.0.0</AssemblyVersion>
     <Title>Microsoft.Extensions.VectorData.Abstractions</Title>
     <PackageId>$(AssemblyName)</PackageId>
     <PackageDescription>Abstractions for vector database access.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorData.Abstractions.csproj
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorData.Abstractions.csproj
@@ -9,7 +9,7 @@
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
 
   <PropertyGroup>
-    <PackageVersion>9.0.0-preview.1.24515.1</PackageVersion>
+    <PackageVersion>9.0.0-preview.1.24518.1</PackageVersion>
     <AssemblyVersion>9.0.0.0</AssemblyVersion>
     <Title>Microsoft.Extensions.VectorData.Abstractions</Title>
     <PackageId>$(AssemblyName)</PackageId>


### PR DESCRIPTION
### Motivation and Context

The vectordata.abstractions.dll had the same version number as the other SK dlls, which is incorrect.
It should have a version number matching it's nuget version number.

### Description

- Setting the version number of the vectordata.abstractions.dll to 9.0.0.0
- Updating the vectordata.abstractions nuget version to today's date.
- Upping the SK version to 1.24.1

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
