### PR TITLE
Python: enable ollama streaming tool calls

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -83,7 +83,7 @@ mistralai = [
     "mistralai >= 1.2,< 2.0"
 ]
 ollama = [
-    "ollama ~= 0.2"
+    "ollama ~= 0.4"
 ]
 onnx = [
     "onnxruntime-genai ~= 0.4; platform_system != 'Darwin'"

--- a/python/semantic_kernel/connectors/ai/azure_ai_inference/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/azure_ai_inference/services/utils.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from azure.ai.inference.models import (
     AssistantMessage,
@@ -98,7 +98,7 @@ def _format_assistant_message(message: ChatMessageContent) -> AssistantMessage:
                     function=FunctionCall(
                         name=item.name or "",
                         arguments=json.dumps(item.arguments)
-                        if isinstance(item.arguments, dict)
+                        if isinstance(item.arguments, Mapping)
                         else item.arguments or "",
                     ),
                 )

--- a/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import partial
 from typing import Any
 
@@ -108,7 +108,9 @@ def _format_assistant_message(message: ChatMessageContent) -> dict[str, Any]:
                 "toolUse": {
                     "toolUseId": item.id,
                     "name": item.custom_fully_qualified_name(BEDROCK_FUNCTION_NAME_SEPARATOR),
-                    "input": item.arguments if isinstance(item.arguments, dict) else json.loads(item.arguments or "{}"),
+                    "input": item.arguments
+                    if isinstance(item.arguments, Mapping)
+                    else json.loads(item.arguments or "{}"),
                 }
             })
         else:

--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -99,7 +99,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         """
         # Create a copy of the settings to avoid modifying the original settings
         settings = copy.deepcopy(settings)
-        # Later on, we already use the tools or equivalant settings, we cast here.
+        # Later on, we already use the tools or equivalent settings, we cast here.
         if not isinstance(settings, self.get_prompt_execution_settings_class()):
             settings = self.get_prompt_execution_settings_from_settings(settings)
 
@@ -214,7 +214,7 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         """
         # Create a copy of the settings to avoid modifying the original settings
         settings = copy.deepcopy(settings)
-        # Later on, we already use the tools or equivalant settings, we cast here.
+        # Later on, we already use the tools or equivalent settings, we cast here.
         if not isinstance(settings, self.get_prompt_execution_settings_class()):
             settings = self.get_prompt_execution_settings_from_settings(settings)
 

--- a/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
+++ b/python/semantic_kernel/connectors/ai/chat_completion_client_base.py
@@ -99,6 +99,9 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         """
         # Create a copy of the settings to avoid modifying the original settings
         settings = copy.deepcopy(settings)
+        # Later on, we already use the tools or equivalant settings, we cast here.
+        if not isinstance(settings, self.get_prompt_execution_settings_class()):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
 
         if not self.SUPPORTS_FUNCTION_CALLING:
             return await self._inner_get_chat_message_contents(chat_history, settings)
@@ -211,6 +214,9 @@ class ChatCompletionClientBase(AIServiceClientBase, ABC):
         """
         # Create a copy of the settings to avoid modifying the original settings
         settings = copy.deepcopy(settings)
+        # Later on, we already use the tools or equivalant settings, we cast here.
+        if not isinstance(settings, self.get_prompt_execution_settings_class()):
+            settings = self.get_prompt_execution_settings_from_settings(settings)
 
         if not self.SUPPORTS_FUNCTION_CALLING:
             async for streaming_chat_message_contents in self._inner_get_streaming_chat_message_contents(

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -300,7 +300,7 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
                     completion_tokens=response.eval_count,
                 )
             return metadata
