### PR TITLE
.Net: fix: distincts parameters before building the OAS function

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -300,7 +300,12 @@ public static partial class OpenApiKernelPluginFactory
                 ParameterType = ConvertParameterDataType(p),
                 Schema = p.Schema ?? (p.Type is null ? null : KernelJsonSchema.Parse($$"""{"type":"{{p.Type}}"}""")),
             })
+#if NET6_0_OR_GREATER
             .DistinctBy(static p => p.Name, StringComparer.Ordinal)
+#else
+            .GroupBy(p => p.Name, StringComparer.Ordinal)
+            .Select(g => g.First())
+#endif
             .ToList();
 
         var returnParameter = operation.GetDefaultReturnParameter();

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -300,6 +300,7 @@ public static partial class OpenApiKernelPluginFactory
                 ParameterType = ConvertParameterDataType(p),
                 Schema = p.Schema ?? (p.Type is null ? null : KernelJsonSchema.Parse($$"""{"type":"{{p.Type}}"}""")),
             })
+            .DistinctBy(static p => p.Name, StringComparer.Ordinal)
             .ToList();
 
         var returnParameter = operation.GetDefaultReturnParameter();


### PR DESCRIPTION
this PR adds a patch to take only distinct parameters before building the function from OAS descriptions in order to avoid a general exception