### PR TITLE
.Net Processes - Fix Serialization of Input Data

### DIFF
--- a/dotnet/src/Experimental/Process.Runtime.Dapr/DaprKernelProcessContext.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/DaprKernelProcessContext.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Dapr.Actors;
 using Dapr.Actors.Client;
 using Microsoft.SemanticKernel.Process;
+using Microsoft.SemanticKernel.Process.Serialization;
 
 namespace Microsoft.SemanticKernel;
 
@@ -40,7 +41,7 @@ public class DaprKernelProcessContext : KernelProcessContext
     {
         var daprProcess = DaprProcessInfo.FromKernelProcess(this._process);
         await this._daprProcess.InitializeProcessAsync(daprProcess, null).ConfigureAwait(false);
-        await this._daprProcess.RunOnceAsync(initialEvent).ConfigureAwait(false);
+        await this._daprProcess.RunOnceAsync(initialEvent.ToJson()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -49,7 +50,7 @@ public class DaprKernelProcessContext : KernelProcessContext
     /// <param name="processEvent">The event to sent to the process.</param>
     /// <returns>A <see cref="Task"/></returns>
     public override async Task SendEventAsync(KernelProcessEvent processEvent) =>
-        await this._daprProcess.SendMessageAsync(processEvent).ConfigureAwait(false);
+        await this._daprProcess.SendMessageAsync(processEvent.ToJson()).ConfigureAwait(false);
 
     /// <summary>
     /// Stops the process.

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Interfaces/IProcess.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Interfaces/IProcess.cs
@@ -31,7 +31,7 @@ public interface IProcess : IActor, IStep
     /// </summary>
     /// <param name="processEvent">Required. The <see cref="KernelProcessEvent"/> to start the process with.</param>
     /// <returns>A <see cref="Task"/></returns>
-    Task RunOnceAsync(KernelProcessEvent processEvent);
+    Task RunOnceAsync(string processEvent);
 
     /// <summary>
     /// Stops a running process. This will cancel the process and wait for it to complete before returning.
@@ -45,7 +45,7 @@ public interface IProcess : IActor, IStep
     /// </summary>
     /// <param name="processEvent">Required. The <see cref="KernelProcessEvent"/> to start the process with.</param>
     /// <returns>A <see cref="Task"/></returns>
-    Task SendMessageAsync(KernelProcessEvent processEvent);
+    Task SendMessageAsync(string processEvent);
 
     /// <summary>
     /// Gets the process information.

--- a/dotnet/src/Experimental/Process.Runtime.Dapr/Serialization/KernelProcessEventSerializer.cs
+++ b/dotnet/src/Experimental/Process.Runtime.Dapr/Serialization/KernelProcessEventSerializer.cs
@@ -34,11 +34,20 @@ internal static class KernelProcessEventSerializer
         {
             foreach (string json in jsonEvents)
             {
-                EventContainer<KernelProcessEvent> eventContainer =
-                    JsonSerializer.Deserialize<EventContainer<KernelProcessEvent>>(json) ??
-                    throw new KernelException($"Unable to deserialize {nameof(KernelProcessEvent)} queue.");
-                yield return eventContainer.Payload with { Data = TypeInfo.ConvertValue(eventContainer.DataTypeName, eventContainer.Payload.Data) };
+                yield return json.ToKernelProcessEvent();
             }
         }
+    }
+
+    /// <summary>
+    /// Deserialize a list of JSON events into a list of <see cref="KernelProcessEvent"/> objects.
+    /// </summary>
+    /// <exception cref="KernelException">If any event fails deserialization</exception>
+    public static KernelProcessEvent ToKernelProcessEvent(this string jsonEvent)
+    {
+        EventContainer<KernelProcessEvent> eventContainer =
+            JsonSerializer.Deserialize<EventContainer<KernelProcessEvent>>(jsonEvent) ??
+            throw new KernelException($"Unable to deserialize {nameof(KernelProcessEvent)} queue.");
+        return eventContainer.Payload with { Data = TypeInfo.ConvertValue(eventContainer.DataTypeName, eventContainer.Payload.Data) };
     }
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Updated ability to serialize complex types here:  https://github.com/microsoft/semantic-kernel/pull/9525

...but missed the remoting boundary for invoke the process.  This change addresses this final gap without altering external patterns.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Convert event to JSON when invoking `ProcessActor` from `DaprKernelProcessContext`

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
