### PR TITLE
Python: improve agent samples and chat history handling

### DIFF
--- a/python/samples/concepts/agents/chat_completion_history_reducer.py
+++ b/python/samples/concepts/agents/chat_completion_history_reducer.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 # Flag to determine whether to use Azure OpenAI services or OpenAI
 # Set this to True if using Azure OpenAI (requires appropriate configuration)
-use_azure_openai = True
+use_azure_openai = False
 
 
 # Helper function to create and configure a Kernel with the desired chat completion service
@@ -117,7 +117,7 @@ class HistoryReducerExample:
         # The index is incremented by 2 because the agent is told to:
         # "Add one to the latest user number and spell it in Spanish without explanation."
         # The user sends 1, 3, 5, etc., and the agent responds with 2, 4, 6, etc. (in Spanish)
-        for index in range(0, message_count, 2):
+        for index in range(1, message_count + 1, 2):
             # Provide user input
             chat_history.add_user_message(str(index))
             print(f"# User: '{index}'")

--- a/python/samples/concepts/agents/chat_completion_history_reducer.py
+++ b/python/samples/concepts/agents/chat_completion_history_reducer.py
@@ -64,12 +64,12 @@ class HistoryReducerExample:
         """
         Creates a ChatCompletionAgent with a truncation-based history reducer.
 
-        Parameters:
-        - reducer_msg_count: Target number of messages to retain after truncation.
-        - reducer_threshold: Threshold number of messages to trigger truncation.
+        Args:
+            reducer_msg_count: Target number of messages to retain after truncation.
+            reducer_threshold: Threshold number of messages to trigger truncation.
 
         Returns:
-        - A configured ChatCompletionAgent instance with truncation enabled.
+            A configured ChatCompletionAgent instance with truncation enabled.
         """
         return ChatCompletionAgent(
             name=self.AGENT_NAME,
@@ -84,12 +84,12 @@ class HistoryReducerExample:
         """
         Creates a ChatCompletionAgent with a summarization-based history reducer.
 
-        Parameters:
-        - reducer_msg_count: Target number of messages to retain after summarization.
-        - reducer_threshold: Threshold number of messages to trigger summarization.
+        Args:
+            reducer_msg_count: Target number of messages to retain after summarization.
+            reducer_threshold: Threshold number of messages to trigger summarization.
 
         Returns:
-        - A configured ChatCompletionAgent instance with summarization enabled.
+            A configured ChatCompletionAgent instance with summarization enabled.
         """
         service_id = "summarize_agent"
         kernel = _create_kernel_with_chat_completion(service_id)
@@ -142,9 +142,9 @@ class HistoryReducerExample:
         """
         Demonstrates agent invocation within a group chat.
 
-        Parameters:
-        - agent: The ChatCompletionAgent to invoke.
-        - message_count: The number of messages to simulate in the conversation.
+        Args:
+            agent: The ChatCompletionAgent to invoke.
+            message_count: The number of messages to simulate in the conversation.
         """
         chat = AgentGroupChat()  # Initialize a new group chat
         last_history_count = 0
@@ -180,8 +180,8 @@ class HistoryReducerExample:
         This assumes that the ChatHistorySummarizationReducer uses the default value for:
         `use_single_summary` which is True, and there is therefor only one summary message.
 
-        Parameters:
-        - messages: List of chat messages to process.
+        Args:
+            messages: List of chat messages to process.
         """
         for msg in messages:
             if msg.metadata and msg.metadata.get("__summary__"):

--- a/python/samples/concepts/agents/chat_completion_history_reducer.py
+++ b/python/samples/concepts/agents/chat_completion_history_reducer.py
@@ -102,7 +102,7 @@ class HistoryReducerExample:
             # Invoke the agent and display its response
             async for response in agent.invoke(chat_history_reducer):
                 chat_history_reducer.add_message(response)
-                print(f"# {response.role} - {response.name}: '{response.content}'")
+                print(f"# Agent - {response.name}: '{response.content}'")
 
             print(f"@ Message Count: {len(chat_history_reducer.messages)}\n")
 

--- a/python/samples/concepts/chat_completion/simple_chatbot_with_summary_history_reducer.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot_with_summary_history_reducer.py
@@ -27,6 +27,9 @@ from semantic_kernel.functions import KernelArguments
 # The purpose of this sample is to demonstrate how to use a kernel function and use a chat history reducer.
 # To build a basic chatbot, it is sufficient to use a ChatCompletionService with a chat history directly.
 
+# Toggle this flag to view the chat history summary after a reduction was performed.
+view_chat_history_summary_after_reduction = True
+
 # You can select from the following chat completion services:
 # - Services.OPENAI
 # - Services.AZURE_OPENAI
@@ -122,7 +125,8 @@ async def chat() -> bool:
         print("\n\nExiting chat...")
         return False
 
-    await summarization_reducer.reduce()
+    if is_reduced := await summarization_reducer.reduce():
+        print(f"@ History reduced to {len(summarization_reducer.messages)} messages.")
 
     kernel_arguments = KernelArguments(
         settings=request_settings,
@@ -135,6 +139,15 @@ async def chat() -> bool:
         print(f"Mosscap:> {answer}")
         summarization_reducer.add_user_message(user_input)
         summarization_reducer.add_message(answer.value[0])
+
+    if view_chat_history_summary_after_reduction and is_reduced:
+        for msg in summarization_reducer.messages:
+            if msg.metadata and msg.metadata.get("__summary__"):
+                print("*" * 60)
+                print(f"Chat History Reduction Summary: {msg.content}")
+                print("*" * 60)
+                break
+        print("\n")
 
     return True
 

--- a/python/samples/concepts/chat_completion/simple_chatbot_with_summary_history_reducer_keep_func_content.py
+++ b/python/samples/concepts/chat_completion/simple_chatbot_with_summary_history_reducer_keep_func_content.py
@@ -32,6 +32,9 @@ from semantic_kernel.functions import KernelArguments
 # The purpose of this sample is to demonstrate how to use a kernel function and use a chat history reducer.
 # To build a basic chatbot, it is sufficient to use a ChatCompletionService with a chat history directly.
 
+# Toggle this flag to view the chat history summary after a reduction was performed.
+view_chat_history_summary_after_reduction = True
+
 # You can select from the following chat completion services:
 # - Services.OPENAI
 # - Services.AZURE_OPENAI
@@ -136,7 +139,8 @@ async def chat() -> bool:
         print("\n\nExiting chat...")
         return False
 
-    await summarization_reducer.reduce()
+    if is_reduced := await summarization_reducer.reduce():
+        print(f"@ History reduced to {len(summarization_reducer.messages)} messages.")
 
     kernel_arguments = KernelArguments(
         settings=request_settings,
@@ -169,16 +173,25 @@ async def chat() -> bool:
                                     frc.append(item)
 
             for i, item in enumerate(fcc):
-                summarization_reducer.add_assistant_message_list([item])
+                summarization_reducer.add_assistant_message([item])
                 processed_fccs.add(item.id)
                 # Safely check if there's a matching FunctionResultContent
                 if i < len(frc):
                     assert fcc[i].id == frc[i].id  # nosec
-                    summarization_reducer.add_tool_message_list([frc[i]])
+                    summarization_reducer.add_tool_message([frc[i]])
                     processed_frcs.add(item.id)
 
         # Since this example is showing how to include FunctionCallContent and FunctionResultContent
         # in the summary, we need to add them to the chat history and also to the processed sets.
+
+        if view_chat_history_summary_after_reduction and is_reduced:
+            for msg in summarization_reducer.messages:
+                if msg.metadata and msg.metadata.get("__summary__"):
+                    print("*" * 60)
+                    print(f"Chat History Reduction Summary: {msg.content}")
+                    print("*" * 60)
+                    break
+            print("\n")
 
     return True
 

--- a/python/samples/concepts/structured_outputs/json_structured_outputs.py
+++ b/python/samples/concepts/structured_outputs/json_structured_outputs.py
@@ -109,7 +109,7 @@ history.add_user_message("how can I solve 8x + 7y = -23, and 4x=12?")
 
 
 async def main():
-    stream = True
+    stream = False
     if stream:
         answer = kernel.invoke_stream(
             chat_function,
@@ -127,7 +127,8 @@ async def main():
             chat_function,
             chat_history=history,
         )
-        print(f"Mosscap:> {result}")
+        reasoned_result = Reasoning.model_validate_json(result.value[0].content)
+        print(f"Mosscap:> {reasoned_result}")
     history.add_assistant_message(str(result))
 
 

--- a/python/samples/getting_started_with_agents/step10_assistant_tool_file_search.py
+++ b/python/samples/getting_started_with_agents/step10_assistant_tool_file_search.py
@@ -1,12 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import os
 
-from semantic_kernel.agents.open_ai.azure_assistant_agent import AzureAssistantAgent
-from semantic_kernel.agents.open_ai.open_ai_assistant_agent import OpenAIAssistantAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.kernel import Kernel
+from semantic_kernel import Kernel
+from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
+from semantic_kernel.contents import AuthorRole, ChatMessageContent
 
 #####################################################################
 # The following sample demonstrates how to create an OpenAI         #
@@ -15,35 +14,21 @@ from semantic_kernel.kernel import Kernel
 #####################################################################
 
 
-AGENT_NAME = "FileSearch"
-AGENT_INSTRUCTIONS = "Find answers to the user's questions in the provided file."
+# Create the instance of the Kernel
+kernel = Kernel()
 
 # Note: you may toggle this to switch between AzureOpenAI and OpenAI
-use_azure_openai = True
-
-
-# A helper method to invoke the agent with the user input
-async def invoke_agent(agent: OpenAIAssistantAgent, thread_id: str, input: str) -> None:
-    """Invoke the agent with the user input."""
-    await agent.add_chat_message(thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=input))
-
-    print(f"# {AuthorRole.USER}: '{input}'")
-
-    async for content in agent.invoke(thread_id=thread_id):
-        if content.role != AuthorRole.TOOL:
-            print(f"# {content.role}: {content.content}")
+use_azure_openai = False
 
 
 async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
+    # Get the path to the employees.pdf file
+    pdf_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources", "employees.pdf")
 
     # Define a service_id for the sample
     service_id = "agent"
-
-    # Get the path to the travelinfo.txt file
-    pdf_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources", "employees.pdf")
-
+    AGENT_NAME = "FileSearch"
+    AGENT_INSTRUCTIONS = "Find answers to the user's questions in the provided file."
     # Create the agent configuration
     if use_azure_openai:
         agent = await AzureAssistantAgent.create(
@@ -67,10 +52,23 @@ async def main():
     # Define a thread and invoke the agent with the user input
     thread_id = await agent.create_thread()
 
+    user_inputs = {
+        "Who is the youngest employee?",
+        "Who works in sales?",
+        "I have a customer request, who can help me?",
+    }
+
     try:
-        await invoke_agent(agent, thread_id=thread_id, input="Who is the youngest employee?")
-        await invoke_agent(agent, thread_id=thread_id, input="Who works in sales?")
-        await invoke_agent(agent, thread_id=thread_id, input="I have a customer request, who can help me?")
+        for user_input in user_inputs:
+            await agent.add_chat_message(
+                thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=user_input)
+            )
+
+            print(f"# User: '{user_input}'")
+
+            async for content in agent.invoke(thread_id=thread_id):
+                if content.role != AuthorRole.TOOL:
+                    print(f"# Agent: {content.content}")
     finally:
         [await agent.delete_file(file_id) for file_id in agent.file_search_file_ids]
         await agent.delete_thread(thread_id)

--- a/python/samples/getting_started_with_agents/step1_agent.py
+++ b/python/samples/getting_started_with_agents/step1_agent.py
@@ -30,11 +30,11 @@ async def main():
     chat_history = ChatHistory()
     chat_history.add_developer_message(AGENT_INSTRUCTIONS)
 
-    user_inputs = {
+    user_inputs = [
         "Fortune favors the bold.",
         "I came, I saw, I conquered.",
         "Practice makes perfect.",
-    }
+    ]
     for user_input in user_inputs:
         # Add the user input to the chat history
         chat_history.add_user_message(user_input)

--- a/python/samples/getting_started_with_agents/step1_agent.py
+++ b/python/samples/getting_started_with_agents/step1_agent.py
@@ -21,7 +21,7 @@ kernel.add_service(OpenAIChatCompletion(service_id="agent"))
 
 # Define the agent with name and instructions
 AGENT_NAME = "Parrot"
-AGENT_INSTRUCTIONS = "You are a helpfull parrot that repeats the user message in a pirate voice."
+AGENT_INSTRUCTIONS = "You are a helpful parrot that repeats the user message in a pirate voice."
 agent = ChatCompletionAgent(service_id="agent", kernel=kernel, name=AGENT_NAME)
 
 

--- a/python/samples/getting_started_with_agents/step1_agent.py
+++ b/python/samples/getting_started_with_agents/step1_agent.py
@@ -1,13 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
-from functools import reduce
 
+from semantic_kernel import Kernel
 from semantic_kernel.agents import ChatCompletionAgent
-from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.contents.chat_history import ChatHistory
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.kernel import Kernel
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.contents import ChatHistory
 
 ###################################################################
 # The following sample demonstrates how to create a simple,       #
@@ -15,52 +13,37 @@ from semantic_kernel.kernel import Kernel
 # of a pirate and then ends with a parrot sound.                  #
 ###################################################################
 
-# To toggle streaming or non-streaming mode, change the following boolean
-streaming = True
+# Create the instance of the Kernel
+kernel = Kernel()
 
-# Define the agent name and instructions
-PARROT_NAME = "Parrot"
-PARROT_INSTRUCTIONS = "Repeat the user message in the voice of a pirate and then end with a parrot sound."
+# Add the OpenAIChatCompletion AI Service to the Kernel
+kernel.add_service(OpenAIChatCompletion(service_id="agent"))
 
-
-async def invoke_agent(agent: ChatCompletionAgent, input: str, chat: ChatHistory):
-    """Invoke the agent with the user input."""
-    chat.add_user_message(input)
-
-    print(f"# {AuthorRole.USER}: '{input}'")
-
-    if streaming:
-        contents = []
-        content_name = ""
-        async for content in agent.invoke_stream(chat):
-            content_name = content.name
-            contents.append(content)
-        streaming_chat_message = reduce(lambda first, second: first + second, contents)
-        print(f"# {content.role} - {content_name or '*'}: '{streaming_chat_message}'")
-        chat.add_message(streaming_chat_message)
-    else:
-        async for content in agent.invoke(chat):
-            print(f"# {content.role} - {content.name or '*'}: '{content.content}'")
-            chat.add_message(content)
+# Define the agent with name and instructions
+AGENT_NAME = "Parrot"
+AGENT_INSTRUCTIONS = "You are a helpfull parrot that repeats the user message in a pirate voice."
+agent = ChatCompletionAgent(service_id="agent", kernel=kernel, name=AGENT_NAME)
 
 
 async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
-
-    # Add the OpenAIChatCompletion AI Service to the Kernel
-    kernel.add_service(AzureChatCompletion(service_id="agent"))
-
-    # Create the agent
-    agent = ChatCompletionAgent(service_id="agent", kernel=kernel, name=PARROT_NAME, instructions=PARROT_INSTRUCTIONS)
-
     # Define the chat history
-    chat = ChatHistory()
+    chat_history = ChatHistory()
+    chat_history.add_developer_message(AGENT_INSTRUCTIONS)
 
-    # Respond to user input
-    await invoke_agent(agent, "Fortune favors the bold.", chat)
-    await invoke_agent(agent, "I came, I saw, I conquered.", chat)
-    await invoke_agent(agent, "Practice makes perfect.", chat)
+    user_inputs = {
+        "Fortune favors the bold.",
+        "I came, I saw, I conquered.",
+        "Practice makes perfect.",
+    }
+    for user_input in user_inputs:
+        # Add the user input to the chat history
+        chat_history.add_user_message(user_input)
+        print(f"# User: '{user_input}'")
+        # Invoke the agent to get a response
+        async for content in agent.invoke(chat_history):
+            # Add the response to the chat history
+            chat_history.add_message(content)
+            print(f"# Agent - {content.name or '*'}: '{content.content}'")
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started_with_agents/step2_plugins.py
+++ b/python/samples/getting_started_with_agents/step2_plugins.py
@@ -1,29 +1,24 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
+from semantic_kernel import Kernel
 from semantic_kernel.agents import ChatCompletionAgent
-from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+from semantic_kernel.connectors.ai import FunctionChoiceBehavior
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.contents.chat_history import ChatHistory
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.functions.kernel_arguments import KernelArguments
-from semantic_kernel.functions.kernel_function_decorator import kernel_function
-from semantic_kernel.kernel import Kernel
+from semantic_kernel.contents import ChatHistory
+from semantic_kernel.functions import KernelArguments, kernel_function
+
+if TYPE_CHECKING:
+    from semantic_kernel.contents import StreamingChatMessageContent
+
 
 ###################################################################
 # The following sample demonstrates how to create a simple,       #
 # non-group agent that utilizes plugins defined as part of        #
 # the Kernel.                                                     #
 ###################################################################
-
-# This sample allows for a streaming response verus a non-streaming response
-streaming = True
-
-# Define the agent name and instructions
-HOST_NAME = "Host"
-HOST_INSTRUCTIONS = "Answer questions about the menu."
 
 
 # Define a sample plugin for the sample
@@ -45,58 +40,59 @@ class MenuPlugin:
         return "$9.99"
 
 
-# A helper method to invoke the agent with the user input
-async def invoke_agent(agent: ChatCompletionAgent, input: str, chat: ChatHistory) -> None:
-    """Invoke the agent with the user input."""
-    chat.add_user_message(input)
+# Create the instance of the Kernel
+kernel = Kernel()
+kernel.add_plugin(MenuPlugin(), plugin_name="menu")
 
-    print(f"# {AuthorRole.USER}: '{input}'")
+service_id = "agent"
+kernel.add_service(AzureChatCompletion(service_id=service_id))
 
-    if streaming:
-        contents = []
-        content_name = ""
-        async for content in agent.invoke_stream(chat):
-            content_name = content.name
-            contents.append(content)
-        message_content = "".join([content.content for content in contents])
-        print(f"# {content.role} - {content_name or '*'}: '{message_content}'")
-        chat.add_assistant_message(message_content)
-    else:
-        async for content in agent.invoke(chat):
-            print(f"# {content.role} - {content.name or '*'}: '{content.content}'")
-        chat.add_message(content)
+settings = kernel.get_prompt_execution_settings_from_service_id(service_id=service_id)
+# Configure the function choice behavior to auto invoke kernel functions
+settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
+
+# Define the agent name and instructions
+AGENT_NAME = "Host"
+AGENT_INSTRUCTIONS = "Answer questions about the menu."
+# Create the agent
+agent = ChatCompletionAgent(
+    service_id=service_id,
+    kernel=kernel,
+    name=AGENT_NAME,
+    instructions=AGENT_INSTRUCTIONS,
+    arguments=KernelArguments(settings=settings),
+)
 
 
 async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
-
-    service_id = "agent"
-    kernel.add_service(AzureChatCompletion(service_id=service_id))
-
-    settings = kernel.get_prompt_execution_settings_from_service_id(service_id=service_id)
-    # Configure the function choice behavior to auto invoke kernel functions
-    settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
-
-    kernel.add_plugin(MenuPlugin(), plugin_name="menu")
-
-    # Create the agent
-    agent = ChatCompletionAgent(
-        service_id="agent",
-        kernel=kernel,
-        name=HOST_NAME,
-        instructions=HOST_INSTRUCTIONS,
-        arguments=KernelArguments(settings=settings),
-    )
-
     # Define the chat history
-    chat = ChatHistory()
+    chat_history = ChatHistory()
 
     # Respond to user input
-    await invoke_agent(agent, "Hello", chat)
-    await invoke_agent(agent, "What is the special soup?", chat)
-    await invoke_agent(agent, "What is the special drink?", chat)
-    await invoke_agent(agent, "Thank you", chat)
+    user_inputs = {
+        "Hello",
+        "What is the special soup?",
+        "What does that cost?",
+        "Thank you",
+    }
+
+    for user_input in user_inputs:
+        # Add the user input to the chat history
+        chat_history.add_user_message(user_input)
+        print(f"# User: '{user_input}'")
+
+        contents: list["StreamingChatMessageContent"] = []
+        agent_name: str | None = None
+        print("# Assistant - ", end="")
+        async for content in agent.invoke_stream(chat_history):
+            if not agent_name:
+                agent_name = content.name
+                print(f"{agent_name}: '", end="")
+            contents.append(content)
+            print(content.content, end="")
+        print("'")
+        message_content = sum(contents[:1], contents[0])
+        chat_history.add_message(message_content)
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started_with_agents/step2_plugins.py
+++ b/python/samples/getting_started_with_agents/step2_plugins.py
@@ -8,10 +8,12 @@ from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.connectors.ai import FunctionChoiceBehavior
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 from semantic_kernel.contents import ChatHistory
+from semantic_kernel.contents.function_call_content import FunctionCallContent
+from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.functions import KernelArguments, kernel_function
 
 if TYPE_CHECKING:
-    from semantic_kernel.contents import StreamingChatMessageContent
+    pass
 
 
 ###################################################################
@@ -69,30 +71,30 @@ async def main():
     chat_history = ChatHistory()
 
     # Respond to user input
-    user_inputs = {
+    user_inputs = [
         "Hello",
         "What is the special soup?",
         "What does that cost?",
         "Thank you",
-    }
+    ]
 
     for user_input in user_inputs:
         # Add the user input to the chat history
         chat_history.add_user_message(user_input)
         print(f"# User: '{user_input}'")
 
-        contents: list["StreamingChatMessageContent"] = []
         agent_name: str | None = None
         print("# Assistant - ", end="")
         async for content in agent.invoke_stream(chat_history):
             if not agent_name:
                 agent_name = content.name
                 print(f"{agent_name}: '", end="")
-            contents.append(content)
-            print(content.content, end="")
+            if (
+                not any(isinstance(item, (FunctionCallContent, FunctionResultContent)) for item in content.items)
+                and content.content.strip()
+            ):
+                print(f"{content.content}", end="", flush=True)
         print("'")
-        message_content = sum(contents[:1], contents[0])
-        chat_history.add_message(message_content)
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started_with_agents/step3_chat.py
+++ b/python/samples/getting_started_with_agents/step3_chat.py
@@ -2,12 +2,11 @@
 
 import asyncio
 
+from semantic_kernel import Kernel
 from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent
-from semantic_kernel.agents.strategies.termination.termination_strategy import TerminationStrategy
-from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import AzureChatCompletion
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.kernel import Kernel
+from semantic_kernel.agents.strategies import TerminationStrategy
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.contents import AuthorRole, ChatMessageContent
 
 ###################################################################
 # The following sample demonstrates how to create a simple,       #
@@ -15,6 +14,12 @@ from semantic_kernel.kernel import Kernel
 # Agent along with a Copy Writer Chat Completion Agent to         #
 # complete a task.                                                #
 ###################################################################
+
+
+def _create_kernel_with_chat_completion(service_id: str) -> Kernel:
+    kernel = Kernel()
+    kernel.add_service(AzureChatCompletion(service_id=service_id))
+    return kernel
 
 
 class ApprovalTerminationStrategy(TerminationStrategy):
@@ -25,32 +30,14 @@ class ApprovalTerminationStrategy(TerminationStrategy):
         return "approved" in history[-1].content.lower()
 
 
-REVIEWER_NAME = "ArtDirector"
-REVIEWER_INSTRUCTIONS = """
-You are an art director who has opinions about copywriting born of a love for David Ogilvy.
-The goal is to determine if the given copy is acceptable to print.
-If so, state that it is approved.
-If not, provide insight on how to refine suggested copy without example.
-"""
-
-COPYWRITER_NAME = "CopyWriter"
-COPYWRITER_INSTRUCTIONS = """
-You are a copywriter with ten years of experience and are known for brevity and a dry humor.
-The goal is to refine and decide on the single best copy as an expert in the field.
-Only provide a single proposal per response.
-You're laser focused on the goal at hand.
-Don't waste time with chit chat.
-Consider suggestions when refining an idea.
-"""
-
-
-def _create_kernel_with_chat_completion(service_id: str) -> Kernel:
-    kernel = Kernel()
-    kernel.add_service(AzureChatCompletion(service_id=service_id))
-    return kernel
-
-
 async def main():
+    REVIEWER_NAME = "ArtDirector"
+    REVIEWER_INSTRUCTIONS = """
+    You are an art director who has opinions about copywriting born of a love for David Ogilvy.
+    The goal is to determine if the given copy is acceptable to print.
+    If so, state that it is approved.
+    If not, provide insight on how to refine suggested copy without example.
+    """
     agent_reviewer = ChatCompletionAgent(
         service_id="artdirector",
         kernel=_create_kernel_with_chat_completion("artdirector"),
@@ -58,6 +45,15 @@ async def main():
         instructions=REVIEWER_INSTRUCTIONS,
     )
 
+    COPYWRITER_NAME = "CopyWriter"
+    COPYWRITER_INSTRUCTIONS = """
+    You are a copywriter with ten years of experience and are known for brevity and a dry humor.
+    The goal is to refine and decide on the single best copy as an expert in the field.
+    Only provide a single proposal per response.
+    You're laser focused on the goal at hand.
+    Don't waste time with chit chat.
+    Consider suggestions when refining an idea.
+    """
     agent_writer = ChatCompletionAgent(
         service_id="copywriter",
         kernel=_create_kernel_with_chat_completion("copywriter"),
@@ -65,20 +61,26 @@ async def main():
         instructions=COPYWRITER_INSTRUCTIONS,
     )
 
-    chat = AgentGroupChat(
-        agents=[agent_writer, agent_reviewer],
-        termination_strategy=ApprovalTerminationStrategy(agents=[agent_reviewer], maximum_iterations=10),
+    group_chat = AgentGroupChat(
+        agents=[
+            agent_writer,
+            agent_reviewer,
+        ],
+        termination_strategy=ApprovalTerminationStrategy(
+            agents=[agent_reviewer],
+            maximum_iterations=10,
+        ),
     )
 
     input = "a slogan for a new line of electric cars."
 
-    await chat.add_chat_message(ChatMessageContent(role=AuthorRole.USER, content=input))
-    print(f"# {AuthorRole.USER}: '{input}'")
+    await group_chat.add_chat_message(ChatMessageContent(role=AuthorRole.USER, content=input))
+    print(f"# User: '{input}'")
 
-    async for content in chat.invoke():
-        print(f"# {content.role} - {content.name or '*'}: '{content.content}'")
+    async for content in group_chat.invoke():
+        print(f"# Agent - {content.name or '*'}: '{content.content}'")
 
-    print(f"# IS COMPLETE: {chat.is_complete}")
+    print(f"# IS COMPLETE: {group_chat.is_complete}")
 
 
 if __name__ == "__main__":

--- a/python/samples/getting_started_with_agents/step4_kernel_function_strategies.py
+++ b/python/samples/getting_started_with_agents/step4_kernel_function_strategies.py
@@ -2,16 +2,15 @@
 
 import asyncio
 
+from semantic_kernel import Kernel
 from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent
 from semantic_kernel.agents.strategies import (
     KernelFunctionSelectionStrategy,
     KernelFunctionTerminationStrategy,
 )
-from semantic_kernel.connectors.ai.open_ai.services.azure_chat_completion import AzureChatCompletion
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.functions.kernel_function_from_prompt import KernelFunctionFromPrompt
-from semantic_kernel.kernel import Kernel
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+from semantic_kernel.contents import AuthorRole, ChatMessageContent
+from semantic_kernel.functions import KernelFunctionFromPrompt
 
 ###################################################################
 # The following sample demonstrates how to create a simple,       #
@@ -23,24 +22,6 @@ from semantic_kernel.kernel import Kernel
 # in the conversation.                                            #
 ###################################################################
 
-REVIEWER_NAME = "ArtDirector"
-REVIEWER_INSTRUCTIONS = """
-You are an art director who has opinions about copywriting born of a love for David Ogilvy.
-The goal is to determine if the given copy is acceptable to print.
-If so, state that it is approved.
-If not, provide insight on how to refine suggested copy without example.
-"""
-
-COPYWRITER_NAME = "CopyWriter"
-COPYWRITER_INSTRUCTIONS = """
-You are a copywriter with ten years of experience and are known for brevity and a dry humor.
-The goal is to refine and decide on the single best copy as an expert in the field.
-Only provide a single proposal per response.
-You're laser focused on the goal at hand.
-Don't waste time with chit chat.
-Consider suggestions when refining an idea.
-"""
-
 
 def _create_kernel_with_chat_completion(service_id: str) -> Kernel:
     kernel = Kernel()
@@ -49,6 +30,13 @@ def _create_kernel_with_chat_completion(service_id: str) -> Kernel:
 
 
 async def main():
+    REVIEWER_NAME = "ArtDirector"
+    REVIEWER_INSTRUCTIONS = """
+    You are an art director who has opinions about copywriting born of a love for David Ogilvy.
+    The goal is to determine if the given copy is acceptable to print.
+    If so, state that it is approved.
+    If not, provide insight on how to refine suggested copy without example.
+    """
     agent_reviewer = ChatCompletionAgent(
         service_id="artdirector",
         kernel=_create_kernel_with_chat_completion("artdirector"),
@@ -56,6 +44,15 @@ async def main():
         instructions=REVIEWER_INSTRUCTIONS,
     )
 
+    COPYWRITER_NAME = "CopyWriter"
+    COPYWRITER_INSTRUCTIONS = """
+    You are a copywriter with ten years of experience and are known for brevity and a dry humor.
+    The goal is to refine and decide on the single best copy as an expert in the field.
+    Only provide a single proposal per response.
+    You're laser focused on the goal at hand.
+    Don't waste time with chit chat.
+    Consider suggestions when refining an idea.
+    """
     agent_writer = ChatCompletionAgent(
         service_id="copywriter",
         kernel=_create_kernel_with_chat_completion("copywriter"),
@@ -116,10 +113,10 @@ async def main():
     input = "a slogan for a new line of electric cars."
 
     await chat.add_chat_message(ChatMessageContent(role=AuthorRole.USER, content=input))
-    print(f"# {AuthorRole.USER}: '{input}'")
+    print(f"# User: '{input}'")
 
     async for content in chat.invoke():
-        print(f"# {content.role} - {content.name or '*'}: '{content.content}'")
+        print(f"# Agent - {content.name or '*'}: '{content.content}'")
 
     print(f"# IS COMPLETE: {chat.is_complete}")
 

--- a/python/samples/getting_started_with_agents/step7_assistant.py
+++ b/python/samples/getting_started_with_agents/step7_assistant.py
@@ -2,11 +2,10 @@
 import asyncio
 from typing import Annotated
 
+from semantic_kernel import Kernel
 from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.functions.kernel_function_decorator import kernel_function
-from semantic_kernel.kernel import Kernel
+from semantic_kernel.contents import AuthorRole, ChatMessageContent
+from semantic_kernel.functions import kernel_function
 
 #####################################################################
 # The following sample demonstrates how to create an OpenAI         #
@@ -16,8 +15,6 @@ from semantic_kernel.kernel import Kernel
 # conversation state, similar to a Semantic Kernel Chat History.    #
 #####################################################################
 
-HOST_NAME = "Host"
-HOST_INSTRUCTIONS = "Answer questions about the menu."
 
 # Note: you may toggle this to switch between AzureOpenAI and OpenAI
 use_azure_openai = False
@@ -42,24 +39,16 @@ class MenuPlugin:
         return "$9.99"
 
 
-# A helper method to invoke the agent with the user input
-async def invoke_agent(agent: OpenAIAssistantAgent, thread_id: str, input: str) -> None:
-    """Invoke the agent with the user input."""
-    await agent.add_chat_message(thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=input))
+# Create the instance of the Kernel
+kernel = Kernel()
 
-    print(f"# {AuthorRole.USER}: '{input}'")
-
-    async for content in agent.invoke(thread_id=thread_id):
-        if content.role != AuthorRole.TOOL:
-            print(f"# {content.role}: {content.content}")
+# Add the sample plugin to the kernel
+kernel.add_plugin(plugin=MenuPlugin(), plugin_name="menu")
 
 
 async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
-
-    # Add the sample plugin to the kernel
-    kernel.add_plugin(plugin=MenuPlugin(), plugin_name="menu")
+    HOST_NAME = "Host"
+    HOST_INSTRUCTIONS = "Answer questions about the menu."
 
     # Create the OpenAI Assistant Agent
     service_id = "agent"
@@ -74,11 +63,17 @@ async def main():
 
     thread_id = await agent.create_thread()
 
+    user_inputs = {"Hello", "What is the special soup?", "What is the special drink?", "Thank you"}
     try:
-        await invoke_agent(agent, thread_id=thread_id, input="Hello")
-        await invoke_agent(agent, thread_id=thread_id, input="What is the special soup?")
-        await invoke_agent(agent, thread_id=thread_id, input="What is the special drink?")
-        await invoke_agent(agent, thread_id=thread_id, input="Thank you")
+        for user_input in user_inputs:
+            await agent.add_chat_message(
+                thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=user_input)
+            )
+            print(f"# User: '{user_input}'")
+            async for content in agent.invoke(thread_id=thread_id):
+                if content.role != AuthorRole.TOOL:
+                    print(f"# Agent: {content.content}")
+
     finally:
         await agent.delete_thread(thread_id)
         await agent.delete()

--- a/python/samples/getting_started_with_agents/step7_assistant.py
+++ b/python/samples/getting_started_with_agents/step7_assistant.py
@@ -63,7 +63,7 @@ async def main():
 
     thread_id = await agent.create_thread()
 
-    user_inputs = {"Hello", "What is the special soup?", "What is the special drink?", "Thank you"}
+    user_inputs = ["Hello", "What is the special soup?", "What is the special drink?", "Thank you"]
     try:
         for user_input in user_inputs:
             await agent.add_chat_message(

--- a/python/samples/getting_started_with_agents/step8_assistant_vision.py
+++ b/python/samples/getting_started_with_agents/step8_assistant_vision.py
@@ -1,14 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
+
 import asyncio
 import os
 
-from semantic_kernel.agents.open_ai.open_ai_assistant_agent import OpenAIAssistantAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.file_reference_content import FileReferenceContent
-from semantic_kernel.contents.image_content import ImageContent
-from semantic_kernel.contents.text_content import TextContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.kernel import Kernel
+from semantic_kernel import Kernel
+from semantic_kernel.agents.open_ai import OpenAIAssistantAgent
+from semantic_kernel.contents import AuthorRole, ChatMessageContent, FileReferenceContent, ImageContent, TextContent
 
 #####################################################################
 # The following sample demonstrates how to create an OpenAI         #
@@ -17,58 +14,20 @@ from semantic_kernel.kernel import Kernel
 # and answer questions about them.                                  #
 #####################################################################
 
-HOST_NAME = "Host"
-HOST_INSTRUCTIONS = "Answer questions about the menu."
 
+# Create the instance of the Kernel
+kernel = Kernel()
 
-def create_message_with_image_url(input: str, url: str) -> ChatMessageContent:
-    return ChatMessageContent(
-        role=AuthorRole.USER,
-        items=[TextContent(text=input), ImageContent(uri=url)],
-    )
-
-
-def create_message_with_image_reference(input: str, file_id: str) -> ChatMessageContent:
-    return ChatMessageContent(
-        role=AuthorRole.USER,
-        items=[TextContent(text=input), FileReferenceContent(file_id=file_id)],
-    )
-
-
+# Toggle streaming or non-streaming mode
 streaming = False
 
 
-# A helper method to invoke the agent with the user input
-async def invoke_agent(agent: OpenAIAssistantAgent, thread_id: str, message: ChatMessageContent) -> None:
-    """Invoke the agent with the user input."""
-    await agent.add_chat_message(thread_id=thread_id, message=message)
-
-    print(f"# {AuthorRole.USER}: '{message.items[0].text}'")
-
-    if streaming:
-        first_chunk = True
-        async for content in agent.invoke_stream(thread_id=thread_id):
-            if content.role != AuthorRole.TOOL:
-                if first_chunk:
-                    print(f"# {content.role}: ", end="", flush=True)
-                    first_chunk = False
-                print(content.content, end="", flush=True)
-        print()
-    else:
-        async for content in agent.invoke(thread_id=thread_id):
-            if content.role != AuthorRole.TOOL:
-                print(f"# {content.role}: {content.content}")
-
-
 async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
-
-    service_id = "agent"
-
     # Create the Assistant Agent
+    AGENT_NAME = "Host"
+    AGENT_INSTRUCTIONS = "Answer questions about the menu."
     agent = await OpenAIAssistantAgent.create(
-        kernel=kernel, service_id=service_id, name=HOST_NAME, instructions=HOST_INSTRUCTIONS
+        kernel=kernel, service_id="agent", name=AGENT_NAME, instructions=AGENT_INSTRUCTIONS
     )
 
     cat_image_file_path = os.path.join(
@@ -83,28 +42,51 @@ async def main():
     # Create a thread for the conversation
     thread_id = await agent.create_thread()
 
+    user_messages = {
+        ChatMessageContent(
+            role=AuthorRole.USER,
+            items=[
+                TextContent(text="Describe this image."),
+                ImageContent(
+                    uri="https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/New_york_times_square-terabass.jpg/1200px-New_york_times_square-terabass.jpg"
+                ),
+            ],
+        ),
+        ChatMessageContent(
+            role=AuthorRole.USER,
+            items=[
+                TextContent(text="What is the main color in this image?"),
+                ImageContent(uri="https://upload.wikimedia.org/wikipedia/commons/5/56/White_shark.jpg"),
+            ],
+        ),
+        ChatMessageContent(
+            role=AuthorRole.USER,
+            items=[
+                TextContent(text="Is there an animal in this image?"),
+                FileReferenceContent(file_id=file_id),
+            ],
+        ),
+    }
     try:
-        await invoke_agent(
-            agent,
-            thread_id=thread_id,
-            message=create_message_with_image_url(
-                "Describe this image.",
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/New_york_times_square-terabass.jpg/1200px-New_york_times_square-terabass.jpg",
-            ),
-        )
-        await invoke_agent(
-            agent,
-            thread_id=thread_id,
-            message=create_message_with_image_url(
-                "What is the main color in this image?",
-                "https://upload.wikimedia.org/wikipedia/commons/5/56/White_shark.jpg",
-            ),
-        )
-        await invoke_agent(
-            agent,
-            thread_id=thread_id,
-            message=create_message_with_image_reference("Is there an animal in this image?", file_id),
-        )
+        for message in user_messages:
+            await agent.add_chat_message(thread_id=thread_id, message=message)
+
+            print(f"# User: '{message.items[0].text}'")
+
+            if streaming:
+                first_chunk = True
+                async for content in agent.invoke_stream(thread_id=thread_id):
+                    if content.role != AuthorRole.TOOL:
+                        if first_chunk:
+                            print("# Agent: ", end="", flush=True)
+                            first_chunk = False
+                        print(content.content, end="", flush=True)
+                print()
+            else:
+                async for content in agent.invoke(thread_id=thread_id):
+                    if content.role != AuthorRole.TOOL:
+                        print(f"# Agent: {content.content}")
+
     finally:
         await agent.delete_file(file_id)
         await agent.delete_thread(thread_id)

--- a/python/samples/getting_started_with_agents/step9_assistant_tool_code_interpreter.py
+++ b/python/samples/getting_started_with_agents/step9_assistant_tool_code_interpreter.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 import asyncio
 
-from semantic_kernel.agents.open_ai.azure_assistant_agent import AzureAssistantAgent
-from semantic_kernel.agents.open_ai.open_ai_assistant_agent import OpenAIAssistantAgent
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.utils.author_role import AuthorRole
-from semantic_kernel.kernel import Kernel
+from semantic_kernel import Kernel
+from semantic_kernel.agents.open_ai import AzureAssistantAgent, OpenAIAssistantAgent
+from semantic_kernel.contents import AuthorRole, ChatMessageContent
 
 #####################################################################
 # The following sample demonstrates how to create an OpenAI         #
@@ -14,32 +12,18 @@ from semantic_kernel.kernel import Kernel
 # Python code to print Fibonacci numbers.                           #
 #####################################################################
 
-
-AGENT_NAME = "CodeRunner"
-AGENT_INSTRUCTIONS = "Run the provided code file and return the result."
+# Create the instance of the Kernel
+kernel = Kernel()
 
 # Note: you may toggle this to switch between AzureOpenAI and OpenAI
-use_azure_openai = True
-
-
-# A helper method to invoke the agent with the user input
-async def invoke_agent(agent: OpenAIAssistantAgent, thread_id: str, input: str) -> None:
-    """Invoke the agent with the user input."""
-    await agent.add_chat_message(thread_id=thread_id, message=ChatMessageContent(role=AuthorRole.USER, content=input))
-
-    print(f"# {AuthorRole.USER}: '{input}'")
-
-    async for content in agent.invoke(thread_id=thread_id):
-        if content.role != AuthorRole.TOOL:
-            print(f"# {content.role}: {content.content}")
+use_azure_openai = False
 
 
 async def main():
-    # Create the instance of the Kernel
-    kernel = Kernel()
-
     # Define a service_id for the sample
     service_id = "agent"
+    AGENT_NAME = "CodeRunner"
+    AGENT_INSTRUCTIONS = "Run the provided code file and return the result."
 
     # Create the agent
     if use_azure_openai:
@@ -61,12 +45,19 @@ async def main():
 
     thread_id = await agent.create_thread()
 
+    user_input = "Use code to determine the values in the Fibonacci sequence that that are less then the value of 101?"
+    print(f"# User: '{user_input}'")
     try:
-        await invoke_agent(
-            agent,
+        await agent.add_chat_message(
             thread_id=thread_id,
-            input="Use code to determine the values in the Fibonacci sequence that that are less then the value of 101?",  # noqa: E501
+            message=ChatMessageContent(
+                role=AuthorRole.USER,
+                content=user_input,
+            ),
         )
+        async for content in agent.invoke(thread_id=thread_id):
+            if content.role != AuthorRole.TOOL:
+                print(f"# Agent: {content.content}")
     finally:
         await agent.delete_thread(thread_id)
         await agent.delete()

--- a/python/semantic_kernel/agents/agent.py
+++ b/python/semantic_kernel/agents/agent.py
@@ -22,6 +22,8 @@ from semantic_kernel.utils.validation import AGENT_NAME_REGEX
 if TYPE_CHECKING:
     from semantic_kernel.contents.chat_history import ChatHistory
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -57,6 +59,12 @@ class Agent(KernelBaseModel):
         """Perform the reduction on the provided history, returning True if reduction occurred."""
         if self.history_reducer is None:
             return False
+
+        if self.history_reducer is history:
+            logger.info("You're reducing the same object, you can call `history.reduce()` instead.")
+            initial_len = len(history.messages)
+            await history.reduce()
+            return len(history.messages) < initial_len
 
         self.history_reducer.messages = history.messages
 

--- a/python/semantic_kernel/agents/agent.py
+++ b/python/semantic_kernel/agents/agent.py
@@ -25,9 +25,6 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-logger: logging.Logger = logging.getLogger(__name__)
-
-
 @experimental_class
 class Agent(KernelBaseModel):
     """Base abstraction for all Semantic Kernel agents.
@@ -62,16 +59,14 @@ class Agent(KernelBaseModel):
 
         if self.history_reducer is history:
             logger.info("You're reducing the same object, you can call `history.reduce()` instead.")
-            initial_len = len(history.messages)
-            await history.reduce()
-            return len(history.messages) < initial_len
+            initial_len = len(self.history_reducer)
+            await self.history_reducer.reduce()
+            return len(self.history_reducer) < initial_len
 
         self.history_reducer.messages = history.messages
-
-        reducer = await self.history_reducer.reduce()
-        if reducer is not None:
-            history.messages.clear()
-            history.messages.extend(reducer.messages)
+        new_messages = await self.history_reducer.reduce()
+        if new_messages is not None:
+            history.replace(new_messages)
             return True
 
         return False

--- a/python/semantic_kernel/agents/agent.py
+++ b/python/semantic_kernel/agents/agent.py
@@ -67,7 +67,7 @@ class Agent(KernelBaseModel):
             raise NotImplementedError("Unable to create channel. Channel type not configured.")
         return self.channel_type()
 
-    async def format_instructions(self, kernel: Kernel, arguments: "KernelArguments") -> str | None:
+    async def format_instructions(self, kernel: Kernel, arguments: KernelArguments) -> str | None:
         """Format the instructions.
 
         Args:

--- a/python/semantic_kernel/agents/channels/chat_history_channel.py
+++ b/python/semantic_kernel/agents/channels/chat_history_channel.py
@@ -64,9 +64,6 @@ class ChatHistoryChannel(AgentChannel, ChatHistory):
                 f"Invalid channel binding for agent with id: `{id}` with name: ({type(agent).__name__})"
             )
 
-        # pre-process history reduction
-        await agent.reduce_history(self)
-
         message_count = len(self.messages)
         mutated_history = set()
         message_queue: Deque[ChatMessageContent] = deque()
@@ -121,9 +118,6 @@ class ChatHistoryChannel(AgentChannel, ChatHistory):
             raise ServiceInvalidTypeError(
                 f"Invalid channel binding for agent with id: `{id}` with name: ({type(agent).__name__})"
             )
-
-        # pre-process history reduction
-        await agent.reduce_history(self)
 
         message_count = len(self.messages)
 

--- a/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
+++ b/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
@@ -12,7 +12,6 @@ from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecut
 from semantic_kernel.const import DEFAULT_SERVICE_NAME
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
 from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.exceptions import KernelServiceNotFoundError
@@ -48,7 +47,6 @@ class ChatCompletionAgent(Agent):
         id: str | None = None,
         description: str | None = None,
         instructions: str | None = None,
-        history_reducer: ChatHistoryReducer | None = None,
         arguments: KernelArguments | None = None,
         prompt_template_config: PromptTemplateConfig | None = None,
     ) -> None:
@@ -63,7 +61,6 @@ class ChatCompletionAgent(Agent):
                 a unique GUID will be generated.
             description: The description of the agent. (optional)
             instructions: The instructions for the agent. (optional)
-            history_reducer: The history reducer for the agent. (optional)
             arguments: The kernel arguments for the agent. (optional) Invoke method arguments take precedence over
                 the arguments provided here.
             prompt_template_config: The prompt template configuration for the agent. (optional)
@@ -81,8 +78,6 @@ class ChatCompletionAgent(Agent):
             args["id"] = id
         if kernel is not None:
             args["kernel"] = kernel
-        if history_reducer is not None:
-            args["history_reducer"] = history_reducer
         if arguments is not None:
             args["arguments"] = arguments
 

--- a/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
+++ b/python/semantic_kernel/agents/chat_completion/chat_completion_agent.py
@@ -248,16 +248,11 @@ class ChatCompletionAgent(Agent):
         self, history: ChatHistory, kernel: "Kernel", arguments: KernelArguments
     ) -> ChatHistory:
         """Setup the agent chat history."""
-        chat = []
-
-        instructions = await self.format_instructions(kernel, arguments)
-
-        if instructions is not None:
-            chat.append(ChatMessageContent(role=AuthorRole.SYSTEM, content=instructions, name=self.name))
-
-        chat.extend(history.messages if history.messages else [])
-
-        return ChatHistory(messages=chat)
+        return (
+            ChatHistory(messages=history.messages)
+            if self.instructions is None
+            else ChatHistory(system_message=self.instructions, messages=history.messages)
+        )
 
     async def _get_chat_completion_service_and_settings(
         self, kernel: "Kernel", arguments: KernelArguments

--- a/python/semantic_kernel/agents/group_chat/agent_chat.py
+++ b/python/semantic_kernel/agents/group_chat/agent_chat.py
@@ -54,7 +54,7 @@ class AgentChat(KernelBaseModel):
         """Invoke the agent asynchronously."""
         raise NotImplementedError("Subclasses should implement this method")
 
-    async def get_messages_in_descending_order(self):
+    async def get_messages_in_descending_order(self) -> AsyncGenerator[ChatMessageContent, None]:
         """Get messages in descending order asynchronously."""
         for index in range(len(self.history.messages) - 1, -1, -1):
             yield self.history.messages[index]

--- a/python/semantic_kernel/agents/group_chat/agent_chat.py
+++ b/python/semantic_kernel/agents/group_chat/agent_chat.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import threading
-from collections.abc import AsyncGenerator, AsyncIterable
+from collections.abc import AsyncIterable
 
 from pydantic import Field, PrivateAttr
 
@@ -54,13 +54,13 @@ class AgentChat(KernelBaseModel):
         """Invoke the agent asynchronously."""
         raise NotImplementedError("Subclasses should implement this method")
 
-    async def get_messages_in_descending_order(self) -> AsyncGenerator[ChatMessageContent, None]:
+    async def get_messages_in_descending_order(self) -> AsyncIterable[ChatMessageContent]:
         """Get messages in descending order asynchronously."""
         for index in range(len(self.history.messages) - 1, -1, -1):
             yield self.history.messages[index]
             await asyncio.sleep(0)  # Yield control to the event loop
 
-    async def get_chat_messages(self, agent: "Agent | None" = None) -> AsyncGenerator[ChatMessageContent, None]:
+    async def get_chat_messages(self, agent: "Agent | None" = None) -> AsyncIterable[ChatMessageContent]:
         """Get chat messages asynchronously."""
         self.set_activity_or_throw()
 

--- a/python/semantic_kernel/agents/strategies/__init__.py
+++ b/python/semantic_kernel/agents/strategies/__init__.py
@@ -9,6 +9,7 @@ from semantic_kernel.agents.strategies.termination.default_termination_strategy 
 from semantic_kernel.agents.strategies.termination.kernel_function_termination_strategy import (
     KernelFunctionTerminationStrategy,
 )
+from semantic_kernel.agents.strategies.termination.termination_strategy import TerminationStrategy
 
 __all__ = [
     "AggregatorTerminationStrategy",
@@ -16,4 +17,5 @@ __all__ = [
     "KernelFunctionSelectionStrategy",
     "KernelFunctionTerminationStrategy",
     "SequentialSelectionStrategy",
+    "TerminationStrategy",
 ]

--- a/python/semantic_kernel/contents/__init__.py
+++ b/python/semantic_kernel/contents/__init__.py
@@ -6,6 +6,7 @@ from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
+from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
 from semantic_kernel.contents.history_reducer.chat_history_summarization_reducer import ChatHistorySummarizationReducer
 from semantic_kernel.contents.history_reducer.chat_history_truncation_reducer import ChatHistoryTruncationReducer
 from semantic_kernel.contents.image_content import ImageContent
@@ -22,6 +23,7 @@ __all__ = [
     "AudioContent",
     "AuthorRole",
     "ChatHistory",
+    "ChatHistoryReducer",
     "ChatHistorySummarizationReducer",
     "ChatHistoryTruncationReducer",
     "ChatMessageContent",

--- a/python/semantic_kernel/contents/__init__.py
+++ b/python/semantic_kernel/contents/__init__.py
@@ -4,6 +4,7 @@ from semantic_kernel.contents.annotation_content import AnnotationContent
 from semantic_kernel.contents.audio_content import AudioContent
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.file_reference_content import FileReferenceContent
 from semantic_kernel.contents.function_call_content import FunctionCallContent
 from semantic_kernel.contents.function_result_content import FunctionResultContent
 from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
@@ -27,6 +28,7 @@ __all__ = [
     "ChatHistorySummarizationReducer",
     "ChatHistoryTruncationReducer",
     "ChatMessageContent",
+    "FileReferenceContent",
     "FinishReason",
     "FunctionCallContent",
     "FunctionResultContent",

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import logging
-from collections.abc import Generator, Iterable, MutableSequence
+from collections.abc import Generator, Iterable
 from functools import singledispatchmethod
 from html import unescape
 from typing import Any, TypeVar
@@ -33,7 +33,7 @@ class ChatHistory(KernelBaseModel):
         messages: The list of chat messages in the history.
     """
 
-    messages: MutableSequence[ChatMessageContent]
+    messages: list[ChatMessageContent]
 
     def __init__(self, **data: Any):
         """Initializes a new instance of the ChatHistory class.
@@ -74,7 +74,7 @@ class ChatHistory(KernelBaseModel):
 
     @field_validator("messages", mode="before")
     @classmethod
-    def _validate_messages(cls, messages: MutableSequence[ChatMessageContent]) -> MutableSequence[ChatMessageContent]:
+    def _validate_messages(cls, messages: list[ChatMessageContent]) -> list[ChatMessageContent]:
         if not messages:
             return messages
         out_msgs: list[ChatMessageContent] = []

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -87,7 +87,13 @@ class ChatHistory(KernelBaseModel):
 
     @singledispatchmethod
     def add_system_message(self, content: str | list[KernelContent], **kwargs) -> None:
-        """Add a system message to the chat history."""
+        """Add a system message to the chat history.
+
+        Args:
+            content: The content of the system message, can be a string or a
+            list of KernelContent instances that are turned into a single ChatMessageContent.
+            **kwargs: Additional keyword arguments.
+        """
         raise NotImplementedError
 
     @add_system_message.register
@@ -102,7 +108,13 @@ class ChatHistory(KernelBaseModel):
 
     @singledispatchmethod
     def add_developer_message(self, content: str | list[KernelContent], **kwargs) -> None:
-        """Add a system message to the chat history."""
+        """Add a system message to the chat history.
+
+        Args:
+            content: The content of the developer message, can be a string or a
+            list of KernelContent instances that are turned into a single ChatMessageContent.
+            **kwargs: Additional keyword arguments.
+        """
         raise NotImplementedError
 
     @add_developer_message.register
@@ -117,7 +129,14 @@ class ChatHistory(KernelBaseModel):
 
     @singledispatchmethod
     def add_user_message(self, content: str | list[KernelContent], **kwargs: Any) -> None:
-        """Add a user message to the chat history."""
+        """Add a user message to the chat history.
+
+        Args:
+            content: The content of the user message, can be a string or a
+            list of KernelContent instances that are turned into a single ChatMessageContent.
+            **kwargs: Additional keyword arguments.
+
+        """
         raise NotImplementedError
 
     @add_user_message.register
@@ -132,7 +151,13 @@ class ChatHistory(KernelBaseModel):
 
     @singledispatchmethod
     def add_assistant_message(self, content: str | list[KernelContent], **kwargs: Any) -> None:
-        """Add an assistant message to the chat history."""
+        """Add an assistant message to the chat history.
+
+        Args:
+            content: The content of the assistant message, can be a string or a
+            list of KernelContent instances that are turned into a single ChatMessageContent.
+            **kwargs: Additional keyword arguments.
+        """
         raise NotImplementedError
 
     @add_assistant_message.register
@@ -147,7 +172,13 @@ class ChatHistory(KernelBaseModel):
 
     @singledispatchmethod
     def add_tool_message(self, content: str | list[KernelContent], **kwargs: Any) -> None:
-        """Add a tool message to the chat history."""
+        """Add a tool message to the chat history.
+
+        Args:
+            content: The content of the tool message, can be a string or a
+            list of KernelContent instances that are turned into a single ChatMessageContent.
+            **kwargs: Additional keyword arguments.
+        """
         raise NotImplementedError
 
     @add_tool_message.register

--- a/python/semantic_kernel/contents/history_reducer/chat_history_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_reducer.py
@@ -4,10 +4,6 @@ import sys
 from abc import ABC, abstractmethod
 from typing import Any
 
-if sys.version < "3.12":
-    pass  # pragma: no cover
-else:
-    pass  # type: ignore # pragma: no cover
 if sys.version < "3.11":
     from typing_extensions import Self  # pragma: no cover
 else:

--- a/python/semantic_kernel/contents/history_reducer/chat_history_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_reducer.py
@@ -2,7 +2,12 @@
 
 import sys
 from abc import ABC, abstractmethod
+from typing import Any
 
+if sys.version < "3.12":
+    pass  # pragma: no cover
+else:
+    pass  # type: ignore # pragma: no cover
 if sys.version < "3.11":
     from typing_extensions import Self  # pragma: no cover
 else:
@@ -11,6 +16,8 @@ else:
 from pydantic import Field
 
 from semantic_kernel.contents.chat_history import ChatHistory
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.exceptions.content_exceptions import ContentInitializationError
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
 
@@ -19,7 +26,11 @@ class ChatHistoryReducer(ChatHistory, ABC):
     """Defines a contract for reducing chat history."""
 
     target_count: int = Field(..., gt=0, description="Target message count.")
-    threshold_count: int = Field(0, ge=0, description="Threshold count to avoid orphaning messages.")
+    threshold_count: int = Field(default=0, ge=0, description="Threshold count to avoid orphaning messages.")
+    auto_reduce: bool = Field(
+        default=False,
+        description="Whether to automatically reduce the chat history, this happens when using add_message_async.",
+    )
 
     @abstractmethod
     async def reduce(self) -> Self | None:
@@ -29,3 +40,28 @@ class ChatHistoryReducer(ChatHistory, ABC):
             A possibly shorter list of messages, or None if no change is needed.
         """
         ...
+
+    async def add_message_async(
+        self,
+        message: ChatMessageContent | dict[str, Any],
+        encoding: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Add a message to the chat history.
+
+        If auto_reduce is enabled, the history will be reduced after adding the message.
+        """
+        if isinstance(message, ChatMessageContent):
+            self.messages.append(message)
+            if self.auto_reduce:
+                await self.reduce()
+            return
+        if "role" not in message:
+            raise ContentInitializationError(f"Dictionary must contain at least the role. Got: {message}")
+        if encoding:
+            message["encoding"] = encoding
+        if metadata:
+            message["metadata"] = metadata
+        self.messages.append(ChatMessageContent(**message))
+        if self.auto_reduce:
+            await self.reduce()

--- a/python/semantic_kernel/contents/history_reducer/chat_history_reducer_utils.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_reducer_utils.py
@@ -96,10 +96,11 @@ def locate_safe_reduction_index(
     message_index = total_count - target_count
 
     # Move backward to avoid cutting function calls / results
+    # also skip over developer/system messages
     while message_index >= offset_count:
-        if not any(
-            isinstance(item, (FunctionCallContent, FunctionResultContent)) for item in history[message_index].items
-        ):
+        if history[message_index].role not in (AuthorRole.DEVELOPER, AuthorRole.SYSTEM):
+            break
+        if not contains_function_call_or_result(history[message_index]):
             break
         message_index -= 1
 
@@ -161,6 +162,11 @@ def extract_range(
 
         # If filter_func excludes it, skip it
         if filter_func and filter_func(msg):
+            i += 1
+            continue
+
+        # skipping system/developer message
+        if msg.role in (AuthorRole.DEVELOPER, AuthorRole.SYSTEM):
             i += 1
             continue
 

--- a/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
@@ -2,19 +2,17 @@
 
 import logging
 import sys
-from typing import Any, override
-
-from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
-from semantic_kernel.utils.experimental_decorator import experimental_class
+from typing import Any
 
 if sys.version < "3.11":
-    from typing_extensions import Self  # pragma: no cover
+    from typing_extensions import Self, override  # pragma: no cover
 else:
-    from typing import Self  # type: ignore # pragma: no cover
+    from typing import Self, override  # type: ignore # pragma: no cover
 
 from pydantic import Field
 
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.const import DEFAULT_SERVICE_NAME
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
@@ -27,6 +25,7 @@ from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import 
     locate_summarization_boundary,
 )
 from semantic_kernel.exceptions.content_exceptions import ChatHistoryReducerException
+from semantic_kernel.utils.experimental_decorator import experimental_class
 
 logger = logging.getLogger(__name__)
 

--- a/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
@@ -5,9 +5,13 @@ import sys
 from typing import Any
 
 if sys.version < "3.11":
-    from typing_extensions import Self, override  # pragma: no cover
+    from typing_extensions import Self  # pragma: no cover
 else:
-    from typing import Self, override  # type: ignore # pragma: no cover
+    from typing import Self  # type: ignore # pragma: no cover
+if sys.version < "3.12":
+    from typing_extensions import override  # pragma: no cover
+else:
+    from typing import override  # pragma: no cover
 
 from pydantic import Field
 

--- a/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
@@ -56,13 +56,13 @@ class ChatHistorySummarizationReducer(ChatHistoryReducer):
         default_factory=lambda: DEFAULT_SUMMARIZATION_PROMPT,
         description="The summarization instructions.",
     )
-    use_single_summary: bool = Field(True, description="Whether to use a single summary message.")
-    fail_on_error: bool = Field(True, description="Raise error if summarization fails.")
+    use_single_summary: bool = Field(default=True, description="Whether to use a single summary message.")
+    fail_on_error: bool = Field(default=True, description="Raise error if summarization fails.")
     service_id: str = Field(
         default_factory=lambda: DEFAULT_SERVICE_NAME, description="The ID of the chat completion service."
     )
     include_function_content_in_summary: bool = Field(
-        False, description="Whether to include function calls/results in the summary."
+        default=False, description="Whether to include function calls/results in the summary."
     )
     execution_settings: PromptExecutionSettings | None = None
 
@@ -82,16 +82,17 @@ class ChatHistorySummarizationReducer(ChatHistoryReducer):
         """Initialize the ChatHistorySummarizationReducer.
 
         Args:
-            service (ChatCompletionClientBase): The chat completion service.
-            target_count (int): The target number of messages to retain after applying summarization.
-            service_id (str | None): The ID of the chat completion service.
-            threshold_count (int | None): The threshold beyond target_count required to trigger reduction.
-            summarization_instructions (str | None): The summarization instructions.
-            use_single_summary (bool | None): Whether to use a single summary message.
-            fail_on_error (bool | None): Raise error if summarization fails.
-            include_function_content_in_summary (bool | None): Whether to include function calls/results in the summary.
-            execution_settings (PromptExecutionSettings | None): The prompt execution settings.
-            **kwargs (Any): Additional keyword arguments.
+            service: The chat completion service.
+            target_count: The target number of messages to retain after applying summarization.
+            service_id: The ID of the chat completion service.
+            threshold_count: The threshold beyond target_count required to trigger reduction.
+            summarization_instructions: The summarization instructions.
+            use_single_summary: Whether to use a single summary message, default is True.
+            fail_on_error: Raise error if summarization fails, default is True.
+            include_function_content_in_summary: Whether to include function calls/results in the summary,
+                default is False.
+            execution_settings: The prompt execution settings.
+            **kwargs: Additional keyword arguments.
         """
         args: dict[str, Any] = {
             "service": service,

--- a/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
@@ -11,7 +11,7 @@ else:
 if sys.version < "3.12":
     from typing_extensions import override  # pragma: no cover
 else:
-    from typing import override  # pragma: no cover
+    from typing import override  # type: ignore # pragma: no cover
 
 from pydantic import Field
 

--- a/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
@@ -2,7 +2,6 @@
 
 import logging
 import sys
-from typing import Any
 
 if sys.version < "3.11":
     from typing_extensions import Self  # pragma: no cover
@@ -17,7 +16,6 @@ from pydantic import Field
 
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
-from semantic_kernel.const import DEFAULT_SERVICE_NAME
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
@@ -52,71 +50,36 @@ This summary must never:
 
 @experimental_class
 class ChatHistorySummarizationReducer(ChatHistoryReducer):
-    """A ChatHistory with logic to summarize older messages past a target count."""
+    """A ChatHistory with logic to summarize older messages past a target count.
+
+    This class inherits from ChatHistoryReducer, which in turn inherits from ChatHistory.
+    It can be used anywhere a ChatHistory is expected, while adding summarization capability.
+
+    Args:
+        target_count: The target message count.
+        threshold_count: The threshold count to avoid orphaning messages.
+        auto_reduce: Whether to automatically reduce the chat history, default is False.
+        service: The ChatCompletion service to use for summarization.
+        summarization_instructions: The summarization instructions, optional.
+        use_single_summary: Whether to use a single summary message, default is True.
+        fail_on_error: Raise error if summarization fails, default is True.
+        include_function_content_in_summary: Whether to include function calls/results in the summary, default is False.
+        execution_settings: The execution settings for the summarization prompt, optional.
+
+    """
 
     service: ChatCompletionClientBase
     summarization_instructions: str = Field(
-        default_factory=lambda: DEFAULT_SUMMARIZATION_PROMPT,
+        default=DEFAULT_SUMMARIZATION_PROMPT,
         description="The summarization instructions.",
+        kw_only=True,
     )
     use_single_summary: bool = Field(default=True, description="Whether to use a single summary message.")
     fail_on_error: bool = Field(default=True, description="Raise error if summarization fails.")
-    service_id: str = Field(
-        default_factory=lambda: DEFAULT_SERVICE_NAME, description="The ID of the chat completion service."
-    )
     include_function_content_in_summary: bool = Field(
         default=False, description="Whether to include function calls/results in the summary."
     )
     execution_settings: PromptExecutionSettings | None = None
-
-    def __init__(
-        self,
-        service: ChatCompletionClientBase,
-        target_count: int,
-        service_id: str | None = None,
-        threshold_count: int | None = None,
-        summarization_instructions: str | None = None,
-        use_single_summary: bool | None = None,
-        fail_on_error: bool | None = None,
-        include_function_content_in_summary: bool | None = None,
-        execution_settings: PromptExecutionSettings | None = None,
-        **kwargs: Any,
-    ):
-        """Initialize the ChatHistorySummarizationReducer.
-
-        Args:
-            service: The chat completion service.
-            target_count: The target number of messages to retain after applying summarization.
-            service_id: The ID of the chat completion service.
-            threshold_count: The threshold beyond target_count required to trigger reduction.
-            summarization_instructions: The summarization instructions.
-            use_single_summary: Whether to use a single summary message, default is True.
-            fail_on_error: Raise error if summarization fails, default is True.
-            include_function_content_in_summary: Whether to include function calls/results in the summary,
-                default is False.
-            execution_settings: The prompt execution settings.
-            **kwargs: Additional keyword arguments.
-        """
-        args: dict[str, Any] = {
-            "service": service,
-            "target_count": target_count,
-        }
-        if service_id is not None:
-            args["service_id"] = service_id
-        if threshold_count is not None:
-            args["threshold_count"] = threshold_count
-        if summarization_instructions is not None:
-            args["summarization_instructions"] = summarization_instructions
-        if use_single_summary is not None:
-            args["use_single_summary"] = use_single_summary
-        if fail_on_error is not None:
-            args["fail_on_error"] = fail_on_error
-        if include_function_content_in_summary is not None:
-            args["include_function_content_in_summary"] = include_function_content_in_summary
-        if execution_settings is not None:
-            args["execution_settings"] = execution_settings
-
-        super().__init__(**args, **kwargs)
 
     @override
     async def reduce(self) -> Self | None:
@@ -191,19 +154,15 @@ class ChatHistorySummarizationReducer(ChatHistoryReducer):
         from semantic_kernel.contents.utils.author_role import AuthorRole
 
         chat_history = ChatHistory(messages=messages)
-
-        role = (
-            getattr(self.execution_settings, "instruction_role", AuthorRole.SYSTEM)
-            if self.execution_settings
-            else AuthorRole.SYSTEM
+        execution_settings = self.execution_settings or self.service.get_prompt_execution_settings_from_settings(
+            PromptExecutionSettings()
         )
-
-        chat_history.add_message(ChatMessageContent(role=role, content=self.summarization_instructions))
-
-        execution_settings = self.execution_settings or self.service.get_prompt_execution_settings_class()(
-            service_id=self.service_id
+        chat_history.add_message(
+            ChatMessageContent(
+                role=getattr(execution_settings, "instruction_role", AuthorRole.SYSTEM),
+                content=self.summarization_instructions,
+            )
         )
-
         return await self.service.get_chat_message_content(chat_history=chat_history, settings=execution_settings)
 
     def __eq__(self, other: object) -> bool:

--- a/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_summarization_reducer.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from typing import Any
+from typing import Any, override
 
 from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.utils.experimental_decorator import experimental_class
@@ -115,8 +115,8 @@ class ChatHistorySummarizationReducer(ChatHistoryReducer):
 
         super().__init__(**args, **kwargs)
 
+    @override
     async def reduce(self) -> Self | None:
-        """Summarize the older messages past the target message count."""
         history = self.messages
         if len(history) <= self.target_count + (self.threshold_count or 0):
             return None  # No summarization needed

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -5,9 +5,13 @@ import sys
 from typing import Any
 
 if sys.version < "3.11":
-    from typing_extensions import Self, override  # pragma: no cover
+    from typing_extensions import Self  # pragma: no cover
 else:
-    from typing import Self, override  # type: ignore # pragma: no cover
+    from typing import Self  # type: ignore # pragma: no cover
+if sys.version < "3.12":
+    from typing_extensions import override  # pragma: no cover
+else:
+    from typing import override  # pragma: no cover
 
 from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
 from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import (

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -11,7 +11,7 @@ else:
 if sys.version < "3.12":
     from typing_extensions import override  # pragma: no cover
 else:
-    from typing import override  # pragma: no cover
+    from typing import override  # type: ignore  # pragma: no cover
 
 from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
 from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import (

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from typing import Any
+from typing import TYPE_CHECKING
 
 if sys.version < "3.11":
     from typing_extensions import Self  # pragma: no cover
@@ -13,12 +13,16 @@ if sys.version < "3.12":
 else:
     from typing import override  # type: ignore  # pragma: no cover
 
+
 from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
 from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import (
     extract_range,
     locate_safe_reduction_index,
 )
 from semantic_kernel.utils.experimental_decorator import experimental_class
+
+if TYPE_CHECKING:
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -29,16 +33,12 @@ class ChatHistoryTruncationReducer(ChatHistoryReducer):
 
     Because this class inherits from ChatHistoryReducer (which in turn inherits from ChatHistory),
     it can also be used anywhere a ChatHistory is expected, while adding truncation capability.
-    """
 
-    def __init__(self, target_count: int, threshold_count: int | None = None, **kwargs: Any):
-        """Initialize the truncation reducer."""
-        args: dict[str, Any] = {
-            "target_count": target_count,
-        }
-        if threshold_count is not None:
-            args["threshold_count"] = threshold_count
-        super().__init__(**args, **kwargs)
+    Args:
+        target_count: The target message count.
+        threshold_count: The threshold count to avoid orphaning messages.
+        auto_reduce: Whether to automatically reduce the chat history, default is False.
+    """
 
     @override
     async def reduce(self) -> Self | None:

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from typing import Any
+from typing import Any, override
 
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
@@ -37,12 +37,8 @@ class ChatHistoryTruncationReducer(ChatHistoryReducer):
             args["threshold_count"] = threshold_count
         super().__init__(**args, **kwargs)
 
+    @override
     async def reduce(self) -> Self | None:
-        """Truncate the chat history to the target message count, avoiding orphaned calls.
-
-        Returns:
-            The truncated list of messages if truncation occurred, or None otherwise.
-        """
         history = self.messages
         if len(history) <= self.target_count + (self.threshold_count or 0):
             # No need to reduce

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -2,14 +2,14 @@
 
 import logging
 import sys
-from typing import Any, override
+from typing import Any
 
 from semantic_kernel.utils.experimental_decorator import experimental_class
 
 if sys.version < "3.11":
-    from typing_extensions import Self  # pragma: no cover
+    from typing_extensions import Self, override  # pragma: no cover
 else:
-    from typing import Self  # type: ignore # pragma: no cover
+    from typing import Self, override  # type: ignore # pragma: no cover
 
 from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
 from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import (

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -2,7 +2,6 @@
 
 import logging
 import sys
-from typing import TYPE_CHECKING
 
 if sys.version < "3.11":
     from typing_extensions import Self  # pragma: no cover
@@ -20,9 +19,6 @@ from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import 
     locate_safe_reduction_index,
 )
 from semantic_kernel.utils.experimental_decorator import experimental_class
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
+++ b/python/semantic_kernel/contents/history_reducer/chat_history_truncation_reducer.py
@@ -4,8 +4,6 @@ import logging
 import sys
 from typing import Any
 
-from semantic_kernel.utils.experimental_decorator import experimental_class
-
 if sys.version < "3.11":
     from typing_extensions import Self, override  # pragma: no cover
 else:
@@ -16,6 +14,7 @@ from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import 
     extract_range,
     locate_safe_reduction_index,
 )
+from semantic_kernel.utils.experimental_decorator import experimental_class
 
 logger = logging.getLogger(__name__)
 

--- a/python/tests/unit/agents/test_agent.py
+++ b/python/tests/unit/agents/test_agent.py
@@ -116,7 +116,8 @@ def test_get_channel_keys_no_channel_type():
 def test_merge_arguments_both_none():
     agent = Agent()
     merged = agent.merge_arguments(None)
-    assert merged is None, "Should return None if both agent.arguments and override_args are None"
+    assert isinstance(merged, KernelArguments)
+    assert len(merged) == 0, "If both arguments are None, should return an empty KernelArguments object"
 
 
 def test_merge_arguments_agent_none_override_not_none():

--- a/python/tests/unit/agents/test_agent.py
+++ b/python/tests/unit/agents/test_agent.py
@@ -8,9 +8,6 @@ import pytest
 
 from semantic_kernel.agents import Agent
 from semantic_kernel.agents.channels.agent_channel import AgentChannel
-from semantic_kernel.contents.chat_message_content import ChatMessageContent
-from semantic_kernel.contents.history_reducer.chat_history_reducer import ChatHistoryReducer
-from semantic_kernel.contents.history_reducer.chat_history_truncation_reducer import ChatHistoryTruncationReducer
 from semantic_kernel.functions.kernel_arguments import KernelArguments
 
 
@@ -110,60 +107,10 @@ async def test_agent_hash():
     assert hash(agent1) != hash(agent3)
 
 
-async def test_reduce_history_no_reducer():
-    agent = Agent()
-    history = MockChatHistory(messages=["msg1", "msg2"])
-
-    result = await agent.reduce_history(history)
-
-    assert result is False, "reduce_history should return False if no history_reducer is set"
-    assert history.messages == ["msg1", "msg2"], "History should remain unchanged"
-
-
-async def test_reduce_history_reducer_returns_none():
-    agent = Agent()
-    agent.history_reducer = AsyncMock(spec=ChatHistoryReducer)
-    agent.history_reducer.reduce = AsyncMock(return_value=None)
-
-    history = MockChatHistory(messages=["original1", "original2"])
-    result = await agent.reduce_history(history)
-
-    assert result is False, "reduce_history should return False if reducer returns None"
-    assert history.messages == ["original1", "original2"], "History should remain unchanged"
-
-
-async def test_reduce_history_reducer_returns_messages():
-    agent = Agent()
-    agent.history_reducer = ChatHistoryTruncationReducer(target_count=1)
-    history = MockChatHistory(
-        messages=[
-            ChatMessageContent(role="user", content="original message"),
-            ChatMessageContent(role="assistant", content="assistant message"),
-        ]
-    )
-
-    result = await agent.reduce_history(history)
-
-    assert result is True, "reduce_history should return True if new messages are returned"
-    assert history.messages is not None
-
-
 def test_get_channel_keys_no_channel_type():
     agent = Agent()
     with pytest.raises(NotImplementedError):
         list(agent.get_channel_keys())
-
-
-def test_get_channel_keys_with_channel_and_reducer():
-    agent = MockAgent()
-    reducer = ChatHistoryTruncationReducer(target_count=1)
-    agent.history_reducer = reducer
-
-    keys = list(agent.get_channel_keys())
-    assert len(keys) == 3, "Should return three keys: channel, reducer class name, and reducer hash"
-    assert keys[0] == "MockChannel"
-    assert keys[1] == "ChatHistoryTruncationReducer"
-    assert keys[2] == str(reducer.__hash__), "Should return the string of the reducer's __hash__"
 
 
 def test_merge_arguments_both_none():

--- a/python/tests/unit/contents/test_chat_history_summarization_reducer.py
+++ b/python/tests/unit/contents/test_chat_history_summarization_reducer.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
-from semantic_kernel.const import DEFAULT_SERVICE_NAME
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.history_reducer.chat_history_reducer_utils import SUMMARY_METADATA_KEY
 from semantic_kernel.contents.history_reducer.chat_history_summarization_reducer import (
@@ -49,7 +49,6 @@ def test_summarization_reducer_init(mock_service):
     reducer = ChatHistorySummarizationReducer(
         service=mock_service,
         target_count=10,
-        service_id="my_service",
         threshold_count=5,
         summarization_instructions="Custom instructions",
         use_single_summary=False,
@@ -58,7 +57,6 @@ def test_summarization_reducer_init(mock_service):
 
     assert reducer.service == mock_service
     assert reducer.target_count == 10
-    assert reducer.service_id == "my_service"
     assert reducer.threshold_count == 5
     assert reducer.summarization_instructions == "Custom instructions"
     assert reducer.use_single_summary is False
@@ -72,7 +70,6 @@ def test_summarization_reducer_defaults(mock_service):
     assert reducer.summarization_instructions in reducer.summarization_instructions
     assert reducer.use_single_summary is True
     assert reducer.fail_on_error is True
-    assert reducer.service_id == DEFAULT_SERVICE_NAME
 
 
 def test_summarization_reducer_eq_and_hash(mock_service):
@@ -115,6 +112,7 @@ async def test_summarization_reducer_reduce_needed(mock_service):
     # Mock that the service will return a single summary message
     summary_content = ChatMessageContent(role=AuthorRole.ASSISTANT, content="This is a summary.")
     mock_service.get_chat_message_content.return_value = summary_content
+    mock_service.get_prompt_execution_settings_from_settings.return_value = PromptExecutionSettings()
 
     result = await reducer.reduce()
     assert result is not None, "We expect a shortened list with a new summary inserted."
@@ -122,6 +120,31 @@ async def test_summarization_reducer_reduce_needed(mock_service):
     assert any(msg.metadata.get(SUMMARY_METADATA_KEY) for msg in result), (
         "We expect to see a newly inserted summary message."
     )
+
+
+async def test_summarization_reducer_reduce_needed_auto(mock_service):
+    # Mock that the service will return a single summary message
+    summary_content = ChatMessageContent(role=AuthorRole.ASSISTANT, content="This is a summary.")
+    mock_service.get_chat_message_content.return_value = summary_content
+    mock_service.get_prompt_execution_settings_from_settings.return_value = PromptExecutionSettings()
+
+    messages = [
+        # A summary message (as in the original test)
+        ChatMessageContent(role=AuthorRole.SYSTEM, content="Existing summary", metadata={SUMMARY_METADATA_KEY: True}),
+        # Enough additional messages so total is > 4
+        ChatMessageContent(role=AuthorRole.USER, content="User says hello"),
+        ChatMessageContent(role=AuthorRole.ASSISTANT, content="Assistant responds"),
+        ChatMessageContent(role=AuthorRole.USER, content="User says more"),
+        ChatMessageContent(role=AuthorRole.ASSISTANT, content="Assistant responds again"),
+        ChatMessageContent(role=AuthorRole.USER, content="User says more"),
+        ChatMessageContent(role=AuthorRole.ASSISTANT, content="Assistant responds again"),
+    ]
+
+    reducer = ChatHistorySummarizationReducer(auto_reduce=True, service=mock_service, target_count=3, threshold_count=1)
+
+    for msg in messages:
+        await reducer.add_message_async(msg)
+        assert len(reducer.messages) <= 5, "We should auto-reduce after each message."
 
 
 async def test_summarization_reducer_reduce_no_messages_to_summarize(mock_service):
@@ -196,6 +219,7 @@ async def test_summarization_reducer_private_summarize(mock_service):
 
     summary_content = ChatMessageContent(role=AuthorRole.ASSISTANT, content="Mock Summary")
     mock_service.get_chat_message_content.return_value = summary_content
+    mock_service.get_prompt_execution_settings_from_settings.return_value = PromptExecutionSettings()
 
     actual_summary = await reducer._summarize(chat_messages)
     assert actual_summary is not None, "We should get a summary message back."

--- a/python/tests/unit/contents/test_chat_history_summarization_reducer.py
+++ b/python/tests/unit/contents/test_chat_history_summarization_reducer.py
@@ -144,7 +144,9 @@ async def test_summarization_reducer_reduce_needed_auto(mock_service):
 
     for msg in messages:
         await reducer.add_message_async(msg)
-        assert len(reducer.messages) <= 5, "We should auto-reduce after each message."
+        assert len(reducer.messages) <= 5, (
+            "We should auto-reduce after each message, we have one summary, and then 4 other messages."
+        )
 
 
 async def test_summarization_reducer_reduce_no_messages_to_summarize(mock_service):


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
When passing the same object to `agent.reduce_history` as is present in the `history_reducer` attribute of the agent that the function doesn't accurately behave. This fixes that.

Also updates the sample to be a bit more concise.

Also fixes the way the single_dispatch is setup in ChatHistory.

Also ensures system/developer messages are not reduced away as that might impact performance.

The `reduce_history` method was removed from the agent base class, in favor of having the caller manage the change history and reduction as needed. The `reduce_history` was added to the agent group chat, as the chat history is managed internally as agents are invoked.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
