### PR TITLE
.Net: ImportPluginFromOpenApiAsync will ignore operations with unsupported content types

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -224,7 +224,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                 }
                 catch (KernelException ke)
                 {
-                    logger.LogWarning(ke, "Error occurred creating REST API operation for {0}. Operation will be ignored.", operationItem.OperationId);
+                    logger.LogWarning(ke, "Error occurred creating REST API operation for {OperationId}. Operation will be ignored.", operationItem.OperationId);
                 }
             }
 

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -203,7 +203,9 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     continue;
                 }
 
-                var operation = new RestApiOperation(
+                try
+                {
+                    var operation = new RestApiOperation(
                     id: operationItem.OperationId,
                     servers: operationServers,
                     path: path,
@@ -214,18 +216,23 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),
                     securityRequirements: CreateRestApiOperationSecurityRequirements(operationItem.Security)
                 )
-                {
-                    Extensions = CreateRestApiOperationExtensions(operationItem.Extensions, logger)
-                };
+                    {
+                        Extensions = CreateRestApiOperationExtensions(operationItem.Extensions, logger)
+                    };
 
-                operations.Add(operation);
+                    operations.Add(operation);
+                }
+                catch (KernelException ke)
+                {
+                    logger.LogWarning(ke, "Error occurred creating REST API operation for {0}. Operation will be ignored.", operationItem.OperationId);
+                }
             }
 
             return operations;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error occurred during REST API operation creation.");
+            logger.LogError(ex, "Fatal error occurred during REST API operation creation.");
             throw;
         }
     }

--- a/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
+++ b/dotnet/src/Functions/Functions.UnitTests/Functions.UnitTests.csproj
@@ -15,6 +15,7 @@
     <None Remove="OpenApi\TestPlugins\ai-plugin.json" />
     <None Remove="OpenApi\TestPlugins\ai-plugin2.json" />
     <None Remove="OpenApi\TestPlugins\documentV3_1.yaml" />
+    <None Remove="OpenApi\TestPlugins\multipart-form-data.json" />
     <None Remove="OpenApi\TestPlugins\no-securityV3_0.json" />
     <None Remove="OpenApi\TestPlugins\apikey-securityV3_0.json" />
     <None Remove="OpenApi\TestPlugins\oauth-securityV3_0.json" />
@@ -66,5 +67,8 @@
     <ProjectReference Include="..\Functions.Markdown\Functions.Markdown.csproj" />
     <ProjectReference Include="..\Functions.OpenApi\Functions.OpenApi.csproj" />
     <ProjectReference Include="..\Functions.Yaml\Functions.Yaml.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="OpenApi\TestPlugins\multipart-form-data.json" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -544,6 +544,19 @@ public sealed class OpenApiKernelPluginFactoryTests
         };
 
     [Fact]
+    public async Task ItShouldCreateFunctionWithMultipartFormDataAsync()
+    {
+        // Arrange
+        var openApiDocument = ResourcePluginsProvider.LoadFromResource("multipart-form-data.json");
+
+        // Act
+        var plugin = await OpenApiKernelPluginFactory.CreateFromOpenApiAsync("fakePlugin", openApiDocument, this._executionParameters);
+
+        // Assert
+        Assert.False(plugin.TryGetFunction("createItem", out var _));
+    }
+
+    [Fact]
     public void Dispose()
     {
         this._openApiDocument.Dispose();

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/multipart-form-data.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/multipart-form-data.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "API with Multipart Form Data",
+    "version": "1.0.0",
+    "description": "API with Multipart Form Data"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/api/items": {
+      "post": {
+        "operationId": "createItem",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "encoding": {
+                "Value": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GenericResult": {
+        "type": "object",
+        "required": [ "type" ],
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type"
+        }
+      }
+    }
+  }
+}  


### PR DESCRIPTION
### Motivation and Context

Closes #8971 

### Description

Operations with unsupported content types should be ignored rather than causing the import to fail.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
