### PR TITLE
Python: Update gen_ai traces and logs

### DIFF
--- a/python/semantic_kernel/utils/telemetry/model_diagnostics/gen_ai_attributes.py
+++ b/python/semantic_kernel/utils/telemetry/model_diagnostics/gen_ai_attributes.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from semantic_kernel.contents.utils.author_role import AuthorRole
+
 # Constants for tracing activities with semantic conventions.
 # Ideally, we should use the attributes from the semcov package.
 # However, many of the attributes are not yet available in the package,
@@ -36,3 +38,11 @@ PROMPT = "gen_ai.prompt"
 
 # Kernel specific attributes
 AVAILABLE_FUNCTIONS = "sk.available_functions"
+
+
+ROLE_EVENT_MAP = {
+    AuthorRole.SYSTEM: SYSTEM_MESSAGE,
+    AuthorRole.USER: USER_MESSAGE,
+    AuthorRole.ASSISTANT: ASSISTANT_MESSAGE,
+    AuthorRole.TOOL: TOOL_MESSAGE,
+}

--- a/python/semantic_kernel/utils/telemetry/model_diagnostics/gen_ai_attributes.py
+++ b/python/semantic_kernel/utils/telemetry/model_diagnostics/gen_ai_attributes.py
@@ -6,27 +6,33 @@
 # so we define them here for now.
 
 # Activity tags
-SYSTEM = "gen_ai.system"
 OPERATION = "gen_ai.operation.name"
-MODEL = "gen_ai.request.model"
-MAX_TOKENS = "gen_ai.request.max_tokens"  # nosec
-TEMPERATURE = "gen_ai.request.temperature"
-TOP_P = "gen_ai.request.top_p"
-RESPONSE_ID = "gen_ai.response.id"
-FINISH_REASON = "gen_ai.response.finish_reason"
-PROMPT_TOKENS = "gen_ai.response.prompt_tokens"  # nosec
-COMPLETION_TOKENS = "gen_ai.response.completion_tokens"  # nosec
-ADDRESS = "server.address"
-PORT = "server.port"
+SYSTEM = "gen_ai.system"
 ERROR_TYPE = "error.type"
+MODEL = "gen_ai.request.model"
+SEED = "gen_ai.request.seed"
+PORT = "server.port"
+ENCODING_FORMATS = "gen_ai.request.encoding_formats"
+FREQUENCY_PENALTY = "gen_ai.request.frequency_penalty"
+MAX_TOKENS = "gen_ai.request.max_tokens"
+STOP_SEQUENCES = "gen_ai.request.stop_sequences"
+TEMPERATURE = "gen_ai.request.temperature"
+TOP_K = "gen_ai.request.top_k"
+TOP_P = "gen_ai.request.top_p"
+FINISH_REASON = "gen_ai.response.finish_reason"
+RESPONSE_ID = "gen_ai.response.id"
+INPUT_TOKENS = "gen_ai.usage.input_tokens"
+OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+ADDRESS = "server.address"
 
 # Activity events
-PROMPT_EVENT = "gen_ai.content.prompt"
-COMPLETION_EVENT = "gen_ai.content.completion"
-
-# Activity event attributes
-PROMPT_EVENT_PROMPT = "gen_ai.prompt"
-COMPLETION_EVENT_COMPLETION = "gen_ai.completion"
+EVENT_NAME = "event.name"
+SYSTEM_MESSAGE = "gen_ai.system.message"
+USER_MESSAGE = "gen_ai.user.message"
+ASSISTANT_MESSAGE = "gen_ai.assistant.message"
+TOOL_MESSAGE = "gen_ai.tool.message"
+CHOICE = "gen_ai.choice"
+PROMPT = "gen_ai.prompt"
 
 # Kernel specific attributes
 AVAILABLE_FUNCTIONS = "sk.available_functions"

--- a/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_chat_completion.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from unittest.mock import patch
+import json
+from unittest.mock import call, patch
 
 import pytest
 from opentelemetry.trace import StatusCode
@@ -14,7 +15,7 @@ from semantic_kernel.exceptions.service_exceptions import ServiceResponseExcepti
 from semantic_kernel.utils.telemetry.model_diagnostics import gen_ai_attributes
 from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
     CHAT_COMPLETION_OPERATION,
-    _messages_to_openai_format,
+    ChatHistoryMessageTimestampFilter,
     trace_chat_completion,
 )
 from tests.unit.utils.model_diagnostics.conftest import MockChatCompletion
