### PR TITLE
.Net: Fixing distance functions for Pinecone, Weaviate and Redis and adding integration tests for score testing for these.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreCollectionCreateMapping.cs
@@ -39,7 +39,7 @@ internal static class PineconeVectorStoreCollectionCreateMapping
         {
             DistanceFunction.CosineSimilarity => Metric.Cosine,
             DistanceFunction.DotProductSimilarity => Metric.DotProduct,
-            DistanceFunction.EuclideanDistance => Metric.Euclidean,
+            DistanceFunction.EuclideanSquaredDistance => Metric.Euclidean,
             null => Metric.Cosine,
             _ => throw new InvalidOperationException($"Distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' is not supported by the Pinecone VectorStore.")
         };

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionCreateMapping.cs
@@ -179,7 +179,7 @@ internal static class RedisVectorStoreCollectionCreateMapping
             DistanceFunction.CosineSimilarity => "COSINE",
             DistanceFunction.CosineDistance => "COSINE",
             DistanceFunction.DotProductSimilarity => "IP",
-            DistanceFunction.EuclideanDistance => "L2",
+            DistanceFunction.EuclideanSquaredDistance => "L2",
             _ => throw new InvalidOperationException($"Distance function '{vectorProperty.DistanceFunction}' for {nameof(VectorStoreRecordVectorProperty)} '{vectorProperty.DataModelPropertyName}' is not supported by the Redis VectorStore.")
         };
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
@@ -159,7 +159,7 @@ internal static class RedisVectorStoreCollectionSearchMapping
             DistanceFunction.CosineSimilarity => 1 - redisScore,
             DistanceFunction.CosineDistance => redisScore,
             DistanceFunction.DotProductSimilarity => redisScore,
-            DistanceFunction.EuclideanDistance => redisScore,
+            DistanceFunction.EuclideanSquaredDistance => redisScore,
             _ => throw new InvalidOperationException($"The distance function '{distanceFunction}' is not supported."),
         };
     }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreCollectionCreateMapping.cs
@@ -112,7 +112,7 @@ internal static class WeaviateVectorStoreCollectionCreateMapping
         return distanceFunction switch
         {
             DistanceFunction.CosineDistance => Cosine,
-            DistanceFunction.DotProductSimilarity => Dot,
+            DistanceFunction.NegativeDotProduct => Dot,
             DistanceFunction.EuclideanSquaredDistance => EuclideanSquared,
             DistanceFunction.Hamming => Hamming,
             DistanceFunction.ManhattanDistance => Manhattan,
@@ -120,7 +120,7 @@ internal static class WeaviateVectorStoreCollectionCreateMapping
                 $"Distance function '{distanceFunction}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorPropertyName}' is not supported by the Weaviate VectorStore. " +
                 $"Supported distance functions: {string.Join(", ",
                     DistanceFunction.CosineDistance,
-                    DistanceFunction.DotProductSimilarity,
+                    DistanceFunction.NegativeDotProduct,
                     DistanceFunction.EuclideanSquaredDistance,
                     DistanceFunction.Hamming,
                     DistanceFunction.ManhattanDistance)}")

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreCollectionCreateMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreCollectionCreateMapping.cs
@@ -112,7 +112,7 @@ internal static class WeaviateVectorStoreCollectionCreateMapping
         return distanceFunction switch
         {
             DistanceFunction.CosineDistance => Cosine,
-            DistanceFunction.NegativeDotProduct => Dot,
+            DistanceFunction.NegativeDotProductSimilarity => Dot,
             DistanceFunction.EuclideanSquaredDistance => EuclideanSquared,
             DistanceFunction.Hamming => Hamming,
             DistanceFunction.ManhattanDistance => Manhattan,
@@ -120,7 +120,7 @@ internal static class WeaviateVectorStoreCollectionCreateMapping
                 $"Distance function '{distanceFunction}' on {nameof(VectorStoreRecordVectorProperty)} '{vectorPropertyName}' is not supported by the Weaviate VectorStore. " +
                 $"Supported distance functions: {string.Join(", ",
                     DistanceFunction.CosineDistance,
-                    DistanceFunction.NegativeDotProduct,
+                    DistanceFunction.NegativeDotProductSimilarity,
                     DistanceFunction.EuclideanSquaredDistance,
                     DistanceFunction.Hamming,
                     DistanceFunction.ManhattanDistance)}")

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionCreateMappingTests.cs
@@ -35,7 +35,7 @@ public class RedisVectorStoreCollectionCreateMappingTests
             new VectorStoreRecordDataProperty("NonFilterableString", typeof(string)),
 
             new VectorStoreRecordVectorProperty("VectorDefaultIndexingOptions", typeof(ReadOnlyMemory<float>)) { Dimensions = 10 },
