### PR TITLE
Python: Improve azure assistant agent settings and retrieval operations.

### DIFF
--- a/python/.vscode/settings.json
+++ b/python/.vscode/settings.json
@@ -29,9 +29,4 @@
     "python.analysis.extraPaths": [
         "${workspaceFolder}/samples/learn_resources"
     ],
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
 }

--- a/python/.vscode/settings.json
+++ b/python/.vscode/settings.json
@@ -29,4 +29,9 @@
     "python.analysis.extraPaths": [
         "${workspaceFolder}/samples/learn_resources"
     ],
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
 }

--- a/python/DEV_SETUP.md
+++ b/python/DEV_SETUP.md
@@ -83,6 +83,18 @@ If prompted, install `ruff`. (It should have been installed as part of `uv sync 
 You also need to install the `ruff` extension in VSCode so that auto-formatting uses the `ruff` formatter on save.
 Read more about the extension [here](https://github.com/astral-sh/ruff-vscode).
 
+### Configuring Unit Testing in VSCode
+
+- We have removed the strict dependency on forcing `pytest` usage via the `.vscode/settings.json` file.
+- Developers are free to set up unit tests using their preferred framework, whether it is `pytest` or `unittest`.
+- If needed, adjust VSCode's local `settings.json` (accessed via the Command Palette: **Open User Settings (JSON)**) to configure the test framework. For example:
+  ```json
+  "pythonTestExplorer.testFramework": "pytest"
+  ```
+  Or, for `unittest`:
+  ```json
+  "pythonTestExplorer.testFramework": "unittest"
+
 ## LLM setup
 
 Make sure you have an

--- a/python/samples/concepts/agents/assistant_agent_retrieval.py
+++ b/python/samples/concepts/agents/assistant_agent_retrieval.py
@@ -1,84 +1,513 @@
 # Copyright (c) Microsoft. All rights reserved.
-import asyncio
 
-from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.file_reference_content import FileReferenceContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.kernel import Kernel
+import logging
+from collections.abc import AsyncIterable, Awaitable, Callable
+from copy import copy
+from typing import TYPE_CHECKING, Any
 
-#####################################################################
-# The following sample demonstrates how to create an OpenAI         #
-# assistant using either Azure OpenAI or OpenAI and retrieve the    #
-# assistant using the `retrieve` class method.                      #
-#####################################################################
+from openai import AsyncAzureOpenAI
+from pydantic import ValidationError
 
-AGENT_NAME = "JokeTeller"
-AGENT_INSTRUCTIONS = "You are a funny comedian who loves telling G-rated jokes."
+from semantic_kernel.agents.open_ai.open_ai_assistant_base import OpenAIAssistantBase
+from semantic_kernel.connectors.ai.open_ai.settings.azure_open_ai_settings import AzureOpenAISettings
+from semantic_kernel.const import DEFAULT_SERVICE_NAME
+from semantic_kernel.exceptions.agent_exceptions import AgentInitializationException
+from semantic_kernel.kernel_pydantic import HttpsUrl
+from semantic_kernel.utils.authentication.entra_id_authentication import get_entra_auth_token
+from semantic_kernel.utils.experimental_decorator import experimental_class
+from semantic_kernel.utils.telemetry.user_agent import APP_INFO, prepend_semantic_kernel_to_user_agent
 
-# Note: you may toggle this to switch between AzureOpenAI and OpenAI
-use_azure_openai = True
-
-
-# A helper method to invoke the agent with the user input
-async def invoke_agent(agent: OpenAIAssistantAgent, thread_id: str, input: str) -> None:
-    """Invoke the agent with the user input."""
-    await agent.add_chat_message(thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=input))
-
-    print(f"# {AuthorRole.USER}: '{input}'")
-
-    async for message in agent.invoke(thread_id=thread_id):
-        if message.content:
-            print(f"# {message.role}: {message.content}")
-
-        if len(message.items) > 0:
-            for item in message.items:
-                if isinstance(item, FileReferenceContent):
-                    print(f"\n`{message.role}` => {item.file_id}")
+if TYPE_CHECKING:
+    from semantic_kernel.kernel import Kernel
 
 
-async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
+logger: logging.Logger = logging.getLogger(__name__)
 
-    # Define a service_id for the sample
-    service_id = "agent"
 
