### PR TITLE
Python: Allow caller to specify file ids that already exist when creating assistant

### DIFF
--- a/python/samples/concepts/agents/assistant_agent_file_manipulation_streaming.py
+++ b/python/samples/concepts/agents/assistant_agent_file_manipulation_streaming.py
@@ -20,7 +20,7 @@ AGENT_INSTRUCTIONS = "Find answers to the user's questions in the provided file.
 
 
 # A helper method to invoke the agent with the user input
-async def invoke_streaming_agent(agent: OpenAIAssistantAgent, thread_id: str, input: str) -> None:
+async def invoke_streaming_agent(agent: OpenAIAssistantAgent | AzureAssistantAgent, thread_id: str, input: str) -> None:
     """Invoke the streaming agent with the user input."""
     await agent.add_chat_message(thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=input))
 

--- a/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
@@ -192,8 +192,10 @@ class AzureAssistantAgent(OpenAIAssistantBase):
         name: str | None = None,
         enable_code_interpreter: bool | None = None,
         code_interpreter_filenames: list[str] | None = None,
+        code_interpreter_file_ids: list[str] | None = None,
         enable_file_search: bool | None = None,
         vector_store_filenames: list[str] | None = None,
+        vector_store_file_ids: list[str] | None = None,
         enable_json_response: bool | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
@@ -226,8 +228,10 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             name: The Agent name. (optional)
             enable_code_interpreter: Enable the code interpreter. (optional)
             code_interpreter_filenames: The filenames/paths to use with the code interpreter. (optional)
+            code_interpreter_file_ids: The existing file IDs to use with the code interpreter. (optional)
             enable_file_search: Enable the file search. (optional)
             vector_store_filenames: The filenames/paths for files to use with file search. (optional)
+            vector_store_file_ids: The existing file IDs to use with file search. (optional)
             enable_json_response: Enable the JSON response. (optional)
             temperature: The temperature. (optional)
             top_p: The top p. (optional)
@@ -275,33 +279,44 @@ class AzureAssistantAgent(OpenAIAssistantBase):
 
         assistant_create_kwargs: dict[str, Any] = {}
 
+        code_interpreter_file_ids_combined: list[str] = []
+
+        if code_interpreter_file_ids is not None:
+            code_interpreter_file_ids_combined.extend(code_interpreter_file_ids)
+
         if code_interpreter_filenames is not None:
-            code_interpreter_file_ids: list[str] = []
             for file_path in code_interpreter_filenames:
                 try:
                     file_id = await agent.add_file(file_path=file_path, purpose="assistants")
-                    code_interpreter_file_ids.append(file_id)
+                    code_interpreter_file_ids_combined.append(file_id)
                 except FileNotFoundError as ex:
                     logger.error(
                         f"Failed to upload code interpreter file with path: `{file_path}` with exception: {ex}"
                     )
                     raise AgentInitializationException("Failed to upload code interpreter files.", ex) from ex
-            agent.code_interpreter_file_ids = code_interpreter_file_ids
-            assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids
+
+        if code_interpreter_file_ids_combined:
+            agent.code_interpreter_file_ids = code_interpreter_file_ids_combined
+            assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids_combined
+
+        vector_store_file_ids_combined: list[str] = []
+
+        if vector_store_file_ids is not None:
+            vector_store_file_ids_combined.extend(vector_store_file_ids)
 
         if vector_store_filenames is not None:
-            file_search_file_ids: list[str] = []
             for file_path in vector_store_filenames:
                 try:
                     file_id = await agent.add_file(file_path=file_path, purpose="assistants")
-                    file_search_file_ids.append(file_id)
+                    vector_store_file_ids_combined.append(file_id)
                 except FileNotFoundError as ex:
-                    logger.error(f"Failed to upload file search file with path: `{file_path}` with exception: {ex}")
-                    raise AgentInitializationException("Failed to upload file search files.", ex) from ex
+                    logger.error(f"Failed to upload vector store file with path: `{file_path}` with exception: {ex}")
+                    raise AgentInitializationException("Failed to upload vector store files.", ex) from ex
 
+        if vector_store_file_ids_combined:
+            agent.file_search_file_ids = vector_store_file_ids_combined
             if enable_file_search or agent.enable_file_search:
-                vector_store_id = await agent.create_vector_store(file_ids=file_search_file_ids)
-                agent.file_search_file_ids = file_search_file_ids
+                vector_store_id = await agent.create_vector_store(file_ids=vector_store_file_ids_combined)
                 agent.vector_store_id = vector_store_id
                 assistant_create_kwargs["vector_store_id"] = vector_store_id
 

--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
@@ -165,8 +165,10 @@ class OpenAIAssistantAgent(OpenAIAssistantBase):
         name: str | None = None,
         enable_code_interpreter: bool | None = None,
         code_interpreter_filenames: list[str] | None = None,
+        code_interpreter_file_ids: list[str] | None = None,
         enable_file_search: bool | None = None,
         vector_store_filenames: list[str] | None = None,
+        vector_store_file_ids: list[str] | None = None,
         enable_json_response: bool | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
@@ -195,9 +197,11 @@ class OpenAIAssistantAgent(OpenAIAssistantBase):
             instructions: The assistant instructions. (optional)
             name: The assistant name. (optional)
             enable_code_interpreter: Enable code interpreter. (optional)
