### PR TITLE
.Net Agents - Fix polling cycle to properly evaluate failure mode on exception

### DIFF
--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -180,7 +180,6 @@ internal static class AssistantThreadActions
         // Evaluate status and process steps and messages, as encountered.
         HashSet<string> processedStepIds = [];
         Dictionary<string, FunctionResultContent> functionSteps = [];
-        bool didDelete = false;
         do
         {
             // Check for cancellation
@@ -288,12 +287,6 @@ internal static class AssistantThreadActions
                 }
 
                 processedStepIds.Add(completedStep.Id);
-            }
-
-            if (!didDelete)
-            {
-                await agent.DeleteThreadAsync(threadId, cancellationToken).ConfigureAwait(false);
-                didDelete = true;
             }
 
             logger.LogOpenAIAssistantProcessedRunMessages(nameof(InvokeAsync), messageCount, run.Id, threadId);

--- a/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
+++ b/dotnet/src/Agents/OpenAI/Internal/AssistantThreadActions.cs
@@ -310,14 +310,15 @@ internal static class AssistantThreadActions
                 {
                     // Reduce polling frequency after a couple attempts
                     await Task.Delay(agent.PollingOptions.GetPollingInterval(count), cancellationToken).ConfigureAwait(false);
-                    ++count;
                 }
+
+                ++count;
 
                 try
                 {
                     run = await client.GetRunAsync(threadId, run.Id, cancellationToken).ConfigureAwait(false);
                 }
-                // The presence of a `Status` code means the server responded with error...alway fail in that case
+                // The presence of a `Status` code means the server responded with error...always fail in that case
                 catch (ClientResultException clientException) when (clientException.Status <= 0)
                 {
                     // Check maximum retry count

--- a/dotnet/src/Agents/OpenAI/RunPollingOptions.cs
+++ b/dotnet/src/Agents/OpenAI/RunPollingOptions.cs
@@ -9,6 +9,11 @@ namespace Microsoft.SemanticKernel.Agents.OpenAI;
 public sealed class RunPollingOptions
 {
     /// <summary>
+    /// The default maximum number or retries when monitoring thread-run status.
+    /// </summary>
+    public static int DefaultMaximumRetryCount { get; } = 3;
+
+    /// <summary>
     /// The default polling interval when monitoring thread-run status.
     /// </summary>
     public static TimeSpan DefaultPollingInterval { get; } = TimeSpan.FromMilliseconds(500);
@@ -27,6 +32,15 @@ public sealed class RunPollingOptions
     /// The default polling delay when retrying message retrieval due to a 404/NotFound from synchronization lag.
     /// </summary>
     public static TimeSpan DefaultMessageSynchronizationDelay { get; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// The maximum retry count when polling thread-run status.
+    /// </summary>
+    /// <remarks>
+    /// Only affects failures that have the potential to be transient.  Explicit server error responses
+    /// will result in immediate failure.
+    /// </remarks>
+    public int MaximumRetryCount { get; set; } = DefaultMaximumRetryCount;
 
     /// <summary>
     /// The polling interval when monitoring thread-run status.


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Assistant polling not propertly responding to terminal error conditions.

Fixes: https://github.com/microsoft/semantic-kernel/issues/9579

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

- Added explicit check for cancelling state: Invoke, InvokeStreaming, & Polling loops
- Discriminate on different exception modes when polling
- Ensure stale run state isn't evaluated in polling loop
- Remove initial polling delay

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
