### PR TITLE
.Net Processes - Update Runtime Exception Handling / Logging

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -91,7 +91,7 @@
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.21" />
     <PackageVersion Include="Microsoft.OpenApi.ApiManifest" Version="0.5.4-preview" />
     <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="[1.60.0.3001, )" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
     <PackageVersion Include="protobuf-net" Version="3.2.30" />
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.12" />
     <PackageVersion Include="YamlDotNet" Version="15.3.0" />

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalKernelProcessContext.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalKernelProcessContext.cs
@@ -15,45 +15,39 @@ public sealed class LocalKernelProcessContext : IDisposable
 
     internal LocalKernelProcessContext(KernelProcess process, Kernel kernel)
     {
-        Verify.NotNull(process);
+        Verify.NotNull(process, nameof(process));
+        Verify.NotNull(kernel, nameof(kernel));
         Verify.NotNullOrWhiteSpace(process.State?.Name);
-        Verify.NotNull(kernel);
 
         this._kernel = kernel;
-        this._localProcess = new LocalProcess(
-            process,
-            kernel: kernel,
-            parentProcessId: null,
-            loggerFactory: null);
+        this._localProcess = new LocalProcess(process, kernel);
     }
 
-    internal async Task StartWithEventAsync(KernelProcessEvent? initialEvent, Kernel? kernel = null)
-    {
-        await this._localProcess.RunOnceAsync(initialEvent).ConfigureAwait(false);
-    }
+    internal Task StartWithEventAsync(KernelProcessEvent? initialEvent, Kernel? kernel = null) =>
+        this._localProcess.RunOnceAsync(initialEvent, kernel);
 
     /// <summary>
     /// Sends a message to the process.
     /// </summary>
     /// <param name="processEvent">The event to sent to the process.</param>
     /// <returns>A <see cref="Task"/></returns>
-    public async Task SendEventAsync(KernelProcessEvent processEvent) =>
-        await this._localProcess.SendMessageAsync(processEvent).ConfigureAwait(false);
+    public Task SendEventAsync(KernelProcessEvent processEvent) =>
+        this._localProcess.SendMessageAsync(processEvent);
 
     /// <summary>
     /// Stops the process.
     /// </summary>
     /// <returns>A <see cref="Task"/></returns>
-    public async Task StopAsync() => await this._localProcess.StopAsync().ConfigureAwait(false);
+    public Task StopAsync() => this._localProcess.StopAsync();
 
     /// <summary>
     /// Gets a snapshot of the current state of the process.
     /// </summary>
     /// <returns>A <see cref="Task{T}"/> where T is <see cref="KernelProcess"/></returns>
-    public async Task<KernelProcess> GetStateAsync() => await this._localProcess.GetProcessInfoAsync().ConfigureAwait(false);
+    public Task<KernelProcess> GetStateAsync() => this._localProcess.GetProcessInfoAsync();
 
     /// <summary>
     /// Disposes of the resources used by the process.
     /// </summary>
-    public void Dispose() => this._localProcess?.Dispose();
+    public void Dispose() => this._localProcess.Dispose();
 }

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalProcess.cs
@@ -35,9 +35,8 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     /// <param name="process">The <see cref="KernelProcess"/> instance.</param>
     /// <param name="kernel">An instance of <see cref="Kernel"/></param>
     /// <param name="parentProcessId">Optional. The Id of the parent process if one exists, otherwise null.</param>
-    /// <param name="loggerFactory">Optional. A <see cref="ILoggerFactory"/>.</param>
-    internal LocalProcess(KernelProcess process, Kernel kernel, string? parentProcessId = null, ILoggerFactory? loggerFactory = null)
-        : base(process, kernel, parentProcessId, loggerFactory)
+    internal LocalProcess(KernelProcess process, Kernel kernel, string? parentProcessId = null)
+        : base(process, kernel, parentProcessId)
     {
         Verify.NotNull(process.Steps);
 
@@ -47,7 +46,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
         this._externalEventChannel = Channel.CreateUnbounded<KernelProcessEvent>();
         this._joinableTaskContext = new JoinableTaskContext();
         this._joinableTaskFactory = new JoinableTaskFactory(this._joinableTaskContext);
-        this._logger = this.LoggerFactory?.CreateLogger(this.Name) ?? new NullLogger<LocalStep>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this.Name) ?? new NullLogger<LocalStep>();
     }
 
     /// <summary>
