### PR TITLE
.Net: Fixed JSON schema name in Structured Outputs for generic types

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -1179,9 +1179,11 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     }
 
     [Theory]
-    [InlineData(typeof(TestStruct))]
-    [InlineData(typeof(TestStruct?))]
-    public async Task GetChatMessageContentsSendsValidJsonSchemaWithStruct(Type responseFormatType)
+    [InlineData(typeof(TestStruct), "TestStruct")]
+    [InlineData(typeof(TestStruct?), "TestStruct")]
+    [InlineData(typeof(TestStruct<string>), "TestStruct1")]
+    [InlineData(typeof(TestStruct<string>?), "TestStruct1")]
+    public async Task GetChatMessageContentsSendsValidJsonSchemaWithStruct(Type responseFormatType, string expectedSchemaName)
     {
         // Arrange
         var executionSettings = new OpenAIPromptExecutionSettings { ResponseFormat = responseFormatType };
@@ -1204,7 +1206,7 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
         var requestResponseFormat = requestJsonElement.GetProperty("response_format");
 
         Assert.Equal("json_schema", requestResponseFormat.GetProperty("type").GetString());
-        Assert.Equal("TestStruct", requestResponseFormat.GetProperty("json_schema").GetProperty("name").GetString());
+        Assert.Equal(expectedSchemaName, requestResponseFormat.GetProperty("json_schema").GetProperty("name").GetString());
         Assert.True(requestResponseFormat.GetProperty("json_schema").GetProperty("strict").GetBoolean());
 
         var schema = requestResponseFormat.GetProperty("json_schema").GetProperty("schema");
@@ -1219,8 +1221,8 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
             schema.GetProperty("required")[1].GetString(),
         };
 
-        Assert.Contains("TextProperty", requiredParentProperties);
-        Assert.Contains("NumericProperty", requiredParentProperties);
+        Assert.Contains("Property1", requiredParentProperties);
+        Assert.Contains("Property2", requiredParentProperties);
     }
 
     [Fact]
@@ -1519,9 +1521,16 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
 
     private struct TestStruct
     {
-        public string TextProperty { get; set; }
+        public string Property1 { get; set; }
 
-        public int? NumericProperty { get; set; }
+        public int? Property2 { get; set; }
+    }
+
+    private struct TestStruct<TProperty>
+    {
+        public TProperty Property1 { get; set; }
+
+        public int? Property2 { get; set; }
     }
 #pragma warning restore CS8618, CA1812
 }

--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Services/OpenAIChatCompletionServiceTests.cs
@@ -1181,8 +1181,10 @@ public sealed class OpenAIChatCompletionServiceTests : IDisposable
     [Theory]
     [InlineData(typeof(TestStruct), "TestStruct")]
     [InlineData(typeof(TestStruct?), "TestStruct")]
-    [InlineData(typeof(TestStruct<string>), "TestStruct1")]
-    [InlineData(typeof(TestStruct<string>?), "TestStruct1")]
+    [InlineData(typeof(TestStruct<string>), "TestStructString")]
+    [InlineData(typeof(TestStruct<string>?), "TestStructString")]
+    [InlineData(typeof(TestStruct<List<float>>), "TestStructListSingle")]
+    [InlineData(typeof(TestStruct<List<float>>?), "TestStructListSingle")]
     public async Task GetChatMessageContentsSendsValidJsonSchemaWithStruct(Type responseFormatType, string expectedSchemaName)
     {
         // Arrange

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JsonSchemaMapper;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/semantic-kernel/issues/9416

When C# type is passed as a response format to OpenAI chat completion service, we use the type name as [JSON schema name](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format). When the type is generic, its name will contain characters that are not allowed in JSON schema name according to OpenAI API. This PR fixes the issue by replacing invalid characters with empty string.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
