### PR TITLE
Python: bug fixes from graphrag insights

### DIFF
--- a/python/.vscode/tasks.json
+++ b/python/.vscode/tasks.json
@@ -135,7 +135,14 @@
         {
             "label": "Python: Tests - Code Coverage",
             "type": "shell",
-            "command": "uv run pytest --cov=semantic_kernel --cov-report=term-missing:skip-covered tests/unit/",
+            "command": "uv",
+            "args": [
+                "run",
+                "pytest",
+                "--cov=semantic_kernel",
+                "--cov-report=term-missing:skip-covered",
+                "tests/unit/"
+            ],
             "group": "test",
             "presentation": {
                 "reveal": "always",

--- a/python/semantic_kernel/agents/group_chat/broadcast_queue.py
+++ b/python/semantic_kernel/agents/group_chat/broadcast_queue.py
@@ -4,6 +4,7 @@
 import asyncio
 from collections import deque
 from dataclasses import dataclass, field
+from typing import Any
 
 from pydantic import Field, SkipValidation, ValidationError, model_validator
 
@@ -28,11 +29,12 @@ class QueueReference(KernelBaseModel):
         return len(self.queue) == 0
 
     @model_validator(mode="before")
-    def validate_receive_task(cls, values):
+    def validate_receive_task(cls, values: Any):
         """Validate the receive task."""
-        receive_task = values.get("receive_task")
-        if receive_task is not None and not isinstance(receive_task, asyncio.Task):
-            raise ValidationError("receive_task must be an instance of asyncio.Task or None")
+        if isinstance(values, dict):
+            receive_task = values.get("receive_task")
+            if receive_task is not None and not isinstance(receive_task, asyncio.Task):
+                raise ValidationError("receive_task must be an instance of asyncio.Task or None")
         return values
 
 

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
@@ -121,8 +121,10 @@ class OpenAIChatPromptExecutionSettings(OpenAIPromptExecutionSettings):
         return v
 
     @model_validator(mode="before")
-    def validate_response_format_and_set_flag(cls, values) -> Any:
+    def validate_response_format_and_set_flag(cls, values: Any) -> Any:
         """Validate the response_format and set structured_json_response accordingly."""
+        if not isinstance(values, dict):
+            return values
         response_format = values.get("response_format", None)
 
         if response_format is None:
@@ -153,7 +155,7 @@ class OpenAIChatPromptExecutionSettings(OpenAIPromptExecutionSettings):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_function_calling_behaviors(cls, data) -> Any:
+    def validate_function_calling_behaviors(cls, data: Any) -> Any:
         """Check if function_call_behavior is set and if so, move to use function_choice_behavior instead."""
         # In an attempt to phase out the use of `function_call_behavior` in favor of `function_choice_behavior`,
         # we are syncing the `function_call_behavior` with `function_choice_behavior` if the former is set.

--- a/python/semantic_kernel/connectors/ai/prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/prompt_execution_settings.py
@@ -38,14 +38,15 @@ class PromptExecutionSettings(KernelBaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def parse_function_choice_behavior(cls: type[_T], data: dict[str, Any]) -> dict[str, Any]:
+    def parse_function_choice_behavior(cls: type[_T], data: Any) -> dict[str, Any]:
         """Parse the function choice behavior data."""
-        function_choice_behavior_data = data.get("function_choice_behavior")
-        if function_choice_behavior_data:
-            if isinstance(function_choice_behavior_data, str):
-                data["function_choice_behavior"] = FunctionChoiceBehavior.from_string(function_choice_behavior_data)
-            elif isinstance(function_choice_behavior_data, dict):
-                data["function_choice_behavior"] = FunctionChoiceBehavior.from_dict(function_choice_behavior_data)
+        if isinstance(data, dict):
+            function_choice_behavior_data = data.get("function_choice_behavior")
+            if function_choice_behavior_data:
+                if isinstance(function_choice_behavior_data, str):
+                    data["function_choice_behavior"] = FunctionChoiceBehavior.from_string(function_choice_behavior_data)
+                elif isinstance(function_choice_behavior_data, dict):
+                    data["function_choice_behavior"] = FunctionChoiceBehavior.from_dict(function_choice_behavior_data)
         return data
 
     def __init__(self, service_id: str | None = None, **kwargs: Any):

--- a/python/semantic_kernel/connectors/memory/qdrant/qdrant_settings.py
+++ b/python/semantic_kernel/connectors/memory/qdrant/qdrant_settings.py
@@ -26,9 +26,15 @@ class QdrantSettings(KernelBaseSettings):
     prefer_grpc: bool = False
 
     @model_validator(mode="before")
-    def validate_settings(cls, values):
+    def validate_settings(cls, values: dict):
         """Validate the settings."""
-        if "url" not in values and "host" not in values and "path" not in values and "location" not in values:
+        if (
+            isinstance(values, dict)
+            and "url" not in values
+            and "host" not in values
+            and "path" not in values
+            and "location" not in values
+        ):
             values["location"] = IN_MEMORY_STRING
         return values
 

--- a/python/semantic_kernel/connectors/memory/weaviate/weaviate_settings.py
+++ b/python/semantic_kernel/connectors/memory/weaviate/weaviate_settings.py
@@ -39,24 +39,25 @@ class WeaviateSettings(KernelBaseSettings):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_settings(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def validate_settings(cls, data: Any) -> dict[str, Any]:
         """Validate Weaviate settings."""
-        enabled = sum([
-            cls.is_using_weaviate_cloud(data),
-            cls.is_using_local_weaviate(data),
-            cls.is_using_client_embedding(data),
-        ])
+        if isinstance(data, dict):
+            enabled = sum([
+                cls.is_using_weaviate_cloud(data),
+                cls.is_using_local_weaviate(data),
+                cls.is_using_client_embedding(data),
+            ])
 
-        if enabled == 0:
-            raise ServiceInvalidExecutionSettingsError(
-                "Weaviate settings must specify either a ",
-                "Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.",
-            )
-        if enabled > 1:
-            raise ServiceInvalidExecutionSettingsError(
-                "Weaviate settings must specify only one of the following: ",
-                "Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.",
-            )
+            if enabled == 0:
+                raise ServiceInvalidExecutionSettingsError(
+                    "Weaviate settings must specify either a ",
+                    "Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.",
+                )
+            if enabled > 1:
+                raise ServiceInvalidExecutionSettingsError(
+                    "Weaviate settings must specify only one of the following: ",
+                    "Weaviate Cloud instance, a local Weaviate instance, or the client embedding options.",
+                )
 
         return data
 

--- a/python/semantic_kernel/contents/utils/data_uri.py
+++ b/python/semantic_kernel/contents/utils/data_uri.py
@@ -41,9 +41,9 @@ class DataUri(KernelBaseModel, validate_assignment=True):
 
     @model_validator(mode="before")
     @classmethod
-    def _validate_data(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def _validate_data(cls, values: Any) -> dict[str, Any]:
         """Validate the data."""
-        if not values.get("data_bytes") and not values.get("data_str"):
+        if isinstance(values, dict) and not values.get("data_bytes") and not values.get("data_str"):
             raise ContentInitializationError("Either data_bytes or data_str must be provided.")
         return values
 

--- a/python/semantic_kernel/data/filter_clauses/any_tags_equal_to_filter_clause.py
+++ b/python/semantic_kernel/data/filter_clauses/any_tags_equal_to_filter_clause.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 
-from pydantic import Field
+from typing import ClassVar
 
 from semantic_kernel.data.filter_clauses.filter_clause_base import FilterClauseBase
 from semantic_kernel.utils.experimental_decorator import experimental_class
@@ -16,4 +16,4 @@ class AnyTagsEqualTo(FilterClauseBase):
         value: The value to compare against the list of tags.
     """
 
-    filter_clause_type: str = Field("any_tags_equal_to", init=False)  # type: ignore
+    filter_clause_type: ClassVar[str] = "any_tags_equal_to"

--- a/python/semantic_kernel/data/filter_clauses/equal_to_filter_clause.py
+++ b/python/semantic_kernel/data/filter_clauses/equal_to_filter_clause.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from pydantic import Field
+from typing import ClassVar
 
 from semantic_kernel.data.filter_clauses.filter_clause_base import FilterClauseBase
 from semantic_kernel.utils.experimental_decorator import experimental_class
@@ -16,4 +16,4 @@ class EqualTo(FilterClauseBase):
 
     """
 
-    filter_clause_type: str = Field("equal_to", init=False)  # type: ignore
+    filter_clause_type: ClassVar[str] = "equal_to"

--- a/python/semantic_kernel/data/filter_clauses/filter_clause_base.py
+++ b/python/semantic_kernel/data/filter_clauses/filter_clause_base.py
@@ -2,9 +2,7 @@
 
 
 from abc import ABC
-from typing import Any
-
-from pydantic import Field
+from typing import Any, ClassVar
 
 from semantic_kernel.kernel_pydantic import KernelBaseModel
 from semantic_kernel.utils.experimental_decorator import experimental_class
@@ -14,6 +12,10 @@ from semantic_kernel.utils.experimental_decorator import experimental_class
 class FilterClauseBase(ABC, KernelBaseModel):
     """A base for all filter clauses."""
 
-    filter_clause_type: str = Field("FilterClauseBase", init=False)  # type: ignore
+    filter_clause_type: ClassVar[str] = "FilterClauseBase"
     field_name: str
     value: Any
+
+    def __str__(self) -> str:
+        """Return a string representation of the filter clause."""
+        return f"filter_clause_type='{self.filter_clause_type}' field_name='{self.field_name}' value='{self.value}'"

--- a/python/semantic_kernel/data/text_search/vector_store_text_search.py
+++ b/python/semantic_kernel/data/text_search/vector_store_text_search.py
@@ -52,18 +52,19 @@ class VectorStoreTextSearch(KernelBaseModel, TextSearch, Generic[TModel]):
 
     @model_validator(mode="before")
     @classmethod
-    def _validate_stores(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def _validate_stores(cls, data: Any) -> dict[str, Any]:
         """Validate the capabilities."""
-        if (
-            not data.get("vectorizable_text_search")
-            and not data.get("vectorized_search")
-            and not data.get("vector_text_search")
-        ):
-            raise VectorStoreInitializationException(
-                "At least one of vectorizable_text_search, vectorized_search or vector_text_search is required."
-            )
-        if data.get("vectorized_search") and not data.get("embedding_service"):
-            raise VectorStoreInitializationException("embedding_service is required when using vectorized_search.")
+        if isinstance(data, dict):
+            if (
+                not data.get("vectorizable_text_search")
+                and not data.get("vectorized_search")
+                and not data.get("vector_text_search")
+            ):
+                raise VectorStoreInitializationException(
+                    "At least one of vectorizable_text_search, vectorized_search or vector_text_search is required."
+                )
+            if data.get("vectorized_search") and not data.get("embedding_service"):
+                raise VectorStoreInitializationException("embedding_service is required when using vectorized_search.")
         return data
 
     @classmethod

--- a/python/semantic_kernel/data/vector_storage/vector_store_record_collection.py
+++ b/python/semantic_kernel/data/vector_storage/vector_store_record_collection.py
@@ -52,9 +52,9 @@ class VectorStoreRecordCollection(KernelBaseModel, Generic[TKey, TModel]):
 
     @model_validator(mode="before")
     @classmethod
-    def _ensure_data_model_definition(cls: type[_T], data: dict[str, Any]) -> dict[str, Any]:
+    def _ensure_data_model_definition(cls: type[_T], data: Any) -> dict[str, Any]:
         """Ensure there is a  data model definition, if it isn't passed, try to get it from the data model type."""
-        if not data.get("data_model_definition"):
+        if isinstance(data, dict) and not data.get("data_model_definition"):
             data["data_model_definition"] = getattr(
                 data["data_model_type"], "__kernel_vectorstoremodel_definition__", None
             )

--- a/python/semantic_kernel/functions/kernel_function_from_prompt.py
+++ b/python/semantic_kernel/functions/kernel_function_from_prompt.py
@@ -135,29 +135,30 @@ through prompt_template_config or in the prompt_template."
     @classmethod
     def rewrite_execution_settings(
         cls,
-        data: dict[str, Any],
+        data: Any,
     ) -> dict[str, PromptExecutionSettings]:
         """Rewrite execution settings to a dictionary.
 
         If the prompt_execution_settings is not a dictionary, it is converted to a dictionary.
         If it is not supplied, but prompt_template is, the prompt_template's execution settings are used.
         """
-        prompt_execution_settings = data.get("prompt_execution_settings")
-        prompt_template = data.get("prompt_template")
-        if not prompt_execution_settings:
-            if prompt_template:
-                prompt_execution_settings = prompt_template.prompt_template_config.execution_settings
-                data["prompt_execution_settings"] = prompt_execution_settings
+        if isinstance(data, dict):
+            prompt_execution_settings = data.get("prompt_execution_settings")
+            prompt_template = data.get("prompt_template")
             if not prompt_execution_settings:
-                return data
-        if isinstance(prompt_execution_settings, PromptExecutionSettings):
-            data["prompt_execution_settings"] = {
-                prompt_execution_settings.service_id or DEFAULT_SERVICE_NAME: prompt_execution_settings
-            }
-        if isinstance(prompt_execution_settings, Sequence):
-            data["prompt_execution_settings"] = {
-                s.service_id or DEFAULT_SERVICE_NAME: s for s in prompt_execution_settings
-            }
+                if prompt_template:
+                    prompt_execution_settings = prompt_template.prompt_template_config.execution_settings
+                    data["prompt_execution_settings"] = prompt_execution_settings
+                if not prompt_execution_settings:
+                    return data
+            if isinstance(prompt_execution_settings, PromptExecutionSettings):
+                data["prompt_execution_settings"] = {
+                    prompt_execution_settings.service_id or DEFAULT_SERVICE_NAME: prompt_execution_settings
+                }
+            if isinstance(prompt_execution_settings, Sequence):
+                data["prompt_execution_settings"] = {
+                    s.service_id or DEFAULT_SERVICE_NAME: s for s in prompt_execution_settings
+                }
         return data
 
     async def _invoke_internal(self, context: FunctionInvocationContext) -> None:

--- a/python/semantic_kernel/processes/local_runtime/local_step.py
+++ b/python/semantic_kernel/processes/local_runtime/local_step.py
@@ -50,20 +50,20 @@ class LocalStep(KernelProcessMessageChannel, KernelBaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def parse_initial_configuration(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def parse_initial_configuration(cls, data: Any) -> Any:
         """Parses the initial configuration of the step."""
-        from semantic_kernel.processes.kernel_process.kernel_process import KernelProcess
+        if isinstance(data, dict):
+            from semantic_kernel.processes.kernel_process.kernel_process import KernelProcess
 
-        step_info = data.get("step_info")
-        assert step_info is not None  # nosec
+            step_info = data.get("step_info")
+            assert step_info is not None  # nosec
 
-        if step_info and isinstance(step_info, KernelProcess) and step_info.state.id is None:
-            step_info.state.id = str(uuid.uuid4().hex)
+            if step_info and isinstance(step_info, KernelProcess) and step_info.state.id is None:
+                step_info.state.id = str(uuid.uuid4().hex)
 
-        data["step_state"] = step_info.state
-        data["output_edges"] = {k: v for k, v in step_info.edges.items()}
-        data["event_namespace"] = f"{step_info.state.name}_{step_info.state.id}"
-
+            data["step_state"] = step_info.state
+            data["output_edges"] = {k: v for k, v in step_info.edges.items()}
+            data["event_namespace"] = f"{step_info.state.name}_{step_info.state.id}"
         return data
 
     @property

--- a/python/semantic_kernel/template_engine/blocks/function_id_block.py
+++ b/python/semantic_kernel/template_engine/blocks/function_id_block.py
@@ -44,21 +44,22 @@ class FunctionIdBlock(Block):
 
     @model_validator(mode="before")
     @classmethod
-    def parse_content(cls, fields: dict[str, Any]) -> dict[str, Any]:
+    def parse_content(cls, fields: Any) -> dict[str, Any]:
         """Parse the content of the function id block and extract the plugin and function name.
 
         If both are present in the fields, return the fields as is.
         Otherwise, use the regex to extract the plugin and function name.
         """
-        if "plugin_name" in fields and "function_name" in fields:
-            return fields
-        content = fields.get("content", "").strip()
-        matches = FUNCTION_ID_BLOCK_MATCHER.match(content)
-        if not matches:
-            raise FunctionIdBlockSyntaxError(content=content)
-        if plugin := matches.groupdict().get("plugin"):
-            fields["plugin_name"] = plugin
-        fields["function_name"] = matches.group("function")
+        if isinstance(fields, dict):
+            if "plugin_name" in fields and "function_name" in fields:
+                return fields
+            content = fields.get("content", "").strip()
+            matches = FUNCTION_ID_BLOCK_MATCHER.match(content)
+            if not matches:
+                raise FunctionIdBlockSyntaxError(content=content)
+            if plugin := matches.groupdict().get("plugin"):
+                fields["plugin_name"] = plugin
+            fields["function_name"] = matches.group("function")
         return fields
 
     def render(self, *_: "Kernel | KernelArguments | None") -> str:

--- a/python/tests/unit/data/test_vector_store_model_decorator.py
+++ b/python/tests/unit/data/test_vector_store_model_decorator.py
@@ -4,7 +4,8 @@
 from dataclasses import dataclass
 from typing import Annotated
 
-from pydantic import BaseModel
+from numpy import ndarray
+from pydantic import BaseModel, ConfigDict
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pytest import raises
 
@@ -228,3 +229,58 @@ def test_non_vector_list_and_dict():
     assert data_model_definition.fields["dict3"].name == "dict3"
     assert data_model_definition.fields["dict3"].property_type == "dict"
     assert data_model_definition.container_mode is False
+
+
+def test_vector_fields_checks():
+    @vectorstoremodel
+    class DataModelClass(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        id: Annotated[str, VectorStoreRecordKeyField()]
+        vector_str: Annotated[str, VectorStoreRecordVectorField()]
+        vector_list: Annotated[list[float], VectorStoreRecordVectorField()]
+        vector_array: Annotated[
+            ndarray,
+            VectorStoreRecordVectorField(
+                serialize_function=lambda _: [0.1],  # fake functions
+                deserialize_function=lambda _: "test",  # fake functions
+            ),
+        ]
+
+    assert hasattr(DataModelClass, "__kernel_vectorstoremodel__")
+    assert hasattr(DataModelClass, "__kernel_vectorstoremodel_definition__")
+    data_model_definition: VectorStoreRecordDefinition = DataModelClass.__kernel_vectorstoremodel_definition__
+    assert len(data_model_definition.fields) == 4
+    assert data_model_definition.fields["id"].name == "id"
+    assert data_model_definition.fields["vector_str"].property_type == "str"
+    assert data_model_definition.fields["vector_list"].property_type == "float"
+    assert data_model_definition.fields["vector_array"].property_type == "ndarray"
+
+
+def test_vector_fields_array_without_serialization():
+    with raises(VectorStoreModelException):
+
+        @vectorstoremodel
+        class DataModelClass(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            id: Annotated[str, VectorStoreRecordKeyField()]
+            vector_array: Annotated[
+                ndarray,
+                VectorStoreRecordVectorField(
+                    serialize_function=lambda _: [0.1],  # fake functions
+                    # deserialize_function=lambda _: "test",  # fake functions
+                ),
+            ]
+
+    with raises(VectorStoreModelException):
+
+        @vectorstoremodel
+        class DataModelClass(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            id: Annotated[str, VectorStoreRecordKeyField()]
+            vector_array: Annotated[
+                ndarray,
+                VectorStoreRecordVectorField(
+                    # serialize_function=lambda _: [0.1],  # fake functions
+                    deserialize_function=lambda _: "test",  # fake functions
+                ),
+            ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -4858,7 +4858,7 @@ requires-dist = [
     { name = "pinecone-client", marker = "extra == 'pinecone'", specifier = "~=5.0" },
     { name = "prance", specifier = "~=23.6.21.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'postgres'", specifier = "~=3.2" },
-    { name = "pyarrow", marker = "extra == 'usearch'", specifier = ">=12.0,<19.0" },
+    { name = "pyarrow", marker = "extra == 'usearch'", specifier = ">=12.0,<20.0" },
     { name = "pybars4", specifier = "~=0.9" },
     { name = "pydantic", specifier = ">=2.0,!=2.10.0,!=2.10.1,!=2.10.2,!=2.10.3,<2.11" },
     { name = "pydantic-settings", specifier = "~=2.0" },


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Based on insights from the graphrag team, several bug fixes related to data and model validators.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
For all cases of model_validator in before mode, there is no guarantee that the data passed is a dict,
especially when a model is used as a field in another model, then a string is passed to the before validator.
So in those cases we check before doing logic, otherwise just pass it on and let Pydantic handle the invalid data.

Some small logic fixes in the vector store model decorator:
- updated docstring with the right exceptions
- additional checks on attributes
- additional checks on VectorFields with tests

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
