### PR TITLE
.Net: Update to OpenApi.NET V2 - Part1

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -104,8 +104,8 @@
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="Microsoft.Graph" Version="4.51.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.28.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0-preview2" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="2.0.0-preview2" />
     <PackageVersion Include="Microsoft.OpenApi.ApiManifest" Version="0.5.6-preview" />
     <PackageVersion Include="Microsoft.Plugins.Manifest" Version="1.0.0-rc2" />
     <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="1.60.0.3001" />

--- a/dotnet/src/Functions/Functions.OpenApi.Extensions/Extensions/ApiManifestKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi.Extensions/Extensions/ApiManifestKernelExtensions.cs
@@ -117,7 +117,7 @@ public static class ApiManifestKernelExtensions
                 {
                     BaseUrl = new(apiDescriptionUrl)
                 },
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             var openApiDocument = documentReadResult.OpenApiDocument;
             var openApiDiagnostic = documentReadResult.OpenApiDiagnostic;

--- a/dotnet/src/Functions/Functions.OpenApi.Extensions/Extensions/ApiManifestKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi.Extensions/Extensions/ApiManifestKernelExtensions.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.OpenApi.ApiManifest;
-using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Services;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
@@ -109,11 +109,16 @@ public static class ApiManifestKernelExtensions
                 DocumentLoader.LoadDocumentFromFilePathAsStream(parsedDescriptionUrl.LocalPath,
                     logger);
 
-            var documentReadResult = await new OpenApiStreamReader(new()
-            {
-                BaseUrl = new(apiDescriptionUrl)
-            }
-            ).ReadAsync(openApiDocumentStream, cancellationToken).ConfigureAwait(false);
+            // TODO: Refactor the code to the new readers available in the OpenAPI.NET V2
+            ReadResult documentReadResult = await OpenApiModelFactory.LoadAsync(
+                input: openApiDocumentStream,
+                format: "TBD",
+                settings: new OpenApiReaderSettings()
+                {
+                    BaseUrl = new(apiDescriptionUrl)
+                },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
             var openApiDocument = documentReadResult.OpenApiDocument;
             var openApiDiagnostic = documentReadResult.OpenApiDiagnostic;
 
@@ -155,7 +160,7 @@ public static class ApiManifestKernelExtensions
                 openApiFunctionExecutionParameters?.EnableDynamicPayload ?? true,
                 openApiFunctionExecutionParameters?.EnablePayloadNamespacing ?? false);
 
