### PR TITLE
.Net: Improved vector search query in Azure CosmosDB NoSQL connector

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests.cs
@@ -27,13 +27,6 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
     public void BuildSearchQueryByDefaultReturnsValidQueryDefinition()
     {
         // Arrange
-        const string ExpectedQueryText =
-            "SELECT x.test_property_1,x.test_property_2,x.test_property_3,VectorDistance(x.test_property_1, @vector) AS TestScore\r\n" +
-            "FROM x\r\n" +
-            "WHERE x.test_property_2 = @cv0 AND ARRAY_CONTAINS(x.test_property_3, @cv1)\r\n" +
-            "ORDER BY VectorDistance(x.test_property_1, @vector)\r\n" +
-            "OFFSET @offset LIMIT @limit\r\n";
-
         var vector = new ReadOnlyMemory<float>([1f, 2f, 3f]);
         var vectorPropertyName = "test_property_1";
         var fields = this._storagePropertyNames.Values.ToList();
@@ -57,7 +50,11 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
         var queryParameters = queryDefinition.GetQueryParameters();
 
         // Assert
-        Assert.Equal(ExpectedQueryText, queryText);
+        Assert.Contains("SELECT x.test_property_1,x.test_property_2,x.test_property_3,VectorDistance(x.test_property_1, @vector) AS TestScore", queryText);
+        Assert.Contains("FROM x", queryText);
+        Assert.Contains("WHERE x.test_property_2 = @cv0 AND ARRAY_CONTAINS(x.test_property_3, @cv1)", queryText);
+        Assert.Contains("ORDER BY VectorDistance(x.test_property_1, @vector)", queryText);
+        Assert.Contains("OFFSET @offset LIMIT @limit", queryText);
 
         Assert.Equal("@vector", queryParameters[0].Name);
         Assert.Equal(vector, queryParameters[0].Value);
@@ -79,12 +76,6 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
     public void BuildSearchQueryWithoutOffsetReturnsQueryDefinitionWithTopParameter()
     {
         // Arrange
-        const string ExpectedQueryText =
-            "SELECT TOP @top x.test_property_1,x.test_property_2,x.test_property_3,VectorDistance(x.test_property_1, @vector) AS TestScore\r\n" +
-            "FROM x\r\n" +
-            "WHERE x.test_property_2 = @cv0 AND ARRAY_CONTAINS(x.test_property_3, @cv1)\r\n" +
-            "ORDER BY VectorDistance(x.test_property_1, @vector)\r\n";
-
         var vector = new ReadOnlyMemory<float>([1f, 2f, 3f]);
         var vectorPropertyName = "test_property_1";
         var fields = this._storagePropertyNames.Values.ToList();
@@ -108,7 +99,12 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
         var queryParameters = queryDefinition.GetQueryParameters();
 
         // Assert
-        Assert.Equal(ExpectedQueryText, queryText);
+        Assert.Contains("SELECT TOP @top x.test_property_1,x.test_property_2,x.test_property_3,VectorDistance(x.test_property_1, @vector) AS TestScore", queryText);
+        Assert.Contains("FROM x", queryText);
+        Assert.Contains("WHERE x.test_property_2 = @cv0 AND ARRAY_CONTAINS(x.test_property_3, @cv1)", queryText);
+        Assert.Contains("ORDER BY VectorDistance(x.test_property_1, @vector)", queryText);
+
+        Assert.DoesNotContain("OFFSET @offset LIMIT @limit", queryText);
 
         Assert.Equal("@vector", queryParameters[0].Name);
         Assert.Equal(vector, queryParameters[0].Value);

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -649,40 +649,43 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
         Assert.Equal(expected.IndexingPolicy.IndexingMode, actual.IndexingPolicy.IndexingMode);
         Assert.Equal(expected.IndexingPolicy.Automatic, actual.IndexingPolicy.Automatic);
 
-        for (var i = 0; i < expected.VectorEmbeddingPolicy.Embeddings.Count; i++)
+        if (expected.IndexingPolicy.IndexingMode != IndexingMode.None)
         {
-            var expectedEmbedding = expected.VectorEmbeddingPolicy.Embeddings[i];
-            var actualEmbedding = actual.VectorEmbeddingPolicy.Embeddings[i];
+            for (var i = 0; i < expected.VectorEmbeddingPolicy.Embeddings.Count; i++)
+            {
+                var expectedEmbedding = expected.VectorEmbeddingPolicy.Embeddings[i];
+                var actualEmbedding = actual.VectorEmbeddingPolicy.Embeddings[i];
 
-            Assert.Equal(expectedEmbedding.DataType, actualEmbedding.DataType);
-            Assert.Equal(expectedEmbedding.Dimensions, actualEmbedding.Dimensions);
-            Assert.Equal(expectedEmbedding.DistanceFunction, actualEmbedding.DistanceFunction);
-            Assert.Equal(expectedEmbedding.Path, actualEmbedding.Path);
-        }
+                Assert.Equal(expectedEmbedding.DataType, actualEmbedding.DataType);
+                Assert.Equal(expectedEmbedding.Dimensions, actualEmbedding.Dimensions);
+                Assert.Equal(expectedEmbedding.DistanceFunction, actualEmbedding.DistanceFunction);
+                Assert.Equal(expectedEmbedding.Path, actualEmbedding.Path);
+            }
 
-        for (var i = 0; i < expected.IndexingPolicy.VectorIndexes.Count; i++)
-        {
-            var expectedIndexPath = expected.IndexingPolicy.VectorIndexes[i];
-            var actualIndexPath = actual.IndexingPolicy.VectorIndexes[i];
+            for (var i = 0; i < expected.IndexingPolicy.VectorIndexes.Count; i++)
+            {
+                var expectedIndexPath = expected.IndexingPolicy.VectorIndexes[i];
+                var actualIndexPath = actual.IndexingPolicy.VectorIndexes[i];
 
-            Assert.Equal(expectedIndexPath.Type, actualIndexPath.Type);
-            Assert.Equal(expectedIndexPath.Path, actualIndexPath.Path);
-        }
+                Assert.Equal(expectedIndexPath.Type, actualIndexPath.Type);
+                Assert.Equal(expectedIndexPath.Path, actualIndexPath.Path);
+            }
 
-        for (var i = 0; i < expected.IndexingPolicy.IncludedPaths.Count; i++)
-        {
-            var expectedIncludedPath = expected.IndexingPolicy.IncludedPaths[i].Path;
-            var actualIncludedPath = actual.IndexingPolicy.IncludedPaths[i].Path;
+            for (var i = 0; i < expected.IndexingPolicy.IncludedPaths.Count; i++)
+            {
+                var expectedIncludedPath = expected.IndexingPolicy.IncludedPaths[i].Path;
+                var actualIncludedPath = actual.IndexingPolicy.IncludedPaths[i].Path;
 
-            Assert.Equal(expectedIncludedPath, actualIncludedPath);
-        }
+                Assert.Equal(expectedIncludedPath, actualIncludedPath);
+            }
 
-        for (var i = 0; i < expected.IndexingPolicy.ExcludedPaths.Count; i++)
-        {
-            var expectedExcludedPath = expected.IndexingPolicy.ExcludedPaths[i].Path;
-            var actualExcludedPath = actual.IndexingPolicy.ExcludedPaths[i].Path;
+            for (var i = 0; i < expected.IndexingPolicy.ExcludedPaths.Count; i++)
+            {
+                var expectedExcludedPath = expected.IndexingPolicy.ExcludedPaths[i].Path;
+                var actualExcludedPath = actual.IndexingPolicy.ExcludedPaths[i].Path;
 
-            Assert.Equal(expectedExcludedPath, actualExcludedPath);
+                Assert.Equal(expectedExcludedPath, actualExcludedPath);
+            }
         }
 
         return true;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.VectorData;
 
@@ -28,9 +29,12 @@ internal static class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder
         string scorePropertyName,
         VectorSearchOptions searchOptions)
     {
+        Verify.NotNull(vector);
+
         const string VectorVariableName = "@vector";
         const string OffsetVariableName = "@offset";
         const string LimitVariableName = "@limit";
+        const string TopVariableName = "@top";
 
         var tableVariableName = AzureCosmosDBNoSQLConstants.TableQueryVariableName;
 
@@ -44,30 +48,52 @@ internal static class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder
 
         var filterQueryParameters = filter?.QueryParameters;
         var filterWhereClauseArguments = filter?.WhereClauseArguments;
+        var queryParameters = new Dictionary<string, object>
+        {
+            [VectorVariableName] = vector
+        };
 
         var whereClause = filterWhereClauseArguments is { Count: > 0 } ?
             $"WHERE {string.Join(AndConditionDelimiter, filterWhereClauseArguments)}" :
             string.Empty;
 
-        var query =
-            $"SELECT {selectClauseArguments} " +
-            $"FROM {tableVariableName} " +
-            $"{whereClause} " +
-            $"ORDER BY {vectorDistanceArgument} " +
-            $"OFFSET {OffsetVariableName} LIMIT {LimitVariableName} ";
+        // If Offset is not configured, use Top parameter instead of Limit/Offset
+        // since it's more optimized.
+        var topArgument = searchOptions.Skip == 0 ? $"TOP {TopVariableName} " : string.Empty;
 
-        var queryDefinition = new QueryDefinition(query);
+        var builder = new StringBuilder();
 
-        queryDefinition.WithParameter(VectorVariableName, vector);
-        queryDefinition.WithParameter(OffsetVariableName, searchOptions.Skip);
-        queryDefinition.WithParameter(LimitVariableName, searchOptions.Top);
+        builder.AppendLine($"SELECT {topArgument}{selectClauseArguments}");
+        builder.AppendLine($"FROM {tableVariableName}");
+
+        if (filterWhereClauseArguments is { Count: > 0 })
+        {
+            builder.AppendLine($"WHERE {string.Join(AndConditionDelimiter, filterWhereClauseArguments)}");
+        }
+
+        builder.AppendLine($"ORDER BY {vectorDistanceArgument}");
+
+        if (!string.IsNullOrEmpty(topArgument))
+        {
+            queryParameters.Add(TopVariableName, searchOptions.Top);
+        }
+        else
+        {
+            builder.AppendLine($"OFFSET {OffsetVariableName} LIMIT {LimitVariableName}");
+            queryParameters.Add(OffsetVariableName, searchOptions.Skip);
+            queryParameters.Add(LimitVariableName, searchOptions.Top);
+        }
+
+        var queryDefinition = new QueryDefinition(builder.ToString());
 
         if (filterQueryParameters is { Count: > 0 })
         {
-            foreach (var queryParameter in filterQueryParameters)
-            {
-                queryDefinition.WithParameter(queryParameter.Key, queryParameter.Value);
-            }
+            queryParameters = queryParameters.Union(filterQueryParameters).ToDictionary(k => k.Key, v => v.Value);
+        }
+
+        foreach (var queryParameter in queryParameters)
+        {
+            queryDefinition.WithParameter(queryParameter.Key, queryParameter.Value);
         }
 
         return queryDefinition;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

If `VectorSearchOptions.Skip` value is zero, in current implementation we are sending `LIMIT 3 OFFSET 0` to CosmosDB NoSQL. It appeared that using `SELECT TOP 3` instead of `LIMIT 3` works more efficiently. This PR contains a change to use `SELECT TOP` instead of `LIMIT/OFFSET` where `OFFSET` value is zero. However, `LIMIT/OFFSET` is still used when `OFFSET` is greater than zero, because `OFFSET` can't be used with `TOP` parameter, it can be used only with `LIMIT`.

This PR also contains a small fix for cases when collection is created with `IndexingMode.None`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
