### PR TITLE
Python: improve Makefile uv installation logic

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -43,7 +43,7 @@ ifndef UV_VERSION
 	curl -LsSf https://astral.sh/uv/install.sh | sh
 	echo "uv installed"
 	# Re-exec the shell so the newly installed uv is available immediately
-    exec $$SHELL
+	exec $$SHELL
 else
 	echo "uv found $(UV_VERSION)"
 	echo "running uv update"

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,13 +1,19 @@
 SHELL = /bin/bash
 
-.PHONY: help install clean build
-.SILENT:
+.PHONY: help install install-uv install-python install-pre-commit install-sk clean build
+.SILENT:  # not strictly required, but included per the original example
 all: install
 
 ifeq ($(PYTHON_VERSION),)
-    PYTHON_VERSION="3.10"
+    PYTHON_VERSION = 3.10
 endif
 
+# Detect uv on PATH
+UV_VERSION := $(shell command -v uv 2> /dev/null)
+
+##############################
+#  HELP
+##############################
 .ONESHELL:
 help:
 	echo -e "\033[1mUSAGE:\033[0m"
@@ -15,10 +21,10 @@ help:
 	echo ""
 	echo -e "\033[1mTARGETS:\033[0m"
 	echo "  help                 - show this help message"
-	echo "  install              - install uv, python, Semantic Kernel and all dependencies"
-	echo "      This is the default and will use Python 3.10."
+	echo "  install              - install uv, python, Semantic Kernel, and all dependencies"
+	echo "                        This is the default and will use Python 3.10."
 	echo "  install-uv           - install uv"
-	echo "  install-python       - install python distributions"
+	echo "  install-python       - install multiple python distributions"
 	echo "  install-sk           - install Semantic Kernel and all dependencies"
 	echo "  install-pre-commit   - install pre-commit hooks"
 	echo "  clean                - remove the virtualenvs"
@@ -26,52 +32,72 @@ help:
 	echo ""
 	echo -e "\033[1mVARIABLES:\033[0m"
 	echo "  PYTHON_VERSION       - Python version to use. Default is 3.10"
-	echo "      By default, 3.10, 3.11 and 3.12 are installed as well."
+	echo "                        By default, 3.10, 3.11, and 3.12 are installed as well."
 
+##############################
+#  INSTALL
+##############################
 install:
 	make install-uv
 	make install-python
 	make install-sk
 	make install-pre-commit
 
-UV_VERSION := $(shell command -v uv 2> /dev/null)
+##############################
+#  INSTALL-UV
+##############################
 install-uv:
-# Check if uv is installed
-ifndef UV_VERSION
-	echo "uv could not be found"
-	echo "Installing uv"
-	curl -LsSf https://astral.sh/uv/install.sh | sh
-	echo "uv installed"
-	# Re-exec the shell so the newly installed uv is available immediately
-	exec $$SHELL
+	# If uv is not found AND we haven't already re-invoked with CONTINUE=1...
+ifneq ($(UV_VERSION),)
+	echo "uv found at: $(UV_VERSION)"
+	echo "running uv self update"
+	uv self update
+else ifeq ($(CONTINUE),1)
+	echo "Skipping uv re-install; continuing with the rest of the steps."
 else
-	echo "uv found $(UV_VERSION)"
-	echo "running uv update"
-	uv self update 
+	echo "uv could not be found."
+	echo "Installing uv..."
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+	echo "uv installed."
+	echo "Re-executing shell so uv is immediately available on PATH..."
+	exec $$SHELL -c 'make install CONTINUE=1'
 endif
 
+##############################
+#  INSTALL-PYTHON
+##############################
 .ONESHELL:
 install-python:
 	echo "Installing python 3.10, 3.11, 3.12"
 	uv python install 3.10 3.11 3.12
 
+##############################
+#  INSTALL-PRE-COMMIT
+##############################
 .ONESHELL:
 install-pre-commit:
 	echo "Installing pre-commit hooks"
 	uv run pre-commit install -c python/.pre-commit-config.yaml
 
-
+##############################
+#  INSTALL-SK
+##############################
 .ONESHELL:
 install-sk:
 	echo "Creating and activating venv for python $(PYTHON_VERSION)"
 	uv venv --python $(PYTHON_VERSION)
 	echo "Installing Semantic Kernel and all dependencies"
 	uv sync --all-extras --dev
-	
+
+##############################
+#  CLEAN
+##############################
 .ONESHELL:
 clean:
-	# Remove the virtualenv
 	rm -rf .venv
 
+##############################
+#  BUILD
+##############################
 build:
 	uvx --from build pyproject-build --installer uv

--- a/python/Makefile
+++ b/python/Makefile
@@ -42,8 +42,8 @@ ifndef UV_VERSION
 	echo "Installing uv"
 	curl -LsSf https://astral.sh/uv/install.sh | sh
 	echo "uv installed"
-	echo "Please restart your shell."
-	exit 1
+	# Re-exec the shell so the newly installed uv is available immediately
+    exec $$SHELL
 else
 	echo "uv found $(UV_VERSION)"
 	echo "running uv update"


### PR DESCRIPTION
### Motivation and Context

Today, If a user runs `make install`, and the uv installation is not found, the current flow is to return `exit 1` to force the user to restart their shell. 

These changes update the Makefile to better handle the case where uv is not installed. The Makefile now uses a “second make invocation” approach with a CONTINUE variable to avoid re-installing uv in the newly spawned shell. If `uv` isn’t found, it installs `uv`, then executes a new shell which immediately calls `make install CONTINUE=1`, allowing the rest of the steps to continue in an environment that now has `uv` on the PATH.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR:
- Updates the make file to provide cleaner logic on handling the `make install` when `uv` isn't present.
- Closes #9067

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
