### PR TITLE
use ubuntu 22 for link check

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # check out the latest version of the code
     steps:
       - uses: actions/checkout@v4

--- a/dotnet/src/Connectors/Connectors.Memory.Chroma/README.md
+++ b/dotnet/src/Connectors/Connectors.Memory.Chroma/README.md
@@ -1,6 +1,6 @@
 # Microsoft.SemanticKernel.Connectors.Chroma
 
-This assembly contains implementation of Semantic Kernel Memory Store using [Chroma](https://docs.trychroma.com/), open-source embedding database.
+This assembly contains implementation of Semantic Kernel Memory Store using [Chroma](https://www.trychroma.com/), open-source embedding database.
 
 **Note:** Chroma connector is verified using Chroma version **0.4.10**. Any higher versions may introduce incompatibility.
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Changed the runner image to explicitly 22.04 ubuntu because 24.04 doesn't work for link inspect.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