@@ -75,7 +74,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     /// <returns>A <see cref="Task"/></returns>
     internal async Task RunOnceAsync(KernelProcessEvent? processEvent, Kernel? kernel = null)
     {
-        Verify.NotNull(processEvent);
+        Verify.NotNull(processEvent, nameof(processEvent));
         await this._externalEventChannel.Writer.WriteAsync(processEvent).ConfigureAwait(false);
         await this.StartAsync(kernel, keepAlive: false).ConfigureAwait(false);
         await this._processTask!.JoinAsync().ConfigureAwait(false);
@@ -116,20 +115,17 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     /// <param name="processEvent">Required. The <see cref="KernelProcessEvent"/> to start the process with.</param>
     /// <param name="kernel">Optional. A <see cref="Kernel"/> to use when executing the process.</param>
     /// <returns>A <see cref="Task"/></returns>
-    internal async Task SendMessageAsync(KernelProcessEvent processEvent, Kernel? kernel = null)
+    internal Task SendMessageAsync(KernelProcessEvent processEvent, Kernel? kernel = null)
     {
-        Verify.NotNull(processEvent);
-        await this._externalEventChannel.Writer.WriteAsync(processEvent).ConfigureAwait(false);
+        Verify.NotNull(processEvent, nameof(processEvent));
+        return this._externalEventChannel.Writer.WriteAsync(processEvent).AsTask();
     }
 
     /// <summary>
     /// Gets the process information.
     /// </summary>
     /// <returns>An instance of <see cref="KernelProcess"/></returns>
-    internal async Task<KernelProcess> GetProcessInfoAsync()
-    {
-        return await this.ToKernelProcessAsync().ConfigureAwait(false);
-    }
+    internal Task<KernelProcess> GetProcessInfoAsync() => this.ToKernelProcessAsync();
 
     /// <summary>
     /// Handles a <see cref="ProcessMessage"/> that has been sent to the process. This happens only in the case
@@ -143,9 +139,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
     {
         if (string.IsNullOrWhiteSpace(message.TargetEventId))
         {
-            string errorMessage = "Internal Process Error: The target event id must be specified when sending a message to a step.";
-            this._logger.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("Internal Process Error: The target event id must be specified when sending a message to a step.").Log(this._logger);
         }
 
         string eventId = message.TargetEventId!;
@@ -190,8 +184,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
                 var process = new LocalProcess(
                     process: kernelStep,
                     kernel: this._kernel,
-                    parentProcessId: this.Id,
-                    loggerFactory: this.LoggerFactory);
+                    parentProcessId: this.Id);
 
                 //await process.StartAsync(kernel: this._kernel, keepAlive: true).ConfigureAwait(false);
                 localStep = process;
@@ -204,8 +197,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
                 localStep = new LocalStep(
                     stepInfo: step,
                     kernel: this._kernel,
-                    parentProcessId: this.Id,
-                    loggerFactory: this.LoggerFactory);
+                    parentProcessId: this.Id);
             }
 
             this._steps.Add(localStep);
@@ -282,7 +274,7 @@ internal sealed class LocalProcess : LocalStep, IDisposable
         }
         catch (Exception ex)
         {
-            this._logger?.LogError("An error occurred while running the process: {ErrorMessage}.", ex.Message);
+            this._logger?.LogError(ex, "An error occurred while running the process.");
             throw;
         }
         finally

--- a/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
+++ b/dotnet/src/Experimental/Process.LocalRuntime/LocalStep.cs
@@ -24,12 +24,11 @@ internal class LocalStep : IKernelProcessMessageChannel
     private readonly ILogger _logger;
 
     protected readonly Kernel _kernel;
+    protected readonly Dictionary<string, KernelFunction> _functions = [];
+
     protected KernelProcessStepState _stepState;
     protected Dictionary<string, Dictionary<string, object?>?>? _inputs = [];
     protected Dictionary<string, Dictionary<string, object?>?>? _initialInputs = [];
