### PR TITLE
Python: [python] Bug fix 10340

### DIFF
--- a/python/semantic_kernel/processes/process_edge_builder.py
+++ b/python/semantic_kernel/processes/process_edge_builder.py
@@ -32,7 +32,9 @@ class ProcessEdgeBuilder(KernelBaseModel):
             raise TypeError("Target cannot be None")
 
         if isinstance(target, ProcessStepBuilder):
-            target = ProcessFunctionTargetBuilder(step=target, parameter_name=kwargs.get("parameter_name"))
+            target = ProcessFunctionTargetBuilder(
+                step=target, parameter_name=kwargs.get("parameter_name"), function_name=kwargs.get("function_name")
+            )
 
         self.target = target
         edge_builder = ProcessStepEdgeBuilder(source=self.source, event_id=self.event_id)


### PR DESCRIPTION
### Motivation and Context

See #10340 

### Description

Implement a similar approach as is done in `process_step_edge_builder.py`, which supports function_name when building the target function.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:

(well, we're still passing/xpass/xfail the same as main is)