### PR TITLE
Python: Add parallel_tool_calls attribute to OpenAI chat prompt execution settings

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
@@ -68,7 +68,7 @@ class OpenAIChatPromptExecutionSettings(OpenAIPromptExecutionSettings):
     functions: list[dict[str, Any]] | None = None
     messages: list[dict[str, Any]] | None = None
     function_call_behavior: FunctionCallBehavior | None = Field(None, exclude=True)
-    parallel_tool_calls: bool = Field(True)
+    parallel_tool_calls: bool = True
     tools: list[dict[str, Any]] | None = Field(
         None,
         max_length=64,

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
@@ -68,6 +68,7 @@ class OpenAIChatPromptExecutionSettings(OpenAIPromptExecutionSettings):
     functions: list[dict[str, Any]] | None = None
     messages: list[dict[str, Any]] | None = None
     function_call_behavior: FunctionCallBehavior | None = Field(None, exclude=True)
+    parallel_tool_calls: bool = Field(True)
     tools: list[dict[str, Any]] | None = Field(
         None,
         max_length=64,

--- a/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/open_ai_handler.py
@@ -44,6 +44,8 @@ class OpenAIHandler(KernelBaseModel, ABC):
             if self.ai_model_type == OpenAIModelTypes.CHAT:
                 assert isinstance(request_settings, OpenAIChatPromptExecutionSettings)  # nosec
                 self._handle_structured_output(request_settings, settings)
+                if request_settings.tools is None:
+                    settings.pop("parallel_tool_calls", None)
                 response = await self.client.chat.completions.create(**settings)
             else:
                 response = await self.client.completions.create(**settings)

--- a/python/tests/unit/connectors/ai/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/connectors/ai/open_ai/services/test_azure_chat_completion.py
@@ -186,6 +186,34 @@ async def test_cmc(
     mock_create.assert_awaited_once_with(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         stream=False,
+        parallel_tool_calls=True,
+        messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
+async def test_cmc_parallel_tool_calls_disabled(
+    mock_create,
+    kernel: Kernel,
+    azure_openai_unit_test_env,
+    chat_history: ChatHistory,
+    mock_chat_completion_response: ChatCompletion,
+) -> None:
+    mock_create.return_value = mock_chat_completion_response
+    chat_history.add_user_message("hello world")
+    complete_prompt_execution_settings = AzureChatPromptExecutionSettings(
+        service_id="test_service_id", parallel_tool_calls=False
+    )
+
+    azure_chat_completion = AzureChatCompletion()
+    await azure_chat_completion.get_chat_message_contents(
+        chat_history=chat_history, settings=complete_prompt_execution_settings, kernel=kernel
+    )
+    mock_create.assert_awaited_once_with(
+        model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
+        stream=False,
+        parallel_tool_calls=False,
         messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
     )
 
@@ -217,6 +245,7 @@ async def test_cmc_with_logit_bias(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
         stream=False,
+        parallel_tool_calls=True,
         logit_bias=token_bias,
     )
 
@@ -245,6 +274,7 @@ async def test_cmc_with_stop(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
         stream=False,
+        parallel_tool_calls=True,
         stop=stop,
     )
 
@@ -314,6 +344,7 @@ async def test_azure_on_your_data(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         messages=azure_chat_completion._prepare_chat_history_for_request(messages_out),
         stream=False,
+        parallel_tool_calls=True,
         extra_body=expected_data_settings,
     )
 
@@ -383,6 +414,7 @@ async def test_azure_on_your_data_string(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         messages=azure_chat_completion._prepare_chat_history_for_request(messages_out),
         stream=False,
+        parallel_tool_calls=True,
         extra_body=expected_data_settings,
     )
 
@@ -441,6 +473,7 @@ async def test_azure_on_your_data_fail(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         messages=azure_chat_completion._prepare_chat_history_for_request(messages_out),
         stream=False,
+        parallel_tool_calls=True,
         extra_body=expected_data_settings,
     )
 
@@ -542,6 +575,7 @@ async def test_cmc_function_calling(
         messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
         stream=False,
         functions=functions,
+        parallel_tool_calls=True,
         function_call=complete_prompt_execution_settings.function_call,
     )
 
@@ -592,6 +626,7 @@ async def test_cmc_tool_calling(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
         stream=False,
+        parallel_tool_calls=True,
     )
 
 
@@ -787,5 +822,34 @@ async def test_cmc_streaming(
     mock_create.assert_awaited_once_with(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         stream=True,
+        parallel_tool_calls=True,
+        messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
+async def test_cmc_streaming_parallel_tool_calls_disabled(
+    mock_create,
+    kernel: Kernel,
+    azure_openai_unit_test_env,
+    chat_history: ChatHistory,
+    mock_streaming_chat_completion_response: AsyncStream[ChatCompletionChunk],
+) -> None:
+    mock_create.return_value = mock_streaming_chat_completion_response
+    chat_history.add_user_message("hello world")
+    complete_prompt_execution_settings = AzureChatPromptExecutionSettings(
+        service_id="test_service_id", parallel_tool_calls=False
+    )
+
+    azure_chat_completion = AzureChatCompletion()
+    async for msg in azure_chat_completion.get_streaming_chat_message_contents(
+        chat_history=chat_history, settings=complete_prompt_execution_settings, kernel=kernel
+    ):
+        assert msg is not None
+    mock_create.assert_awaited_once_with(
+        model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
+        stream=True,
+        parallel_tool_calls=False,
         messages=azure_chat_completion._prepare_chat_history_for_request(chat_history),
     )

--- a/python/tests/unit/connectors/ai/open_ai/services/test_open_ai_chat_completion_base.py
+++ b/python/tests/unit/connectors/ai/open_ai/services/test_open_ai_chat_completion_base.py
@@ -89,34 +89,6 @@ async def test_cmc(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=False,
-        parallel_tool_calls=True,
-        messages=openai_chat_completion._prepare_chat_history_for_request(chat_history),
-    )
-
-
-@pytest.mark.asyncio
-@patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
-async def test_cmc_parallel_tool_calls_disabled(
-    mock_create,
-    kernel: Kernel,
-    chat_history: ChatHistory,
-    mock_chat_completion_response: ChatCompletion,
-    openai_unit_test_env,
-):
-    mock_create.return_value = mock_chat_completion_response
-    chat_history.add_user_message("hello world")
-    complete_prompt_execution_settings = OpenAIChatPromptExecutionSettings(
-        service_id="test_service_id", parallel_tool_calls=False
-    )
-
-    openai_chat_completion = OpenAIChatCompletion()
-    await openai_chat_completion.get_chat_message_contents(
-        chat_history=chat_history, settings=complete_prompt_execution_settings, kernel=kernel
-    )
-    mock_create.assert_awaited_once_with(
-        model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
-        stream=False,
-        parallel_tool_calls=False,
         messages=openai_chat_completion._prepare_chat_history_for_request(chat_history),
     )
 
@@ -141,7 +113,6 @@ async def test_cmc_singular(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=False,
-        parallel_tool_calls=True,
         messages=openai_chat_completion._prepare_chat_history_for_request(chat_history),
     )
 
@@ -166,7 +137,6 @@ async def test_cmc_prompt_execution_settings(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=False,
-        parallel_tool_calls=True,
         messages=openai_chat_completion._prepare_chat_history_for_request(chat_history),
     )
 
@@ -217,7 +187,6 @@ async def test_cmc_function_call_behavior(
         mock_create.assert_awaited_once_with(
             model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
             stream=False,
-            parallel_tool_calls=True,
             messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
         )
         mock_process_function_call.assert_awaited()
@@ -255,6 +224,14 @@ async def test_cmc_function_choice_behavior(
     complete_prompt_execution_settings = OpenAIChatPromptExecutionSettings(
         service_id="test_service_id", function_choice_behavior=FunctionChoiceBehavior.Auto()
     )
+
+    class MockPlugin:
+        @kernel_function(name="test_tool")
+        def test_tool(self, key: str):
+            return "test"
+
+    kernel.add_plugin(MockPlugin(), plugin_name="test_tool")
+
     with patch(
         "semantic_kernel.kernel.Kernel.invoke_function_call",
         new_callable=AsyncMock,
@@ -269,8 +246,100 @@ async def test_cmc_function_choice_behavior(
         mock_create.assert_awaited_once_with(
             model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
             stream=False,
-            parallel_tool_calls=True,
             messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
+            parallel_tool_calls=True,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool-test_tool",
+                        "description": "",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"key": {"type": "string"}},
+                            "required": ["key"],
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
+        )
+        mock_process_function_call.assert_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
+async def test_cmc_fcb_parallel_func_calling_disabled(
+    mock_create,
+    kernel: Kernel,
+    chat_history: ChatHistory,
+    mock_chat_completion_response: ChatCompletion,
+    openai_unit_test_env,
+):
+    mock_chat_completion_response.choices = [
+        Choice(
+            index=0,
+            message=ChatCompletionMessage(
+                content=None,
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "test id",
+                        "function": {"name": "test-tool", "arguments": '{"key": "value"}'},
+                        "type": "function",
+                    }
+                ],
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_create.return_value = mock_chat_completion_response
+    chat_history.add_user_message("hello world")
+    orig_chat_history = deepcopy(chat_history)
+    complete_prompt_execution_settings = OpenAIChatPromptExecutionSettings(
+        service_id="test_service_id",
+        function_choice_behavior=FunctionChoiceBehavior.Auto(),
+        parallel_tool_calls=False,
+    )
+
+    class MockPlugin:
+        @kernel_function(name="test_tool")
+        def test_tool(self, key: str):
+            return "test"
+
+    kernel.add_plugin(MockPlugin(), plugin_name="test_tool")
+
+    with patch(
+        "semantic_kernel.kernel.Kernel.invoke_function_call",
+        new_callable=AsyncMock,
+    ) as mock_process_function_call:
+        openai_chat_completion = OpenAIChatCompletion()
+        await openai_chat_completion.get_chat_message_contents(
+            chat_history=chat_history,
+            settings=complete_prompt_execution_settings,
+            kernel=kernel,
+            arguments=KernelArguments(),
+        )
+        mock_create.assert_awaited_once_with(
+            model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
+            stream=False,
+            messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
+            parallel_tool_calls=False,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool-test_tool",
+                        "description": "",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"key": {"type": "string"}},
+                            "required": ["key"],
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
         )
         mock_process_function_call.assert_awaited()
 
@@ -349,7 +418,6 @@ async def test_cmc_no_fcc_in_response(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=False,
-        parallel_tool_calls=True,
         messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
     )
 
@@ -446,7 +514,6 @@ async def test_scmc_prompt_execution_settings(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,
-        parallel_tool_calls=True,
         stream_options={"include_usage": True},
         messages=openai_chat_completion._prepare_chat_history_for_request(chat_history),
     )
@@ -515,55 +582,6 @@ async def test_scmc(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,
-        parallel_tool_calls=True,
-        stream_options={"include_usage": True},
-        messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
-    )
-
-
-@pytest.mark.asyncio
-@patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
-async def test_scmc_parallel_tool_calls_disabled(
-    mock_create,
-    kernel: Kernel,
-    chat_history: ChatHistory,
-    openai_unit_test_env,
-):
-    content1 = ChatCompletionChunk(
-        id="test_id",
-        choices=[],
-        created=0,
-        model="test",
-        object="chat.completion.chunk",
-    )
-    content2 = ChatCompletionChunk(
-        id="test_id",
-        choices=[ChunkChoice(index=0, delta=ChunkChoiceDelta(content="test", role="assistant"), finish_reason="stop")],
-        created=0,
-        model="test",
-        object="chat.completion.chunk",
-    )
-    stream = MagicMock(spec=AsyncStream)
-    stream.__aiter__.return_value = [content1, content2]
-    mock_create.return_value = stream
-    chat_history.add_user_message("hello world")
-    orig_chat_history = deepcopy(chat_history)
-    complete_prompt_execution_settings = OpenAIChatPromptExecutionSettings(
-        service_id="test_service_id", parallel_tool_calls=False
-    )
-
-    openai_chat_completion = OpenAIChatCompletion()
-    async for msg in openai_chat_completion.get_streaming_chat_message_contents(
-        chat_history=chat_history,
-        settings=complete_prompt_execution_settings,
-        kernel=kernel,
-        arguments=KernelArguments(),
-    ):
-        assert isinstance(msg[0], StreamingChatMessageContent)
-    mock_create.assert_awaited_once_with(
-        model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
-        stream=True,
-        parallel_tool_calls=False,
         stream_options={"include_usage": True},
         messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
     )
@@ -609,7 +627,6 @@ async def test_scmc_singular(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,
-        parallel_tool_calls=True,
         stream_options={"include_usage": True},
         messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
     )
@@ -690,7 +707,6 @@ async def test_scmc_function_call_behavior(
         mock_create.assert_awaited_once_with(
             model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
             stream=True,
-            parallel_tool_calls=True,
             stream_options={"include_usage": True},
             messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
         )
@@ -711,6 +727,14 @@ async def test_scmc_function_choice_behavior(
     complete_prompt_execution_settings = OpenAIChatPromptExecutionSettings(
         service_id="test_service_id", function_choice_behavior=FunctionChoiceBehavior.Auto()
     )
+
+    class MockPlugin:
+        @kernel_function(name="test_tool")
+        def test_tool(self, key: str):
+            return "test"
+
+    kernel.add_plugin(MockPlugin(), plugin_name="test_tool")
+
     with patch(
         "semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion_base.OpenAIChatCompletionBase._process_function_call",
         new_callable=AsyncMock,
@@ -728,6 +752,83 @@ async def test_scmc_function_choice_behavior(
             model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
             stream=True,
             parallel_tool_calls=True,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool-test_tool",
+                        "description": "",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"key": {"type": "string"}},
+                            "required": ["key"],
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
+            stream_options={"include_usage": True},
+            messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
+        )
+
+
+@pytest.mark.asyncio
+@patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
+async def test_scmc_fcb_parallel_tool_call_disabled(
+    mock_create,
+    kernel: Kernel,
+    chat_history: ChatHistory,
+    mock_streaming_chat_completion_response: ChatCompletion,
+    openai_unit_test_env,
+):
+    mock_create.return_value = mock_streaming_chat_completion_response
+    chat_history.add_user_message("hello world")
+    orig_chat_history = deepcopy(chat_history)
+    complete_prompt_execution_settings = OpenAIChatPromptExecutionSettings(
+        service_id="test_service_id",
+        function_choice_behavior=FunctionChoiceBehavior.Auto(),
+        parallel_tool_calls=False,
+    )
+
+    class MockPlugin:
+        @kernel_function(name="test_tool")
+        def test_tool(self, key: str):
+            return "test"
+
+    kernel.add_plugin(MockPlugin(), plugin_name="test_tool")
+
+    with patch(
+        "semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion_base.OpenAIChatCompletionBase._process_function_call",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        openai_chat_completion = OpenAIChatCompletion()
+        async for msg in openai_chat_completion.get_streaming_chat_message_contents(
+            chat_history=chat_history,
+            settings=complete_prompt_execution_settings,
+            kernel=kernel,
+            arguments=KernelArguments(),
+        ):
+            assert isinstance(msg[0], StreamingChatMessageContent)
+        mock_create.assert_awaited_once_with(
+            model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
+            stream=True,
+            parallel_tool_calls=False,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool-test_tool",
+                        "description": "",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"key": {"type": "string"}},
+                            "required": ["key"],
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
             stream_options={"include_usage": True},
             messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
         )
@@ -799,7 +900,6 @@ async def test_scmc_no_fcc_in_response(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,
-        parallel_tool_calls=True,
         stream_options={"include_usage": True},
         messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
     )
@@ -903,7 +1003,6 @@ async def test_tc(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=False,
-        parallel_tool_calls=True,
         messages=[{"role": "user", "content": "test"}],
     )
 
@@ -926,7 +1025,6 @@ async def test_stc(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,
-        parallel_tool_calls=True,
         messages=[{"role": "user", "content": "test"}],
     )
 
@@ -951,7 +1049,6 @@ async def test_stc_with_msgs(
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,
-        parallel_tool_calls=True,
         messages=[{"role": "system", "content": "system prompt"}, {"role": "user", "content": "test"}],
     )
 


### PR DESCRIPTION
### Motivation and Context

OpenAI / Azure OpenAI released the ability to specify the `parallel_tool_calls` = True | False boolean attribute on the prompt execution settings in July. This was never brought into SK Python.

Further, there appears to be a pesky bug related to function calling where enabling parallel tool calls can cause 500s. The only way to get around this is to disable parallel function calling. This has been both tested on the Azure Chat Completion and OpenAI Chat Completion code and works well -- the chat history shows the synchronous function calls if multiple tool calls are required.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Add the `parallel_tool_calls` attribute on the OpenAIChatPromptExecutionExecution settings, which are also used by the AzureChatCompletionClass.
- Closes #9478
- Adds unit tests for this prompt execution setting

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