-    # Create the agent configuration
-    if use_azure_openai:
-        agent = await AzureAssistantAgent.create(
+@experimental_class
+class AzureAssistantAgent(OpenAIAssistantBase):
+    """Azure OpenAI Assistant Agent class.
+
+    Provides the ability to interact with Azure OpenAI Assistants.
+    """
+
+    # region Agent Initialization
+
+    def __init__(
+        self,
+        kernel: "Kernel | None" = None,
+        service_id: str | None = None,
+        deployment_name: str | None = None,
+        api_key: str | None = None,
+        endpoint: HttpsUrl | None = None,
+        api_version: str | None = None,
+        ad_token: str | None = None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
+        client: AsyncAzureOpenAI | None = None,
+        default_headers: dict[str, str] | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+        description: str | None = None,
+        id: str | None = None,
+        instructions: str | None = None,
+        name: str | None = None,
+        enable_code_interpreter: bool | None = None,
+        enable_file_search: bool | None = None,
+        enable_json_response: bool | None = None,
+        file_ids: list[str] | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        vector_store_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        max_completion_tokens: int | None = None,
+        max_prompt_tokens: int | None = None,
+        parallel_tool_calls_enabled: bool | None = True,
+        truncation_message_count: int | None = None,
+        token_endpoint: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize an Azure OpenAI Assistant Agent.
+
+        Args:
+            kernel: The Kernel instance. (optional)
+            service_id: The service ID. (optional)
+            deployment_name: The deployment name. (optional)
+            api_key: The Azure OpenAI API key. (optional)
+            endpoint: The Azure OpenAI endpoint. (optional)
+            api_version: The Azure OpenAI API version. (optional)
+            ad_token: The Azure AD token. (optional)
+            ad_token_provider: The Azure AD token provider. (optional)
+            client: The Azure OpenAI client. (optional)
+            default_headers: The default headers. (optional)
+            env_file_path: The environment file path. (optional)
+            env_file_encoding: The environment file encoding. (optional)
+            description: The description. (optional)
+            id: The Agent ID. (optional)
+            instructions: The Agent instructions. (optional)
+            name: The Agent name. (optional)
+            enable_code_interpreter: Enable the code interpreter. (optional)
+            enable_file_search: Enable the file search. (optional)
+            enable_json_response: Enable the JSON response. (optional)
+            file_ids: The file IDs. (optional)
+            temperature: The temperature. (optional)
+            top_p: The top p. (optional)
+            vector_store_id: The vector store ID. (optional)
+            metadata: The metadata. (optional)
+            max_completion_tokens: The maximum completion tokens. (optional)
+            max_prompt_tokens: The maximum prompt tokens. (optional)
+            parallel_tool_calls_enabled: Enable parallel tool calls. (optional)
+            truncation_message_count: The truncation message count. (optional)
+            token_endpoint: The Azure AD token endpoint. (optional)
+            **kwargs: Additional keyword arguments.
+
+        Raises:
+            AgentInitializationError: If the api_key is not provided in the configuration.
+        """
+        azure_openai_settings = self._create_azure_openai_settings(
+            api_key=api_key,
+            endpoint=endpoint,
+            deployment_name=deployment_name,
+            api_version=api_version,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+            token_endpoint=token_endpoint,
+        )
+
+        # We centralize the client/ad_token setup
+        client, ad_token = self._setup_client_and_token(
+            azure_openai_settings=azure_openai_settings,
+            ad_token=ad_token,
+            ad_token_provider=ad_token_provider,
+            client=client,
+            default_headers=default_headers,
+        )
+
+        # Once the client is configured, we proceed
+        service_id = service_id if service_id else DEFAULT_SERVICE_NAME
+
+        args: dict[str, Any] = {
+            "kernel": kernel,
+            "ai_model_id": azure_openai_settings.chat_deployment_name,
+            "service_id": service_id,
+            "client": client,
+            "name": name,
+            "description": description,
+            "instructions": instructions,
+            "enable_code_interpreter": enable_code_interpreter,
+            "enable_file_search": enable_file_search,
+            "enable_json_response": enable_json_response,
+            "file_ids": file_ids or [],
+            "temperature": temperature,
+            "top_p": top_p,
+            "vector_store_id": vector_store_id,
+            "metadata": metadata or {},
+            "max_completion_tokens": max_completion_tokens,
+            "max_prompt_tokens": max_prompt_tokens,
+            "parallel_tool_calls_enabled": parallel_tool_calls_enabled,
+            "truncation_message_count": truncation_message_count,
+        }
+
+        if id is not None:
+            args["id"] = id
+        if kernel is not None:
+            args["kernel"] = kernel
+        if kwargs:
+            args.update(kwargs)
+
+        super().__init__(**args)
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        kernel: "Kernel | None" = None,
+        service_id: str | None = None,
+        deployment_name: str | None = None,
+        api_key: str | None = None,
+        endpoint: HttpsUrl | None = None,
+        api_version: str | None = None,
+        ad_token: str | None = None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
+        client: AsyncAzureOpenAI | None = None,
+        default_headers: dict[str, str] | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+        description: str | None = None,
+        id: str | None = None,
+        instructions: str | None = None,
+        name: str | None = None,
+        enable_code_interpreter: bool | None = None,
+        code_interpreter_filenames: list[str] | None = None,
+        code_interpreter_file_ids: list[str] | None = None,
+        enable_file_search: bool | None = None,
+        vector_store_filenames: list[str] | None = None,
+        vector_store_file_ids: list[str] | None = None,
+        enable_json_response: bool | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        vector_store_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        max_completion_tokens: int | None = None,
+        max_prompt_tokens: int | None = None,
+        parallel_tool_calls_enabled: bool | None = True,
+        truncation_message_count: int | None = None,
+        token_endpoint: str | None = None,
+        **kwargs: Any,
+    ) -> "AzureAssistantAgent":
+        """Asynchronous class method used to create the OpenAI Assistant Agent.
+
+        Args:
+            kernel: The Kernel instance. (optional)
+            service_id: The service ID. (optional)
+            deployment_name: The deployment name. (optional)
+            api_key: The Azure OpenAI API key. (optional)
+            endpoint: The Azure OpenAI endpoint. (optional)
+            api_version: The Azure OpenAI API version. (optional)
+            ad_token: The Azure AD token. (optional)
+            ad_token_provider: The Azure AD token provider. (optional)
+            client: The Azure OpenAI client. (optional)
+            default_headers: The default headers. (optional)
+            env_file_path: The environment file path. (optional)
+            env_file_encoding: The environment file encoding. (optional)
+            description: The description. (optional)
+            id: The Agent ID. (optional)
+            instructions: The Agent instructions. (optional)
+            name: The Agent name. (optional)
+            enable_code_interpreter: Enable the code interpreter. (optional)
+            code_interpreter_filenames: The filenames/paths to use with the code interpreter. (optional)
+            code_interpreter_file_ids: The existing file IDs to use with the code interpreter. (optional)
+            enable_file_search: Enable the file search. (optional)
+            vector_store_filenames: The filenames/paths for files to use with file search. (optional)
+            vector_store_file_ids: The existing file IDs to use with file search. (optional)
+            enable_json_response: Enable the JSON response. (optional)
+            temperature: The temperature. (optional)
+            top_p: The top p. (optional)
+            vector_store_id: The vector store ID. (optional)
+            metadata: The metadata. (optional)
+            max_completion_tokens: The maximum completion tokens. (optional)
+            max_prompt_tokens: The maximum prompt tokens. (optional)
+            parallel_tool_calls_enabled: Enable parallel tool calls. (optional)
+            truncation_message_count: The truncation message count. (optional)
+            token_endpoint: The Azure AD token endpoint. (optional)
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            An instance of the AzureAssistantAgent
+        """
+        # Create the agent
+        agent = cls(
             kernel=kernel,
             service_id=service_id,
-            name=AGENT_NAME,
-            instructions=AGENT_INSTRUCTIONS,
-            enable_code_interpreter=True,
+            deployment_name=deployment_name,
+            api_key=api_key,
+            endpoint=endpoint,
+            api_version=api_version,
+            ad_token=ad_token,
+            ad_token_provider=ad_token_provider,
+            client=client,
+            default_headers=default_headers,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+            description=description,
+            id=id,
+            instructions=instructions,
+            name=name,
+            enable_code_interpreter=enable_code_interpreter,
+            enable_file_search=enable_file_search,
+            enable_json_response=enable_json_response,
+            temperature=temperature,
+            top_p=top_p,
+            vector_store_id=vector_store_id,
+            metadata=metadata or {},
+            max_completion_tokens=max_completion_tokens,
+            max_prompt_tokens=max_prompt_tokens,
+            parallel_tool_calls_enabled=parallel_tool_calls_enabled,
+            truncation_message_count=truncation_message_count,
+            token_endpoint=token_endpoint,
+            **kwargs,
         )
-    else:
-        agent = await OpenAIAssistantAgent.create(
-            kernel=kernel,
-            service_id=service_id,
-            name=AGENT_NAME,
-            instructions=AGENT_INSTRUCTIONS,
-            enable_code_interpreter=True,
+
+        # Additional logic for uploading code/vector store files, etc.
+        assistant_create_kwargs: dict[str, Any] = {}
+
+        # Code interpreter files
+        code_interpreter_file_ids_combined: list[str] = []
+        if code_interpreter_file_ids is not None:
+            code_interpreter_file_ids_combined.extend(code_interpreter_file_ids)
+        if code_interpreter_filenames is not None:
+            for file_path in code_interpreter_filenames:
+                try:
+                    file_id = await agent.add_file(file_path=file_path, purpose="assistants")
+                    code_interpreter_file_ids_combined.append(file_id)
+                except FileNotFoundError as ex:
+                    logger.error(
+                        f"Failed to upload code interpreter file with path: `{file_path}` with exception: {ex}"
+                    )
+                    raise AgentInitializationException("Failed to upload code interpreter files.", ex) from ex
+        if code_interpreter_file_ids_combined:
+            agent.code_interpreter_file_ids = code_interpreter_file_ids_combined
+            assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids_combined
+
+        # Vector store files
+        vector_store_file_ids_combined: list[str] = []
+        if vector_store_file_ids is not None:
+            vector_store_file_ids_combined.extend(vector_store_file_ids)
+        if vector_store_filenames is not None:
+            for file_path in vector_store_filenames:
+                try:
+                    file_id = await agent.add_file(file_path=file_path, purpose="assistants")
+                    vector_store_file_ids_combined.append(file_id)
+                except FileNotFoundError as ex:
+                    logger.error(f"Failed to upload vector store file with path: `{file_path}` with exception: {ex}")
+                    raise AgentInitializationException("Failed to upload vector store files.", ex) from ex
+        if vector_store_file_ids_combined:
+            agent.file_search_file_ids = vector_store_file_ids_combined
+            if enable_file_search or agent.enable_file_search:
+                vector_store_id = await agent.create_vector_store(file_ids=vector_store_file_ids_combined)
+                agent.vector_store_id = vector_store_id
+                assistant_create_kwargs["vector_store_id"] = vector_store_id
+
+        # Create assistant internally
+        agent.assistant = await agent.create_assistant(**assistant_create_kwargs)
+        return agent
+
+    @classmethod
+    async def retrieve(
+        cls,
+        *,
+        id: str,
+        api_key: str | None = None,
+        endpoint: HttpsUrl | None = None,
+        api_version: str | None = None,
+        ad_token: str | None = None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
+        client: AsyncAzureOpenAI | None = None,
+        kernel: "Kernel | None" = None,
+        default_headers: dict[str, str] | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+        token_endpoint: str | None = None,
+    ) -> "AzureAssistantAgent":
+        """Retrieve an assistant by ID.
+
+        Args:
+            id: The assistant ID.
+            api_key: The Azure OpenAI API key. (optional)
+            endpoint: The Azure OpenAI endpoint. (optional)
+            api_version: The Azure OpenAI API version. (optional)
+            ad_token: The Azure AD token. (optional)
+            ad_token_provider: The Azure AD token provider. (optional)
+            client: The Azure OpenAI client. (optional)
+            kernel: The Kernel instance. (optional)
+            default_headers: The default headers. (optional)
+            env_file_path: The environment file path. (optional)
+            env_file_encoding: The environment file encoding. (optional)
+            token_endpoint: The Azure AD token endpoint. (optional)
+
+        Returns:
+            An AzureAssistantAgent instance.
+        """
+        # Create minimal settings for the retrieve flow. (Deployment not needed for retrieve)
+        azure_openai_settings = cls._create_azure_openai_settings(
+            api_key=api_key,
+            endpoint=endpoint,
+            deployment_name=None,  # Not required for retrieving an existing assistant
+            api_version=api_version,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+            token_endpoint=token_endpoint,
         )
 
-    assistant_id = agent.assistant.id
+        # Centralize client/ad_token setup
+        client, ad_token = cls._setup_client_and_token(
+            azure_openai_settings=azure_openai_settings,
+            ad_token=ad_token,
+            ad_token_provider=ad_token_provider,
+            client=client,
+            default_headers=default_headers,
+        )
 
-    # Retrieve the agent using the assistant_id
-    retrieved_agent: OpenAIAssistantAgent = await OpenAIAssistantAgent.retrieve(
-        id=assistant_id,
-        kernel=kernel,
-    )
+        # Get the assistant from the Beta endpoint
+        assistant = await client.beta.assistants.retrieve(id)
+        assistant_definition = OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
 
-    # Define a thread and invoke the agent with the user input
-    thread_id = await retrieved_agent.create_thread()
+        return AzureAssistantAgent(kernel=kernel, assistant=assistant, **assistant_definition)
 
-    try:
-        await invoke_agent(retrieved_agent, thread_id, "Tell me a joke about bears.")
-    finally:
-        await agent.delete()
-        await retrieved_agent.delete_thread(thread_id)
+    @staticmethod
+    def _setup_client_and_token(
+        azure_openai_settings: AzureOpenAISettings,
+        ad_token: str | None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None,
+        client: AsyncAzureOpenAI | None,
+        default_headers: dict[str, str] | None,
+    ) -> tuple[AsyncAzureOpenAI, str | None]:
+        """
+        Helper method that ensures either an AD token or an API key is present,
+        retrieves a new AD token if needed, and configures the AsyncAzureOpenAI client.
 
+        Returns:
+            A tuple of (client, ad_token), where client is guaranteed not to be None.
+        """
+        if not azure_openai_settings.chat_deployment_name:
+            raise AgentInitializationException("The Azure OpenAI chat_deployment_name is required.")
 
-if __name__ == "__main__":
-    asyncio.run(main())
+        # If everything is missing, but there is a token_endpoint, try to get the token.
+        if (
+            client is None
+            and azure_openai_settings.api_key is None
+            and ad_token_provider is None
+            and ad_token is None
+            and azure_openai_settings.token_endpoint
+        ):
+            ad_token = get_entra_auth_token(azure_openai_settings.token_endpoint)
+
+        # If we still have no credentials, we can't proceed
+        if not client and not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
+            raise AgentInitializationException("Please provide either api_key, ad_token or ad_token_provider.")
+
+        # Build the client if it's not supplied
+        if not client:
+            client = AzureAssistantAgent._create_client(
+                api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
+                endpoint=azure_openai_settings.endpoint,
+                api_version=azure_openai_settings.api_version,
+                ad_token=ad_token,
+                ad_token_provider=ad_token_provider,
+                default_headers=default_headers,
+            )
+
+        return client, ad_token
+
+    @staticmethod
+    def _create_client(
+        api_key: str | None = None,
+        endpoint: HttpsUrl | None = None,
+        api_version: str | None = None,
+        ad_token: str | None = None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
+        default_headers: dict[str, str] | None = None,
+    ) -> AsyncAzureOpenAI:
+        """Create the OpenAI client from configuration.
+
+        Args:
+            api_key: The OpenAI API key.
+            endpoint: The OpenAI endpoint.
+            api_version: The OpenAI API version.
+            ad_token: The Azure AD token.
+            ad_token_provider: The Azure AD token provider.
+            default_headers: The default headers.
+
+        Returns:
+            An AsyncAzureOpenAI client instance.
+        """
+        merged_headers = dict(copy(default_headers)) if default_headers else {}
+        if APP_INFO:
+            merged_headers.update(APP_INFO)
+            merged_headers = prepend_semantic_kernel_to_user_agent(merged_headers)
+
+        if not api_key and not ad_token and not ad_token_provider:
+            raise AgentInitializationException(
+                "Please provide either AzureOpenAI api_key, an ad_token, ad_token_provider, or a client."
+            )
+        if not endpoint:
+            raise AgentInitializationException("Please provide an AzureOpenAI endpoint.")
+
+        return AsyncAzureOpenAI(
+            azure_endpoint=str(endpoint),
+            api_version=api_version,
+            api_key=api_key,
+            azure_ad_token=ad_token,
+            azure_ad_token_provider=ad_token_provider,
+            default_headers=merged_headers,
+        )
+
+    @staticmethod
+    def _create_azure_openai_settings(
+        api_key: str | None = None,
+        endpoint: HttpsUrl | None = None,
+        deployment_name: str | None = None,
+        api_version: str | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+        token_endpoint: str | None = None,
+    ) -> AzureOpenAISettings:
+        """Create the Azure OpenAI settings.
+
+        Args:
+            api_key: The Azure OpenAI API key.
+            endpoint: The Azure OpenAI endpoint.
+            deployment_name: The Azure OpenAI chat deployment name.
+            api_version: The Azure OpenAI API version.
+            env_file_path: The environment file path.
+            env_file_encoding: The environment file encoding.
+            token_endpoint: The Azure AD token endpoint.
+
+        Returns:
+            An instance of the AzureOpenAISettings.
+        """
+        try:
+            azure_openai_settings = AzureOpenAISettings.create(
+                api_key=api_key,
+                endpoint=endpoint,
+                chat_deployment_name=deployment_name,
+                api_version=api_version,
+                env_file_path=env_file_path,
+                env_file_encoding=env_file_encoding,
+                token_endpoint=token_endpoint,
+            )
+        except ValidationError as ex:
+            raise AgentInitializationException("Failed to create Azure OpenAI settings.", ex) from ex
+
+        return azure_openai_settings
+
+    async def list_definitions(self) -> AsyncIterable[dict[str, Any]]:
+        """List the assistant definitions.
+
+        Yields:
+            An AsyncIterable of dictionaries representing the OpenAIAssistantDefinition.
+        """
+        assistants = await self.client.beta.assistants.list(order="desc")
+        for assistant in assistants.data:
+            yield OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
+
+    # endregion

--- a/python/samples/concepts/agents/assistant_agent_retrieval.py
+++ b/python/samples/concepts/agents/assistant_agent_retrieval.py
@@ -1,513 +1,91 @@
 # Copyright (c) Microsoft. All rights reserved.
+import asyncio
 
-import logging
-from collections.abc import AsyncIterable, Awaitable, Callable
-from copy import copy
-from typing import TYPE_CHECKING, Any
+from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.file_reference_content import FileReferenceContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.kernel import Kernel
 
-from openai import AsyncAzureOpenAI
-from pydantic import ValidationError
+#####################################################################
+# The following sample demonstrates how to create an OpenAI         #
+# assistant using either Azure OpenAI or OpenAI and retrieve the    #
+# assistant using the `retrieve` class method.                      #
+#####################################################################
 
-from semantic_kernel.agents.open_ai.open_ai_assistant_base import OpenAIAssistantBase
-from semantic_kernel.connectors.ai.open_ai.settings.azure_open_ai_settings import AzureOpenAISettings
-from semantic_kernel.const import DEFAULT_SERVICE_NAME
-from semantic_kernel.exceptions.agent_exceptions import AgentInitializationException
-from semantic_kernel.kernel_pydantic import HttpsUrl
-from semantic_kernel.utils.authentication.entra_id_authentication import get_entra_auth_token
-from semantic_kernel.utils.experimental_decorator import experimental_class
-from semantic_kernel.utils.telemetry.user_agent import APP_INFO, prepend_semantic_kernel_to_user_agent
+AGENT_NAME = "JokeTeller"
+AGENT_INSTRUCTIONS = "You are a funny comedian who loves telling G-rated jokes."
 
-if TYPE_CHECKING:
-    from semantic_kernel.kernel import Kernel
-
-
-logger: logging.Logger = logging.getLogger(__name__)
+# Note: you may toggle this to switch between AzureOpenAI and OpenAI
+use_azure_openai = True
 
 
-@experimental_class
-class AzureAssistantAgent(OpenAIAssistantBase):
-    """Azure OpenAI Assistant Agent class.
+# A helper method to invoke the agent with the user input
+async def invoke_agent(agent: OpenAIAssistantAgent, thread_id: str, input: str) -> None:
+    """Invoke the agent with the user input."""
+    await agent.add_chat_message(thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=input))
 
-    Provides the ability to interact with Azure OpenAI Assistants.
-    """
+    print(f"# {AuthorRole.USER}: '{input}'")
 
-    # region Agent Initialization
+    async for message in agent.invoke(thread_id=thread_id):
+        if message.content:
+            print(f"# {message.role}: {message.content}")
 
-    def __init__(
-        self,
-        kernel: "Kernel | None" = None,
-        service_id: str | None = None,
-        deployment_name: str | None = None,
-        api_key: str | None = None,
-        endpoint: HttpsUrl | None = None,
-        api_version: str | None = None,
-        ad_token: str | None = None,
-        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
-        client: AsyncAzureOpenAI | None = None,
-        default_headers: dict[str, str] | None = None,
-        env_file_path: str | None = None,
-        env_file_encoding: str | None = None,
-        description: str | None = None,
-        id: str | None = None,
-        instructions: str | None = None,
-        name: str | None = None,
-        enable_code_interpreter: bool | None = None,
-        enable_file_search: bool | None = None,
-        enable_json_response: bool | None = None,
-        file_ids: list[str] | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        vector_store_id: str | None = None,
-        metadata: dict[str, Any] | None = None,
-        max_completion_tokens: int | None = None,
-        max_prompt_tokens: int | None = None,
-        parallel_tool_calls_enabled: bool | None = True,
-        truncation_message_count: int | None = None,
-        token_endpoint: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        """Initialize an Azure OpenAI Assistant Agent.
+        if len(message.items) > 0:
+            for item in message.items:
+                if isinstance(item, FileReferenceContent):
+                    print(f"\n`{message.role}` => {item.file_id}")
 
-        Args:
-            kernel: The Kernel instance. (optional)
-            service_id: The service ID. (optional)
-            deployment_name: The deployment name. (optional)
-            api_key: The Azure OpenAI API key. (optional)
-            endpoint: The Azure OpenAI endpoint. (optional)
-            api_version: The Azure OpenAI API version. (optional)
-            ad_token: The Azure AD token. (optional)
-            ad_token_provider: The Azure AD token provider. (optional)
-            client: The Azure OpenAI client. (optional)
-            default_headers: The default headers. (optional)
-            env_file_path: The environment file path. (optional)
-            env_file_encoding: The environment file encoding. (optional)
-            description: The description. (optional)
-            id: The Agent ID. (optional)
-            instructions: The Agent instructions. (optional)
-            name: The Agent name. (optional)
-            enable_code_interpreter: Enable the code interpreter. (optional)
-            enable_file_search: Enable the file search. (optional)
-            enable_json_response: Enable the JSON response. (optional)
-            file_ids: The file IDs. (optional)
-            temperature: The temperature. (optional)
-            top_p: The top p. (optional)
-            vector_store_id: The vector store ID. (optional)
-            metadata: The metadata. (optional)
-            max_completion_tokens: The maximum completion tokens. (optional)
-            max_prompt_tokens: The maximum prompt tokens. (optional)
-            parallel_tool_calls_enabled: Enable parallel tool calls. (optional)
-            truncation_message_count: The truncation message count. (optional)
-            token_endpoint: The Azure AD token endpoint. (optional)
-            **kwargs: Additional keyword arguments.
 
-        Raises:
-            AgentInitializationError: If the api_key is not provided in the configuration.
-        """
-        azure_openai_settings = self._create_azure_openai_settings(
-            api_key=api_key,
-            endpoint=endpoint,
-            deployment_name=deployment_name,
-            api_version=api_version,
-            env_file_path=env_file_path,
-            env_file_encoding=env_file_encoding,
-            token_endpoint=token_endpoint,
-        )
+async def main():
+    # Create the instance of the Kernel
+    kernel = Kernel()
 
-        # We centralize the client/ad_token setup
-        client, ad_token = self._setup_client_and_token(
-            azure_openai_settings=azure_openai_settings,
-            ad_token=ad_token,
-            ad_token_provider=ad_token_provider,
-            client=client,
-            default_headers=default_headers,
-        )
+    # Define a service_id for the sample
+    service_id = "agent"
 
-        # Once the client is configured, we proceed
-        service_id = service_id if service_id else DEFAULT_SERVICE_NAME
+    # Specify an assistant ID which is used
+    # to retrieve the agent
+    assistant_id: str = None
 
-        args: dict[str, Any] = {
-            "kernel": kernel,
-            "ai_model_id": azure_openai_settings.chat_deployment_name,
-            "service_id": service_id,
-            "client": client,
-            "name": name,
-            "description": description,
-            "instructions": instructions,
-            "enable_code_interpreter": enable_code_interpreter,
-            "enable_file_search": enable_file_search,
-            "enable_json_response": enable_json_response,
-            "file_ids": file_ids or [],
-            "temperature": temperature,
-            "top_p": top_p,
-            "vector_store_id": vector_store_id,
-            "metadata": metadata or {},
-            "max_completion_tokens": max_completion_tokens,
-            "max_prompt_tokens": max_prompt_tokens,
-            "parallel_tool_calls_enabled": parallel_tool_calls_enabled,
-            "truncation_message_count": truncation_message_count,
-        }
-
-        if id is not None:
-            args["id"] = id
-        if kernel is not None:
-            args["kernel"] = kernel
-        if kwargs:
-            args.update(kwargs)
-
-        super().__init__(**args)
-
-    @classmethod
-    async def create(
-        cls,
-        *,
-        kernel: "Kernel | None" = None,
-        service_id: str | None = None,
-        deployment_name: str | None = None,
-        api_key: str | None = None,
-        endpoint: HttpsUrl | None = None,
-        api_version: str | None = None,
-        ad_token: str | None = None,
-        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
-        client: AsyncAzureOpenAI | None = None,
-        default_headers: dict[str, str] | None = None,
-        env_file_path: str | None = None,
-        env_file_encoding: str | None = None,
-        description: str | None = None,
-        id: str | None = None,
-        instructions: str | None = None,
-        name: str | None = None,
-        enable_code_interpreter: bool | None = None,
-        code_interpreter_filenames: list[str] | None = None,
-        code_interpreter_file_ids: list[str] | None = None,
-        enable_file_search: bool | None = None,
-        vector_store_filenames: list[str] | None = None,
-        vector_store_file_ids: list[str] | None = None,
-        enable_json_response: bool | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        vector_store_id: str | None = None,
-        metadata: dict[str, Any] | None = None,
-        max_completion_tokens: int | None = None,
-        max_prompt_tokens: int | None = None,
-        parallel_tool_calls_enabled: bool | None = True,
-        truncation_message_count: int | None = None,
-        token_endpoint: str | None = None,
-        **kwargs: Any,
-    ) -> "AzureAssistantAgent":
-        """Asynchronous class method used to create the OpenAI Assistant Agent.
-
-        Args:
-            kernel: The Kernel instance. (optional)
-            service_id: The service ID. (optional)
-            deployment_name: The deployment name. (optional)
-            api_key: The Azure OpenAI API key. (optional)
-            endpoint: The Azure OpenAI endpoint. (optional)
-            api_version: The Azure OpenAI API version. (optional)
-            ad_token: The Azure AD token. (optional)
-            ad_token_provider: The Azure AD token provider. (optional)
-            client: The Azure OpenAI client. (optional)
-            default_headers: The default headers. (optional)
-            env_file_path: The environment file path. (optional)
-            env_file_encoding: The environment file encoding. (optional)
-            description: The description. (optional)
-            id: The Agent ID. (optional)
-            instructions: The Agent instructions. (optional)
-            name: The Agent name. (optional)
-            enable_code_interpreter: Enable the code interpreter. (optional)
-            code_interpreter_filenames: The filenames/paths to use with the code interpreter. (optional)
-            code_interpreter_file_ids: The existing file IDs to use with the code interpreter. (optional)
-            enable_file_search: Enable the file search. (optional)
-            vector_store_filenames: The filenames/paths for files to use with file search. (optional)
-            vector_store_file_ids: The existing file IDs to use with file search. (optional)
-            enable_json_response: Enable the JSON response. (optional)
-            temperature: The temperature. (optional)
-            top_p: The top p. (optional)
-            vector_store_id: The vector store ID. (optional)
-            metadata: The metadata. (optional)
-            max_completion_tokens: The maximum completion tokens. (optional)
-            max_prompt_tokens: The maximum prompt tokens. (optional)
-            parallel_tool_calls_enabled: Enable parallel tool calls. (optional)
-            truncation_message_count: The truncation message count. (optional)
-            token_endpoint: The Azure AD token endpoint. (optional)
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            An instance of the AzureAssistantAgent
-        """
-        # Create the agent
-        agent = cls(
+    # Create the agent configuration
+    if use_azure_openai:
+        agent = await AzureAssistantAgent.create(
             kernel=kernel,
             service_id=service_id,
-            deployment_name=deployment_name,
-            api_key=api_key,
-            endpoint=endpoint,
-            api_version=api_version,
-            ad_token=ad_token,
-            ad_token_provider=ad_token_provider,
-            client=client,
-            default_headers=default_headers,
-            env_file_path=env_file_path,
-            env_file_encoding=env_file_encoding,
-            description=description,
-            id=id,
-            instructions=instructions,
-            name=name,
-            enable_code_interpreter=enable_code_interpreter,
-            enable_file_search=enable_file_search,
-            enable_json_response=enable_json_response,
-            temperature=temperature,
-            top_p=top_p,
-            vector_store_id=vector_store_id,
-            metadata=metadata or {},
-            max_completion_tokens=max_completion_tokens,
-            max_prompt_tokens=max_prompt_tokens,
-            parallel_tool_calls_enabled=parallel_tool_calls_enabled,
-            truncation_message_count=truncation_message_count,
-            token_endpoint=token_endpoint,
-            **kwargs,
+            name=AGENT_NAME,
+            instructions=AGENT_INSTRUCTIONS,
+            enable_code_interpreter=True,
         )
 
-        # Additional logic for uploading code/vector store files, etc.
-        assistant_create_kwargs: dict[str, Any] = {}
-
-        # Code interpreter files
-        code_interpreter_file_ids_combined: list[str] = []
-        if code_interpreter_file_ids is not None:
-            code_interpreter_file_ids_combined.extend(code_interpreter_file_ids)
-        if code_interpreter_filenames is not None:
-            for file_path in code_interpreter_filenames:
-                try:
-                    file_id = await agent.add_file(file_path=file_path, purpose="assistants")
-                    code_interpreter_file_ids_combined.append(file_id)
-                except FileNotFoundError as ex:
-                    logger.error(
-                        f"Failed to upload code interpreter file with path: `{file_path}` with exception: {ex}"
-                    )
-                    raise AgentInitializationException("Failed to upload code interpreter files.", ex) from ex
-        if code_interpreter_file_ids_combined:
-            agent.code_interpreter_file_ids = code_interpreter_file_ids_combined
-            assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids_combined
-
-        # Vector store files
-        vector_store_file_ids_combined: list[str] = []
-        if vector_store_file_ids is not None:
-            vector_store_file_ids_combined.extend(vector_store_file_ids)
-        if vector_store_filenames is not None:
-            for file_path in vector_store_filenames:
-                try:
-                    file_id = await agent.add_file(file_path=file_path, purpose="assistants")
-                    vector_store_file_ids_combined.append(file_id)
-                except FileNotFoundError as ex:
-                    logger.error(f"Failed to upload vector store file with path: `{file_path}` with exception: {ex}")
-                    raise AgentInitializationException("Failed to upload vector store files.", ex) from ex
-        if vector_store_file_ids_combined:
-            agent.file_search_file_ids = vector_store_file_ids_combined
-            if enable_file_search or agent.enable_file_search:
-                vector_store_id = await agent.create_vector_store(file_ids=vector_store_file_ids_combined)
-                agent.vector_store_id = vector_store_id
-                assistant_create_kwargs["vector_store_id"] = vector_store_id
-
-        # Create assistant internally
-        agent.assistant = await agent.create_assistant(**assistant_create_kwargs)
-        return agent
-
-    @classmethod
-    async def retrieve(
-        cls,
-        *,
-        id: str,
-        api_key: str | None = None,
-        endpoint: HttpsUrl | None = None,
-        api_version: str | None = None,
-        ad_token: str | None = None,
-        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
-        client: AsyncAzureOpenAI | None = None,
-        kernel: "Kernel | None" = None,
-        default_headers: dict[str, str] | None = None,
-        env_file_path: str | None = None,
-        env_file_encoding: str | None = None,
-        token_endpoint: str | None = None,
-    ) -> "AzureAssistantAgent":
-        """Retrieve an assistant by ID.
-
-        Args:
-            id: The assistant ID.
-            api_key: The Azure OpenAI API key. (optional)
-            endpoint: The Azure OpenAI endpoint. (optional)
-            api_version: The Azure OpenAI API version. (optional)
-            ad_token: The Azure AD token. (optional)
-            ad_token_provider: The Azure AD token provider. (optional)
-            client: The Azure OpenAI client. (optional)
-            kernel: The Kernel instance. (optional)
-            default_headers: The default headers. (optional)
-            env_file_path: The environment file path. (optional)
-            env_file_encoding: The environment file encoding. (optional)
-            token_endpoint: The Azure AD token endpoint. (optional)
-
-        Returns:
-            An AzureAssistantAgent instance.
-        """
-        # Create minimal settings for the retrieve flow. (Deployment not needed for retrieve)
-        azure_openai_settings = cls._create_azure_openai_settings(
-            api_key=api_key,
-            endpoint=endpoint,
-            deployment_name=None,  # Not required for retrieving an existing assistant
-            api_version=api_version,
-            env_file_path=env_file_path,
-            env_file_encoding=env_file_encoding,
-            token_endpoint=token_endpoint,
+        retrieved_agent: AzureAssistantAgent = await AzureAssistantAgent.retrieve(
+            id=assistant_id,
+            kernel=kernel,
+        )
+    else:
+        agent = await OpenAIAssistantAgent.create(
+            kernel=kernel,
+            service_id=service_id,
+            name=AGENT_NAME,
+            instructions=AGENT_INSTRUCTIONS,
+            enable_code_interpreter=True,
         )
 
-        # Centralize client/ad_token setup
-        client, ad_token = cls._setup_client_and_token(
-            azure_openai_settings=azure_openai_settings,
-            ad_token=ad_token,
-            ad_token_provider=ad_token_provider,
-            client=client,
-            default_headers=default_headers,
+        # Retrieve the agent using the assistant_id
+        retrieved_agent: OpenAIAssistantAgent = await OpenAIAssistantAgent.retrieve(
+            id=assistant_id,
+            kernel=kernel,
         )
 
-        # Get the assistant from the Beta endpoint
-        assistant = await client.beta.assistants.retrieve(id)
-        assistant_definition = OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
+    # Define a thread and invoke the agent with the user input
+    thread_id = await retrieved_agent.create_thread()
 
-        return AzureAssistantAgent(kernel=kernel, assistant=assistant, **assistant_definition)
+    try:
+        await invoke_agent(retrieved_agent, thread_id, "Tell me a joke about bears.")
+    finally:
+        await agent.delete()
+        await retrieved_agent.delete_thread(thread_id)
 
-    @staticmethod
-    def _setup_client_and_token(
-        azure_openai_settings: AzureOpenAISettings,
-        ad_token: str | None,
-        ad_token_provider: Callable[[], str | Awaitable[str]] | None,
-        client: AsyncAzureOpenAI | None,
-        default_headers: dict[str, str] | None,
-    ) -> tuple[AsyncAzureOpenAI, str | None]:
-        """
-        Helper method that ensures either an AD token or an API key is present,
-        retrieves a new AD token if needed, and configures the AsyncAzureOpenAI client.
 
-        Returns:
-            A tuple of (client, ad_token), where client is guaranteed not to be None.
-        """
-        if not azure_openai_settings.chat_deployment_name:
-            raise AgentInitializationException("The Azure OpenAI chat_deployment_name is required.")
-
-        # If everything is missing, but there is a token_endpoint, try to get the token.
-        if (
-            client is None
-            and azure_openai_settings.api_key is None
-            and ad_token_provider is None
-            and ad_token is None
-            and azure_openai_settings.token_endpoint
-        ):
-            ad_token = get_entra_auth_token(azure_openai_settings.token_endpoint)
-
-        # If we still have no credentials, we can't proceed
-        if not client and not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
-            raise AgentInitializationException("Please provide either api_key, ad_token or ad_token_provider.")
-
-        # Build the client if it's not supplied
-        if not client:
-            client = AzureAssistantAgent._create_client(
-                api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
-                endpoint=azure_openai_settings.endpoint,
-                api_version=azure_openai_settings.api_version,
-                ad_token=ad_token,
-                ad_token_provider=ad_token_provider,
-                default_headers=default_headers,
-            )
-
-        return client, ad_token
-
-    @staticmethod
-    def _create_client(
-        api_key: str | None = None,
-        endpoint: HttpsUrl | None = None,
-        api_version: str | None = None,
-        ad_token: str | None = None,
-        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
-        default_headers: dict[str, str] | None = None,
-    ) -> AsyncAzureOpenAI:
-        """Create the OpenAI client from configuration.
-
-        Args:
-            api_key: The OpenAI API key.
-            endpoint: The OpenAI endpoint.
-            api_version: The OpenAI API version.
-            ad_token: The Azure AD token.
-            ad_token_provider: The Azure AD token provider.
-            default_headers: The default headers.
-
-        Returns:
-            An AsyncAzureOpenAI client instance.
-        """
-        merged_headers = dict(copy(default_headers)) if default_headers else {}
-        if APP_INFO:
-            merged_headers.update(APP_INFO)
-            merged_headers = prepend_semantic_kernel_to_user_agent(merged_headers)
-
-        if not api_key and not ad_token and not ad_token_provider:
-            raise AgentInitializationException(
-                "Please provide either AzureOpenAI api_key, an ad_token, ad_token_provider, or a client."
-            )
-        if not endpoint:
-            raise AgentInitializationException("Please provide an AzureOpenAI endpoint.")
-
-        return AsyncAzureOpenAI(
-            azure_endpoint=str(endpoint),
-            api_version=api_version,
-            api_key=api_key,
-            azure_ad_token=ad_token,
-            azure_ad_token_provider=ad_token_provider,
-            default_headers=merged_headers,
-        )
-
-    @staticmethod
-    def _create_azure_openai_settings(
-        api_key: str | None = None,
-        endpoint: HttpsUrl | None = None,
-        deployment_name: str | None = None,
-        api_version: str | None = None,
-        env_file_path: str | None = None,
-        env_file_encoding: str | None = None,
-        token_endpoint: str | None = None,
-    ) -> AzureOpenAISettings:
-        """Create the Azure OpenAI settings.
-
-        Args:
-            api_key: The Azure OpenAI API key.
-            endpoint: The Azure OpenAI endpoint.
-            deployment_name: The Azure OpenAI chat deployment name.
-            api_version: The Azure OpenAI API version.
-            env_file_path: The environment file path.
-            env_file_encoding: The environment file encoding.
-            token_endpoint: The Azure AD token endpoint.
-
-        Returns:
-            An instance of the AzureOpenAISettings.
-        """
-        try:
-            azure_openai_settings = AzureOpenAISettings.create(
-                api_key=api_key,
-                endpoint=endpoint,
-                chat_deployment_name=deployment_name,
-                api_version=api_version,
-                env_file_path=env_file_path,
-                env_file_encoding=env_file_encoding,
-                token_endpoint=token_endpoint,
-            )
-        except ValidationError as ex:
-            raise AgentInitializationException("Failed to create Azure OpenAI settings.", ex) from ex
-
-        return azure_openai_settings
-
-    async def list_definitions(self) -> AsyncIterable[dict[str, Any]]:
-        """List the assistant definitions.
-
-        Yields:
-            An AsyncIterable of dictionaries representing the OpenAIAssistantDefinition.
-        """
-        assistants = await self.client.beta.assistants.list(order="desc")
-        for assistant in assistants.data:
-            yield OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
-
-    # endregion
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
@@ -103,7 +103,7 @@ class AzureAssistantAgent(OpenAIAssistantBase):
         Raises:
             AgentInitializationError: If the api_key is not provided in the configuration.
         """
-        azure_openai_settings = AzureAssistantAgent._create_azure_openai_settings(
+        azure_openai_settings = self._create_azure_openai_settings(
             api_key=api_key,
             endpoint=endpoint,
             deployment_name=deployment_name,
@@ -113,30 +113,16 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             token_endpoint=token_endpoint,
         )
 
-        if not azure_openai_settings.chat_deployment_name:
-            raise AgentInitializationException("The Azure OpenAI chat_deployment_name is required.")
+        # We centralize the client/ad_token setup
+        client, ad_token = self._setup_client_and_token(
+            azure_openai_settings=azure_openai_settings,
+            ad_token=ad_token,
+            ad_token_provider=ad_token_provider,
+            client=client,
+            default_headers=default_headers,
+        )
 
-        if (
-            client is None
-            and azure_openai_settings.api_key is None
-            and ad_token_provider is None
-            and ad_token is None
-            and azure_openai_settings.token_endpoint
-        ):
-            ad_token = get_entra_auth_token(azure_openai_settings.token_endpoint)
-
-        if not client and not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
-            raise AgentInitializationException("Please provide either api_key, ad_token or ad_token_provider.")
-
-        if not client:
-            client = self._create_client(
-                api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
-                endpoint=azure_openai_settings.endpoint,
-                api_version=azure_openai_settings.api_version,
-                ad_token=ad_token,
-                ad_token_provider=ad_token_provider,
-                default_headers=default_headers,
-            )
+        # Once the client is configured, we proceed
         service_id = service_id if service_id else DEFAULT_SERVICE_NAME
 
         args: dict[str, Any] = {
@@ -167,6 +153,7 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             args["kernel"] = kernel
         if kwargs:
             args.update(kwargs)
+
         super().__init__(**args)
 
     @classmethod
@@ -204,6 +191,7 @@ class AzureAssistantAgent(OpenAIAssistantBase):
         max_prompt_tokens: int | None = None,
         parallel_tool_calls_enabled: bool | None = True,
         truncation_message_count: int | None = None,
+        token_endpoint: str | None = None,
         **kwargs: Any,
     ) -> "AzureAssistantAgent":
         """Asynchronous class method used to create the OpenAI Assistant Agent.
@@ -240,10 +228,11 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             max_prompt_tokens: The maximum prompt tokens. (optional)
             parallel_tool_calls_enabled: Enable parallel tool calls. (optional)
             truncation_message_count: The truncation message count. (optional)
+            token_endpoint: The Azure AD token endpoint. (optional)
             **kwargs: Additional keyword arguments.
 
         Returns:
-            An instance of the AzureOpenAIAssistantAgent
+            An instance of the AzureAssistantAgent
         """
         agent = cls(
             kernel=kernel,
@@ -273,16 +262,15 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             max_prompt_tokens=max_prompt_tokens,
             parallel_tool_calls_enabled=parallel_tool_calls_enabled,
             truncation_message_count=truncation_message_count,
+            token_endpoint=token_endpoint,
             **kwargs,
         )
 
         assistant_create_kwargs: dict[str, Any] = {}
 
         code_interpreter_file_ids_combined: list[str] = []
-
         if code_interpreter_file_ids is not None:
             code_interpreter_file_ids_combined.extend(code_interpreter_file_ids)
-
         if code_interpreter_filenames is not None:
             for file_path in code_interpreter_filenames:
                 try:
@@ -293,16 +281,13 @@ class AzureAssistantAgent(OpenAIAssistantBase):
                         f"Failed to upload code interpreter file with path: `{file_path}` with exception: {ex}"
                     )
                     raise AgentInitializationException("Failed to upload code interpreter files.", ex) from ex
-
         if code_interpreter_file_ids_combined:
             agent.code_interpreter_file_ids = code_interpreter_file_ids_combined
             assistant_create_kwargs["code_interpreter_file_ids"] = code_interpreter_file_ids_combined
 
         vector_store_file_ids_combined: list[str] = []
-
         if vector_store_file_ids is not None:
             vector_store_file_ids_combined.extend(vector_store_file_ids)
-
         if vector_store_filenames is not None:
             for file_path in vector_store_filenames:
                 try:
@@ -311,7 +296,6 @@ class AzureAssistantAgent(OpenAIAssistantBase):
                 except FileNotFoundError as ex:
                     logger.error(f"Failed to upload vector store file with path: `{file_path}` with exception: {ex}")
                     raise AgentInitializationException("Failed to upload vector store files.", ex) from ex
-
         if vector_store_file_ids_combined:
             agent.file_search_file_ids = vector_store_file_ids_combined
             if enable_file_search or agent.enable_file_search:
@@ -321,6 +305,110 @@ class AzureAssistantAgent(OpenAIAssistantBase):
 
         agent.assistant = await agent.create_assistant(**assistant_create_kwargs)
         return agent
+
+    @classmethod
+    async def retrieve(
+        cls,
+        *,
+        id: str,
+        api_key: str | None = None,
+        endpoint: HttpsUrl | None = None,
+        api_version: str | None = None,
+        ad_token: str | None = None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
+        client: AsyncAzureOpenAI | None = None,
+        kernel: "Kernel | None" = None,
+        default_headers: dict[str, str] | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+        token_endpoint: str | None = None,
+    ) -> "AzureAssistantAgent":
+        """Retrieve an assistant by ID.
+
+        Args:
+            id: The assistant ID.
+            api_key: The Azure OpenAI API key. (optional)
+            endpoint: The Azure OpenAI endpoint. (optional)
+            api_version: The Azure OpenAI API version. (optional)
+            ad_token: The Azure AD token. (optional)
+            ad_token_provider: The Azure AD token provider. (optional)
+            client: The Azure OpenAI client. (optional)
+            kernel: The Kernel instance. (optional)
+            default_headers: The default headers. (optional)
+            env_file_path: The environment file path. (optional)
+            env_file_encoding: The environment file encoding. (optional)
+            token_endpoint: The Azure AD token endpoint. (optional)
+
+        Returns:
+            An AzureAssistantAgent instance.
+        """
+        azure_openai_settings = cls._create_azure_openai_settings(
+            api_key=api_key,
+            endpoint=endpoint,
+            deployment_name=None,  # Not required for retrieving an existing assistant
+            api_version=api_version,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+            token_endpoint=token_endpoint,
+        )
+
+        client, ad_token = cls._setup_client_and_token(
+            azure_openai_settings=azure_openai_settings,
+            ad_token=ad_token,
+            ad_token_provider=ad_token_provider,
+            client=client,
+            default_headers=default_headers,
+        )
+
+        assistant = await client.beta.assistants.retrieve(id)
+        assistant_definition = OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
+
+        return AzureAssistantAgent(kernel=kernel, assistant=assistant, **assistant_definition)
+
+    @staticmethod
+    def _setup_client_and_token(
+        azure_openai_settings: AzureOpenAISettings,
+        ad_token: str | None,
+        ad_token_provider: Callable[[], str | Awaitable[str]] | None,
+        client: AsyncAzureOpenAI | None,
+        default_headers: dict[str, str] | None,
+    ) -> tuple[AsyncAzureOpenAI, str | None]:
+        """Helper method that ensures either an AD token or an API key is present.
+
+        Retrieves a new AD token if needed, and configures the AsyncAzureOpenAI client.
+
+        Returns:
+            A tuple of (client, ad_token), where client is guaranteed not to be None.
+        """
+        if not azure_openai_settings.chat_deployment_name:
+            raise AgentInitializationException("The Azure OpenAI chat_deployment_name is required.")
+
+        # If everything is missing, but there is a token_endpoint, try to get the token.
+        if (
+            client is None
+            and azure_openai_settings.api_key is None
+            and ad_token_provider is None
+            and ad_token is None
+            and azure_openai_settings.token_endpoint
+        ):
+            ad_token = get_entra_auth_token(azure_openai_settings.token_endpoint)
+
+        # If we still have no credentials, we can't proceed
+        if not client and not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
+            raise AgentInitializationException("Please provide either api_key, ad_token or ad_token_provider.")
+
+        # Build the client if it's not supplied
+        if not client:
+            client = AzureAssistantAgent._create_client(
+                api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
+                endpoint=azure_openai_settings.endpoint,
+                api_version=azure_openai_settings.api_version,
+                ad_token=ad_token,
+                ad_token_provider=ad_token_provider,
+                default_headers=default_headers,
+            )
+
+        return client, ad_token
 
     @staticmethod
     def _create_client(
@@ -351,10 +439,11 @@ class AzureAssistantAgent(OpenAIAssistantBase):
 
         if not api_key and not ad_token and not ad_token_provider:
             raise AgentInitializationException(
-                "Please provide either AzureOpenAI api_key, an ad_token or an ad_token_provider or a client."
+                "Please provide either AzureOpenAI api_key, an ad_token, ad_token_provider, or a client."
             )
         if not endpoint:
             raise AgentInitializationException("Please provide an AzureOpenAI endpoint.")
+
         return AsyncAzureOpenAI(
             azure_endpoint=str(endpoint),
             api_version=api_version,
@@ -412,65 +501,5 @@ class AzureAssistantAgent(OpenAIAssistantBase):
         assistants = await self.client.beta.assistants.list(order="desc")
         for assistant in assistants.data:
             yield OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
-
-    @classmethod
-    async def retrieve(
-        cls,
-        *,
-        id: str,
-        api_key: str | None = None,
-        endpoint: HttpsUrl | None = None,
-        api_version: str | None = None,
-        ad_token: str | None = None,
-        ad_token_provider: Callable[[], str | Awaitable[str]] | None = None,
-        client: AsyncAzureOpenAI | None = None,
-        kernel: "Kernel | None" = None,
-        default_headers: dict[str, str] | None = None,
-        env_file_path: str | None = None,
-        env_file_encoding: str | None = None,
-    ) -> "AzureAssistantAgent":
-        """Retrieve an assistant by ID.
-
-        Args:
-            id: The assistant ID.
-            api_key: The Azure OpenAI API
-            endpoint: The Azure OpenAI endpoint. (optional)
-            api_version: The Azure OpenAI API version. (optional)
-            ad_token: The Azure AD token. (optional)
-            ad_token_provider: The Azure AD token provider. (optional)
-            client: The Azure OpenAI client. (optional)
-            kernel: The Kernel instance. (optional)
-            default_headers: The default headers. (optional)
-            env_file_path: The environment file path. (optional)
-            env_file_encoding: The environment file encoding. (optional)
-
-        Returns:
-            An AzureAssistantAgent instance.
-        """
-        azure_openai_settings = AzureAssistantAgent._create_azure_openai_settings(
-            api_key=api_key,
-            endpoint=endpoint,
-            api_version=api_version,
-            env_file_path=env_file_path,
-            env_file_encoding=env_file_encoding,
-        )
-
-        if not azure_openai_settings.chat_deployment_name:
-            raise AgentInitializationException("The Azure OpenAI chat_deployment_name is required.")
-        if not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
-            raise AgentInitializationException("Please provide either api_key, ad_token or ad_token_provider.")
-
-        if not client:
-            client = AzureAssistantAgent._create_client(
-                api_key=api_key,
-                endpoint=endpoint,
-                api_version=api_version,
-                ad_token=ad_token,
-                ad_token_provider=ad_token_provider,
-                default_headers=default_headers,
-            )
-        assistant = await client.beta.assistants.retrieve(id)
-        assistant_definition = OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
-        return AzureAssistantAgent(kernel=kernel, assistant=assistant, **assistant_definition)
 
     # endregion

--- a/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
@@ -113,7 +113,6 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             token_endpoint=token_endpoint,
         )
 
-        # We centralize the client/ad_token setup
         client, ad_token = self._setup_client_and_token(
             azure_openai_settings=azure_openai_settings,
             ad_token=ad_token,
@@ -122,7 +121,6 @@ class AzureAssistantAgent(OpenAIAssistantBase):
             default_headers=default_headers,
         )
 
-        # Once the client is configured, we proceed
         service_id = service_id if service_id else DEFAULT_SERVICE_NAME
 
         args: dict[str, Any] = {


### PR DESCRIPTION
### Motivation and Context

The AzureAssistantAgent retrieval path was not handling the optional ad_token. The agent constructor was handling it, to a degree, but there were improvements to make and a helper function to introduce so that we remove some code duplication.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR:
- Cleans up the code used to create the azure settings for an azure assistant agent by introducing a helper function to streamline the logic
- Allows the AzureAssistantAgent.retrieve() method to use an ad_token, if desired.
- Adds unit tests for the new logic. Other unit tests are still passing after the refactor.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
