### PR TITLE
.Net: Allow strings to be passed for int arguments in TextSearch KernelFunctions

### DIFF
--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
@@ -390,9 +390,16 @@ public static class TextSearchExtensions
     /// <param name="defaultValue">Default value of the argument.</param>
     private static int GetArgumentValue(KernelArguments arguments, IReadOnlyList<KernelParameterMetadata> parameters, string name, int defaultValue)
     {
-        if (arguments.TryGetValue(name, out var value) && value is int argument)
+        if (arguments.TryGetValue(name, out var value))
         {
-            return argument;
+            if (value is int argument)
+            {
+                return argument;
+            }
+            else if (value is string argumentString && int.TryParse(argumentString, out var parsedArgument))
+            {
+                return parsedArgument;
+            }
         }
 
         value = parameters.FirstOrDefault(parameter => parameter.Name == name)?.DefaultValue;

--- a/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchExtensionsTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/TextSearchExtensionsTests.cs
@@ -149,6 +149,21 @@ public class TextSearchExtensionsTests
         Assert.Equal(5, results.Count());
     }
 
+    [Theory]
+    [MemberData(nameof(StandardFunctions))]
+    public async Task CountCanBeOverriddenInArgumentsWithStringAsync(KernelFunction function, string _)
+    {
+        // Act
+        var result = await function.InvokeAsync(new(), new() { ["query"] = "What is the Semantic Kernel?", ["count"] = "5" });
+
+        // Assert
+        Assert.NotNull(result);
+        var results = result.GetValue<IEnumerable<object>>();
+        Assert.NotNull(results);
+        Assert.NotEmpty(results);
+        Assert.Equal(5, results.Count());
+    }
+
     #region private
     /// <summary>
     /// Create the default <see cref="KernelFunctionFromMethodOptions"/> for <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.


### PR DESCRIPTION
### Motivation and Context

The `GetArgumentValue` method that is called as part of creating KernelFunctions for TextSearch in `TestSearchExtensions` requires that arguments be passed as integers for "count" and "skip". While using this functionality with a gpt-4o model through Azure OpenAI, the function calls were given arguments that had values encoded as strings. This caused the default count of 2 to always be used, no matter what the LLM was calling for. I noticed this behavior even if I explicitly set the ParameteryType of the KernelParameterMetadata to be int. 

### Description

This changes the `GetArgumentValue` method in `TextSearchExtensions` to allow for integers passed as string values. This will avoid the confusing behavior of the arguments being ignored for TextSearch plugins.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
