### PR TITLE
.Net: Added a streaming flag to filter context models

### DIFF
--- a/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
+++ b/dotnet/src/Connectors/Connectors.MistralAI/Client/MistralClient.cs
@@ -178,7 +178,8 @@ internal sealed class MistralClient
                     RequestSequenceIndex = requestIndex - 1,
                     FunctionSequenceIndex = toolCallIndex,
                     FunctionCount = chatChoice.ToolCalls.Count,
-                    CancellationToken = cancellationToken
+                    CancellationToken = cancellationToken,
+                    IsStreaming = false
                 };
                 s_inflightAutoInvokes.Value++;
                 try
@@ -408,7 +409,8 @@ internal sealed class MistralClient
                     RequestSequenceIndex = requestIndex - 1,
                     FunctionSequenceIndex = toolCallIndex,
                     FunctionCount = toolCalls.Count,
-                    CancellationToken = cancellationToken
+                    CancellationToken = cancellationToken,
+                    IsStreaming = true
                 };
                 s_inflightAutoInvokes.Value++;
                 try

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -209,7 +209,9 @@ internal partial class ClientCore
                 (FunctionCallContent content) => IsRequestableTool(chatOptions.Tools, content),
                 functionCallingConfig.Options ?? new FunctionChoiceBehaviorOptions(),
                 kernel,
+                isStreaming: false,
                 cancellationToken).ConfigureAwait(false);
+
             if (lastMessage != null)
             {
                 return [lastMessage];
@@ -388,7 +390,9 @@ internal partial class ClientCore
                 (FunctionCallContent content) => IsRequestableTool(chatOptions.Tools, content),
                 functionCallingConfig.Options ?? new FunctionChoiceBehaviorOptions(),
                 kernel,
+                isStreaming: true,
                 cancellationToken).ConfigureAwait(false);
