### PR TITLE
Python: Improve agent retrieval by passing necessary kwargs. Add unit tests.

### DIFF
--- a/python/samples/concepts/agents/assistant_agent_retrieval.py
+++ b/python/samples/concepts/agents/assistant_agent_retrieval.py
@@ -58,6 +58,8 @@ async def main():
             enable_code_interpreter=True,
         )
 
+        assistant_id = agent.assistant.id
+
         retrieved_agent: AzureAssistantAgent = await AzureAssistantAgent.retrieve(
             id=assistant_id,
             kernel=kernel,
@@ -70,6 +72,8 @@ async def main():
             instructions=AGENT_INSTRUCTIONS,
             enable_code_interpreter=True,
         )
+
+        assistant_id = agent.assistant.id
 
         # Retrieve the agent using the assistant_id
         retrieved_agent: OpenAIAssistantAgent = await OpenAIAssistantAgent.retrieve(

--- a/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/azure_assistant_agent.py
@@ -361,7 +361,20 @@ class AzureAssistantAgent(OpenAIAssistantBase):
         assistant = await client.beta.assistants.retrieve(id)
         assistant_definition = OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
 
-        return AzureAssistantAgent(kernel=kernel, assistant=assistant, **assistant_definition)
+        return AzureAssistantAgent(
+            kernel=kernel,
+            assistant=assistant,
+            client=client,
+            ad_token=ad_token,
+            api_key=api_key,
+            endpoint=endpoint,
+            api_version=api_version,
+            default_headers=default_headers,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+            token_endpoint=token_endpoint,
+            **assistant_definition,
+        )
 
     @staticmethod
     def _setup_client_and_token(
@@ -393,7 +406,9 @@ class AzureAssistantAgent(OpenAIAssistantBase):
 
         # If we still have no credentials, we can't proceed
         if not client and not azure_openai_settings.api_key and not ad_token and not ad_token_provider:
-            raise AgentInitializationException("Please provide either api_key, ad_token or ad_token_provider.")
+            raise AgentInitializationException(
+                "Please provide either a client, an api_key, ad_token or ad_token_provider."
+            )
 
         # Build the client if it's not supplied
         if not client:

--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
@@ -412,6 +412,15 @@ class OpenAIAssistantAgent(OpenAIAssistantBase):
             )
         assistant = await client.beta.assistants.retrieve(id)
         assistant_definition = OpenAIAssistantBase._create_open_ai_assistant_definition(assistant)
-        return OpenAIAssistantAgent(kernel=kernel, assistant=assistant, **assistant_definition)
+        return OpenAIAssistantAgent(
+            kernel=kernel,
+            assistant=assistant,
+            client=client,
+            api_key=api_key,
+            default_headers=default_headers,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+            **assistant_definition,
+        )
 
     # endregion


### PR DESCRIPTION
### Motivation and Context

The assistant retrieval methods for OpenAI and AzureOpenAI didn't propagate the api_key or client, if specified. For AzureOpenAI, it's also important to propagate more settings info.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR:
- improves the handling for retrieving an agent by making sure we pass along specified keyword arguments
- adds unit tests to ensure the new functionality works as expected

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
