### PR TITLE
.Net: chore: avoid awaiting delay if its zero

### DIFF
--- a/dotnet/src/Experimental/Orchestration.Flow/Execution/FlowExecutor.cs
+++ b/dotnet/src/Experimental/Orchestration.Flow/Execution/FlowExecutor.cs
@@ -679,7 +679,10 @@ internal partial class FlowExecutor : IFlowExecutor
                 string? actionResult;
                 try
                 {
-                    await Task.Delay(this._config.MinIterationTimeMs).ConfigureAwait(false);
+                    if (this._config.MinIterationTimeMs > 0)
+                    {
+                        await Task.Delay(this._config.MinIterationTimeMs).ConfigureAwait(false);
+                    }
                     actionResult = await this._reActEngine.InvokeActionAsync(actionStep, input, chatHistory, kernel, actionContextVariables).ConfigureAwait(false);
 
                     if (string.IsNullOrEmpty(actionResult))
@@ -776,8 +779,11 @@ internal partial class FlowExecutor : IFlowExecutor
                 this._logger?.LogWarning("Action: No action to take");
             }
 
-            // continue to next iteration
-            await Task.Delay(this._config.MinIterationTimeMs).ConfigureAwait(false);
+            if (this._config.MinIterationTimeMs > 0)
+            {
+                // continue to next iteration
+                await Task.Delay(this._config.MinIterationTimeMs).ConfigureAwait(false);
+            }
         }
 
         throw new KernelException($"Failed to complete step {stepId} for session {sessionId}.");

--- a/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
+++ b/dotnet/src/Planners/Planners.OpenAI/Stepwise/FunctionCallingStepwisePlanner.cs
@@ -88,7 +88,7 @@ public sealed class FunctionCallingStepwisePlanner
         for (int i = 0; i < this._options.MaxIterations; i++)
         {
             // sleep for a bit to avoid rate limiting
-            if (i > 0)
+            if (i > 0 && this._options.MinIterationTimeMs > 0)
             {
                 await Task.Delay(this._options.MinIterationTimeMs, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
This pull request adds conditions to avoid awaiting a delay task if the delays is zero ms to reduce unnecessary allocs/context switching/etc...