### PR TITLE
.Net: Include the operation in the KernelFunction.Metadata

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
@@ -52,7 +52,7 @@ public sealed class RestApiOperation
     /// <summary>
     /// The server.
     /// </summary>
-    public RestApiOperationServer Server { get; }
+    internal RestApiOperationServer Server { get; }
 
     /// <summary>
     /// The operation parameters.

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -266,7 +266,7 @@ public static partial class OpenApiKernelPluginFactory
         var additionalMetadata = new Dictionary<string, object?>
         {
             { OpenApiKernelPluginFactory.OperationExtensionsMethodKey, operation.Method.ToString().ToUpperInvariant() },
-            { OpenApiKernelPluginFactory.OperationExtensionsPathKey, operation.Path },
+            { OpenApiKernelPluginFactory.OperationExtensionsOperationKey, operation },
             { OpenApiKernelPluginFactory.OperationExtensionsServerUrlsKey, string.IsNullOrEmpty(operation.Server?.Url) ? Array.Empty<string>() : [ operation.Server!.Url! ] }
         };
         if (operation.Extensions is { Count: > 0 })
@@ -292,8 +292,8 @@ public static partial class OpenApiKernelPluginFactory
     /// <summary>The metadata property bag key to use when storing the method of an operation.</summary>
     private const string OperationExtensionsMethodKey = "method";
 
-    /// <summary>The metadata property bag key to use when storing the path of an operation.</summary>
-    private const string OperationExtensionsPathKey = "path";
+    /// <summary>The metadata property bag key to use when storing the operation.</summary>
+    private const string OperationExtensionsOperationKey = "operation";
 
     /// <summary>The metadata property bag key to use when storing the server of an operation.</summary>
     private const string OperationExtensionsServerUrlsKey = "server-urls";

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiKernelExtensionsTests.cs
@@ -279,12 +279,14 @@ public sealed class OpenApiKernelExtensionsTests : IDisposable
         Assert.Equal(4, additionalProperties.Count);
 
         Assert.Contains("method", additionalProperties.Keys);
-        Assert.Contains("path", additionalProperties.Keys);
+        Assert.Contains("operation", additionalProperties.Keys);
         Assert.Contains("server-urls", additionalProperties.Keys);
         Assert.Contains("operation-extensions", additionalProperties.Keys);
 
+        var operation = additionalProperties["operation"] as RestApiOperation;
+        Assert.NotNull(operation);
         Assert.Equal("GET", additionalProperties["method"]);
-        Assert.Equal("/api-with-open-api-extensions", additionalProperties["path"]);
+        Assert.Equal("/api-with-open-api-extensions", operation.Path);
         var serverUrls = additionalProperties["server-urls"] as string[];
         Assert.NotNull(serverUrls);
         Assert.Equal(["https://my-key-vault.vault.azure.net"], serverUrls);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -270,12 +270,14 @@ public sealed class OpenApiKernelPluginFactoryTests
         Assert.Equal(4, additionalProperties.Count);
 
         Assert.Contains("method", additionalProperties.Keys);
-        Assert.Contains("path", additionalProperties.Keys);
+        Assert.Contains("operation", additionalProperties.Keys);
         Assert.Contains("server-urls", additionalProperties.Keys);
         Assert.Contains("operation-extensions", additionalProperties.Keys);
 
+        var operation = additionalProperties["operation"] as RestApiOperation;
+        Assert.NotNull(operation);
         Assert.Equal("GET", additionalProperties["method"]);
-        Assert.Equal("/api-with-open-api-extensions", additionalProperties["path"]);
+        Assert.Equal("/api-with-open-api-extensions", operation.Path);
         var serverUrls = additionalProperties["server-urls"] as string[];
         Assert.NotNull(serverUrls);
         Assert.Equal(["https://my-key-vault.vault.azure.net"], serverUrls);


### PR DESCRIPTION
### Motivation and Context

Update for #9496 to include the `RestApiOperation` in the `KernelFunction.MetaData`

### Description

This will help us avoid having to add all `RestApiOperation` properties individually to metadata.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
