### PR TITLE
Python: Fix pydantic alias issue

### DIFF
--- a/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
+++ b/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
@@ -21,4 +21,8 @@ class AzureCosmosDBSettings(KernelBaseSettings):
     env_prefix: ClassVar[str] = "COSMOSDB_"
 
     api: str | None = None
-    connection_string: SecretStr | None = None
+    connection_string: SecretStr | None = Field(None, alias="AZCOSMOS_CONNSTR")
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )

--- a/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
+++ b/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
@@ -21,4 +21,4 @@ class AzureCosmosDBSettings(KernelBaseSettings):
     env_prefix: ClassVar[str] = "COSMOSDB_"
 
     api: str | None = None
-    connection_string: SecretStr | None = Field(None, alias="AZCOSMOS_CONNSTR")
+    connection_string: SecretStr | None = None

--- a/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
+++ b/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar
 
-from pydantic import Field, SecretStr, ConfigDict
+from pydantic import ConfigDict, Field, SecretStr
 
 from semantic_kernel.kernel_pydantic import KernelBaseSettings
 from semantic_kernel.utils.experimental_decorator import experimental_class

--- a/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
+++ b/python/semantic_kernel/connectors/memory/azure_cosmosdb/azure_cosmosdb_settings.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar
 
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, ConfigDict
 
 from semantic_kernel.kernel_pydantic import KernelBaseSettings
 from semantic_kernel.utils.experimental_decorator import experimental_class


### PR DESCRIPTION
### Motivation and Context
fix #10026

### Description

This PR removes the alias as pydantic requires the usage of the alias when initializing the class not the original name which prevents this code from working.

```py
cosmosdb_settings = AzureCosmosDBSettings.create(
                env_file_path=env_file_path,
                connection_string=cosmos_connstr,
            )
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
