### PR TITLE
.Net: fix: includes path item path parameters to OpenAPI document parsing

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection.Metadata;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -211,7 +211,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     path: path,
                     method: new HttpMethod(method),
                     description: string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description,
-                    parameters: CreateRestApiOperationParameters(operationItem.OperationId, GetDeduplicatedParametersOverrides(pathItem, operationItem)),
+                    parameters: CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters.Union(pathItem.Parameters, s_parameterNameAndLocationComparer)),
                     payload: CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),
                     securityRequirements: CreateRestApiOperationSecurityRequirements(operationItem.Security)
@@ -235,18 +235,6 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
             logger.LogError(ex, "Fatal error occurred during REST API operation creation.");
             throw;
         }
-    }
-
-    /// <summary>
-    /// Returns a list of parameters that are defined in the path and operation.
-    /// Will deduplicate operation parameters overrides.
-    /// </summary>
-    /// <param name="pathItem">The path item.</param>
-    /// <param name="operation">The operation.</param>
-    /// <returns>The list of parameters.</returns>
-    private static IEnumerable<OpenApiParameter> GetDeduplicatedParametersOverrides(OpenApiPathItem pathItem, OpenApiOperation operation)
-    {
-        return operation.Parameters.Union(pathItem.Parameters, s_parameterNameAndLocationComparer);
     }
 
     private static readonly ParameterNameAndLocationComparer s_parameterNameAndLocationComparer = new();

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -246,11 +246,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
     /// <returns>The list of parameters.</returns>
     private static IEnumerable<OpenApiParameter> GetDeduplicatedParametersOverrides(OpenApiPathItem pathItem, OpenApiOperation operation)
     {
-        return pathItem.Parameters
-                .Select(static x => (Parameter: x, IsInPath: true))
-                .Union(operation.Parameters.Select(static x => (Parameter: x, IsInPath: false)))
-                .GroupBy(static x => x.Parameter, s_parameterNameAndLocationComparer)
-                .Select(static x => x.OrderBy(static y => y.IsInPath).First().Parameter);
+        return operation.Parameters.Union(pathItem.Parameters, s_parameterNameAndLocationComparer);
     }
 
     private static readonly ParameterNameAndLocationComparer s_parameterNameAndLocationComparer = new();

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -211,7 +211,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     path: path,
                     method: new HttpMethod(method),
                     description: string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description,
-                    parameters: CreateRestApiOperationParameters(operationItem.OperationId, pathItem.Parameters.Union(operationItem.Parameters).ToList()),
+                    parameters: CreateRestApiOperationParameters(operationItem.OperationId, pathItem.Parameters.Union(operationItem.Parameters)),
                     payload: CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),
                     securityRequirements: CreateRestApiOperationSecurityRequirements(operationItem.Security)
@@ -381,7 +381,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
     /// <param name="operationId">The operation id.</param>
     /// <param name="parameters">The OpenAPI parameters.</param>
     /// <returns>The parameters.</returns>