-            new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions", typeof(ReadOnlyMemory<float>)) { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanDistance },
+            new VectorStoreRecordVectorProperty("VectorSpecificIndexingOptions", typeof(ReadOnlyMemory<float>)) { Dimensions = 20, IndexKind = IndexKind.Flat, DistanceFunction = DistanceFunction.EuclideanSquaredDistance },
         };
 
         var storagePropertyNames = new Dictionary<string, string>()

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisVectorStoreCollectionSearchMappingTests.cs
@@ -254,7 +254,7 @@ public class RedisVectorStoreCollectionSearchMappingTests
     [Theory]
     [InlineData(DistanceFunction.CosineDistance, 2)]
     [InlineData(DistanceFunction.DotProductSimilarity, 2)]
-    [InlineData(DistanceFunction.EuclideanDistance, 2)]
+    [InlineData(DistanceFunction.EuclideanSquaredDistance, 2)]
     public void GetOutputScoreFromRedisScoreLeavesNonConsineSimilarityUntouched(string distanceFunction, float score)
     {
         // Act & Assert.

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreCollectionCreateMappingTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreCollectionCreateMappingTests.cs
@@ -80,7 +80,7 @@ public sealed class WeaviateVectorStoreCollectionCreateMappingTests
 
     [Theory]
     [InlineData(DistanceFunction.CosineDistance, "cosine")]
-    [InlineData(DistanceFunction.DotProductSimilarity, "dot")]
+    [InlineData(DistanceFunction.NegativeDotProductSimilarity, "dot")]
     [InlineData(DistanceFunction.EuclideanSquaredDistance, "l2-squared")]
     [InlineData(DistanceFunction.Hamming, "hamming")]
     [InlineData(DistanceFunction.ManhattanDistance, "manhattan")]

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/DistanceFunction.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/DistanceFunction.cs
@@ -48,9 +48,9 @@ public static class DistanceFunction
     /// </summary>
     /// <remarks>
     /// The value of NegativeDotProduct = -1 * DotProductSimilarity.
-    /// The higher the value, the greater the distance beteen the vectors and the less similar the vectors.
+    /// The higher the value, the greater the distance between the vectors and the less similar the vectors.
     /// </remarks>
-    public const string NegativeDotProduct = nameof(NegativeDotProduct);
+    public const string NegativeDotProductSimilarity = nameof(NegativeDotProductSimilarity);
 
     /// <summary>
     /// Measures the Euclidean distance between two vectors.

--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/DistanceFunction.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/DistanceFunction.cs
@@ -39,9 +39,18 @@ public static class DistanceFunction
     /// Measures both the length and angle between two vectors.
     /// </summary>
     /// <remarks>
-    /// Same as cosine similarity if the vectors are the same length, but more performant.
+    /// The higher the value, the more similar the vectors.
     /// </remarks>
     public const string DotProductSimilarity = nameof(DotProductSimilarity);
+
+    /// <summary>
+    /// Measures both the length and angle between two vectors.
+    /// </summary>
+    /// <remarks>
+    /// The value of NegativeDotProduct = -1 * DotProductSimilarity.
+    /// The higher the value, the greater the distance beteen the vectors and the less similar the vectors.
+    /// </remarks>
+    public const string NegativeDotProduct = nameof(NegativeDotProduct);
 
     /// <summary>
     /// Measures the Euclidean distance between two vectors.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseVectorStoreRecordCollectionTests.cs
@@ -62,7 +62,7 @@ public abstract class BaseVectorStoreRecordCollectionTests<TKey>
         // Arrange
         var definition = CreateKeyWithVectorRecordDefinition(4, distanceFunction);
         var sut = this.GetTargetRecordCollection<KeyWithVectorRecord<TKey>>(
-            $"scorebydistancefunction{distanceFunction}",
+            $"scorebydf{distanceFunction}",
             definition);
 
         await sut.CreateCollectionIfNotExistsAsync();

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/CommonPineconeVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/CommonPineconeVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.Pinecone;
+using SemanticKernel.IntegrationTests.Connectors.Memory.Pinecone.Xunit;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Pinecone;
+
+/// <summary>
+/// Inherits common integration tests that should pass for any <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+/// </summary>
+/// <param name="fixture">Pinecone setup and teardown.</param>
+[Collection("PineconeVectorStoreTests")]
+[PineconeApiKeySetCondition]
+public class CommonPineconeVectorStoreRecordCollectionTests(PineconeVectorStoreFixture fixture) : BaseVectorStoreRecordCollectionTests<string>, IClassFixture<PineconeVectorStoreFixture>
+{
+    protected override string Key1 => "1";
+    protected override string Key2 => "2";
+    protected override string Key3 => "3";
+    protected override string Key4 => "4";
+
+    protected override int DelayAfterIndexCreateInMilliseconds => 2000;
+
+    protected override int DelayAfterUploadInMilliseconds => 15000;
+
+    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Pinecone collection names should be lower case.")]
+    protected override IVectorStoreRecordCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    {
+        return new PineconeVectorStoreRecordCollection<TRecord>(fixture.Client, recordCollectionName.ToLowerInvariant(), new()
+        {
+            VectorStoreRecordDefinition = vectorStoreRecordDefinition
+        });
+    }
+
+    protected override HashSet<string> GetSupportedDistanceFunctions()
+    {
+        return [DistanceFunction.CosineSimilarity, DistanceFunction.DotProductSimilarity, DistanceFunction.EuclideanSquaredDistance];
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/CommonPineconeVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/CommonPineconeVectorStoreRecordCollectionTests.cs
@@ -9,13 +9,17 @@ using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.Pinecone;
 
+// Disable unused class warning, as this class is marked internal to disable the tests in the base class.
+#pragma warning disable CA1812
+#pragma warning disable CA1852
+
 /// <summary>
 /// Inherits common integration tests that should pass for any <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
 /// </summary>
 /// <param name="fixture">Pinecone setup and teardown.</param>
 [Collection("PineconeVectorStoreTests")]
 [PineconeApiKeySetCondition]
-public class CommonPineconeVectorStoreRecordCollectionTests(PineconeVectorStoreFixture fixture) : BaseVectorStoreRecordCollectionTests<string>, IClassFixture<PineconeVectorStoreFixture>
+internal class CommonPineconeVectorStoreRecordCollectionTests(PineconeVectorStoreFixture fixture) : BaseVectorStoreRecordCollectionTests<string>, IClassFixture<PineconeVectorStoreFixture>
 {
     protected override string Key1 => "1";
     protected override string Key2 => "2";

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisHashsetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisHashsetVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.Redis;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
+
+// Disable unused class warning, as this class is marked internal to disable the tests in the base class.
+#pragma warning disable CA1812
+#pragma warning disable CA1852
+
+/// <summary>
+/// Inherits common integration tests that should pass for any <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+/// </summary>
+/// <param name="fixture">Redis setup and teardown.</param>
+[Collection("RedisVectorStoreCollection")]
+internal class CommonRedisHashsetVectorStoreRecordCollectionTests(RedisVectorStoreFixture fixture) : BaseVectorStoreRecordCollectionTests<string>
+{
+    protected override string Key1 => "1";
+    protected override string Key2 => "2";
+    protected override string Key3 => "3";
+    protected override string Key4 => "4";
+
+    protected override IVectorStoreRecordCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    {
+        return new RedisHashSetVectorStoreRecordCollection<TRecord>(fixture.Database, recordCollectionName + "hashset", new()
+        {
+            VectorStoreRecordDefinition = vectorStoreRecordDefinition
+        });
+    }
+
+    protected override HashSet<string> GetSupportedDistanceFunctions()
+    {
+        // Excluding DotProductSimilarity from the test even though Redis supports it, because the values that redis returns
+        // are neither DotProductSimilarity nor NegativeDotProduct, but rather 1 - DotProductSimilarity.
+        return [DistanceFunction.CosineDistance, DistanceFunction.CosineSimilarity, DistanceFunction.EuclideanSquaredDistance];
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/CommonRedisJsonVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.Redis;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Redis;
+
+// Disable unused class warning, as this class is marked internal to disable the tests in the base class.
+#pragma warning disable CA1812
+#pragma warning disable CA1852
+
+/// <summary>
+/// Inherits common integration tests that should pass for any <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+/// </summary>
+/// <param name="fixture">Redis setup and teardown.</param>
+[Collection("RedisVectorStoreCollection")]
+internal class CommonRedisJsonVectorStoreRecordCollectionTests(RedisVectorStoreFixture fixture) : BaseVectorStoreRecordCollectionTests<string>
+{
+    protected override string Key1 => "1";
+    protected override string Key2 => "2";
+    protected override string Key3 => "3";
+    protected override string Key4 => "4";
+
+    protected override IVectorStoreRecordCollection<string, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    {
+        return new RedisJsonVectorStoreRecordCollection<TRecord>(fixture.Database, recordCollectionName + "json", new()
+        {
+            VectorStoreRecordDefinition = vectorStoreRecordDefinition
+        });
+    }
+
+    protected override HashSet<string> GetSupportedDistanceFunctions()
+    {
+        // Excluding DotProductSimilarity from the test even though Redis supports it, because the values that redis returns
+        // are neither DotProductSimilarity nor NegativeDotProduct, but rather 1 - DotProductSimilarity.
+        return [DistanceFunction.CosineDistance, DistanceFunction.CosineSimilarity, DistanceFunction.EuclideanSquaredDistance];
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.Weaviate;
+using Xunit;
+
+namespace SemanticKernel.IntegrationTests.Connectors.Memory.Weaviate;
+
+/// <summary>
+/// Inherits common integration tests that should pass for any <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+/// </summary>
+/// <param name="fixture">Weaviate setup and teardown.</param>
+[Collection("WeaviateVectorStoreCollection")]
+public class CommonWeaviateVectorStoreRecordCollectionTests(WeaviateVectorStoreFixture fixture) : BaseVectorStoreRecordCollectionTests<Guid>
+{
+    protected override Guid Key1 => new("11111111-1111-1111-1111-111111111111");
+    protected override Guid Key2 => new("22222222-2222-2222-2222-222222222222");
+    protected override Guid Key3 => new("33333333-3333-3333-3333-333333333333");
+    protected override Guid Key4 => new("44444444-4444-4444-4444-444444444444");
+
+    protected override int DelayAfterUploadInMilliseconds => 1000;
+
+    protected override IVectorStoreRecordCollection<Guid, TRecord> GetTargetRecordCollection<TRecord>(string recordCollectionName, VectorStoreRecordDefinition? vectorStoreRecordDefinition)
+    {
+        // Weaviate collection names must start with an upper case letter.
+        var recordCollectionNameChars = recordCollectionName.ToCharArray();
+        recordCollectionNameChars[0] = char.ToUpperInvariant(recordCollectionNameChars[0]);
+
+        return new WeaviateVectorStoreRecordCollection<TRecord>(fixture.HttpClient!, new string(recordCollectionNameChars), new()
+        {
+            VectorStoreRecordDefinition = vectorStoreRecordDefinition
+        });
+    }
+
+    protected override HashSet<string> GetSupportedDistanceFunctions()
+    {
+        return [DistanceFunction.CosineDistance, DistanceFunction.NegativeDotProduct, DistanceFunction.EuclideanSquaredDistance, DistanceFunction.Hamming, DistanceFunction.ManhattanDistance];
+    }
+}

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/CommonWeaviateVectorStoreRecordCollectionTests.cs
@@ -36,6 +36,6 @@ public class CommonWeaviateVectorStoreRecordCollectionTests(WeaviateVectorStoreF
 
     protected override HashSet<string> GetSupportedDistanceFunctions()
     {
-        return [DistanceFunction.CosineDistance, DistanceFunction.NegativeDotProduct, DistanceFunction.EuclideanSquaredDistance, DistanceFunction.Hamming, DistanceFunction.ManhattanDistance];
+        return [DistanceFunction.CosineDistance, DistanceFunction.NegativeDotProductSimilarity, DistanceFunction.EuclideanSquaredDistance, DistanceFunction.Hamming, DistanceFunction.ManhattanDistance];
     }
 }


### PR DESCRIPTION
### Motivation and Context

#10103

### Description

- Adding integration tests for Pinecone, Weaviate and Redis.
- Changing EuclideanDistance to EuclideanSquaredDistance for Redis and Pinecone
- Changing DotProductSimilarity to NegativeDotProduct for Weaviate

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
