### PR TITLE
.Net: Add AudioTimestamp Property to GeminiPromptExecutionSettings

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiChatGenerationTests.cs
@@ -236,7 +236,8 @@ public sealed class GeminiChatGenerationTests : IDisposable
         {
             MaxTokens = 102,
             Temperature = 0.45,
-            TopP = 0.6
+            TopP = 0.6,
+            AudioTimestamp = true
         };
 
         // Act
@@ -247,6 +248,7 @@ public sealed class GeminiChatGenerationTests : IDisposable
         Assert.NotNull(geminiRequest);
         Assert.Equal(executionSettings.MaxTokens, geminiRequest.Configuration!.MaxOutputTokens);
         Assert.Equal(executionSettings.Temperature, geminiRequest.Configuration!.Temperature);
+        Assert.Equal(executionSettings.AudioTimestamp, geminiRequest.Configuration!.AudioTimestamp);
         Assert.Equal(executionSettings.TopP, geminiRequest.Configuration!.TopP);
     }
 

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/GeminiRequestTests.cs
@@ -24,6 +24,7 @@ public sealed class GeminiRequestTests
             Temperature = 1.5,
             MaxTokens = 10,
             TopP = 0.9,
+            AudioTimestamp = true
         };
 
         // Act
@@ -33,6 +34,7 @@ public sealed class GeminiRequestTests
         Assert.NotNull(request.Configuration);
         Assert.Equal(executionSettings.Temperature, request.Configuration.Temperature);
         Assert.Equal(executionSettings.MaxTokens, request.Configuration.MaxOutputTokens);
+        Assert.Equal(executionSettings.AudioTimestamp, request.Configuration.AudioTimestamp);
         Assert.Equal(executionSettings.TopP, request.Configuration.TopP);
     }
 
@@ -85,6 +87,7 @@ public sealed class GeminiRequestTests
             Temperature = 1.5,
             MaxTokens = 10,
             TopP = 0.9,
+            AudioTimestamp = true
         };
 
         // Act
@@ -94,6 +97,7 @@ public sealed class GeminiRequestTests
         Assert.NotNull(request.Configuration);
         Assert.Equal(executionSettings.Temperature, request.Configuration.Temperature);
         Assert.Equal(executionSettings.MaxTokens, request.Configuration.MaxOutputTokens);
+        Assert.Equal(executionSettings.AudioTimestamp, request.Configuration.AudioTimestamp);
         Assert.Equal(executionSettings.TopP, request.Configuration.TopP);
     }
 

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/GeminiPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/GeminiPromptExecutionSettingsTests.cs
@@ -26,6 +26,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.Null(executionSettings.StopSequences);
         Assert.Null(executionSettings.CandidateCount);
         Assert.Null(executionSettings.SafetySettings);
+        Assert.Null(executionSettings.AudioTimestamp);
         Assert.Equal(GeminiPromptExecutionSettings.DefaultTextMaxTokens, executionSettings.MaxTokens);
     }
 
@@ -39,6 +40,7 @@ public sealed class GeminiPromptExecutionSettingsTests
             TopP = 0.7,
             TopK = 20,
             CandidateCount = 3,
+            AudioTimestamp = true,
             StopSequences = ["foo", "bar"],
             MaxTokens = 128,
             SafetySettings =
@@ -64,7 +66,8 @@ public sealed class GeminiPromptExecutionSettingsTests
             ExtensionData = new Dictionary<string, object>
             {
                 { "max_tokens", 1000 },
-                { "temperature", 0 }
+                { "temperature", 0 },
+                { "audio_timestamp", true }
             }
         };
 
@@ -75,6 +78,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.NotNull(executionSettings);
         Assert.Equal(1000, executionSettings.MaxTokens);
         Assert.Equal(0, executionSettings.Temperature);
+        Assert.True(executionSettings.AudioTimestamp);
     }
 
     [Fact]
