### PR TITLE
.Net: Fix bug where has named vectors wasn't passed to record collection in GetCollection.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStore.cs
@@ -64,7 +64,11 @@ public sealed class QdrantVectorStore : IVectorStore
             throw new NotSupportedException("Only ulong and Guid keys are supported.");
         }
 
-        var recordCollection = new QdrantVectorStoreRecordCollection<TRecord>(this._qdrantClient, name, new QdrantVectorStoreRecordCollectionOptions<TRecord>() { VectorStoreRecordDefinition = vectorStoreRecordDefinition });
+        var recordCollection = new QdrantVectorStoreRecordCollection<TRecord>(this._qdrantClient, name, new QdrantVectorStoreRecordCollectionOptions<TRecord>()
+        {
+            HasNamedVectors = this._options.HasNamedVectors,
+            VectorStoreRecordDefinition = vectorStoreRecordDefinition
+        });
         var castRecordCollection = recordCollection as IVectorStoreRecordCollection<TKey, TRecord>;
         return castRecordCollection!;
     }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreTests.cs
@@ -12,6 +12,30 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 public class QdrantVectorStoreTests(ITestOutputHelper output, QdrantVectorStoreFixture fixture)
 {
     [Fact]
+    public async Task ItPassesSettingsFromVectorStoreToCollectionAsync()
+    {
+        // Arrange
+        var sut = new QdrantVectorStore(fixture.QdrantClient, new() { HasNamedVectors = true });
+
+        // Act
+        var collectionFromVS = sut.GetCollection<ulong, QdrantVectorStoreFixture.HotelInfo>("SettingsPassedCollection");
+        await collectionFromVS.CreateCollectionIfNotExistsAsync();
+
+        var directCollection = new QdrantVectorStoreRecordCollection<QdrantVectorStoreFixture.HotelInfo>(fixture.QdrantClient, "SettingsPassedCollection", new() { HasNamedVectors = true });
+        await directCollection.UpsertAsync(new QdrantVectorStoreFixture.HotelInfo
+        {
+            HotelId = 1ul,
+            HotelName = "My Hotel 1",
+            HotelCode = 1,
+            HotelRating = 4.5f,
+            ParkingIncluded = true,
+            Tags = { "t1", "t2" },
+            Description = "This is a great hotel.",
+            DescriptionEmbedding = new float[1536],
+        });
+    }
+
+    [Fact]
     public async Task ItCanGetAListOfExistingCollectionNamesAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context

We allow users to provide a setting to indicate whether they are using a collection which has named vectors or not when using Qdrant.

#9520

### Description

- Fixing a bug where the has named vectors setting wasn't passed from the vector store to the collection in GetCollection.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
