### PR TITLE
.Net: Make new API of Core package AOT compatible

### DIFF
--- a/dotnet/samples/GettingStartedWithProcesses/Step04/SchemaGenerator.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step04/SchemaGenerator.cs
@@ -63,6 +63,6 @@ internal static class JsonSchemaGenerator
             }
         };
 
-        return KernelJsonSchemaBuilder.Build(null, typeof(SchemaType), "Intent Result", config).AsJson();
+        return KernelJsonSchemaBuilder.Build(typeof(SchemaType), "Intent Result", config).AsJson();
     }
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
@@ -28,7 +28,7 @@ public interface IVectorStore
     /// <seealso cref="VectorStoreRecordKeyAttribute"/>
     /// <seealso cref="VectorStoreRecordDataAttribute"/>
     /// <seealso cref="VectorStoreRecordVectorAttribute"/>
-    IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull;
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.AotTests/SemanticKernel.AotTests.csproj
+++ b/dotnet/src/SemanticKernel.AotTests/SemanticKernel.AotTests.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
-    <NoWarn>VSTHRD111,CA2007;CA1031;CA1812;IDE1006,SKEXP0120</NoWarn>
+    <NoWarn>VSTHRD111,CA2007,CA1031,CA1812,CS1998,IDE1006,SKEXP0120,SKEXP0001</NoWarn>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
     <IlcTrimMetadata>false</IlcTrimMetadata> <!-- This property should be dropped after SK migrates to STJ v9, which does not have the issue - https://github.com/eiriktsarpalis/stj-schema-mapper/issues/7. -->
   </PropertyGroup>

--- a/dotnet/src/SemanticKernel.Core/Data/ServiceCollectionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/ServiceCollectionExtensions.cs
@@ -39,6 +39,9 @@ public static class ServiceCollectionExtensions
     /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
     [Obsolete("This has been replaced by the Microsoft.SemanticKernel.Connectors.InMemory nuget package.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2091:Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.", Justification = "This method is obsolete")]
