### PR TITLE
.Net: Added implementation of MongoDB connector for new memory design

### DIFF
--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -373,11 +373,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Connectors.InMemory.UnitTes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GettingStartedWithTextSearch", "samples\GettingStartedWithTextSearch\GettingStartedWithTextSearch.csproj", "{16AFA226-E417-490D-9311-9F2099A1EEC8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VectorStoreRAG", "samples\Demos\VectorStoreRAG\VectorStoreRAG.csproj", "{28DFAF27-8FF3-4373-AAA4-2A6969C86246}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VectorStoreRAG", "samples\Demos\VectorStoreRAG\VectorStoreRAG.csproj", "{28DFAF27-8FF3-4373-AAA4-2A6969C86246}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Process.Runtime.Dapr", "src\Experimental\Process.Runtime.Dapr\Process.Runtime.Dapr.csproj", "{9D5B4B53-0E97-42D9-B37E-CD263B6A1892}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProcessWithDapr", "samples\Demos\ProcessWithDapr\ProcessWithDapr.csproj", "{95163AA2-1ED5-412A-990B-C40B81934BFD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProcessWithDapr", "samples\Demos\ProcessWithDapr\ProcessWithDapr.csproj", "{95163AA2-1ED5-412A-990B-C40B81934BFD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Connectors.MongoDB.UnitTests", "src\Connectors\Connectors.MongoDB.UnitTests\Connectors.MongoDB.UnitTests.csproj", "{6F591D05-5F7F-4211-9042-42D8BCE60415}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -992,6 +994,12 @@ Global
 		{95163AA2-1ED5-412A-990B-C40B81934BFD}.Publish|Any CPU.Build.0 = Debug|Any CPU
 		{95163AA2-1ED5-412A-990B-C40B81934BFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95163AA2-1ED5-412A-990B-C40B81934BFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F591D05-5F7F-4211-9042-42D8BCE60415}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F591D05-5F7F-4211-9042-42D8BCE60415}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F591D05-5F7F-4211-9042-42D8BCE60415}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F591D05-5F7F-4211-9042-42D8BCE60415}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{6F591D05-5F7F-4211-9042-42D8BCE60415}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F591D05-5F7F-4211-9042-42D8BCE60415}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1129,6 +1137,7 @@ Global
 		{28DFAF27-8FF3-4373-AAA4-2A6969C86246} = {5D4C0700-BBB5-418F-A7B2-F392B9A18263}
 		{9D5B4B53-0E97-42D9-B37E-CD263B6A1892} = {0D8C6358-5DAA-4EA6-A924-C268A9A21BC9}
 		{95163AA2-1ED5-412A-990B-C40B81934BFD} = {5D4C0700-BBB5-418F-A7B2-F392B9A18263}