@@ -91,6 +95,7 @@ public sealed class GeminiPromptExecutionSettingsTests
                           "candidate_count": 2,
                           "stop_sequences": [ "foo", "bar" ],
                           "max_tokens": 128,
+                          "audio_timestamp": true,
                           "safety_settings": [
                             {
                               "category": "{{category.Label}}",
@@ -112,6 +117,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.Equal(2, executionSettings.CandidateCount);
         Assert.Equal(["foo", "bar"], executionSettings.StopSequences);
         Assert.Equal(128, executionSettings.MaxTokens);
+        Assert.True(executionSettings.AudioTimestamp);
         Assert.Single(executionSettings.SafetySettings!, settings =>
             settings.Category.Equals(category) &&
             settings.Threshold.Equals(threshold));
@@ -130,6 +136,7 @@ public sealed class GeminiPromptExecutionSettingsTests
                           "top_p": 0.7,
                           "top_k": 25,
                           "candidate_count": 2,
+                          "audio_timestamp": true,
                           "stop_sequences": [ "foo", "bar" ],
                           "max_tokens": 128,
                           "safety_settings": [
@@ -152,6 +159,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.Equivalent(executionSettings.ExtensionData, clone.ExtensionData);
         Assert.Equivalent(executionSettings.StopSequences, clone.StopSequences);
         Assert.Equivalent(executionSettings.SafetySettings, clone.SafetySettings);
+        Assert.Equal(executionSettings.AudioTimestamp, clone.AudioTimestamp);
     }
 
     [Fact]
@@ -167,6 +175,7 @@ public sealed class GeminiPromptExecutionSettingsTests
                           "top_p": 0.7,
                           "top_k": 25,
                           "candidate_count": 2,
+                          "audio_timestamp": true,
                           "stop_sequences": [ "foo", "bar" ],
                           "max_tokens": 128,
                           "safety_settings": [
@@ -187,6 +196,7 @@ public sealed class GeminiPromptExecutionSettingsTests
         Assert.Throws<InvalidOperationException>(() => executionSettings.ModelId = "gemini-ultra");
         Assert.Throws<InvalidOperationException>(() => executionSettings.CandidateCount = 5);
         Assert.Throws<InvalidOperationException>(() => executionSettings.Temperature = 0.5);
+        Assert.Throws<InvalidOperationException>(() => executionSettings.AudioTimestamp = false);
         Assert.Throws<NotSupportedException>(() => executionSettings.StopSequences!.Add("baz"));
     }
 }

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GeminiRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Models/GeminiRequest.cs
@@ -247,7 +247,8 @@ internal sealed class GeminiRequest
             TopK = executionSettings.TopK,
             MaxOutputTokens = executionSettings.MaxTokens,
             StopSequences = executionSettings.StopSequences,
-            CandidateCount = executionSettings.CandidateCount
+            CandidateCount = executionSettings.CandidateCount,
+            AudioTimestamp = executionSettings.AudioTimestamp
         };
     }
 
@@ -282,5 +283,9 @@ internal sealed class GeminiRequest
         [JsonPropertyName("candidateCount")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? CandidateCount { get; set; }
+
+        [JsonPropertyName("audioTimestamp")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? AudioTimestamp { get; set; }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
@@ -23,7 +23,7 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
     private int? _maxTokens;
     private int? _candidateCount;
     private IList<string>? _stopSequences;
-    private bool?_audioTimestamp;
+    private bool? _audioTimestamp;
     private IList<GeminiSafetySetting>? _safetySettings;
     private GeminiToolCallBehavior? _toolCallBehavior;
 

--- a/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
@@ -23,6 +23,7 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
     private int? _maxTokens;
     private int? _candidateCount;
     private IList<string>? _stopSequences;
+    private string? _responseFormat;
     private IList<GeminiSafetySetting>? _safetySettings;
     private GeminiToolCallBehavior? _toolCallBehavior;
 
@@ -171,6 +172,22 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
         }
     }
 