-            var server = filteredOpenApiDocument.Servers.FirstOrDefault();
+            var server = filteredOpenApiDocument.Servers?.FirstOrDefault();
             if (server?.Url is null)
             {
                 logger.LogWarning("Server URI not found. Plugin: {0}", pluginName);

--- a/dotnet/src/Functions/Functions.OpenApi.Extensions/Extensions/CopilotAgentPluginKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi.Extensions/Extensions/CopilotAgentPluginKernelExtensions.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Services;
 using Microsoft.Plugins.Manifest;
 using Microsoft.SemanticKernel.Http;
@@ -128,11 +128,16 @@ public static class CopilotAgentPluginKernelExtensions
                 DocumentLoader.LoadDocumentFromFilePathAsStream(parsedDescriptionUrl.LocalPath,
                     logger);
 
-            var documentReadResult = await new OpenApiStreamReader(new()
-            {
-                BaseUrl = parsedDescriptionUrl
-            }
-            ).ReadAsync(openApiDocumentStream, cancellationToken).ConfigureAwait(false);
+            // TODO: Refactor the code to the new readers available in the OpenAPI.NET V2
+            ReadResult documentReadResult = await OpenApiModelFactory.LoadAsync(
+                input: openApiDocumentStream,
+                format: "TBD",
+                settings: new OpenApiReaderSettings()
+                {
+                    BaseUrl = new(apiDescriptionUrl)
+                },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
             var openApiDocument = documentReadResult.OpenApiDocument;
             var openApiDiagnostic = documentReadResult.OpenApiDiagnostic;
 
@@ -141,7 +146,7 @@ public static class CopilotAgentPluginKernelExtensions
             var predicate = OpenApiFilterService.CreatePredicate(string.Join(",", manifestFunctions.Select(static f => f.Name)), null, null, openApiDocument);
             var filteredOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(openApiDocument, predicate);
 
-            var server = filteredOpenApiDocument.Servers.FirstOrDefault();
+            var server = filteredOpenApiDocument.Servers?.FirstOrDefault();
             if (server?.Url is null)
             {
                 logger.LogWarning("Server URI not found. Plugin: {0}", pluginName);

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/RestApiOperationExtensions.cs
@@ -130,7 +130,7 @@ internal static partial class RestApiOperationExtensions
     {
         return new RestApiParameter(
             RestApiOperation.ContentTypeArgumentName,
-            "string",
+            RestApiParameterType.String,
             isRequired: false,
             expand: false,
             RestApiParameterLocation.Body,
@@ -147,7 +147,7 @@ internal static partial class RestApiOperationExtensions
     {
         return new RestApiParameter(
             RestApiOperation.PayloadArgumentName,
-            operation.Payload?.MediaType == MediaTypeTextPlain ? "string" : "object",
+            operation.Payload?.MediaType == MediaTypeTextPlain ? RestApiParameterType.String : RestApiParameterType.Object,
             isRequired: true,
             expand: false,
             RestApiParameterLocation.Body,

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiParameter.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiParameter.cs
@@ -31,9 +31,9 @@ public sealed class RestApiParameter
     }
 
     /// <summary>
-    /// The parameter type - string, integer, number, boolean, array and object.
+    /// The parameter type.
     /// </summary>
-    internal string Type { get; }
+    internal RestApiParameterType? Type { get; }
 
     /// <summary>
     /// The parameter type modifier that refines the generic parameter type to a more specific one.
@@ -64,7 +64,7 @@ public sealed class RestApiParameter
     /// <summary>
     /// Type of array item for parameters of "array" type.
     /// </summary>
-    internal string? ArrayItemType { get; }
+    internal RestApiParameterType? ArrayItemType { get; }
 
     /// <summary>
     /// The default value.
@@ -98,12 +98,12 @@ public sealed class RestApiParameter
     /// <param name="schema">The parameter schema.</param>
     internal RestApiParameter(
         string name,
-        string type,
+        RestApiParameterType? type,
         bool isRequired,
         bool expand,
         RestApiParameterLocation location,
         RestApiParameterStyle? style = null,
-        string? arrayItemType = null,
+        RestApiParameterType? arrayItemType = null,
         object? defaultValue = null,
         string? description = null,
         string? format = null,

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiParameterType.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiParameterType.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.SemanticKernel.Plugins.OpenApi;
+
+/// <summary>
+/// Represents the JSON schema type.
+/// </summary>
+[Experimental("SKEXP0040")]
+[Flags]
+[SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Type name is appropriate for the enum representing JSON schema types.")]
+public enum RestApiParameterType
+{
+    /// <summary>
+    /// Represents a null type.
+    /// </summary>
+    Null = 1,
+
+    /// <summary>
+    /// Represents a boolean type.
+    /// </summary>
+    Boolean = 2,
+
+    /// <summary>
+    /// Represents an integer type.
+    /// </summary>
+    Integer = 4,
+
+    /// <summary>
+    /// Represents a number type.
+    /// </summary>
+    Number = 8,
+
+    /// <summary>
+    /// Represents a string type.
+    /// </summary>
+    String = 16,
+
+    /// <summary>
+    /// Represents an object type.
+    /// </summary>
+    Object = 32,
+
+    /// <summary>
+    /// Represents an array type.
+    /// </summary>
+    Array = 64,
+}

--- a/dotnet/src/Functions/Functions.OpenApi/Model/RestApiPayloadProperty.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Model/RestApiPayloadProperty.cs
@@ -35,7 +35,7 @@ public sealed class RestApiPayloadProperty
     /// <summary>
     /// The property type.
     /// </summary>
-    internal string Type { get; }
+    internal RestApiParameterType? Type { get; }
 
     /// <summary>
     /// The property type modifier that refines the generic parameter type to a more specific one.
@@ -82,7 +82,7 @@ public sealed class RestApiPayloadProperty
     /// <returns>Returns a new instance of the <see cref="RestApiPayloadProperty"/> class.</returns>
     internal RestApiPayloadProperty(
         string name,
-        string type,
+        RestApiParameterType? type,
         bool isRequired,
         IList<RestApiPayloadProperty> properties,
         string? description = null,

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -356,7 +356,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
         {
             if (extension.Value is OpenApiAny any)
             {
-                // Convert the node to the appropriate type based on the node value kind and parsing logic because no schema is not available.
+                // Convert the node to the appropriate type based on the node value kind and parsing logic because no schema is available.
                 object? extensionValueObj = any.Node.GetValueKind() switch
                 {
                     JsonValueKind.True => true,

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -428,21 +428,21 @@ public static partial class OpenApiKernelPluginFactory
     {
         return parameter.Type switch
         {
-            "string" => typeof(string),
-            "boolean" => typeof(bool),
-            "number" => parameter.Format switch
+            RestApiParameterType.String => typeof(string),
+            RestApiParameterType.Boolean => typeof(bool),
+            RestApiParameterType.Number => parameter.Format switch
             {
                 "float" => typeof(float),
                 "double" => typeof(double),
                 _ => typeof(double)
             },
-            "integer" => parameter.Format switch
+            RestApiParameterType.Integer => parameter.Format switch
             {
                 "int32" => typeof(int),
                 "int64" => typeof(long),
                 _ => typeof(long)
             },
-            "object" => typeof(object),
+            RestApiParameterType.Object => typeof(object),
             _ => null
         };
     }

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
@@ -379,7 +379,7 @@ internal sealed class RestApiOperationRunner
         {
             var argumentName = this.GetArgumentNameForPayload(propertyMetadata.Name, propertyNamespace);
 
-            if (propertyMetadata.Type == "object")
+            if (propertyMetadata.Type == RestApiParameterType.Object)
             {
                 var node = this.BuildJsonObject(propertyMetadata.Properties, arguments, argumentName);
                 result.Add(propertyMetadata.Name, node);

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/FormStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/FormStyleParameterSerializer.cs
@@ -19,8 +19,6 @@ internal static class FormStyleParameterSerializer
     /// <returns>The serialized parameter.</returns>
     public static string Serialize(RestApiParameter parameter, JsonNode argument)
     {
-        const string ArrayType = "array";
-
         Verify.NotNull(parameter);
         Verify.NotNull(argument);
 
@@ -31,7 +29,7 @@ internal static class FormStyleParameterSerializer
         }
 
         // Handling parameters of array type.
-        if (parameter.Type == ArrayType)
+        if (parameter.Type == RestApiParameterType.Array)
         {
             return SerializeArrayParameter(parameter, argument);
         }

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/OpenApiTypeConverter.cs
@@ -19,43 +19,47 @@ internal static class OpenApiTypeConverter
     /// <param name="type">The parameter type.</param>
     /// <param name="argument">The argument to be converted.</param>
     /// <returns>A JsonNode representing the converted value.</returns>
-    public static JsonNode Convert(string name, string type, object argument)
+    public static JsonNode Convert(string name, RestApiParameterType? type, object argument)
     {
         Verify.NotNull(argument);
 
         try
         {
-            JsonNode? converter = type switch
+#pragma warning disable IDE0072 // Add missing cases
+            JsonNode? node = type switch
             {
-                "string" => JsonValue.Create(argument),
-                "array" => argument switch
+                RestApiParameterType.String => JsonValue.Create(argument),
+                RestApiParameterType.Array => argument switch
                 {
                     string s => JsonArray.Parse(s) as JsonArray,
                     _ => JsonSerializer.SerializeToNode(argument) as JsonArray
                 },
-                "integer" => argument switch
+                RestApiParameterType.Integer => argument switch
                 {
                     string stringArgument => JsonValue.Create(long.Parse(stringArgument, CultureInfo.InvariantCulture)),
                     byte or sbyte or short or ushort or int or uint or long or ulong => JsonValue.Create(argument),
                     _ => null
                 },
-                "boolean" => argument switch
+                RestApiParameterType.Boolean => argument switch
                 {
                     bool b => JsonValue.Create(b),
                     string s => JsonValue.Create(bool.Parse(s)),
                     _ => null
                 },
-                "number" => argument switch
+                RestApiParameterType.Number => argument switch
                 {
                     string stringArgument when long.TryParse(stringArgument, out var intValue) => JsonValue.Create(intValue),
                     string stringArgument when double.TryParse(stringArgument, out var doubleValue) => JsonValue.Create(doubleValue),
                     byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal => JsonValue.Create(argument),
                     _ => null
                 },
+                // Type may not be specified in the schema which means it can be any type.
+                null => JsonSerializer.SerializeToNode(argument),
                 _ => throw new NotSupportedException($"Unexpected type '{type}' of parameter '{name}' with argument '{argument}'."),
             };
+#pragma warning restore IDE0072 // Add missing cases
 
-            return converter ?? throw new ArgumentOutOfRangeException(name, argument, $"Argument type '{argument.GetType()}' is not convertible to parameter type '{type}'.");
+            return node ?? throw new ArgumentOutOfRangeException(name, argument, $"Argument type '{argument.GetType()}' is not convertible to parameter type '{type}'.");
         }
         catch (ArgumentException ex)
         {

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/PipeDelimitedStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/PipeDelimitedStyleParameterSerializer.cs
@@ -18,8 +18,6 @@ internal static class PipeDelimitedStyleParameterSerializer
     /// <returns>The serialized parameter.</returns>
     public static string Serialize(RestApiParameter parameter, JsonNode argument)
     {
-        const string ArrayType = "array";
-
         Verify.NotNull(parameter);
         Verify.NotNull(argument);
 
@@ -28,7 +26,7 @@ internal static class PipeDelimitedStyleParameterSerializer
             throw new NotSupportedException($"Unsupported Rest API parameter style '{parameter.Style}' for parameter '{parameter.Name}'");
         }
 
-        if (parameter.Type != ArrayType)
+        if (parameter.Type != RestApiParameterType.Array)
         {
             throw new NotSupportedException($"Unsupported Rest API parameter type '{parameter.Type}' for parameter '{parameter.Name}'");
         }

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/SimpleStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/SimpleStyleParameterSerializer.cs
@@ -18,8 +18,6 @@ internal static class SimpleStyleParameterSerializer
     /// <returns>The serialized parameter.</returns>
     public static string Serialize(RestApiParameter parameter, JsonNode argument)
     {
-        const string ArrayType = "array";
-
         Verify.NotNull(parameter);
         Verify.NotNull(argument);
 
@@ -30,7 +28,7 @@ internal static class SimpleStyleParameterSerializer
         }
 
         // Serializing parameters of array type.
-        if (parameter.Type == ArrayType)
+        if (parameter.Type == RestApiParameterType.Array)
         {
             return SerializeArrayParameter(parameter, argument);
         }

--- a/dotnet/src/Functions/Functions.OpenApi/Serialization/SpaceDelimitedStyleParameterSerializer.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Serialization/SpaceDelimitedStyleParameterSerializer.cs
@@ -18,8 +18,6 @@ internal static class SpaceDelimitedStyleParameterSerializer
     /// <returns>The serialized parameter.</returns>
     public static string Serialize(RestApiParameter parameter, JsonNode argument)
     {
-        const string ArrayType = "array";
-
         Verify.NotNull(parameter);
 
         if (parameter.Style != RestApiParameterStyle.SpaceDelimited)
@@ -27,7 +25,7 @@ internal static class SpaceDelimitedStyleParameterSerializer
             throw new NotSupportedException($"Unsupported Rest API parameter style '{parameter.Style}' for parameter '{parameter.Name}'");
         }
 
-        if (parameter.Type != ArrayType)
+        if (parameter.Type != RestApiParameterType.Array)
         {
             throw new NotSupportedException($"Unsupported Rest API parameter type '{parameter.Type}' for parameter '{parameter.Name}'");
         }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using Microsoft.OpenApi.Any;
+using System.Text.Json.Nodes;
 using Microsoft.OpenApi.Models;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
 using Xunit;
@@ -16,14 +16,14 @@ public class OpenApiSchemaExtensionsTests
         // Arrange
         var schema = new OpenApiSchema
         {
-            Type = "object",
+            Type = JsonSchemaType.Object,
             Properties = new Dictionary<string, OpenApiSchema>
             {
                 ["property1"] = new OpenApiSchema
                 {
-                    Type = "number",
+                    Type = JsonSchemaType.Number,
                     Format = "double",
-                    Default = new OpenApiDouble(12.01)
+                    Default = JsonValue.Create(12.01)
                 }
             }
         };

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/RestApiOperationExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/RestApiOperationExtensionsTests.cs
@@ -29,13 +29,13 @@ public class RestApiOperationExtensionsTests
 
         var payloadParam = parameters.FirstOrDefault(p => p.Name == "payload");
         Assert.NotNull(payloadParam);
-        Assert.Equal("object", payloadParam.Type);
+        Assert.Equal(RestApiParameterType.Object, payloadParam.Type);
         Assert.True(payloadParam.IsRequired);
         Assert.Equal("REST API request body.", payloadParam.Description);
 
         var contentTypeParam = parameters.FirstOrDefault(p => p.Name == "content-type");
         Assert.NotNull(contentTypeParam);
-        Assert.Equal("string", contentTypeParam.Type);
+        Assert.Equal(RestApiParameterType.String, contentTypeParam.Type);
         Assert.False(contentTypeParam.IsRequired);
         Assert.Equal("Content type of REST API request body.", contentTypeParam.Description);
     }
@@ -58,13 +58,13 @@ public class RestApiOperationExtensionsTests
 
         var payloadProp = parameters.FirstOrDefault(p => p.Name == "payload");
         Assert.NotNull(payloadProp);
-        Assert.Equal("object", payloadProp.Type);
+        Assert.Equal(RestApiParameterType.Object, payloadProp.Type);
         Assert.True(payloadProp.IsRequired);
         Assert.Equal("REST API request body.", payloadProp.Description);
 
         var contentTypeProp = parameters.FirstOrDefault(p => p.Name == "content-type");
         Assert.NotNull(contentTypeProp);
-        Assert.Equal("string", contentTypeProp.Type);
+        Assert.Equal(RestApiParameterType.String, contentTypeProp.Type);
         Assert.False(contentTypeProp.IsRequired);
         Assert.Equal("Content type of REST API request body.", contentTypeProp.Description);
     }
@@ -87,13 +87,13 @@ public class RestApiOperationExtensionsTests
 
         var payloadParam = parameters.FirstOrDefault(p => p.Name == "payload");
         Assert.NotNull(payloadParam);
-        Assert.Equal("string", payloadParam.Type);
+        Assert.Equal(RestApiParameterType.String, payloadParam.Type);
         Assert.True(payloadParam.IsRequired);
         Assert.Equal("REST API request body.", payloadParam.Description);
 
         var contentTypeParam = parameters.FirstOrDefault(p => p.Name == "content-type");
         Assert.NotNull(contentTypeParam);
-        Assert.Equal("string", contentTypeParam.Type);
+        Assert.Equal(RestApiParameterType.String, contentTypeParam.Type);
         Assert.False(contentTypeParam.IsRequired);
         Assert.Equal("Content type of REST API request body.", contentTypeParam.Description);
     }
@@ -116,13 +116,13 @@ public class RestApiOperationExtensionsTests
 
         var payloadParam = parameters.FirstOrDefault(p => p.Name == "payload");
         Assert.NotNull(payloadParam);
-        Assert.Equal("object", payloadParam.Type);
+        Assert.Equal(RestApiParameterType.Object, payloadParam.Type);
         Assert.True(payloadParam.IsRequired);
         Assert.Equal("REST API request body.", payloadParam.Description);
 
         var contentTypeParam = parameters.FirstOrDefault(p => p.Name == "content-type");
         Assert.NotNull(contentTypeParam);
-        Assert.Equal("string", contentTypeParam.Type);
+        Assert.Equal(RestApiParameterType.String, contentTypeParam.Type);
         Assert.False(contentTypeParam.IsRequired);
         Assert.Equal("Content type of REST API request body.", contentTypeParam.Description);
     }
@@ -147,31 +147,31 @@ public class RestApiOperationExtensionsTests
 
         var name = parameters.FirstOrDefault(p => p.Name == "name");
         Assert.NotNull(name);
-        Assert.Equal("string", name.Type);
+        Assert.Equal(RestApiParameterType.String, name.Type);
         Assert.True(name.IsRequired);
         Assert.Equal("The name.", name.Description);
 
         var landmarks = parameters.FirstOrDefault(p => p.Name == "landmarks");
         Assert.NotNull(landmarks);
-        Assert.Equal("array", landmarks.Type);
+        Assert.Equal(RestApiParameterType.Array, landmarks.Type);
         Assert.False(landmarks.IsRequired);
         Assert.Equal("The landmarks.", landmarks.Description);
 
         var leader = parameters.FirstOrDefault(p => p.Name == "leader");
         Assert.NotNull(leader);
-        Assert.Equal("string", leader.Type);
+        Assert.Equal(RestApiParameterType.String, leader.Type);
         Assert.True(leader.IsRequired);
         Assert.Equal("The leader.", leader.Description);
 
         var population = parameters.FirstOrDefault(p => p.Name == "population");
         Assert.NotNull(population);
-        Assert.Equal("integer", population.Type);
+        Assert.Equal(RestApiParameterType.Integer, population.Type);
         Assert.True(population.IsRequired);
         Assert.Equal("The population.", population.Description);
 
         var hasMagicWards = parameters.FirstOrDefault(p => p.Name == "hasMagicWards");
         Assert.NotNull(hasMagicWards);
-        Assert.Equal("boolean", hasMagicWards.Type);
+        Assert.Equal(RestApiParameterType.Boolean, hasMagicWards.Type);
         Assert.False(hasMagicWards.IsRequired);
         Assert.Null(hasMagicWards.Description);
     }
@@ -196,31 +196,31 @@ public class RestApiOperationExtensionsTests
 
         var name = parameters.FirstOrDefault(p => p.Name == "name");
         Assert.NotNull(name);
-        Assert.Equal("string", name.Type);
+        Assert.Equal(RestApiParameterType.String, name.Type);
         Assert.True(name.IsRequired);
         Assert.Equal("The name.", name.Description);
 
         var landmarks = parameters.FirstOrDefault(p => p.Name == "location.landmarks");
         Assert.NotNull(landmarks);
-        Assert.Equal("array", landmarks.Type);
+        Assert.Equal(RestApiParameterType.Array, landmarks.Type);
         Assert.False(landmarks.IsRequired);
         Assert.Equal("The landmarks.", landmarks.Description);
 
         var leader = parameters.FirstOrDefault(p => p.Name == "rulingCouncil.leader");
         Assert.NotNull(leader);
-        Assert.Equal("string", leader.Type);
+        Assert.Equal(RestApiParameterType.String, leader.Type);
         Assert.True(leader.IsRequired);
         Assert.Equal("The leader.", leader.Description);
 
         var population = parameters.FirstOrDefault(p => p.Name == "population");
         Assert.NotNull(population);
-        Assert.Equal("integer", population.Type);
+        Assert.Equal(RestApiParameterType.Integer, population.Type);
         Assert.True(population.IsRequired);
         Assert.Equal("The population.", population.Description);
 
         var hasMagicWards = parameters.FirstOrDefault(p => p.Name == "hasMagicWards");
         Assert.NotNull(hasMagicWards);
-        Assert.Equal("boolean", hasMagicWards.Type);
+        Assert.Equal(RestApiParameterType.Boolean, hasMagicWards.Type);
         Assert.False(hasMagicWards.IsRequired);
         Assert.Null(hasMagicWards.Description);
     }
@@ -231,8 +231,8 @@ public class RestApiOperationExtensionsTests
     public void ItShouldSetArgumentNameToPayloadParameters(string method)
     {
         //Arrange
-        var latitude = new RestApiPayloadProperty("location.latitude", "number", false, []);
-        var place = new RestApiPayloadProperty("place", "string", true, []);
+        var latitude = new RestApiPayloadProperty("location.latitude", RestApiParameterType.Number, false, []);
+        var place = new RestApiPayloadProperty("place", RestApiParameterType.String, true, []);
 
         var payload = new RestApiPayload("application/json", [place, latitude]);
 
@@ -259,8 +259,8 @@ public class RestApiOperationExtensionsTests
     public void ItShouldNotSetArgumentNameToPayloadParametersIfItIsAlreadyProvided(string method)
     {
         //Arrange
-        var latitude = new RestApiPayloadProperty("location.latitude", "number", false, []) { ArgumentName = "alt.location.latitude" };
-        var place = new RestApiPayloadProperty("place", "string", true, []) { ArgumentName = "alt+place" };
+        var latitude = new RestApiPayloadProperty("location.latitude", RestApiParameterType.Number, false, []) { ArgumentName = "alt.location.latitude" };
+        var place = new RestApiPayloadProperty("place", RestApiParameterType.String, true, []) { ArgumentName = "alt+place" };
 
         var payload = new RestApiPayload("application/json", [place, latitude]);
 
@@ -286,9 +286,9 @@ public class RestApiOperationExtensionsTests
     {
         //Arrange
         List<RestApiParameter> parameters = [
-            new RestApiParameter("p-1", "number", false, false, RestApiParameterLocation.Path),
-            new RestApiParameter("p$2", "string", false, false, RestApiParameterLocation.Query),
-            new RestApiParameter("p3", "number", false, false, RestApiParameterLocation.Header)
+            new RestApiParameter("p-1", RestApiParameterType.Number, false, false, RestApiParameterLocation.Path),
+            new RestApiParameter("p$2", RestApiParameterType.String, false, false, RestApiParameterLocation.Query),
+            new RestApiParameter("p3", RestApiParameterType.Number, false, false, RestApiParameterLocation.Header)
         ];
 
         var operation = CreateTestOperation("GET", parameters: parameters);
@@ -317,9 +317,9 @@ public class RestApiOperationExtensionsTests
     {
         //Arrange
         List<RestApiParameter> parameters = [
-            new RestApiParameter("p-1", "number", false, false, RestApiParameterLocation.Path) { ArgumentName = "alt.p1" },
-            new RestApiParameter("p$2", "string", false, false, RestApiParameterLocation.Query) { ArgumentName = "alt.p2" },
-            new RestApiParameter("p3", "number", false, false, RestApiParameterLocation.Header) { ArgumentName = "alt.p3" }
+            new RestApiParameter("p-1", RestApiParameterType.Number, false, false, RestApiParameterLocation.Path) { ArgumentName = "alt.p1" },
+            new RestApiParameter("p$2", RestApiParameterType.String, false, false, RestApiParameterLocation.Query) { ArgumentName = "alt.p2" },
+            new RestApiParameter("p3", RestApiParameterType.Number, false, false, RestApiParameterLocation.Header) { ArgumentName = "alt.p3" }
         ];
 
         var operation = CreateTestOperation("GET", parameters: parameters);
@@ -361,49 +361,49 @@ public class RestApiOperationExtensionsTests
     {
         var name = new RestApiPayloadProperty(
             name: "name",
-            type: "string",
+            type: RestApiParameterType.String,
             isRequired: true,
             properties: [],
             description: "The name.");
 
         var leader = new RestApiPayloadProperty(
             name: "leader",
-            type: "string",
+            type: RestApiParameterType.String,
             isRequired: true,
             properties: [],
             description: "The leader.");
 
         var landmarks = new RestApiPayloadProperty(
             name: "landmarks",
-            type: "array",
+            type: RestApiParameterType.Array,
             isRequired: false,
             properties: [],
             description: "The landmarks.");
 
         var location = new RestApiPayloadProperty(
             name: "location",
-            type: "object",
+            type: RestApiParameterType.Object,
             isRequired: true,
             properties: [landmarks],
             description: "The location.");
 
         var rulingCouncil = new RestApiPayloadProperty(
             name: "rulingCouncil",
-            type: "object",
+            type: RestApiParameterType.Object,
             isRequired: true,
             properties: [leader],
             description: "The ruling council.");
 
         var population = new RestApiPayloadProperty(
             name: "population",
-            type: "integer",
+            type: RestApiParameterType.Integer,
             isRequired: true,
             properties: [],
             description: "The population.");
 
         var hasMagicWards = new RestApiPayloadProperty(
             name: "hasMagicWards",
-            type: "boolean",
+            type: RestApiParameterType.Boolean,
             isRequired: false,
             properties: []);
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
@@ -61,7 +61,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         Assert.NotNull(valueProperty);
         Assert.True(valueProperty.IsRequired);
         Assert.Equal("The value of the secret.", valueProperty.Description);
-        Assert.Equal("string", valueProperty.Type);
+        Assert.Equal(RestApiParameterType.String, valueProperty.Type);
         Assert.NotNull(valueProperty.Properties);
         Assert.False(valueProperty.Properties.Any());
         Assert.NotNull(valueProperty.Schema);
@@ -72,7 +72,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         Assert.NotNull(attributesProperty);
         Assert.False(attributesProperty.IsRequired);
         Assert.Equal("attributes", attributesProperty.Description);
-        Assert.Equal("object", attributesProperty.Type);
+        Assert.Equal(RestApiParameterType.Object, attributesProperty.Type);
         Assert.NotNull(attributesProperty.Properties);
         Assert.True(attributesProperty.Properties.Any());
         Assert.NotNull(attributesProperty.Schema);
@@ -83,7 +83,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         Assert.NotNull(enabledProperty);
         Assert.True(enabledProperty.IsRequired);
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
-        Assert.Equal("boolean", enabledProperty.Type);
+        Assert.Equal(RestApiParameterType.Boolean, enabledProperty.Type);
         Assert.False(enabledProperty.Properties?.Any());
         Assert.NotNull(enabledProperty.Schema);
         Assert.Equal("boolean", enabledProperty.Schema.RootElement.GetProperty("type").GetString());
@@ -93,7 +93,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         Assert.NotNull(encryptedProperty);
         Assert.False(encryptedProperty.IsRequired);
         Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Description);
-        Assert.Equal("boolean", encryptedProperty.Type);
+        Assert.Equal(RestApiParameterType.Boolean, encryptedProperty.Type);
         Assert.False(encryptedProperty.Properties?.Any());
         Assert.NotNull(encryptedProperty.Schema);
         Assert.Equal("boolean", encryptedProperty.Schema.RootElement.GetProperty("type").GetString());
@@ -176,7 +176,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         //Assert string header parameter metadata
         var accept = GetParameterMetadata(restApi.Operations, "SetSecret", RestApiParameterLocation.Header, "Accept");
 
-        Assert.Equal("string", accept.Type);
+        Assert.Equal(RestApiParameterType.String, accept.Type);
         Assert.Equal("application/json", accept.DefaultValue);
         Assert.Equal("Indicates which content types, expressed as MIME types, the client is able to understand.", accept.Description);
         Assert.False(accept.IsRequired);
@@ -184,7 +184,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         //Assert integer header parameter metadata
         var apiVersion = GetParameterMetadata(restApi.Operations, "SetSecret", RestApiParameterLocation.Header, "X-API-Version");
 
-        Assert.Equal("integer", apiVersion.Type);
+        Assert.Equal(RestApiParameterType.Integer, apiVersion.Type);
         Assert.Equal(10, apiVersion.DefaultValue);
         Assert.Equal("Requested API version.", apiVersion.Description);
         Assert.True(apiVersion.IsRequired);
@@ -201,10 +201,10 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
 
         Assert.Null(acceptParameter.DefaultValue);
         Assert.False(acceptParameter.IsRequired);
-        Assert.Equal("array", acceptParameter.Type);
+        Assert.Equal(RestApiParameterType.Array, acceptParameter.Type);
         Assert.Equal(RestApiParameterStyle.Simple, acceptParameter.Style);
         Assert.Equal("The comma separated list of operation ids.", acceptParameter.Description);
-        Assert.Equal("string", acceptParameter.ArrayItemType);
+        Assert.Equal(RestApiParameterType.String, acceptParameter.ArrayItemType);
     }
 
     [Fact]
@@ -377,15 +377,15 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
     }
 
     [Theory]
-    [InlineData("string-parameter", "string", null)]
-    [InlineData("boolean-parameter", "boolean", null)]
-    [InlineData("number-parameter", "number", null)]
-    [InlineData("float-parameter", "number", "float")]
-    [InlineData("double-parameter", "number", "double")]
-    [InlineData("integer-parameter", "integer", null)]
-    [InlineData("int32-parameter", "integer", "int32")]
-    [InlineData("int64-parameter", "integer", "int64")]
-    public async Task ItCanParseParametersOfPrimitiveDataTypeAsync(string name, string type, string? format)
+    [InlineData("string-parameter", RestApiParameterType.String, null)]
+    [InlineData("boolean-parameter", RestApiParameterType.Boolean, null)]
+    [InlineData("number-parameter", RestApiParameterType.Number, null)]
+    [InlineData("float-parameter", RestApiParameterType.Number, "float")]
+    [InlineData("double-parameter", RestApiParameterType.Number, "double")]
+    [InlineData("integer-parameter", RestApiParameterType.Integer, null)]
+    [InlineData("int32-parameter", RestApiParameterType.Integer, "int32")]
+    [InlineData("int64-parameter", RestApiParameterType.Integer, "int64")]
+    public async Task ItCanParseParametersOfPrimitiveDataTypeAsync(string name, RestApiParameterType type, string? format)
     {
         // Arrange & Act
         var restApiSpec = await this._sut.ParseAsync(this._openApiDocument);
@@ -410,7 +410,7 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
         var properties = restApiSpec.Operations.Single(o => o.Id == "TestParameterDataTypes").Payload!.Properties;
 
         var property = properties.Single(p => p.Name == "attributes");
-        Assert.Equal("object", property.Type);
+        Assert.Equal(RestApiParameterType.Object, property.Type);
         Assert.Null(property.Format);
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
@@ -62,7 +62,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.NotNull(valueProperty);
         Assert.True(valueProperty.IsRequired);
         Assert.Equal("The value of the secret.", valueProperty.Description);
-        Assert.Equal("string", valueProperty.Type);
+        Assert.Equal(RestApiParameterType.String, valueProperty.Type);
         Assert.NotNull(valueProperty.Properties);
         Assert.False(valueProperty.Properties.Any());
         Assert.NotNull(valueProperty.Schema);
@@ -73,7 +73,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.NotNull(attributesProperty);
         Assert.False(attributesProperty.IsRequired);
         Assert.Equal("attributes", attributesProperty.Description);
-        Assert.Equal("object", attributesProperty.Type);
+        Assert.Equal(RestApiParameterType.Object, attributesProperty.Type);
         Assert.NotNull(attributesProperty.Properties);
         Assert.True(attributesProperty.Properties.Any());
         Assert.NotNull(attributesProperty.Schema);
@@ -84,7 +84,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.NotNull(enabledProperty);
         Assert.True(enabledProperty.IsRequired);
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
-        Assert.Equal("boolean", enabledProperty.Type);
+        Assert.Equal(RestApiParameterType.Boolean, enabledProperty.Type);
         Assert.False(enabledProperty.Properties?.Any());
         Assert.NotNull(enabledProperty.Schema);
         Assert.Equal("boolean", enabledProperty.Schema.RootElement.GetProperty("type").GetString());
@@ -94,7 +94,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.NotNull(encryptedProperty);
         Assert.False(encryptedProperty.IsRequired);
         Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Description);
-        Assert.Equal("boolean", encryptedProperty.Type);
+        Assert.Equal(RestApiParameterType.Boolean, encryptedProperty.Type);
         Assert.False(encryptedProperty.Properties?.Any());
         Assert.NotNull(encryptedProperty.Schema);
         Assert.Equal("boolean", encryptedProperty.Schema.RootElement.GetProperty("type").GetString());
@@ -162,7 +162,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         //Assert string header parameter metadata
         var accept = GetParameterMetadata(restApi.Operations, "SetSecret", RestApiParameterLocation.Header, "Accept");
 
-        Assert.Equal("string", accept.Type);
+        Assert.Equal(RestApiParameterType.String, accept.Type);
         Assert.Equal("application/json", accept.DefaultValue);
         Assert.Equal("Indicates which content types, expressed as MIME types, the client is able to understand.", accept.Description);
         Assert.False(accept.IsRequired);
@@ -170,7 +170,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         //Assert integer header parameter metadata
         var apiVersion = GetParameterMetadata(restApi.Operations, "SetSecret", RestApiParameterLocation.Header, "X-API-Version");
 
-        Assert.Equal("integer", apiVersion.Type);
+        Assert.Equal(RestApiParameterType.Integer, apiVersion.Type);
         Assert.Equal(10, apiVersion.DefaultValue);
         Assert.Equal("Requested API version.", apiVersion.Description);
         Assert.True(apiVersion.IsRequired);
@@ -202,10 +202,10 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
 
         Assert.Null(acceptParameter.DefaultValue);
         Assert.False(acceptParameter.IsRequired);
-        Assert.Equal("array", acceptParameter.Type);
+        Assert.Equal(RestApiParameterType.Array, acceptParameter.Type);
         Assert.Equal(RestApiParameterStyle.Simple, acceptParameter.Style);
         Assert.Equal("The comma separated list of operation ids.", acceptParameter.Description);
-        Assert.Equal("string", acceptParameter.ArrayItemType);
+        Assert.Equal(RestApiParameterType.String, acceptParameter.ArrayItemType);
     }
 
     [Fact]
@@ -450,15 +450,15 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
     }
 
     [Theory]
-    [InlineData("string-parameter", "string", null)]
-    [InlineData("boolean-parameter", "boolean", null)]
-    [InlineData("number-parameter", "number", null)]
-    [InlineData("float-parameter", "number", "float")]
-    [InlineData("double-parameter", "number", "double")]
-    [InlineData("integer-parameter", "integer", null)]
-    [InlineData("int32-parameter", "integer", "int32")]
-    [InlineData("int64-parameter", "integer", "int64")]
-    public async Task ItCanParseParametersOfPrimitiveDataTypeAsync(string name, string type, string? format)
+    [InlineData("string-parameter", RestApiParameterType.String, null)]
+    [InlineData("boolean-parameter", RestApiParameterType.Boolean, null)]
+    [InlineData("number-parameter", RestApiParameterType.Number, null)]
+    [InlineData("float-parameter", RestApiParameterType.Number, "float")]
+    [InlineData("double-parameter", RestApiParameterType.Number, "double")]
+    [InlineData("integer-parameter", RestApiParameterType.Integer, null)]
+    [InlineData("int32-parameter", RestApiParameterType.Integer, "int32")]
+    [InlineData("int64-parameter", RestApiParameterType.Integer, "int64")]
+    public async Task ItCanParseParametersOfPrimitiveDataTypeAsync(string name, RestApiParameterType type, string? format)
     {
         // Arrange & Act
         var restApiSpec = await this._sut.ParseAsync(this._openApiDocument);
@@ -483,7 +483,7 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         var properties = restApiSpec.Operations.Single(o => o.Id == "TestParameterDataTypes").Payload!.Properties;
 
         var property = properties.Single(p => p.Name == "attributes");
-        Assert.Equal("object", property.Type);
+        Assert.Equal(RestApiParameterType.Object, property.Type);
         Assert.Null(property.Format);
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
@@ -62,7 +62,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         Assert.NotNull(valueProperty);
         Assert.True(valueProperty.IsRequired);
         Assert.Equal("The value of the secret.", valueProperty.Description);
-        Assert.Equal("string", valueProperty.Type);
+        Assert.Equal(RestApiParameterType.String, valueProperty.Type);
         Assert.NotNull(valueProperty.Properties);
         Assert.False(valueProperty.Properties.Any());
         Assert.NotNull(valueProperty.Schema);
@@ -73,7 +73,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         Assert.NotNull(attributesProperty);
         Assert.False(attributesProperty.IsRequired);
         Assert.Equal("attributes", attributesProperty.Description);
-        Assert.Equal("object", attributesProperty.Type);
+        Assert.Equal(RestApiParameterType.Object, attributesProperty.Type);
         Assert.NotNull(attributesProperty.Properties);
         Assert.True(attributesProperty.Properties.Any());
         Assert.NotNull(attributesProperty.Schema);
@@ -84,7 +84,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         Assert.NotNull(enabledProperty);
         Assert.True(enabledProperty.IsRequired);
         Assert.Equal("Determines whether the object is enabled.", enabledProperty.Description);
-        Assert.Equal("boolean", enabledProperty.Type);
+        Assert.Equal(RestApiParameterType.Boolean, enabledProperty.Type);
         Assert.False(enabledProperty.Properties?.Any());
         Assert.NotNull(enabledProperty.Schema);
         Assert.Equal("boolean", enabledProperty.Schema.RootElement.GetProperty("type").GetString());
@@ -94,7 +94,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         Assert.NotNull(encryptedProperty);
         Assert.False(encryptedProperty.IsRequired);
         Assert.Equal("Determines whether the object is encrypted.", encryptedProperty.Description);
-        Assert.Equal("boolean", encryptedProperty.Type);
+        Assert.Equal(RestApiParameterType.Boolean, encryptedProperty.Type);
         Assert.False(encryptedProperty.Properties?.Any());
         Assert.NotNull(encryptedProperty.Schema);
         Assert.Equal("boolean", encryptedProperty.Schema.RootElement.GetProperty("type").GetString());
@@ -177,7 +177,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         //Assert string header parameter metadata
         var accept = GetParameterMetadata(restApi.Operations, "SetSecret", RestApiParameterLocation.Header, "Accept");
 
-        Assert.Equal("string", accept.Type);
+        Assert.Equal(RestApiParameterType.String, accept.Type);
         Assert.Equal("application/json", accept.DefaultValue);
         Assert.Equal("Indicates which content types, expressed as MIME types, the client is able to understand.", accept.Description);
         Assert.False(accept.IsRequired);
@@ -185,7 +185,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         //Assert integer header parameter metadata
         var apiVersion = GetParameterMetadata(restApi.Operations, "SetSecret", RestApiParameterLocation.Header, "X-API-Version");
 
-        Assert.Equal("integer", apiVersion.Type);
+        Assert.Equal(RestApiParameterType.Integer, apiVersion.Type);
         Assert.Equal(10, apiVersion.DefaultValue);
         Assert.Equal("Requested API version.", apiVersion.Description);
         Assert.True(apiVersion.IsRequired);
@@ -202,10 +202,10 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
 
         Assert.Null(acceptParameter.DefaultValue);
         Assert.False(acceptParameter.IsRequired);
-        Assert.Equal("array", acceptParameter.Type);
+        Assert.Equal(RestApiParameterType.Array, acceptParameter.Type);
         Assert.Equal(RestApiParameterStyle.Simple, acceptParameter.Style);
         Assert.Equal("The comma separated list of operation ids.", acceptParameter.Description);
-        Assert.Equal("string", acceptParameter.ArrayItemType);
+        Assert.Equal(RestApiParameterType.String, acceptParameter.ArrayItemType);
     }
 
     [Fact]
@@ -427,15 +427,15 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
     }
 
     [Theory]
-    [InlineData("string-parameter", "string", null)]
-    [InlineData("boolean-parameter", "boolean", null)]
-    [InlineData("number-parameter", "number", null)]
-    [InlineData("float-parameter", "number", "float")]
-    [InlineData("double-parameter", "number", "double")]
-    [InlineData("integer-parameter", "integer", null)]
-    [InlineData("int32-parameter", "integer", "int32")]
-    [InlineData("int64-parameter", "integer", "int64")]
-    public async Task ItCanParseParametersOfPrimitiveDataTypeAsync(string name, string type, string? format)
+    [InlineData("string-parameter", RestApiParameterType.String, null)]
+    [InlineData("boolean-parameter", RestApiParameterType.Boolean, null)]
+    [InlineData("number-parameter", RestApiParameterType.Number, null)]
+    [InlineData("float-parameter", RestApiParameterType.Number, "float")]
+    [InlineData("double-parameter", RestApiParameterType.Number, "double")]
+    [InlineData("integer-parameter", RestApiParameterType.Integer, null)]
+    [InlineData("int32-parameter", RestApiParameterType.Integer, "int32")]
+    [InlineData("int64-parameter", RestApiParameterType.Integer, "int64")]
+    public async Task ItCanParseParametersOfPrimitiveDataTypeAsync(string name, RestApiParameterType type, string? format)
     {
         // Arrange & Act
         var restApiSpec = await this._sut.ParseAsync(this._openApiDocument);
@@ -460,7 +460,7 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
         var properties = restApiSpec.Operations.Single(o => o.Id == "TestParameterDataTypes").Payload!.Properties;
 
         var property = properties.Single(p => p.Name == "attributes");
-        Assert.Equal("object", property.Type);
+        Assert.Equal(RestApiParameterType.Object, property.Type);
         Assert.Null(property.Format);
     }
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -196,18 +196,18 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         // Arrange
         var parameters = new List<RestApiParameter>
         {
-            new(name: "X-HS-1", type: "string", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HA-1", type: "array", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HA-2", type: "array", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HB-1", type: "boolean", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HB-2", type: "boolean", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HI-1", type: "integer", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HI-2", type: "integer", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HN-1", type: "number", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HN-2", type: "number", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HD-1", type: "string", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HD-2", type: "string", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "X-HD-3", type: "string", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HS-1", type: RestApiParameterType.String, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HA-1", type: RestApiParameterType.Array, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HA-2", type: RestApiParameterType.Array, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HB-1", type: RestApiParameterType.Boolean, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HB-2", type: RestApiParameterType.Boolean, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HI-1", type: RestApiParameterType.Integer, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HI-2", type: RestApiParameterType.Integer, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HN-1", type: RestApiParameterType.Number, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HN-2", type: RestApiParameterType.Number, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HD-1", type: RestApiParameterType.String, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HD-2", type: RestApiParameterType.String, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "X-HD-3", type: RestApiParameterType.String, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
         };
 
         var operation = new RestApiOperation(
@@ -270,7 +270,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         {
             new(
             name: "fake-header",
-            type: "string",
+            type: RestApiParameterType.String,
             isRequired: true,
             expand: false,
             location: RestApiParameterLocation.Header,
@@ -315,10 +315,10 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []),
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []),
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []),
+                new("enabled", RestApiParameterType.Boolean, false, []),
             ])
         ];
 
@@ -377,14 +377,14 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []),
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []),
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []),
-                new("cardinality", "number", false, []),
-                new("coefficient", "number", false, []),
-                new("count", "integer", false, []),
-                new("params", "array", false, []),
+                new("enabled", RestApiParameterType.Boolean, false, []),
+                new("cardinality", RestApiParameterType.Number, false, []),
+                new("coefficient", RestApiParameterType.Number, false, []),
+                new("count", RestApiParameterType.Integer, false, []),
+                new("params", RestApiParameterType.Array, false, []),
             ])
         ];
 
@@ -464,18 +464,18 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("upn", "string", true, []),
-            new("receiver", "object", false,
+            new("upn", RestApiParameterType.String, true, []),
+            new("receiver", RestApiParameterType.Object, false,
             [
-                new("upn", "string", false, []),
-                new("alternative", "object", false,
+                new("upn", RestApiParameterType.String, false, []),
+                new("alternative", RestApiParameterType.Object, false,
                 [
-                    new("upn", "string", false, []),
+                    new("upn", RestApiParameterType.String, false, []),
                 ]),
             ]),
-            new("cc", "object", false,
+            new("cc", RestApiParameterType.Object, false,
             [
-                new("upn", "string", false, []),
+                new("upn", RestApiParameterType.String, false, []),
             ])
         ];
 
@@ -700,7 +700,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("upn", "string", false, []),
+            new("upn", RestApiParameterType.String, false, []),
         ];
 
         var payload = new RestApiPayload(MediaTypeNames.Application.Json, payloadProperties);
@@ -748,7 +748,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("upn", "string", false, []),
+            new("upn", RestApiParameterType.String, false, []),
         ];
 
         var payload = new RestApiPayload(MediaTypeNames.Application.Json, payloadProperties);
@@ -796,7 +796,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var firstParameter = new RestApiParameter(
             "p1",
-            "string",
+            RestApiParameterType.String,
             isRequired: true, //Marking the parameter as required
             false,
             RestApiParameterLocation.Query,
@@ -804,7 +804,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var secondParameter = new RestApiParameter(
             "p2",
-            "integer",
+            RestApiParameterType.Integer,
             isRequired: true, //Marking the parameter as required
             false,
             RestApiParameterLocation.Query,
@@ -845,7 +845,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var firstParameter = new RestApiParameter(
             "p1",
-            "string",
+            RestApiParameterType.String,
             isRequired: false, //Marking the parameter as not required
             false,
             RestApiParameterLocation.Query,
@@ -853,7 +853,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var secondParameter = new RestApiParameter(
             "p2",
-            "string",
+            RestApiParameterType.String,
             isRequired: false, //Marking the parameter as not required
             false,
             RestApiParameterLocation.Query,
@@ -894,7 +894,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var firstParameter = new RestApiParameter(
             "p1",
-            "string",
+            RestApiParameterType.String,
             isRequired: false, //Marking the parameter as not required
             false,
             RestApiParameterLocation.Query,
@@ -902,7 +902,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var secondParameter = new RestApiParameter(
             "p2",
-            "string",
+            RestApiParameterType.String,
             isRequired: true, //Marking the parameter as required
             false,
             RestApiParameterLocation.Query,
@@ -942,7 +942,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         var parameter = new RestApiParameter(
             "p1",
-            "string",
+            RestApiParameterType.String,
             isRequired: true, //Marking the parameter as required
             false,
             RestApiParameterLocation.Query,
@@ -1094,10 +1094,10 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []),
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []),
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []),
+                new("enabled", RestApiParameterType.Boolean, false, []),
             ])
         ];
 
@@ -1144,10 +1144,10 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []),
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []),
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []),
+                new("enabled", RestApiParameterType.Boolean, false, []),
             ])
         ];
 
