### PR TITLE
Python: add diskann index type

### DIFF
--- a/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmos_db_memory_store.py
+++ b/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmos_db_memory_store.py
@@ -42,6 +42,9 @@ class AzureCosmosDBMemoryStore(MemoryStoreBase):
     m = None
     ef_construction = None
     ef_search = None
+    max_degree = None
+    l_build = None
+    l_search = None
 
     def __init__(
         self,
@@ -55,6 +58,9 @@ class AzureCosmosDBMemoryStore(MemoryStoreBase):
         m: int = 16,
         ef_construction: int = 64,
         ef_search: int = 40,
+        max_degree: int = 32,
+        l_build: int = 50,
+        l_search: int = 40,
     ):
         """Initializes a new instance of the AzureCosmosDBMemoryStore class."""
         if vector_dimensions <= 0:
@@ -72,6 +78,9 @@ class AzureCosmosDBMemoryStore(MemoryStoreBase):
         self.m = m
         self.ef_construction = ef_construction
         self.ef_search = ef_search
+        self.max_degree = max_degree
+        self.l_build = l_build
+        self.l_search = l_search
 
     @staticmethod
     async def create(
@@ -84,6 +93,9 @@ class AzureCosmosDBMemoryStore(MemoryStoreBase):
         m: int,
         ef_construction: int,
         ef_search: int,
+        max_degree: int,
+        l_build: int,
+        l_search: int,
         index_name: str | None = None,
         cosmos_connstr: str | None = None,
         application_name: str | None = None,
@@ -115,6 +127,9 @@ class AzureCosmosDBMemoryStore(MemoryStoreBase):
                 m=m,
                 ef_construction=ef_construction,
                 ef_search=ef_search,
+                max_degree=max_degree,
+                l_build=l_build,
+                l_search=l_search,
             )
         else:
             raise MemoryConnectorInitializationError(f"API type {cosmos_api} is not supported.")
@@ -130,6 +145,9 @@ class AzureCosmosDBMemoryStore(MemoryStoreBase):
             m,
             ef_construction,
             ef_search,
+            max_degree,
+            l_build,
+            l_search,
         )
         await store.create_collection(collection_name)
         return store

--- a/python/semantic_kernel/connectors/memory/azure_cosmosdb/utils.py
+++ b/python/semantic_kernel/connectors/memory/azure_cosmosdb/utils.py
@@ -25,3 +25,5 @@ class CosmosDBVectorSearchType(str, Enum):
     """IVF vector index"""
     VECTOR_HNSW = "vector-hnsw"
     """HNSW vector index"""
+    VECTOR_DISKANN = "vector-diskann"
+    """DISKANN vector index"""

--- a/python/tests/integration/memory/memory_stores/test_azure_cosmosdb_memory_store.py
+++ b/python/tests/integration/memory/memory_stores/test_azure_cosmosdb_memory_store.py
@@ -29,6 +29,7 @@ cosmos_connstr = ""
 application_name = "PYTHON_SEMANTIC_KERNEL"
 cosmos_api = "mongo-vcore"
 index_name = "sk_test_vector_search_index"
+index_name_vector_diskann = "sk_test_vector_search_index_diskann"
 vector_dimensions = 1536
 num_lists = 1
 similarity = CosmosDBSimilarityType.COS
@@ -109,6 +110,9 @@ async def azurecosmosdb_memorystore() -> MemoryStoreBase:
         m=m,
         ef_construction=ef_construction,
         ef_search=ef_search,
+        max_degree=50,
+        l_build=40,
+        l_search=100,
     )
 
 
@@ -190,6 +194,123 @@ async def test_get_nearest_matches(
     memory_record3: MemoryRecord,
 ):
     store = await azurecosmosdb_memorystore()
