### PR TITLE
.Net: Make OpenApi model classes experimental

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiInfo.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiInfo.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API information.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiInfo
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Nodes;
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <summary>
 /// The REST API operation.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperation
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationExpectedResponse.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationExpectedResponse.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API operation response.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperationExpectedResponse
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationParameter.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationParameter.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API operation parameter.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperationParameter
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationParameterLocation.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationParameterLocation.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API operation parameter location.
 /// </summary>
+[Experimental("SKEXP0040")]
 public enum RestApiOperationParameterLocation
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationParameterStyle.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationParameterStyle.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API operation parameter style.
 /// </summary>
+[Experimental("SKEXP0040")]
 public enum RestApiOperationParameterStyle
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationPayload.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationPayload.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API operation payload.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperationPayload
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationPayloadProperty.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationPayloadProperty.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// The REST API operation payload property.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperationPayloadProperty
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationServer.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationServer.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// REST API Operation Server.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperationServer
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationServerVariable.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperationServerVariable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <summary>
 /// REST API Operation Server Variable.
 /// </summary>
+[Experimental("SKEXP0040")]
 public sealed class RestApiOperationServerVariable
 {
     /// <summary>


### PR DESCRIPTION
### Motivation, Context and Description
Taking into account that the OpenAPI model classes have become exposed through the `KernelFunction.Metadata` property and that there could be requests to change their public API surface, it makes sense to label them as experimental to communicate the potential changes to the consumers of the classes.

Related task: https://github.com/microsoft/semantic-kernel/issues/6884