@@ -1194,10 +1194,10 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []),
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []),
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []),
+                new("enabled", RestApiParameterType.Boolean, false, []),
             ])
         ];
 
@@ -1395,10 +1395,10 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []) { ArgumentName = "alt-name" },
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []) { ArgumentName = "alt-name" },
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []) { ArgumentName = "alt-enabled" },
+                new("enabled", RestApiParameterType.Boolean, false, []) { ArgumentName = "alt-enabled" },
             ])
         ];
 
@@ -1460,10 +1460,10 @@ public sealed class RestApiOperationRunnerTests : IDisposable
 
         List<RestApiPayloadProperty> payloadProperties =
         [
-            new("name", "string", true, []) { ArgumentName = "alt-name" },
-            new("attributes", "object", false,
+            new("name", RestApiParameterType.String, true, []) { ArgumentName = "alt-name" },
+            new("attributes", RestApiParameterType.Object, false,
             [
-                new("enabled", "boolean", false, []) { ArgumentName = "alt-enabled" },
+                new("enabled", RestApiParameterType.Boolean, false, []) { ArgumentName = "alt-enabled" },
             ])
         ];
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationTests.cs
@@ -75,14 +75,14 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
                 style: RestApiParameterStyle.Simple),
             new(
                 name: "p2",
-                type: "number",
+                type: RestApiParameterType.Number,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
@@ -120,14 +120,14 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
                 style: RestApiParameterStyle.Simple){ ArgumentName = "alt-p1" },
             new(
                 name: "p2",
-                type: "number",
+                type: RestApiParameterType.Number,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
@@ -165,14 +165,14 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
                 style: RestApiParameterStyle.Simple){ ArgumentName = "alt-p1" },
             new(
                 name: "p2",
-                type: "number",
+                type: RestApiParameterType.Number,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
@@ -210,14 +210,14 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
                 style: RestApiParameterStyle.Simple),
             new(
                 name: "p2",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Path,
@@ -255,14 +255,14 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query,
                 defaultValue: "dv1"),
             new(
                 name: "fake-path",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Path)
