### PR TITLE
.Net: fix: array query parameters with single entries

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
@@ -35,7 +35,7 @@ internal static class OpenApiTypeConverter
 #else
                     string s when s.Trim().StartsWith("[", StringComparison.OrdinalIgnoreCase) => JsonArray.Parse(s) as JsonArray,
 #endif
-                    string s => new JsonArray(JsonValue.Create(s)),
+                    string s => [JsonValue.Create(s)],
                     _ => JsonSerializer.SerializeToNode(argument) as JsonArray
                 },
                 "integer" => argument switch

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
@@ -30,7 +30,8 @@ internal static class OpenApiTypeConverter
                 "string" => JsonValue.Create(argument),
                 "array" => argument switch
                 {
-                    string s => JsonArray.Parse(s) as JsonArray,
+                    string s when s.Trim().StartsWith('[') => JsonArray.Parse(s) as JsonArray,
+                    string s => new JsonArray(JsonValue.Create(s)),
                     _ => JsonSerializer.SerializeToNode(argument) as JsonArray
                 },
                 "integer" => argument switch

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
@@ -30,7 +30,11 @@ internal static class OpenApiTypeConverter
                 "string" => JsonValue.Create(argument),
                 "array" => argument switch
                 {
+#if NETSTANDARD2_1_OR_GREATER
                     string s when s.Trim().StartsWith('[') => JsonArray.Parse(s) as JsonArray,
+#else
+                    string s when s.Trim().StartsWith("[", StringComparison.OrdinalIgnoreCase) => JsonArray.Parse(s) as JsonArray,
+#endif
                     string s => new JsonArray(JsonValue.Create(s)),
                     _ => JsonSerializer.SerializeToNode(argument) as JsonArray
                 },

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/OpenApiTypeConverterTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/OpenApiTypeConverterTests.cs
@@ -111,5 +111,7 @@ public class OpenApiTypeConverterTests
         Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new Collection() { 1, 2, 3 }).ToJsonString());
 
         Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", "[1, 2, 3]").ToJsonString());
+
+        Assert.Equal("[\"createdDate desc\"]", OpenApiTypeConverter.Convert("id", "array", "createdDate desc").ToJsonString());
     }
 }


### PR DESCRIPTION
fixes an issue where OpenAPI query parameters of type array with a single value would break the request generation