### PR TITLE
Python: Include the sessions plugin status key in return value

### DIFF
--- a/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
@@ -200,7 +200,7 @@ class SessionsPythonTool(KernelBaseModel):
             )
             response.raise_for_status()
             result = response.json()["properties"]
-            return f"Result:\n{result['result']}Stdout:\n{result['stdout']}Stderr:\n{result['stderr']}"
+            return f"Status:\n{result['status']}Result:\n{result['result']}Stdout:\n{result['stdout']}Stderr:\n{result['stderr']}"  # noqa: E501
         except HTTPStatusError as e:
             error_message = e.response.text if e.response.text else e.response.reason_phrase
             raise FunctionExecutionException(

--- a/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
+++ b/python/semantic_kernel/core_plugins/sessions_python_tool/sessions_python_plugin.py
@@ -200,7 +200,12 @@ class SessionsPythonTool(KernelBaseModel):
             )
             response.raise_for_status()
             result = response.json()["properties"]
-            return f"Status:\n{result['status']}Result:\n{result['result']}Stdout:\n{result['stdout']}Stderr:\n{result['stderr']}"  # noqa: E501
+            return (
+                f"Status:\n{result['status']}\n"
+                f"Result:\n{result['result']}\n"
+                f"Stdout:\n{result['stdout']}\n"
+                f"Stderr:\n{result['stderr']}"
+            )
         except HTTPStatusError as e:
             error_message = e.response.text if e.response.text else e.response.reason_phrase
             raise FunctionExecutionException(


### PR DESCRIPTION
### Motivation and Context

The Python sessions plugin (ACA) includes a `status` now in their result once code is executed. This looks to have been added recently as we weren't including it in the original return string. This PR adds that.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Add the `status` key value to the return string.
- Fixes Python bug for #9902 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