@@ -300,13 +300,13 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "since_create_time",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query),
             new(
                 name: "before_create_time",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query),
@@ -343,13 +343,13 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query) { ArgumentName = "alt_p1" },
             new(
                 name: "p2",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query)  { ArgumentName = "alt_p2" },
@@ -386,13 +386,13 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "p1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query) { ArgumentName = "alt_p1" },
             new(
                 name: "p2",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query)  { ArgumentName = "alt_p2" },
@@ -429,7 +429,7 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "has_quotes",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query)
@@ -465,7 +465,7 @@ public class RestApiOperationTests
         var parameters = new List<RestApiParameter> {
             new(
                 name: "times",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: false,
                 expand: false,
                 location: RestApiParameterLocation.Query),
@@ -502,7 +502,7 @@ public class RestApiOperationTests
         {
             new(
                 name: "fake_header_one",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Header,
@@ -510,7 +510,7 @@ public class RestApiOperationTests
 
             new(
                 name: "fake_header_two",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Header,
@@ -555,7 +555,7 @@ public class RestApiOperationTests
         {
             new(
                 name: "h1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Header,
@@ -563,7 +563,7 @@ public class RestApiOperationTests
 
             new(
                 name: "h2",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Header,
@@ -607,7 +607,7 @@ public class RestApiOperationTests
         {
             new(
                 name: "h1",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Header,
@@ -615,7 +615,7 @@ public class RestApiOperationTests
 
             new(
                 name: "h2",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Header,
@@ -658,8 +658,8 @@ public class RestApiOperationTests
         // Arrange
         var parameters = new List<RestApiParameter>
         {
-            new(name: "fake_header_one", type: "string", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple)
+            new(name: "fake_header_one", type: RestApiParameterType.String, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "fake_header_two", type : RestApiParameterType.String, isRequired : false, expand : false, location : RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple)
         };
 
         var sut = new RestApiOperation(
@@ -686,8 +686,8 @@ public class RestApiOperationTests
         // Arrange
         var parameters = new List<RestApiParameter>
         {
-            new(name: "fake_header_one", type : "string", isRequired : true, expand : false, location : RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "fake_header_two", type : "string", isRequired : false, expand : false, location : RestApiParameterLocation.Header, style : RestApiParameterStyle.Simple)
+            new(name: "fake_header_one", type : RestApiParameterType.String, isRequired : true, expand : false, location : RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "fake_header_two", type : RestApiParameterType.String, isRequired : false, expand : false, location : RestApiParameterLocation.Header, style : RestApiParameterStyle.Simple)
         };
 
         var arguments = new Dictionary<string, object?>
@@ -722,8 +722,8 @@ public class RestApiOperationTests
         // Arrange
         var parameters = new List<RestApiParameter>
         {
-            new( name: "h1", type: "array", isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: "string"),
-            new( name: "h2", type: "array", isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: "integer")
+            new( name: "h1", type: RestApiParameterType.Array, isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: RestApiParameterType.String),
+            new( name: "h2", type: RestApiParameterType.Array, isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: RestApiParameterType.Integer)
         };
 
         var arguments = new Dictionary<string, object?>
@@ -760,8 +760,8 @@ public class RestApiOperationTests
         // Arrange
         var parameters = new List<RestApiParameter>
         {
-            new( name: "h1", type: "string", isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new( name: "h2", type: "boolean", isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple)
+            new( name: "h1", type: RestApiParameterType.String, isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new( name: "h2", type: RestApiParameterType.Boolean, isRequired: false, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple)
         };
 
         var arguments = new Dictionary<string, object?>
@@ -798,8 +798,8 @@ public class RestApiOperationTests
         // Arrange
         var parameters = new List<RestApiParameter>
         {
-            new(name: "h1", type: "array", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
-            new(name: "h2", type: "boolean", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "h1", type: RestApiParameterType.Array, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
+            new(name: "h2", type: RestApiParameterType.Boolean, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple),
         };
 
         var arguments = new Dictionary<string, object?>
@@ -1212,7 +1212,7 @@ public class RestApiOperationTests
             parameters: [
                 new RestApiParameter(
                     name: "p2",
-                    type: "string",
+                    type: RestApiParameterType.String,
                     isRequired: false,
                     expand: false,
                     location: RestApiParameterLocation.Query),
@@ -1222,7 +1222,7 @@ public class RestApiOperationTests
                 mediaType: "application/json",
                 properties: new List<RestApiPayloadProperty> { { new RestApiPayloadProperty (
                     name: "p3",
-                    type: "string",
+                    type: RestApiParameterType.String,
                     isRequired: false,
                     properties: []
                 ) } }
@@ -1236,7 +1236,7 @@ public class RestApiOperationTests
         sut.Servers[0].Variables["p1"].Enum!.Add("ev2");
 
         sut.Payload!.Properties.Single(p => p.Name == "p3").ArgumentName = "a value";
-        sut.Payload!.Properties.Single(p => p.Name == "p3").Properties.Add(new RestApiPayloadProperty("p4", "string", false, []));
+        sut.Payload!.Properties.Single(p => p.Name == "p3").Properties.Add(new RestApiPayloadProperty("p4", RestApiParameterType.String, false, []));
 
         sut.Parameters.Single(p => p.Name == "p2").ArgumentName = "a value";
 
@@ -1271,7 +1271,7 @@ public class RestApiOperationTests
             parameters: [
                 new RestApiParameter(
                     name: "p2",
-                    type: "string",
+                    type: RestApiParameterType.String,
                     isRequired: false,
                     expand: false,
                     location: RestApiParameterLocation.Query),
@@ -1281,7 +1281,7 @@ public class RestApiOperationTests
                 mediaType: "application/json",
                 properties: new List<RestApiPayloadProperty> { { new RestApiPayloadProperty (
                     name: "p3",
-                    type: "string",
+                    type: RestApiParameterType.String,
                     isRequired: false,
                     properties: []
                 ) } }
@@ -1298,7 +1298,7 @@ public class RestApiOperationTests
         Assert.Throws<NotSupportedException>(() => sut.Servers[0].Variables["p1"].Enum!.Add("ev2"));
 
         Assert.Throws<InvalidOperationException>(() => sut.Payload!.Properties.Single(p => p.Name == "p3").ArgumentName = "a value");
-        Assert.Throws<NotSupportedException>(() => sut.Payload!.Properties.Single(p => p.Name == "p3").Properties.Add(new RestApiPayloadProperty("p4", "string", false, [])));
+        Assert.Throws<NotSupportedException>(() => sut.Payload!.Properties.Single(p => p.Name == "p3").Properties.Add(new RestApiPayloadProperty("p4", RestApiParameterType.String, false, [])));
 
         Assert.Throws<InvalidOperationException>(() => sut.Parameters.Single(p => p.Name == "p2").ArgumentName = "a value");
 

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/FormStyleParametersSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/FormStyleParametersSerializerTests.cs
@@ -15,12 +15,12 @@ public class FormStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: true,
                 expand: true, //Specify generating a separate parameter for each array item.
                 location: RestApiParameterLocation.Query,
                 style: RestApiParameterStyle.Form,
-                arrayItemType: "integer");
+                arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = FormStyleParameterSerializer.Serialize(parameter, new JsonArray(1, 2, 3));
@@ -37,12 +37,12 @@ public class FormStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: true,
                 expand: false, //Specify generating a parameter with comma-separated values for each array item.
                 location: RestApiParameterLocation.Query,
                 style: RestApiParameterStyle.Form,
-                arrayItemType: "integer");
+                arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = FormStyleParameterSerializer.Serialize(parameter, new JsonArray(1, 2, 3));
@@ -59,7 +59,7 @@ public class FormStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "integer",
+                type: RestApiParameterType.Integer,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Query,
@@ -80,7 +80,7 @@ public class FormStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Query,
@@ -102,7 +102,7 @@ public class FormStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "string",
+                type: RestApiParameterType.String,
                 isRequired: true,
                 expand: false,
                 location: RestApiParameterLocation.Query,
@@ -125,7 +125,7 @@ public class FormStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInPrimitiveParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter("id", "string", false, false, RestApiParameterLocation.Query, RestApiParameterStyle.Form);
+        var parameter = new RestApiParameter("id", RestApiParameterType.String, false, false, RestApiParameterLocation.Query, RestApiParameterStyle.Form);
 
         // Act
         var result = FormStyleParameterSerializer.Serialize(parameter, $"fake_query_param_value{specialSymbol}");
@@ -144,7 +144,7 @@ public class FormStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInAmpersandSeparatedParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter("id", "array", false, true, RestApiParameterLocation.Query, RestApiParameterStyle.Form);
+        var parameter = new RestApiParameter("id", RestApiParameterType.Array, false, true, RestApiParameterLocation.Query, RestApiParameterStyle.Form);
 
         // Act
         var result = FormStyleParameterSerializer.Serialize(parameter, new JsonArray($"{specialSymbol}"));
@@ -163,7 +163,7 @@ public class FormStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInCommaSeparatedParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter("id", "array", false, false, RestApiParameterLocation.Query, RestApiParameterStyle.Form);
+        var parameter = new RestApiParameter("id", RestApiParameterType.Array, false, false, RestApiParameterLocation.Query, RestApiParameterStyle.Form);
 
         // Act
         var result = FormStyleParameterSerializer.Serialize(parameter, new JsonArray($"{specialSymbol}"));

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/OpenApiTypeConverterTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/OpenApiTypeConverterTests.cs
@@ -18,7 +18,7 @@ public class OpenApiTypeConverterTests
         object? value = "test";
 
         // Act
-        var result = OpenApiTypeConverter.Convert("id", "string", value);
+        var result = OpenApiTypeConverter.Convert("id", RestApiParameterType.String, value);
 
         // Assert
         Assert.Equal("\"test\"", result.ToString());
@@ -28,56 +28,56 @@ public class OpenApiTypeConverterTests
     public void ItShouldConvertNumber()
     {
         // Act & Assert
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (byte)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (sbyte)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (byte)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (sbyte)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (short)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (ushort)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (short)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (ushort)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (int)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (uint)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (int)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (uint)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (long)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", (ulong)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (long)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (ulong)10).ToString());
 
-        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", "number", (float)10.5).ToString());
-        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", "number", (double)10.5).ToString());
-        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", "number", (decimal)10.5).ToString());
+        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (float)10.5).ToString());
+        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (double)10.5).ToString());
+        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, (decimal)10.5).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "number", "10").ToString());
-        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", "number", "10.5").ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, "10").ToString());
+        Assert.Equal("10.5", OpenApiTypeConverter.Convert("id", RestApiParameterType.Number, "10.5").ToString());
     }
 
     [Fact]
     public void ItShouldConvertInteger()
     {
         // Act & Assert
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (byte)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (sbyte)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (byte)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (sbyte)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (short)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (ushort)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (short)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (ushort)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (int)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (uint)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (int)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (uint)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (long)10).ToString());
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", (ulong)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (long)10).ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, (ulong)10).ToString());
 
-        Assert.Equal("10", OpenApiTypeConverter.Convert("id", "integer", "10").ToString());
+        Assert.Equal("10", OpenApiTypeConverter.Convert("id", RestApiParameterType.Integer, "10").ToString());
     }
 
     [Fact]
     public void ItShouldConvertBoolean()
     {
         // Act & Assert
-        Assert.Equal("true", OpenApiTypeConverter.Convert("id", "boolean", true).ToString());
+        Assert.Equal("true", OpenApiTypeConverter.Convert("id", RestApiParameterType.Boolean, true).ToString());
 
-        Assert.Equal("false", OpenApiTypeConverter.Convert("id", "boolean", false).ToString());
+        Assert.Equal("false", OpenApiTypeConverter.Convert("id", RestApiParameterType.Boolean, false).ToString());
 
-        Assert.Equal("true", OpenApiTypeConverter.Convert("id", "boolean", "true").ToString());
+        Assert.Equal("true", OpenApiTypeConverter.Convert("id", RestApiParameterType.Boolean, "true").ToString());
 
-        Assert.Equal("false", OpenApiTypeConverter.Convert("id", "boolean", "false").ToString());
+        Assert.Equal("false", OpenApiTypeConverter.Convert("id", RestApiParameterType.Boolean, "false").ToString());
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class OpenApiTypeConverterTests
         var dateTime = DateTime.ParseExact("06.12.2023 11:53:36+02:00", "dd.MM.yyyy HH:mm:sszzz", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
 
         // Act & Assert
-        Assert.Equal("\"2023-12-06T09:53:36Z\"", OpenApiTypeConverter.Convert("id", "string", dateTime).ToString());
+        Assert.Equal("\"2023-12-06T09:53:36Z\"", OpenApiTypeConverter.Convert("id", RestApiParameterType.String, dateTime).ToString());
     }
 
     [Fact]
@@ -97,19 +97,19 @@ public class OpenApiTypeConverterTests
         var offset = DateTimeOffset.ParseExact("06.12.2023 11:53:36 +02:00", "dd.MM.yyyy HH:mm:ss zzz", CultureInfo.InvariantCulture);
 
         // Act & Assert
-        Assert.Equal("\"2023-12-06T11:53:36+02:00\"", OpenApiTypeConverter.Convert("id", "string", offset).ToString());
+        Assert.Equal("\"2023-12-06T11:53:36+02:00\"", OpenApiTypeConverter.Convert("id", RestApiParameterType.String, offset).ToString());
     }
 
     [Fact]
     public void ItShouldConvertCollections()
     {
         // Act & Assert
-        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new[] { 1, 2, 3 }).ToJsonString());
+        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", RestApiParameterType.Array, new[] { 1, 2, 3 }).ToJsonString());
 
-        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new List<int> { 1, 2, 3 }).ToJsonString());
+        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", RestApiParameterType.Array, new List<int> { 1, 2, 3 }).ToJsonString());
 
-        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", new Collection() { 1, 2, 3 }).ToJsonString());
+        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", RestApiParameterType.Array, new Collection() { 1, 2, 3 }).ToJsonString());
 
-        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", "array", "[1, 2, 3]").ToJsonString());
+        Assert.Equal("[1,2,3]", OpenApiTypeConverter.Convert("id", RestApiParameterType.Array, "[1, 2, 3]").ToJsonString());
     }
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/PipeDelimitedStyleParametersSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/PipeDelimitedStyleParametersSerializerTests.cs
@@ -13,19 +13,19 @@ public class PipeDelimitedStyleParametersSerializerTests
     public void ItShouldThrowExceptionForUnsupportedParameterStyle()
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "p1", type: "string", isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.Form);
+        var parameter = new RestApiParameter(name: "p1", type: RestApiParameterType.String, isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.Form);
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => PipeDelimitedStyleParameterSerializer.Serialize(parameter, "fake-argument"));
     }
 
     [Theory]
