### PR TITLE
.Net: OllamaPromptExecutionSettings doesn't have NumPredict property

### DIFF
--- a/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Settings/OllamaPromptExecutionSettingsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama.UnitTests/Settings/OllamaPromptExecutionSettingsTests.cs
@@ -50,7 +50,8 @@ public class OllamaPromptExecutionSettingsTests
                                     "stop": ["stop me"],
                                     "temperature": 0.5,
                                     "top_p": 0.9,
-                                    "top_k": 100
+                                    "top_k": 100,
+                                    "num_predict": 50
                                 }
                                 """;
 
@@ -61,6 +62,7 @@ public class OllamaPromptExecutionSettingsTests
         Assert.Equal(0.5f, ollamaExecutionSettings.Temperature);
         Assert.Equal(0.9f, ollamaExecutionSettings.TopP!.Value, 0.1f);
         Assert.Equal(100, ollamaExecutionSettings.TopK);
+        Assert.Equal(50, ollamaExecutionSettings.NumPredict);
     }
 
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaTextGenerationService.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Services/OllamaTextGenerationService.cs
@@ -131,7 +131,8 @@ public sealed class OllamaTextGenerationService : ServiceBase, ITextGenerationSe
                 Temperature = settings.Temperature,
                 TopP = settings.TopP,
                 TopK = settings.TopK,
-                Stop = settings.Stop?.ToArray()
+                Stop = settings.Stop?.ToArray(),
+                NumPredict = settings.NumPredict
             },
             Model = selectedModel,
             Stream = true

--- a/dotnet/src/Connectors/Connectors.Ollama/Settings/OllamaPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.Ollama/Settings/OllamaPromptExecutionSettings.cs
@@ -115,12 +115,29 @@ public sealed class OllamaPromptExecutionSettings : PromptExecutionSettings
         }
     }
 
+    /// <summary>
+    /// Maximum number of output tokens. (Default: -1, infinite generation)
+    /// </summary>
+    [JsonPropertyName("num_predict")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? NumPredict
+    {
+        get => this._numPredict;
+
+        set
+        {
+            this.ThrowIfFrozen();
+            this._numPredict = value;
+        }
+    }
+
     #region private
 
     private List<string>? _stop;
     private float? _temperature;
     private float? _topP;
     private int? _topK;
+    private int? _numPredict;
 
     #endregion
 }


### PR DESCRIPTION
### Motivation and Context

`OllamaPromptExecutionSettings` does not have property `NumPredict` that allows to limit maximum allowed tokens to generate

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Proposed change just add missing field to the `OllamaPromptExecutionSettings` and make sure it will be used also within CreateRequest of `OllamaTextGenerationService`

related issue: #10226

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