-        metadata: dict[str, Any] = {
+        metadata = {
             "model": response.get("model"),
         }
 

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -186,11 +186,6 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
             settings = self.get_prompt_execution_settings_from_settings(settings)
         assert isinstance(settings, OllamaChatPromptExecutionSettings)  # nosec
 
-        if settings.tools:
-            raise ServiceInvalidExecutionSettingsError(
-                "Ollama does not support tool calling in streaming chat completion."
-            )
-
         prepared_chat_history = self._prepare_chat_history_for_request(chat_history)
 
         response_object = await self.client.chat(

--- a/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/ollama_chat_completion.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -46,6 +46,8 @@ from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
 
 if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+
+CMC_TYPE = TypeVar("CMC_TYPE", bound=ChatMessageContent)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -163,17 +165,14 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
             **settings.prepare_settings_dict(),
         )
 
-        if not isinstance(response_object, Mapping):
-            raise ServiceInvalidResponseError(
-                f"Invalid response type from Ollama chat completion. Expected Mapping but got {type(response_object)}."
-            )
-
-        return [
-            self._create_chat_message_content(
-                response_object,
-                self._get_metadata_from_response(response_object),
-            )
-        ]
+        if isinstance(response_object, ChatResponse):
+            return [self._create_chat_message_content_by_type(response_object, ChatMessageContent)]
+        if isinstance(response_object, Mapping):
+            return [self._create_chat_message_content(response_object)]
+        raise ServiceInvalidResponseError(
+            "Invalid response type from Ollama chat completion. "
+            f"Expected Mapping or ChatResponse but got {type(response_object)}."
+        )
 
     @override
     @trace_streaming_chat_completion(OllamaBase.MODEL_PROVIDER_NAME)
@@ -197,21 +196,66 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
 
         if not isinstance(response_object, AsyncIterator):
             raise ServiceInvalidResponseError(
-                "Invalid response type from Ollama chat completion. "
+                "Invalid response type from Ollama streaming chat completion. "
                 f"Expected AsyncIterator but got {type(response_object)}."
             )
 
         async for part in response_object:
-            yield [
-                self._create_streaming_chat_message_content(
-                    part,
-                    self._get_metadata_from_response(part),
-                )
-            ]
+            if isinstance(part, ChatResponse):
+                yield [self._create_chat_message_content_by_type(part, StreamingChatMessageContent)]
+                continue
+            if isinstance(part, Mapping):
+                yield [self._create_streaming_chat_message_content(part)]
+                continue
+            raise ServiceInvalidResponseError(
+                "Invalid response type from Ollama streaming chat completion. "
+                f"Expected mapping or ChatResponse but got {type(part)}."
+            )
 
     # endregion
 
-    def _create_chat_message_content(self, response: Mapping[str, Any], metadata: dict[str, Any]) -> ChatMessageContent:
+    def _create_chat_message_content_by_type(self, response: ChatResponse, type: type[CMC_TYPE]) -> CMC_TYPE:
+        """Create a chat message content from the response."""
+        items: list[ITEM_TYPES] = []
+        if response.message is None:
+            raise ServiceInvalidResponseError("No message content found in response.")
+        if response.message.content:
+            items.append(
+                TextContent(
+                    text=response.message.content,
+                    inner_content=response.message,
+                )
+            )
+        if response.message.tool_calls:
+            for tool_call in response.message.tool_calls:
+                items.append(
+                    FunctionCallContent(
+                        inner_content=tool_call,
+                        ai_model_id=self.ai_model_id,
+                        name=tool_call.function.name,
+                        arguments=tool_call.function.arguments,
+                    )
+                )
+        metadata = self._get_metadata_from_chat_response(response)
+        if type is StreamingChatMessageContent:
+            return type(
+                choice_index=0,
+                role=AuthorRole.ASSISTANT,
+                items=items,
+                inner_content=response,
+                ai_model_id=self.ai_model_id,
+                metadata=metadata,
+            )
+
+        return type(
+            role=AuthorRole.ASSISTANT,
+            items=items,
+            inner_content=response,
+            ai_model_id=self.ai_model_id,
+            metadata=metadata,
+        )
+
+    def _create_chat_message_content(self, response: Mapping[str, Any]) -> ChatMessageContent:
         """Create a chat message content from the response."""
         items: list[ITEM_TYPES] = []
         if not (message := response.get("message", None)):
@@ -239,34 +283,12 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
             role=AuthorRole.ASSISTANT,
             items=items,
             inner_content=response,
-            metadata=metadata,
+            metadata=self._get_metadata_from_response(response),
         )
 