@@ -80,9 +81,11 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+@patch("semantic_kernel.utils.telemetry.model_diagnostics.decorators.logger")
 @patch("opentelemetry.trace.INVALID_SPAN")  # When no tracer provider is available, the span will be an INVALID_SPAN
 async def test_trace_chat_completion(
     mock_span,
+    mock_logger,
     execution_settings,
     mock_response,
     chat_history,
@@ -124,9 +127,18 @@ async def test_trace_chat_completion(
         if execution_settings.extension_data.get("top_p") is not None:
             mock_span.set_attribute.assert_any_call(gen_ai_attributes.TOP_P, execution_settings.extension_data["top_p"])
 
-        mock_span.add_event.assert_any_call(
-            gen_ai_attributes.PROMPT_EVENT,
-            {gen_ai_attributes.PROMPT_EVENT_PROMPT: _messages_to_openai_format(chat_history)},
+        mock_logger.info.assert_has_calls(
+            [
+                call(
+                    json.dumps(message.to_dict()),
+                    extra={
+                        gen_ai_attributes.EVENT_NAME: gen_ai_attributes.ROLE_EVENT_MAP.get(message.role),
+                        gen_ai_attributes.SYSTEM: MockChatCompletion.MODEL_PROVIDER_NAME,
+                        ChatHistoryMessageTimestampFilter.INDEX_KEY: idx,
+                    },
+                )
+            ]
+            for idx, message in enumerate(chat_history)
         )
 
         # After the call to the model
@@ -139,15 +151,20 @@ async def test_trace_chat_completion(
                 ",".join([str(completion.finish_reason) for completion in mock_response]),
             )
 
-        mock_span.add_event.assert_any_call(
-            gen_ai_attributes.COMPLETION_EVENT,
-            {gen_ai_attributes.COMPLETION_EVENT_COMPLETION: _messages_to_openai_format(mock_response)},
+        mock_logger.info.assert_any_call(
+            json.dumps({"message": results[0].to_dict(), "finish_reason": results[0].finish_reason}),
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.CHOICE,
+                gen_ai_attributes.SYSTEM: MockChatCompletion.MODEL_PROVIDER_NAME,
+            },
         )
 
 
+@patch("semantic_kernel.utils.telemetry.model_diagnostics.decorators.logger")
 @patch("opentelemetry.trace.INVALID_SPAN")  # When no tracer provider is available, the span will be an INVALID_SPAN
 async def test_trace_chat_completion_exception(
     mock_span,
+    mock_logger,
     execution_settings,
     mock_response,
     chat_history,
@@ -170,3 +187,17 @@ async def test_trace_chat_completion_exception(
         mock_span.set_status.assert_any_call(StatusCode.ERROR, repr(exception))
 
         mock_span.end.assert_any_call()
+
+        mock_logger.info.assert_has_calls(
+            [
+                call(
+                    json.dumps(message.to_dict()),
+                    extra={
+                        gen_ai_attributes.EVENT_NAME: gen_ai_attributes.ROLE_EVENT_MAP.get(message.role),
+                        gen_ai_attributes.SYSTEM: MockChatCompletion.MODEL_PROVIDER_NAME,
+                        ChatHistoryMessageTimestampFilter.INDEX_KEY: idx,
+                    },
+                )
+            ]
+            for idx, message in enumerate(chat_history)
+        )

--- a/python/tests/unit/utils/model_diagnostics/test_trace_streaming_text_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_streaming_text_completion.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import json
 from collections.abc import AsyncGenerator
 from functools import reduce
 from unittest.mock import ANY, MagicMock, patch
@@ -14,7 +15,6 @@ from semantic_kernel.exceptions.service_exceptions import ServiceResponseExcepti
 from semantic_kernel.utils.telemetry.model_diagnostics import gen_ai_attributes
 from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
     TEXT_STREAMING_COMPLETION_OPERATION,
-    _messages_to_openai_format,
     trace_streaming_text_completion,
 )
 from tests.unit.utils.model_diagnostics.conftest import MockTextCompletion
@@ -68,9 +68,11 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+@patch("semantic_kernel.utils.telemetry.model_diagnostics.decorators.logger")
 @patch("opentelemetry.trace.INVALID_SPAN")  # When no tracer provider is available, the span will be an INVALID_SPAN
 async def test_trace_streaming_text_completion(
     mock_span,
+    mock_logger,
     execution_settings,
     mock_response,
     prompt,
@@ -117,8 +119,12 @@ async def test_trace_streaming_text_completion(
         if execution_settings.extension_data.get("top_p") is not None:
             mock_span.set_attribute.assert_any_call(gen_ai_attributes.TOP_P, execution_settings.extension_data["top_p"])
 
-        mock_span.add_event.assert_any_call(
-            gen_ai_attributes.PROMPT_EVENT, {gen_ai_attributes.PROMPT_EVENT_PROMPT: prompt}
+        mock_logger.info.assert_any_call(
+            prompt,
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.PROMPT,
+                gen_ai_attributes.SYSTEM: MockTextCompletion.MODEL_PROVIDER_NAME,
+            },
         )
 
         # After the call to the model
@@ -126,15 +132,20 @@ async def test_trace_streaming_text_completion(
         if mock_response[0].metadata.get("id") is not None:
             mock_span.set_attribute.assert_any_call(gen_ai_attributes.RESPONSE_ID, mock_response[0].metadata["id"])
 
-        mock_span.add_event.assert_any_call(
-            gen_ai_attributes.COMPLETION_EVENT,
-            {gen_ai_attributes.COMPLETION_EVENT_COMPLETION: _messages_to_openai_format(mock_response)},
+        mock_logger.info.assert_any_call(
+            json.dumps({"message": updates_flatten[0].to_dict(), "index": 0}),
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.CHOICE,
+                gen_ai_attributes.SYSTEM: MockTextCompletion.MODEL_PROVIDER_NAME,
+            },
         )
 
 
+@patch("semantic_kernel.utils.telemetry.model_diagnostics.decorators.logger")
 @patch("opentelemetry.trace.INVALID_SPAN")  # When no tracer provider is available, the span will be an INVALID_SPAN
 async def test_trace_streaming_text_completion_exception(
     mock_span,
+    mock_logger,
     execution_settings,
     mock_response,
     prompt,
@@ -158,3 +169,11 @@ async def test_trace_streaming_text_completion_exception(
         mock_span.set_status.assert_any_call(StatusCode.ERROR, repr(exception))
 
         mock_span.end.assert_any_call()
+
+        mock_logger.info.assert_any_call(
+            prompt,
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.PROMPT,
+                gen_ai_attributes.SYSTEM: MockTextCompletion.MODEL_PROVIDER_NAME,
+            },
+        )

--- a/python/tests/unit/utils/model_diagnostics/test_trace_text_completion.py
+++ b/python/tests/unit/utils/model_diagnostics/test_trace_text_completion.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import json
 from unittest.mock import ANY, patch
 
 import pytest
@@ -13,7 +14,6 @@ from semantic_kernel.exceptions.service_exceptions import ServiceResponseExcepti
 from semantic_kernel.utils.telemetry.model_diagnostics import gen_ai_attributes
 from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
     TEXT_COMPLETION_OPERATION,
-    _messages_to_openai_format,
     trace_text_completion,
 )
 from tests.unit.utils.model_diagnostics.conftest import MockTextCompletion
@@ -64,9 +64,11 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+@patch("semantic_kernel.utils.telemetry.model_diagnostics.decorators.logger")
 @patch("opentelemetry.trace.INVALID_SPAN")  # When no tracer provider is available, the span will be an INVALID_SPAN
 async def test_trace_text_completion(
     mock_span,
+    mock_logger,
     execution_settings,
     mock_response,
     prompt,
@@ -110,8 +112,12 @@ async def test_trace_text_completion(
         if execution_settings.extension_data.get("top_p") is not None:
             mock_span.set_attribute.assert_any_call(gen_ai_attributes.TOP_P, execution_settings.extension_data["top_p"])
 
-        mock_span.add_event.assert_any_call(
-            gen_ai_attributes.PROMPT_EVENT, {gen_ai_attributes.PROMPT_EVENT_PROMPT: prompt}
+        mock_logger.info.assert_any_call(
+            prompt,
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.PROMPT,
+                gen_ai_attributes.SYSTEM: MockTextCompletion.MODEL_PROVIDER_NAME,
+            },
         )
 
         # After the call to the model
@@ -119,15 +125,20 @@ async def test_trace_text_completion(
         if mock_response[0].metadata.get("id") is not None:
             mock_span.set_attribute.assert_any_call(gen_ai_attributes.RESPONSE_ID, mock_response[0].metadata["id"])
 
-        mock_span.add_event.assert_any_call(
-            gen_ai_attributes.COMPLETION_EVENT,
-            {gen_ai_attributes.COMPLETION_EVENT_COMPLETION: _messages_to_openai_format(mock_response)},
+        mock_logger.info.assert_any_call(
+            json.dumps({"message": results[0].to_dict()}),
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.CHOICE,
+                gen_ai_attributes.SYSTEM: MockTextCompletion.MODEL_PROVIDER_NAME,
+            },
         )
 
 
+@patch("semantic_kernel.utils.telemetry.model_diagnostics.decorators.logger")
 @patch("opentelemetry.trace.INVALID_SPAN")  # When no tracer provider is available, the span will be an INVALID_SPAN
 async def test_trace_text_completion_exception(
     mock_span,
+    mock_logger,
     execution_settings,
     mock_response,
     prompt,
@@ -150,3 +161,11 @@ async def test_trace_text_completion_exception(
         mock_span.set_status.assert_any_call(StatusCode.ERROR, repr(exception))
 
         mock_span.end.assert_any_call()
+
+        mock_logger.info.assert_any_call(
+            prompt,
+            extra={
+                gen_ai_attributes.EVENT_NAME: gen_ai_attributes.PROMPT,
+                gen_ai_attributes.SYSTEM: MockTextCompletion.MODEL_PROVIDER_NAME,
+            },
+        )


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The gen_ai semantic convention has gone through some updates since we started generating telemetry for gen_ai operations. We would like to align with the latest conventions, and most importantly allow our users to visualize the gen_ai traces on the Azure AI Foundry Tracing UI, which relies on the gen_ai conventions.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

1. Updates the gen_ai telemetry module to align with the latest gen_ai convention so that all AI connectors generate telemetry data that can be visualized on Azure AI Foundry.
2. Unit tests for the update.

> Note that this is a breaking change as this feature is still experimental. Anyone who is relying on the previous gen_ai conventions should also update.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