-            code_interpreter_filenames: The filenames/paths for files to use with file search. (optional)
-            enable_file_search: Enable file search. (optional)
-            vector_store_filenames: The list of file paths to upload and attach to the file search. (optional)
+            code_interpreter_filenames: The filenames/paths for files to use with code interpreter. (optional)
+            code_interpreter_file_ids: The existing file IDs to use with the code interpreter. (optional)
+            enable_file_search: Enable the file search. (optional)
+            vector_store_filenames: The filenames/paths for files to use with file search. (optional)
+            vector_store_file_ids: The existing file IDs to use with file search. (optional)
             enable_json_response: Enable JSON response. (optional)
             temperature: The temperature. (optional)
             top_p: The top p. (optional)
@@ -242,33 +246,44 @@ class OpenAIAssistantAgent(OpenAIAssistantBase):
 
         assistant_create_kwargs: dict[str, Any] = {}
 
+        code_interpreter_file_ids_combined: list[str] = []
+
+        if code_interpreter_file_ids is not None:
+            code_interpreter_file_ids_combined.extend(code_interpreter_file_ids)
+
         if code_interpreter_filenames is not None:
-            code_interpreter_file_ids: list[str] = []
             for file_path in code_interpreter_filenames:
                 try:
                     file_id = await agent.add_file(file_path=file_path, purpose="assistants")
-                    code_interpreter_file_ids.append(file_id)
+                    code_interpreter_file_ids_combined.append(file_id)
                 except FileNotFoundError as ex:
                     logger.error(
                         f"Failed to upload code interpreter file with path: `{file_path}` with exception: {ex}"
                     )
                     raise AgentInitializationException("Failed to upload code interpreter files.", ex) from ex
-            agent.code_interpreter_file_ids = code_interpreter_file_ids
-            assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids
+
+        if code_interpreter_file_ids_combined:
+            agent.code_interpreter_file_ids = code_interpreter_file_ids_combined
+            assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids_combined
+
+        vector_store_file_ids_combined: list[str] = []
+
+        if vector_store_file_ids is not None:
+            vector_store_file_ids_combined.extend(vector_store_file_ids)
 
         if vector_store_filenames is not None:
-            file_search_file_ids: list[str] = []
             for file_path in vector_store_filenames:
                 try:
                     file_id = await agent.add_file(file_path=file_path, purpose="assistants")
-                    file_search_file_ids.append(file_id)
+                    vector_store_file_ids_combined.append(file_id)
                 except FileNotFoundError as ex:
-                    logger.error(f"Failed to upload file search file with path: `{file_path}` with exception: {ex}")
-                    raise AgentInitializationException("Failed to upload file search files.", ex) from ex
+                    logger.error(f"Failed to upload vector store file with path: `{file_path}` with exception: {ex}")
+                    raise AgentInitializationException("Failed to upload vector store files.", ex) from ex
 
+        if vector_store_file_ids_combined:
+            agent.file_search_file_ids = vector_store_file_ids_combined
             if enable_file_search or agent.enable_file_search:
-                vector_store_id = await agent.create_vector_store(file_ids=file_search_file_ids)
-                agent.file_search_file_ids = file_search_file_ids
+                vector_store_id = await agent.create_vector_store(file_ids=vector_store_file_ids_combined)
                 agent.vector_store_id = vector_store_id
                 assistant_create_kwargs["vector_store_id"] = vector_store_id
 

--- a/python/tests/unit/agents/test_azure_assistant_agent.py
+++ b/python/tests/unit/agents/test_azure_assistant_agent.py
@@ -167,7 +167,7 @@ async def test_create_agent_with_search_files_not_found_raises_exception(kernel:
         patch.object(AzureAssistantAgent, "create_assistant", new_callable=AsyncMock) as mock_create_assistant,
     ):
         mock_create_assistant.return_value = MagicMock(spec=Assistant)
-        with pytest.raises(AgentInitializationException, match="Failed to upload file search files."):
+        with pytest.raises(AgentInitializationException, match="Failed to upload vector store files."):
             _ = await AzureAssistantAgent.create(
                 kernel=kernel,
                 service_id="test_service",

--- a/python/tests/unit/agents/test_open_ai_assistant_agent.py
+++ b/python/tests/unit/agents/test_open_ai_assistant_agent.py
@@ -195,7 +195,7 @@ async def test_create_agent_with_search_files_not_found_raises_exception(kernel:
         patch.object(OpenAIAssistantAgent, "create_assistant", new_callable=AsyncMock) as mock_create_assistant,
     ):
         mock_create_assistant.return_value = MagicMock(spec=Assistant)
-        with pytest.raises(AgentInitializationException, match="Failed to upload file search files."):
+        with pytest.raises(AgentInitializationException, match="Failed to upload vector store files."):
             _ = await OpenAIAssistantAgent.create(
                 kernel=kernel,
                 service_id="test_service",


### PR DESCRIPTION
### Motivation and Context

Today, when creating an OpenAI Assistant Agent, one can specify vector store file names or code interpreter files names (paths to files) that will be uploaded and used. If one wants to include a file ID that was already uploaded, this isn't possible.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR allows for users to specify file IDs that were already uploaded.
- Closes #9159 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
