### PR TITLE
.Net: Fix mapping issue of the required payload properties

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -328,7 +328,7 @@ internal sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null
         var mediaType = s_supportedMediaTypes.FirstOrDefault(requestBody.Content.ContainsKey) ?? throw new KernelException($"Neither of the media types of {operationId} is supported.");
         var mediaTypeMetadata = requestBody.Content[mediaType];
 
-        var payloadProperties = GetPayloadProperties(operationId, mediaTypeMetadata.Schema, mediaTypeMetadata.Schema?.Required ?? new HashSet<string>());
+        var payloadProperties = GetPayloadProperties(operationId, mediaTypeMetadata.Schema);
 
         return new RestApiOperationPayload(mediaType, payloadProperties, requestBody.Description, mediaTypeMetadata?.Schema?.ToJsonSchema());
     }
@@ -353,11 +353,9 @@ internal sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null
     /// </summary>
     /// <param name="operationId">The operation id.</param>
     /// <param name="schema">An OpenAPI document schema representing request body properties.</param>
-    /// <param name="requiredProperties">List of required properties.</param>
     /// <param name="level">Current level in OpenAPI schema.</param>
     /// <returns>The REST API operation payload properties.</returns>
-    private static List<RestApiOperationPayloadProperty> GetPayloadProperties(string operationId, OpenApiSchema? schema, ISet<string> requiredProperties,
-        int level = 0)
+    private static List<RestApiOperationPayloadProperty> GetPayloadProperties(string operationId, OpenApiSchema? schema, int level = 0)
     {
         if (schema is null)
         {
@@ -380,8 +378,8 @@ internal sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null
             var property = new RestApiOperationPayloadProperty(
                 propertyName,
                 propertySchema.Type,
-                requiredProperties.Contains(propertyName),
-                GetPayloadProperties(operationId, propertySchema, requiredProperties, level + 1),
+                schema.Required.Contains(propertyName),
+                GetPayloadProperties(operationId, propertySchema, level + 1),
                 propertySchema.Description,
                 propertySchema.Format,
                 propertySchema.ToJsonSchema(),

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
@@ -81,13 +81,23 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
 
         var enabledProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "enabled");
         Assert.NotNull(enabledProperty);
-        Assert.False(enabledProperty.IsRequired);
+        Assert.True(enabledProperty.IsRequired);
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
         Assert.Equal("boolean", enabledProperty.Type);
         Assert.False(enabledProperty.Properties?.Any());
         Assert.NotNull(enabledProperty.Schema);
         Assert.Equal("boolean", enabledProperty.Schema.RootElement.GetProperty("type").GetString());
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Schema.RootElement.GetProperty("description").GetString());
+
+        var encryptedProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "encrypted");
+        Assert.NotNull(encryptedProperty);
+        Assert.False(encryptedProperty.IsRequired);
+        Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Description);
+        Assert.Equal("boolean", encryptedProperty.Type);
+        Assert.False(encryptedProperty.Properties?.Any());
+        Assert.NotNull(encryptedProperty.Schema);
+        Assert.Equal("boolean", encryptedProperty.Schema.RootElement.GetProperty("type").GetString());
+        Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Schema.RootElement.GetProperty("description").GetString());
     }
 
     [Fact]

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
@@ -82,13 +82,23 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
 
         var enabledProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "enabled");
         Assert.NotNull(enabledProperty);
-        Assert.False(enabledProperty.IsRequired);
+        Assert.True(enabledProperty.IsRequired);
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
         Assert.Equal("boolean", enabledProperty.Type);
         Assert.False(enabledProperty.Properties?.Any());
         Assert.NotNull(enabledProperty.Schema);
         Assert.Equal("boolean", enabledProperty.Schema.RootElement.GetProperty("type").GetString());
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Schema.RootElement.GetProperty("description").GetString());
+
+        var encryptedProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "encrypted");
+        Assert.NotNull(encryptedProperty);
+        Assert.False(encryptedProperty.IsRequired);
+        Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Description);
+        Assert.Equal("boolean", encryptedProperty.Type);
+        Assert.False(encryptedProperty.Properties?.Any());
+        Assert.NotNull(encryptedProperty.Schema);
+        Assert.Equal("boolean", encryptedProperty.Schema.RootElement.GetProperty("type").GetString());
+        Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Schema.RootElement.GetProperty("description").GetString());
     }
 
     [Fact]

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
@@ -82,13 +82,23 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
 
         var enabledProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "enabled");
         Assert.NotNull(enabledProperty);
-        Assert.False(enabledProperty.IsRequired);
+        Assert.True(enabledProperty.IsRequired);
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
         Assert.Equal("boolean", enabledProperty.Type);
         Assert.False(enabledProperty.Properties?.Any());
         Assert.NotNull(enabledProperty.Schema);
         Assert.Equal("boolean", enabledProperty.Schema.RootElement.GetProperty("type").GetString());
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Schema.RootElement.GetProperty("description").GetString());
+
+        var encryptedProperty = attributesProperty.Properties.FirstOrDefault(p => p.Name == "encrypted");
+        Assert.NotNull(encryptedProperty);
+        Assert.False(encryptedProperty.IsRequired);
+        Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Description);
+        Assert.Equal("boolean", encryptedProperty.Type);
+        Assert.False(encryptedProperty.Properties?.Any());
+        Assert.NotNull(encryptedProperty.Schema);
+        Assert.Equal("boolean", encryptedProperty.Schema.RootElement.GetProperty("type").GetString());
+        Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Schema.RootElement.GetProperty("description").GetString());
     }
 
     [Fact]

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV2_0.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV2_0.json
@@ -105,8 +105,15 @@
                     "enabled": {
                       "description": "Determines whether the object is enabled.",
                       "type": "boolean"
+                    },
+                    "encrypted": {
+                      "description": "Determines whether the object is encrypted.",
+                      "type": "boolean"
                     }
                   },
+                  "required": [
+                    "enabled"
+                  ],
                   "type": "object"
                 },
                 "value": {

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_0.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_0.json
@@ -151,8 +151,15 @@
                       "enabled": {
                         "type": "boolean",
                         "description": "Determines whether the object is enabled."
+                      },
+                      "encrypted": {
+                        "type": "boolean",
+                        "description": "Determines whether the object is encrypted."
                       }
                     },
+                    "required": [
+                      "enabled"
+                    ],
                     "description": "attributes"
                   },
                   "value": {

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_1.yaml
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/documentV3_1.yaml
@@ -105,6 +105,11 @@ paths:
                     enabled:
                       type: boolean
                       description: Determines whether the object is enabled.
+                    encrypted:
+                      type: boolean
+                      description: Determines whether the object is encrypted.
+                  required:
+                    - enabled
                   description: attributes
                 value:
                   type: string


### PR DESCRIPTION
### Motivation, Context and Description
This PR fixes the issue of mapping the `required` flag in the OpenAPI document to the `IsRequired` property of the `RestApiOperationPayloadProperty` model class, which manifested for descendants of the root payload properties.