### PR TITLE
Python: Improve handling for kernel plugin from file.

### DIFF
--- a/python/semantic_kernel/functions/kernel_function_extension.py
+++ b/python/semantic_kernel/functions/kernel_function_extension.py
@@ -86,6 +86,8 @@ class KernelFunctionExtension(KernelBaseModel, ABC):
             return self.plugins[plugin.name]
         if not plugin_name:
             raise ValueError("plugin_name must be provided if a plugin is not supplied.")
+        if not isinstance(plugin_name, str):
+            raise TypeError("plugin_name must be a string.")
         if plugin:
             self.plugins[plugin_name] = KernelPlugin.from_object(
                 plugin_name=plugin_name, plugin_instance=plugin, description=description

--- a/python/tests/unit/kernel/test_kernel.py
+++ b/python/tests/unit/kernel/test_kernel.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import os
+from pathlib import Path
 from typing import Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -481,6 +482,11 @@ def test_plugin_no_plugin(kernel: Kernel):
 def test_plugin_name_error(kernel: Kernel):
     with pytest.raises(ValueError):
         kernel.add_plugin(" ", None)
+
+
+def test_plugin_name_not_string_error(kernel: Kernel):
+    with pytest.raises(TypeError):
+        kernel.add_plugin(" ", plugin_name=Path(__file__).parent)
 
 
 def test_plugins_add_plugins(kernel: Kernel):


### PR DESCRIPTION
### Motivation and Context

This PR addresses an issue in the `KernelPlugin.from_directory()` method where classes without any `@kernel_function` decorated methods are still being initialized during plugin loading.

The fix makes sure that only classes with at least one `@kernel_function` decorated method are instantiated and included as plugins. Classes without `@kernel_function` methods are now skipped entirely.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR:
- Updates the `from_python_file` to inspect each class for `@kernel_function` decorated methods before instantiation.
- Updates the `add_plugin` method `plugin_name` to make sure it is indeed a string, per the type hint.
   - Adds a unit test to exercise the new behavior
- Closes #10280

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