-    private static List<RestApiParameter> CreateRestApiOperationParameters(string operationId, IList<OpenApiParameter> parameters)
+    private static List<RestApiParameter> CreateRestApiOperationParameters(string operationId, IEnumerable<OpenApiParameter> parameters)
     {
         var result = new List<RestApiParameter>();
 

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -211,7 +211,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
                     path: path,
                     method: new HttpMethod(method),
                     description: string.IsNullOrEmpty(operationItem.Description) ? operationItem.Summary : operationItem.Description,
-                    parameters: CreateRestApiOperationParameters(operationItem.OperationId, operationItem.Parameters),
+                    parameters: CreateRestApiOperationParameters(operationItem.OperationId, pathItem.Parameters.Union(operationItem.Parameters).ToList()),
                     payload: CreateRestApiOperationPayload(operationItem.OperationId, operationItem.RequestBody),
                     responses: CreateRestApiOperationExpectedResponses(operationItem.Responses).ToDictionary(static item => item.Item1, static item => item.Item2),
                     securityRequirements: CreateRestApiOperationSecurityRequirements(operationItem.Security)

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV20Tests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -433,6 +434,165 @@ public sealed class OpenApiDocumentParserV20Tests : IDisposable
 
         Assert.Contains(restApiSpec.Operations, o => o.Id == "SetSecret");
         Assert.Contains(restApiSpec.Operations, o => o.Id == "GetSecret");
+    }
+    [Fact]
+    public async Task ItCanParsePathItemPathParametersAsync()
+    {
+        var document =
+        """
+        {
+            "swagger": "2.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0"
+            },
+            "paths": {
+                "/items/{itemId}/{format}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "format",
+                                "in": "path",
+                                "required": true,
+                                "type": "string"
+                            }
+                        ],
+                        "summary": "Get an item by ID",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));
+        var restApi = await this._sut.ParseAsync(steam);
+
+        Assert.NotNull(restApi);
+        Assert.NotNull(restApi.Operations);
+        Assert.NotEmpty(restApi.Operations);
+
+        var firstOperation = restApi.Operations[0];
+
+        Assert.NotNull(firstOperation);
+        Assert.Equal("Get an item by ID", firstOperation.Description);
+        Assert.Equal("/items/{itemId}/{format}", firstOperation.Path);
+
+        var parameters = firstOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(2, parameters.Count);
+
+        var pathParameter = parameters.Single(static p => "itemId".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(pathParameter);
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, pathParameter.Location);
+        Assert.Null(pathParameter.DefaultValue);
+        Assert.NotNull(pathParameter.Schema);
+        Assert.Equal("string", pathParameter.Schema.RootElement.GetProperty("type").GetString());
+
+        var formatParameter = parameters.Single(static p => "format".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(formatParameter);
+        Assert.True(formatParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, formatParameter.Location);
+        Assert.Null(formatParameter.DefaultValue);
+        Assert.NotNull(formatParameter.Schema);
+        Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task ItCanParsePathItemPathParametersAndOverridesAsync()
+    {
+        var document =
+        """
+        {
+            "swagger": "2.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0"
+            },
+            "paths": {
+                "/items/{itemId}/{format}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "format",
+                                "in": "path",
+                                "required": true,
+                                "type": "string"
+                            },
+                            {
+                                "name": "itemId",
+                                "in": "path",
+                                "description": "item ID override",
+                                "required": true,
+                                "type": "string"
+                            }
+                        ],
+                        "summary": "Get an item by ID",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));
+        var restApi = await this._sut.ParseAsync(steam);
+
+        Assert.NotNull(restApi);
+        Assert.NotNull(restApi.Operations);
+        Assert.NotEmpty(restApi.Operations);
+
+        var firstOperation = restApi.Operations[0];
+
+        Assert.NotNull(firstOperation);
+        Assert.Equal("Get an item by ID", firstOperation.Description);
+        Assert.Equal("/items/{itemId}/{format}", firstOperation.Path);
+
+        var parameters = firstOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(2, parameters.Count);
+
+        var pathParameter = parameters.Single(static p => "itemId".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(pathParameter);
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, pathParameter.Location);
+        Assert.Null(pathParameter.DefaultValue);
+        Assert.NotNull(pathParameter.Schema);
+        Assert.Equal("string", pathParameter.Schema.RootElement.GetProperty("type").GetString());
+        Assert.Equal("item ID override", pathParameter.Description);
+
+        var formatParameter = parameters.Single(static p => "format".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(formatParameter);
+        Assert.True(formatParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, formatParameter.Location);
+        Assert.Null(formatParameter.DefaultValue);
+        Assert.NotNull(formatParameter.Schema);
+        Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
     }
 
     private static RestApiParameter GetParameterMetadata(IList<RestApiOperation> operations, string operationId,

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
@@ -581,6 +581,96 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
         Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
     }
 
