### PR TITLE
.Net: Add new 2024-09-01-preview version

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/Services/AzureOpenAIChatCompletionServiceTests.cs
@@ -1541,6 +1541,10 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         { "V2024_10_01_PREVIEW", "2024-10-01-preview" },
         { "2024_10_01_Preview", "2024-10-01-preview" },
         { "2024-10-01-preview", "2024-10-01-preview" },
+        { "V2024_09_01_preview", "2024-09-01-preview" },
+        { "V2024_09_01_PREVIEW", "2024-09-01-preview" },
+        { "2024_09_01_Preview", "2024-09-01-preview" },
+        { "2024-09-01-preview", "2024-09-01-preview" },
         { "V2024_08_01_preview", "2024-08-01-preview" },
         { "V2024_08_01_PREVIEW", "2024-08-01-preview" },
         { "2024_08_01_Preview", "2024-08-01-preview" },
@@ -1549,6 +1553,7 @@ public sealed class AzureOpenAIChatCompletionServiceTests : IDisposable
         { "2024_06_01", "2024-06-01" },
         { "2024-06-01", "2024-06-01" },
         { AzureOpenAIClientOptions.ServiceVersion.V2024_10_01_Preview.ToString(), null },
+        { AzureOpenAIClientOptions.ServiceVersion.V2024_09_01_Preview.ToString(), null },
         { AzureOpenAIClientOptions.ServiceVersion.V2024_08_01_Preview.ToString(), null },
         { AzureOpenAIClientOptions.ServiceVersion.V2024_06_01.ToString(), null }
     };

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Core/AzureClientCore.cs
@@ -136,7 +136,9 @@ internal partial class AzureClientCore : ClientCore
             {
                 "2024-06-01" or "V2024_06_01" or "2024_06_01" => AzureOpenAIClientOptions.ServiceVersion.V2024_06_01,
                 "2024-08-01-PREVIEW" or "V2024_08_01_PREVIEW" or "2024_08_01_PREVIEW" => AzureOpenAIClientOptions.ServiceVersion.V2024_08_01_Preview,
+                "2024-09-01-PREVIEW" or "V2024_09_01_PREVIEW" or "2024_09_01_PREVIEW" => AzureOpenAIClientOptions.ServiceVersion.V2024_09_01_Preview,
                 "2024-10-01-PREVIEW" or "V2024_10_01_PREVIEW" or "2024_10_01_PREVIEW" => AzureOpenAIClientOptions.ServiceVersion.V2024_10_01_Preview,
+
                 _ => throw new NotSupportedException($"The service version '{serviceVersion}' is not supported.")
             };
         }


### PR DESCRIPTION
### Motivation and Context

Add new version `2024-09-01-preview` option available in Azure.AI.OpenAI 2.0.0-beta.2