### PR TITLE
Python: Add PR number to test coverage workflow

### DIFF
--- a/.github/workflows/python-test-coverage-report.yml
+++ b/.github/workflows/python-test-coverage-report.yml
@@ -25,10 +25,19 @@ jobs:
           merge-multiple: true
       - name: Display structure of downloaded files
         run: ls
+      - name: Read and set PR number
+        # Need to read the PR number from the file saved in the previous workflow
+        # because the workflow_run event does not have access to the PR number
+        # The PR number is needed to post the comment on the PR
+        run: |
+          PR_NUMBER=$(cat pr_number)
+          echo "PR number: $PR_NUMBER"
+          echo "::set-env name=PR_NUMBER::$PR_NUMBER"
       - name: Pytest coverage comment
         id: coverageComment
         uses: MishaKav/pytest-coverage-comment@main
         with:
+          issue-number: ${{ env.PR_NUMBER }}
           pytest-coverage-path: python/python-coverage.txt
           title: "Python Test Coverage Report"
           badge-title: "Python Test Coverage"

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -21,6 +21,11 @@ jobs:
       UV_PYTHON: "3.10"
     steps:
       - uses: actions/checkout@v4
+      # Save the PR number to a file since the workflow_run event
+      # in the coverage report workflow does not have access to it
+      - name: Save PR number
+        run: |
+          echo ${{ github.event.number }} > ./pr_number
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -37,6 +42,7 @@ jobs:
           path: |
             python/python-coverage.txt
             python/pytest.xml
+            python/pr_number
           overwrite: true
           retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The test coverage workflow needs the PR number to post comments to PRs. However, the `workflow_run` context doesn't contain the PR number thus we need to save it.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Save the PR number in a file and upload it as artifact for the second workflow to use.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
