### PR TITLE
Comment out broken link

### DIFF
--- a/docs/decisions/0054-processes.md
+++ b/docs/decisions/0054-processes.md
@@ -315,4 +315,4 @@ The following packages will be created for Processes:
 In validation of the proposed solution, two runtimes were created, one for the local/server scenario and one for the distributed actor scenario using Orleans. Both of these implementation were based on the [Pregel Algorithm](https://kowshik.github.io/JPregel/pregel_paper.pdf) for large-scale graph processing. This algorithm is well tested and well suited for single machine scenarios as well as distributed systems. More information on how the Pregel algorithm works can be found in the following links.
 
 - [Pregel - The Morning Paper](https://blog.acolyer.org/2015/05/26/pregel-a-system-for-large-scale-graph-processing/)
-- [Pregel - Distributed Algorithms and Optimization](https://web.stanford.edu/~rezab/classes/cme323/S15/notes/lec8.pdf)
+<!-- [Pregel - Distributed Algorithms and Optimization](https://web.stanford.edu/~rezab/classes/cme323/S15/notes/lec8.pdf) -->


### PR DESCRIPTION
### Motivation and Context
The `markdown-link-check` tool fails - [32656031279](https://github.com/microsoft/semantic-kernel/actions/runs/11723502773/job/32656031279?pr=9595) trying to access the broken link - [web.stanford.edu](https://web.stanford.edu/~rezab/classes/cme323/S15/notes/lec8.pdf)

This PR comments out the link until the working one is found.