+		{6F591D05-5F7F-4211-9042-42D8BCE60415} = {5A7028A7-4DDF-4E4F-84A9-37CE8F8D7E89}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBDC56A3-86AD-4323-AA0F-201E59123B83}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/Connectors.Memory.MongoDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/Connectors.Memory.MongoDB.csproj
@@ -26,4 +26,8 @@
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SemanticKernel.Connectors.MongoDB.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/Connectors.Memory.MongoDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/Connectors.Memory.MongoDB.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.MongoDB</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <VersionSuffix>alpha</VersionSuffix>
+    <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/IMongoDBVectorStoreRecordCollectionFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/IMongoDBVectorStoreRecordCollectionFactory.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using MongoDB.Driver;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Interface for constructing <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> MongoDB instances when using <see cref="IVectorStore"/> to retrieve these.
+/// </summary>
+public interface IMongoDBVectorStoreRecordCollectionFactory
+{
+    /// <summary>
+    /// Constructs a new instance of the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The data type of the record key.</typeparam>
+    /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</param>
+    /// <param name="name">The name of the collection to connect to.</param>
+    /// <param name="vectorStoreRecordDefinition">An optional record definition that defines the schema of the record type. If not present, attributes on <typeparamref name="TRecord"/> will be used.</param>
+    /// <returns>The new instance of <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</returns>
+    IVectorStoreRecordCollection<TKey, TRecord> CreateVectorStoreRecordCollection<TKey, TRecord>(IMongoDatabase mongoDatabase, string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+        where TKey : notnull;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBConstants.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBConstants.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Constants for MongoDB vector store implementation.
+/// </summary>
+internal static class MongoDBConstants
+{
+    /// <summary>Default ratio of number of nearest neighbors to number of documents to return.</summary>
+    internal const int DefaultNumCandidatesRatio = 10;
+
+    /// <summary>Default vector index name.</summary>
+    internal const string DefaultVectorIndexName = "vector_index";
+
+    /// <summary>Default index kind for vector search.</summary>
+    internal const string DefaultIndexKind = IndexKind.IvfFlat;
+
+    /// <summary>Default distance function for vector search.</summary>
+    internal const string DefaultDistanceFunction = DistanceFunction.CosineDistance;
+
+    /// <summary>Reserved key property name in MongoDB.</summary>
+    internal const string MongoReservedKeyPropertyName = "_id";
+
+    /// <summary>Reserved key property name in data model.</summary>
+    internal const string DataModelReservedKeyPropertyName = "Id";
+
+    /// <summary>A <see cref="HashSet{Type}"/> containing the supported key types.</summary>
+    internal static readonly HashSet<Type> SupportedKeyTypes =
+    [
+        typeof(string)
+    ];
+
+    /// <summary>A <see cref="HashSet{Type}"/> containing the supported data property types.</summary>
+    internal static readonly HashSet<Type> SupportedDataTypes =
+    [
+        typeof(bool),
+        typeof(bool?),
+        typeof(string),
+        typeof(int),
+        typeof(int?),
+        typeof(long),
+        typeof(long?),
+        typeof(float),
+        typeof(float?),
+        typeof(double),
+        typeof(double?),
+        typeof(decimal),
+        typeof(decimal?),
+        typeof(DateTime),
+        typeof(DateTime?),
+    ];
+
+    /// <summary>A <see cref="HashSet{Type}"/> containing the supported vector types.</summary>
+    internal static readonly HashSet<Type> SupportedVectorTypes =
+    [
+        typeof(ReadOnlyMemory<float>),
+        typeof(ReadOnlyMemory<float>?),
+        typeof(ReadOnlyMemory<double>),
+        typeof(ReadOnlyMemory<double>?)
+    ];
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBGenericDataModelMapper.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// A mapper that maps between the generic Semantic Kernel data model and the model that the data is stored under, within MongoDB.
+/// </summary>
+internal sealed class MongoDBGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, BsonDocument>
+{
+    /// <summary>A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</summary>
+    private readonly VectorStoreRecordDefinition _vectorStoreRecordDefinition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDBGenericDataModelMapper"/> class.
+    /// </summary>
+    /// <param name="vectorStoreRecordDefinition">A <see cref="VectorStoreRecordDefinition"/> that defines the schema of the data in the database.</param>
+    public MongoDBGenericDataModelMapper(VectorStoreRecordDefinition vectorStoreRecordDefinition)
+    {
+        Verify.NotNull(vectorStoreRecordDefinition);
+
+        this._vectorStoreRecordDefinition = vectorStoreRecordDefinition;
+    }
+
+    /// <inheritdoc />
+    public BsonDocument MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)
+    {
+        Verify.NotNull(dataModel);
+
+        var document = new BsonDocument();
+
+        // Loop through all known properties and map each from the data model to the storage model.
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            var storagePropertyName = property.StoragePropertyName ?? property.DataModelPropertyName;
+
+            if (property is VectorStoreRecordKeyProperty keyProperty)
+            {
+                document[MongoDBConstants.MongoReservedKeyPropertyName] = dataModel.Key;
+            }
+            else if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                if (dataModel.Data is not null && dataModel.Data.TryGetValue(dataProperty.DataModelPropertyName, out var dataValue))
+                {
+                    document[storagePropertyName] = BsonValue.Create(dataValue);
+                }
+            }
+            else if (property is VectorStoreRecordVectorProperty vectorProperty)
+            {
+                if (dataModel.Vectors is not null && dataModel.Vectors.TryGetValue(vectorProperty.DataModelPropertyName, out var vectorValue))
+                {
+                    document[storagePropertyName] = BsonArray.Create(GetVectorArray(vectorValue));
+                }
+            }
+        }
+
+        return document;
+    }
+
+    /// <inheritdoc />
+    public VectorStoreGenericDataModel<string> MapFromStorageToDataModel(BsonDocument storageModel, StorageToDataModelMapperOptions options)
+    {
+        Verify.NotNull(storageModel);
+
+        // Create variables to store the response properties.
+        string? key = null;
+        var dataProperties = new Dictionary<string, object?>();
+        var vectorProperties = new Dictionary<string, object?>();
+
+        // Loop through all known properties and map each from the storage model to the data model.
+        foreach (var property in this._vectorStoreRecordDefinition.Properties)
+        {
+            var storagePropertyName = property.StoragePropertyName ?? property.DataModelPropertyName;
+
+            if (property is VectorStoreRecordKeyProperty keyProperty)
+            {
+                if (storageModel.TryGetValue(MongoDBConstants.MongoReservedKeyPropertyName, out var keyValue))
+                {
+                    key = keyValue.AsString;
+                }
+            }
+            else if (property is VectorStoreRecordDataProperty dataProperty)
+            {
+                if (!storageModel.TryGetValue(storagePropertyName, out var dataValue))
+                {
+                    continue;
+                }
+
+                dataProperties.Add(dataProperty.DataModelPropertyName, GetDataPropertyValue(property.DataModelPropertyName, property.PropertyType, dataValue));
+            }
+            else if (property is VectorStoreRecordVectorProperty vectorProperty && options.IncludeVectors)
+            {
+                if (!storageModel.TryGetValue(storagePropertyName, out var vectorValue))
+                {
+                    continue;
+                }
+
+                vectorProperties.Add(vectorProperty.DataModelPropertyName, GetVectorPropertyValue(property.DataModelPropertyName, property.PropertyType, vectorValue));
+            }
+        }
+
+        if (key is null)
+        {
+            throw new VectorStoreRecordMappingException("No key property was found in the record retrieved from storage.");
+        }
+
+        return new VectorStoreGenericDataModel<string>(key) { Data = dataProperties, Vectors = vectorProperties };
+    }
+
+    #region private
+
+    private static object? GetDataPropertyValue(string propertyName, Type propertyType, BsonValue value)
+    {
+        if (value.IsBsonNull)
+        {
+            return null;
+        }
+
+        return propertyType switch
+        {
+            Type t when t == typeof(bool) => value.AsBoolean,
+            Type t when t == typeof(bool?) => value.AsNullableBoolean,
+            Type t when t == typeof(string) => value.AsString,
+            Type t when t == typeof(int) => value.AsInt32,
+            Type t when t == typeof(int?) => value.AsNullableInt32,
+            Type t when t == typeof(long) => value.AsInt64,
+            Type t when t == typeof(long?) => value.AsNullableInt64,
+            Type t when t == typeof(float) => ((float)value.AsDouble),
+            Type t when t == typeof(float?) => ((float?)value.AsNullableDouble),
+            Type t when t == typeof(double) => value.AsDouble,
+            Type t when t == typeof(double?) => value.AsNullableDouble,
+            Type t when t == typeof(decimal) => value.AsDecimal,
+            Type t when t == typeof(decimal?) => value.AsNullableDecimal,
+            Type t when t == typeof(DateTime) => value.ToUniversalTime(),
+            Type t when t == typeof(DateTime?) => value.ToNullableUniversalTime(),
+            Type t when typeof(IEnumerable).IsAssignableFrom(t) => value.AsBsonArray.Select(
+                item => GetDataPropertyValue(propertyName, VectorStoreRecordPropertyVerification.GetCollectionElementType(t), item)),
+            _ => throw new NotSupportedException($"Mapping for property {propertyName} with type {propertyType.FullName} is not supported in generic data model.")
+        };
+    }
+
+    private static object? GetVectorPropertyValue(string propertyName, Type propertyType, BsonValue value)
+    {
+        if (value.IsBsonNull)
+        {
+            return null;
+        }
+
+        return propertyType switch
+        {
+            Type t when t == typeof(ReadOnlyMemory<float>) || t == typeof(ReadOnlyMemory<float>?) =>
+                new ReadOnlyMemory<float>(value.AsBsonArray.Select(item => (float)item.AsDouble).ToArray()),
+            Type t when t == typeof(ReadOnlyMemory<double>) || t == typeof(ReadOnlyMemory<double>?) =>
+                new ReadOnlyMemory<double>(value.AsBsonArray.Select(item => item.AsDouble).ToArray()),
+            _ => throw new NotSupportedException($"Mapping for property {propertyName} with type {propertyType.FullName} is not supported in generic data model.")
+        };
+    }
+
+    private static object GetVectorArray(object? vector)
+    {
+        if (vector is null)
+        {
+            return Array.Empty<object>();
+        }
+
+        return vector switch
+        {
+            ReadOnlyMemory<float> memoryFloat => memoryFloat.ToArray(),
+            ReadOnlyMemory<double> memoryDouble => memoryDouble.ToArray(),
+            _ => throw new NotSupportedException($"Mapping for type {vector.GetType().FullName} is not supported in generic data model.")
+        };
+    }
+
+    #endregion
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBServiceCollectionExtensions.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using Microsoft.SemanticKernel.Http;
+using MongoDB.Driver;
+
+namespace Microsoft.SemanticKernel;
+
+/// <summary>
+/// Extension methods to register MongoDB <see cref="IVectorStore"/> instances on an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class MongoDBServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register a MongoDB <see cref="IVectorStore"/> with the specified service ID
+    /// and where the MongoDB <see cref="IMongoDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddMongoDBVectorStore(
+        this IServiceCollection services,
+        MongoDBVectorStoreOptions? options = default,
+        string? serviceId = default)
+    {
+        // If we are not constructing MongoDatabase, add the IVectorStore as transient, since we
+        // cannot make assumptions about how MongoDatabase is being managed.
+        services.AddKeyedTransient<IVectorStore>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = sp.GetRequiredService<IMongoDatabase>();
+                var selectedOptions = options ?? sp.GetService<MongoDBVectorStoreOptions>();
+
+                return new MongoDBVectorStore(database, options);
+            });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a MongoDB <see cref="IVectorStore"/> with the specified service ID
+    /// and where the MongoDB <see cref="IMongoDatabase"/> is constructed using the provided <paramref name="connectionString"/> and <paramref name="databaseName"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="connectionString">Connection string required to connect to MongoDB.</param>
+    /// <param name="databaseName">Database name for MongoDB.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddMongoDBVectorStore(
+        this IServiceCollection services,
+        string connectionString,
+        string databaseName,
+        MongoDBVectorStoreOptions? options = default,
+        string? serviceId = default)
+    {
+        // If we are constructing IMongoDatabase, add the IVectorStore as singleton, since we are managing the lifetime of it,
+        // and the recommendation from Mongo is to register it with a singleton lifetime.
+        services.AddKeyedSingleton<IVectorStore>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var settings = MongoClientSettings.FromConnectionString(connectionString);
+                settings.ApplicationName = HttpHeaderConstant.Values.UserAgent;
+
+                var mongoClient = new MongoClient(settings);
+                var database = mongoClient.GetDatabase(databaseName);
+
+                var selectedOptions = options ?? sp.GetService<MongoDBVectorStoreOptions>();
+
+                return new MongoDBVectorStore(database, options);
+            });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a MongoDB <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the MongoDB <see cref="IMongoDatabase"/> is retrieved from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddMongoDBVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        MongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+    {
+        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var database = sp.GetRequiredService<IMongoDatabase>();
+                var selectedOptions = options ?? sp.GetService<MongoDBVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new MongoDBVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register a MongoDB <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
+    /// and where the MongoDB <see cref="IMongoDatabase"/> is constructed using the provided <paramref name="connectionString"/> and <paramref name="databaseName"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="connectionString">Connection string required to connect to MongoDB.</param>
+    /// <param name="databaseName">Database name for MongoDB.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddMongoDBVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection services,
+        string collectionName,
+        string connectionString,
+        string databaseName,
+        MongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        string? serviceId = default)
+    {
+        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                var settings = MongoClientSettings.FromConnectionString(connectionString);
+                settings.ApplicationName = HttpHeaderConstant.Values.UserAgent;
+
+                var mongoClient = new MongoClient(settings);
+                var database = mongoClient.GetDatabase(databaseName);
+
+                var selectedOptions = options ?? sp.GetService<MongoDBVectorStoreRecordCollectionOptions<TRecord>>();
+
+                return new MongoDBVectorStoreRecordCollection<TRecord>(database, collectionName, selectedOptions);
+            });
+
+        AddVectorizedSearch<TRecord>(services, serviceId);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="services">The service collection to register on.</param>
+    /// <param name="serviceId">The service id that the registrations should use.</param>
+    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+    {
+        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
+            serviceId,
+            (sp, obj) =>
+            {
+                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
+            });
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStore.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Driver;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Class for accessing the list of collections in a MongoDB vector store.
+/// </summary>
+/// <remarks>
+/// This class can be used with collections of any schema type, but requires you to provide schema information when getting a collection.
+/// </remarks>
+public sealed class MongoDBVectorStore : IVectorStore
+{
+    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</summary>
+    private readonly IMongoDatabase _mongoDatabase;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly MongoDBVectorStoreOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDBVectorStore"/> class.
+    /// </summary>
+    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    public MongoDBVectorStore(IMongoDatabase mongoDatabase, MongoDBVectorStoreOptions? options = default)
+    {
+        Verify.NotNull(mongoDatabase);
+
+        this._mongoDatabase = mongoDatabase;
+        this._options = options ?? new();
+    }
+
+    /// <inheritdoc />
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+        where TKey : notnull
+    {
+        if (typeof(TKey) != typeof(string))
+        {
+            throw new NotSupportedException("Only string keys are supported.");
+        }
+
+        if (this._options.VectorStoreCollectionFactory is not null)
+        {
+            return this._options.VectorStoreCollectionFactory.CreateVectorStoreRecordCollection<TKey, TRecord>(this._mongoDatabase, name, vectorStoreRecordDefinition);
+        }
+
+        var recordCollection = new MongoDBVectorStoreRecordCollection<TRecord>(
+            this._mongoDatabase,
+            name,
+            new() { VectorStoreRecordDefinition = vectorStoreRecordDefinition }) as IVectorStoreRecordCollection<TKey, TRecord>;
+
+        return recordCollection!;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        using var cursor = await this._mongoDatabase
+            .ListCollectionNamesAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        while (await cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var name in cursor.Current)
+            {
+                yield return name;
+            }
+        }
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreCollectionCreateMapping.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Contains mapping helpers to use when creating a collection in MongoDB.
+/// </summary>
+internal static class MongoDBVectorStoreCollectionCreateMapping
+{
+    /// <summary>
+    /// Returns an array of indexes to create for vector properties.
+    /// </summary>
+    /// <param name="vectorProperties">Collection of vector properties for index creation.</param>
+    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the storage name.</param>
+    public static BsonArray GetVectorIndexFields(
+        IReadOnlyList<VectorStoreRecordVectorProperty> vectorProperties,
+        Dictionary<string, string> storagePropertyNames)
+    {
+        var indexArray = new BsonArray();
+
+        // Create separate index for each vector property
+        foreach (var property in vectorProperties)
+        {
+            // Use index name same as vector property name with underscore
+            var vectorPropertyName = storagePropertyNames[property.DataModelPropertyName];
+
+            var indexDocument = new BsonDocument
+            {
+                { "type", "vector" },
+                { "numDimensions", property.Dimensions },
+                { "path", vectorPropertyName },
+                { "similarity", GetDistanceFunction(property.DistanceFunction, vectorPropertyName) },
+            };
+
+            indexArray.Add(indexDocument);
+        }
+
+        return indexArray;
+    }
+
+    /// <summary>
+    /// Returns an array of indexes to create for filterable data properties.
+    /// </summary>
+    /// <param name="dataProperties">Collection of data properties for index creation.</param>
+    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the storage name.</param>
+    public static BsonArray GetFilterableDataIndexFields(
+        IReadOnlyList<VectorStoreRecordDataProperty> dataProperties,
+        Dictionary<string, string> storagePropertyNames)
+    {
+        var indexArray = new BsonArray();
+
+        // Create separate index for each data property
+        foreach (var property in dataProperties)
+        {
+            if (property.IsFilterable)
+            {
+                // Use index name same as data property name with underscore
+                var dataPropertyName = storagePropertyNames[property.DataModelPropertyName];
+
+                var indexDocument = new BsonDocument
+                {
+                    { "type", "filter" },
+                    { "path", dataPropertyName },
+                };
+
+                indexArray.Add(indexDocument);
+            }
+        }
+
+        return indexArray;
+    }
+
+    /// <summary>
+    /// More information about MongoDB distance functions here: <see href="https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields" />.
+    /// </summary>
+    private static string GetDistanceFunction(string? distanceFunction, string vectorPropertyName)
+    {
+        var vectorPropertyDistanceFunction = MongoDBVectorStoreCollectionSearchMapping.GetVectorPropertyDistanceFunction(distanceFunction);
+
+        return vectorPropertyDistanceFunction switch
+        {
+            DistanceFunction.CosineSimilarity => "cosine",
+            DistanceFunction.DotProductSimilarity => "dotProduct",
+            DistanceFunction.EuclideanDistance => "euclidean",
+            _ => throw new InvalidOperationException($"Distance function '{distanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorPropertyName}' is not supported by the MongoDB VectorStore.")
+        };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreCollectionSearchMapping.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Contains mapping helpers to use when searching for documents using MongoDB.
+/// </summary>
+internal static class MongoDBVectorStoreCollectionSearchMapping
+{
+    /// <summary>Returns distance function specified on vector property or default <see cref="MongoDBConstants.DefaultDistanceFunction"/>.</summary>
+    public static string GetVectorPropertyDistanceFunction(string? distanceFunction) => !string.IsNullOrWhiteSpace(distanceFunction) ? distanceFunction! : MongoDBConstants.DefaultDistanceFunction;
+
+    /// <summary>
+    /// Build MongoDB filter from the provided <see cref="VectorSearchFilter"/>.
+    /// </summary>
+    /// <param name="vectorSearchFilter">The <see cref="VectorSearchFilter"/> to build MongoDB filter from.</param>
+    /// <param name="storagePropertyNames">A dictionary that maps from a property name to the storage name.</param>
+    /// <exception cref="NotSupportedException">Thrown when the provided filter type is unsupported.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when property name specified in filter doesn't exist.</exception>
+    public static BsonDocument? BuildFilter(
+        VectorSearchFilter? vectorSearchFilter,
+        Dictionary<string, string> storagePropertyNames)
+    {
+        const string EqualOperator = "$eq";
+
+        var filterClauses = vectorSearchFilter?.FilterClauses.ToList();
+
+        if (filterClauses is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var filter = new BsonDocument();
+
+        foreach (var filterClause in filterClauses)
+        {
+            string propertyName;
+            BsonValue propertyValue;
+            string filterOperator;
+
+            if (filterClause is EqualToFilterClause equalToFilterClause)
+            {
+                propertyName = equalToFilterClause.FieldName;
+                propertyValue = BsonValue.Create(equalToFilterClause.Value);
+                filterOperator = EqualOperator;
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    $"Unsupported filter clause type '{filterClause.GetType().Name}'. " +
+                    $"Supported filter clause types are: {string.Join(", ", [
+                        nameof(EqualToFilterClause)])}");
+            }
+
+            if (!storagePropertyNames.TryGetValue(propertyName, out var storagePropertyName))
+            {
+                throw new InvalidOperationException($"Property name '{propertyName}' provided as part of the filter clause is not a valid property name.");
+            }
+
+            if (filter.Contains(storagePropertyName))
+            {
+                if (filter[storagePropertyName] is BsonDocument document && document.Contains(filterOperator))
+                {
+                    throw new NotSupportedException(
+                        $"Filter with operator '{filterOperator}' is already added to '{propertyName}' property. " +
+                        "Multiple filters of the same type in the same property are not supported.");
+                }
+
+                filter[storagePropertyName][filterOperator] = propertyValue;
+            }
+            else
+            {
+                filter[storagePropertyName] = new BsonDocument() { [filterOperator] = propertyValue };
+            }
+        }
+
+        return filter;
+    }
+
+    /// <summary>Returns search part of the search query.</summary>
+    public static BsonDocument GetSearchQuery<TVector>(
+        TVector vector,
+        string indexName,
+        string vectorPropertyName,
+        int limit,
+        int numCandidates,
+        BsonDocument? filter)
+    {
+        var searchQuery = new BsonDocument
+        {
+            { "index", indexName },
+            { "queryVector", BsonArray.Create(vector) },
+            { "path", vectorPropertyName },
+            { "limit", limit },
+            { "numCandidates", numCandidates },
+        };
+
+        if (filter is not null)
+        {
+            searchQuery["filter"] = filter;
+        }
+
+        return new BsonDocument
+        {
+            { "$vectorSearch", searchQuery }
+        };
+    }
+
+    /// <summary>Returns projection part of the search query to return similarity score together with document.</summary>
+    public static BsonDocument GetProjectionQuery(string scorePropertyName, string documentPropertyName)
+    {
+        return new BsonDocument
+        {
+            { "$project",
+                new BsonDocument
+                {
+                    { scorePropertyName, new BsonDocument { { "$meta", "vectorSearchScore" } } },
+                    { documentPropertyName, "$$ROOT" }
+                }
+            }
+        };
+    }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Options when creating a <see cref="MongoDBVectorStore"/>
+/// </summary>
+public sealed class MongoDBVectorStoreOptions
+{
+    /// <summary>
+    /// An optional factory to use for constructing <see cref="MongoDBVectorStoreRecordCollection{TRecord}"/> instances, if a custom record collection is required.
+    /// </summary>
+    public IMongoDBVectorStoreRecordCollectionFactory? VectorStoreCollectionFactory { get; init; }
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -1,0 +1,615 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Service for storing and retrieving vector records, that uses MongoDB as the underlying storage.
+/// </summary>
+/// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+{
+    /// <summary>The name of this database for telemetry purposes.</summary>
+    private const string DatabaseName = "MongoDB";
+
+    /// <summary>Property name to be used for search similarity score value.</summary>
+    private const string ScorePropertyName = "similarityScore";
+
+    /// <summary>Property name to be used for search document value.</summary>
+    private const string DocumentPropertyName = "document";
+
+    /// <summary>The default options for vector search.</summary>
+    private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
+
+    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</summary>
+    private readonly IMongoDatabase _mongoDatabase;
+
+    /// <summary>MongoDB collection to perform record operations.</summary>
+    private readonly IMongoCollection<BsonDocument> _mongoCollection;
+
+    /// <summary>Optional configuration options for this class.</summary>
+    private readonly MongoDBVectorStoreRecordCollectionOptions<TRecord> _options;
+
+    /// <summary>Interface for mapping between a storage model, and the consumer record data model.</summary>
+    private readonly IVectorStoreRecordMapper<TRecord, BsonDocument> _mapper;
+
+    /// <summary>A dictionary that maps from a property name to the storage name that should be used when serializing it for data and vector properties.</summary>
+    private readonly Dictionary<string, string> _storagePropertyNames;
+
+    /// <summary>Collection of vector storage property names.</summary>
+    private readonly List<string> _vectorStoragePropertyNames;
+
+    /// <summary>A helper to access property information for the current data model and record definition.</summary>
+    private readonly VectorStoreRecordPropertyReader _propertyReader;
+
+    /// <inheritdoc />
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDBVectorStoreRecordCollection{TRecord}"/> class.
+    /// </summary>
+    /// <param name="mongoDatabase"><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="MongoDBVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="options">Optional configuration options for this class.</param>
+    public MongoDBVectorStoreRecordCollection(
+        IMongoDatabase mongoDatabase,
+        string collectionName,
+        MongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default)
+    {
+        // Verify.
+        Verify.NotNull(mongoDatabase);
+        Verify.NotNullOrWhiteSpace(collectionName);
+        VectorStoreRecordPropertyVerification.VerifyGenericDataModelKeyType(typeof(TRecord), options?.BsonDocumentCustomMapper is not null, MongoDBConstants.SupportedKeyTypes);
+        VectorStoreRecordPropertyVerification.VerifyGenericDataModelDefinitionSupplied(typeof(TRecord), options?.VectorStoreRecordDefinition is not null);
+
+        // Assign.
+        this._mongoDatabase = mongoDatabase;
+        this._mongoCollection = mongoDatabase.GetCollection<BsonDocument>(collectionName);
+        this.CollectionName = collectionName;
+        this._options = options ?? new MongoDBVectorStoreRecordCollectionOptions<TRecord>();
+        this._propertyReader = new VectorStoreRecordPropertyReader(typeof(TRecord), this._options.VectorStoreRecordDefinition, new() { RequiresAtLeastOneVector = false, SupportsMultipleKeys = false, SupportsMultipleVectors = true });
+
+        this._storagePropertyNames = GetStoragePropertyNames(this._propertyReader.Properties, typeof(TRecord));
+
+        // Use Mongo reserved key property name as storage key property name
+        this._storagePropertyNames[this._propertyReader.KeyPropertyName] = MongoDBConstants.MongoReservedKeyPropertyName;
+
+        this._vectorStoragePropertyNames = this._propertyReader.VectorProperties.Select(property => this._storagePropertyNames[property.DataModelPropertyName]).ToList();
+
+        this._mapper = this.InitializeMapper();
+    }
+
+    /// <inheritdoc />
+    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+        => this.RunOperationAsync("ListCollectionNames", () => this.InternalCollectionExistsAsync(cancellationToken));
+
+    /// <inheritdoc />
+    public async Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        await this.RunOperationAsync("CreateCollection",
+            () => this._mongoDatabase.CreateCollectionAsync(this.CollectionName, cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        await this.RunOperationWithRetryAsync(
+            "CreateIndexes",
+            this._options.MaxRetries,
+            this._options.DelayInMilliseconds,
+            () => this.CreateIndexesAsync(this.CollectionName, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await this.CollectionExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await this.CreateCollectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(string key, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(key);
+
+        await this.RunOperationAsync("DeleteOne", () => this._mongoCollection.DeleteOneAsync(this.GetFilterById(key), cancellationToken))
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteBatchAsync(IEnumerable<string> keys, DeleteRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(keys);
+
+        await this.RunOperationAsync("DeleteMany", () => this._mongoCollection.DeleteManyAsync(this.GetFilterByIds(keys), cancellationToken))
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+        => this.RunOperationAsync("DropCollection", () => this._mongoDatabase.DropCollectionAsync(this.CollectionName, cancellationToken));
+
+    /// <inheritdoc />
+    public async Task<TRecord?> GetAsync(string key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(key);
+
+        const string OperationName = "Find";
+
+        var includeVectors = options?.IncludeVectors ?? false;
+
+        var record = await this.RunOperationAsync(OperationName, async () =>
+        {
+            using var cursor = await this
+                .FindAsync(this.GetFilterById(key), options, cancellationToken)
+                .ConfigureAwait(false);
+
+            return await cursor.SingleOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        if (record is null)
+        {
+            return default;
+        }
+
+        return VectorStoreErrorHandler.RunModelConversion(
+            DatabaseName,
+            this.CollectionName,
+            OperationName,
+            () => this._mapper.MapFromStorageToDataModel(record, new() { IncludeVectors = includeVectors }));
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TRecord> GetBatchAsync(
+        IEnumerable<string> keys,
+        GetRecordOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(keys);
+
+        const string OperationName = "Find";
+
+        using var cursor = await this
+            .FindAsync(this.GetFilterByIds(keys), options, cancellationToken)
+            .ConfigureAwait(false);
+
+        while (await cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var record in cursor.Current)
+            {
+                if (record is not null)
+                {
+                    yield return VectorStoreErrorHandler.RunModelConversion(
+                        DatabaseName,
+                        this.CollectionName,
+                        OperationName,
+                        () => this._mapper.MapFromStorageToDataModel(record, new()));
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<string> UpsertAsync(TRecord record, UpsertRecordOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(record);
+
+        const string OperationName = "ReplaceOne";
+
+        var replaceOptions = new ReplaceOptions { IsUpsert = true };
+        var storageModel = VectorStoreErrorHandler.RunModelConversion(
+            DatabaseName,
+            this.CollectionName,
+            OperationName,
+            () => this._mapper.MapFromDataToStorageModel(record));
+
+        var key = storageModel[MongoDBConstants.MongoReservedKeyPropertyName].AsString;
+
+        return this.RunOperationAsync(OperationName, async () =>
+        {
+            await this._mongoCollection
+                .ReplaceOneAsync(this.GetFilterById(key), storageModel, replaceOptions, cancellationToken)
+                .ConfigureAwait(false);
+
+            return key;
+        });
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> UpsertBatchAsync(
+        IEnumerable<TRecord> records,
+        UpsertRecordOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(records);
+
+        var tasks = records.Select(record => this.UpsertAsync(record, options, cancellationToken));
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        foreach (var result in results)
+        {
+            if (result is not null)
+            {
+                yield return result;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
+        TVector vector,
+        VectorSearchOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(vector);
+
+        Array vectorArray = vector switch
+        {
+            ReadOnlyMemory<float> memoryFloat => memoryFloat.ToArray(),
+            ReadOnlyMemory<double> memoryDouble => memoryDouble.ToArray(),
+            _ => throw new NotSupportedException(
+                $"The provided vector type {vector.GetType().FullName} is not supported by the MongoDB connector. " +
+                $"Supported types are: {string.Join(", ", [
+                    typeof(ReadOnlyMemory<float>).FullName,
+                    typeof(ReadOnlyMemory<double>).FullName])}")
+        };
+
+        var searchOptions = options ?? s_defaultVectorSearchOptions;
+        var vectorProperty = this.GetVectorPropertyForSearch(searchOptions.VectorPropertyName);
+
+        if (vectorProperty is null)
+        {
+            throw new InvalidOperationException("The collection does not have any vector properties, so vector search is not possible.");
+        }
+
+        var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
+
+        var filter = MongoDBVectorStoreCollectionSearchMapping.BuildFilter(
+            searchOptions.Filter,
+            this._storagePropertyNames);
+
+        // Constructing a query to fetch "skip + top" total items
+        // to perform skip logic locally, since skip option is not part of API. 
+        var itemsAmount = searchOptions.Skip + searchOptions.Top;
+
+        var numCandidates = this._options.NumCandidates ?? itemsAmount * MongoDBConstants.DefaultNumCandidatesRatio;
+
+        var searchQuery = MongoDBVectorStoreCollectionSearchMapping.GetSearchQuery(
+            vectorArray,
+            this._options.VectorIndexName,
+            vectorPropertyName,
+            itemsAmount,
+            numCandidates,
+            filter);
+
+        var projectionQuery = MongoDBVectorStoreCollectionSearchMapping.GetProjectionQuery(
+            ScorePropertyName,
+            DocumentPropertyName);
+
+        BsonDocument[] pipeline = [searchQuery, projectionQuery];
+
+        return await this.RunOperationWithRetryAsync(
+            "VectorizedSearch",
+            this._options.MaxRetries,
+            this._options.DelayInMilliseconds,
+            async () =>
+            {
+                var cursor = await this._mongoCollection
+                    .AggregateAsync<BsonDocument>(pipeline, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+                return new VectorSearchResults<TRecord>(this.EnumerateAndMapSearchResultsAsync(cursor, searchOptions, cancellationToken));
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    #region private
+
+    private async Task CreateIndexesAsync(string collectionName, CancellationToken cancellationToken)
+    {
+        var indexCursor = await this._mongoCollection.Indexes.ListAsync(cancellationToken).ConfigureAwait(false);
+        var indexes = indexCursor.ToList(cancellationToken).Select(index => index["name"].ToString()) ?? [];
+
+        if (indexes.Contains(this._options.VectorIndexName))
+        {
+            // Vector index already exists.
+            return;
+        }
+
+        var fieldsArray = new BsonArray();
+
+        fieldsArray.AddRange(MongoDBVectorStoreCollectionCreateMapping.GetVectorIndexFields(
+            this._propertyReader.VectorProperties,
+            this._storagePropertyNames));
+
+        fieldsArray.AddRange(MongoDBVectorStoreCollectionCreateMapping.GetFilterableDataIndexFields(
+            this._propertyReader.DataProperties,
+            this._storagePropertyNames));
+
+        if (fieldsArray.Count > 0)
+        {
+            var indexArray = new BsonArray
+            {
+                new BsonDocument
+                {
+                    { "name", this._options.VectorIndexName },
+                    { "type", "vectorSearch" },
+                    { "definition", new BsonDocument { ["fields"] = fieldsArray } },
+                }
+            };
+
+            var createIndexCommand = new BsonDocument
+            {
+                { "createSearchIndexes", collectionName },
+                { "indexes", indexArray }
+            };
+
+            await this._mongoDatabase.RunCommandAsync<BsonDocument>(createIndexCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<IAsyncCursor<BsonDocument>> FindAsync(FilterDefinition<BsonDocument> filter, GetRecordOptions? options, CancellationToken cancellationToken)
+    {
+        ProjectionDefinitionBuilder<BsonDocument> projectionBuilder = Builders<BsonDocument>.Projection;
+        ProjectionDefinition<BsonDocument>? projectionDefinition = null;
+
+        var includeVectors = options?.IncludeVectors ?? false;
+
+        if (!includeVectors && this._vectorStoragePropertyNames.Count > 0)
+        {
+            foreach (var vectorPropertyName in this._vectorStoragePropertyNames)
+            {
+                projectionDefinition = projectionDefinition is not null ?
+                    projectionDefinition.Exclude(vectorPropertyName) :
+                    projectionBuilder.Exclude(vectorPropertyName);
+            }
+        }
+
+        var findOptions = projectionDefinition is not null ?
+            new FindOptions<BsonDocument> { Projection = projectionDefinition } :
+            null;
+
+        return await this._mongoCollection.FindAsync(filter, findOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async IAsyncEnumerable<VectorSearchResult<TRecord>> EnumerateAndMapSearchResultsAsync(
+        IAsyncCursor<BsonDocument> cursor,
+        VectorSearchOptions searchOptions,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        const string OperationName = "Aggregate";
+
+        var skipCounter = 0;
+
+        while (await cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var response in cursor.Current)
+            {
+                if (skipCounter >= searchOptions.Skip)
+                {
+                    var score = response[ScorePropertyName].AsDouble;
+                    var record = VectorStoreErrorHandler.RunModelConversion(
+                        DatabaseName,
+                        this.CollectionName,
+                        OperationName,
+                        () => this._mapper.MapFromStorageToDataModel(response[DocumentPropertyName].AsBsonDocument, new() { IncludeVectors = searchOptions.IncludeVectors }));
+
+                    yield return new VectorSearchResult<TRecord>(record, score);
+                }
+
+                skipCounter++;
+            }
+        }
+    }
+
+    private FilterDefinition<BsonDocument> GetFilterById(string id)
+        => Builders<BsonDocument>.Filter.Eq(document => document[MongoDBConstants.MongoReservedKeyPropertyName], id);
+
+    private FilterDefinition<BsonDocument> GetFilterByIds(IEnumerable<string> ids)
+        => Builders<BsonDocument>.Filter.In(document => document[MongoDBConstants.MongoReservedKeyPropertyName].AsString, ids);
+
+    private async Task<bool> InternalCollectionExistsAsync(CancellationToken cancellationToken)
+    {
+        var filter = new BsonDocument("name", this.CollectionName);
+        var options = new ListCollectionNamesOptions { Filter = filter };
+
+        using var cursor = await this._mongoDatabase.ListCollectionNamesAsync(options, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return await cursor.AnyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task RunOperationAsync(string operationName, Func<Task> operation)
+    {
+        try
+        {
+            await operation.Invoke().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                VectorStoreType = DatabaseName,
+                CollectionName = this.CollectionName,
+                OperationName = operationName
+            };
+        }
+    }
+
+    private async Task<T> RunOperationAsync<T>(string operationName, Func<Task<T>> operation)
+    {
+        try
+        {
+            return await operation.Invoke().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new VectorStoreOperationException("Call to vector store failed.", ex)
+            {
+                VectorStoreType = DatabaseName,
+                CollectionName = this.CollectionName,
+                OperationName = operationName
+            };
+        }
+    }
+
+    private async Task RunOperationWithRetryAsync(
+        string operationName,
+        int maxRetries,
+        int delayInMilliseconds,
+        Func<Task> operation,
+        CancellationToken cancellationToken)
+    {
+        var retries = 0;
+
+        while (retries < maxRetries)
+        {
+            try
+            {
+                await operation.Invoke().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex)
+            {
+                retries++;
+
+                if (retries >= maxRetries)
+                {
+                    throw new VectorStoreOperationException("Call to vector store failed.", ex)
+                    {
+                        VectorStoreType = DatabaseName,
+                        CollectionName = this.CollectionName,
+                        OperationName = operationName
+                    };
+                }
+
+                await Task.Delay(delayInMilliseconds, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task<T> RunOperationWithRetryAsync<T>(
+        string operationName,
+        int maxRetries,
+        int delayInMilliseconds,
+        Func<Task<T>> operation,
+        CancellationToken cancellationToken)
+    {
+        var retries = 0;
+
+        while (retries < maxRetries)
+        {
+            try
+            {
+                return await operation.Invoke().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                retries++;
+
+                if (retries >= maxRetries)
+                {
+                    throw new VectorStoreOperationException("Call to vector store failed.", ex)
+                    {
+                        VectorStoreType = DatabaseName,
+                        CollectionName = this.CollectionName,
+                        OperationName = operationName
+                    };
+                }
+
+                await Task.Delay(delayInMilliseconds, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new VectorStoreOperationException("Retry logic failed.");
+    }
+
+    /// <summary>
+    /// Gets storage property names taking into account BSON serialization attributes.
+    /// </summary>
+    private static Dictionary<string, string> GetStoragePropertyNames(
+        IReadOnlyList<VectorStoreRecordProperty> properties,
+        Type dataModel)
+    {
+        var storagePropertyNames = new Dictionary<string, string>();
+
+        foreach (var property in properties)
+        {
+            var propertyInfo = dataModel.GetProperty(property.DataModelPropertyName);
+            string propertyName;
+
+            if (propertyInfo != null)
+            {
+                var bsonElementAttribute = propertyInfo.GetCustomAttribute<BsonElementAttribute>();
+
+                propertyName = bsonElementAttribute?.ElementName ?? property.DataModelPropertyName;
+            }
+            else
+            {
+                propertyName = property.DataModelPropertyName;
+            }
+
+            storagePropertyNames[property.DataModelPropertyName] = propertyName;
+        }
+
+        return storagePropertyNames;
+    }
+
+    /// <summary>
+    /// Get vector property to use for a search by using the storage name for the field name from options
+    /// if available, and falling back to the first vector property in <typeparamref name="TRecord"/> if not.
+    /// </summary>
+    /// <param name="vectorFieldName">The vector field name.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the provided field name is not a valid field name.</exception>
+    private VectorStoreRecordVectorProperty? GetVectorPropertyForSearch(string? vectorFieldName)
+    {
+        // If vector property name is provided in options, try to find it in schema or throw an exception.
+        if (!string.IsNullOrWhiteSpace(vectorFieldName))
+        {
+            // Check vector properties by data model property name.
+            var vectorProperty = this._propertyReader.VectorProperties
+                .FirstOrDefault(l => l.DataModelPropertyName.Equals(vectorFieldName, StringComparison.Ordinal));
+
+            if (vectorProperty is not null)
+            {
+                return vectorProperty;
+            }
+
+            throw new InvalidOperationException($"The {typeof(TRecord).FullName} type does not have a vector property named '{vectorFieldName}'.");
+        }
+
+        // If vector property is not provided in options, return first vector property from schema.
+        return this._propertyReader.VectorProperty;
+    }
+
+    /// <summary>
+    /// Returns custom mapper, generic data model mapper or default record mapper.
+    /// </summary>
+    private IVectorStoreRecordMapper<TRecord, BsonDocument> InitializeMapper()
+    {
+        if (this._options.BsonDocumentCustomMapper is not null)
+        {
+            return this._options.BsonDocumentCustomMapper;
+        }
+
+        if (typeof(TRecord) == typeof(VectorStoreGenericDataModel<string>))
+        {
+            return (new MongoDBGenericDataModelMapper(this._propertyReader.RecordDefinition) as IVectorStoreRecordMapper<TRecord, BsonDocument>)!;
+        }
+
+        return new MongoDBVectorStoreRecordMapper<TRecord>(this._propertyReader);
+    }
+
+    #endregion
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollectionOptions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+/// <summary>
+/// Options when creating a <see cref="MongoDBVectorStoreRecordCollection{TRecord}"/>.
+/// </summary>
+public sealed class MongoDBVectorStoreRecordCollectionOptions<TRecord>
+{
+    /// <summary>
+    /// Gets or sets an optional custom mapper to use when converting between the data model and the MongoDB BSON object.
+    /// </summary>
+    public IVectorStoreRecordMapper<TRecord, BsonDocument>? BsonDocumentCustomMapper { get; init; } = null;
+
+    /// <summary>
+    /// Gets or sets an optional record definition that defines the schema of the record type.
+    /// </summary>
+    /// <remarks>
+    /// If not provided, the schema will be inferred from the record model class using reflection.
+    /// In this case, the record model properties must be annotated with the appropriate attributes to indicate their usage.
+    /// See <see cref="VectorStoreRecordKeyAttribute"/>, <see cref="VectorStoreRecordDataAttribute"/> and <see cref="VectorStoreRecordVectorAttribute"/>.
+    /// </remarks>
+    public VectorStoreRecordDefinition? VectorStoreRecordDefinition { get; init; } = null;
+
+    /// <summary>
+    /// Vector index name to use. If null, the default "vector_index" name will be used.
+    /// </summary>
+    public string VectorIndexName { get; init; } = MongoDBConstants.DefaultVectorIndexName;
+
+    /// <summary>
+    /// Number of max retries for vector collection operation.
+    /// </summary>
+    public int MaxRetries { get; init; } = 5;
+
+    /// <summary>
+    /// Delay in milliseconds between retries for vector collection operation.
+    /// </summary>
+    public int DelayInMilliseconds { get; init; } = 1_000;
+
+    /// <summary>
+    /// Number of nearest neighbors to use during the vector search.
+    /// Value must be less than or equal to 10000.
+    /// Recommended value should be higher than number of documents to return.
+    /// If not provided, "number of documents * 10" value will be used.
+    /// </summary>
+    public int? NumCandidates { get; init; } = null;
+}

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordMapper.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Reflection;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Microsoft.SemanticKernel.Connectors.MongoDB;
+
+internal sealed class MongoDBVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, BsonDocument>
+{
+    /// <summary>A key property info of the data model.</summary>
+    private readonly PropertyInfo _keyProperty;
+
+    /// <summary>A key property name of the data model.</summary>
+    private readonly string _keyPropertyName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDBVectorStoreRecordMapper{TRecord}"/> class.
+    /// </summary>
+    /// <param name="propertyReader">A helper to access property information for the current data model and record definition.</param>
+    public MongoDBVectorStoreRecordMapper(VectorStoreRecordPropertyReader propertyReader)
+    {
+        propertyReader.VerifyKeyProperties(MongoDBConstants.SupportedKeyTypes);
+        propertyReader.VerifyDataProperties(MongoDBConstants.SupportedDataTypes, supportEnumerable: true);
+        propertyReader.VerifyVectorProperties(MongoDBConstants.SupportedVectorTypes);
+
+        this._keyPropertyName = propertyReader.KeyPropertyName;
+        this._keyProperty = propertyReader.KeyPropertyInfo;
+
+        var conventionPack = new ConventionPack
+        {
+            new IgnoreExtraElementsConvention(ignoreExtraElements: true)
+        };
+
+        ConventionRegistry.Register(
+            nameof(MongoDBVectorStoreRecordMapper<TRecord>),
+            conventionPack,
+            type => type == typeof(TRecord));
+    }
+
+    public BsonDocument MapFromDataToStorageModel(TRecord dataModel)
+    {
+        var document = dataModel.ToBsonDocument();
+
+        // Handle key property mapping due to reserved key name in Mongo.
+        if (!document.Contains(MongoDBConstants.MongoReservedKeyPropertyName))
+        {
+            var value = document[this._keyPropertyName];
+
+            document.Remove(this._keyPropertyName);
+
+            document[MongoDBConstants.MongoReservedKeyPropertyName] = value;
+        }
+
+        return document;
+    }
+
+    public TRecord MapFromStorageToDataModel(BsonDocument storageModel, StorageToDataModelMapperOptions options)
+    {
+        // Handle key property mapping due to reserved key name in Mongo.
+        if (!this._keyPropertyName.Equals(MongoDBConstants.DataModelReservedKeyPropertyName, StringComparison.OrdinalIgnoreCase) &&
+            this._keyProperty.GetCustomAttribute<BsonIdAttribute>() is null)
+        {
+            var value = storageModel[MongoDBConstants.MongoReservedKeyPropertyName];
+
+            storageModel.Remove(MongoDBConstants.MongoReservedKeyPropertyName);
+
+            storageModel[this._keyPropertyName] = value;
+        }
+
+        return BsonSerializer.Deserialize<TRecord>(storageModel);
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/.editorconfig
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/.editorconfig
@@ -1,0 +1,6 @@
+# Suppressing errors for Test projects under dotnet folder
+[*.cs]
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.VSTHRD111.severity = none # Use .ConfigureAwait(bool) is hidden by default, set to none to prevent IDE from changing on autosave
+dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
+dotnet_diagnostic.IDE1006.severity = warning # Naming rule violations

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/Connectors.MongoDB.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/Connectors.MongoDB.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>SemanticKernel.Connectors.MongoDB.UnitTests</AssemblyName>
+    <RootNamespace>SemanticKernel.Connectors.MongoDB.UnitTests</RootNamespace>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);SKEXP0001,SKEXP0020,VSTHRD111,CA2007,CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Connectors.Memory.MongoDB\Connectors.Memory.MongoDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBGenericDataModelMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBGenericDataModelMapperTests.cs
@@ -1,0 +1,310 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Bson;
+using Xunit;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MongoDBGenericDataModelMapper"/> class.
+/// </summary>
+public sealed class MongoDBGenericDataModelMapperTests
+{
+    private static readonly VectorStoreRecordDefinition s_vectorStoreRecordDefinition = new()
+    {
+        Properties = new List<VectorStoreRecordProperty>
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(string)),
+            new VectorStoreRecordDataProperty("BoolDataProp", typeof(bool)),
+            new VectorStoreRecordDataProperty("NullableBoolDataProp", typeof(bool?)),
+            new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+            new VectorStoreRecordDataProperty("IntDataProp", typeof(int)),
+            new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+            new VectorStoreRecordDataProperty("LongDataProp", typeof(long)),
+            new VectorStoreRecordDataProperty("NullableLongDataProp", typeof(long?)),
+            new VectorStoreRecordDataProperty("FloatDataProp", typeof(float)),
+            new VectorStoreRecordDataProperty("NullableFloatDataProp", typeof(float?)),
+            new VectorStoreRecordDataProperty("DoubleDataProp", typeof(double)),
+            new VectorStoreRecordDataProperty("NullableDoubleDataProp", typeof(double?)),
+            new VectorStoreRecordDataProperty("DecimalDataProp", typeof(decimal)),
+            new VectorStoreRecordDataProperty("NullableDecimalDataProp", typeof(decimal?)),
+            new VectorStoreRecordDataProperty("DateTimeDataProp", typeof(DateTime)),
+            new VectorStoreRecordDataProperty("NullableDateTimeDataProp", typeof(DateTime?)),
+            new VectorStoreRecordDataProperty("TagListDataProp", typeof(List<string>)),
+            new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+            new VectorStoreRecordVectorProperty("DoubleVector", typeof(ReadOnlyMemory<double>)),
+            new VectorStoreRecordVectorProperty("NullableDoubleVector", typeof(ReadOnlyMemory<double>?)),
+        },
+    };
+
+    private static readonly float[] s_floatVector = [1.0f, 2.0f, 3.0f];
+    private static readonly double[] s_doubleVector = [1.0f, 2.0f, 3.0f];
+    private static readonly List<string> s_taglist = ["tag1", "tag2"];
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsAllSupportedTypes()
+    {
+        // Arrange
+        var sut = new MongoDBGenericDataModelMapper(s_vectorStoreRecordDefinition);
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["BoolDataProp"] = true,
+                ["NullableBoolDataProp"] = false,
+                ["StringDataProp"] = "string",
+                ["IntDataProp"] = 1,
+                ["NullableIntDataProp"] = 2,
+                ["LongDataProp"] = 3L,
+                ["NullableLongDataProp"] = 4L,
+                ["FloatDataProp"] = 5.0f,
+                ["NullableFloatDataProp"] = 6.0f,
+                ["DoubleDataProp"] = 7.0,
+                ["NullableDoubleDataProp"] = 8.0,
+                ["DecimalDataProp"] = 9.0m,
+                ["NullableDecimalDataProp"] = 10.0m,
+                ["DateTimeDataProp"] = new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(),
+                ["NullableDateTimeDataProp"] = new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(),
+                ["TagListDataProp"] = s_taglist,
+            },
+            Vectors =
+            {
+                ["FloatVector"] = new ReadOnlyMemory<float>(s_floatVector),
+                ["NullableFloatVector"] = new ReadOnlyMemory<float>(s_floatVector),
+                ["DoubleVector"] = new ReadOnlyMemory<double>(s_doubleVector),
+                ["NullableDoubleVector"] = new ReadOnlyMemory<double>(s_doubleVector),
+            },
+        };
+
+        // Act
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", storageModel["_id"]);
+        Assert.Equal(true, (bool?)storageModel["BoolDataProp"]);
+        Assert.Equal(false, (bool?)storageModel["NullableBoolDataProp"]);
+        Assert.Equal("string", (string?)storageModel["StringDataProp"]);
+        Assert.Equal(1, (int?)storageModel["IntDataProp"]);
+        Assert.Equal(2, (int?)storageModel["NullableIntDataProp"]);
+        Assert.Equal(3L, (long?)storageModel["LongDataProp"]);
+        Assert.Equal(4L, (long?)storageModel["NullableLongDataProp"]);
+        Assert.Equal(5.0f, (float?)storageModel["FloatDataProp"].AsDouble);
+        Assert.Equal(6.0f, (float?)storageModel["NullableFloatDataProp"].AsNullableDouble);
+        Assert.Equal(7.0, (double?)storageModel["DoubleDataProp"]);
+        Assert.Equal(8.0, (double?)storageModel["NullableDoubleDataProp"]);
+        Assert.Equal(9.0m, (decimal?)storageModel["DecimalDataProp"]);
+        Assert.Equal(10.0m, (decimal?)storageModel["NullableDecimalDataProp"]);
+        Assert.Equal(new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(), storageModel["DateTimeDataProp"].ToUniversalTime());
+        Assert.Equal(new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(), storageModel["NullableDateTimeDataProp"].ToUniversalTime());
+        Assert.Equal(s_taglist, storageModel["TagListDataProp"]!.AsBsonArray.Select(x => (string)x!).ToArray());
+        Assert.Equal(s_floatVector, storageModel["FloatVector"]!.AsBsonArray.Select(x => (float)x.AsDouble!).ToArray());
+        Assert.Equal(s_floatVector, storageModel["NullableFloatVector"]!.AsBsonArray.Select(x => (float)x.AsNullableDouble!).ToArray());
+        Assert.Equal(s_doubleVector, storageModel["DoubleVector"]!.AsBsonArray.Select(x => (double)x!).ToArray());
+        Assert.Equal(s_doubleVector, storageModel["NullableDoubleVector"]!.AsBsonArray.Select(x => (double)x!).ToArray());
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelMapsNullValues()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+                new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+            },
+        };
+
+        var dataModel = new VectorStoreGenericDataModel<string>("key")
+        {
+            Data =
+            {
+                ["StringDataProp"] = null,
+                ["NullableIntDataProp"] = null,
+            },
+            Vectors =
+            {
+                ["NullableFloatVector"] = null,
+            },
+        };
+
+        var sut = new MongoDBGenericDataModelMapper(vectorStoreRecordDefinition);
+
+        // Act
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal(BsonNull.Value, storageModel["StringDataProp"]);
+        Assert.Equal(BsonNull.Value, storageModel["NullableIntDataProp"]);
+        Assert.Empty(storageModel["NullableFloatVector"].AsBsonArray);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsAllSupportedTypes()
+    {
+        // Arrange
+        var sut = new MongoDBGenericDataModelMapper(s_vectorStoreRecordDefinition);
+        var storageModel = new BsonDocument
+        {
+            ["_id"] = "key",
+            ["BoolDataProp"] = true,
+            ["NullableBoolDataProp"] = false,
+            ["StringDataProp"] = "string",
+            ["IntDataProp"] = 1,
+            ["NullableIntDataProp"] = 2,
+            ["LongDataProp"] = 3L,
+            ["NullableLongDataProp"] = 4L,
+            ["FloatDataProp"] = 5.0f,
+            ["NullableFloatDataProp"] = 6.0f,
+            ["DoubleDataProp"] = 7.0,
+            ["NullableDoubleDataProp"] = 8.0,
+            ["DecimalDataProp"] = 9.0m,
+            ["NullableDecimalDataProp"] = 10.0m,
+            ["DateTimeDataProp"] = new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(),
+            ["NullableDateTimeDataProp"] = new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(),
+            ["TagListDataProp"] = BsonArray.Create(s_taglist),
+            ["FloatVector"] = BsonArray.Create(s_floatVector),
+            ["NullableFloatVector"] = BsonArray.Create(s_floatVector),
+            ["DoubleVector"] = BsonArray.Create(s_doubleVector),
+            ["NullableDoubleVector"] = BsonArray.Create(s_doubleVector)
+        };
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal("key", dataModel.Key);
+        Assert.Equal(true, dataModel.Data["BoolDataProp"]);
+        Assert.Equal(false, dataModel.Data["NullableBoolDataProp"]);
+        Assert.Equal("string", dataModel.Data["StringDataProp"]);
+        Assert.Equal(1, dataModel.Data["IntDataProp"]);
+        Assert.Equal(2, dataModel.Data["NullableIntDataProp"]);
+        Assert.Equal(3L, dataModel.Data["LongDataProp"]);
+        Assert.Equal(4L, dataModel.Data["NullableLongDataProp"]);
+        Assert.Equal(5.0f, dataModel.Data["FloatDataProp"]);
+        Assert.Equal(6.0f, dataModel.Data["NullableFloatDataProp"]);
+        Assert.Equal(7.0, dataModel.Data["DoubleDataProp"]);
+        Assert.Equal(8.0, dataModel.Data["NullableDoubleDataProp"]);
+        Assert.Equal(9.0m, dataModel.Data["DecimalDataProp"]);
+        Assert.Equal(10.0m, dataModel.Data["NullableDecimalDataProp"]);
+        Assert.Equal(new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(), dataModel.Data["DateTimeDataProp"]);
+        Assert.Equal(new DateTime(2021, 1, 1, 0, 0, 0).ToUniversalTime(), dataModel.Data["NullableDateTimeDataProp"]);
+        Assert.Equal(s_taglist, dataModel.Data["TagListDataProp"]);
+        Assert.Equal(s_floatVector, ((ReadOnlyMemory<float>)dataModel.Vectors["FloatVector"]!).ToArray());
+        Assert.Equal(s_floatVector, ((ReadOnlyMemory<float>)dataModel.Vectors["NullableFloatVector"]!)!.ToArray());
+        Assert.Equal(s_doubleVector, ((ReadOnlyMemory<double>)dataModel.Vectors["DoubleVector"]!).ToArray());
+        Assert.Equal(s_doubleVector, ((ReadOnlyMemory<double>)dataModel.Vectors["NullableDoubleVector"]!)!.ToArray());
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelMapsNullValues()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordDataProperty("NullableIntDataProp", typeof(int?)),
+                new VectorStoreRecordVectorProperty("NullableFloatVector", typeof(ReadOnlyMemory<float>?)),
+            },
+        };
+
+        var storageModel = new BsonDocument
+        {
+            ["_id"] = "key",
+            ["StringDataProp"] = BsonNull.Value,
+            ["NullableIntDataProp"] = BsonNull.Value,
+            ["NullableFloatVector"] = BsonNull.Value
+        };
+
+        var sut = new MongoDBGenericDataModelMapper(vectorStoreRecordDefinition);
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal("key", dataModel.Key);
+        Assert.Null(dataModel.Data["StringDataProp"]);
+        Assert.Null(dataModel.Data["NullableIntDataProp"]);
+        Assert.Null(dataModel.Vectors["NullableFloatVector"]);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelThrowsForMissingKey()
+    {
+        // Arrange
+        var sut = new MongoDBGenericDataModelMapper(s_vectorStoreRecordDefinition);
+        var storageModel = new BsonDocument();
+
+        // Act & Assert
+        var exception = Assert.Throws<VectorStoreRecordMappingException>(
+            () => sut.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true }));
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelSkipsMissingProperties()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var dataModel = new VectorStoreGenericDataModel<string>("key");
+        var sut = new MongoDBGenericDataModelMapper(vectorStoreRecordDefinition);
+
+        // Act
+        var storageModel = sut.MapFromDataToStorageModel(dataModel);
+
+        // Assert
+        Assert.Equal("key", (string?)storageModel["_id"]);
+        Assert.False(storageModel.Contains("StringDataProp"));
+        Assert.False(storageModel.Contains("FloatVector"));
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelSkipsMissingProperties()
+    {
+        // Arrange
+        VectorStoreRecordDefinition vectorStoreRecordDefinition = new()
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Key", typeof(string)),
+                new VectorStoreRecordDataProperty("StringDataProp", typeof(string)),
+                new VectorStoreRecordVectorProperty("FloatVector", typeof(ReadOnlyMemory<float>)),
+            },
+        };
+
+        var storageModel = new BsonDocument
+        {
+            ["_id"] = "key"
+        };
+
+        var sut = new MongoDBGenericDataModelMapper(vectorStoreRecordDefinition);
+
+        // Act
+        var dataModel = sut.MapFromStorageToDataModel(storageModel, new StorageToDataModelMapperOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.Equal("key", dataModel.Key);
+        Assert.False(dataModel.Data.ContainsKey("StringDataProp"));
+        Assert.False(dataModel.Vectors.ContainsKey("FloatVector"));
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBHotelModel.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBHotelModel.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+public class MongoDBHotelModel(string hotelId)
+{
+    /// <summary>The key of the record.</summary>
+    [VectorStoreRecordKey]
+    public string HotelId { get; init; } = hotelId;
+
+    /// <summary>A string metadata field.</summary>
+    [VectorStoreRecordData(IsFilterable = true)]
+    public string? HotelName { get; set; }
+
+    /// <summary>An int metadata field.</summary>
+    [VectorStoreRecordData]
+    public int HotelCode { get; set; }
+
+    /// <summary>A float metadata field.</summary>
+    [VectorStoreRecordData]
+    public float? HotelRating { get; set; }
+
+    /// <summary>A bool metadata field.</summary>
+    [BsonElement("parking_is_included")]
+    [VectorStoreRecordData]
+    public bool ParkingIncluded { get; set; }
+
+    /// <summary>An array metadata field.</summary>
+    [VectorStoreRecordData]
+    public List<string> Tags { get; set; } = [];
+
+    /// <summary>A data field.</summary>
+    [VectorStoreRecordData]
+    public string? Description { get; set; }
+
+    /// <summary>A vector field.</summary>
+    [VectorStoreRecordVector(Dimensions: 4, DistanceFunction: DistanceFunction.CosineSimilarity)]
+    public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBServiceCollectionExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBServiceCollectionExtensionsTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using Microsoft.SemanticKernel.Http;
+using MongoDB.Driver;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MongoDBServiceCollectionExtensions"/> class.
+/// </summary>
+public sealed class MongoDBServiceCollectionExtensionsTests
+{
+    private readonly IServiceCollection _serviceCollection = new ServiceCollection();
+
+    [Fact]
+    public void AddVectorStoreRegistersClass()
+    {
+        // Arrange
+        this._serviceCollection.AddSingleton<IMongoDatabase>(Mock.Of<IMongoDatabase>());
+
+        // Act
+        this._serviceCollection.AddMongoDBVectorStore();
+
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
+
+        // Assert
+        Assert.NotNull(vectorStore);
+        Assert.IsType<MongoDBVectorStore>(vectorStore);
+    }
+
+    [Fact]
+    public void AddVectorStoreWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._serviceCollection.AddMongoDBVectorStore("mongodb://localhost:27017", "mydb");
+
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+        var vectorStore = serviceProvider.GetRequiredService<IVectorStore>();
+
+        // Assert
+        Assert.NotNull(vectorStore);
+        Assert.IsType<MongoDBVectorStore>(vectorStore);
+
+        var database = (IMongoDatabase)vectorStore.GetType().GetField("_mongoDatabase", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(vectorStore)!;
+        Assert.Equal(HttpHeaderConstant.Values.UserAgent, database.Client.Settings.ApplicationName);
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionRegistersClass()
+    {
+        // Arrange
+        this._serviceCollection.AddSingleton<IMongoDatabase>(Mock.Of<IMongoDatabase>());
+
+        // Act
+        this._serviceCollection.AddMongoDBVectorStoreRecordCollection<TestRecord>("testcollection");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    [Fact]
+    public void AddVectorStoreRecordCollectionWithConnectionStringRegistersClass()
+    {
+        // Act
+        this._serviceCollection.AddMongoDBVectorStoreRecordCollection<TestRecord>("testcollection", "mongodb://localhost:27017", "mydb");
+
+        // Assert
+        this.AssertVectorStoreRecordCollectionCreated();
+    }
+
+    private void AssertVectorStoreRecordCollectionCreated()
+    {
+        var serviceProvider = this._serviceCollection.BuildServiceProvider();
+
+        var collection = serviceProvider.GetRequiredService<IVectorStoreRecordCollection<string, TestRecord>>();
+        Assert.NotNull(collection);
+        Assert.IsType<MongoDBVectorStoreRecordCollection<TestRecord>>(collection);
+
+        var vectorizedSearch = serviceProvider.GetRequiredService<IVectorizedSearch<TestRecord>>();
+        Assert.NotNull(vectorizedSearch);
+        Assert.IsType<MongoDBVectorStoreRecordCollection<TestRecord>>(vectorizedSearch);
+    }
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+    private sealed class TestRecord
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [VectorStoreRecordKey]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreCollectionSearchMappingTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Bson;
+using Xunit;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MongoDBVectorStoreCollectionSearchMapping"/> class.
+/// </summary>
+public sealed class MongoDBVectorStoreCollectionSearchMappingTests
+{
+    private readonly Dictionary<string, string> _storagePropertyNames = new()
+    {
+        ["Property1"] = "property_1",
+        ["Property2"] = "property_2",
+    };
+
+    [Fact]
+    public void BuildFilterWithNullVectorSearchFilterReturnsNull()
+    {
+        // Arrange
+        VectorSearchFilter? vectorSearchFilter = null;
+
+        // Act
+        var filter = MongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames);
+
+        // Assert
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildFilterWithoutFilterClausesReturnsNull()
+    {
+        // Arrange
+        VectorSearchFilter vectorSearchFilter = new();
+
+        // Act
+        var filter = MongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames);
+
+        // Assert
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildFilterThrowsExceptionWithUnsupportedFilterClause()
+    {
+        // Arrange
+        var vectorSearchFilter = new VectorSearchFilter().AnyTagEqualTo("NonExistentProperty", "TestValue");
+
+        // Act & Assert
+        Assert.Throws<NotSupportedException>(() => MongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames));
+    }
+
+    [Fact]
+    public void BuildFilterThrowsExceptionWithNonExistentPropertyName()
+    {
+        // Arrange
+        var vectorSearchFilter = new VectorSearchFilter().EqualTo("NonExistentProperty", "TestValue");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => MongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames));
+    }
+
+    [Fact]
+    public void BuildFilterThrowsExceptionWithMultipleFilterClausesOfSameType()
+    {
+        // Arrange
+        var vectorSearchFilter = new VectorSearchFilter()
+            .EqualTo("Property1", "TestValue1")
+            .EqualTo("Property1", "TestValue2");
+
+        // Act & Assert
+        Assert.Throws<NotSupportedException>(() => MongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames));
+    }
+
+    [Fact]
+    public void BuilderFilterByDefaultReturnsValidFilter()
+    {
+        // Arrange
+        var expectedFilter = new BsonDocument() { ["property_1"] = new BsonDocument() { ["$eq"] = "TestValue1" } };
+        var vectorSearchFilter = new VectorSearchFilter().EqualTo("Property1", "TestValue1");
+
+        // Act
+        var filter = MongoDBVectorStoreCollectionSearchMapping.BuildFilter(vectorSearchFilter, this._storagePropertyNames);
+
+        Assert.Equal(filter.ToJson(), expectedFilter.ToJson());
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,843 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MongoDBVectorStoreRecordCollection{TRecord}"/> class.
+/// </summary>
+public sealed class MongoDBVectorStoreRecordCollectionTests
+{
+    private readonly Mock<IMongoDatabase> _mockMongoDatabase = new();
+    private readonly Mock<IMongoCollection<BsonDocument>> _mockMongoCollection = new();
+
+    public MongoDBVectorStoreRecordCollectionTests()
+    {
+        this._mockMongoDatabase
+            .Setup(l => l.GetCollection<BsonDocument>(It.IsAny<string>(), It.IsAny<MongoCollectionSettings>()))
+            .Returns(this._mockMongoCollection.Object);
+    }
+
+    [Fact]
+    public void ConstructorForModelWithoutKeyThrowsException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() => new MongoDBVectorStoreRecordCollection<object>(this._mockMongoDatabase.Object, "collection"));
+        Assert.Contains("No key property found", exception.Message);
+    }
+
+    [Fact]
+    public void ConstructorWithDeclarativeModelInitializesCollection()
+    {
+        // Act & Assert
+        var collection = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        Assert.NotNull(collection);
+    }
+
+    [Fact]
+    public void ConstructorWithImperativeModelInitializesCollection()
+    {
+        // Arrange
+        var definition = new VectorStoreRecordDefinition
+        {
+            Properties = [new VectorStoreRecordKeyProperty("Id", typeof(string))]
+        };
+
+        // Act
+        var collection = new MongoDBVectorStoreRecordCollection<TestModel>(
+            this._mockMongoDatabase.Object,
+            "collection",
+            new() { VectorStoreRecordDefinition = definition });
+
+        // Assert
+        Assert.NotNull(collection);
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionExistsData))]
+    public async Task CollectionExistsReturnsValidResultAsync(List<string> collections, string collectionName, bool expectedResult)
+    {
+        // Arrange
+        var mockCursor = new Mock<IAsyncCursor<string>>();
+
+        mockCursor
+            .Setup(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns(collections);
+
+        this._mockMongoDatabase
+            .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            collectionName);
+
+        // Act
+        var actualResult = await sut.CollectionExistsAsync();
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory]
+    [InlineData(true, 0)]
+    [InlineData(false, 1)]
+    public async Task CreateCollectionInvokesValidMethodsAsync(bool indexExists, int actualIndexCreations)
+    {
+        // Arrange
+        const string CollectionName = "collection";
+
+        List<BsonDocument> indexes = indexExists ? [new BsonDocument { ["name"] = "vector_index" }] : [];
+
+        var mockIndexCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        mockIndexCursor
+            .SetupSequence(l => l.MoveNext(It.IsAny<CancellationToken>()))
+            .Returns(true)
+            .Returns(false);
+
+        mockIndexCursor
+            .Setup(l => l.Current)
+            .Returns(indexes);
+
+        var mockMongoIndexManager = new Mock<IMongoIndexManager<BsonDocument>>();
+
+        mockMongoIndexManager
+            .Setup(l => l.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockIndexCursor.Object);
+
+        this._mockMongoCollection
+            .Setup(l => l.Indexes)
+            .Returns(mockMongoIndexManager.Object);
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(this._mockMongoDatabase.Object, CollectionName);
+
+        // Act
+        await sut.CreateCollectionAsync();
+
+        // Assert
+        this._mockMongoDatabase.Verify(l => l.CreateCollectionAsync(
+            CollectionName,
+            It.IsAny<CreateCollectionOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+
+        this._mockMongoDatabase.Verify(l => l.RunCommandAsync<BsonDocument>(
+            It.Is<BsonDocumentCommand<BsonDocument>>(command =>
+                command.Document["createSearchIndexes"] == CollectionName &&
+                command.Document["indexes"].GetType() == typeof(BsonArray) &&
+                ((BsonArray)command.Document["indexes"]).Count == 1),
+            It.IsAny<ReadPreference>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(actualIndexCreations));
+    }
+
+    [Theory]
+    [MemberData(nameof(CreateCollectionIfNotExistsData))]
+    public async Task CreateCollectionIfNotExistsInvokesValidMethodsAsync(List<string> collections, int actualCollectionCreations)
+    {
+        // Arrange
+        const string CollectionName = "collection";
+
+        var mockCursor = new Mock<IAsyncCursor<string>>();
+        mockCursor
+            .Setup(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns(collections);
+
+        this._mockMongoDatabase
+            .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+
+        var mockIndexCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        mockIndexCursor
+            .SetupSequence(l => l.MoveNext(It.IsAny<CancellationToken>()))
+            .Returns(true)
+            .Returns(false);
+
+        mockIndexCursor
+            .Setup(l => l.Current)
+            .Returns([]);
+
+        var mockMongoIndexManager = new Mock<IMongoIndexManager<BsonDocument>>();
+
+        mockMongoIndexManager
+            .Setup(l => l.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockIndexCursor.Object);
+
+        this._mockMongoCollection
+            .Setup(l => l.Indexes)
+            .Returns(mockMongoIndexManager.Object);
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            CollectionName);
+
+        // Act
+        await sut.CreateCollectionIfNotExistsAsync();
+
+        // Assert
+        this._mockMongoDatabase.Verify(l => l.CreateCollectionAsync(
+            CollectionName,
+            It.IsAny<CreateCollectionOptions>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(actualCollectionCreations));
+    }
+
+    [Fact]
+    public async Task DeleteInvokesValidMethodsAsync()
+    {
+        // Arrange
+        const string RecordKey = "key";
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        var serializerRegistry = BsonSerializer.SerializerRegistry;
+        var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+        var expectedDefinition = Builders<BsonDocument>.Filter.Eq(document => document["_id"], RecordKey);
+
+        // Act
+        await sut.DeleteAsync(RecordKey);
+
+        // Assert
+        this._mockMongoCollection.Verify(l => l.DeleteOneAsync(
+            It.Is<FilterDefinition<BsonDocument>>(definition =>
+                CompareFilterDefinitions(definition, expectedDefinition, documentSerializer, serializerRegistry)),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task DeleteBatchInvokesValidMethodsAsync()
+    {
+        // Arrange
+        List<string> recordKeys = ["key1", "key2"];
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        var serializerRegistry = BsonSerializer.SerializerRegistry;
+        var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+        var expectedDefinition = Builders<BsonDocument>.Filter.In(document => document["_id"].AsString, recordKeys);
+
+        // Act
+        await sut.DeleteBatchAsync(recordKeys);
+
+        // Assert
+        this._mockMongoCollection.Verify(l => l.DeleteManyAsync(
+            It.Is<FilterDefinition<BsonDocument>>(definition =>
+                CompareFilterDefinitions(definition, expectedDefinition, documentSerializer, serializerRegistry)),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task DeleteCollectionInvokesValidMethodsAsync()
+    {
+        // Arrange
+        const string CollectionName = "collection";
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            CollectionName);
+
+        // Act
+        await sut.DeleteCollectionAsync();
+
+        // Assert
+        this._mockMongoDatabase.Verify(l => l.DropCollectionAsync(
+            It.Is<string>(name => name == CollectionName),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task GetReturnsValidRecordAsync()
+    {
+        // Arrange
+        const string RecordKey = "key";
+
+        var document = new BsonDocument { ["_id"] = RecordKey, ["HotelName"] = "Test Name" };
+
+        var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        mockCursor
+            .Setup(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns([document]);
+
+        this._mockMongoCollection
+            .Setup(l => l.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act
+        var result = await sut.GetAsync(RecordKey);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(RecordKey, result.HotelId);
+        Assert.Equal("Test Name", result.HotelName);
+    }
+
+    [Fact]
+    public async Task GetBatchReturnsValidRecordAsync()
+    {
+        // Arrange
+        var document1 = new BsonDocument { ["_id"] = "key1", ["HotelName"] = "Test Name 1" };
+        var document2 = new BsonDocument { ["_id"] = "key2", ["HotelName"] = "Test Name 2" };
+        var document3 = new BsonDocument { ["_id"] = "key3", ["HotelName"] = "Test Name 3" };
+
+        var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        mockCursor
+            .SetupSequence(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns([document1, document2, document3]);
+
+        this._mockMongoCollection
+            .Setup(l => l.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act
+        var results = await sut.GetBatchAsync(["key1", "key2", "key3"]).ToListAsync();
+
+        // Assert
+        Assert.NotNull(results[0]);
+        Assert.Equal("key1", results[0].HotelId);
+        Assert.Equal("Test Name 1", results[0].HotelName);
+
+        Assert.NotNull(results[1]);
+        Assert.Equal("key2", results[1].HotelId);
+        Assert.Equal("Test Name 2", results[1].HotelName);
+
+        Assert.NotNull(results[2]);
+        Assert.Equal("key3", results[2].HotelId);
+        Assert.Equal("Test Name 3", results[2].HotelName);
+    }
+
+    [Fact]
+    public async Task UpsertReturnsRecordKeyAsync()
+    {
+        // Arrange
+        var hotel = new MongoDBHotelModel("key") { HotelName = "Test Name" };
+
+        var serializerRegistry = BsonSerializer.SerializerRegistry;
+        var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+        var expectedDefinition = Builders<BsonDocument>.Filter.Eq(document => document["_id"], "key");
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act
+        var result = await sut.UpsertAsync(hotel);
+
+        // Assert
+        Assert.Equal("key", result);
+
+        this._mockMongoCollection.Verify(l => l.ReplaceOneAsync(
+            It.Is<FilterDefinition<BsonDocument>>(definition =>
+                CompareFilterDefinitions(definition, expectedDefinition, documentSerializer, serializerRegistry)),
+            It.Is<BsonDocument>(document =>
+                document["_id"] == "key" &&
+                document["HotelName"] == "Test Name"),
+            It.IsAny<ReplaceOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task UpsertBatchReturnsRecordKeysAsync()
+    {
+        // Arrange
+        var hotel1 = new MongoDBHotelModel("key1") { HotelName = "Test Name 1" };
+        var hotel2 = new MongoDBHotelModel("key2") { HotelName = "Test Name 2" };
+        var hotel3 = new MongoDBHotelModel("key3") { HotelName = "Test Name 3" };
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act
+        var results = await sut.UpsertBatchAsync([hotel1, hotel2, hotel3]).ToListAsync();
+
+        // Assert
+        Assert.NotNull(results);
+        Assert.Equal(3, results.Count);
+
+        Assert.Equal("key1", results[0]);
+        Assert.Equal("key2", results[1]);
+        Assert.Equal("key3", results[2]);
+    }
+
+    [Fact]
+    public async Task UpsertWithModelWorksCorrectlyAsync()
+    {
+        var definition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string))
+            }
+        };
+
+        await this.TestUpsertWithModelAsync<TestModel>(
+            dataModel: new TestModel { Id = "key", HotelName = "Test Name" },
+            expectedPropertyName: "HotelName",
+            definition: definition);
+    }
+
+    [Fact]
+    public async Task UpsertWithVectorStoreModelWorksCorrectlyAsync()
+    {
+        await this.TestUpsertWithModelAsync<VectorStoreTestModel>(
+            dataModel: new VectorStoreTestModel { Id = "key", HotelName = "Test Name" },
+            expectedPropertyName: "HotelName");
+    }
+
+    [Fact]
+    public async Task UpsertWithBsonModelWorksCorrectlyAsync()
+    {
+        var definition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string))
+            }
+        };
+
+        await this.TestUpsertWithModelAsync<BsonTestModel>(
+            dataModel: new BsonTestModel { Id = "key", HotelName = "Test Name" },
+            expectedPropertyName: "hotel_name",
+            definition: definition);
+    }
+
+    [Fact]
+    public async Task UpsertWithBsonVectorStoreModelWorksCorrectlyAsync()
+    {
+        await this.TestUpsertWithModelAsync<BsonVectorStoreTestModel>(
+            dataModel: new BsonVectorStoreTestModel { Id = "key", HotelName = "Test Name" },
+            expectedPropertyName: "hotel_name");
+    }
+
+    [Fact]
+    public async Task UpsertWithBsonVectorStoreWithNameModelWorksCorrectlyAsync()
+    {
+        await this.TestUpsertWithModelAsync<BsonVectorStoreWithNameTestModel>(
+            dataModel: new BsonVectorStoreWithNameTestModel { Id = "key", HotelName = "Test Name" },
+            expectedPropertyName: "bson_hotel_name");
+    }
+
+    [Fact]
+    public async Task UpsertWithCustomMapperWorksCorrectlyAsync()
+    {
+        // Arrange
+        var hotel = new MongoDBHotelModel("key") { HotelName = "Test Name" };
+
+        var mockMapper = new Mock<IVectorStoreRecordMapper<MongoDBHotelModel, BsonDocument>>();
+
+        mockMapper
+            .Setup(l => l.MapFromDataToStorageModel(It.IsAny<MongoDBHotelModel>()))
+            .Returns(new BsonDocument { ["_id"] = "key", ["my_name"] = "Test Name" });
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection",
+            new() { BsonDocumentCustomMapper = mockMapper.Object });
+
+        // Act
+        var result = await sut.UpsertAsync(hotel);
+
+        // Assert
+        Assert.Equal("key", result);
+
+        this._mockMongoCollection.Verify(l => l.ReplaceOneAsync(
+            It.IsAny<FilterDefinition<BsonDocument>>(),
+            It.Is<BsonDocument>(document =>
+                document["_id"] == "key" &&
+                document["my_name"] == "Test Name"),
+            It.IsAny<ReplaceOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task GetWithCustomMapperWorksCorrectlyAsync()
+    {
+        // Arrange
+        const string RecordKey = "key";
+
+        var document = new BsonDocument { ["_id"] = RecordKey, ["my_name"] = "Test Name" };
+
+        var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        mockCursor
+            .Setup(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns([document]);
+
+        this._mockMongoCollection
+            .Setup(l => l.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+
+        var mockMapper = new Mock<IVectorStoreRecordMapper<MongoDBHotelModel, BsonDocument>>();
+
+        mockMapper
+            .Setup(l => l.MapFromStorageToDataModel(It.IsAny<BsonDocument>(), It.IsAny<StorageToDataModelMapperOptions>()))
+            .Returns(new MongoDBHotelModel(RecordKey) { HotelName = "Name from mapper" });
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection",
+            new() { BsonDocumentCustomMapper = mockMapper.Object });
+
+        // Act
+        var result = await sut.GetAsync(RecordKey);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(RecordKey, result.HotelId);
+        Assert.Equal("Name from mapper", result.HotelName);
+    }
+
+    [Theory]
+    [MemberData(nameof(VectorizedSearchVectorTypeData))]
+    public async Task VectorizedSearchThrowsExceptionWithInvalidVectorTypeAsync(object vector, bool exceptionExpected)
+    {
+        // Arrange
+        this.MockCollectionForSearch();
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act & Assert
+        if (exceptionExpected)
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await sut.VectorizedSearchAsync(vector));
+        }
+        else
+        {
+            var actual = await sut.VectorizedSearchAsync(vector);
+
+            Assert.NotNull(actual);
+        }
+    }
+
+    [Theory]
+    [InlineData(null, "TestEmbedding1", 1, 1)]
+    [InlineData("", "TestEmbedding1", 2, 2)]
+    [InlineData("TestEmbedding1", "TestEmbedding1", 3, 3)]
+    [InlineData("TestEmbedding2", "test_embedding_2", 4, 4)]
+    public async Task VectorizedSearchUsesValidQueryAsync(
+        string? vectorPropertyName,
+        string expectedVectorPropertyName,
+        int actualTop,
+        int expectedTop)
+    {
+        // Arrange
+        var vector = new ReadOnlyMemory<float>([1f, 2f, 3f]);
+
+        var expectedSearch = new BsonDocument
+        {
+            { "$vectorSearch",
+                new BsonDocument
+                {
+                    { "index", "vector_index" },
+                    { "queryVector", BsonArray.Create(vector.ToArray()) },
+                    { "path", expectedVectorPropertyName },
+                    { "limit", expectedTop },
+                    { "numCandidates", expectedTop * 10 },
+                }
+            }
+        };
+
+        var expectedProjection = new BsonDocument
+        {
+            { "$project",
+                new BsonDocument
+                {
+                    { "similarityScore", new BsonDocument { { "$meta", "vectorSearchScore" } } },
+                    { "document", "$$ROOT" }
+                }
+            }
+        };
+
+        this.MockCollectionForSearch();
+
+        var sut = new MongoDBVectorStoreRecordCollection<VectorSearchModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act
+        var actual = await sut.VectorizedSearchAsync(vector, new()
+        {
+            VectorPropertyName = vectorPropertyName,
+            Top = actualTop,
+        });
+
+        // Assert
+        Assert.NotNull(await actual.Results.FirstOrDefaultAsync());
+
+        this._mockMongoCollection.Verify(l => l.AggregateAsync(
+            It.Is<PipelineDefinition<BsonDocument, BsonDocument>>(pipeline =>
+                this.ComparePipeline(pipeline, expectedSearch, expectedProjection)),
+            It.IsAny<AggregateOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task VectorizedSearchThrowsExceptionWithNonExistentVectorPropertyNameAsync()
+    {
+        // Arrange
+        this.MockCollectionForSearch();
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        var options = new VectorSearchOptions { VectorPropertyName = "non-existent-property" };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await (await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]), options)).Results.FirstOrDefaultAsync());
+    }
+
+    [Fact]
+    public async Task VectorizedSearchReturnsRecordWithScoreAsync()
+    {
+        // Arrange
+        this.MockCollectionForSearch();
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection");
+
+        // Act
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([1f, 2f, 3f]));
+
+        // Assert
+        var result = await actual.Results.FirstOrDefaultAsync();
+        Assert.NotNull(result);
+        Assert.Equal("key", result.Record.HotelId);
+        Assert.Equal("Test Name", result.Record.HotelName);
+        Assert.Equal(0.99f, result.Score);
+    }
+
+    public static TheoryData<List<string>, string, bool> CollectionExistsData => new()
+    {
+        { ["collection-2"], "collection-2", true },
+        { [], "non-existent-collection", false }
+    };
+
+    public static TheoryData<List<string>, int> CreateCollectionIfNotExistsData => new()
+    {
+        { ["collection"], 0 },
+        { [], 1 }
+    };
+
+    public static TheoryData<object, bool> VectorizedSearchVectorTypeData => new()
+    {
+        { new ReadOnlyMemory<float>([1f, 2f, 3f]), false },
+        { new ReadOnlyMemory<double>([1f, 2f, 3f]), false },
+        { new ReadOnlyMemory<float>?(new([1f, 2f, 3f])), false },
+        { new ReadOnlyMemory<double>?(new([1f, 2f, 3f])), false },
+        { new List<float>([1f, 2f, 3f]), true },
+    };
+
+    #region private
+
+    private bool ComparePipeline(
+        PipelineDefinition<BsonDocument, BsonDocument> actualPipeline,
+        BsonDocument expectedSearch,
+        BsonDocument expectedProjection)
+    {
+        var serializerRegistry = BsonSerializer.SerializerRegistry;
+        var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+
+        var documents = actualPipeline.Render(new RenderArgs<BsonDocument>(documentSerializer, serializerRegistry)).Documents;
+
+        return
+            documents[0].ToJson() == expectedSearch.ToJson() &&
+            documents[1].ToJson() == expectedProjection.ToJson();
+    }
+
+    private void MockCollectionForSearch()
+    {
+        var document = new BsonDocument { ["_id"] = "key", ["HotelName"] = "Test Name" };
+        var searchResult = new BsonDocument { ["document"] = document, ["similarityScore"] = 0.99f };
+
+        var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();
+        mockCursor
+            .Setup(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns([searchResult]);
+
+        this._mockMongoCollection
+            .Setup(l => l.AggregateAsync(
+                It.IsAny<PipelineDefinition<BsonDocument, BsonDocument>>(),
+                It.IsAny<AggregateOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+    }
+
+    private async Task TestUpsertWithModelAsync<TDataModel>(
+        TDataModel dataModel,
+        string expectedPropertyName,
+        VectorStoreRecordDefinition? definition = null)
+        where TDataModel : class
+    {
+        // Arrange
+        var serializerRegistry = BsonSerializer.SerializerRegistry;
+        var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+        var expectedDefinition = Builders<BsonDocument>.Filter.Eq(document => document["_id"], "key");
+
+        MongoDBVectorStoreRecordCollectionOptions<TDataModel>? options = definition != null ?
+            new() { VectorStoreRecordDefinition = definition } :
+            null;
+
+        var sut = new MongoDBVectorStoreRecordCollection<TDataModel>(
+            this._mockMongoDatabase.Object,
+            "collection",
+            options);
+
+        // Act
+        var result = await sut.UpsertAsync(dataModel);
+
+        // Assert
+        Assert.Equal("key", result);
+
+        this._mockMongoCollection.Verify(l => l.ReplaceOneAsync(
+            It.Is<FilterDefinition<BsonDocument>>(definition =>
+                CompareFilterDefinitions(definition, expectedDefinition, documentSerializer, serializerRegistry)),
+            It.Is<BsonDocument>(document =>
+                document["_id"] == "key" &&
+                document.Contains(expectedPropertyName) &&
+                document[expectedPropertyName] == "Test Name"),
+            It.IsAny<ReplaceOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    private static bool CompareFilterDefinitions(
+        FilterDefinition<BsonDocument> actual,
+        FilterDefinition<BsonDocument> expected,
+        IBsonSerializer<BsonDocument> documentSerializer,
+        IBsonSerializerRegistry serializerRegistry)
+    {
+        return actual.Render(new RenderArgs<BsonDocument>(documentSerializer, serializerRegistry)) ==
+            expected.Render(new RenderArgs<BsonDocument>(documentSerializer, serializerRegistry));
+    }
+
+#pragma warning disable CA1812
+    private sealed class TestModel
+    {
+        public string? Id { get; set; }
+
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class VectorStoreTestModel
+    {
+        [VectorStoreRecordKey]
+        public string? Id { get; set; }
+
+        [VectorStoreRecordData(StoragePropertyName = "hotel_name")]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class BsonTestModel
+    {
+        [BsonId]
+        public string? Id { get; set; }
+
+        [BsonElement("hotel_name")]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class BsonVectorStoreTestModel
+    {
+        [BsonId]
+        [VectorStoreRecordKey]
+        public string? Id { get; set; }
+
+        [BsonElement("hotel_name")]
+        [VectorStoreRecordData]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class BsonVectorStoreWithNameTestModel
+    {
+        [BsonId]
+        [VectorStoreRecordKey]
+        public string? Id { get; set; }
+
+        [BsonElement("bson_hotel_name")]
+        [VectorStoreRecordData(StoragePropertyName = "storage_hotel_name")]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class VectorSearchModel
+    {
+        [BsonId]
+        [VectorStoreRecordKey]
+        public string? Id { get; set; }
+
+        [VectorStoreRecordData]
+        public string? HotelName { get; set; }
+
+        [VectorStoreRecordVector(Dimensions: 4, DistanceFunction: DistanceFunction.CosineDistance, IndexKind: IndexKind.IvfFlat, StoragePropertyName = "test_embedding_1")]
+        public ReadOnlyMemory<float> TestEmbedding1 { get; set; }
+
+        [BsonElement("test_embedding_2")]
+        [VectorStoreRecordVector(Dimensions: 4, DistanceFunction: DistanceFunction.CosineDistance, IndexKind: IndexKind.IvfFlat)]
+        public ReadOnlyMemory<float> TestEmbedding2 { get; set; }
+    }
+#pragma warning restore CA1812
+
+    #endregion
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordMapperTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordMapperTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Bson;
+using Xunit;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MongoDBVectorStoreRecordMapper{TRecord}"/> class.
+/// </summary>
+public sealed class MongoDBVectorStoreRecordMapperTests
+{
+    private readonly MongoDBVectorStoreRecordMapper<MongoDBHotelModel> _sut;
+
+    public MongoDBVectorStoreRecordMapperTests()
+    {
+        var keyProperty = new VectorStoreRecordKeyProperty("HotelId", typeof(string));
+
+        var definition = new VectorStoreRecordDefinition
+        {
+            Properties =
+            [
+                keyProperty,
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)),
+                new VectorStoreRecordDataProperty("Tags", typeof(List<string>)),
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?))
+            ]
+        };
+
+        this._sut = new(new VectorStoreRecordPropertyReader(typeof(MongoDBHotelModel), definition, null));
+    }
+
+    [Fact]
+    public void MapFromDataToStorageModelReturnsValidObject()
+    {
+        // Arrange
+        var hotel = new MongoDBHotelModel("key")
+        {
+            HotelName = "Test Name",
+            Tags = ["tag1", "tag2"],
+            ParkingIncluded = true,
+            DescriptionEmbedding = new ReadOnlyMemory<float>([1f, 2f, 3f])
+        };
+
+        // Act
+        var document = this._sut.MapFromDataToStorageModel(hotel);
+
+        // Assert
+        Assert.NotNull(document);
+
+        Assert.Equal("key", document["_id"]);
+        Assert.Equal("Test Name", document["HotelName"]);
+        Assert.Equal(["tag1", "tag2"], document["Tags"].AsBsonArray);
+        Assert.True(document["parking_is_included"].AsBoolean);
+        Assert.Equal([1f, 2f, 3f], document["DescriptionEmbedding"].AsBsonArray);
+    }
+
+    [Fact]
+    public void MapFromStorageToDataModelReturnsValidObject()
+    {
+        // Arrange
+        var document = new BsonDocument
+        {
+            ["_id"] = "key",
+            ["HotelName"] = "Test Name",
+            ["Tags"] = BsonArray.Create(new List<string> { "tag1", "tag2" }),
+            ["parking_is_included"] = BsonValue.Create(true),
+            ["DescriptionEmbedding"] = BsonArray.Create(new List<float> { 1f, 2f, 3f })
+        };
+
+        // Act
+        var hotel = this._sut.MapFromStorageToDataModel(document, new());
+
+        // Assert
+        Assert.NotNull(hotel);
+
+        Assert.Equal("key", hotel.HotelId);
+        Assert.Equal("Test Name", hotel.HotelName);
+        Assert.Equal(["tag1", "tag2"], hotel.Tags);
+        Assert.True(hotel.ParkingIncluded);
+        Assert.True(new ReadOnlyMemory<float>([1f, 2f, 3f]).Span.SequenceEqual(hotel.DescriptionEmbedding!.Value.Span));
+    }
+}

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Driver;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.Connectors.MongoDB.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MongoDBVectorStore"/> class.
+/// </summary>
+public sealed class MongoDBVectorStoreTests
+{
+    private readonly Mock<IMongoDatabase> _mockMongoDatabase = new();
+
+    [Fact]
+    public void GetCollectionWithNotSupportedKeyThrowsException()
+    {
+        // Arrange
+        var sut = new MongoDBVectorStore(this._mockMongoDatabase.Object);
+
+        // Act & Assert
+        Assert.Throws<NotSupportedException>(() => sut.GetCollection<Guid, MongoDBHotelModel>("collection"));
+    }
+
+    [Fact]
+    public void GetCollectionWithFactoryReturnsCustomCollection()
+    {
+        // Arrange
+        var mockFactory = new Mock<IMongoDBVectorStoreRecordCollectionFactory>();
+        var mockRecordCollection = new Mock<IVectorStoreRecordCollection<string, MongoDBHotelModel>>();
+
+        mockFactory
+            .Setup(l => l.CreateVectorStoreRecordCollection<string, MongoDBHotelModel>(
+                this._mockMongoDatabase.Object,
+                "collection",
+                It.IsAny<VectorStoreRecordDefinition>()))
+            .Returns(mockRecordCollection.Object);
+
+        var sut = new MongoDBVectorStore(
+            this._mockMongoDatabase.Object,
+            new MongoDBVectorStoreOptions { VectorStoreCollectionFactory = mockFactory.Object });
+
+        // Act
+        var collection = sut.GetCollection<string, MongoDBHotelModel>("collection");
+
+        // Assert
+        Assert.Same(mockRecordCollection.Object, collection);
+        mockFactory.Verify(l => l.CreateVectorStoreRecordCollection<string, MongoDBHotelModel>(
+            this._mockMongoDatabase.Object,
+            "collection",
+            It.IsAny<VectorStoreRecordDefinition>()), Times.Once());
+    }
+
+    [Fact]
+    public void GetCollectionWithoutFactoryReturnsDefaultCollection()
+    {
+        // Arrange
+        var sut = new MongoDBVectorStore(this._mockMongoDatabase.Object);
+
+        // Act
+        var collection = sut.GetCollection<string, MongoDBHotelModel>("collection");
+
+        // Assert
+        Assert.NotNull(collection);
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesReturnsCollectionNamesAsync()
+    {
+        // Arrange
+        var expectedCollectionNames = new List<string> { "collection-1", "collection-2", "collection-3" };
+
+        var mockCursor = new Mock<IAsyncCursor<string>>();
+        mockCursor
+            .SetupSequence(l => l.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        mockCursor
+            .Setup(l => l.Current)
+            .Returns(expectedCollectionNames);
+
+        this._mockMongoDatabase
+            .Setup(l => l.ListCollectionNamesAsync(It.IsAny<ListCollectionNamesOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+
+        var sut = new MongoDBVectorStore(this._mockMongoDatabase.Object);
+
+        // Act
+        var actualCollectionNames = await sut.ListCollectionNamesAsync().ToListAsync();
+
+        // Assert
+        Assert.Equal(expectedCollectionNames, actualCollectionNames);
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreCollectionFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreCollectionFixture.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
+
+[CollectionDefinition("MongoDBVectorStoreCollection")]
+public class MongoDBVectorStoreCollectionFixture : ICollectionFixture<MongoDBVectorStoreFixture>
+{ }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreFixture.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Docker.DotNet.Models;
+using Docker.DotNet;
+using Microsoft.Extensions.VectorData;
+using MongoDB.Driver;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
+
+public class MongoDBVectorStoreFixture : IAsyncLifetime
+{
+    private readonly List<string> _testCollections = ["sk-test-hotels", "sk-test-contacts", "sk-test-addresses"];
+
+    /// <summary>Main test collection for tests.</summary>
+    public string TestCollection => this._testCollections[0];
+
+    /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</summary>
+    public IMongoDatabase MongoDatabase { get; }
+
+    /// <summary>Gets the manually created vector store record definition for MongoDB test model.</summary>
+    public VectorStoreRecordDefinition HotelVectorStoreRecordDefinition { get; private set; }
+
+    /// <summary>The id of the MongoDB container that we are testing with.</summary>
+    private string? _containerId = null;
+
+    /// <summary>The Docker client we are using to create a MongoDB container with.</summary>
+    private readonly DockerClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDBVectorStoreFixture"/> class.
+    /// </summary>
+    public MongoDBVectorStoreFixture()
+    {
+        using var dockerClientConfiguration = new DockerClientConfiguration();
+        this._client = dockerClientConfiguration.CreateClient();
+
+        var mongoClient = new MongoClient("mongodb://localhost:27017/?directConnection=true");
+
+        this.MongoDatabase = mongoClient.GetDatabase("test");
+
+        this.HotelVectorStoreRecordDefinition = new()
+        {
+            Properties =
+            [
+                new VectorStoreRecordKeyProperty("HotelId", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelCode", typeof(int)),
+                new VectorStoreRecordDataProperty("ParkingIncluded", typeof(bool)) { StoragePropertyName = "parking_is_included" },
+                new VectorStoreRecordDataProperty("HotelRating", typeof(float)),
+                new VectorStoreRecordDataProperty("Tags", typeof(List<string>)),
+                new VectorStoreRecordDataProperty("Timestamp", typeof(DateTime)),
+                new VectorStoreRecordDataProperty("Description", typeof(string)),
+                new VectorStoreRecordVectorProperty("DescriptionEmbedding", typeof(ReadOnlyMemory<float>?)) { Dimensions = 4, IndexKind = IndexKind.IvfFlat, DistanceFunction = DistanceFunction.CosineDistance }
+            ]
+        };
+    }
+
+    public async Task InitializeAsync()
+    {
+        this._containerId = await SetupMongoDBContainerAsync(this._client);
+
+        foreach (var collection in this._testCollections)
+        {
+            await this.MongoDatabase.CreateCollectionAsync(collection);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        var cursor = await this.MongoDatabase.ListCollectionNamesAsync();
+
+        while (await cursor.MoveNextAsync().ConfigureAwait(false))
+        {
+            foreach (var collection in cursor.Current)
+            {
+                await this.MongoDatabase.DropCollectionAsync(collection);
+            }
+        }
+
+        if (this._containerId != null)
+        {
+            await this._client.Containers.StopContainerAsync(this._containerId, new ContainerStopParameters());
+            await this._client.Containers.RemoveContainerAsync(this._containerId, new ContainerRemoveParameters());
+        }
+    }
+
+#pragma warning disable CS8618
+    public record MongoDBHotel()
+    {
+        /// <summary>The key of the record.</summary>
+        [VectorStoreRecordKey]
+        public string HotelId { get; init; }
+
+        /// <summary>A string metadata field.</summary>
+        [VectorStoreRecordData(IsFilterable = true)]
+        public string? HotelName { get; set; }
+
+        /// <summary>An int metadata field.</summary>
+        [VectorStoreRecordData]
+        public int HotelCode { get; set; }
+
+        /// <summary>A float metadata field.</summary>
+        [VectorStoreRecordData]
+        public float? HotelRating { get; set; }
+
+        /// <summary>A bool metadata field.</summary>
+        [VectorStoreRecordData(StoragePropertyName = "parking_is_included")]
+        public bool ParkingIncluded { get; set; }
+
+        /// <summary>An array metadata field.</summary>
+        [VectorStoreRecordData]
+        public List<string> Tags { get; set; } = [];
+
+        /// <summary>A data field.</summary>
+        [VectorStoreRecordData]
+        public string Description { get; set; }
+
+        /// <summary>A datetime metadata field.</summary>
+        [VectorStoreRecordData]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>A vector field.</summary>
+        [VectorStoreRecordVector(Dimensions: 4, DistanceFunction: DistanceFunction.CosineSimilarity, IndexKind: IndexKind.IvfFlat)]
+        public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
+    }
+#pragma warning restore CS8618
+
+    #region private
+
+    private static async Task<string> SetupMongoDBContainerAsync(DockerClient client)
+    {
+        const string Image = "mongodb/mongodb-atlas-local";
+        const string Tag = "latest";
+
+        await client.Images.CreateImageAsync(
+            new ImagesCreateParameters
+            {
+                FromImage = Image,
+                Tag = Tag,
+            },
+            null,
+            new Progress<JSONMessage>());
+
+        var container = await client.Containers.CreateContainerAsync(new CreateContainerParameters()
+        {
+            Image = $"{Image}:{Tag}",
+            HostConfig = new HostConfig()
+            {
+                PortBindings = new Dictionary<string, IList<PortBinding>>
+                {
+                    { "27017", new List<PortBinding> { new() { HostPort = "27017" } } },
+                },
+                PublishAllPorts = true
+            },
+            ExposedPorts = new Dictionary<string, EmptyStruct>
+            {
+                { "27017", default },
+            },
+        });
+
+        await client.Containers.StartContainerAsync(
+            container.ID,
+            new ContainerStartParameters());
+
+        return container.ID;
+    }
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,534 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using Xunit;
+using static SemanticKernel.IntegrationTests.Connectors.MongoDB.MongoDBVectorStoreFixture;
+
+namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
+
+[Collection("MongoDBVectorStoreCollection")]
+public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture fixture)
+{
+    [Theory]
+    [InlineData("sk-test-hotels", true)]
+    [InlineData("nonexistentcollection", false)]
+    public async Task CollectionExistsReturnsCollectionStateAsync(string collectionName, bool expectedExists)
+    {
+        // Arrange
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, collectionName);
+
+        // Act
+        var actual = await sut.CollectionExistsAsync();
+
+        // Assert
+        Assert.Equal(expectedExists, actual);
+    }
+
+    [Fact]
+    public async Task ItCanCreateCollectionAsync()
+    {
+        // Arrange
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        // Act
+        await sut.CreateCollectionAsync();
+
+        // Assert
+        Assert.True(await sut.CollectionExistsAsync());
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task ItCanCreateCollectionUpsertAndGetAsync(bool includeVectors, bool useRecordDefinition)
+    {
+        // Arrange
+        const string HotelId = "55555555-5555-5555-5555-555555555555";
+
+        var collectionNamePostfix = useRecordDefinition ? "with-definition" : "with-type";
+        var collectionName = $"collection-{collectionNamePostfix}";
+
+        var options = new MongoDBVectorStoreRecordCollectionOptions<MongoDBHotel>
+        {
+            VectorStoreRecordDefinition = useRecordDefinition ? fixture.HotelVectorStoreRecordDefinition : null
+        };
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, collectionName);
+
+        var record = this.CreateTestHotel(HotelId);
+
+        // Act
+        await sut.CreateCollectionAsync();
+        var upsertResult = await sut.UpsertAsync(record);
+        var getResult = await sut.GetAsync(HotelId, new() { IncludeVectors = includeVectors });
+
+        // Assert
+        Assert.True(await sut.CollectionExistsAsync());
+        await sut.DeleteCollectionAsync();
+
+        Assert.Equal(HotelId, upsertResult);
+        Assert.NotNull(getResult);
+
+        Assert.Equal(record.HotelId, getResult.HotelId);
+        Assert.Equal(record.HotelName, getResult.HotelName);
+        Assert.Equal(record.HotelCode, getResult.HotelCode);
+        Assert.Equal(record.HotelRating, getResult.HotelRating);
+        Assert.Equal(record.ParkingIncluded, getResult.ParkingIncluded);
+        Assert.Equal(record.Tags.ToArray(), getResult.Tags.ToArray());
+        Assert.Equal(record.Description, getResult.Description);
+        Assert.Equal(record.Timestamp.ToUniversalTime(), getResult.Timestamp.ToUniversalTime());
+
+        if (includeVectors)
+        {
+            Assert.NotNull(getResult.DescriptionEmbedding);
+            Assert.Equal(record.DescriptionEmbedding!.Value.ToArray(), getResult.DescriptionEmbedding.Value.ToArray());
+        }
+        else
+        {
+            Assert.Null(getResult.DescriptionEmbedding);
+        }
+    }
+
+    [Fact]
+    public async Task ItCanDeleteCollectionAsync()
+    {
+        // Arrange
+        const string TempCollectionName = "temp-test";
+        await fixture.MongoDatabase.CreateCollectionAsync(TempCollectionName);
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, TempCollectionName);
+
+        Assert.True(await sut.CollectionExistsAsync());
+
+        // Act
+        await sut.DeleteCollectionAsync();
+
+        // Assert
+        Assert.False(await sut.CollectionExistsAsync());
+    }
+
+    [Fact]
+    public async Task ItCanGetAndDeleteRecordAsync()
+    {
+        // Arrange
+        const string HotelId = "55555555-5555-5555-5555-555555555555";
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        var record = this.CreateTestHotel(HotelId);
+
+        var upsertResult = await sut.UpsertAsync(record);
+        var getResult = await sut.GetAsync(HotelId);
+
+        Assert.Equal(HotelId, upsertResult);
+        Assert.NotNull(getResult);
+
+        // Act
+        await sut.DeleteAsync(HotelId);
+
+        getResult = await sut.GetAsync(HotelId);
+
+        // Assert
+        Assert.Null(getResult);
+    }
+
+    [Fact]
+    public async Task ItCanGetAndDeleteBatchAsync()
+    {
+        // Arrange
+        const string HotelId1 = "11111111-1111-1111-1111-111111111111";
+        const string HotelId2 = "22222222-2222-2222-2222-222222222222";
+        const string HotelId3 = "33333333-3333-3333-3333-333333333333";
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        var record1 = this.CreateTestHotel(HotelId1);
+        var record2 = this.CreateTestHotel(HotelId2);
+        var record3 = this.CreateTestHotel(HotelId3);
+
+        var upsertResults = await sut.UpsertBatchAsync([record1, record2, record3]).ToListAsync();
+        var getResults = await sut.GetBatchAsync([HotelId1, HotelId2, HotelId3]).ToListAsync();
+
+        Assert.Equal([HotelId1, HotelId2, HotelId3], upsertResults);
+
+        Assert.NotNull(getResults.First(l => l.HotelId == HotelId1));
+        Assert.NotNull(getResults.First(l => l.HotelId == HotelId2));
+        Assert.NotNull(getResults.First(l => l.HotelId == HotelId3));
+
+        // Act
+        await sut.DeleteBatchAsync([HotelId1, HotelId2, HotelId3]);
+
+        getResults = await sut.GetBatchAsync([HotelId1, HotelId2, HotelId3]).ToListAsync();
+
+        // Assert
+        Assert.Empty(getResults);
+    }
+
+    [Fact]
+    public async Task ItCanUpsertRecordAsync()
+    {
+        // Arrange
+        const string HotelId = "55555555-5555-5555-5555-555555555555";
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        var record = this.CreateTestHotel(HotelId);
+
+        var upsertResult = await sut.UpsertAsync(record);
+        var getResult = await sut.GetAsync(HotelId);
+
+        Assert.Equal(HotelId, upsertResult);
+        Assert.NotNull(getResult);
+
+        // Act
+        record.HotelName = "Updated name";
+        record.HotelRating = 10;
+
+        upsertResult = await sut.UpsertAsync(record);
+        getResult = await sut.GetAsync(HotelId);
+
+        // Assert
+        Assert.NotNull(getResult);
+        Assert.Equal("Updated name", getResult.HotelName);
+        Assert.Equal(10, getResult.HotelRating);
+    }
+
+    [Fact]
+    public async Task UpsertWithModelWorksCorrectlyAsync()
+    {
+        // Arrange
+        var definition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string))
+            }
+        };
+
+        var model = new TestModel { Id = "key", HotelName = "Test Name" };
+
+        var sut = new MongoDBVectorStoreRecordCollection<TestModel>(
+            fixture.MongoDatabase,
+            fixture.TestCollection,
+            new() { VectorStoreRecordDefinition = definition });
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(model);
+        var getResult = await sut.GetAsync(model.Id);
+
+        // Assert
+        Assert.Equal("key", upsertResult);
+
+        Assert.NotNull(getResult);
+        Assert.Equal("key", getResult.Id);
+        Assert.Equal("Test Name", getResult.HotelName);
+    }
+
+    [Fact]
+    public async Task UpsertWithVectorStoreModelWorksCorrectlyAsync()
+    {
+        // Arrange
+        var model = new VectorStoreTestModel { HotelId = "key", HotelName = "Test Name" };
+
+        var sut = new MongoDBVectorStoreRecordCollection<VectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(model);
+        var getResult = await sut.GetAsync(model.HotelId);
+
+        // Assert
+        Assert.Equal("key", upsertResult);
+
+        Assert.NotNull(getResult);
+        Assert.Equal("key", getResult.HotelId);
+        Assert.Equal("Test Name", getResult.HotelName);
+    }
+
+    [Fact]
+    public async Task UpsertWithBsonModelWorksCorrectlyAsync()
+    {
+        // Arrange
+        var definition = new VectorStoreRecordDefinition
+        {
+            Properties = new List<VectorStoreRecordProperty>
+            {
+                new VectorStoreRecordKeyProperty("Id", typeof(string)),
+                new VectorStoreRecordDataProperty("HotelName", typeof(string))
+            }
+        };
+
+        var model = new BsonTestModel { Id = "key", HotelName = "Test Name" };
+
+        var sut = new MongoDBVectorStoreRecordCollection<BsonTestModel>(
+            fixture.MongoDatabase,
+            fixture.TestCollection,
+            new() { VectorStoreRecordDefinition = definition });
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(model);
+        var getResult = await sut.GetAsync(model.Id);
+
+        // Assert
+        Assert.Equal("key", upsertResult);
+
+        Assert.NotNull(getResult);
+        Assert.Equal("key", getResult.Id);
+        Assert.Equal("Test Name", getResult.HotelName);
+    }
+
+    [Fact]
+    public async Task UpsertWithBsonVectorStoreModelWorksCorrectlyAsync()
+    {
+        // Arrange
+        var model = new BsonVectorStoreTestModel { HotelId = "key", HotelName = "Test Name" };
+
+        var sut = new MongoDBVectorStoreRecordCollection<BsonVectorStoreTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(model);
+        var getResult = await sut.GetAsync(model.HotelId);
+
+        // Assert
+        Assert.Equal("key", upsertResult);
+
+        Assert.NotNull(getResult);
+        Assert.Equal("key", getResult.HotelId);
+        Assert.Equal("Test Name", getResult.HotelName);
+    }
+
+    [Fact]
+    public async Task UpsertWithBsonVectorStoreWithNameModelWorksCorrectlyAsync()
+    {
+        // Arrange
+        var model = new BsonVectorStoreWithNameTestModel { Id = "key", HotelName = "Test Name" };
+
+        var sut = new MongoDBVectorStoreRecordCollection<BsonVectorStoreWithNameTestModel>(fixture.MongoDatabase, fixture.TestCollection);
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(model);
+        var getResult = await sut.GetAsync(model.Id);
+
+        // Assert
+        Assert.Equal("key", upsertResult);
+
+        Assert.NotNull(getResult);
+        Assert.Equal("key", getResult.Id);
+        Assert.Equal("Test Name", getResult.HotelName);
+    }
+
+    [Fact]
+    public async Task VectorizedSearchReturnsValidResultsByDefaultAsync()
+    {
+        // Arrange
+        var hotel1 = this.CreateTestHotel(hotelId: "key1", embedding: new[] { 30f, 31f, 32f, 33f });
+        var hotel2 = this.CreateTestHotel(hotelId: "key2", embedding: new[] { 31f, 32f, 33f, 34f });
+        var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
+        var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearch");
+
+        await sut.CreateCollectionIfNotExistsAsync();
+
+        await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
+
+        // Act
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]));
+
+        // Assert
+        var searchResults = await actual.Results.ToListAsync();
+        var ids = searchResults.Select(l => l.Record.HotelId).ToList();
+
+        Assert.Equal("key1", ids[0]);
+        Assert.Equal("key2", ids[1]);
+        Assert.Equal("key3", ids[2]);
+
+        Assert.DoesNotContain("key4", ids);
+
+        Assert.Equal(1, searchResults.First(l => l.Record.HotelId == "key1").Score);
+    }
+
+    [Fact]
+    public async Task VectorizedSearchReturnsValidResultsWithOffsetAsync()
+    {
+        // Arrange
+        var hotel1 = this.CreateTestHotel(hotelId: "key1", embedding: new[] { 30f, 31f, 32f, 33f });
+        var hotel2 = this.CreateTestHotel(hotelId: "key2", embedding: new[] { 31f, 32f, 33f, 34f });
+        var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
+        var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+
+        await sut.CreateCollectionIfNotExistsAsync();
+
+        await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
+
+        // Act
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        {
+            Top = 2,
+            Skip = 2
+        });
+
+        // Assert
+        var searchResults = await actual.Results.ToListAsync();
+        var ids = searchResults.Select(l => l.Record.HotelId).ToList();
+
+        Assert.Equal("key3", ids[0]);
+        Assert.Equal("key4", ids[1]);
+
+        Assert.DoesNotContain("key1", ids);
+        Assert.DoesNotContain("key2", ids);
+    }
+
+    [Fact]
+    public async Task VectorizedSearchReturnsValidResultsWithFilterAsync()
+    {
+        // Arrange
+        var hotel1 = this.CreateTestHotel(hotelId: "key1", embedding: new[] { 30f, 31f, 32f, 33f });
+        var hotel2 = this.CreateTestHotel(hotelId: "key2", embedding: new[] { 31f, 32f, 33f, 34f });
+        var hotel3 = this.CreateTestHotel(hotelId: "key3", embedding: new[] { 20f, 20f, 20f, 20f });
+        var hotel4 = this.CreateTestHotel(hotelId: "key4", embedding: new[] { -1000f, -1000f, -1000f, -1000f });
+
+        var sut = new MongoDBVectorStoreRecordCollection<MongoDBHotel>(fixture.MongoDatabase, "TestVectorizedSearchWithOffset");
+
+        await sut.CreateCollectionIfNotExistsAsync();
+
+        await sut.UpsertBatchAsync([hotel4, hotel2, hotel3, hotel1]).ToListAsync();
+
+        // Act
+        var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
+        {
+            Filter = new VectorSearchFilter().EqualTo(nameof(MongoDBHotel.HotelName), "My Hotel key2")
+        });
+
+        // Assert
+        var searchResults = await actual.Results.ToListAsync();
+        var ids = searchResults.Select(l => l.Record.HotelId).ToList();
+
+        Assert.Equal("key2", ids[0]);
+
+        Assert.DoesNotContain("key1", ids);
+        Assert.DoesNotContain("key3", ids);
+        Assert.DoesNotContain("key4", ids);
+    }
+
+    [Fact]
+    public async Task ItCanUpsertAndRetrieveUsingTheGenericMapperAsync()
+    {
+        // Arrange
+        var options = new MongoDBVectorStoreRecordCollectionOptions<VectorStoreGenericDataModel<string>>
+        {
+            VectorStoreRecordDefinition = fixture.HotelVectorStoreRecordDefinition
+        };
+
+        var sut = new MongoDBVectorStoreRecordCollection<VectorStoreGenericDataModel<string>>(fixture.MongoDatabase, fixture.TestCollection, options);
+
+        // Act
+        var upsertResult = await sut.UpsertAsync(new VectorStoreGenericDataModel<string>("GenericMapper-1")
+        {
+            Data =
+            {
+                { "HotelName", "Generic Mapper Hotel" },
+                { "Description", "This is a generic mapper hotel" },
+                { "Tags", new string[] { "generic" } },
+                { "ParkingIncluded", false },
+                { "Timestamp", new DateTime(1970, 1, 18, 0, 0, 0).ToUniversalTime() },
+                { "HotelRating", 3.6f }
+            },
+            Vectors =
+            {
+                { "DescriptionEmbedding", new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]) }
+            }
+        });
+
+        var localGetResult = await sut.GetAsync("GenericMapper-1", new GetRecordOptions { IncludeVectors = true });
+
+        // Assert
+        Assert.NotNull(upsertResult);
+        Assert.Equal("GenericMapper-1", upsertResult);
+
+        Assert.NotNull(localGetResult);
+        Assert.Equal("Generic Mapper Hotel", localGetResult.Data["HotelName"]);
+        Assert.Equal("This is a generic mapper hotel", localGetResult.Data["Description"]);
+        Assert.Equal(new[] { "generic" }, localGetResult.Data["Tags"]);
+        Assert.False((bool?)localGetResult.Data["ParkingIncluded"]);
+        Assert.Equal(new DateTime(1970, 1, 18, 0, 0, 0).ToUniversalTime(), localGetResult.Data["Timestamp"]);
+        Assert.Equal(3.6f, localGetResult.Data["HotelRating"]);
+        Assert.Equal(new[] { 30f, 31f, 32f, 33f }, ((ReadOnlyMemory<float>)localGetResult.Vectors["DescriptionEmbedding"]!).ToArray());
+    }
+
+    #region private
+
+    private MongoDBHotel CreateTestHotel(string hotelId, ReadOnlyMemory<float>? embedding = null)
+    {
+        return new MongoDBHotel
+        {
+            HotelId = hotelId,
+            HotelName = $"My Hotel {hotelId}",
+            HotelCode = 42,
+            HotelRating = 4.5f,
+            ParkingIncluded = true,
+            Tags = { "t1", "t2" },
+            Description = "This is a great hotel.",
+            Timestamp = new DateTime(2024, 09, 23, 15, 32, 33),
+            DescriptionEmbedding = embedding ?? new[] { 30f, 31f, 32f, 33f },
+        };
+    }
+
+    private sealed class TestModel
+    {
+        public string? Id { get; set; }
+
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class VectorStoreTestModel
+    {
+        [VectorStoreRecordKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreRecordData(StoragePropertyName = "hotel_name")]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class BsonTestModel
+    {
+        [BsonId]
+        public string? Id { get; set; }
+
+        [BsonElement("hotel_name")]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class BsonVectorStoreTestModel
+    {
+        [BsonId]
+        [VectorStoreRecordKey]
+        public string? HotelId { get; set; }
+
+        [BsonElement("hotel_name")]
+        [VectorStoreRecordData]
+        public string? HotelName { get; set; }
+    }
+
+    private sealed class BsonVectorStoreWithNameTestModel
+    {
+        [BsonId]
+        [VectorStoreRecordKey]
+        public string? Id { get; set; }
+
+        [BsonElement("bson_hotel_name")]
+        [VectorStoreRecordData(StoragePropertyName = "storage_hotel_name")]
+        public string? HotelName { get; set; }
+    }
+
+    #endregion
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.MongoDB;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
+
+[Collection("MongoDBVectorStoreCollection")]
+public class MongoDBVectorStoreTests(MongoDBVectorStoreFixture fixture)
+{
+    [Fact]
+    public async Task ItCanGetAListOfExistingCollectionNamesAsync()
+    {
+        // Arrange
+        var sut = new MongoDBVectorStore(fixture.MongoDatabase);
+
+        // Act
+        var collectionNames = await sut.ListCollectionNamesAsync().ToListAsync();
+
+        // Assert
+        Assert.Contains("sk-test-hotels", collectionNames);
+        Assert.Contains("sk-test-contacts", collectionNames);
+        Assert.Contains("sk-test-addresses", collectionNames);
+    }
+}


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Related: https://github.com/microsoft/semantic-kernel/issues/6524

In this PR:
- Implemented `IVectorStore`
- Implemented `IVectorizedSearch`
- Implemented `IVectorStoreRecordCollection<TKey, TRecord>`
- MongoDB default record mapper
- MongoDB generic data model mapper
- `Options` classes
- Extension methods for DI
- Integration tests  
- Unit tests

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