+
             if (lastMessage != null)
             {
                 yield return new OpenAIStreamingChatMessageContent(lastMessage.Role, lastMessage.Content);

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/FunctionCallsProcessor.cs
@@ -131,7 +131,7 @@ internal sealed class FunctionCallsProcessor
     /// <param name="checkIfFunctionAdvertised">Callback to check if a function was advertised to AI model or not.</param>
     /// <param name="options">Function choice behavior options.</param>
     /// <param name="kernel">The <see cref="Kernel"/>.</param>
-    /// <param name="isStreaming">Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.</param>
+    /// <param name="isStreaming">Boolean flag which indicates whether an operation is invoked within streaming or non-streaming mode.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>Last chat history message if function invocation filter requested processing termination, otherwise null.</returns>
     public async Task<ChatMessageContent?> ProcessFunctionCallsAsync(

--- a/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/FunctionCallsProcessor.cs
+++ b/dotnet/src/InternalUtilities/connectors/AI/FunctionCalling/FunctionCallsProcessor.cs
@@ -131,6 +131,7 @@ internal sealed class FunctionCallsProcessor
     /// <param name="checkIfFunctionAdvertised">Callback to check if a function was advertised to AI model or not.</param>
     /// <param name="options">Function choice behavior options.</param>
     /// <param name="kernel">The <see cref="Kernel"/>.</param>
+    /// <param name="isStreaming">Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>Last chat history message if function invocation filter requested processing termination, otherwise null.</returns>
     public async Task<ChatMessageContent?> ProcessFunctionCallsAsync(
@@ -140,6 +141,7 @@ internal sealed class FunctionCallsProcessor
         Func<FunctionCallContent, bool> checkIfFunctionAdvertised,
         FunctionChoiceBehaviorOptions options,
         Kernel? kernel,
+        bool isStreaming,
         CancellationToken cancellationToken)
     {
         var functionCalls = FunctionCallContent.GetFunctionCalls(chatMessageContent).ToList();
@@ -201,7 +203,9 @@ internal sealed class FunctionCallsProcessor
                 Arguments = functionCall.Arguments,
                 RequestSequenceIndex = requestIndex,
                 FunctionSequenceIndex = functionCallIndex,
-                FunctionCount = functionCalls.Count
+                FunctionCount = functionCalls.Count,
+                CancellationToken = cancellationToken,
+                IsStreaming = isStreaming
             };
 
             var functionTask = Task.Run<(string? Result, string? ErrorMessage, FunctionCallContent FunctionCall, bool Terminate)>(async () =>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/AutoFunctionInvocationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/AutoFunctionInvocationContext.cs
@@ -47,6 +47,11 @@ public class AutoFunctionInvocationContext
     public CancellationToken CancellationToken { get; init; }
 
     /// <summary>
+    /// Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.
+    /// </summary>
+    public bool IsStreaming { get; init; }
+
+    /// <summary>
     /// Gets the arguments associated with the operation.
     /// </summary>
     public KernelArguments? Arguments { get; init; }

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvocationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvocationContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.SemanticKernel;
@@ -33,6 +34,12 @@ public class FunctionInvocationContext
     /// The default is <see cref="CancellationToken.None"/>.
     /// </summary>
     public CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.
+    /// </summary>
+    [Experimental("SKEXP0001")]
+    public bool IsStreaming { get; init; }
 
     /// <summary>
     /// Gets the <see cref="Microsoft.SemanticKernel.Kernel"/> containing services, plugins, and other state for use throughout the operation.

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 namespace Microsoft.SemanticKernel;
 
@@ -32,6 +33,12 @@ public sealed class PromptRenderContext
     /// The default is <see cref="CancellationToken.None"/>.
     /// </summary>
     public CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.
+    /// </summary>
+    [Experimental("SKEXP0001")]
+    public bool IsStreaming { get; init; }
 
     /// <summary>
     /// Gets the <see cref="Microsoft.SemanticKernel.Kernel"/> containing services, plugins, and other state for use throughout the operation.

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
@@ -249,7 +249,7 @@ public abstract class KernelFunction
                 throw new OperationCanceledException($"A {nameof(Kernel)}.{nameof(Kernel.FunctionInvoking)} event handler requested cancellation before function invocation.");
             }
 
-            var invocationContext = await kernel.OnFunctionInvocationAsync(this, arguments, functionResult, async (context) =>
+            var invocationContext = await kernel.OnFunctionInvocationAsync(this, arguments, functionResult, isStreaming: false, async (context) =>
             {
                 // Invoking the function and updating context with result.
                 context.Result = functionResult = await this.InvokeCoreAsync(kernel, context.Arguments, cancellationToken).ConfigureAwait(false);
@@ -381,7 +381,7 @@ public abstract class KernelFunction
 
                 FunctionResult functionResult = new(this, culture: kernel.Culture);
 
-                var invocationContext = await kernel.OnFunctionInvocationAsync(this, arguments, functionResult, (context) =>
+                var invocationContext = await kernel.OnFunctionInvocationAsync(this, arguments, functionResult, isStreaming: true, (context) =>
                 {
                     // Invoke the function and get its streaming enumerable.
                     var enumerable = this.InvokeStreamingCoreAsync<TResult>(kernel, context.Arguments, cancellationToken);

--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -311,12 +311,14 @@ public sealed class Kernel
         KernelFunction function,
         KernelArguments arguments,
         FunctionResult functionResult,
+        bool isStreaming,
         Func<FunctionInvocationContext, Task> functionCallback,
         CancellationToken cancellationToken)
     {
         FunctionInvocationContext context = new(this, function, arguments, functionResult)
         {
-            CancellationToken = cancellationToken
+            CancellationToken = cancellationToken,
+            IsStreaming = isStreaming
         };
 
         await InvokeFilterOrFunctionAsync(this._functionInvocationFilters, functionCallback, context).ConfigureAwait(false);

--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -353,12 +353,14 @@ public sealed class Kernel
     internal async Task<PromptRenderContext> OnPromptRenderAsync(
         KernelFunction function,
         KernelArguments arguments,
+        bool isStreaming,
         Func<PromptRenderContext, Task> renderCallback,
         CancellationToken cancellationToken)
     {
         PromptRenderContext context = new(this, function, arguments)
         {
-            CancellationToken = cancellationToken
+            CancellationToken = cancellationToken,
+            IsStreaming = isStreaming
         };
 
         await InvokeFilterOrPromptRenderAsync(this._promptRenderFilters, renderCallback, context).ConfigureAwait(false);

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -235,7 +235,11 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     {
         this.AddDefaultValues(arguments);
 
-        var promptRenderingResult = await this.RenderPromptAsync(kernel, arguments, cancellationToken).ConfigureAwait(false);
+        var promptRenderingResult = await this.RenderPromptAsync(
+            kernel,
+            arguments,
+            isStreaming: false,
+            cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable CS0612 // Events are deprecated
         if (promptRenderingResult.RenderedEventArgs?.Cancel is true)
@@ -268,7 +272,11 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     {
         this.AddDefaultValues(arguments);
 
-        var result = await this.RenderPromptAsync(kernel, arguments, cancellationToken).ConfigureAwait(false);
+        var result = await this.RenderPromptAsync(
+            kernel,
+            arguments,
+            isStreaming: true,
+            cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable CS0612 // Events are deprecated
         if (result.RenderedEventArgs?.Cancel is true)
@@ -479,7 +487,11 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
         }
     }
 
-    private async Task<PromptRenderingResult> RenderPromptAsync(Kernel kernel, KernelArguments arguments, CancellationToken cancellationToken)
+    private async Task<PromptRenderingResult> RenderPromptAsync(
+        Kernel kernel,
+        KernelArguments arguments,
+        bool isStreaming,
+        CancellationToken cancellationToken)
     {
         var serviceSelector = kernel.ServiceSelector;
 
@@ -506,7 +518,7 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
         kernel.OnPromptRendering(this, arguments);
 #pragma warning restore CS0618 // Events are deprecated
 
-        var renderingContext = await kernel.OnPromptRenderAsync(this, arguments, async (context) =>
+        var renderingContext = await kernel.OnPromptRenderAsync(this, arguments, isStreaming, async (context) =>
         {
             renderedPrompt = await this._promptTemplate.RenderAsync(kernel, context.Arguments, cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/AIConnectors/FunctionCallsProcessorTests.cs
@@ -99,6 +99,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
         }
 
@@ -127,6 +128,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: CreateKernel(),
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -154,6 +156,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: CreateKernel(),
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -186,6 +189,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -213,6 +217,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => false, // Return false to simulate that the function is not advertised
                 options: this._functionChoiceBehaviorOptions,
                 kernel: CreateKernel(),
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -240,6 +245,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: CreateKernel(),
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -280,6 +286,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -345,6 +352,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -433,6 +441,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -480,6 +489,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -531,6 +541,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         var firstFunctionResult = chatHistory[^2].Content;
@@ -582,6 +593,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -627,6 +639,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -670,6 +683,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel!,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -723,6 +737,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert
@@ -757,6 +772,7 @@ public class FunctionCallsProcessorTests
                 checkIfFunctionAdvertised: (_) => true,
                 options: this._functionChoiceBehaviorOptions,
                 kernel: kernel,
+                isStreaming: false,
                 cancellationToken: CancellationToken.None);
 
         // Assert


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/7336

This PR adds a boolean flag to identify whether a filter is invoked within streaming or non-streaming mode. This provides an ability to use the same filter for both scenarios and access filter context data in easier way based on used mode.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