-    [InlineData("integer")]
-    [InlineData("number")]
-    [InlineData("string")]
-    [InlineData("boolean")]
-    [InlineData("object")]
-    public void ItShouldThrowExceptionIfParameterTypeIsNotArray(string parameterType)
+    [InlineData(RestApiParameterType.Integer)]
+    [InlineData(RestApiParameterType.Number)]
+    [InlineData(RestApiParameterType.String)]
+    [InlineData(RestApiParameterType.Boolean)]
+    [InlineData(RestApiParameterType.Object)]
+    public void ItShouldThrowExceptionIfParameterTypeIsNotArray(RestApiParameterType parameterType)
     {
         // Arrange
         var parameter = new RestApiParameter(name: "p1", type: parameterType, isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.PipeDelimited);
@@ -40,12 +40,12 @@ public class PipeDelimitedStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: true,
                 expand: true, //Specifies to generate a separate parameter for each array item.
                 location: RestApiParameterLocation.Query,
                 style: RestApiParameterStyle.PipeDelimited,
-                arrayItemType: "integer");
+                arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = PipeDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray(1, 2, 3));
@@ -62,12 +62,12 @@ public class PipeDelimitedStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: true,
                 expand: false, //Specify generating a parameter with pipe-separated values for each array item.
                 location: RestApiParameterLocation.Query,
                 style: RestApiParameterStyle.PipeDelimited,