-    def _create_streaming_chat_message_content(
-        self, part: Mapping[str, Any] | ChatResponse, metadata: dict[str, Any]
-    ) -> StreamingChatMessageContent:
+    def _create_streaming_chat_message_content(self, part: Mapping[str, Any]) -> StreamingChatMessageContent:
         """Create a streaming chat message content from the response part."""
         items: list[STREAMING_ITEM_TYPES] = []
-        if isinstance(part, ChatResponse):
-            if part.message is None:
-                raise ServiceInvalidResponseError("No message content found in response part.")
-            if part.message.content:
-                items.append(
-                    StreamingTextContent(
-                        choice_index=0,
-                        text=part.message.content,
-                        inner_content=part.message,
-                    )
-                )
-            return StreamingChatMessageContent(
-                role=AuthorRole.ASSISTANT,
-                choice_index=0,
-                items=items,
-                inner_content=part,
-                ai_model_id=self.ai_model_id,
-                metadata=metadata,
-            )
-
         if not (message := part.get("message", None)):
             raise ServiceInvalidResponseError("No message content found in response part.")
 
@@ -278,6 +300,16 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
                     inner_content=message,
                 )
             )
+        if tool_calls := message.get("tool_calls", None):
+            for tool_call in tool_calls:
+                items.append(
+                    FunctionCallContent(
+                        inner_content=tool_call,
+                        ai_model_id=self.ai_model_id,
+                        name=tool_call.get("function").get("name"),
+                        arguments=tool_call.get("function").get("arguments"),
+                    )
+                )
 
         return StreamingChatMessageContent(
             role=AuthorRole.ASSISTANT,
@@ -285,21 +317,11 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
             items=items,
             inner_content=part,
             ai_model_id=self.ai_model_id,
-            metadata=metadata,
+            metadata=self._get_metadata_from_response(part),
         )
 
-    def _get_metadata_from_response(self, response: Mapping[str, Any] | ChatResponse) -> dict[str, Any]:
+    def _get_metadata_from_response(self, response: Mapping[str, Any]) -> dict[str, Any]:
         """Get metadata from the response."""
-        if isinstance(response, ChatResponse):
-            metadata: dict[str, Any] = {
-                "model": response.model,
-            }
-            if response.prompt_eval_count and response.eval_count:
-                metadata["usage"] = CompletionUsage(
-                    prompt_tokens=response.prompt_eval_count,
-                    completion_tokens=response.eval_count,
-                )
-            return metadata
         metadata = {
             "model": response.get("model"),
         }
@@ -310,4 +332,16 @@ class OllamaChatCompletion(OllamaBase, ChatCompletionClientBase):
                 completion_tokens=response.get("eval_count"),
             )
 
+        return metadata
+
+    def _get_metadata_from_chat_response(self, response: ChatResponse) -> dict[str, Any]:
+        """Get metadata from the response."""
+        metadata: dict[str, Any] = {
+            "model": response.model,
+        }
+        if response.prompt_eval_count and response.eval_count:
+            metadata["usage"] = CompletionUsage(
+                prompt_tokens=response.prompt_eval_count,
+                completion_tokens=response.eval_count,
+            )
         return metadata

--- a/python/semantic_kernel/connectors/ai/ollama/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from ollama._types import Message
 
@@ -75,7 +75,7 @@ def _format_assistant_message(message: ChatMessageContent) -> Message:
                 "function": {
                     "name": tool_call.function_name,
                     "arguments": tool_call.arguments
-                    if isinstance(tool_call.arguments, dict)
+                    if isinstance(tool_call.arguments, Mapping)
                     else json.loads(tool_call.arguments or "{}"),
                 }
             }

--- a/python/semantic_kernel/connectors/ai/ollama/services/utils.py
+++ b/python/semantic_kernel/connectors/ai/ollama/services/utils.py
@@ -125,6 +125,6 @@ def update_settings_from_function_choice_configuration(
             for f in function_choice_configuration.available_functions
         ]
         try:
-            settings.tools = tools
+            settings.tools = tools  # type: ignore
         except Exception:
             settings.extension_data["tools"] = tools

--- a/python/tests/integration/completions/chat_completion_test_base.py
+++ b/python/tests/integration/completions/chat_completion_test_base.py
@@ -38,7 +38,7 @@ from semantic_kernel.kernel import Kernel
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 from semantic_kernel.utils.authentication.entra_id_authentication import get_entra_auth_token
 from tests.integration.completions.completion_test_base import CompletionTestBase, ServiceType
-from tests.utils import is_service_setup_for_testing, is_test_running_on_supported_platforms
+from tests.utils import is_service_setup_for_testing
 
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
@@ -56,15 +56,9 @@ mistral_ai_setup: bool = is_service_setup_for_testing(
 # There is no single model in Ollama that supports both image and tool call in chat completion
 # We are splitting the Ollama test into three services: chat, image, and tool call. The chat model
 # can be any model that supports chat completion. Also, Ollama is only available on Linux runners in our pipeline.
-ollama_setup: bool = is_service_setup_for_testing(["OLLAMA_CHAT_MODEL_ID"]) and is_test_running_on_supported_platforms([
-    "Linux"
-])
-ollama_image_setup: bool = is_service_setup_for_testing([
-    "OLLAMA_CHAT_MODEL_ID_IMAGE"
-]) and is_test_running_on_supported_platforms(["Linux"])
-ollama_tool_call_setup: bool = is_service_setup_for_testing([
-    "OLLAMA_CHAT_MODEL_ID_TOOL_CALL"
-]) and is_test_running_on_supported_platforms(["Linux"])
+ollama_setup: bool = is_service_setup_for_testing(["OLLAMA_CHAT_MODEL_ID"])
+ollama_image_setup: bool = is_service_setup_for_testing(["OLLAMA_CHAT_MODEL_ID_IMAGE"])
+ollama_tool_call_setup: bool = is_service_setup_for_testing(["OLLAMA_CHAT_MODEL_ID_TOOL_CALL"])
 google_ai_setup: bool = is_service_setup_for_testing(["GOOGLE_AI_API_KEY", "GOOGLE_AI_GEMINI_MODEL_ID"])
 vertex_ai_setup: bool = is_service_setup_for_testing(["VERTEX_AI_PROJECT_ID", "VERTEX_AI_GEMINI_MODEL_ID"])
 onnx_setup: bool = is_service_setup_for_testing(

--- a/python/tests/integration/completions/test_chat_completion_with_function_calling.py
+++ b/python/tests/integration/completions/test_chat_completion_with_function_calling.py
@@ -674,7 +674,6 @@ pytestmark = pytest.mark.parametrize(
             ],
             {
                 "test_type": FunctionChoiceTestTypes.AUTO,
-                "streaming": False,  # Streaming tool calls are not supported by Ollama
             },
             marks=pytest.mark.skipif(not ollama_tool_call_setup, reason="Need local Ollama setup"),
             id="ollama_tool_call_auto",
@@ -697,7 +696,6 @@ pytestmark = pytest.mark.parametrize(
             ],
             {
                 "test_type": FunctionChoiceTestTypes.NON_AUTO,
-                "streaming": False,  # Streaming tool calls are not supported by Ollama
             },
             marks=pytest.mark.skipif(not ollama_tool_call_setup, reason="Need local Ollama setup"),
             id="ollama_tool_call_non_auto",
@@ -727,7 +725,6 @@ pytestmark = pytest.mark.parametrize(
             ],
             {
                 "test_type": FunctionChoiceTestTypes.FLOW,
-                "streaming": False,  # Streaming tool calls are not supported by Ollama
             },
             marks=pytest.mark.skipif(not ollama_tool_call_setup, reason="Need local Ollama setup"),
             id="ollama_tool_call_flow",
@@ -749,7 +746,6 @@ pytestmark = pytest.mark.parametrize(
             ],
             {
                 "test_type": FunctionChoiceTestTypes.AUTO,
-                "streaming": False,  # Streaming tool calls are not supported by Ollama
             },
             marks=pytest.mark.skipif(not ollama_tool_call_setup, reason="Need local Ollama setup"),
             id="ollama_tool_call_auto_complex_return_type",

--- a/python/tests/unit/connectors/ai/ollama/services/test_ollama_chat_completion.py
+++ b/python/tests/unit/connectors/ai/ollama/services/test_ollama_chat_completion.py
@@ -234,22 +234,3 @@ async def test_streaming_chat_completion_wrong_return_type(
             OllamaChatPromptExecutionSettings(service_id=service_id, options=default_options),
         ):
             pass
-
-
-@pytest.mark.asyncio
-async def test_streaming_chat_completion_with_tools_raise(
-    model_id,
-    service_id,
-    chat_history,
-    default_options,
-):
-    """Test that the chat completion streaming service fails when tool calls are requested."""
-    ollama = OllamaChatCompletion(ai_model_id=model_id)
-    with pytest.raises(ServiceInvalidExecutionSettingsError):
-        async for _ in ollama.get_streaming_chat_message_contents(
-            chat_history,
-            OllamaChatPromptExecutionSettings(
-                tools=[{"type": "function"}], service_id=service_id, options=default_options
-            ),
-        ):
-            pass

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4696,7 +4696,7 @@ wheels = [
 
 [[package]]
 name = "semantic-kernel"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2824,14 +2824,15 @@ wheels = [
 
 [[package]]
 name = "ollama"
-version = "0.3.3"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/8e/60a9b065eb796ef3996451cbe2d8044f6b030696166693b9805ae33b8b4c/ollama-0.3.3.tar.gz", hash = "sha256:f90a6d61803117f40b0e8ff17465cab5e1eb24758a473cfe8101aff38bc13b51", size = 10390 }
+sdist = { url = "https://files.pythonhosted.org/packages/92/cf/d3035090602cf325d200e85df355253b6210ae81e6c6e21b57ece76c2b16/ollama-0.4.2.tar.gz", hash = "sha256:5dffc826737a1d121c9ae371439cace20ab02ec4b0840fd55c56efa9a3fb3646", size = 13098 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/ca/d22905ac3f768523f778189d38c9c6cd9edf4fa9dd09cb5a3fc57b184f90/ollama-0.3.3-py3-none-any.whl", hash = "sha256:ca6242ce78ab34758082b7392df3f9f6c2cb1d070a9dede1a4c545c929e16dba", size = 10267 },
+    { url = "https://files.pythonhosted.org/packages/da/8e/b651790e301c555fe76869308f9c8af1014146ce4187291cf13eb8109096/ollama-0.4.2-py3-none-any.whl", hash = "sha256:3059fe1fe34e24c782e9e8eebf69bcd2d7037007cb4b3cfda4b32bfee36ae2ef", size = 13138 },
 ]
 
 [[package]]
@@ -4833,7 +4834,7 @@ requires-dist = [
     { name = "nest-asyncio", specifier = "~=1.6" },
     { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.25.0" },
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
-    { name = "ollama", marker = "extra == 'ollama'", specifier = "~=0.2" },
+    { name = "ollama", marker = "extra == 'ollama'", specifier = "~=0.4" },
     { name = "onnxruntime-genai", marker = "platform_system != 'Darwin' and extra == 'onnx'", specifier = "~=0.4" },
     { name = "openai", specifier = "~=1.0" },
     { name = "openapi-core", specifier = ">=0.18,<0.20" },


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Ollama has enabled streaming tool calling, and so we add that too!
See release notes: https://github.com/ollama/ollama/releases/tag/v0.4.6

Also encountered a bug when passing generic PromptExecutionSettings to all ChatCompletions with Function calling enabled, the _verify_function_choice_settings often check if something is a type of PES matching the service, that is not the case and throws even though it should work (for instance when using a yaml based function), this fixes that as well by casting in the public methods of chat completion base. 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
