### PR TITLE
.Net: Don't allow function name/id to be overwritten with an empty string

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/FunctionCallContentBuilder.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/FunctionCallContentBuilder.cs
@@ -181,13 +181,13 @@ public sealed class FunctionCallContentBuilder
 
         // If we have an call id, ensure the index is being tracked. Even if it's not a function update,
         // we want to keep track of it so we can send back an error.
-        if (update.CallId is string id)
+        if (update.CallId is string id && !string.IsNullOrEmpty(id))
         {
             (functionCallIdsByIndex ??= [])[update.FunctionCallIndex] = id;
         }
 
         // Ensure we're tracking the function's name.
-        if (update.Name is string name)
+        if (update.Name is string name && !string.IsNullOrEmpty(name))
         {
             (functionNamesByIndex ??= [])[update.FunctionCallIndex] = name;
         }


### PR DESCRIPTION
### Motivation and Context

Closes #9567 

### Description

The fix handles the case where a streaming update contains an empty string for the function name. I haven't been able to reproduce the scenario where this happens and I have asked the issue creator for more information. The function name has a max size of 64 chars and when I use that the function isn't split over multiple streaming responses.

Referencing the approach shown here: https://community.openai.com/t/functions-calling-with-streaming/305742

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
