### PR TITLE
.Net: Add JsonNumberHandling Attribute to Execution Settings in Ollama, ONNX, and Other Connectors

### DIFF
--- a/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFacePromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.HuggingFace/HuggingFacePromptExecutionSettings.cs
@@ -10,6 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.HuggingFace;
 /// <summary>
 /// HuggingFace Execution Settings.
 /// </summary>
+[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
 public sealed class HuggingFacePromptExecutionSettings : PromptExecutionSettings
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Ollama/Settings/OllamaPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Settings/OllamaPromptExecutionSettings.cs
@@ -11,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Ollama;
 /// <summary>
 /// Ollama Prompt Execution Settings.
 /// </summary>
+[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
 public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIAudioToTextExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIAudioToTextExecutionSettings.cs
@@ -12,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 /// Execution settings for OpenAI audio-to-text request.
 /// </summary>
 [Experimental("SKEXP0010")]
+[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
 public sealed class OpenAIAudioToTextExecutionSettings : PromptExecutionSettings
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAITextToAudioExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAITextToAudioExecutionSettings.cs
@@ -12,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.OpenAI;
 /// Execution settings for OpenAI text-to-audio request.
 /// </summary>
 [Experimental("SKEXP0001")]
+[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
 public sealed class OpenAITextToAudioExecutionSettings : PromptExecutionSettings
 {
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

This PR addresses a deserialization issue in the `Ollama` and `ONNX` connectors where execution settings fail to handle non-string properties (e.g., "temperature") during JSON parsing.

### Description

**Impact:**
- Ensures compatibility with templates containing non-string numeric properties.
- Aligns behavior with `OpenAIPromptExecutionSettings`, which already includes the necessary attribute.

### Contribution Checklist

- [Y] The code builds clean without any errors or warnings
- [Y] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [Y] All unit tests pass, and I have added new tests where possible
- [Y] I didn't break anyone :smile:

- Fixes #9318 