-                arrayItemType: "integer");
+                arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = PipeDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray("1", "2", "3"));
@@ -86,7 +86,7 @@ public class PipeDelimitedStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInPipeDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.PipeDelimited);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.PipeDelimited);
 
         // Act
         var result = PipeDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray(specialSymbol));
@@ -105,7 +105,7 @@ public class PipeDelimitedStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInAmpersandDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: false, expand: true, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.PipeDelimited);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: false, expand: true, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.PipeDelimited);
 
         // Act
         var result = PipeDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray(specialSymbol));

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/SimpleStyleParametersSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/SimpleStyleParametersSerializerTests.cs
@@ -13,7 +13,7 @@ public class SimpleStyleParametersSerializerTests
     public void ItShouldCreateParameterWithCommaSeparatedValuePerArrayItem()
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: "integer");
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = SimpleStyleParameterSerializer.Serialize(parameter, new JsonArray(1, 2, 3));
@@ -28,7 +28,7 @@ public class SimpleStyleParametersSerializerTests
     public void ItShouldCreateParameterWithCommaSeparatedValuePerArrayStringItem()
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: "integer");
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple, arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = SimpleStyleParameterSerializer.Serialize(parameter, new JsonArray("1", "2", "3"));
@@ -43,7 +43,7 @@ public class SimpleStyleParametersSerializerTests
     public void ItShouldCreateParameterForPrimitiveValue()
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "integer", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Integer, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple);
 
         // Act
         var result = SimpleStyleParameterSerializer.Serialize(parameter, "28");
