### PR TITLE
.Net: Add factory for customizing OpenAPI plugins responses

### DIFF
--- a/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs
+++ b/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs
@@ -56,7 +56,7 @@ public sealed class OpenApiPlugin_RestApiOperationResponseFactory(ITestOutputHel
     private static async Task<RestApiOperationResponse> IncludeHeadersIntoRestApiOperationResponseAsync(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
     {
         // Create the response using the internal factory
-        var response = await context.InternalFactory();
+        RestApiOperationResponse response = await context.InternalFactory!(context, cancellationToken);
 
         // Obtain the 'repair-id' header value from the HTTP response and include it in the operation response only for the 'createRepair' operation
         if (context.Operation.Id == "createRepair" && context.Response.Headers.TryGetValues("repair-id", out IEnumerable<string>? values))

--- a/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs
+++ b/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs
@@ -56,7 +56,7 @@ public sealed class OpenApiPlugin_RestApiOperationResponseFactory(ITestOutputHel
     private static async Task<RestApiOperationResponse> IncludeHeadersIntoRestApiOperationResponseAsync(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
     {
         // Create the response using the internal factory
-        RestApiOperationResponse response = await context.InternalFactory!(context, cancellationToken);
+        RestApiOperationResponse response = await context.InternalFactory(context, cancellationToken);
 
         // Obtain the 'repair-id' header value from the HTTP response and include it in the operation response only for the 'createRepair' operation
         if (context.Operation.Id == "createRepair" && context.Response.Headers.TryGetValues("repair-id", out IEnumerable<string>? values))

--- a/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs
+++ b/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Net;
+using System.Text;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Plugins.OpenApi;
+
+namespace Plugins;
+
+/// <summary>
+/// Sample shows how to register the <see cref="RestApiOperationResponseFactory"/> to transform existing or create new <see cref="RestApiOperationResponse"/>.
+/// </summary>
+public sealed class OpenApiPlugin_RestApiOperationResponseFactory(ITestOutputHelper output) : BaseTest(output)
+{
+    private readonly HttpClient _httpClient = new(new StubHttpHandler(InterceptRequestAndCustomizeResponseAsync));
+
+    [Fact]
+    public async Task IncludeResponseHeadersToOperationResponseAsync()
+    {
+        Kernel kernel = new();
+
+        // Register the operation response factory and the custom HTTP client
+        OpenApiFunctionExecutionParameters executionParameters = new()
+        {
+            RestApiOperationResponseFactory = IncludeHeadersIntoRestApiOperationResponseAsync,
+            HttpClient = this._httpClient
+        };
+
+        // Create OpenAPI plugin
+        KernelPlugin plugin = await OpenApiKernelPluginFactory.CreateFromOpenApiAsync("RepairService", "Resources/Plugins/RepairServicePlugin/repair-service.json", executionParameters);
+
+        // Create arguments for a new repair
+        KernelArguments arguments = new()
+        {
+            ["title"] = "The Case of the Broken Gizmo",
+            ["description"] = "It's broken. Send help!",
+            ["assignedTo"] = "Tech Magician"
+        };
+
+        // Create the repair
+        FunctionResult createResult = await plugin["createRepair"].InvokeAsync(kernel, arguments);
+
+        // Get operation response that was modified
+        RestApiOperationResponse response = createResult.GetValue<RestApiOperationResponse>()!;
+
+        // Display the 'repair-id' header value
+        Console.WriteLine(response.Headers!["repair-id"].First());
+    }
+
+    /// <summary>
+    /// A custom factory to transform the operation response.
+    /// </summary>
+    /// <param name="context">The context for the <see cref="RestApiOperationResponseFactory"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The transformed operation response.</returns>
+    private static async Task<RestApiOperationResponse> IncludeHeadersIntoRestApiOperationResponseAsync(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
+    {
+        // Create the response using the internal factory
+        var response = await context.InternalFactory();
+
+        // Obtain the 'repair-id' header value from the HTTP response and include it in the operation response only for the 'createRepair' operation
+        if (context.Operation.Id == "createRepair" && context.Response.Headers.TryGetValues("repair-id", out IEnumerable<string>? values))
+        {
+            response.Headers ??= new Dictionary<string, IEnumerable<string>>();
+            response.Headers["repair-id"] = values;
+        }
+
+        // Return the modified response that will be returned to the caller
+        return response;
+    }
+
+    /// <summary>
+    /// A custom HTTP handler to intercept HTTP requests and return custom responses.
+    /// </summary>
+    /// <param name="request">The original HTTP request.</param>
+    /// <returns>The custom HTTP response.</returns>
+    private static async Task<HttpResponseMessage> InterceptRequestAndCustomizeResponseAsync(HttpRequestMessage request)
+    {
+        // Return a mock response that includes the 'repair-id' header for the 'createRepair' operation
+        if (request.RequestUri!.AbsolutePath == "/repairs" && request.Method == HttpMethod.Post)
+        {
+            return new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("Success", Encoding.UTF8, "application/json"),
+                Headers =
+                {
+                    { "repair-id", "repair-12345" }
+                }
+            };
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.NoContent);
+    }
+
+    private sealed class StubHttpHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> requestHandler) : DelegatingHandler()
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _requestHandler = requestHandler;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return await this._requestHandler(request);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        this._httpClient.Dispose();
+    }
+}

--- a/dotnet/samples/Concepts/README.md
+++ b/dotnet/samples/Concepts/README.md
@@ -169,6 +169,7 @@ dotnet test -l "console;verbosity=detailed" --filter "FullyQualifiedName=ChatCom
 - [OpenApiPlugin_Customization](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/OpenApiPlugin_Customization.cs)
 - [OpenApiPlugin_Filtering](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/OpenApiPlugin_Filtering.cs)
 - [OpenApiPlugin_Telemetry](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/OpenApiPlugin_Telemetry.cs)
+- [OpenApiPlugin_RestApiOperationResponseFactory](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/OpenApiPlugin_RestApiOperationResponseFactory.cs)
 - [CustomMutablePlugin](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/CustomMutablePlugin.cs)
 - [DescribeAllPluginsAndFunctions](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/DescribeAllPluginsAndFunctions.cs)
 - [GroundednessChecks](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Plugins/GroundednessChecks.cs)

--- a/dotnet/src/Functions/Functions.Grpc/Functions.Grpc.csproj
+++ b/dotnet/src/Functions/Functions.Grpc/Functions.Grpc.csproj
@@ -10,7 +10,6 @@
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />
-  
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - gRPC Plugins</Title>

--- a/dotnet/src/Functions/Functions.Grpc/Functions.Grpc.csproj
+++ b/dotnet/src/Functions/Functions.Grpc/Functions.Grpc.csproj
@@ -10,7 +10,7 @@
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />
-
+  
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Semantic Kernel - gRPC Plugins</Title>
@@ -34,6 +34,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Exclude utilities that are not used by the project  -->
+    <Compile Remove="$(RepoRoot)/dotnet/src/InternalUtilities/src/Http/HttpResponseStream.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Functions/Functions.Markdown/Functions.Markdown.csproj
+++ b/dotnet/src/Functions/Functions.Markdown/Functions.Markdown.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />
-
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->
@@ -28,6 +26,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\SemanticKernel.Core\SemanticKernel.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/**/*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/System/AppContextSwitchHelper.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
@@ -80,6 +80,15 @@ public class OpenApiFunctionExecutionParameters
     public HttpResponseContentReader? HttpResponseContentReader { get; set; }
 
     /// <summary>
+    /// A custom factory for the <see cref="RestApiOperationResponse"/>.
+    /// It allows modifications of various aspects of the original response, such as adding response headers,
+    /// changing response content, adjusting the schema, or providing a completely new response.
+    /// If a custom factory is not supplied, the internal factory will be used by default.
+    /// </summary>
+    [Experimental("SKEXP0040")]
+    public RestApiOperationResponseFactory? RestApiOperationResponseFactory { get; set; }
+
+    /// <summary>
     /// A custom REST API parameter filter.
     /// </summary>
     [Experimental("SKEXP0040")]

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -216,7 +216,8 @@ public static partial class OpenApiKernelPluginFactory
             executionParameters?.UserAgent,
             executionParameters?.EnableDynamicPayload ?? true,
             executionParameters?.EnablePayloadNamespacing ?? false,
-            executionParameters?.HttpResponseContentReader);
+            executionParameters?.HttpResponseContentReader,
+            executionParameters?.RestApiOperationResponseFactory);
 
         var functions = new List<KernelFunction>();
         ILogger logger = loggerFactory.CreateLogger(typeof(OpenApiKernelExtensions)) ?? NullLogger.Instance;

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Plugins.OpenApi;
+
+/// <summary>
+/// Represents a factory for creating instances of the <see cref="RestApiOperationResponse"/>.
+/// </summary>
+/// <param name="context">The context that contains the operation details.</param>
+/// <param name="cancellationToken">The cancellation token used to signal cancellation.</param>
+/// <returns>A task that represents the asynchronous operation, containing an instance of <see cref="RestApiOperationResponse"/>.</returns>
+[Experimental("SKEXP0040")]
+public delegate Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken = default);

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
@@ -18,7 +18,7 @@ public sealed class RestApiOperationResponseFactoryContext
     /// <param name="request">The HTTP request message.</param>
     /// <param name="response">The HTTP response message.</param>
     /// <param name="internalFactory">The internal factory to create instances of the <see cref="RestApiOperationResponse"/>.</param>
-    internal RestApiOperationResponseFactoryContext(RestApiOperation operation, HttpRequestMessage request, HttpResponseMessage response, RestApiOperationResponseFactory? internalFactory)
+    internal RestApiOperationResponseFactoryContext(RestApiOperation operation, HttpRequestMessage request, HttpResponseMessage response, RestApiOperationResponseFactory internalFactory)
     {
         this.InternalFactory = internalFactory;
         this.Operation = operation;
@@ -44,5 +44,5 @@ public sealed class RestApiOperationResponseFactoryContext
     /// <summary>
     /// The internal factory to create instances of the <see cref="RestApiOperationResponse"/>.
     /// </summary>
-    public RestApiOperationResponseFactory? InternalFactory { get; }
+    public RestApiOperationResponseFactory InternalFactory { get; }
 }

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.SemanticKernel.Plugins.OpenApi;
+
+/// <summary>
+/// Represents the context for the <see cref="RestApiOperationResponseFactory"/>."/>
+/// </summary>
+[Experimental("SKEXP0040")]
+public sealed class RestApiOperationResponseFactoryContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RestApiOperationResponseFactoryContext"/> class.
+    /// </summary>
+    /// <param name="operation">The REST API operation.</param>
+    /// <param name="request">The HTTP request message.</param>
+    /// <param name="response">The HTTP response message.</param>
+    /// <param name="internalFactory">The internal factory to create instances of the <see cref="RestApiOperationResponse"/>.</param>
+    internal RestApiOperationResponseFactoryContext(RestApiOperation operation, HttpRequestMessage request, HttpResponseMessage response, Func<Task<RestApiOperationResponse>> internalFactory)
+    {
+        this.InternalFactory = internalFactory;
+        this.Operation = operation;
+        this.Request = request;
+        this.Response = response;
+    }
+
+    /// <summary>
+    /// The REST API operation.
+    /// </summary>
+    public RestApiOperation Operation { get; }
+
+    /// <summary>
+    /// The HTTP request message.
+    /// </summary>
+    public HttpRequestMessage Request { get; }
+
+    /// <summary>
+    /// The HTTP response message.
+    /// </summary>
+    public HttpResponseMessage Response { get; }
+
+    /// <summary>
+    /// The internal factory to create instances of the <see cref="RestApiOperationResponse"/>.
+    /// </summary>
+    public Func<Task<RestApiOperationResponse>> InternalFactory { get; }
+}

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
@@ -20,7 +18,7 @@ public sealed class RestApiOperationResponseFactoryContext
     /// <param name="request">The HTTP request message.</param>
     /// <param name="response">The HTTP response message.</param>
     /// <param name="internalFactory">The internal factory to create instances of the <see cref="RestApiOperationResponse"/>.</param>