+    [UnconditionalSuppressMessage("Trimming", "IL2095:'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.", Justification = "This method is obsolete")]
+
     public static IServiceCollection AddVolatileVectorStoreTextSearch<TKey, TRecord>(
         this IServiceCollection services,
         string collectionName,

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
@@ -414,12 +414,7 @@ public static class TextSearchExtensions
         {
             FunctionName = "Search",
             Description = "Perform a search for content related to the specified query and return string results",
-            Parameters =
-            [
-                new KernelParameterMetadata("query") { Description = "What to search for", IsRequired = true },
-                new KernelParameterMetadata("count") { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
-                new KernelParameterMetadata("skip") { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
-            ],
+            Parameters = GetDefaultKernelParameterMetadata(),
             ReturnParameter = new() { ParameterType = typeof(KernelSearchResults<string>) },
         };
 
@@ -432,12 +427,7 @@ public static class TextSearchExtensions
         {
             FunctionName = "Search",
             Description = "Perform a search for content related to the specified query and return string results",
-            Parameters =
-            [
-                new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
-                new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
-                new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
-            ],
+            Parameters = CreateDefaultKernelParameterMetadata(jsonSerializerOptions),
             ReturnParameter = new(jsonSerializerOptions) { ParameterType = typeof(KernelSearchResults<string>) },
         };
 
@@ -451,12 +441,7 @@ public static class TextSearchExtensions
         {
             FunctionName = "GetTextSearchResults",
             Description = "Perform a search for content related to the specified query. The search will return the name, value and link for the related content.",
-            Parameters =
-            [
-                new KernelParameterMetadata("query") { Description = "What to search for", IsRequired = true },
-                new KernelParameterMetadata("count") { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
-                new KernelParameterMetadata("skip") { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
-            ],
+            Parameters = GetDefaultKernelParameterMetadata(),
             ReturnParameter = new() { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
         };
 
@@ -469,12 +454,7 @@ public static class TextSearchExtensions
         {
             FunctionName = "GetTextSearchResults",
             Description = "Perform a search for content related to the specified query. The search will return the name, value and link for the related content.",
-            Parameters =
-            [
-                new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
-                new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
-                new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
-            ],
+            Parameters = CreateDefaultKernelParameterMetadata(jsonSerializerOptions),
             ReturnParameter = new(jsonSerializerOptions) { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
         };
 
@@ -488,12 +468,7 @@ public static class TextSearchExtensions
         {
             FunctionName = "GetSearchResults",
             Description = "Perform a search for content related to the specified query.",
-            Parameters =
-            [
-                new KernelParameterMetadata("query") { Description = "What to search for", IsRequired = true },
-                new KernelParameterMetadata("count") { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
-                new KernelParameterMetadata("skip") { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
-            ],
+            Parameters = GetDefaultKernelParameterMetadata(),
             ReturnParameter = new() { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
         };
 
@@ -506,12 +481,7 @@ public static class TextSearchExtensions
         {
             FunctionName = "GetSearchResults",
             Description = "Perform a search for content related to the specified query.",
-            Parameters =
-            [
-                new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
-                new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
-                new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
-            ],
+            Parameters = CreateDefaultKernelParameterMetadata(jsonSerializerOptions),
             ReturnParameter = new(jsonSerializerOptions) { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
         };
 
@@ -545,5 +515,28 @@ public static class TextSearchExtensions
 
         return filter;
     }
+
+    private static IEnumerable<KernelParameterMetadata> CreateDefaultKernelParameterMetadata(JsonSerializerOptions jsonSerializerOptions)
+    {
+        return [
+            new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
+            new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
+            new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
+        ];
+    }
+
+    [RequiresUnreferencedCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
+    private static IEnumerable<KernelParameterMetadata> GetDefaultKernelParameterMetadata()
+    {
+        return s_kernelParameterMetadata ??= [
+            new KernelParameterMetadata("query") { Description = "What to search for", IsRequired = true },
+            new KernelParameterMetadata("count") { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
+            new KernelParameterMetadata("skip") { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
+        ];
+    }
+
+    private static IEnumerable<KernelParameterMetadata>? s_kernelParameterMetadata;
+
     #endregion
 }

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,12 +27,35 @@ public static class TextSearchExtensions
     /// <param name="pluginName">The name for the plugin.</param>
     /// <param name="description">A description of the plugin.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelPlugin CreateWithSearch(this ITextSearch textSearch, string pluginName, string? description = null)
     {
         Verify.NotNull(textSearch);
         Verify.NotNull(pluginName);
 
         return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateSearch()]);
+    }
+
+    /// <summary>
+    /// Creates a plugin from an ITextSearch implementation.
+    /// </summary>
+    /// <remarks>
+    /// The plugin will have a single function called `Search` which
+    /// will return a <see cref="IEnumerable{String}"/>
+    /// </remarks>
+    /// <param name="textSearch">The instance of ITextSearch to be used by the plugin.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelPlugin CreateWithSearch(this ITextSearch textSearch, string pluginName, JsonSerializerOptions jsonSerializerOptions, string? description = null)
+    {
+        Verify.NotNull(textSearch);
+        Verify.NotNull(pluginName);
+
+        return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateSearch(jsonSerializerOptions)]);
     }
 
     /// <summary>
@@ -45,6 +69,8 @@ public static class TextSearchExtensions
     /// <param name="pluginName">The name for the plugin.</param>
     /// <param name="description">A description of the plugin.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a GetTextSearchResults operation that calls the provided <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelPlugin CreateWithGetTextSearchResults(this ITextSearch textSearch, string pluginName, string? description = null)
     {
         Verify.NotNull(textSearch);
@@ -62,14 +88,58 @@ public static class TextSearchExtensions
     /// </remarks>
     /// <param name="textSearch">The instance of ITextSearch to be used by the plugin.</param>
     /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> instance with a GetTextSearchResults operation that calls the provided <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelPlugin CreateWithGetTextSearchResults(this ITextSearch textSearch, string pluginName, JsonSerializerOptions jsonSerializerOptions, string? description = null)
+    {
+        Verify.NotNull(textSearch);
+        Verify.NotNull(pluginName);
+
+        return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateGetTextSearchResults(jsonSerializerOptions)]);
+    }
+
+    /// <summary>
+    /// Creates a plugin from an ITextSearch implementation.
+    /// </summary>
+    /// <remarks>
+    /// The plugin will have a single function called `GetSearchResults` which
+    /// will return a <see cref="IEnumerable{TextSearchResult}"/>
+    /// </remarks>
+    /// <param name="textSearch">The instance of ITextSearch to be used by the plugin.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
     /// <param name="description">A description of the plugin.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a GetSearchResults operation that calls the provided <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelPlugin CreateWithGetSearchResults(this ITextSearch textSearch, string pluginName, string? description = null)
     {
         Verify.NotNull(textSearch);
         Verify.NotNull(pluginName);
 
         return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateGetSearchResults()]);
+    }
+
+    /// <summary>
+    /// Creates a plugin from an ITextSearch implementation.
+    /// </summary>
+    /// <remarks>
+    /// The plugin will have a single function called `GetSearchResults` which
+    /// will return a <see cref="IEnumerable{TextSearchResult}"/>
+    /// </remarks>
+    /// <param name="textSearch">The instance of ITextSearch to be used by the plugin.</param>
+    /// <param name="pluginName">The name for the plugin.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="description">A description of the plugin.</param>
+    /// <returns>A <see cref="KernelPlugin"/> instance with a GetSearchResults operation that calls the provided <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelPlugin CreateWithGetSearchResults(this ITextSearch textSearch, string pluginName, JsonSerializerOptions jsonSerializerOptions, string? description = null)
+    {
+        Verify.NotNull(textSearch);
+        Verify.NotNull(pluginName);
+
+        return KernelPluginFactory.CreateFromFunctions(pluginName, description, [textSearch.CreateGetSearchResults(jsonSerializerOptions)]);
     }
     #endregion
 
@@ -81,6 +151,8 @@ public static class TextSearchExtensions
     /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
     /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunction CreateSearch(this ITextSearch textSearch, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
     {
         async Task<IEnumerable<string>> SearchAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken)
@@ -112,12 +184,54 @@ public static class TextSearchExtensions
     }
 
     /// <summary>
+    /// Create a <see cref="KernelFunction"/> which invokes <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.
+    /// </summary>
+    /// <param name="textSearch">The ITextSearch instance to use.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
+    /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
+    /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelFunction CreateSearch(this ITextSearch textSearch, JsonSerializerOptions jsonSerializerOptions, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
+    {
+        async Task<IEnumerable<string>> SearchAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken)
+        {
+            arguments.TryGetValue("query", out var query);
+            if (string.IsNullOrEmpty(query?.ToString()))
+            {
+                return [];
+            }
+
+            var parameters = function.Metadata.Parameters;
+
+            searchOptions ??= new()
+            {
+                Top = GetArgumentValue(arguments, parameters, "count", 2),
+                Skip = GetArgumentValue(arguments, parameters, "skip", 0),
+                Filter = CreateBasicFilter(options, arguments)
+            };
+
+            var result = await textSearch.SearchAsync(query?.ToString()!, searchOptions, cancellationToken).ConfigureAwait(false);
+            var resultList = await result.Results.ToListAsync(cancellationToken).ConfigureAwait(false);
+            return resultList;
+        }
+
+        options ??= DefaultSearchMethodOptions(jsonSerializerOptions);
+        return KernelFunctionFactory.CreateFromMethod(
+                SearchAsync,
+                jsonSerializerOptions,
+                options);
+    }
+
+    /// <summary>
     /// Create a <see cref="KernelFunction"/> which invokes <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
     /// </summary>
     /// <param name="textSearch">The ITextSearch instance to use.</param>
     /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
     /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunction CreateGetTextSearchResults(this ITextSearch textSearch, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
     {
         async Task<IEnumerable<TextSearchResult>> GetTextSearchResultAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken)
@@ -148,12 +262,53 @@ public static class TextSearchExtensions
     }
 
     /// <summary>
+    /// Create a <see cref="KernelFunction"/> which invokes <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
+    /// </summary>
+    /// <param name="textSearch">The ITextSearch instance to use.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
+    /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
+    /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelFunction CreateGetTextSearchResults(this ITextSearch textSearch, JsonSerializerOptions jsonSerializerOptions, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
+    {
+        async Task<IEnumerable<TextSearchResult>> GetTextSearchResultAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken)
+        {
+            arguments.TryGetValue("query", out var query);
+            if (string.IsNullOrEmpty(query?.ToString()))
+            {
+                return [];
+            }
+
+            var parameters = function.Metadata.Parameters;
+
+            searchOptions ??= new()
+            {
+                Top = GetArgumentValue(arguments, parameters, "count", 2),
+                Skip = GetArgumentValue(arguments, parameters, "skip", 0),
+                Filter = CreateBasicFilter(options, arguments)
+            };
+
+            var result = await textSearch.GetTextSearchResultsAsync(query?.ToString()!, searchOptions, cancellationToken).ConfigureAwait(false);
+            return await result.Results.ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        options ??= DefaultGetTextSearchResultsMethodOptions(jsonSerializerOptions);
+        return KernelFunctionFactory.CreateFromMethod(
+                GetTextSearchResultAsync,
+                jsonSerializerOptions,
+                options);
+    }
+
+    /// <summary>
     /// Create a <see cref="KernelFunction"/> which invokes <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
     /// </summary>
     /// <param name="textSearch">The ITextSearch instance to use.</param>
     /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
     /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunction CreateGetSearchResults(this ITextSearch textSearch, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
     {
         async Task<IEnumerable<object>> GetSearchResultAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken)
@@ -182,6 +337,46 @@ public static class TextSearchExtensions
                 GetSearchResultAsync,
                 options);
     }
+
+    /// <summary>
+    /// Create a <see cref="KernelFunction"/> which invokes <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
+    /// </summary>
+    /// <param name="textSearch">The ITextSearch instance to use.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
+    /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
+    /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelFunction CreateGetSearchResults(this ITextSearch textSearch, JsonSerializerOptions jsonSerializerOptions, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
+    {
+        async Task<IEnumerable<object>> GetSearchResultAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken)
+        {
+            arguments.TryGetValue("query", out var query);
+            if (string.IsNullOrEmpty(query?.ToString()))
+            {
+                return [];
+            }
+
+            var parameters = function.Metadata.Parameters;
+
+            searchOptions ??= new()
+            {
+                Top = GetArgumentValue(arguments, parameters, "count", 2),
+                Skip = GetArgumentValue(arguments, parameters, "skip", 0),
+                Filter = CreateBasicFilter(options, arguments)
+            };
+
+            var result = await textSearch.GetSearchResultsAsync(query?.ToString()!, searchOptions, cancellationToken).ConfigureAwait(false);
+            return await result.Results.ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        options ??= DefaultGetSearchResultsMethodOptions(jsonSerializerOptions);
+        return KernelFunctionFactory.CreateFromMethod(
+                GetSearchResultAsync,
+                jsonSerializerOptions,
+                options);
+    }
+
     #endregion
 
     #region private
@@ -212,6 +407,8 @@ public static class TextSearchExtensions
     /// <summary>
     /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.
     /// </summary>
+    [RequiresUnreferencedCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
     private static KernelFunctionFromMethodOptions DefaultSearchMethodOptions() =>
         new()
         {
@@ -227,8 +424,28 @@ public static class TextSearchExtensions
         };
 
     /// <summary>
+    /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> used for generating JSON schema for method parameters and return type.</param>
+    /// </summary>
+    private static KernelFunctionFromMethodOptions DefaultSearchMethodOptions(JsonSerializerOptions jsonSerializerOptions) =>
+        new()
+        {
+            FunctionName = "Search",
+            Description = "Perform a search for content related to the specified query and return string results",
+            Parameters =
+            [
+                new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
+                new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
+                new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
+            ],
+            ReturnParameter = new(jsonSerializerOptions) { ParameterType = typeof(KernelSearchResults<string>) },
+        };
+
+    /// <summary>
     /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
     /// </summary>
+    [RequiresUnreferencedCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
     private static KernelFunctionFromMethodOptions DefaultGetTextSearchResultsMethodOptions() =>
         new()
         {
@@ -244,8 +461,28 @@ public static class TextSearchExtensions
         };
 
     /// <summary>
+    /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> used for generating JSON schema for method parameters and return type.</param>
+    /// </summary>
+    private static KernelFunctionFromMethodOptions DefaultGetTextSearchResultsMethodOptions(JsonSerializerOptions jsonSerializerOptions) =>
+        new()
+        {
+            FunctionName = "GetTextSearchResults",
+            Description = "Perform a search for content related to the specified query. The search will return the name, value and link for the related content.",
+            Parameters =
+            [
+                new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
+                new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
+                new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
+            ],
+            ReturnParameter = new(jsonSerializerOptions) { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
+        };
+
+    /// <summary>
     /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
     /// </summary>
+    [RequiresUnreferencedCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection for generating JSON schema for method parameters and return type, making it incompatible with AOT scenarios.")]
     private static KernelFunctionFromMethodOptions DefaultGetSearchResultsMethodOptions() =>
         new()
         {
@@ -258,6 +495,24 @@ public static class TextSearchExtensions
                 new KernelParameterMetadata("skip") { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
             ],
             ReturnParameter = new() { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
+        };
+
+    /// <summary>
+    /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.
+    /// </summary>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> used for generating JSON schema for method parameters and return type.</param>
+    private static KernelFunctionFromMethodOptions DefaultGetSearchResultsMethodOptions(JsonSerializerOptions jsonSerializerOptions) =>
+        new()
+        {
+            FunctionName = "GetSearchResults",
+            Description = "Perform a search for content related to the specified query.",
+            Parameters =
+            [
+                new KernelParameterMetadata("query", jsonSerializerOptions) { Description = "What to search for", IsRequired = true },
+                new KernelParameterMetadata("count", jsonSerializerOptions) { Description = "Number of results", IsRequired = false, DefaultValue = 2 },
+                new KernelParameterMetadata("skip", jsonSerializerOptions) { Description = "Number of results to skip", IsRequired = false, DefaultValue = 0 },
+            ],
+            ReturnParameter = new(jsonSerializerOptions) { ParameterType = typeof(KernelSearchResults<TextSearchResult>) },
         };
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchKernelBuilderExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchKernelBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class TextSearchKernelBuilderExtensions
     /// <param name="resultMapper"><see cref="ITextSearchResultMapper" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
     /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    public static IKernelBuilder AddVectorStoreTextSearch<TRecord>(
+    public static IKernelBuilder AddVectorStoreTextSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TRecord>(
         this IKernelBuilder builder,
         ITextSearchStringMapper? stringMapper = null,
         ITextSearchResultMapper? resultMapper = null,

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchResultPropertyReader.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchResultPropertyReader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Microsoft.SemanticKernel.Data;
@@ -26,7 +27,7 @@ internal sealed class TextSearchResultPropertyReader
     /// Create a new instance of <see cref="TextSearchResultPropertyReader"/>.
     /// </summary>
     /// <param name="dataModelType">Type of the data model.</param>
-    public TextSearchResultPropertyReader(Type dataModelType)
+    public TextSearchResultPropertyReader([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type dataModelType)
     {
         this._dataModelType = dataModelType;
 
@@ -68,7 +69,7 @@ internal sealed class TextSearchResultPropertyReader
     /// </summary>
     /// <param name="type">The data model to find the properties on.</param>
     /// <returns>The properties.</returns>
-    private static (PropertyInfo? NameProperty, PropertyInfo? ValueProperty, PropertyInfo? LinkProperty) FindPropertiesInfo(Type type)
+    private static (PropertyInfo? NameProperty, PropertyInfo? ValueProperty, PropertyInfo? LinkProperty) FindPropertiesInfo([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
     {
         PropertyInfo? nameProperty = null;
         PropertyInfo? valueProperty = null;

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchServiceCollectionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class TextSearchServiceCollectionExtensions
     /// <param name="resultMapper"><see cref="ITextSearchResultMapper" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
     /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    public static IServiceCollection AddVectorStoreTextSearch<TRecord>(
+    public static IServiceCollection AddVectorStoreTextSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TRecord>(
         this IServiceCollection services,
         ITextSearchStringMapper? stringMapper = null,
         ITextSearchResultMapper? resultMapper = null,
@@ -77,7 +77,7 @@ public static class TextSearchServiceCollectionExtensions
     /// <param name="resultMapper"><see cref="ITextSearchResultMapper" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
     /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    public static IServiceCollection AddVectorStoreTextSearch<TRecord>(
+    public static IServiceCollection AddVectorStoreTextSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TRecord>(
         this IServiceCollection services,
         string vectorizableTextSearchServiceId,
         ITextSearchStringMapper? stringMapper = null,
@@ -122,7 +122,7 @@ public static class TextSearchServiceCollectionExtensions
     /// <param name="resultMapper"><see cref="ITextSearchResultMapper" /> instance that can map a TRecord to a <see cref="TextSearchResult"/></param>
     /// <param name="options">Options used to construct an instance of <see cref="VectorStoreTextSearch{TRecord}"/></param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
-    public static IServiceCollection AddVectorStoreTextSearch<TRecord>(
+    public static IServiceCollection AddVectorStoreTextSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TRecord>(
         this IServiceCollection services,
         string vectorizedSearchServiceId,
         string textEmbeddingGenerationServiceId,

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// A Vector Store Text Search implementation that can be used to perform searches using a <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
 /// </summary>
 [Experimental("SKEXP0001")]
-public sealed class VectorStoreTextSearch<TRecord> : ITextSearch
+public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TRecord> : ITextSearch
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStore.cs
@@ -39,7 +39,7 @@ public sealed class VolatileVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
         if (this._internalCollectionTypes.TryGetValue(name, out var existingCollectionDataType) && existingCollectionDataType != typeof(TRecord))

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreCollectionSearchMapping.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics.Tensors;
 using System.Reflection;
@@ -206,6 +207,7 @@ internal static class VolatileVectorStoreCollectionSearchMapping
     /// <param name="propertyName">The name of the property to find.</param>
     /// <returns>The property info for the required property.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the required property does not exist on the record.</exception>
+    [UnconditionalSuppressMessage("Analysis", "IL2075:Suppress IL2075 warning", Justification = "This class is obsolete")]
     private static PropertyInfo GetPropertyInfo(object record, string propertyName)
     {
         var propertyInfo = record.GetType().GetProperty(propertyName);

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -27,6 +28,8 @@ public static class VolatileVectorStoreExtensions
     /// <param name="collectionName">The collection name.</param>
     /// <param name="stream">The stream to write the serialized JSON to.</param>
     /// <param name="jsonSerializerOptions">The JSON serializer options to use.</param>
+    [RequiresUnreferencedCode("Uses reflection for collection serialization, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection for collection serialization, making it incompatible with AOT scenarios.")]
     public static async Task SerializeCollectionAsJsonAsync<TKey, TRecord>(
         this VolatileVectorStore vectorStore,
         string collectionName,
@@ -56,6 +59,8 @@ public static class VolatileVectorStoreExtensions
     /// <typeparam name="TRecord">Type of the record.</typeparam>
     /// <param name="vectorStore">Instance of <see cref="VolatileVectorStore"/> used to retrieve the collection.</param>
     /// <param name="stream">The stream to read the serialized JSON from.</param>
+    [RequiresUnreferencedCode("Uses reflection for collection deserialization, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection for collection deserialization, making it incompatible with AOT scenarios.")]
     public static async Task<IVectorStoreRecordCollection<TKey, TRecord>?> DeserializeCollectionFromJsonAsync<TKey, TRecord>(
         this VolatileVectorStore vectorStore,
         Stream stream)

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -18,7 +19,7 @@ namespace Microsoft.SemanticKernel.Data;
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 [Obsolete("This has been replaced by InMemoryVectorStoreRecordCollection in the Microsoft.SemanticKernel.Connectors.InMemory nuget package.")]
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class VolatileVectorStoreRecordCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
+public sealed class VolatileVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TKey : notnull
 {
@@ -61,6 +62,7 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, [DynamicallyAccess
     /// </summary>
     /// <param name="collectionName">The name of the collection that this <see cref="VolatileVectorStoreRecordCollection{TKey,TRecord}"/> will access.</param>
     /// <param name="options">Optional configuration options for this class.</param>
+    [UnconditionalSuppressMessage("Trimming", "IL2087:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.", Justification = "This class is obsolete")]
     public VolatileVectorStoreRecordCollection(string collectionName, VolatileVectorStoreRecordCollectionOptions<TKey, TRecord>? options = default)
     {
         // Verify.
@@ -296,6 +298,7 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, [DynamicallyAccess
     /// <param name="overrideVectorResolver">The override vector resolver if one was provided.</param>
     /// <param name="vectorProperties">A dictionary of vector properties from the record definition.</param>
     /// <returns>The <see cref="VolatileVectorStoreVectorResolver{TRecord}"/>.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.", Justification = "This class is obsolete")]
     private static VolatileVectorStoreVectorResolver<TRecord> CreateVectorResolver(VolatileVectorStoreVectorResolver<TRecord>? overrideVectorResolver, Dictionary<string, VectorStoreRecordVectorProperty> vectorProperties)
     {
         // Custom resolver.
@@ -346,6 +349,7 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, [DynamicallyAccess
     /// <param name="overrideKeyResolver">The override key resolver if one was provided.</param>
     /// <param name="keyProperty">They key property from the record definition.</param>
     /// <returns>The <see cref="VolatileVectorStoreKeyResolver{TKey, TRecord}"/>.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.", Justification = "This class is obsolete")]
     private static VolatileVectorStoreKeyResolver<TKey, TRecord> CreateKeyResolver(VolatileVectorStoreKeyResolver<TKey, TRecord>? overrideKeyResolver, VectorStoreRecordKeyProperty keyProperty)
     {
         // Custom resolver.

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -195,6 +195,8 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
     [Experimental("SKEXP0001")]
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunctionMetadata CreateMetadata(
         MethodInfo method,
         string? functionName = null,
@@ -217,9 +219,43 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// Creates a <see cref="KernelFunctionMetadata"/> instance for a method, specified via an <see cref="MethodInfo"/> instance.
     /// </summary>
     /// <param name="method">The method to be represented via the created <see cref="KernelFunction"/>.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="functionName">The name to use for the function. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
+    /// <param name="description">The description to use for the function. If null, it will default to one derived from the method represented by <paramref name="method"/>, if possible (e.g. via a <see cref="DescriptionAttribute"/> on the method).</param>
+    /// <param name="parameters">Optional parameter descriptions. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
+    /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelFunctionMetadata CreateMetadata(
+        MethodInfo method,
+        JsonSerializerOptions jsonSerializerOptions,
+        string? functionName = null,
+        string? description = null,
+        IEnumerable<KernelParameterMetadata>? parameters = null,
+        KernelReturnParameterMetadata? returnParameter = null,
+        ILoggerFactory? loggerFactory = null)
+        => CreateMetadata(
+            method,
+            jsonSerializerOptions,
+            new KernelFunctionFromMethodOptions
+            {
+                FunctionName = functionName,
+                Description = description,
+                Parameters = parameters,
+                ReturnParameter = returnParameter,
+                LoggerFactory = loggerFactory
+            });
+
+    /// <summary>
+    /// Creates a <see cref="KernelFunctionMetadata"/> instance for a method, specified via an <see cref="MethodInfo"/> instance.
+    /// </summary>
+    /// <param name="method">The method to be represented via the created <see cref="KernelFunction"/>.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
     [Experimental("SKEXP0001")]
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunctionMetadata CreateMetadata(
         MethodInfo method,
         KernelFunctionFromMethodOptions? options = default)
@@ -233,6 +269,40 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
             options?.Description ?? methodDetails.Description,
             options?.Parameters?.ToList() ?? methodDetails.Parameters,
             options?.ReturnParameter ?? methodDetails.ReturnParameter,
+            options?.AdditionalMetadata);
+
+        if (options?.LoggerFactory?.CreateLogger(method.DeclaringType ?? typeof(KernelFunctionFromPrompt)) is ILogger logger &&
+            logger.IsEnabled(LogLevel.Trace))
+        {
+            logger.LogTrace("Created KernelFunctionMetadata '{Name}' for '{MethodName}'", result.Name, method.Name);
+        }
+
+        return result.Metadata;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="KernelFunctionMetadata"/> instance for a method, specified via an <see cref="MethodInfo"/> instance.
+    /// </summary>
+    /// <param name="method">The method to be represented via the created <see cref="KernelFunction"/>.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="options">Optional function creation options.</param>
+    /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
+    [Experimental("SKEXP0120")]
+    public static KernelFunctionMetadata CreateMetadata(
+        MethodInfo method,
+        JsonSerializerOptions jsonSerializerOptions,
+        KernelFunctionFromMethodOptions? options = default)
+    {
+        Verify.NotNull(method);
+
+        MethodDetails methodDetails = GetMethodDetails(options?.FunctionName, method, jsonSerializerOptions, target: null);
+        var result = new KernelFunctionFromMethod(
+            methodDetails.Function,
+            methodDetails.Name,
+            options?.Description ?? methodDetails.Description,
+            options?.Parameters?.ToList() ?? methodDetails.Parameters,
+            options?.ReturnParameter ?? methodDetails.ReturnParameter,
+            jsonSerializerOptions,
             options?.AdditionalMetadata);
 
         if (options?.LoggerFactory?.CreateLogger(method.DeclaringType ?? typeof(KernelFunctionFromPrompt)) is ILogger logger &&

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionMetadataFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionMetadataFactory.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.SemanticKernel;
@@ -25,6 +26,8 @@ public static class KernelFunctionMetadataFactory
     /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
     /// Attributed methods must all have different names; overloads are not supported.
     /// </remarks>
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static IEnumerable<KernelFunctionMetadata> CreateFromType(Type instanceType, ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(instanceType);
@@ -39,6 +42,42 @@ public static class KernelFunctionMetadataFactory
             if (method.GetCustomAttribute<KernelFunctionAttribute>() is not null)
             {
                 functionMetadata.Add(KernelFunctionFromMethod.CreateMetadata(method, loggerFactory: loggerFactory));
+            }
+        }
+        if (functionMetadata.Count == 0)
+        {
+            throw new ArgumentException($"The {instanceType} instance doesn't implement any [KernelFunction]-attributed methods.");
+        }
+
+        return functionMetadata;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="KernelFunctionMetadata"/> enumeration for a method, specified via an <see cref="MethodInfo"/> instance.
+    /// </summary>
+    /// <param name="instanceType">Specifies the type of the object to extract <see cref="KernelFunctionMetadata"/> for.</param>
+    /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
+    /// <returns>A <see cref="KernelPlugin"/> containing <see cref="KernelFunction"/>s for all relevant members of <paramref name="instanceType"/>.</returns>
+    /// <remarks>
+    /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
+    /// Attributed methods must all have different names; overloads are not supported.
+    /// </remarks>
+    [Experimental("SKEXP0120")]
+    public static IEnumerable<KernelFunctionMetadata> CreateFromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type instanceType, JsonSerializerOptions jsonSerializerOptions, ILoggerFactory? loggerFactory = null)
+    {
+        Verify.NotNull(instanceType);
+
+        MethodInfo[] methods = instanceType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+
+        // Filter out non-KernelFunctions and fail if two functions have the same name (with or without the same casing).
+        var functionMetadata = new List<KernelFunctionMetadata>();
+        KernelFunctionFromMethodOptions options = new();
+        foreach (MethodInfo method in methods)
+        {
+            if (method.GetCustomAttribute<KernelFunctionAttribute>() is not null)
+            {
+                functionMetadata.Add(KernelFunctionFromMethod.CreateMetadata(method, jsonSerializerOptions, loggerFactory: loggerFactory));
             }
         }
         if (functionMetadata.Count == 0)

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelPluginFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelPluginFactory.cs
@@ -40,29 +40,6 @@ public static partial class KernelPluginFactory
         return CreateFromObject(ActivatorUtilities.CreateInstance<T>(serviceProvider)!, pluginName, serviceProvider?.GetService<ILoggerFactory>());
     }
 
-    /// <summary>Creates a plugin that wraps a new instance of the specified type <paramref name="instanceType"/>.</summary>
-    /// <param name="instanceType">
-    /// Specifies the type of the object to wrap.
-    /// </param>
-    /// <param name="pluginName">
-    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the <paramref name="instanceType"/>.
-    /// </param>
-    /// <param name="serviceProvider">
-    /// The <see cref="IServiceProvider"/> to use for resolving any required services, such as an <see cref="ILoggerFactory"/>
-    /// and any services required to satisfy a constructor on <paramref name="instanceType"/>.
-    /// </param>
-    /// <returns>A <see cref="KernelPlugin"/> containing <see cref="KernelFunction"/>s for all relevant members of <paramref name="instanceType"/>.</returns>
-    /// <remarks>
-    /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
-    /// Attributed methods must all have different names; overloads are not supported.
-    /// </remarks>
-    [Experimental("SKEXP0001")]
-    public static KernelPlugin CreateFromType(Type instanceType, string? pluginName = null, IServiceProvider? serviceProvider = null)
-    {
-        serviceProvider ??= EmptyServiceProvider.Instance;
-        return CreateFromObject(ActivatorUtilities.CreateInstance(serviceProvider, instanceType)!, pluginName, serviceProvider?.GetService<ILoggerFactory>());
-    }
-
     /// <summary>Creates a plugin that wraps a new instance of the specified type <typeparamref name="T"/>.</summary>
     /// <typeparam name="T">Specifies the type of the object to wrap.</typeparam>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
@@ -86,6 +63,60 @@ public static partial class KernelPluginFactory
     {
         serviceProvider ??= EmptyServiceProvider.Instance;
         return CreateFromObject<T>(ActivatorUtilities.CreateInstance<T>(serviceProvider)!, jsonSerializerOptions, pluginName, serviceProvider?.GetService<ILoggerFactory>());
+    }
+
+    /// <summary>Creates a plugin that wraps a new instance of the specified type <paramref name="instanceType"/>.</summary>
+    /// <param name="instanceType">
+    /// Specifies the type of the object to wrap.
+    /// </param>
+    /// <param name="pluginName">
+    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the <paramref name="instanceType"/>.
+    /// </param>
+    /// <param name="serviceProvider">
+    /// The <see cref="IServiceProvider"/> to use for resolving any required services, such as an <see cref="ILoggerFactory"/>
+    /// and any services required to satisfy a constructor on <paramref name="instanceType"/>.
+    /// </param>
+    /// <returns>A <see cref="KernelPlugin"/> containing <see cref="KernelFunction"/>s for all relevant members of <paramref name="instanceType"/>.</returns>
+    /// <remarks>
+    /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
+    /// Attributed methods must all have different names; overloads are not supported.
+    /// </remarks>
+    [Experimental("SKEXP0001")]
+    [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
+    public static KernelPlugin CreateFromType(Type instanceType, string? pluginName = null, IServiceProvider? serviceProvider = null)
+    {
+        serviceProvider ??= EmptyServiceProvider.Instance;
+        return CreateFromObject(ActivatorUtilities.CreateInstance(serviceProvider, instanceType)!, pluginName, serviceProvider?.GetService<ILoggerFactory>());
+    }
+
+    /// <summary>Creates a plugin that wraps a new instance of the specified type <paramref name="instanceType"/>.</summary>
+    /// <param name="instanceType">
+    /// Specifies the type of the object to wrap.
+    /// </param>
+    /// <param name="jsonSerializerOptions">
+    /// The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.
+    /// </param>
+    /// <param name="pluginName">
+    /// Name of the plugin for function collection and prompt templates. If the value is null, a plugin name is derived from the <paramref name="instanceType"/>.
+    /// </param>
+    /// <param name="serviceProvider">
+    /// The <see cref="IServiceProvider"/> to use for resolving any required services, such as an <see cref="ILoggerFactory"/>
+    /// and any services required to satisfy a constructor on <paramref name="instanceType"/>.
+    /// </param>
+    /// <returns>A <see cref="KernelPlugin"/> containing <see cref="KernelFunction"/>s for all relevant members of <paramref name="instanceType"/>.</returns>
+    /// <remarks>
+    /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
+    /// Attributed methods must all have different names; overloads are not supported.
+    /// </remarks>
+    [Experimental("SKEXP0120")]
+    public static KernelPlugin CreateFromType([DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.NonPublicMethods)] Type instanceType, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null, IServiceProvider? serviceProvider = null)
+    {
+        serviceProvider ??= EmptyServiceProvider.Instance;
+        return CreateFromObject(ActivatorUtilities.CreateInstance(serviceProvider, instanceType)!, jsonSerializerOptions, pluginName, serviceProvider?.GetService<ILoggerFactory>());
     }
 
     /// <summary>Creates a plugin that wraps the specified target object.</summary>

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionFromMethodTests1.cs
@@ -1433,6 +1433,68 @@ public sealed class KernelFunctionFromMethodTests1
         Assert.Equal(34, result?.Result);
     }
 
+    [Theory]
+    [ClassData(typeof(TestJsonSerializerOptionsForTestParameterAndReturnTypes))]
+    public void ItCanCreateFunctionMetadata(JsonSerializerOptions? jsos)
+    {
+        // Arrange
+        static TestReturnType StaticMethod(TestParameterType p1)
+        {
+            return new TestReturnType() { Result = int.Parse(p1.Value!) };
+        }
+
+        // Act
+        KernelFunctionMetadata metadata = jsos is not null ?
+            KernelFunctionFromMethod.CreateMetadata(((Func<TestParameterType, TestReturnType>)StaticMethod).Method, jsos, functionName: "f1_name", description: "f1-description") :
+            KernelFunctionFromMethod.CreateMetadata(((Func<TestParameterType, TestReturnType>)StaticMethod).Method, functionName: "f1_name", description: "f1-description");
+
+        // Assert
+        Assert.Equal("f1_name", metadata.Name);
+        Assert.Equal("f1-description", metadata.Description);
+
+        Assert.NotEmpty(metadata.Parameters);
+        Assert.NotNull(metadata.Parameters[0].Schema);
+        Assert.Equal("""{"type":"object","properties":{"Value":{"type":["string","null"]}}}""", metadata.Parameters[0].Schema!.ToString());
+
+        Assert.NotNull(metadata.ReturnParameter);
+        Assert.NotNull(metadata.ReturnParameter.Schema);
+        Assert.Equal("""{"type":"object","properties":{"Result":{"type":"integer"}}}""", metadata.ReturnParameter.Schema!.ToString());
+    }
+
+    [Theory]
+    [ClassData(typeof(TestJsonSerializerOptionsForTestParameterAndReturnTypes))]
+    public void ItCanCreateFunctionMetadataUsingOverloadWithOptions(JsonSerializerOptions? jsos)
+    {
+        // Arrange
+        static TestReturnType StaticMethod(TestParameterType p1)
+        {
+            return new TestReturnType() { Result = int.Parse(p1.Value!) };
+        }
+
+        KernelFunctionFromMethodOptions options = new()
+        {
+            FunctionName = "f1_name",
+            Description = "f1-description"
+        };
+
+        // Act
+        KernelFunctionMetadata metadata = jsos is not null ?
+            KernelFunctionFromMethod.CreateMetadata(((Func<TestParameterType, TestReturnType>)StaticMethod).Method, jsos, options) :
+            KernelFunctionFromMethod.CreateMetadata(((Func<TestParameterType, TestReturnType>)StaticMethod).Method, options);
+
+        // Assert
+        Assert.Equal("f1_name", metadata.Name);
+        Assert.Equal("f1-description", metadata.Description);
+
+        Assert.NotEmpty(metadata.Parameters);
+        Assert.NotNull(metadata.Parameters[0].Schema);
+        Assert.Equal("""{"type":"object","properties":{"Value":{"type":["string","null"]}}}""", metadata.Parameters[0].Schema!.ToString());
+
+        Assert.NotNull(metadata.ReturnParameter);
+        Assert.NotNull(metadata.ReturnParameter.Schema);
+        Assert.Equal("""{"type":"object","properties":{"Result":{"type":"integer"}}}""", metadata.ReturnParameter.Schema!.ToString());
+    }
+
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
     private sealed class CustomTypeForJsonTests
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes

--- a/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionMetadataFactoryTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Functions/KernelFunctionMetadataFactoryTests.cs
@@ -1,52 +1,104 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.SemanticKernel;
+using SemanticKernel.UnitTests.Functions.JsonSerializerContexts;
 using Xunit;
 
 namespace SemanticKernel.UnitTests.Functions;
 
 public class KernelFunctionMetadataFactoryTests
 {
-    [Fact]
-    public void ItCanCreateFromType()
+    [Theory]
+    [ClassData(typeof(TestJsonSerializerOptionsForTestParameterAndReturnTypes))]
+    public void ItCanCreateFromType(JsonSerializerOptions? jsos)
     {
         // Arrange
-        var instanceType = typeof(MyKernelFunctions);
+        Type type = typeof(MyKernelFunctions);
 
         // Act
-        var functionMetadata = KernelFunctionMetadataFactory.CreateFromType(instanceType);
+        IEnumerable<KernelFunctionMetadata> metadata = (jsos is not null ?
+            KernelFunctionMetadataFactory.CreateFromType(type, jsos) :
+            KernelFunctionMetadataFactory.CreateFromType(type)).ToArray();
 
         // Assert
-        Assert.NotNull(functionMetadata);
-        Assert.Equal(3, functionMetadata.Count<KernelFunctionMetadata>());
-        Assert.Contains(functionMetadata, f => f.Name == "Function1");
-        Assert.Contains(functionMetadata, f => f.Name == "Function2");
-        Assert.Contains(functionMetadata, f => f.Name == "Function3");
+        Assert.Equal(2, metadata.Count());
+
+        // Assert Function1 metadata
+        KernelFunctionMetadata metadata1 = metadata.ElementAt(0);
+
+        Assert.Equal("Function1", metadata1.Name);
+        Assert.Equal("Description for function 1.", metadata1.Description);
+
+        Assert.NotEmpty(metadata1.Parameters);
+        Assert.NotNull(metadata1.Parameters[0].Schema);
+        Assert.Equal("""{"type":"string","description":"Description for parameter 1"}""", metadata1.Parameters[0].Schema!.ToString());
+
+        Assert.NotNull(metadata1.ReturnParameter);
+        Assert.NotNull(metadata1.ReturnParameter.Schema);
+        Assert.Equal("""{"type":"string"}""", metadata1.ReturnParameter.Schema!.ToString());
+
+        // Assert Function2 metadata
+        KernelFunctionMetadata metadata2 = metadata.ElementAt(1);
+
+        Assert.Equal("Function2", metadata2.Name);
+        Assert.Equal("Description for function 2.", metadata2.Description);
+
+        Assert.NotEmpty(metadata2.Parameters);
+        Assert.NotNull(metadata2.Parameters[0].Schema);
+        Assert.Equal("""{"type":"object","properties":{"Value":{"type":["string","null"]}},"description":"Description for parameter 1"}""", metadata2.Parameters[0].Schema!.ToString());
+
+        Assert.NotNull(metadata2.ReturnParameter);
+        Assert.NotNull(metadata2.ReturnParameter.Schema);
+        Assert.Equal("""{"type":"object","properties":{"Result":{"type":"integer"}}}""", metadata2.ReturnParameter.Schema!.ToString());
+    }
+
+    [Theory]
+    [ClassData(typeof(TestJsonSerializerOptionsForTestParameterAndReturnTypes))]
+    public void ItThrowsExceptionIfTypeDoesNotHaveKernelFunctions(JsonSerializerOptions? jsos)
+    {
+        // Arrange
+        Type type = typeof(PluginWithNoKernelFunctions);
+
+        // Act & Assert
+        if (jsos is not null)
+        {
+            Assert.Throws<ArgumentException>(() => KernelFunctionMetadataFactory.CreateFromType(type, jsos));
+        }
+        else
+        {
+            Assert.Throws<ArgumentException>(() => KernelFunctionMetadataFactory.CreateFromType(type));
+        }
     }
 
     #region private
 #pragma warning disable CA1812 // Used in test case above
     private sealed class MyKernelFunctions
     {
-        // Disallow instantiation of this class.
-        private MyKernelFunctions()
-        {
-        }
-
         [KernelFunction("Function1")]
         [Description("Description for function 1.")]
         public string Function1([Description("Description for parameter 1")] string param1) => $"Function1: {param1}";
 
         [KernelFunction("Function2")]
         [Description("Description for function 2.")]
-        public string Function2([Description("Description for parameter 1")] string param1) => $"Function2: {param1}";
+        private TestReturnType Function3([Description("Description for parameter 1")] TestParameterType param1)
+        {
+            return new TestReturnType() { Result = int.Parse(param1.Value!) };
+        }
+    }
 
-        [KernelFunction("Function3")]
-        [Description("Description for function 3.")]
-        public string Function3([Description("Description for parameter 1")] string param1) => $"Function3: {param1}";
+    private sealed class PluginWithNoKernelFunctions
+    {
+        public string Function1([Description("Description for parameter 1")] string param1) => $"Function1: {param1}";
+
+        private TestReturnType Function3([Description("Description for parameter 1")] TestParameterType param1)
+        {
+            return new TestReturnType() { Result = int.Parse(param1.Value!) };
+        }
     }
 #pragma warning restore CA1812
     #endregion

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>    <!-- ;net48 -->
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050,SKEXP0110,SKEXP0120</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,IDE1006,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050,SKEXP0110,SKEXP0120</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
+++ b/dotnet/src/SemanticKernel.UnitTests/SemanticKernel.UnitTests.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>    <!-- ;net48 -->
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050,SKEXP0110</NoWarn>
+    <NoWarn>$(NoWarn);CA2007,CA1861,VSTHRD111,SKEXP0001,SKEXP0010,SKEXP0020,SKEXP0050,SKEXP0110,SKEXP0120</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation, Context  
This PR adds AOT compatibility to the newly introduced text search API and to the new kernel function factory methods.  
   
### Description  
1. Removes a few no longer relevant `DynamicallyAccessedMembers` annotations for the `TRecord` generic parameter of the vector store API.  
2. Adds new AOT-compatible overloads to the new text search functionality and annotates the existing overload as not AOT-compatible.  
3. Adds new AOT-compatible overloads to the kernel function factory methods and annotates the existing overload as not AOT-compatible.  
4. Annotates the `Type` parameter of `TextSearchResultPropertyReader` with the `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]` attribute to inform the AOT trimmer not to trim the public properties of the type the class works with. The same changes bubble up to all APIs that use the reader.  
5. Suppresses AOT warnings for obsolete APIs.
6. Increases unit tests code coverage to be above 80%