@@ -62,7 +62,7 @@ public class SimpleStyleParametersSerializerTests
     public void ItShouldNotEncodeSpecialSymbolsInPrimitiveParameterValues(string specialSymbol, string expectedSymbol)
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "string", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.String, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple);
 
         // Act
         var result = SimpleStyleParameterSerializer.Serialize(parameter, $"fake_query_param_value{specialSymbol}");
@@ -81,7 +81,7 @@ public class SimpleStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInCommaSeparatedParameterValues(string specialSymbol, string expectedSymbol)
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: true, expand: false, location: RestApiParameterLocation.Header, style: RestApiParameterStyle.Simple);
 
         // Act
         var result = SimpleStyleParameterSerializer.Serialize(parameter, new JsonArray(specialSymbol));

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/SpaceDelimitedStyleParametersSerializerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Serialization/SpaceDelimitedStyleParametersSerializerTests.cs
@@ -13,19 +13,19 @@ public class SpaceDelimitedStyleParametersSerializerTests
     public void ItShouldThrowExceptionForUnsupportedParameterStyle()
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "p1", type: "string", isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.Label);
+        var parameter = new RestApiParameter(name: "p1", type: RestApiParameterType.String, isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.Label);
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => SpaceDelimitedStyleParameterSerializer.Serialize(parameter, "fake-argument"));
     }
 
     [Theory]
