### PR TITLE
.Net Processes - Sync parameter name for error handler

### DIFF
--- a/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
@@ -21,7 +21,7 @@ namespace Step04;
 public class Step04_AgentOrchestration(ITestOutputHelper output) : BaseTest(output, redirectSystemConsoleOutput: true)
 {
     // Target Open AI Services
-    protected override bool ForceOpenAI => true;
+    //protected override bool ForceOpenAI => true;
 
     /// <summary>
     /// Orchestrates a single agent gathering user input and then delegating to a group of agents.
@@ -166,7 +166,7 @@ public class Step04_AgentOrchestration(ITestOutputHelper output) : BaseTest(outp
             {
                 step
                     .OnFunctionError(functionName)
-                    .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.Functions.RenderError, "exception"))
+                    .SendEventTo(new ProcessFunctionTargetBuilder(renderMessageStep, RenderMessageStep.Functions.RenderError, "error"))
                     .StopProcess();
             }
         }

--- a/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
+++ b/dotnet/samples/GettingStartedWithProcesses/Step04/Step04_AgentOrchestration.cs
@@ -21,7 +21,7 @@ namespace Step04;
 public class Step04_AgentOrchestration(ITestOutputHelper output) : BaseTest(output, redirectSystemConsoleOutput: true)
 {
     // Target Open AI Services
-    //protected override bool ForceOpenAI => true;
+    protected override bool ForceOpenAI => true;
 
     /// <summary>
     /// Orchestrates a single agent gathering user input and then delegating to a group of agents.


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Update sample `Step04_AgentOrchestration` to correctly specify the name of the function parameter.

Fixes: https://github.com/microsoft/semantic-kernel/issues/9778

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Sample specified parameter name `exception` but the actual name had been refactored to `error`.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