-    internal RestApiOperationResponseFactoryContext(RestApiOperation operation, HttpRequestMessage request, HttpResponseMessage response, Func<Task<RestApiOperationResponse>> internalFactory)
+    internal RestApiOperationResponseFactoryContext(RestApiOperation operation, HttpRequestMessage request, HttpResponseMessage response, RestApiOperationResponseFactory? internalFactory)
     {
         this.InternalFactory = internalFactory;
         this.Operation = operation;
@@ -46,5 +44,5 @@ public sealed class RestApiOperationResponseFactoryContext
     /// <summary>
     /// The internal factory to create instances of the <see cref="RestApiOperationResponse"/>.
     /// </summary>
-    public Func<Task<RestApiOperationResponse>> InternalFactory { get; }
+    public RestApiOperationResponseFactory? InternalFactory { get; }
 }

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationRunner.cs
@@ -609,7 +609,7 @@ internal sealed class RestApiOperationRunner
             return response;
         }
 
-        return await Build(new(operation: operation, request: requestMessage, response: responseMessage, internalFactory: null), cancellationToken).ConfigureAwait(false);
+        return await Build(new(operation: operation, request: requestMessage, response: responseMessage, internalFactory: null!), cancellationToken).ConfigureAwait(false);
     }
 
     #endregion

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -617,7 +617,7 @@ public sealed class OpenApiKernelPluginFactoryTests
         {
             restApiOperationResponseFactoryIsInvoked = true;
 
-            return await context.InternalFactory!(context, cancellationToken);
+            return await context.InternalFactory(context, cancellationToken);
         }
 
         using var messageHandlerStub = new HttpMessageHandlerStub();

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -617,7 +617,7 @@ public sealed class OpenApiKernelPluginFactoryTests
         {
             restApiOperationResponseFactoryIsInvoked = true;
 
-            return await context.InternalFactory();
+            return await context.InternalFactory!(context, cancellationToken);
         }
 
         using var messageHandlerStub = new HttpMessageHandlerStub();

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/OpenApiKernelPluginFactoryTests.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
@@ -604,6 +605,42 @@ public sealed class OpenApiKernelPluginFactoryTests
         Assert.NotNull(deserializedPayload);
 
         Assert.Equal(23.4f, deserializedPayload["float?parameter"]!.GetValue<float>());
