### PR TITLE
Adding issue type support for template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,6 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: 'Bug: '
+type: 'bug'
 labels: ["bug"]
 projects: ["semantic-kernel"]
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_graduation.md
+++ b/.github/ISSUE_TEMPLATE/feature_graduation.md
@@ -3,6 +3,7 @@ name: Feature graduation
 about: Plan the graduation of an experimental feature
 title: 'Graduate XXX feature'
 labels: ["feature_graduation"]
+type: 'feature'
 projects: ["semantic-kernel"]
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,6 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: 'New Feature: '
 labels: ''
+type: 'feature'
 projects: ["semantic-kernel"]
 assignees: ''
 


### PR DESCRIPTION
### Motivation and Context

Automatically sets the new category type for github issues from the template.

As described in this post.

- https://github.com/orgs/community/discussions/139933