### PR TITLE
.Net: fix: adds support of allOf for OpenAPI dynamic payload generation

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -524,7 +524,7 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
 
         var result = new List<RestApiPayloadProperty>();
 
-        foreach(var allOfEntry in schema.AllOf)
+        foreach (var allOfEntry in schema.AllOf)
         {
             result.AddRange(GetPayloadProperties(operationId, allOfEntry, level + 1));
         }

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -524,6 +524,11 @@ public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
 
         var result = new List<RestApiPayloadProperty>();
 
+        foreach(var allOfEntry in schema.AllOf)
+        {
+            result.AddRange(GetPayloadProperties(operationId, allOfEntry, level + 1));
+        }
+
         foreach (var propertyPair in schema.Properties)
         {
             var propertyName = propertyPair.Key;


### PR DESCRIPTION
### Motivation and Context

Current dynamic payload generation does not support allOf in OpenAPI.

### Description

This recursively parses allOf entries to add all properties from parent schemas.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