+    }
+
+    [Fact]
+    public async Task ItShouldPropagateRestApiOperationResponseFactoryToRunnerAsync()
+    {
+        // Arrange
+        bool restApiOperationResponseFactoryIsInvoked = false;
+
+        async Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
+        {
+            restApiOperationResponseFactoryIsInvoked = true;
+
+            return await context.InternalFactory();
+        }
+
+        using var messageHandlerStub = new HttpMessageHandlerStub();
+        using var httpClient = new HttpClient(messageHandlerStub, false);
+
+        this._executionParameters.HttpClient = httpClient;
+        this._executionParameters.RestApiOperationResponseFactory = RestApiOperationResponseFactory;
+
+        var openApiPlugins = await OpenApiKernelPluginFactory.CreateFromOpenApiAsync("fakePlugin", this._openApiDocument, this._executionParameters);
+
+        var kernel = new Kernel();
+
+        var arguments = new KernelArguments
+        {
+            { "secret-name", "fake-secret-name" },
+            { "api-version", "fake-api-version" }
+        };
+
+        // Act
+        await kernel.InvokeAsync(openApiPlugins["GetSecret"], arguments);
+
+        // Assert
+        Assert.True(restApiOperationResponseFactoryIsInvoked);
     }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1757,7 +1757,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         async Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
         {
             factoryContext = context;
-            factoryInternalResponse = await context.InternalFactory!(context, cancellationToken);
+            factoryInternalResponse = await context.InternalFactory(context, cancellationToken);
             factoryCancellationToken = cancellationToken;
 
             return factoryInternalResponse;

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -1757,7 +1757,7 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         async Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
         {
             factoryContext = context;
-            factoryInternalResponse = await context.InternalFactory();
+            factoryInternalResponse = await context.InternalFactory!(context, cancellationToken);
             factoryCancellationToken = cancellationToken;
 
             return factoryInternalResponse;

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/RestApiOperationRunnerTests.cs
@@ -15,6 +15,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Plugins.OpenApi;
 using Moq;
 using SemanticKernel.Functions.UnitTests.OpenApi.TestResponses;
@@ -1741,6 +1742,158 @@ public sealed class RestApiOperationRunnerTests : IDisposable
         // Assert
         Assert.NotNull(this._httpMessageHandlerStub.ContentHeaders);
         Assert.Contains(this._httpMessageHandlerStub.ContentHeaders, h => h.Key == "Content-Type" && h.Value.Any(h => h.StartsWith(normalizedContentType, StringComparison.InvariantCulture)));
+    }
+
+    [Fact]
+    public async Task ItShouldProvideValidContextToRestApiOperationResponseFactoryAsync()
+    {
+        // Arrange
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Text.Plain);
+
+        RestApiOperationResponseFactoryContext? factoryContext = null;
+        RestApiOperationResponse? factoryInternalResponse = null;
+        CancellationToken? factoryCancellationToken = null;
+
+        async Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
+        {
+            factoryContext = context;
+            factoryInternalResponse = await context.InternalFactory();
+            factoryCancellationToken = cancellationToken;
+
+            return factoryInternalResponse;
+        }
+
+        var operation = new RestApiOperation(
+            id: "fake-id",
+            servers: [new RestApiServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: [],
+            payload: null
+        );
+
+        var arguments = new KernelArguments
+        {
+            { "payload", "fake-input-value" },
+            { "content-type", "text/plain" },
+        };
+
+        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var cancellationToken = cancellationTokenSource.Token;
+
+        // Act
+        var response = await sut.RunAsync(operation, arguments, cancellationToken: cancellationToken);
+
+        // Assert
+        Assert.NotNull(factoryContext);
+        Assert.Same(operation, factoryContext.Operation);
+        Assert.Same(this._httpMessageHandlerStub.RequestMessage, factoryContext.Request);
+        Assert.Same(this._httpMessageHandlerStub.ResponseToReturn, factoryContext.Response);
+
+        Assert.Same(factoryInternalResponse, response);
+
+        Assert.Equal(cancellationToken, factoryCancellationToken);
+    }
+
+    [Fact]
+    public async Task ItShouldWrapStreamContentIntoHttpResponseStreamAsync()
+    {
+        // Arrange
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Text.Plain);
+
+        var factoryStream = new MemoryStream();
+
+        async Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult(new RestApiOperationResponse(factoryStream, contentType: MediaTypeNames.Text.Plain));
+        }
+
+        var operation = new RestApiOperation(
+            id: "fake-id",
+            servers: [new RestApiServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: [],
+            payload: null
+        );
+
+        var arguments = new KernelArguments
+        {
+            { "payload", "fake-input-value" },
+            { "content-type", "text/plain" },
+        };
+
+        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory);
+
+        // Act
+        var response = await sut.RunAsync(operation, arguments);
+
+        // Assert
+        var httpResponseStream = Assert.IsType<HttpResponseStream>(response.Content);
+
+        // Assert that neither the HttResponseMessage nor stream returned by factory is disposed
+        this._httpMessageHandlerStub.ResponseToReturn!.Version = Version.Parse("1.1.1");
+        Assert.True(factoryStream!.CanRead);
+        Assert.True(factoryStream!.CanSeek);
+
+        // Dispose the response stream
+        httpResponseStream.Dispose();
+
+        // Assert both the stream and the response message are disposed
+        Assert.Throws<ObjectDisposedException>(() => this._httpMessageHandlerStub.ResponseToReturn!.Version = Version.Parse("1.1.1"));
+        Assert.False(httpResponseStream!.CanRead);
+        Assert.False(httpResponseStream!.CanSeek);
+    }
+
+    [Fact]
+    public async Task ItShouldNotWrapStreamContentIntoHttpResponseStreamIfItIsAlreadyOfHttpResponseStreamTypeAsync()
+    {
+        // Arrange
+        this._httpMessageHandlerStub.ResponseToReturn.Content = new StringContent("fake-content", Encoding.UTF8, MediaTypeNames.Text.Plain);
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        await using var httpResponseStream = new HttpResponseStream(new MemoryStream(), new HttpResponseMessage());
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+        async Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult(new RestApiOperationResponse(httpResponseStream, contentType: MediaTypeNames.Text.Plain));
+        }
+
+        var operation = new RestApiOperation(
+            id: "fake-id",
+            servers: [new RestApiServer("https://fake-random-test-host")],
+            path: "fake-path",
+            method: HttpMethod.Post,
+            description: "fake-description",
+            parameters: [],
+            responses: new Dictionary<string, RestApiExpectedResponse>(),
+            securityRequirements: [],
+            payload: null
+        );
+
+        var arguments = new KernelArguments
+        {
+            { "payload", "fake-input-value" },
+            { "content-type", "text/plain" },
+        };
+
+        var sut = new RestApiOperationRunner(this._httpClient, responseFactory: RestApiOperationResponseFactory);
+
+        // Act
+        var response = await sut.RunAsync(operation, arguments);
+
+        // Assert
+        Assert.Same(httpResponseStream, response.Content);
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel;
 
@@ -14,7 +17,7 @@ public sealed class RestApiOperationResponse
     /// <summary>
     /// Gets the content of the response.
     /// </summary>
-    public object? Content { get; }
+    public object? Content { get; set; }
 
     /// <summary>
     /// Gets the content type of the response.
@@ -40,6 +43,13 @@ public sealed class RestApiOperationResponse
     /// Gets the payload sent in the request.
     /// </summary>
     public object? RequestPayload { get; init; }
+
+    /// <summary>
+    /// The response headers.
+    /// </summary>
+    [Experimental("SKEXP0040")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IDictionary<string, IEnumerable<string>>? Headers { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RestApiOperationResponse"/> class.


### PR DESCRIPTION
### Motivation and Context  
Currently, it's impossible to access the HTTP response and response content headers returned by a REST API requested from OpenAPI plugins.  
   
### Description  
This PR adds `RestApiOperationResponseFactory`, which can be used to customize the responses of OpenAPI plugins before returning them to the caller. The customization may include modifying the original response by adding response headers, changing the response content, adjusting the schema, or providing a completely new response.

Closes: https://github.com/microsoft/semantic-kernel/issues/9986