### PR TITLE
.Net: Expose response and response content headers

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
@@ -241,6 +241,8 @@ internal sealed class RestApiOperationRunner
 
             response.ExpectedSchema ??= GetExpectedSchema(expectedSchemas, responseMessage.StatusCode);
 
+            response.Headers = GetResponseHeaders(responseMessage);
+
             return response;
         }
         catch (HttpRequestException ex)
@@ -558,6 +560,27 @@ internal sealed class RestApiOperationRunner
         }
 
         return content;
+    }
+
+    /// <summary>
+    /// Retrieves the headers from the specified HTTP response message, including content headers.
+    /// </summary>
+    /// <param name="responseMessage">The HTTP response message from which to extract headers.</param>
+    /// <returns>
+    /// A dictionary containing the headers of the HTTP response message, including content headers.
+    /// The dictionary keys are header names, and the values are collections of header values.
+    /// </returns>
+    private static Dictionary<string, IEnumerable<string>>? GetResponseHeaders(HttpResponseMessage responseMessage)
+    {
+        var headers = responseMessage.Headers.ToDictionary(h => h.Key, h => h.Value);
+
+        // Add the content headers as well.
+        foreach (var item_ in responseMessage.Content.Headers)
+        {
+            headers[item_.Key] = item_.Value;
+        }
+
+        return headers;
     }
 
     #endregion

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1703,7 +1703,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
     }
 
     [Fact]
-    public async Task ItShouldReturnResponseAndResponseContentHadersAsync()
+    public async Task ItShouldReturnResponseAndResponseContentHeadersAsync()
     {
         // Arrange
         this._httpMessageHandlerStub.ResponseToReturn.Headers.Add("fake-response-header", "fake-response-header-value");

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1702,6 +1702,38 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         Assert.Equal(JsonSerializer.Serialize(expected), JsonSerializer.Serialize(result.ExpectedSchema));
     }
 
+    [Fact]
+    public async Task ItShouldReturnResponseAndResponseContentHadersAsync()
+    {
+        // Arrange
+        this._httpMessageHandlerStub.ResponseToReturn.Headers.Add("fake-response-header", "fake-response-header-value");
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Application.Json);
+        this._httpMessageHandlerStub.ResponseToReturn.Content.Headers.Add("fake-response-content-header", "fake-response-content-header-value");
+
+        var operation = new RestApiOperation(
+            id: "fake-id",
+            servers: [new RestApiServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Get,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: []
+        );
+
+        var sut = new RestApiOperationRunner(this._httpClient);
+
+        // Act
+        var result = await sut.RunAsync(operation, []);
+
+        // Assert
+        Assert.NotNull(result.Headers);
+
+        Assert.Contains(result.Headers, h => h.Key == "fake-response-header" && h.Value.Contains("fake-response-header-value"));
+
+        Assert.Contains(result.Headers, h => h.Key == "fake-response-content-header" && h.Value.Contains("fake-response-content-header-value"));
+    }
+
     /// <summary>
     /// Disposes resources used by this class.
     /// </summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel;
 
@@ -40,6 +43,13 @@ public sealed class RestApiOperationResponse
     /// Gets the payload sent in the request.
     /// </summary>
     public object? RequestPayload { get; init; }
+
+    /// <summary>
+    /// The response headers.
+    /// </summary>
+    [Experimental("SKEXP0040")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IDictionary<string, IEnumerable<string>>? Headers { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RestApiOperationResponse"/> class.

--- a/python/semantic_kernel/__init__.py
+++ b/python/semantic_kernel/__init__.py
@@ -2,5 +2,5 @@
 
 from semantic_kernel.kernel import Kernel
 
-__version__ = "1.17.0"
+__version__ = "1.17.1"
 __all__ = ["Kernel", "__version__"]


### PR DESCRIPTION
### Motivation, Context and Description
Today, it's difficult to access response and response content headers returned by OpenAPI plugins. This PR exposes the `Headers` property, allowing easy access to both response and response content headers.

Closes - https://github.com/microsoft/semantic-kernel/issues/9986