-    protected readonly Dictionary<string, KernelFunction> _functions = [];
-    protected readonly string? ParentProcessId;
-    protected readonly ILoggerFactory? LoggerFactory;
     protected Dictionary<string, List<KernelProcessEdge>> _outputEdges;
 
     /// <summary>
@@ -38,29 +37,33 @@ internal class LocalStep : IKernelProcessMessageChannel
     /// <param name="stepInfo">An instance of <see cref="KernelProcessStepInfo"/></param>
     /// <param name="kernel">Required. An instance of <see cref="Kernel"/>.</param>
     /// <param name="parentProcessId">Optional. The Id of the parent process if one exists.</param>
-    /// <param name="loggerFactory">An instance of <see cref="LoggerFactory"/> used to create loggers.</param>
-    public LocalStep(KernelProcessStepInfo stepInfo, Kernel kernel, string? parentProcessId = null, ILoggerFactory? loggerFactory = null)
+    public LocalStep(KernelProcessStepInfo stepInfo, Kernel kernel, string? parentProcessId = null)
     {
+        Verify.NotNull(kernel, nameof(kernel));
+        Verify.NotNull(stepInfo, nameof(stepInfo));
+
         // This special handling will be removed with the refactoring of KernelProcessState
         if (string.IsNullOrEmpty(stepInfo.State.Id) && stepInfo is KernelProcess)
         {
             stepInfo = stepInfo with { State = stepInfo.State with { Id = Guid.NewGuid().ToString() } };
         }
 
-        Verify.NotNull(stepInfo);
-        Verify.NotNull(kernel);
         Verify.NotNull(stepInfo.State.Id);
 
         this.ParentProcessId = parentProcessId;
-        this.LoggerFactory = loggerFactory;
         this._kernel = kernel;
         this._stepInfo = stepInfo;
         this._stepState = stepInfo.State;
         this._initializeTask = new Lazy<ValueTask>(this.InitializeStepAsync);
-        this._logger = this.LoggerFactory?.CreateLogger(this._stepInfo.InnerStepType) ?? new NullLogger<LocalStep>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._stepInfo.InnerStepType) ?? new NullLogger<LocalStep>();
         this._outputEdges = this._stepInfo.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
         this._eventNamespace = $"{this._stepInfo.State.Name}_{this._stepInfo.State.Id}";
     }
+
+    /// <summary>
+    /// The Id of the parent process if one exists.
+    /// </summary>
+    protected string? ParentProcessId { get; }
 
     /// <summary>
     /// The name of the step.
@@ -122,14 +125,14 @@ internal class LocalStep : IKernelProcessMessageChannel
     /// <exception cref="KernelException"></exception>
     internal virtual async Task HandleMessageAsync(ProcessMessage message)
     {
-        Verify.NotNull(message);
+        Verify.NotNull(message, nameof(message));
 
         // Lazy one-time initialization of the step before processing a message
         await this._initializeTask.Value.ConfigureAwait(false);
 
         if (this._functions is null || this._inputs is null || this._initialInputs is null)
         {
-            throw new KernelException("The step has not been initialized.");
+            throw new KernelException("The step has not been initialized.").Log(this._logger);
         }
 
         string messageLogParameters = string.Join(", ", message.Values.Select(kvp => $"{kvp.Key}: {kvp.Value}"));
@@ -232,18 +235,14 @@ internal class LocalStep : IKernelProcessMessageChannel
 
         if (stateObject is null)
         {
-            var errorMessage = "The state object for the KernelProcessStep could not be created.";
-            this._logger.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("The state object for the KernelProcessStep could not be created.").Log(this._logger);
         }
 
         MethodInfo? methodInfo = this._stepInfo.InnerStepType.GetMethod(nameof(KernelProcessStep.ActivateAsync), [stateType]);
 
         if (methodInfo is null)
         {
-            var errorMessage = "The ActivateAsync method for the KernelProcessStep could not be found.";
-            this._logger.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("The ActivateAsync method for the KernelProcessStep could not be found.").Log(this._logger);
         }
 
         this._stepState = stateObject;
@@ -251,9 +250,7 @@ internal class LocalStep : IKernelProcessMessageChannel
         ValueTask? activateTask = (ValueTask?)methodInfo.Invoke(stepInstance, [stateObject]);
         if (activateTask == null)
         {
-            var errorMessage = "The ActivateAsync method failed to complete.";
-            this._logger.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("The ActivateAsync method failed to complete.").Log(this._logger);
         }
 
         await stepInstance.ActivateAsync(stateObject).ConfigureAwait(false);
@@ -282,7 +279,7 @@ internal class LocalStep : IKernelProcessMessageChannel
         // This allows state information to be extracted even if the step has not been activated.
         await this._initializeTask.Value.ConfigureAwait(false);
 
-        var stepInfo = new KernelProcessStepInfo(this._stepInfo.InnerStepType, this._stepState!, this._outputEdges);
+        KernelProcessStepInfo stepInfo = new(this._stepInfo.InnerStepType, this._stepState!, this._outputEdges);
         return stepInfo;
     }
 