+    await store.upsert_batch("", [memory_record1, memory_record2, memory_record3])
+    test_embedding = memory_record2.embedding.copy()
+    test_embedding[0] = test_embedding[4] + 0.1
+
+    result = await store.get_nearest_matches("", test_embedding, limit=2, min_relevance_score=0.0, with_embeddings=True)
+    assert len(result) == 2
+    assert all(result[i][0]._id in [memory_record1._id, memory_record2._id] for i in range(2))
+
+    await store.remove_batch("", [memory_record1._id, memory_record2._id, memory_record3._id])
+
+
+"""
+    Test cases for the similarity algorithm using vector-diskann
+"""
+
+
+async def azurecosmosdb_memorystore_vector_diskann() -> MemoryStoreBase:
+    return await AzureCosmosDBMemoryStore.create(
+        cosmos_connstr=cosmos_connstr,
+        application_name=application_name,
+        cosmos_api=cosmos_api,
+        database_name=database_name,
+        collection_name=collection_name,
+        index_name=index_name_vector_diskann,
+        vector_dimensions=vector_dimensions,
+        num_lists=num_lists,
+        similarity=similarity,
+        kind=CosmosDBVectorSearchType.VECTOR_DISKANN,
+        m=m,
+        ef_construction=ef_construction,
+        ef_search=ef_search,
+        max_degree=50,
+        l_build=40,
+        l_search=100,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(skip_test, reason="Skipping test because AZCOSMOS_CONNSTR is not set")
+async def test_create_get_drop_exists_collection_vector_diskann():
+    store = await azurecosmosdb_memorystore_vector_diskann()
+    test_collection = "test_collection"
+
+    await store.create_collection(test_collection)
+
+    collection_list = await store.get_collections()
+    assert test_collection in collection_list
+
+    await store.delete_collection(test_collection)
+
+    result = await store.does_collection_exist(test_collection)
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(skip_test, reason="Skipping test because AZCOSMOS_CONNSTR is not set")
+async def test_upsert_and_get_and_remove_vector_diskann(
+    memory_record1: MemoryRecord,
+):
+    store = await azurecosmosdb_memorystore_vector_diskann()
+    doc_id = await store.upsert("", memory_record1)
+    assert doc_id == memory_record1._id
+
+    result = await store.get("", memory_record1._id, with_embedding=True)
+
+    assert result is not None
+    assert result._id == memory_record1._id
+    assert all(result._embedding[i] == memory_record1._embedding[i] for i in range(len(result._embedding)))
+
+    await store.remove("", memory_record1._id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(skip_test, reason="Skipping test because AZCOSMOS_CONNSTR is not set")
+async def test_upsert_batch_and_get_batch_remove_batch_vector_diskann(
+    memory_record2: MemoryRecord, memory_record3: MemoryRecord
+):
+    store = await azurecosmosdb_memorystore_vector_diskann()
+    doc_ids = await store.upsert_batch("", [memory_record2, memory_record3])
+    assert len(doc_ids) == 2
+    assert all(doc_id in [memory_record2._id, memory_record3._id] for doc_id in doc_ids)
+
+    results = await store.get_batch("", [memory_record2._id, memory_record3._id], with_embeddings=True)
+
+    assert len(results) == 2
+    assert all(result._id in [memory_record2._id, memory_record3._id] for result in results)
+
+    await store.remove_batch("", [memory_record2._id, memory_record3._id])
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(skip_test, reason="Skipping test because AZCOSMOS_CONNSTR is not set")
+async def test_get_nearest_match_vector_diskann(memory_record1: MemoryRecord, memory_record2: MemoryRecord):
+    store = await azurecosmosdb_memorystore_vector_diskann()
+    await store.upsert_batch("", [memory_record1, memory_record2])
+    test_embedding = memory_record1.embedding.copy()
+    test_embedding[0] = test_embedding[0] + 0.1
+
+    result = await store.get_nearest_match(
+        collection_name, test_embedding, min_relevance_score=0.0, with_embedding=True
+    )
+
+    assert result is not None
+    assert result[0]._id == memory_record1._id
+    assert all(result[0]._embedding[i] == memory_record1._embedding[i] for i in range(len(result[0]._embedding)))
+
+    await store.remove_batch("", [memory_record1._id, memory_record2._id])
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(skip_test, reason="Skipping test because AZCOSMOS_CONNSTR is not set")
+async def test_get_nearest_matches_vector_diskann(
+    memory_record1: MemoryRecord,
+    memory_record2: MemoryRecord,
+    memory_record3: MemoryRecord,
+):
+    store = await azurecosmosdb_memorystore_vector_diskann()
     await store.upsert_batch("", [memory_record1, memory_record2, memory_record3])
     test_embedding = memory_record2.embedding.copy()
     test_embedding[0] = test_embedding[4] + 0.1


### PR DESCRIPTION
### Motivation and Context

Add a new vector index type `diskann` to Azure Cosmos DB Mongo vCore vector store.
Issue [#9676](https://github.com/microsoft/semantic-kernel/issues/9676)

Why is this change required? **This change enables MongoDB vCore to support the new `diskann` vector index as a preview feature for vector search. The diskann index, as described in the [DiskANN paper](https://proceedings.neurips.cc/paper_files/paper/2019/file/09853c7fb1d3f8ee67a61b6bf4a7f8e6-Paper.pdf), offers an additional option for fast nearest neighbor searches.**

### Description


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile: