### PR TITLE
.Net: Prepare OpenApi model classes to changes in OpenApi.NET v2 SDK

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiOperation.cs
@@ -34,12 +34,12 @@ public sealed class RestApiOperation
     /// <summary>
     /// The operation identifier.
     /// </summary>
-    public string Id { get; }
+    public string? Id { get; }
 
     /// <summary>
     /// The operation description.
     /// </summary>
-    public string Description { get; }
+    public string? Description { get; }
 
     /// <summary>
     /// The operation path.
@@ -59,7 +59,7 @@ public sealed class RestApiOperation
     /// <summary>
     /// The security requirements.
     /// </summary>
-    public IReadOnlyList<RestApiSecurityRequirement>? SecurityRequirements { get; }
+    public IReadOnlyList<RestApiSecurityRequirement> SecurityRequirements { get; }
 
     /// <summary>
     /// The operation parameters.
@@ -90,19 +90,19 @@ public sealed class RestApiOperation
     /// <param name="method">The operation method.</param>
     /// <param name="description">The operation description.</param>
     /// <param name="parameters">The operation parameters.</param>
-    /// <param name="payload">The operation payload.</param>
     /// <param name="responses">The operation responses.</param>
     /// <param name="securityRequirements">The operation security requirements.</param>
+    /// <param name="payload">The operation payload.</param>
     internal RestApiOperation(
-        string id,
+        string? id,
         IReadOnlyList<RestApiOperationServer> servers,
         string path,
         HttpMethod method,
-        string description,
+        string? description,
         IReadOnlyList<RestApiOperationParameter> parameters,
-        RestApiOperationPayload? payload = null,
-        IReadOnlyDictionary<string, RestApiOperationExpectedResponse>? responses = null,
-        IReadOnlyList<RestApiSecurityRequirement>? securityRequirements = null)
+        IReadOnlyDictionary<string, RestApiOperationExpectedResponse> responses,
+        IReadOnlyList<RestApiSecurityRequirement> securityRequirements,
+        RestApiOperationPayload? payload = null)
     {
         this.Id = id;
         this.Servers = servers;
@@ -110,9 +110,9 @@ public sealed class RestApiOperation
         this.Method = method;
         this.Description = description;
         this.Parameters = parameters;
-        this.Payload = payload;
-        this.Responses = responses ?? new Dictionary<string, RestApiOperationExpectedResponse>();
+        this.Responses = responses;
         this.SecurityRequirements = securityRequirements;
+        this.Payload = payload;
     }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -325,7 +325,7 @@ public static partial class OpenApiKernelPluginFactory
     {
         if (!string.IsNullOrWhiteSpace(operation.Id))
         {
-            return ConvertOperationIdToValidFunctionName(operationId: operation.Id, logger: logger);
+            return ConvertOperationIdToValidFunctionName(operationId: operation.Id!, logger: logger);
         }
 
         // Tokenize operation path on forward and back slashes

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/RestApiOperationExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/RestApiOperationExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
@@ -255,13 +256,15 @@ public class RestApiOperationExtensionsTests
     private static RestApiOperation CreateTestOperation(string method, RestApiOperationPayload? payload = null, Uri? url = null)
     {
         return new RestApiOperation(
-                    id: "fake-id",
-                    servers: [new(url?.AbsoluteUri)],
-                    path: "fake-path",
-                    method: new HttpMethod(method),
-                    description: "fake-description",
-                    parameters: [],
-                    payload: payload);
+            id: "fake-id",
+            servers: [new(url?.AbsoluteUri)],
+            path: "fake-path",
+            method: new HttpMethod(method),
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload);
     }
 
     private static RestApiOperationPayload CreateTestJsonPayload()

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -65,13 +65,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var httpMethod = new HttpMethod(method);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            httpMethod,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: httpMethod,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var payload = new
@@ -143,13 +144,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var httpMethod = new HttpMethod(method);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            httpMethod,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: httpMethod,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -209,12 +211,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         };
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            parameters
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -274,12 +278,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         };
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            parameters
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -319,13 +325,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -383,13 +391,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -472,13 +482,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -542,12 +554,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     {
         // Arrange
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
             payload: null
         );
 
@@ -569,12 +583,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     {
         // Arrange
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
             payload: null
         );
 
@@ -600,13 +616,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Text.Plain, []);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -640,12 +658,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Text.Plain);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
             payload: null
         );
 
@@ -686,13 +706,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments();
@@ -732,13 +754,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments { ["upn"] = "fake-sender-upn" };
@@ -787,13 +811,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             RestApiOperationParameterStyle.Form);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [firstParameter, secondParameter],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [firstParameter, secondParameter],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -835,13 +860,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             RestApiOperationParameterStyle.Form);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [firstParameter, secondParameter],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [firstParameter, secondParameter],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -883,13 +909,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             RestApiOperationParameterStyle.Form);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [firstParameter, secondParameter],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [firstParameter, secondParameter],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -922,13 +949,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
             RestApiOperationParameterStyle.Form);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [parameter],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [parameter],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments(); //Providing no arguments
@@ -953,13 +981,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, contentType);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -995,13 +1024,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpMessageHandlerStub.ResponseToReturn.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -1030,13 +1060,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, "fake/type");
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -1073,13 +1104,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -1121,13 +1154,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -1169,13 +1204,15 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         var payload = new RestApiOperationPayload(MediaTypeNames.Application.Json, payloadProperties);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: [],
+            payload: payload
         );
 
         var arguments = new KernelArguments
@@ -1213,13 +1250,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpMessageHandlerStub.ExceptionToThrow = new OperationCanceledException();
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Post,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new KernelArguments
@@ -1243,13 +1281,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     {
         // Arrange
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var expectedCancellationToken = new CancellationToken();
@@ -1277,13 +1316,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
 
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var readerHasBeenCalled = false;
@@ -1309,13 +1349,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     {
         // Arrange
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [],
-            payload: null
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         HttpResponseMessage? responseMessage = null;
@@ -1396,14 +1437,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     public async Task ItShouldReturnExpectedSchemaAsync(string expectedStatusCode, params (string, RestApiOperationExpectedResponse)[] responses)
     {
         var operation = new RestApiOperation(
-            "fake-id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path",
-            HttpMethod.Get,
-            "fake-description",
-            [],
-            null,
-            responses.ToDictionary(item => item.Item1, item => item.Item2)
+            id: "fake-id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [],
+            responses: responses.ToDictionary(item => item.Item1, item => item.Item2),
+            securityRequirements: []
         );
 
         var sut = new RestApiOperationRunner(this._httpClient, this._authenticationHandlerMock.Object);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationTests.cs
@@ -23,12 +23,14 @@ public class RestApiOperationTests
     {
         // Arrange
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "/",
-            HttpMethod.Get,
-            "fake_description",
-            []
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "/",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new Dictionary<string, object?>();
@@ -45,12 +47,14 @@ public class RestApiOperationTests
     {
         // Arrange
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "/",
-            HttpMethod.Get,
-            "fake_description",
-            []
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "/",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var fakeHostUrlOverride = "https://fake-random-test-host-override";
@@ -86,12 +90,14 @@ public class RestApiOperationTests
         };
 
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "/{p1}/{p2}/other_fake_path_section",
-            HttpMethod.Get,
-            "fake_description",
-            parameters
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "/{p1}/{p2}/other_fake_path_section",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new Dictionary<string, object?>
@@ -129,12 +135,14 @@ public class RestApiOperationTests
         };
 
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "/{p1}/{p2}/other_fake_path_section",
-            HttpMethod.Get,
-            "fake_description",
-            parameters
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "/{p1}/{p2}/other_fake_path_section",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new Dictionary<string, object?>
@@ -171,12 +179,15 @@ public class RestApiOperationTests
         };
 
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "{fake-path}/",
-            HttpMethod.Get,
-            "fake_description",
-            parameters);
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "{fake-path}/",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         var fakeHostUrlOverride = "https://fake-random-test-host-override";
 
@@ -212,12 +223,15 @@ public class RestApiOperationTests
         };
 
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path/",
-            HttpMethod.Get,
-            "fake_description",
-            parameters);
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path/",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         var arguments = new Dictionary<string, object?>
         {
@@ -246,12 +260,15 @@ public class RestApiOperationTests
         };
 
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path/",
-            HttpMethod.Get,
-            "fake_description",
-            parameters);
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path/",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         var arguments = new Dictionary<string, object?>
         {
@@ -279,12 +296,15 @@ public class RestApiOperationTests
         };
 
         var sut = new RestApiOperation(
-            "fake_id",
-            [new RestApiOperationServer("https://fake-random-test-host")],
-            "fake-path/",
-            HttpMethod.Get,
-            "fake_description",
-            parameters);
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake-path/",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         var arguments = new Dictionary<string, object?>
         {
@@ -327,7 +347,16 @@ public class RestApiOperationTests
             { "fake_header_two", "fake_header_two_value" }
         };
 
-        var sut = new RestApiOperation("fake_id", [new RestApiOperationServer("http://fake_url")], "fake_path", HttpMethod.Get, "fake_description", parameters);
+        var sut = new RestApiOperation(
+            id: "fake_id",
+            servers: [new RestApiOperationServer("http://fake_url")],
+            path: "fake_path",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         // Act
         var headers = sut.BuildHeaders(arguments);
@@ -346,13 +375,22 @@ public class RestApiOperationTests
     public void ShouldThrowExceptionIfNoValueProvidedForRequiredHeader()
     {
         // Arrange
-        var metadata = new List<RestApiOperationParameter>
+        var parameters = new List<RestApiOperationParameter>
         {
             new(name: "fake_header_one", type: "string", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
             new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple)
         };
 
-        var sut = new RestApiOperation("fake_id", [new RestApiOperationServer("http://fake_url")], "fake_path", HttpMethod.Get, "fake_description", metadata);
+        var sut = new RestApiOperation(
+            id: "fake_id",
+            servers: [new RestApiOperationServer("http://fake_url")],
+            path: "fake_path",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         // Act
         void Act() => sut.BuildHeaders(new Dictionary<string, object?>());
@@ -365,7 +403,7 @@ public class RestApiOperationTests
     public void ItShouldSkipOptionalHeaderHavingNoValue()
     {
         // Arrange
-        var metadata = new List<RestApiOperationParameter>
+        var parameters = new List<RestApiOperationParameter>
         {
             new(name: "fake_header_one", type : "string", isRequired : true, expand : false, location : RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
             new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiOperationParameterLocation.Header, style : RestApiOperationParameterStyle.Simple)
@@ -376,7 +414,16 @@ public class RestApiOperationTests
             ["fake_header_one"] = "fake_header_one_value"
         };
 
-        var sut = new RestApiOperation("fake_id", [new RestApiOperationServer("http://fake_url")], "fake_path", HttpMethod.Get, "fake_description", metadata);
+        var sut = new RestApiOperation(
+            id: "fake_id",
+            servers: [new RestApiOperationServer("http://fake_url")],
+            path: "fake_path",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         // Act
         var headers = sut.BuildHeaders(arguments);
@@ -392,7 +439,7 @@ public class RestApiOperationTests
     public void ItShouldCreateHeaderWithCommaSeparatedValues()
     {
         // Arrange
-        var metadata = new List<RestApiOperationParameter>
+        var parameters = new List<RestApiOperationParameter>
         {
             new( name: "h1", type: "array", isRequired: false, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple, arrayItemType: "string"),
             new( name: "h2", type: "array", isRequired: false, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple, arrayItemType: "integer")
@@ -404,7 +451,16 @@ public class RestApiOperationTests
             ["h2"] = "[1,2,3]"
         };
 
-        var sut = new RestApiOperation("fake_id", [new RestApiOperationServer("https://fake-random-test-host")], "fake_path", HttpMethod.Get, "fake_description", metadata);
+        var sut = new RestApiOperation(
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake_path",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         // Act
         var headers = sut.BuildHeaders(arguments);
@@ -421,7 +477,7 @@ public class RestApiOperationTests
     public void ItShouldCreateHeaderWithPrimitiveValue()
     {
         // Arrange
-        var metadata = new List<RestApiOperationParameter>
+        var parameters = new List<RestApiOperationParameter>
         {
             new( name: "h1", type: "string", isRequired: false, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
             new( name: "h2", type: "boolean", isRequired: false, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple)
@@ -433,7 +489,16 @@ public class RestApiOperationTests
             ["h2"] = true
         };
 
-        var sut = new RestApiOperation("fake_id", [new RestApiOperationServer("https://fake-random-test-host")], "fake_path", HttpMethod.Get, "fake_description", metadata);
+        var sut = new RestApiOperation(
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake_path",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         // Act
         var headers = sut.BuildHeaders(arguments);
@@ -450,7 +515,7 @@ public class RestApiOperationTests
     public void ItShouldMixAndMatchHeadersOfDifferentValueTypes()
     {
         // Arrange
-        var metadata = new List<RestApiOperationParameter>
+        var parameters = new List<RestApiOperationParameter>
         {
             new(name: "h1", type: "array", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
             new(name: "h2", type: "boolean", isRequired: true, expand: false, location: RestApiOperationParameterLocation.Header, style: RestApiOperationParameterStyle.Simple),
@@ -462,7 +527,16 @@ public class RestApiOperationTests
             ["h2"] = "false"
         };
 
-        var sut = new RestApiOperation("fake_id", [new RestApiOperationServer("https://fake-random-test-host")], "fake_path", HttpMethod.Get, "fake_description", metadata);
+        var sut = new RestApiOperation(
+            id: "fake_id",
+            servers: [new RestApiOperationServer("https://fake-random-test-host")],
+            path: "fake_path",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: parameters,
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
+        );
 
         // Act
         var headers = sut.BuildHeaders(arguments);
@@ -708,15 +782,17 @@ public class RestApiOperationTests
     {
         // Arrange
         var sut = new RestApiOperation(
-            "fake_id",
-            [
+            id: "fake_id",
+            servers: [
                 new RestApiOperationServer("https://example.com/{version}", new Dictionary<string, RestApiOperationServerVariable> { { "version", new RestApiOperationServerVariable("v2") } }),
                 new RestApiOperationServer("https://ppe.example.com/{version}", new Dictionary<string, RestApiOperationServerVariable> { { "version", new RestApiOperationServerVariable("v2") } })
             ],
-            "/items",
-            HttpMethod.Get,
-            "fake_description",
-            []
+            path: "/items",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new Dictionary<string, object?>();
@@ -734,15 +810,17 @@ public class RestApiOperationTests
         // Arrange
         var version = new RestApiOperationServerVariable("v2", null, ["v1", "v2"]);
         var sut = new RestApiOperation(
-            "fake_id",
-            [
+            id: "fake_id",
+            servers: [
                 new RestApiOperationServer("https://example.com/{version}", new Dictionary<string, RestApiOperationServerVariable> { { "version", version } }),
                 new RestApiOperationServer("https://ppe.example.com/{version}", new Dictionary<string, RestApiOperationServerVariable> { { "version", new RestApiOperationServerVariable("v2") } })
             ],
-            "/items",
-            HttpMethod.Get,
-            "fake_description",
-            []
+            path: "/items",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new Dictionary<string, object?>() { { "version", "v3" } };
@@ -760,15 +838,17 @@ public class RestApiOperationTests
         // Arrange
         var version = new RestApiOperationServerVariable("v2", null, ["v1", "v2", "v3"]);
         var sut = new RestApiOperation(
-            "fake_id",
-            [
+            id: "fake_id",
+            servers: [
                 new RestApiOperationServer("https://example.com/{version}", new Dictionary<string, RestApiOperationServerVariable> { { "version", version } }),
                 new RestApiOperationServer("https://ppe.example.com/{version}", new Dictionary<string, RestApiOperationServerVariable> { { "version", new RestApiOperationServerVariable("v2") } })
             ],
-            "/items",
-            HttpMethod.Get,
-            "fake_description",
-            []
+            path: "/items",
+            method: HttpMethod.Get,
+            description: "fake_description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiOperationExpectedResponse>(),
+            securityRequirements: []
         );
 
         var arguments = new Dictionary<string, object?>() { { "version", "v3" } };


### PR DESCRIPTION
### Motivation, Context and Description
The new version, V2, of the [OpenAPI.NET](https://github.com/microsoft/OpenAPI.NET/pull/1906) SDK comes with changes to its model classes. This PR updates the SK OpenAPI model classes to match the SDK's ones. The goal is to reduce breaking changes from the update.

Similar changes were done in this PR - [.Net: Rename OpenAPI model classes](https://github.com/microsoft/semantic-kernel/pull/9595) where the `RestApiPayloadProperty.Type`, `RestApiParameter.Type`, and `RestApiParameter.ArrayItemType` were made internal to simplify the update to OpenAPI.NET v2, where their types have been changed.

Related task: https://github.com/microsoft/semantic-kernel/issues/6884