### PR TITLE
.Net: Fixed the condition judgment of the TrackStreamingToolingUpdate method

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Core/OpenAIFunctionToolCallTests.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI.UnitTests/Core/OpenAIFunctionToolCallTests.cs
@@ -126,6 +126,7 @@ public sealed class OpenAIFunctionToolCallTests
             """, functionArgumentBuildersByIndex![0].ToString());
         Assert.Null(exception);
     }
+
     [Fact]
     public void TrackStreamingToolingUpdateWithEmptyIdNameDoesNotThrowException()
     {
@@ -133,31 +134,24 @@ public sealed class OpenAIFunctionToolCallTests
         Dictionary<int, string>? toolCallIdsByIndex = null;
         Dictionary<int, string>? functionNamesByIndex = null;
         Dictionary<int, StringBuilder>? functionArgumentBuildersByIndex = null;
-        IReadOnlyList<StreamingChatToolCallUpdate>? updates = [];
-        //This is a sample of SSE updates from Qwen model
-        var sseUpdates = @"{""function"":{""name"":""WeatherPlugin-GetWeather"",""arguments"":""{\""addressCode""},""index"":0,""id"":""call_74f02d5863864109bae3d1"",""type"":""function""}
-{""function"":{""name"":"""",""arguments"":""\"": \""44""},""index"":0,""id"":"""",""type"":""function""}
-{""function"":{""name"":"""",""arguments"":""0100""},""index"":0,""id"":"""",""type"":""function""}";
 
-        var sseLines = sseUpdates.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-        var sseUpdatesList = new List<StreamingChatToolCallUpdate>();
-        foreach (var item in sseLines)
-        {
-            sseUpdatesList.Add(GetUpdateChunkFromString(item));
-        }
         // Act
         var exception = Record.Exception(() =>
             OpenAIFunctionToolCall.TrackStreamingToolingUpdate(
-                sseUpdatesList,
+                [
+                    GetUpdateChunkFromString("""{"function":{"name":"WeatherPlugin-GetWeather","arguments":"{\"addressCode"},"index":0,"id":"call_74f02d5863864109bae3d1","type":"function"}"""),
+                    GetUpdateChunkFromString("""{"function":{"name":"","arguments":"\": \"44"},"index":0,"id":"","type":"function"}"""),
+                    GetUpdateChunkFromString("""{"function":{"name":"","arguments":"0100"},"index":0,"id":"","type":"function"}"""),
+                ],
                 ref toolCallIdsByIndex,
                 ref functionNamesByIndex,
                 ref functionArgumentBuildersByIndex
             ));
 
         // Assert
+        Assert.Null(exception);
         Assert.False(string.IsNullOrEmpty(toolCallIdsByIndex![0]));
         Assert.False(string.IsNullOrEmpty(functionNamesByIndex![0]));
-        Assert.Null(exception);
     }
 
     private static StreamingChatToolCallUpdate GetUpdateChunkFromString(string jsonChunk)

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/OpenAIFunctionToolCall.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/OpenAIFunctionToolCall.cs
@@ -109,15 +109,15 @@ public sealed class OpenAIFunctionToolCall
         {
             // If we have an ID, ensure the index is being tracked. Even if it's not a function update,
             // we want to keep track of it so we can send back an error.
-            if (update.ToolCallId is string id)
+            if (!string.IsNullOrWhiteSpace(update.ToolCallId))
             {
-                (toolCallIdsByIndex ??= [])[update.Index] = id;
+                (toolCallIdsByIndex ??= [])[update.Index] = update.ToolCallId;
             }
 
             // Ensure we're tracking the function's name.
-            if (update.FunctionName is string name)
+            if (!string.IsNullOrWhiteSpace(update.FunctionName))
             {
-                (functionNamesByIndex ??= [])[update.Index] = name;
+                (functionNamesByIndex ??= [])[update.Index] = update.FunctionName;
             }
 
             // Ensure we're tracking the function's arguments.

--- a/python/semantic_kernel/__init__.py
+++ b/python/semantic_kernel/__init__.py
@@ -2,5 +2,5 @@
 
 from semantic_kernel.kernel import Kernel
 
-__version__ = "1.18.1"
+__version__ = "1.18.2"
 __all__ = ["Kernel", "__version__"]


### PR DESCRIPTION
In the OpenAIFunctionToolCallTests.cs file, a new test method, TrackStreamingToolingUpdateWithEmptyIdNameDoesNotThrowException, has been added. This method tests that the TrackStreamingToolingUpdate method does not throw an exception when id and name are empty. In the OpenAIFunctionToolCall.cs file, two conditional judgments in the TrackStreamingToolingUpdate method have been modified:
* Replace if (update. ToolCallId is string id) to if (!string. IsNullOrWhiteSpace(update. ToolCallId)), make sure that the ToolCallId is neither empty nor full of whitespace.
* Replace if (update. FunctionName is string name) to if (!string. IsNullOrWhiteSpace(update. FunctionName)), making sure that FunctionName is neither empty nor full of whitespace.
