### PR TITLE
Python: fix a bug in the Makefile for checking if `uv` is installed or not

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -39,7 +39,7 @@ install:
 UV_VERSION = $(shell uv --version 2> /dev/null)
 install-uv:
 # Check if uv is installed
-ifeq ($(UV_VERSION),"")
+ifneq ($(UV_VERSION),)
 	echo "uv found $(UV_VERSION)"
 	echo "running uv update"
 	uv self update 

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,7 +1,9 @@
 SHELL = /bin/bash
 
 .PHONY: help install clean build
+ifndef VERBOSE
 .SILENT:
+endif
 all: install
 
 ifeq ($(PYTHON_VERSION),)

--- a/python/Makefile
+++ b/python/Makefile
@@ -37,7 +37,7 @@ install:
 UV_VERSION = $(shell uv --version 2> /dev/null)
 install-uv:
 # Check if uv is installed
-ifdef UV_VERSION
+ifeq ($(UV_VERSION),"")
 	echo "uv found $(UV_VERSION)"
 	echo "running uv update"
 	uv self update 


### PR DESCRIPTION
### Motivation and Context

1. Why is this change required?
This is the issue: https://github.com/microsoft/semantic-kernel/issues/9067
A user reports that the Makefile cannot install `uv`.

2. What problem does it solve?


3. What scenario does it contribute to?
With this fix, users who do not have `uv` installed in their machine will now have the Makefile to install `uv` for them.

4. If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/semantic-kernel/issues/9067

### Description

In the current Makefile, we assign the evaluation result of `$(shell uv --version 2> /dev/null)` to `UV_VERSION`, which will be an empty string `""`. If we use `ifdef UV_VERSION` to check whether `uv` is installed or not, it will always be true. Therefore, I use `ifneq ($(UV_VERSION),)` to check the existence `uv`.

Another minor improvement that I made to the `Makefile` is that I guard the `.SILENT` keyword with `ifndef` so that users can turn on/off the `VERBOSE` mode easily. For example, they can enable `VERBOSE` mode by running `make install VERBOSE=1`. By default, it uses the `SILENT` mode. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
