### PR TITLE
Python: Return streaming tool call output to the caller

### DIFF
--- a/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
@@ -180,8 +180,6 @@ def generate_streaming_message_content(
                         file_id=file_id,
                     )
                 )
-        elif delta_block.type == "tool_calls":
-            print("hello")
 
     return StreamingChatMessageContent(role=role, name=assistant_name, items=items, choice_index=0)  # type: ignore
 

--- a/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
@@ -8,6 +8,7 @@ from openai.types.beta.threads.file_path_delta_annotation import FilePathDeltaAn
 from openai.types.beta.threads.image_file_content_block import ImageFileContentBlock
 from openai.types.beta.threads.image_file_delta_block import ImageFileDeltaBlock
 from openai.types.beta.threads.message_delta_event import MessageDeltaEvent
+from openai.types.beta.threads.runs import CodeInterpreterLogs
 from openai.types.beta.threads.runs.code_interpreter_tool_call import CodeInterpreter
 from openai.types.beta.threads.text_content_block import TextContentBlock
 from openai.types.beta.threads.text_delta_block import TextDeltaBlock
@@ -179,6 +180,8 @@ def generate_streaming_message_content(
                         file_id=file_id,
                     )
                 )
+        elif delta_block.type == "tool_calls":
+            print("hello")
 
     return StreamingChatMessageContent(role=role, name=assistant_name, items=items, choice_index=0)  # type: ignore
 
@@ -261,7 +264,45 @@ def generate_code_interpreter_content(agent_name: str, code: str) -> "ChatMessag
 
 
 @experimental_function
-def generate_streaming_tools_content(
+def generate_streaming_function_content(
+    agent_name: str, step_details: "ToolCallsStepDetails"
+) -> "StreamingChatMessageContent":
+    """Generate streaming function content.
+
+    Args:
+        agent_name: The agent name.
+        step_details: The function step.
+
+    Returns:
+        StreamingChatMessageContent: The chat message content.
+    """
+    items: list[FunctionCallContent] = []
+
+    for tool in step_details.tool_calls:
+        if tool.type == "function":
+            items.append(
+                FunctionCallContent(
+                    id=tool.id,
+                    index=getattr(tool, "index", None),
+                    name=tool.function.name,
+                    arguments=tool.function.arguments,
+                )
+            )
+
+    return (
+        StreamingChatMessageContent(
+            role=AuthorRole.ASSISTANT,
+            name=agent_name,
+            items=items,  # type: ignore
+            choice_index=0,
+        )
+        if len(items) > 0
+        else None
+    )
+
+
+@experimental_function
+def generate_streaming_code_interpreter_content(
     agent_name: str, step_details: "ToolCallsStepDetails"
 ) -> "StreamingChatMessageContent | None":
     """Generate code interpreter content.
@@ -277,29 +318,34 @@ def generate_streaming_tools_content(
 
     metadata: dict[str, bool] = {}
     for index, tool in enumerate(step_details.tool_calls):
-        if tool.type != "code_interpreter":
-            continue
-        if tool.code_interpreter.input:
-            items.append(
-                StreamingTextContent(
-                    choice_index=index,
-                    text=tool.code_interpreter.input,
-                )
-            )
-            metadata["code"] = True
-        if len(tool.code_interpreter.outputs) > 0:
-            for output in tool.code_interpreter.outputs:
-                assert isinstance(output, CodeInterpreter)  # nosec
-                if output.image.file_id:
-                    items.append(
-                        StreamingFileReferenceContent(
-                            file_id=output.image.file_id,
-                        )
+        if tool.type == "code_interpreter":
+            if tool.code_interpreter.input:
+                items.append(
+                    StreamingTextContent(
+                        choice_index=index,
+                        text=tool.code_interpreter.input,
                     )
+                )
+                metadata["code"] = True
+            if tool.code_interpreter.outputs:
+                for output in tool.code_interpreter.outputs:
+                    if isinstance(output, CodeInterpreter) and output.image.file_id:
+                        items.append(
+                            StreamingFileReferenceContent(
+                                file_id=output.image.file_id,
+                            )
+                        )
+                    if isinstance(output, CodeInterpreterLogs) and output.logs:
+                        items.append(
+                            StreamingTextContent(
+                                choice_index=index,
+                                text=output.logs,
+                            )
+                        )
 
     return (
         StreamingChatMessageContent(
-            role=AuthorRole.TOOL,
+            role=AuthorRole.ASSISTANT,
             name=agent_name,
             items=items,  # type: ignore
             choice_index=0,

--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
@@ -24,8 +24,9 @@ from semantic_kernel.agents.open_ai.assistant_content_generation import (
     generate_function_call_content,
     generate_function_result_content,
     generate_message_content,
+    generate_streaming_code_interpreter_content,
+    generate_streaming_function_content,
     generate_streaming_message_content,
-    generate_streaming_tools_content,
     get_function_call_contents,
     get_message_contents,
 )
@@ -921,10 +922,22 @@ class OpenAIAssistantBase(Agent):
                             message_id = event.data.step_details.message_creation.message_id
                             if message_id not in active_messages:
                                 active_messages[message_id] = event.data
-                        elif hasattr(event.data.step_details, "tool_calls"):
-                            tool_content = generate_streaming_tools_content(self.name, event.data.step_details)
-                            if tool_content:
-                                yield tool_content
+                    elif event.event == "thread.run.step.delta":
+                        step_details = event.data.delta.step_details
+                        if (
+                            step_details is not None
+                            and hasattr(step_details, "tool_calls")
+                            and step_details.tool_calls is not None
+                            and isinstance(step_details.tool_calls, list)
+                        ):
+                            for tool_call in step_details.tool_calls:
+                                tool_content = None
+                                if tool_call.type == "function":
+                                    tool_content = generate_streaming_function_content(self.name, step_details)
+                                elif tool_call.type == "code_interpreter":
+                                    tool_content = generate_streaming_code_interpreter_content(self.name, step_details)
+                                if tool_content:
+                                    yield tool_content
                     elif event.event == "thread.run.requires_action":
                         run = event.data
                         function_action_result = await self._handle_streaming_requires_action(run, function_steps)
@@ -933,8 +946,12 @@ class OpenAIAssistantBase(Agent):
                                 f"Function call required but no function steps found for agent `{self.name}` "
                                 f"thread: {thread_id}."
                             )
-                        if function_action_result.function_result_content and messages is not None:
-                            messages.append(function_action_result.function_result_content)
+                        if function_action_result.function_result_content:
+                            # Yield the function result content to the caller
+                            yield function_action_result.function_result_content
+                            if messages is not None:
+                                # Add the function result content to the messages list, if it exists
+                                messages.append(function_action_result.function_result_content)
                         if function_action_result.function_call_content:
                             if messages is not None:
                                 messages.append(function_action_result.function_call_content)

--- a/python/semantic_kernel/contents/binary_content.py
+++ b/python/semantic_kernel/contents/binary_content.py
@@ -85,7 +85,10 @@ class BinaryContent(KernelContent):
                     data_bytes=data, data_format=data_format, mime_type=mime_type or self.default_mime_type
                 )
         if uri is not None:
-            uri = FilePath(uri) if os.path.exists(uri) else Url(uri)
+            if isinstance(uri, str) and os.path.exists(uri):
+                uri = str(FilePath(uri))
+            elif isinstance(uri, str):
+                uri = Url(uri)
 
         super().__init__(uri=uri, **kwargs)
         self._data_uri = _data_uri


### PR DESCRIPTION
### Motivation and Context

The streaming function call content, function result content, or code interpreter output was not being streamed back to the caller chunk by chunk.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR enabled yielding the proper chunks to the caller based on handling the `thread.run.step.delta` event.
- Fixes #9352 
- Adds test coverage
- Fixes a separate mypy issue related to BinaryContent

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