-    [InlineData("integer")]
-    [InlineData("number")]
-    [InlineData("string")]
-    [InlineData("boolean")]
-    [InlineData("object")]
-    public void ItShouldThrowExceptionIfParameterTypeIsNotArray(string parameterType)
+    [InlineData(RestApiParameterType.Integer)]
+    [InlineData(RestApiParameterType.Number)]
+    [InlineData(RestApiParameterType.String)]
+    [InlineData(RestApiParameterType.Boolean)]
+    [InlineData(RestApiParameterType.Object)]
+    public void ItShouldThrowExceptionIfParameterTypeIsNotArray(RestApiParameterType parameterType)
     {
         // Arrange
         var parameter = new RestApiParameter(name: "p1", type: parameterType, isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.SpaceDelimited);
@@ -40,12 +40,12 @@ public class SpaceDelimitedStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: true,
                 expand: true, //Specifies to generate a separate parameter for each array item.
                 location: RestApiParameterLocation.Query,
                 style: RestApiParameterStyle.SpaceDelimited,
-                arrayItemType: "integer");
+                arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray("1", "2", "3"));
@@ -62,12 +62,12 @@ public class SpaceDelimitedStyleParametersSerializerTests
         // Arrange
         var parameter = new RestApiParameter(
                 name: "id",
-                type: "array",
+                type: RestApiParameterType.Array,
                 isRequired: true,
                 expand: false, //Specify generating a parameter with space-separated values for each array item.
                 location: RestApiParameterLocation.Query,
                 style: RestApiParameterStyle.SpaceDelimited,
-                arrayItemType: "integer");
+                arrayItemType: RestApiParameterType.Integer);
 
         // Act
         var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray(1, 2, 3));
@@ -86,7 +86,7 @@ public class SpaceDelimitedStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInSpaceDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.SpaceDelimited);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: false, expand: false, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.SpaceDelimited);
 
         // Act
         var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray(specialSymbol));
@@ -105,7 +105,7 @@ public class SpaceDelimitedStyleParametersSerializerTests
     public void ItShouldEncodeSpecialSymbolsInAmpersandDelimitedParameterValues(string specialSymbol, string encodedEquivalent)
     {
         // Arrange
-        var parameter = new RestApiParameter(name: "id", type: "array", isRequired: false, expand: true, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.SpaceDelimited);
+        var parameter = new RestApiParameter(name: "id", type: RestApiParameterType.Array, isRequired: false, expand: true, location: RestApiParameterLocation.Query, style: RestApiParameterStyle.SpaceDelimited);
 
         // Act
         var result = SpaceDelimitedStyleParameterSerializer.Serialize(parameter, new JsonArray(specialSymbol));


### PR DESCRIPTION
### Motivation and Context
Currently, SK OpenAPI functionality uses the OpenApi.NET v1.6 SDK to parse OpenAPI documents. The library version supports only OpenAPI v2 - v3.0.1 versions but does not support OpenAPI v3.1. The OpenApi.NET v2 SDK has added support for OpenAPI v3.1 together with some public API changes that caused several breaking changes on SK OpenAPI functionality.

### Description
This PR adapts SK OpenAPI functionality to the new OpenApi.NET v2 SDK public API surface.

### Out of scope of this PR
[.Net: [OpenAPI.Net V2] Refactor OpenAPI functionality to use new content readers](https://github.com/microsoft/semantic-kernel/issues/9857)
[.Net: [OpenAPI.Net V2] Refactor ApiManifest and CopilotAgentPlugin functionality to use new content readers](https://github.com/microsoft/semantic-kernel/issues/9859)
[.Net: [OpenAPI.Net V2] Remove temp. solution to support OpenAPI v3.1](https://github.com/microsoft/semantic-kernel/issues/9860)

Contributes to: https://github.com/microsoft/semantic-kernel/issues/9832