@@ -303,7 +300,7 @@ internal class LocalStep : IKernelProcessMessageChannel
     /// <returns>A <see cref="ProcessEvent"/> with the correctly scoped namespace.</returns>
     protected ProcessEvent ScopedEvent(ProcessEvent localEvent)
     {
-        Verify.NotNull(localEvent);
+        Verify.NotNull(localEvent, nameof(localEvent));
         return localEvent with { Namespace = $"{this.Name}_{this.Id}" };
     }
 
@@ -314,7 +311,7 @@ internal class LocalStep : IKernelProcessMessageChannel
     /// <returns>A <see cref="ProcessEvent"/> with the correctly scoped namespace.</returns>
     protected ProcessEvent ScopedEvent(KernelProcessEvent processEvent)
     {
-        Verify.NotNull(processEvent);
+        Verify.NotNull(processEvent, nameof(processEvent));
         return ProcessEvent.FromKernelProcessEvent(processEvent, $"{this.Name}_{this.Id}");
     }
 }

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/ProcessActor.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/ProcessActor.cs
@@ -36,9 +36,8 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     /// </summary>
     /// <param name="host">The Dapr host actor</param>
     /// <param name="kernel">An instance of <see cref="Kernel"/></param>
-    /// <param name="loggerFactory">Optional. A <see cref="ILoggerFactory"/>.</param>
-    public ProcessActor(ActorHost host, Kernel kernel, ILoggerFactory? loggerFactory)
-        : base(host, kernel, loggerFactory)
+    public ProcessActor(ActorHost host, Kernel kernel)
+        : base(host, kernel)
     {
         this._externalEventChannel = Channel.CreateUnbounded<KernelProcessEvent>();
         this._joinableTaskContext = new JoinableTaskContext();
@@ -78,7 +77,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     {
         if (!this._isInitialized)
         {
-            throw new InvalidOperationException("The process cannot be started before it has been initialized.");
+            throw new InvalidOperationException("The process cannot be started before it has been initialized.").Log(this._logger);
         }
 
         this._processCancelSource = new CancellationTokenSource();
@@ -96,7 +95,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     /// <returns>A <see cref="Task"/></returns>
     public async Task RunOnceAsync(KernelProcessEvent processEvent)
     {
-        Verify.NotNull(processEvent);
+        Verify.NotNull(processEvent, nameof(processEvent));
         var externalEventQueue = this.ProxyFactory.CreateActorProxy<IExternalEventBuffer>(new ActorId(this.Id.GetId()), nameof(ExternalEventBufferActor));
         await externalEventQueue.EnqueueAsync(processEvent).ConfigureAwait(false);
         await this.StartAsync(keepAlive: false).ConfigureAwait(false);
@@ -139,7 +138,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     /// <returns>A <see cref="Task"/></returns>
     public async Task SendMessageAsync(KernelProcessEvent processEvent)
     {
-        Verify.NotNull(processEvent);
+        Verify.NotNull(processEvent, nameof(processEvent));
         await this._externalEventChannel.Writer.WriteAsync(processEvent).ConfigureAwait(false);
     }
 
@@ -175,7 +174,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     /// <summary>
     /// The name of the step.
     /// </summary>
-    protected override string Name => this._process?.State.Name ?? throw new KernelException("The Process must be initialized before accessing the Name property.");
+    protected override string Name => this._process?.State.Name ?? throw new KernelException("The Process must be initialized before accessing the Name property.").Log(this._logger);
 
     #endregion
 
@@ -189,9 +188,7 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
     {
         if (string.IsNullOrWhiteSpace(message.TargetEventId))
         {
-            string errorMessage = "Internal Process Error: The target event id must be specified when sending a message to a step.";
-            this._logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("Internal Process Error: The target event id must be specified when sending a message to a step.").Log(this._logger);
         }
 
         string eventId = message.TargetEventId!;
@@ -223,13 +220,13 @@ internal sealed class ProcessActor : StepActor, IProcess, IDisposable
 
     private async Task InitializeProcessActorAsync(DaprProcessInfo processInfo, string? parentProcessId)
     {
-        Verify.NotNull(processInfo);
+        Verify.NotNull(processInfo, nameof(processInfo));
         Verify.NotNull(processInfo.Steps);
 
         this.ParentProcessId = parentProcessId;
         this._process = processInfo;
         this._stepsInfos = new List<DaprStepInfo>(this._process.Steps);
-        this._logger = this.LoggerFactory?.CreateLogger(this._process.State.Name) ?? new NullLogger<ProcessActor>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._process.State.Name) ?? new NullLogger<ProcessActor>();
 
         // Initialize the input and output edges for the process
         this._outputEdges = this._process.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/StepActor.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Actors/StepActor.cs
@@ -31,7 +31,6 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     internal Queue<ProcessMessage> _incomingMessages = new();
     internal KernelProcessStepState? _stepState;
     internal Type? _stepStateType;
-    internal readonly ILoggerFactory? LoggerFactory;
     internal Dictionary<string, List<KernelProcessEdge>>? _outputEdges;
     internal readonly Dictionary<string, KernelFunction> _functions = [];
     internal Dictionary<string, Dictionary<string, object?>?>? _inputs = [];
@@ -44,11 +43,9 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// </summary>
     /// <param name="host">The host.</param>
     /// <param name="kernel">Required. An instance of <see cref="Kernel"/>.</param>
-    /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/> used to create loggers.</param>
-    public StepActor(ActorHost host, Kernel kernel, ILoggerFactory? loggerFactory)
+    public StepActor(ActorHost host, Kernel kernel)
         : base(host)
     {
-        this.LoggerFactory = loggerFactory;
         this._kernel = kernel;
         this._activateTask = new Lazy<ValueTask>(this.ActivateStepAsync);
     }
@@ -63,7 +60,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// <returns>A <see cref="ValueTask"/></returns>
     public async Task InitializeStepAsync(DaprStepInfo stepInfo, string? parentProcessId)
     {
-        Verify.NotNull(stepInfo);
+        Verify.NotNull(stepInfo, nameof(stepInfo));
 
         // Only initialize once. This check is required as the actor can be re-activated from persisted state and
         // this should not result in multiple initializations.
@@ -88,21 +85,19 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// <returns>A <see cref="ValueTask"/></returns>
     public Task Int_InitializeStepAsync(DaprStepInfo stepInfo, string? parentProcessId)
     {
-        Verify.NotNull(stepInfo);
+        Verify.NotNull(stepInfo, nameof(stepInfo));
 
         // Attempt to load the inner step type
         this._innerStepType = Type.GetType(stepInfo.InnerStepDotnetType);
         if (this._innerStepType is null)
         {
-            var errorMessage = $"Could not load the inner step type '{stepInfo.InnerStepDotnetType}'.";
-            this._logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException($"Could not load the inner step type '{stepInfo.InnerStepDotnetType}'.").Log(this._logger);
         }
 
         this.ParentProcessId = parentProcessId;
         this._stepInfo = stepInfo;
         this._stepState = this._stepInfo.State;
-        this._logger = this.LoggerFactory?.CreateLogger(this._innerStepType) ?? new NullLogger<StepActor>();
+        this._logger = this._kernel.LoggerFactory?.CreateLogger(this._innerStepType) ?? new NullLogger<StepActor>();
         this._outputEdges = this._stepInfo.Edges.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
         this._eventNamespace = $"{this._stepInfo.State.Name}_{this._stepInfo.State.Id}";
         this._isInitialized = true;
@@ -188,7 +183,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// <summary>
     /// The name of the step.
     /// </summary>
-    protected virtual string Name => this._stepInfo?.State.Name ?? throw new KernelException("The Step must be initialized before accessing the Name property.");
+    protected virtual string Name => this._stepInfo?.State.Name ?? throw new KernelException("The Step must be initialized before accessing the Name property.").Log(this._logger);
 
     /// <summary>
     /// Emits an event from the step.
@@ -208,14 +203,14 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// <exception cref="KernelException"></exception>
     internal virtual async Task HandleMessageAsync(ProcessMessage message)
     {
-        Verify.NotNull(message);
+        Verify.NotNull(message, nameof(message));
 
         // Lazy one-time initialization of the step before processing a message
         await this._activateTask.Value.ConfigureAwait(false);
 
         if (this._functions is null || this._inputs is null || this._initialInputs is null)
         {
-            throw new KernelException("The step has not been initialized.");
+            throw new KernelException("The step has not been initialized.").Log(this._logger);
         }
 
         string messageLogParameters = string.Join(", ", message.Values.Select(kvp => $"{kvp.Key}: {kvp.Value}"));
@@ -251,7 +246,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
 
         // A message can only target one function and should not result in a different function being invoked.
         var targetFunction = invocableFunctions.FirstOrDefault((name) => name == message.FunctionName) ??
-            throw new InvalidOperationException($"A message targeting function '{message.FunctionName}' has resulted in a function named '{invocableFunctions.First()}' becoming invocable. Are the function names configured correctly?");
+            throw new InvalidOperationException($"A message targeting function '{message.FunctionName}' has resulted in a function named '{invocableFunctions.First()}' becoming invocable. Are the function names configured correctly?").Log(this._logger);
 
         this._logger?.LogInformation("Step with Id `{StepId}` received all required input for function [{TargetFunction}] and is executing.", this.Name, targetFunction);
 
@@ -259,7 +254,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
         KernelArguments arguments = new(this._inputs[targetFunction]!);
         if (!this._functions.TryGetValue(targetFunction, out KernelFunction? function) || function == null)
         {
-            throw new ArgumentException($"Function {targetFunction} not found in plugin {this.Name}");
+            throw new InvalidOperationException($"Function {targetFunction} not found in plugin {this.Name}").Log(this._logger);
         }
 
         FunctionResult? invokeResult = null;
@@ -307,9 +302,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     {
         if (this._stepInfo is null)
         {
-            var errorMessage = "A step cannot be activated before it has been initialized.";
-            this._logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("A step cannot be activated before it has been initialized.").Log(this._logger);
         }
 
         // Instantiate an instance of the inner step object
@@ -351,18 +344,14 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
 
         if (stateType is null || stateObject is null)
         {
-            var errorMessage = "The state object for the KernelProcessStep could not be created.";
-            this._logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("The state object for the KernelProcessStep could not be created.").Log(this._logger);
         }
 
         MethodInfo? methodInfo = this._innerStepType!.GetMethod(nameof(KernelProcessStep.ActivateAsync), [stateType]);
 
         if (methodInfo is null)
         {
-            var errorMessage = "The ActivateAsync method for the KernelProcessStep could not be found.";
-            this._logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("The ActivateAsync method for the KernelProcessStep could not be found.").Log(this._logger);
         }
 
         this._stepState = stateObject;
@@ -419,7 +408,7 @@ internal class StepActor : Actor, IStep, IKernelProcessMessageChannel
     /// <returns>A <see cref="ProcessEvent"/> with the correctly scoped namespace.</returns>
     internal ProcessEvent ScopedEvent(ProcessEvent daprEvent)
     {
-        Verify.NotNull(daprEvent);
+        Verify.NotNull(daprEvent, nameof(daprEvent));
         return daprEvent with { Namespace = $"{this.Name}_{this.Id}" };
     }
 

--- a/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalProcessTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalProcessTests.cs
@@ -25,7 +25,7 @@ public class LocalProcessTests
         ], []);
 
         var mockKernel = new Kernel();
-        using var localProcess = new LocalProcess(mockKernelProcess, mockKernel, loggerFactory: null);
+        using var localProcess = new LocalProcess(mockKernelProcess, mockKernel);
 
         // Act
         await localProcess.StartAsync();
@@ -52,7 +52,7 @@ public class LocalProcessTests
         ], []);
 
         // Act
-        using var localProcess = new LocalProcess(mockKernelProcess, mockKernel, loggerFactory: null);
+        using var localProcess = new LocalProcess(mockKernelProcess, mockKernel);
 
         // Assert
         Assert.NotEmpty(localProcess.Id);
@@ -74,7 +74,7 @@ public class LocalProcessTests
         ], []);
 
         // Act
-        using var localProcess = new LocalProcess(mockKernelProcess, mockKernel, loggerFactory: null);
+        using var localProcess = new LocalProcess(mockKernelProcess, mockKernel);
 
         // Assert
         Assert.NotEmpty(localProcess.Id);

--- a/dotnet/src/InternalUtilities/process/Abstractions/ExceptionExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/ExceptionExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.SemanticKernel.Process.Runtime;
+
+internal static class ExceptionExtensions
+{
+    public static Exception Log(this Exception exception, ILogger? logger)
+    {
+        logger?.LogError(exception, "{ErrorMessage}", exception.Message);
+        return exception;
+    }
+}

--- a/dotnet/src/InternalUtilities/process/Abstractions/StepExtensions.cs
+++ b/dotnet/src/InternalUtilities/process/Abstractions/StepExtensions.cs
@@ -35,9 +35,7 @@ internal static class StepExtensions
         KernelProcessStepState? newState = (KernelProcessStepState?)Activator.CreateInstance(stateType, sourceState.Name, sourceState.Id);
         if (newState == null)
         {
-            string errorMessage = $"Failed to instantiate state: {stateType.Name} [{sourceState.Id}].";
-            logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException($"Failed to instantiate state: {stateType.Name} [{sourceState.Id}].").Log(logger);
         }
 
         if (userStateType != null)
@@ -59,17 +57,13 @@ internal static class StepExtensions
             userStateType = genericStepType.GetGenericArguments()[0];
             if (userStateType is null)
             {
-                string errorMessage = "The generic type argument for the KernelProcessStep subclass could not be determined.";
-                logger?.LogError("{ErrorMessage}", errorMessage);
-                throw new KernelException(errorMessage);
+                throw new KernelException("The generic type argument for the KernelProcessStep subclass could not be determined.").Log(logger);
             }
 
             stateType = typeof(KernelProcessStepState<>).MakeGenericType(userStateType);
             if (stateType is null)
             {
-                string errorMessage = "The generic type argument for the KernelProcessStep subclass could not be determined.";
-                logger?.LogError("{ErrorMessage}", errorMessage);
-                throw new KernelException(errorMessage);
+                throw new KernelException("The generic type argument for the KernelProcessStep subclass could not be determined.").Log(logger);
             }
         }
         else
@@ -108,9 +102,7 @@ internal static class StepExtensions
     {
         if (functions is null)
         {
-            string errorMessage = "Internal Error: The step has not been initialized.";
-            logger?.LogError("{ErrorMessage}", errorMessage);
-            throw new KernelException(errorMessage);
+            throw new KernelException("Internal Error: The step has not been initialized.").Log(logger);
         }
 
         Dictionary<string, Dictionary<string, object?>?> inputs = new();


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Throwing and logging exceptions in the runtime is a little verbose.  It also creates quite a few conditional arcs for test coverage (or lack there-of).  Utility method streamlines this pattern and eliminates all but one conditional arc.

```c#
throw new KernelException("message").Log(this._logger);
```

Note:  Considered this pattern, opted on favoring the _never-null_ object as the root of the extention method.

```c#
throw this._logger.LogException(new KernelException("message"));
```


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Introduced shared exception extension to streamline logging and minimize conditional arcs.
- Switched to `LogError` override that accepts the exception object.
- Initialize logger based on `Kernel.LoggingFactory` (was previously always null)
- Opportunistically added parameter names to usage of `Verify`
- Opportunistically removed `async`/`await` for methods where not required.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
