### PR TITLE
Python: Temporarily xFail some google ai integration tests to unblock

### DIFF
--- a/python/tests/integration/completions/test_chat_completion_with_function_calling.py
+++ b/python/tests/integration/completions/test_chat_completion_with_function_calling.py
@@ -503,7 +503,13 @@ pytestmark = pytest.mark.parametrize(
                 ]
             ],
             {"test_type": FunctionChoiceTestTypes.AUTO},
-            marks=pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+            marks=[
+                pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+                pytest.mark.xfail(
+                    reason="Temporarily failing due to Google AI API issue on streaming only: "
+                    "400 Function calling is not enabled for models/gemini-1.5-flash"
+                ),
+            ],
             id="google_ai_tool_call_auto",
         ),
         pytest.param(
@@ -523,7 +529,13 @@ pytestmark = pytest.mark.parametrize(
                 ]
             ],
             {"test_type": FunctionChoiceTestTypes.NON_AUTO},
-            marks=pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+            marks=[
+                pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+                pytest.mark.xfail(
+                    reason="Temporarily failing due to Google AI API issue on streaming only: "
+                    "400 Function calling is not enabled for models/gemini-1.5-flash"
+                ),
+            ],
             id="google_ai_tool_call_non_auto",
         ),
         pytest.param(
@@ -569,7 +581,13 @@ pytestmark = pytest.mark.parametrize(
                 ]
             ],
             {"test_type": FunctionChoiceTestTypes.AUTO},
-            marks=pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+            marks=[
+                pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+                pytest.mark.xfail(
+                    reason="Temporarily failing due to Google AI API issue on streaming only: "
+                    "400 Function calling is not enabled for models/gemini-1.5-flash"
+                ),
+            ],
             id="google_ai_tool_call_auto_complex_return_type",
         ),
         # endregion

--- a/python/tests/integration/completions/test_chat_completion_with_image_input_text_output.py
+++ b/python/tests/integration/completions/test_chat_completion_with_image_input_text_output.py
@@ -183,7 +183,13 @@ pytestmark = pytest.mark.parametrize(
                 ),
             ],
             {},
-            marks=pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+            marks=[
+                pytest.mark.skipif(not google_ai_setup, reason="Google AI Environment Variables not set"),
+                pytest.mark.xfail(
+                    reason="Temporarily failing due to Google AI API issue on streaming only: "
+                    "400 Image input modality is not enabled for models/gemini-1.5-flash"
+                ),
+            ],
             id="google_ai_image_input_file",
         ),
         pytest.param(


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
This pull request includes updates to the test cases in the `python/tests/integration/completions/test_chat_completion_with_function_calling.py` and `python/tests/integration/completions/test_chat_completion_with_image_input_text_output.py` files. The changes primarily address the handling of Google AI API issues by adding markers to the tests.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
* [`python/tests/integration/completions/test_chat_completion_with_function_calling.py`](diffhunk://#diff-530ae449ac82bcd42280dcf440a135e38acc53a5362940fdbb64edfdc4300abcL506-R512): Added `xfail` markers to multiple test cases to handle temporary failures due to Google AI API issues related to function calling not being enabled for models/gemini-1.5-flash. [[1]](diffhunk://#diff-530ae449ac82bcd42280dcf440a135e38acc53a5362940fdbb64edfdc4300abcL506-R512) [[2]](diffhunk://#diff-530ae449ac82bcd42280dcf440a135e38acc53a5362940fdbb64edfdc4300abcL526-R538) [[3]](diffhunk://#diff-530ae449ac82bcd42280dcf440a135e38acc53a5362940fdbb64edfdc4300abcL572-R590)
* [`python/tests/integration/completions/test_chat_completion_with_image_input_text_output.py`](diffhunk://#diff-9c1b24d0f91106612c3b55b1f63122811cf4d3cb6dbc6908e50b8a3804bd42ecL186-R192): Added an `xfail` marker to handle temporary failure due to Google AI API issues related to image input modality not being enabled for models/gemini-1.5-flash.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
