### PR TITLE
.Net: Removed experimental flags in Filters

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/AutoFunctionInvocationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/AutoFunctionInvocationContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.SemanticKernel.ChatCompletion;
 
@@ -9,7 +8,6 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Class with data related to automatic function invocation.
 /// </summary>
-[Experimental("SKEXP0001")]
 public class AutoFunctionInvocationContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/IAutoFunctionInvocationFilter.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/IAutoFunctionInvocationFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel;
@@ -11,7 +10,6 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Interface for filtering actions during automatic function invocation.
 /// </summary>
-[Experimental("SKEXP0001")]
 public interface IAutoFunctionInvocationFilter
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvocationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Function/FunctionInvocationContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.SemanticKernel;
@@ -38,7 +37,6 @@ public class FunctionInvocationContext
     /// <summary>
     /// Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.
     /// </summary>
-    [Experimental("SKEXP0001")]
     public bool IsStreaming { get; init; }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderContext.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+
 namespace Microsoft.SemanticKernel;
 
 /// <summary>
@@ -37,7 +37,6 @@ public sealed class PromptRenderContext
     /// <summary>
     /// Boolean flag which indicates whether a filter is invoked within streaming or non-streaming mode.
     /// </summary>
-    [Experimental("SKEXP0001")]
     public bool IsStreaming { get; init; }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Kernel.cs
@@ -144,7 +144,6 @@ public sealed class Kernel
     /// <summary>
     /// Gets the collection of auto function invocation filters available through the kernel.
     /// </summary>
-    [Experimental("SKEXP0001")]
     public IList<IAutoFunctionInvocationFilter> AutoFunctionInvocationFilters =>
         this._autoFunctionInvocationFilters ??
         Interlocked.CompareExchange(ref this._autoFunctionInvocationFilters, [], null) ??


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Closes: https://github.com/microsoft/semantic-kernel/issues/9499

1. Removed `Experimental` flag from `AutoFunctionInvocationFilter` classes and properties.
2. Removed `Experimental` flag from `IsStreaming` boolean property in filter context models.
3. Added a unit test to verify function sequence index property behavior.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
