### PR TITLE
Python: Add ability to specify a default timeout for the polling operation.

### DIFF
--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
@@ -93,7 +93,7 @@ class OpenAIAssistantBase(Agent):
 
     allowed_message_roles: ClassVar[list[str]] = [AuthorRole.USER, AuthorRole.ASSISTANT]
     polling_status: ClassVar[list[str]] = ["queued", "in_progress", "cancelling"]
-    error_message_states: ClassVar[list[str]] = ["failed", "canceled", "expired"]
+    error_message_states: ClassVar[list[str]] = ["failed", "canceled", "expired", "incomplete"]
 
     channel_type: ClassVar[type[AgentChannel]] = OpenAIAssistantChannel
 
@@ -1108,14 +1108,31 @@ class OpenAIAssistantBase(Agent):
             thread_id: The thread id.
 
         Returns:
-            The run.
+            The updated run.
         """
         logger.info(f"Polling run status: {run.id}, threadId: {thread_id}")
 
         count = 0
 
+        try:
+            run = await asyncio.wait_for(
+                self._poll_loop(run, thread_id, count), timeout=self.polling_options.run_polling_timeout.total_seconds()
+            )
+        except asyncio.TimeoutError:
+            timeout_duration = self.polling_options.run_polling_timeout
+            logger.error(
+                f"Polling timed out for run id: `{run.id}` and thread id: `{thread_id}` after waiting {timeout_duration}."  # noqa: E501
+            )
+            raise AgentInvokeException(
+                f"Polling timed out for run id: `{run.id}` and thread id: `{thread_id}` after waiting {timeout_duration}."  # noqa: E501
+            )
+
+        logger.info(f"Polled run status: {run.status}, {run.id}, threadId: {thread_id}")
+        return run
+
+    async def _poll_loop(self, run: Run, thread_id: str, count: int) -> Run:
+        """Internal polling loop."""
         while True:
-            # Reduce polling frequency after a couple attempts
             await asyncio.sleep(self.polling_options.get_polling_interval(count).total_seconds())
             count += 1
 
@@ -1128,7 +1145,6 @@ class OpenAIAssistantBase(Agent):
             if run.status not in self.polling_status:
                 break
 
-        logger.info(f"Polled run status: {run.status}, {run.id}, threadId: {thread_id}")
         return run
 
     async def _retrieve_message(self, thread_id: str, message_id: str) -> Message | None:

--- a/python/semantic_kernel/agents/open_ai/run_polling_options.py
+++ b/python/semantic_kernel/agents/open_ai/run_polling_options.py
@@ -20,6 +20,7 @@ class RunPollingOptions(KernelBaseModel):
     run_polling_backoff: timedelta = Field(default=timedelta(seconds=1))
     run_polling_backoff_threshold: int = Field(default=2)
     message_synchronization_delay: timedelta = Field(default=timedelta(milliseconds=250))
+    run_polling_timeout: timedelta = Field(default=timedelta(minutes=1))  # New timeout attribute
 
     def get_polling_interval(self, iteration_count: int) -> timedelta:
         """Get the polling interval for the given iteration count."""

--- a/python/tests/unit/agents/test_open_ai_assistant_base.py
+++ b/python/tests/unit/agents/test_open_ai_assistant_base.py
@@ -281,6 +281,32 @@ def mock_run_completed():
 
 
 @pytest.fixture
+def mock_run_incomplete():
+    return Run(
+        id="run_id",
+        status="incomplete",
+        assistant_id="assistant_id",
+        created_at=123456789,
+        instructions="instructions",
+        model="model",
+        object="thread.run",
+        thread_id="thread_id",
+        tools=[],
+        required_action=RequiredAction(
+            type="submit_tool_outputs",
+            submit_tool_outputs=RequiredActionSubmitToolOutputs(
+                tool_calls=[
+                    RequiredActionFunctionToolCall(
+                        id="tool_call_id", type="function", function=Function(arguments="{}", name="function_name")
+                    )
+                ]
+            ),
+        ),
+        parallel_tool_calls=True,
+    )
+
+
+@pytest.fixture
 def mock_function_call_content():
     return FunctionCallContent(id="function_call_id", name="function_name", arguments={})
 
@@ -1522,10 +1548,40 @@ async def test_poll_run_status(
 
         mock_client.beta.threads.runs.retrieve = AsyncMock(return_value=mock_run_completed)
 
+        # Test successful polling
         run = await azure_openai_assistant_agent._poll_run_status(
             run=mock_run_required_action, thread_id="test_thread_id"
         )
-        assert run.status == "completed"
+        assert run.status == "completed", f"Expected status 'completed', but got '{run.status}'"
+
+        # Test timeout scenario
+        mock_client.beta.threads.runs.retrieve = AsyncMock(side_effect=TimeoutError)
+        azure_openai_assistant_agent.polling_options.run_polling_timeout = timedelta(milliseconds=10)
+
+        with pytest.raises(AgentInvokeException) as excinfo:
+            await azure_openai_assistant_agent._poll_run_status(
+                run=mock_run_required_action, thread_id="test_thread_id"
+            )
+
+        assert "Polling timed out" in str(excinfo.value)
+        assert f"after waiting {azure_openai_assistant_agent.polling_options.run_polling_timeout}" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_poll_run_status_incomplete_throws(
+    azure_openai_assistant_agent, mock_run_required_action, mock_run_incomplete, openai_unit_test_env
+):
+    with patch.object(azure_openai_assistant_agent, "client", spec=AsyncAzureOpenAI) as mock_client:
+        mock_client.beta = MagicMock()
+        mock_client.beta.assistants = MagicMock()
+
+        mock_client.beta.threads.runs.retrieve = AsyncMock(return_value=mock_run_incomplete)
+
+        run = await azure_openai_assistant_agent._poll_run_status(
+            run=mock_run_required_action, thread_id="test_thread_id"
+        )
+
+        assert run.status in azure_openai_assistant_agent.error_message_states
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation and Context

With OpenAI assistants there is currently no way to specify a polling timeout. For long running operations, or other ones that fail to complete this can be dangerous as the polling code could run infinitely, theoretically. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR adds the ability to specify a `run_polling_timeout` attribute as part of the `run_polling_options`. 
- Adds the `incomplete` status to the list of error states. 
- Adds a unit test for the run polling timeout as well as the incomplete returned state.
- Closes #9364 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
