### PR TITLE
.Net: issue-10278 : Change ChatPromptParser to enable 0-n text part instead of single value

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
@@ -112,19 +112,12 @@ internal static class ChatPromptParser
     /// TagName = "message"<br/>
     /// Attributes = { "role" : "..." }<br/>
     /// optional one or more child nodes <image>...</image><br/>
-    /// content not null or single child node <text>...</text>
+    /// optional one or more child node <text>...</text>
     /// </remarks>
     private static bool IsValidChatMessage(PromptNode node)
     {
         return
             node.TagName.Equals(MessageTagName, StringComparison.OrdinalIgnoreCase) &&
-            node.Attributes.ContainsKey(RoleAttributeName) &&
-            IsValidChildNodes(node);
-    }
-
-    private static bool IsValidChildNodes(PromptNode node)
-    {
-        var textTagsCount = node.ChildNodes.Count(n => n.TagName.Equals(TextTagName, StringComparison.OrdinalIgnoreCase));
-        return textTagsCount == 1 || (textTagsCount == 0 && node.Content is not null);
+            node.Attributes.ContainsKey(RoleAttributeName);
     }
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatPromptParser.cs
@@ -112,7 +112,7 @@ internal static class ChatPromptParser
     /// TagName = "message"<br/>
     /// Attributes = { "role" : "..." }<br/>
     /// optional one or more child nodes <image>...</image><br/>
-    /// optional one or more child node <text>...</text>
+    /// optional one or more child nodes <text>...</text>
     /// </remarks>
     private static bool IsValidChatMessage(PromptNode node)
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Prompt/ChatPromptParserTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Prompt/ChatPromptParserTests.cs
@@ -178,6 +178,7 @@ public sealed class ChatPromptParserTests
                     });
             });
     }
+
     [Fact]
     public void ItReturnsChatHistoryWithMixedXmlContent()
     {

--- a/dotnet/src/SemanticKernel.UnitTests/Prompt/ChatPromptParserTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Prompt/ChatPromptParserTests.cs
@@ -12,7 +12,7 @@ public sealed class ChatPromptParserTests
     [Theory]
     [InlineData("This is plain prompt")]
     [InlineData("<message This is invalid chat prompt>")]
-    [InlineData("<message role='user'><text>This is invalid</text><text>chat prompt</text></message>")]
+    [InlineData("<message role='user'><text>This is an invalid chat prompt</message></text>")]
     public void ItReturnsNullChatHistoryWhenPromptIsPlainTextOrInvalid(string prompt)
     {
         // Act
@@ -149,6 +149,85 @@ public sealed class ChatPromptParserTests
     }
 
     [Fact]
+    public void ItReturnsChatHistoryWithMultipleTextParts()
+    {
+        // Arrange
+        string prompt = GetValidPromptWithMultipleTextParts();
+
+        // Act
+        bool result = ChatPromptParser.TryParse(prompt, out var chatHistory);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(chatHistory);
+
+        Assert.Collection(chatHistory,
+            c => Assert.Equal("What can I help with?", c.Content),
+            c =>
+            {
+                Assert.Equal("Hello", c.Content);
+                Assert.Collection(c.Items,
+                    o =>
+                    {
+                        Assert.IsType<TextContent>(o);
+                        Assert.Equal("Hello", ((TextContent)o).Text);
+                    }, o =>
+                    {
+                        Assert.IsType<TextContent>(o);
+                        Assert.Equal("I am user", ((TextContent)o).Text);
+                    });
+            });
+    }
+    [Fact]
+    public void ItReturnsChatHistoryWithMixedXmlContent()
+    {
+        // Arrange
+        string prompt = GetValidPromptWithMixedXmlContent();
+
+        // Act
+        bool result = ChatPromptParser.TryParse(prompt, out var chatHistory);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(chatHistory);
+
+        Assert.Collection(chatHistory,
+            c => Assert.Equal("What can I help with?", c.Content),
+            c =>
+            {
+                Assert.Equal("Hi how are you?", c.Content);
+                Assert.Single(c.Items);
+            });
+    }
+
+    [Fact]
+    public void ItReturnsChatHistoryWithEmptyContent()
+    {
+        // Arrange
+        string prompt = GetValidPromptWithEmptyContent();
+
+        // Act
+        bool result = ChatPromptParser.TryParse(prompt, out var chatHistory);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(chatHistory);
+
+        Assert.Collection(chatHistory,
+            c => Assert.Equal("What can I help with?", c.Content),
+            c =>
+            {
+                Assert.Null(c.Content);
+                Assert.Empty(c.Items);
+            },
+            c =>
+            {
+                Assert.Null(c.Content);
+                Assert.Empty(c.Items);
+            });
+    }
+
+    [Fact]
     public void ItReturnsChatHistoryWithValidContentItemsIncludeCode()
     {
         // Arrange
@@ -254,6 +333,50 @@ public sealed class ChatPromptParserTests
             <message role='user'>
                 <text>Explain this image</text>
                 <image>data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAACVJREFUKFNj/KTO/J+BCMA4iBUyQX1A0I10VAizCj1oMdyISyEAFoQbHwTcuS8AAAAASUVORK5CYII=</image>
+            </message>
+
+            """;
+    }
+
+    private static string GetValidPromptWithMultipleTextParts()
+    {
+        return
+            """
+
+            <message role="assistant">What can I help with?</message>
+
+            <message role='user'>
+                <text>Hello</text>
+                <text>I am user</text>
+            </message>
+
+            """;
+    }
+
+    private static string GetValidPromptWithMixedXmlContent()
+    {
+        return
+            """
+
+            <message role="assistant">What can I help with?</message>
+
+            <message role='user'>
+                This part will be discarded upon parsing
+                <text>Hi how are you?</text>
+                This part will also be discarded upon parsing
+            </message>
+
+            """;
+    }
+
+    private static string GetValidPromptWithEmptyContent()
+    {
+        return
+            """
+
+            <message role="assistant">What can I help with?</message>
+            <message role='user'/>
+            <message role='user'>
             </message>
 
             """;


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
See [Issue #10278](https://github.com/microsoft/semantic-kernel/issues/10278
)

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
**`ChatPromptParser.cs` :**
Remove method `IsValidChildNodes` and its call in `IsValidChatMessage` : A chat message is valid as long as it has a role attribute. Messages with no text child or multiple text children are now valid


**`ChatPromptParserTests` :** 
- Changed 3rd invalid example since the former one is now valid
- Added tests for :  Message with multiple text nodes, mixed XML content and empty XML node
Remark : The expected behavior for mixed XML content is unclear so I kept it as it was : the content of the message node ends up in a `TextContent` if and only if the message has no valid text or image child node. 
So for instance, if the prompt has a message that is a mixed XML with content and a child `image` node, the content would be ignored and the `ChatMessageContent` object will have only an `ImageContent` item

**Other remark :** 
`ChatMessageContent.Content` property only returns/sets the first `TextContent` item.
I thought about changing it to : 
- get : return a concatenation of the `TextContent` items separated by `\n`
- set : set the first `TextContent` element (or add one if there is none) and remove other `TextContent` items

But its current behavior seems intended (it is even included in some unit tests) and I felt like such a change would have too much impact across the code. So I left it as it is. But I think that such a change could be beneficial.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible : 
    I have the same test fails with the unmodified `main` branch. For instance the test `GettingStarted/Step1_Create_Kernel` fails with `ConfigurationNotFoundException : Configuration section 'OpenAI' not found`. I think there are some missing config files
- [x] I didn't break anyone :smile:
