### PR TITLE
.Net: Scoping step Ids to a process.

### DIFF
--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/StepActor.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/StepActor.cs
@@ -506,7 +506,8 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
         foreach (var edge in this.GetEdgeForEvent(daprEvent.Id!))
         {
             DaprMessage message = DaprMessageFactory.CreateFromEdge(edge, daprEvent.Data);
-            var targetStep = this.ProxyFactory.CreateActorProxy<IMessageBuffer>(new ActorId(edge.OutputTarget.StepId), nameof(MessageBufferActor));
+            var scopedStepId = this.ScopedActorId(new ActorId(edge.OutputTarget.StepId));
+            var targetStep = this.ProxyFactory.CreateActorProxy<IMessageBuffer>(scopedStepId, nameof(MessageBufferActor));
             await targetStep.EnqueueAsync(message).ConfigureAwait(false);
         }
     }
@@ -516,21 +517,20 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// </summary>
     /// <param name="daprEvent">The event.</param>
     /// <returns>A <see cref="DaprEvent"/> with the correctly scoped namespace.</returns>
-    internal DaprEvent ScopedEvent(DaprEvent daprEvent)
+    private DaprEvent ScopedEvent(DaprEvent daprEvent)
     {
         Verify.NotNull(daprEvent);
         return daprEvent with { Namespace = $"{this.Name}_{this.Id}" };
     }
 
     /// <summary>
-    /// Generates a scoped event for the step.
+    /// Scopes the Id of a step within the process to the process.
     /// </summary>
-    /// <param name="processEvent">The event.</param>
-    /// <returns>A <see cref="DaprEvent"/> with the correctly scoped namespace.</returns>
-    internal DaprEvent ScopedEvent(KernelProcessEvent processEvent)
+    /// <param name="actorId">The actor Id to scope.</param>
+    /// <returns>A new <see cref="ActorId"/> which is scoped to the process.</returns>
+    private ActorId ScopedActorId(ActorId actorId)
     {
-        Verify.NotNull(processEvent);
-        return DaprEvent.FromKernelProcessEvent(processEvent, $"{this.Name}_{this.Id}");
+        return new ActorId($"{this.ParentProcessId}.{actorId.GetId()}");
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

The PR ensures that the Ids of steps within a Process are scoped to the processes when run within the Dapr runtime. This is required for running multiple instances of the same processes concurently since the actors are "universal" within the Dapr runtime and are identified only by their Id and Type.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
