### PR TITLE
Python: Agent content generation for function call content should be assistant role

### DIFF
--- a/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
@@ -216,7 +216,7 @@ def generate_function_call_content(agent_name: str, fccs: list[FunctionCallConte
     Returns:
         ChatMessageContent: The chat message content containing the function call content as the items.
     """
-    return ChatMessageContent(role=AuthorRole.TOOL, name=agent_name, items=fccs)  # type: ignore
+    return ChatMessageContent(role=AuthorRole.ASSISTANT, name=agent_name, items=fccs)  # type: ignore
 
 
 @experimental_function

--- a/python/tests/unit/agents/test_open_ai_assistant_base.py
+++ b/python/tests/unit/agents/test_open_ai_assistant_base.py
@@ -1670,4 +1670,20 @@ def test_generate_options(azure_openai_assistant_agent: AzureAssistantAgent, ope
     assert options == expected_options, f"Expected {expected_options}, but got {options}"
 
 
+def test_generate_function_call_content_sets_assistant_role():
+    fcc1 = FunctionCallContent(name="function_name1", arguments={"input": "some input"})
+    fcc2 = FunctionCallContent(name="function_name2", arguments={"input": "other input"})
+    agent_name = "TestAgent"
+
+    result = generate_function_call_content(agent_name=agent_name, fccs=[fcc1, fcc2])
+
+    assert result.role == AuthorRole.ASSISTANT
+    assert result.name == agent_name
+    assert len(result.items) == 2
+    assert isinstance(result.items[0], FunctionCallContent)
+    assert isinstance(result.items[1], FunctionCallContent)
+    assert result.items[0].name == "function_name1"
+    assert result.items[1].name == "function_name2"
+
+
 # endregion


### PR DESCRIPTION
### Motivation and Context

The (Azure)OpenAIAssistant content generation for function call content was specifying the tool role instead of an assistant role. This was causing an issue in the `.to_dict()` method in `chat_message_content` because a `TOOL` role should only have `FunctionResultContent`. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR fixes the AuthorRole to be ASSISTANT instead of TOOL for function call content, which matches how it's handled in the chat completion case.
- Adds a specific unit test for test coverage (previous test coverage was indirect and didn't catch this)
- Closes #10075

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
