### PR TITLE
Python: Make sure the coverage workflow checks out the PR

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -4,9 +4,9 @@ on:
   pull_request_target:
     branches: ["main", "feature*"]
     types: [opened, synchronize, reopened]
-    # paths:
-    #   - "python/semantic_kernel/**"
-    #   - "python/tests/unit/**"
+    paths:
+      - "python/semantic_kernel/**"
+      - "python/tests/unit/**"
 env:
   # Configure a constant location for the uv cache
   UV_CACHE_DIR: /tmp/.uv-cache

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -12,8 +12,6 @@ env:
   UV_CACHE_DIR: /tmp/.uv-cache
 
 permissions:
-  contents: write
-  checks: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -3,9 +3,9 @@ name: Python Test Coverage
 on:
   pull_request_target:
     branches: ["main", "feature*"]
-    paths:
-      - "python/semantic_kernel/**"
-      - "python/tests/unit/**"
+    # paths:
+    #   - "python/semantic_kernel/**"
+    #   - "python/tests/unit/**"
 env:
   # Configure a constant location for the uv cache
   UV_CACHE_DIR: /tmp/.uv-cache

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -1,7 +1,7 @@
 name: Python Test Coverage
 
 on:
-  pull_request:
+  pull_request_target:
     branches: ["main", "feature*"]
     paths:
       - "python/semantic_kernel/**"
@@ -26,6 +26,9 @@ jobs:
       UV_PYTHON: "3.10"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup filename variables
         run: echo "FILE_ID=${{ github.event.number }}" >> $GITHUB_ENV
       - name: Set up uv

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -3,6 +3,7 @@ name: Python Test Coverage
 on:
   pull_request_target:
     branches: ["main", "feature*"]
+    types: [opened, synchronize, reopened]
     # paths:
     #   - "python/semantic_kernel/**"
     #   - "python/tests/unit/**"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The `python-test-coverage` workflow needs the write permission to post comments on PRs. However, with the `pull_request` trigger, if a PR is from a fork, the max permission the workflow has is read ([link](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)). Thus, we need to use the `pull_request_target` trigger. 

The `pull_request_target` makes sure the workflow runs in the context of the base on the target branch. This won't work since we need to run the test coverage on the changes in the PR. Thus, we need to check out the changes in the PR instead of the base of the PR.

### Description

Make sure the `python-test-coverage` workflow has the required permissions and checks out the PR changes.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