+    [Fact]
+    public async Task ItCanParsePathItemPathParametersAndOverridesAsync()
+    {
+        var document =
+        """
+        {
+            "openapi": "3.0.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0"
+            },
+            "paths": {
+                "/items/{itemId}/{format}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": true,
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "format",
+                                "in": "path",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "name": "itemId",
+                                "in": "path",
+                                "description": "item ID override",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        ],
+                        "summary": "Get an item by ID",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));
+        var restApi = await this._sut.ParseAsync(steam);
+
+        Assert.NotNull(restApi);
+        Assert.NotNull(restApi.Operations);
+        Assert.NotEmpty(restApi.Operations);
+
+        var firstOperation = restApi.Operations[0];
+
+        Assert.NotNull(firstOperation);
+        Assert.Equal("Get an item by ID", firstOperation.Description);
+        Assert.Equal("/items/{itemId}/{format}", firstOperation.Path);
+
+        var parameters = firstOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(2, parameters.Count);
+
+        var pathParameter = parameters.Single(static p => "itemId".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(pathParameter);
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, pathParameter.Location);
+        Assert.Null(pathParameter.DefaultValue);
+        Assert.NotNull(pathParameter.Schema);
+        Assert.Equal("string", pathParameter.Schema.RootElement.GetProperty("type").GetString());
+        Assert.Equal("item ID override", pathParameter.Description);
+
+        var formatParameter = parameters.Single(static p => "format".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(formatParameter);
+        Assert.True(formatParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, formatParameter.Location);
+        Assert.Null(formatParameter.DefaultValue);
+        Assert.NotNull(formatParameter.Schema);
+        Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
+    }
+
     private static MemoryStream ModifyOpenApiDocument(Stream openApiDocument, Action<JsonObject> transformer)
     {
         var json = JsonSerializer.Deserialize<JsonObject>(openApiDocument);

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -498,6 +499,86 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
 
         Assert.Equal("https://my-key-vault.vault.azure.net", restApi.Operations[0].Servers[0].Url);
         Assert.Equal("https://ppe.my-key-vault.vault.azure.net", restApi.Operations[0].Servers[1].Url);
+    }
+
+    [Fact]
+    public async Task ItCanParsePathItemPathParametersAsync()
+    {
+        var document =
+        """
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "title": "Test API",
+                    "version": "1.0.0"
+                },
+                "paths": {
+                    "/items/{itemId}/{format}": {
+                        "parameters": [
+                            {
+                                "name": "itemId",
+                                "in": "path",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        ],
+                        "get": {
+                            "parameters": [
+                                {
+                                    "name": "format",
+                                    "in": "path",
+                                    "required": true,
+                                    "schema": {
+                                        "type": "string"
+                                    }
+                                }
+                            ],
+                            "summary": "Get an item by ID",
+                            "responses": {
+                                "200": {
+                                    "description": "Successful response"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """;
+
+        await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));
+        var restApi = await this._sut.ParseAsync(steam);
+
+        Assert.NotNull(restApi);
+        Assert.NotNull(restApi.Operations);
+        Assert.NotEmpty(restApi.Operations);
+
+        var firstOperation = restApi.Operations[0];
+
+        Assert.NotNull(firstOperation);
+        Assert.Equal("Get an item by ID", firstOperation.Description);
+        Assert.Equal("/items/{itemId}/{format}", firstOperation.Path);
+
+        var parameters = firstOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(2, parameters.Count);
+
+        var pathParameter = parameters.Single(static p => "itemId".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(pathParameter);
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, pathParameter.Location);
+        Assert.Null(pathParameter.DefaultValue);
+        Assert.NotNull(pathParameter.Schema);
+        Assert.Equal("string", pathParameter.Schema.RootElement.GetProperty("type").GetString());
+
+        var formatParameter = parameters.Single(static p => "format".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(formatParameter);
+        Assert.True(formatParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, formatParameter.Location);
+        Assert.Null(formatParameter.DefaultValue);
+        Assert.NotNull(formatParameter.Schema);
+        Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
     }
 
     private static MemoryStream ModifyOpenApiDocument(Stream openApiDocument, Action<JsonObject> transformer)

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV30Tests.cs
@@ -506,17 +506,28 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
     {
         var document =
         """
-            {
-                "openapi": "3.0.0",
-                "info": {
-                    "title": "Test API",
-                    "version": "1.0.0"
-                },
-                "paths": {
-                    "/items/{itemId}/{format}": {
+        {
+            "openapi": "3.0.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0"
+            },
+            "paths": {
+                "/items/{itemId}/{format}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": true,
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "get": {
                         "parameters": [
                             {
-                                "name": "itemId",
+                                "name": "format",
                                 "in": "path",
                                 "required": true,
                                 "schema": {
@@ -524,27 +535,16 @@ public sealed class OpenApiDocumentParserV30Tests : IDisposable
                                 }
                             }
                         ],
-                        "get": {
-                            "parameters": [
-                                {
-                                    "name": "format",
-                                    "in": "path",
-                                    "required": true,
-                                    "schema": {
-                                        "type": "string"
-                                    }
-                                }
-                            ],
-                            "summary": "Get an item by ID",
-                            "responses": {
-                                "200": {
-                                    "description": "Successful response"
-                                }
+                        "summary": "Get an item by ID",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response"
                             }
                         }
                     }
                 }
             }
+        }
         """;
 
         await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiDocumentParserV31Tests.cs
@@ -6,6 +6,7 @@ using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -475,6 +476,176 @@ public sealed class OpenApiDocumentParserV31Tests : IDisposable
 
         Assert.Equal("https://my-key-vault.vault.azure.net", restApi.Operations[0].Servers[0].Url);
         Assert.Equal("https://ppe.my-key-vault.vault.azure.net", restApi.Operations[0].Servers[1].Url);
+    }
+
+    [Fact]
+    public async Task ItCanParsePathItemPathParametersAsync()
+    {//TODO update the document version when upgrading Microsoft.OpenAPI to v2
+        var document =
+        """
+        {
+            "openapi": "3.0.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0"
+            },
+            "paths": {
+                "/items/{itemId}/{format}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": true,
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "format",
+                                "in": "path",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        ],
+                        "summary": "Get an item by ID",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));
+        var restApi = await this._sut.ParseAsync(steam);
+
+        Assert.NotNull(restApi);
+        Assert.NotNull(restApi.Operations);
+        Assert.NotEmpty(restApi.Operations);
+
+        var firstOperation = restApi.Operations[0];
+
+        Assert.NotNull(firstOperation);
+        Assert.Equal("Get an item by ID", firstOperation.Description);
+        Assert.Equal("/items/{itemId}/{format}", firstOperation.Path);
+
+        var parameters = firstOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(2, parameters.Count);
+
+        var pathParameter = parameters.Single(static p => "itemId".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(pathParameter);
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, pathParameter.Location);
+        Assert.Null(pathParameter.DefaultValue);
+        Assert.NotNull(pathParameter.Schema);
+        Assert.Equal("string", pathParameter.Schema.RootElement.GetProperty("type").GetString());
+
+        var formatParameter = parameters.Single(static p => "format".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(formatParameter);
+        Assert.True(formatParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, formatParameter.Location);
+        Assert.Null(formatParameter.DefaultValue);
+        Assert.NotNull(formatParameter.Schema);
+        Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task ItCanParsePathItemPathParametersAndOverridesAsync()
+    {//TODO update the document version when upgrading Microsoft.OpenAPI to v2
+        var document =
+        """
+        {
+            "openapi": "3.0.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0"
+            },
+            "paths": {
+                "/items/{itemId}/{format}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": true,
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "format",
+                                "in": "path",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "name": "itemId",
+                                "in": "path",
+                                "description": "item ID override",
+                                "required": true,
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        ],
+                        "summary": "Get an item by ID",
+                        "responses": {
+                            "200": {
+                                "description": "Successful response"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        await using var steam = new MemoryStream(Encoding.UTF8.GetBytes(document));
+        var restApi = await this._sut.ParseAsync(steam);
+
+        Assert.NotNull(restApi);
+        Assert.NotNull(restApi.Operations);
+        Assert.NotEmpty(restApi.Operations);
+
+        var firstOperation = restApi.Operations[0];
+
+        Assert.NotNull(firstOperation);
+        Assert.Equal("Get an item by ID", firstOperation.Description);
+        Assert.Equal("/items/{itemId}/{format}", firstOperation.Path);
+
+        var parameters = firstOperation.GetParameters();
+        Assert.NotNull(parameters);
+        Assert.Equal(2, parameters.Count);
+
+        var pathParameter = parameters.Single(static p => "itemId".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(pathParameter);
+        Assert.True(pathParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, pathParameter.Location);
+        Assert.Null(pathParameter.DefaultValue);
+        Assert.NotNull(pathParameter.Schema);
+        Assert.Equal("string", pathParameter.Schema.RootElement.GetProperty("type").GetString());
+        Assert.Equal("item ID override", pathParameter.Description);
+
+        var formatParameter = parameters.Single(static p => "format".Equals(p.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(formatParameter);
+        Assert.True(formatParameter.IsRequired);
+        Assert.Equal(RestApiParameterLocation.Path, formatParameter.Location);
+        Assert.Null(formatParameter.DefaultValue);
+        Assert.NotNull(formatParameter.Schema);
+        Assert.Equal("string", formatParameter.Schema.RootElement.GetProperty("type").GetString());
     }
 
     private static MemoryStream ModifyOpenApiDocument(Stream openApiDocument, Action<IDictionary<string, object>> transformer)


### PR DESCRIPTION
fixes #9962