+    /// <summary>
+    /// The format of the transcript output, in one of these options: json, srt, verbose_json, or vtt. Default is 'json'.
+    /// </summary>
+    [JsonPropertyName("response_format")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ResponseFormat
+    {
+        get => this._responseFormat;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._responseFormat = value;
+        }
+    }
+
     /// <inheritdoc />
     public override void Freeze()
     {
@@ -207,6 +224,7 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
             StopSequences = this.StopSequences is not null ? new List<string>(this.StopSequences) : null,
             SafetySettings = this.SafetySettings?.Select(setting => new GeminiSafetySetting(setting)).ToList(),
             ToolCallBehavior = this.ToolCallBehavior?.Clone(),
+            ResponseFormat = this.ResponseFormat
         };
     }
 

--- a/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Google/GeminiPromptExecutionSettings.cs
@@ -23,7 +23,7 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
     private int? _maxTokens;
     private int? _candidateCount;
     private IList<string>? _stopSequences;
-    private string? _responseFormat;
+    private bool?_audioTimestamp;
     private IList<GeminiSafetySetting>? _safetySettings;
     private GeminiToolCallBehavior? _toolCallBehavior;
 
@@ -173,18 +173,17 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
     }
 
     /// <summary>
-    /// The format of the transcript output, in one of these options: json, srt, verbose_json, or vtt. Default is 'json'.
+    /// Indicates if the audio response should include timestamps.
+    /// if enabled, audio timestamp will be included in the request to the model.
     /// </summary>
-    [JsonPropertyName("response_format")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ResponseFormat
+    [JsonPropertyName("audio_timestamp")]
+    public bool? AudioTimestamp
     {
-        get => this._responseFormat;
-
+        get => this._audioTimestamp;
         set
         {
             this.ThrowIfFrozen();
-            this._responseFormat = value;
+            this._audioTimestamp = value;
         }
     }
 
@@ -224,7 +223,7 @@ public sealed class GeminiPromptExecutionSettings : PromptExecutionSettings
             StopSequences = this.StopSequences is not null ? new List<string>(this.StopSequences) : null,
             SafetySettings = this.SafetySettings?.Select(setting => new GeminiSafetySetting(setting)).ToList(),
             ToolCallBehavior = this.ToolCallBehavior?.Clone(),
-            ResponseFormat = this.ResponseFormat
+            AudioTimestamp = this.AudioTimestamp
         };
     }
 


### PR DESCRIPTION
### Motivation and Context

**Why is this change required?**
This change is required to enhance the functionality of audio processing in the Semantic Kernel by allowing the inclusion of timestamps in audio responses.

**What problem does it solve?**
It resolves the limitation of missing audio timestamp support in the `GeminiPromptExecutionSettings`, which has been a significant blocker for developers trying to utilize audio prompts effectively.

**What scenario does it contribute to?**
This contribution is particularly useful for applications that require precise audio response management, enabling better synchronization and analysis of audio data in real-time scenarios.

If it fixes an open issue, please link to the issue here.
#9500

### Description

This contribution adds a new feature that allows audio responses to include timestamps, a crucial element for many applications. Here’s a quick overview of what’s been implemented:

**New Property:** The `AudioTimestamp` property indicates whether the audio response should include timestamps. When enabled, this property will ensure that audio timestamps are included in requests to the model, providing developers with the precise control they need for their applications.

**Seamless Integration:** I conducted a thorough review of the existing codebase to ensure that this new feature integrates smoothly without disrupting current functionalities. This change is designed to be backward-compatible, making it easier for developers to adopt.

**Future-Proofing:** By adding this property, we’re not just solving an immediate need; we’re also paving the way for future enhancements in audio processing capabilities within the Semantic Kernel framework.

### Contribution Checklist

- [Y] The code builds clean without any errors or warnings
- [Y] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [Y] All unit tests pass, and I have added new tests where possible
- [Y] I didn't break anyone :smile:
