### PR TITLE
.Net: Remove experimental flag from VectorStore implementations.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryRecord.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Memory;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// Azure AI Search record and index definition.
 /// Note: once defined, index cannot be modified.
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class AzureAISearchMemoryRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryStore.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -23,6 +24,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// <summary>
 /// <see cref="AzureAISearchMemoryStore"/> is a memory store implementation using Azure AI Search.
 /// </summary>
+[Experimental("SKEXP0020")]
 public partial class AzureAISearchMemoryStore : IMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/Connectors.Memory.AzureAISearch.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/Connectors.Memory.AzureAISearch.csproj
@@ -5,8 +5,6 @@
     <RootNamespace>Microsoft.SemanticKernel.Connectors.AzureAISearch</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <VersionSuffix>preview</VersionSuffix>
-    <!--NU5104: A stable release of a package should not have a prerelease dependency.-->
-    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConfig.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConfig.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <remarks>
 /// Initialize the <see cref="AzureCosmosDBMongoDBConfig"/> with default values.
 /// </remarks>
+[Experimental("SKEXP0020")]
 public class AzureCosmosDBMongoDBConfig(int dimensions)
 {
     private const string DefaultIndexName = "default_index";

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecord.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson;
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// A MongoDB memory record.
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class AzureCosmosDBMongoDBMemoryRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// A MongoDB memory record metadata.
 /// </summary>
 #pragma warning disable CA1815 // Override equals and operator equals on value types
+[Experimental("SKEXP0020")]
 internal struct AzureCosmosDBMongoDBMemoryRecordMetadata
 #pragma warning restore CA1815 // Override equals and operator equals on value types
 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -17,6 +18,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// An implementation of <see cref="IMemoryStore"/> backed by a Azure CosmosDB Mongo vCore database.
 /// Get more details about Azure Cosmos Mongo vCore vector search  https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search
 /// </summary>
+[Experimental("SKEXP0020")]
 public class AzureCosmosDBMongoDBMemoryStore : IMemoryStore, IDisposable
 {
     private readonly MongoClient _mongoClient;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBSimilarityType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBSimilarityType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Similarity metric to use with the index. Possible options are COS (cosine distance), L2 (Euclidean distance), and IP (inner product).
 /// </summary>
+[Experimental("SKEXP0020")]
 public enum AzureCosmosDBSimilarityType
 {
     /// <summary>
@@ -31,6 +33,7 @@ public enum AzureCosmosDBSimilarityType
     Euclidean
 }
 
+[Experimental("SKEXP0020")]
 internal static class AzureCosmosDBSimilarityTypeExtensions
 {
     public static string GetCustomName(this AzureCosmosDBSimilarityType type)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBVectorSearchType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBVectorSearchType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Type of vector index to create. The options are vector-ivf and vector-hnsw.
 /// </summary>
+[Experimental("SKEXP0020")]
 public enum AzureCosmosDBVectorSearchType
 {
     /// <summary>
@@ -24,6 +26,7 @@ public enum AzureCosmosDBVectorSearchType
     VectorHNSW
 }
 
+[Experimental("SKEXP0020")]
 internal static class AzureCosmosDBVectorSearchTypeExtensions
 {
     public static string GetCustomName(this AzureCosmosDBVectorSearchType type)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/Connectors.Memory.AzureCosmosDBMongoDB.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/Connectors.Memory.AzureCosmosDBMongoDB.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);NU5104;SKEXP0001,SKEXP0010</NoWarn>
     <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -21,6 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// An implementation of <see cref="IMemoryStore"/> backed by a Azure Cosmos DB database.
 /// Get more details about Azure Cosmos DB vector search  https://learn.microsoft.com/en-us/azure/cosmos-db/
 /// </summary>
+[Experimental("SKEXP0020")]
 public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 {
     private const string EmbeddingPath = "/embedding";
@@ -444,6 +446,7 @@ public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 /// <param name="timestamp"></param>
 [DebuggerDisplay("{GetDebuggerDisplay()}")]
 #pragma warning disable CA1812 // 'MemoryRecordWithSimilarityScore' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic). (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812)
+[Experimental("SKEXP0020")]
 internal sealed class MemoryRecordWithSimilarityScore(
 #pragma warning restore CA1812
     MemoryRecordMetadata metadata,
@@ -465,6 +468,7 @@ internal sealed class MemoryRecordWithSimilarityScore(
 /// <summary>
 /// Creates a new record that also serializes an "id" property.
 /// </summary>
+[Experimental("SKEXP0020")]
 [DebuggerDisplay("{GetDebuggerDisplay()}")]
 internal sealed class MemoryRecordWithId : MemoryRecord
 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/Connectors.Memory.AzureCosmosDBNoSQL.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/Connectors.Memory.AzureCosmosDBNoSQL.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);NU5104;SKEXP0001,SKEXP0010</NoWarn>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryEntry.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryEntry.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// <summary>
 /// A MongoDB memory entry.
 /// </summary>
+[Experimental("SKEXP0020")]
 public sealed class MongoDBMemoryEntry
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryRecordMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryRecordMetadata.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// A MongoDB record metadata.
 /// </summary>
 #pragma warning disable CA1815 // Override equals and operator equals on value types
+[Experimental("SKEXP0020")]
 public struct MongoDBMemoryRecordMetadata
 #pragma warning restore CA1815 // Override equals and operator equals on value types
 {

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a MongoDB database.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class MongoDBMemoryStore : IMemoryStore, IDisposable
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ConfigureIndexRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ConfigureIndexRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// This operation specifies the pod type and number of replicas for an index.
 /// See https://docs.pinecone.io/reference/configure_index
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class ConfigureIndexRequest
 {
     public string IndexName { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteIndexRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteIndexRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Deletes an index and all its data.
 /// See https://docs.pinecone.io/reference/delete_index
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class DeleteIndexRequest
 {
     public static DeleteIndexRequest Create(string indexName)

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// DeleteRequest
 /// See https://docs.pinecone.io/reference/delete_post
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class DeleteRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Get information about an index.
 /// See https://docs.pinecone.io/reference/describe_index
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class DescribeIndexRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexStatsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexStatsRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// DescribeIndexStatsRequest
 /// See https://docs.pinecone.io/reference/describe_index_stats_post
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class DescribeIndexStatsRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// FetchRequest
 /// See https://docs.pinecone.io/reference/fetch
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class FetchRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchResponse.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json.Serialization;
 
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// FetchResponse
 /// See https://docs.pinecone.io/reference/fetch
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class FetchResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ListIndexesRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ListIndexesRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// ListIndexesRequest
 /// See https://docs.pinecone.io/reference/list_indexes
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class ListIndexesRequest
 {
     public static ListIndexesRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryRequest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// QueryRequest
 /// See https://docs.pinecone.io/reference/query
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class QueryRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryResponse.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// QueryResponse
 /// See https://docs.pinecone.io/reference/query
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class QueryResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpdateVectorRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpdateVectorRequest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -13,6 +14,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// If a set_metadata is included, the values of the fields specified in it will be added or overwrite the previous value.
 /// See https://docs.pinecone.io/reference/update
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class UpdateVectorRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// UpsertRequest
 /// See https://docs.pinecone.io/reference/upsert
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class UpsertRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// UpsertResponse
 /// See https://docs.pinecone.io/reference/upsert
 /// </summary>
+[Experimental("SKEXP0020")]
 internal sealed class UpsertResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Interface for a Pinecone client
 /// </summary>
+[Experimental("SKEXP0020")]
 public interface IPineconeClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Memory;
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Interface for Pinecone memory store that extends the memory store interface
 /// to add support for namespaces
 /// </summary>
+[Experimental("SKEXP0020")]
 public interface IPineconeMemoryStore : IMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexDefinition.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexDefinition.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Used to create a new index.
 /// See https://docs.pinecone.io/reference/create_index
 /// </summary>
+[Experimental("SKEXP0020")]
 public class IndexDefinition
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetadataConfig.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetadataConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Memory;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed; when metadata_config is present, only specified metadata fields are indexed.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class MetadataIndexConfig
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetric.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetric.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// The vector similarity metric of the index
 /// </summary>
 /// <value>The vector similarity metric of the index</value>
+[Experimental("SKEXP0020")]
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum IndexMetric
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexNamespaceStats.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexNamespaceStats.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -7,6 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Index namespace parameters.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class IndexNamespaceStats
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexState.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexState.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// The current status of a index.
 /// </summary>
+[Experimental("SKEXP0020")]
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum IndexState
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStats.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStats.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Index parameters.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class IndexStats
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStatus.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStatus.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -7,6 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Status of the index.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class IndexStatus
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/OperationType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/OperationType.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
+[Experimental("SKEXP0020")]
 internal enum OperationType
 {
     Upsert,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PineconeIndex.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PineconeIndex.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -7,6 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Index entity.
 /// </summary>
+[Experimental("SKEXP0020")]
 public sealed class PineconeIndex
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PodType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PodType.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Pod type of the index, see https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes.
 /// </summary>
+[Experimental("SKEXP0020")]
 [JsonConverter(typeof(PodTypeJsonConverter))]
 public enum PodType
 {
@@ -106,6 +108,7 @@ public enum PodType
 }
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
+[Experimental("SKEXP0020")]
 internal sealed class PodTypeJsonConverter : JsonConverter<PodType>
 #pragma warning restore CA1812
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/Query.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/Query.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Query parameters for use in a query request.
 /// </summary>
+[Experimental("SKEXP0020")]
 public sealed class Query
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/SparseVectorData.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/SparseVectorData.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Represents a sparse vector data, which is a list of indices and a list of corresponding values, both of the same length.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class SparseVectorData
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -19,6 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// A client for the Pinecone API
 /// </summary>
+[Experimental("SKEXP0020")]
 public sealed class PineconeClient : IPineconeClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocument.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocument.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -12,6 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Pinecone Document entity.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class PineconeDocument
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocumentExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocumentExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.SemanticKernel.Memory;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Extensions for <see cref="PineconeDocument"/> class.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class PineconeDocumentExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Pinecone connector.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class PineconeMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -22,6 +23,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// For that reason, we use the term "Index" in Pinecone to refer to what is a "Collection" in IMemoryStore. So, in the case of Pinecone,
 ///  "Collection" is synonymous with "Index" when referring to IMemoryStore.
 /// </remarks>
+[Experimental("SKEXP0020")]
 public class PineconeMemoryStore : IPineconeMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeUtils.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeUtils.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -15,6 +16,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Utils for Pinecone connector.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class PineconeUtils
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/CreateCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/CreateCollectionRequest.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class CreateCollectionRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteCollectionRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class DeleteCollectionRequest
 {
     public static DeleteCollectionRequest Create(string collectionName)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class DeleteVectorsRequest
 {
     [JsonPropertyName("points")]

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 /// <summary>
 /// Empty qdrant response for requests that return nothing but status / error.
 /// </summary>
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes. Justification: deserialized by QdrantVectorDbClient.DeleteVectorsByIdAsync & QdrantVectorDbClient.DeleteVectorByPayloadIdAsync
+[Experimental("SKEXP0020")]
 internal sealed class DeleteVectorsResponse : QdrantResponse;
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetCollectionRequest.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class GetCollectionsRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class GetVectorsRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsResponse.cs
@@ -2,11 +2,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
+[Experimental("SKEXP0020")]
 internal sealed class GetVectorsResponse : QdrantResponse
 {
     internal sealed class Record

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class ListCollectionsRequest
 {
     public static ListCollectionsRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsResponse.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
+[Experimental("SKEXP0020")]
 internal sealed class ListCollectionsResponse : QdrantResponse
 {
     internal sealed class CollectionResult

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/NumberToStringConverter.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/NumberToStringConverter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -8,6 +9,7 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
+[Experimental("SKEXP0020")]
 internal sealed class NumberToStringConverter : JsonConverter<string>
 {
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/QdrantResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/QdrantResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
@@ -7,6 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Base class for Qdrant response schema.
 /// </summary>
+[Experimental("SKEXP0020")]
 internal abstract class QdrantResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
@@ -2,11 +2,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class SearchVectorsRequest
 {
     [JsonPropertyName("vector")]

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
@@ -2,11 +2,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
+[Experimental("SKEXP0020")]
 internal sealed class SearchVectorsResponse : QdrantResponse
 {
     internal sealed class ScoredPoint

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
@@ -2,11 +2,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+[Experimental("SKEXP0020")]
 internal sealed class UpsertVectorRequest
 {
     public static UpsertVectorRequest Create(string collectionName)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
+[Experimental("SKEXP0020")]
 internal sealed class UpsertVectorResponse : QdrantResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Interface for a Qdrant vector database client.
 /// </summary>
+[Experimental("SKEXP0020")]
 public interface IQdrantVectorDbClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantDistanceType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantDistanceType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// The vector distance type used by Qdrant.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
+[Experimental("SKEXP0020")]
 public enum QdrantDistanceType
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Qdrant connector.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class QdrantMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -19,6 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <remarks>The Embedding data is saved to a Qdrant Vector Database instance specified in the constructor by url and port.
 /// The embedding data persists between subsequent instances and has similarity search capability.
 /// </remarks>
+[Experimental("SKEXP0020")]
 public class QdrantMemoryStore : IMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,6 +21,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// connect, create, delete, and get embeddings data from a Qdrant Vector Database instance.
 /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
+[Experimental("SKEXP0020")]
 public sealed class QdrantVectorDbClient : IQdrantVectorDbClient
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecord.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// A record structure used by Qdrant that contains an embedding and metadata.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class QdrantVectorRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -23,6 +24,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// <remarks>The embedded data is saved to the Redis server database specified in the constructor.
 /// Similarity search capability is provided through the RediSearch module. Use RediSearch's "Index" to implement "Collection".
 /// </remarks>
+[Experimental("SKEXP0020")]
 public class RedisMemoryStore : IMemoryStore, IDisposable
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorDistanceMetric.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorDistanceMetric.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 
 /// <summary>
 /// Supported distance metrics are {L2, IP, COSINE}. The default value is "COSINE".
 /// <see href="https://redis.io/docs/interact/search-and-query/search/vectors/"/>
 /// </summary>
+[Experimental("SKEXP0020")]
 public enum VectorDistanceMetric
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -9,6 +10,7 @@ using Microsoft.Data.Sqlite;
 
 namespace Microsoft.SemanticKernel.Connectors.Sqlite;
 
+[Experimental("SKEXP0020")]
 internal struct DatabaseEntry
 {
     public string Key { get; set; }
@@ -20,6 +22,7 @@ internal struct DatabaseEntry
     public string? Timestamp { get; set; }
 }
 
+[Experimental("SKEXP0020")]
 internal sealed class Database
 {
     private const string TableName = "SKMemoryTable";

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Numerics.Tensors;
@@ -21,6 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Sqlite;
 /// <remarks>The data is saved to a database file, specified in the constructor.
 /// The data persists between subsequent instances. Only one instance may access the file at a time.
 /// The caller is responsible for deleting the file.</remarks>
+[Experimental("SKEXP0020")]
 public class SqliteMemoryStore : IMemoryStore, IDisposable
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchRequest.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class BatchRequest
 {
     private readonly string _class;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchResponse.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 #pragma warning disable CA1812 // 'BatchResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class BatchResponse : WeaviateObject
 #pragma warning restore CA1812 // 'BatchResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class CreateClassSchemaRequest
 {
     private CreateClassSchemaRequest(string @class, string description)

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaResponse.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'CreateClassSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class CreateClassSchemaResponse
 #pragma warning restore CA1812 // 'CreateClassSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateGraphRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateGraphRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -8,6 +9,7 @@ using System.Net.Http;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassCannotBeInstantiated
+[Experimental("SKEXP0020")]
 internal sealed class CreateGraphRequest
 {
 #pragma warning disable CS8618

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteObjectRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteObjectRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class DeleteObjectRequest
 {
     public string? Class { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteSchemaRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class DeleteSchemaRequest
 {
     private readonly string _class;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassRequest.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class GetClassRequest
 {
     private GetClassRequest(string @class)

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassResponse.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GetClassResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class GetClassResponse
 #pragma warning restore CA1812 // 'GetClassResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetObjectRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetObjectRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class GetObjectRequest
 {
     public string? Id { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaRequest.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class GetSchemaRequest
 {
     public static GetSchemaRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaResponse.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GetSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class GetSchemaResponse
 #pragma warning restore CA1812 // 'GetSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GraphResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GraphResponse.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class GraphResponse
 #pragma warning restore CA1812 // 'GraphResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/ObjectResponseResult.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/ObjectResponseResult.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 #pragma warning disable CA1812 // 'ObjectResponseResult' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class ObjectResponseResult
 #pragma warning restore CA1812 // 'ObjectResponseResult' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/JsonConverter/UnixSecondsDateTimeJsonConverter.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/JsonConverter/UnixSecondsDateTimeJsonConverter.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'UnixSecondsDateTimeJsonConverter' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class UnixSecondsDateTimeJsonConverter : JsonConverter<DateTime?>
 #pragma warning restore CA1812 // 'UnixSecondsDateTimeJsonConverter' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Deprecation.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Deprecation.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'Deprecation' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class Deprecation
 #pragma warning restore CA1812 // 'Deprecation' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphError.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphError.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphError' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class GraphError
 #pragma warning restore CA1812 // 'GraphError' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphErrorLocationsItems.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphErrorLocationsItems.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphErrorLocationsItems' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
+[Experimental("SKEXP0020")]
 internal sealed class GraphErrorLocationsItems
 #pragma warning restore CA1812 // 'GraphErrorLocationsItems' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Property.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Property.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal sealed class Property
 {
     public string? Name { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/WeaviateObject.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/WeaviateObject.cs
@@ -2,9 +2,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+[Experimental("SKEXP0020")]
 internal class WeaviateObject
 {
     public string? Id { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Weaviate connector.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class WeaviateMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -28,6 +29,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// </remarks>
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
+[Experimental("SKEXP0020")]
 public partial class WeaviateMemoryStore : IMemoryStore
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
 {

--- a/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/ModelDiagnostics.cs
@@ -21,6 +21,7 @@ namespace Microsoft.SemanticKernel.Diagnostics;
 ///    `SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS`
 ///    `SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS_SENSITIVE`
 /// </summary>
+[Experimental("SKEXP0001")]
 [ExcludeFromCodeCoverage]
 internal static class ModelDiagnostics
 {


### PR DESCRIPTION
### Motivation and Context

As part of graduating vector stores we want to remove the experimental flag from the implementations and only keep them on memory store implementations.

#8539

### Description

- Remove experimental flag from packages with vector store implementations.
- Add experimental flag to any memory store files in the same package.
- Clean up warning suppressions in vector store projects.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
