### PR TITLE
Python: Configure top_p and temp for assistant agents if configured

### DIFF
--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
@@ -277,6 +277,12 @@ class OpenAIAssistantBase(Agent):
         if self.max_prompt_tokens:
             execution_settings["max_prompt_tokens"] = self.max_prompt_tokens
 
+        if self.top_p:
+            execution_settings["top_p"] = self.top_p
+
+        if self.temperature:
+            execution_settings["temperature"] = self.temperature
+
         if self.parallel_tool_calls_enabled:
             execution_settings["parallel_tool_calls_enabled"] = self.parallel_tool_calls_enabled
 

--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_base.py
@@ -270,18 +270,20 @@ class OpenAIAssistantBase(Agent):
         if kwargs:
             create_assistant_kwargs.update(kwargs)
 
-        execution_settings = {}
+        execution_settings: dict[str, Any] = {}
         if self.max_completion_tokens:
             execution_settings["max_completion_tokens"] = self.max_completion_tokens
 
         if self.max_prompt_tokens:
             execution_settings["max_prompt_tokens"] = self.max_prompt_tokens
 
-        if self.top_p:
+        if self.top_p is not None:
             execution_settings["top_p"] = self.top_p
+            create_assistant_kwargs["top_p"] = self.top_p
 
-        if self.temperature:
+        if self.temperature is not None:
             execution_settings["temperature"] = self.temperature
+            create_assistant_kwargs["temperature"] = self.temperature
 
         if self.parallel_tool_calls_enabled:
             execution_settings["parallel_tool_calls_enabled"] = self.parallel_tool_calls_enabled


### PR DESCRIPTION
### Motivation and Context

The assistant agent class was storing top_p and temp, but never sending it during agent creation.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Send the top_p and temp params if configured while creating an assistant agent.
- Closes #10162

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile: