### PR TITLE
.Net: fix: hard limit to functions descriptions for OAS imports

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -205,12 +205,13 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
 
                 try
                 {
+                    var description = string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description;
                     var operation = new RestApiOperation(
                     id: operationItem.OperationId,
                     servers: operationServers,
                     path: path,
                     method: new HttpMethod(method),
-                    description: string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description,
+                    description: description[..Math.Min(description.Length, 1000)],
                     parameters: CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters),
                     payload: CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -211,7 +211,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     servers: operationServers,
                     path: path,
                     method: new HttpMethod(method),
-                    description: description[..Math.Min(description.Length, 1000)],
+                    description: description.Substring(0, Math.Min(description.Length, 1000)),
                     parameters: CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters),
                     payload: CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -211,7 +211,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     servers: operationServers,
                     path: path,
                     method: new HttpMethod(method),
-                    description: description.Substring(0, Math.Min(description.Length, 1000)),
+                    description: description?.Substring(0, Math.Min(description.Length, 1000)),
                     parameters: CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters),
                     payload: CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),


### PR DESCRIPTION
this PR adds a hard limit to function descriptions to avoid hitting the limit from the model planner