### PR TITLE
.Net: Updated chat history reducers to include system message

### DIFF
--- a/dotnet/samples/Concepts/ChatCompletion/ChatHistoryReducers/ChatHistoryReducerTests.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/ChatHistoryReducers/ChatHistoryReducerTests.cs
@@ -18,7 +18,7 @@ public class ChatHistoryReducerTests(ITestOutputHelper output) : BaseTest(output
     [InlineData(6, "SystemMessage", null, 100, 5)]
     [InlineData(6, null, new int[] { 1 }, 100, 4)]
     [InlineData(6, "SystemMessage", new int[] { 2 }, 100, 4)]
-    public async Task VerifyChatHistoryMaxTokensReducerAsync(int messageCount, string? systemMessage, int[]? functionCallIndexes, int maxTokens, int expectedSize)
+    public async Task VerifyMaxTokensChatHistoryReducerAsync(int messageCount, string? systemMessage, int[]? functionCallIndexes, int maxTokens, int expectedSize)
     {
         // Arrange
         var chatHistory = CreateHistoryWithUserInput(messageCount, systemMessage, functionCallIndexes, true);

--- a/dotnet/samples/Concepts/ChatCompletion/ChatHistoryReducers/ChatHistoryReducerTests.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/ChatHistoryReducers/ChatHistoryReducerTests.cs
@@ -12,13 +12,36 @@ namespace ChatCompletion;
 public class ChatHistoryReducerTests(ITestOutputHelper output) : BaseTest(output)
 {
     [Theory]
+    [InlineData(3, null, null, 5, 0)]
+    [InlineData(2, null, null, 1, 1)]
+    [InlineData(2, "SystemMessage", null, 2, 2)]
+    [InlineData(10, null, null, 3, 3)]
+    [InlineData(10, "SystemMessage", null, 3, 3)]
+    [InlineData(9, null, null, 5, 5)]
+    [InlineData(11, null, null, 5, 5)]
+    [InlineData(8, "SystemMessage", null, 5, 5)]
+    [InlineData(10, "SystemMessage", null, 5, 5)]
+    public async Task VerifyChatHistoryTruncationReducerAsync(int messageCount, string? systemMessage, int[]? functionCallIndexes, int truncatedSize, int expectedSize)
+    {
+        // Arrange
+        var chatHistory = CreateHistoryWithUserInput(messageCount, systemMessage, functionCallIndexes);
+        var reducer = new ChatHistoryTruncationReducer(truncatedSize);
+
+        // Act
+        var reducedHistory = await reducer.ReduceAsync(chatHistory);
+
+        // Assert
+        VerifyReducedHistory(reducedHistory, ComputeExpectedMessages(chatHistory, expectedSize));
+    }
+
+    [Theory]
     [InlineData(3, null, null, 100, 0)]
     [InlineData(3, "SystemMessage", null, 100, 0)]
     [InlineData(6, null, null, 100, 4)]
     [InlineData(6, "SystemMessage", null, 100, 5)]
     [InlineData(6, null, new int[] { 1 }, 100, 4)]
     [InlineData(6, "SystemMessage", new int[] { 2 }, 100, 4)]
-    public async Task VerifyMaxTokensChatHistoryReducerAsync(int messageCount, string? systemMessage, int[]? functionCallIndexes, int maxTokens, int expectedSize)
+    public async Task VerifyChatHistoryMaxTokensReducerAsync(int messageCount, string? systemMessage, int[]? functionCallIndexes, int maxTokens, int expectedSize)
     {
         // Arrange
         var chatHistory = CreateHistoryWithUserInput(messageCount, systemMessage, functionCallIndexes, true);

--- a/dotnet/samples/Concepts/ChatCompletion/ChatHistoryReducers/ChatHistoryReducerTests.cs
+++ b/dotnet/samples/Concepts/ChatCompletion/ChatHistoryReducers/ChatHistoryReducerTests.cs
@@ -12,29 +12,6 @@ namespace ChatCompletion;
 public class ChatHistoryReducerTests(ITestOutputHelper output) : BaseTest(output)
 {
     [Theory]
-    [InlineData(3, null, null, 5, 0)]
-    [InlineData(2, null, null, 1, 1)]
-    [InlineData(2, "SystemMessage", null, 2, 2)]
-    [InlineData(10, null, null, 3, 3)]
-    [InlineData(10, "SystemMessage", null, 3, 3)]
-    [InlineData(9, null, null, 5, 5)]
-    [InlineData(11, null, null, 5, 5)]
-    [InlineData(8, "SystemMessage", null, 5, 5)]
-    [InlineData(10, "SystemMessage", null, 5, 5)]
-    public async Task VerifyChatHistoryTruncationReducerAsync(int messageCount, string? systemMessage, int[]? functionCallIndexes, int truncatedSize, int expectedSize)
-    {
-        // Arrange
-        var chatHistory = CreateHistoryWithUserInput(messageCount, systemMessage, functionCallIndexes);
-        var reducer = new ChatHistoryTruncationReducer(truncatedSize);
-
-        // Act
-        var reducedHistory = await reducer.ReduceAsync(chatHistory);
-
-        // Assert
-        VerifyReducedHistory(reducedHistory, ComputeExpectedMessages(chatHistory, expectedSize));
-    }
-
-    [Theory]
     [InlineData(3, null, null, 100, 0)]
     [InlineData(3, "SystemMessage", null, 100, 0)]
     [InlineData(6, null, null, 100, 4)]

--- a/dotnet/src/IntegrationTests/Connectors/Google/Gemini/GeminiChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Google/Gemini/GeminiChatCompletionTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/dotnet/src/IntegrationTests/Connectors/Google/TestsBase.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Google/TestsBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Google;

--- a/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistorySummarizationReducer.cs
+++ b/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistorySummarizationReducer.cs
@@ -89,11 +89,17 @@ public class ChatHistorySummarizationReducer : IChatHistoryReducer
     /// <inheritdoc/>
     public async Task<IEnumerable<ChatMessageContent>?> ReduceAsync(IReadOnlyList<ChatMessageContent> chatHistory, CancellationToken cancellationToken = default)
     {
+        var systemMessage = chatHistory.FirstOrDefault(l => l.Role == AuthorRole.System);
+
         // Identify where summary messages end and regular history begins
         int insertionPoint = chatHistory.LocateSummarizationBoundary(SummaryMetadataKey);
 
         // First pass to determine the truncation index
-        int truncationIndex = chatHistory.LocateSafeReductionIndex(this._targetCount, this._thresholdCount, insertionPoint);
+        int truncationIndex = chatHistory.LocateSafeReductionIndex(
+            this._targetCount,
+            this._thresholdCount,
+            insertionPoint,
+            hasSystemMessage: systemMessage is not null);
 
         IEnumerable<ChatMessageContent>? truncatedHistory = null;
 
@@ -110,11 +116,11 @@ public class ChatHistorySummarizationReducer : IChatHistoryReducer
             {
                 // Summarize
                 ChatHistory summarizationRequest = [.. summarizedHistory, new ChatMessageContent(AuthorRole.System, this.SummarizationInstructions)];
-                ChatMessageContent summary = await this._service.GetChatMessageContentAsync(summarizationRequest, cancellationToken: cancellationToken).ConfigureAwait(false);
-                summary.Metadata = new Dictionary<string, object?> { { SummaryMetadataKey, true } };
+                ChatMessageContent summaryMessage = await this._service.GetChatMessageContentAsync(summarizationRequest, cancellationToken: cancellationToken).ConfigureAwait(false);
+                summaryMessage.Metadata = new Dictionary<string, object?> { { SummaryMetadataKey, true } };
 
                 // Assembly the summarized history
-                truncatedHistory = AssemblySummarizedHistory(summary);
+                truncatedHistory = AssemblySummarizedHistory(summaryMessage, systemMessage);
             }
             catch
             {
@@ -128,8 +134,13 @@ public class ChatHistorySummarizationReducer : IChatHistoryReducer
         return truncatedHistory;
 
         // Inner function to assemble the summarized history
-        IEnumerable<ChatMessageContent> AssemblySummarizedHistory(ChatMessageContent? summary)
+        IEnumerable<ChatMessageContent> AssemblySummarizedHistory(ChatMessageContent? summaryMessage, ChatMessageContent? systemMessage)
         {
+            if (systemMessage is not null)
+            {
+                yield return systemMessage;
+            }
+
             if (insertionPoint > 0 && !this.UseSingleSummary)
             {
                 for (int index = 0; index <= insertionPoint - 1; ++index)
@@ -138,9 +149,9 @@ public class ChatHistorySummarizationReducer : IChatHistoryReducer
                 }
             }
 
-            if (summary != null)
+            if (summaryMessage is not null)
             {
-                yield return summary;
+                yield return summaryMessage;
             }
 
             for (int index = truncationIndex; index < chatHistory.Count; ++index)

--- a/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistorySummarizationReducer.cs
+++ b/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistorySummarizationReducer.cs
@@ -104,7 +104,7 @@ public class ChatHistorySummarizationReducer : IChatHistoryReducer
                 chatHistory.Extract(
                     this.UseSingleSummary ? 0 : insertionPoint,
                     truncationIndex,
-                    (m) => m.Items.Any(i => i is FunctionCallContent || i is FunctionResultContent));
+                    filter: (m) => m.Items.Any(i => i is FunctionCallContent || i is FunctionResultContent));
 
             try
             {

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatHistorySummarizationReducerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatHistorySummarizationReducerTests.cs
@@ -224,6 +224,27 @@ public class ChatHistorySummarizationReducerTests
         VerifySummarization(messages[1]);
     }
 
+    /// <summary>
+    /// Validate history reduced and system message preserved when source history exceeds target threshold.
+    /// </summary>
+    [Fact]
+    public async Task VerifySystemMessageIsNotReducedAsync()
+    {
+        // Arrange
+        Mock<IChatCompletionService> mockCompletionService = this.CreateMockCompletionService();
+        IReadOnlyList<ChatMessageContent> sourceHistory = MockChatHistoryGenerator.CreateSimpleHistory(20, includeSystemMessage: true).ToArray();
+        ChatHistorySummarizationReducer reducer = new(mockCompletionService.Object, 10);
+
+        // Act
+        IEnumerable<ChatMessageContent>? reducedHistory = await reducer.ReduceAsync(sourceHistory);
+
+        // Assert
+        ChatMessageContent[] messages = VerifyReducedHistory(reducedHistory, 11);
+        VerifySummarization(messages[1]);
+
+        Assert.Contains(messages, m => m.Role == AuthorRole.System);
+    }
+
     private static ChatMessageContent[] VerifyReducedHistory(IEnumerable<ChatMessageContent>? reducedHistory, int expectedCount)
     {
         Assert.NotNull(reducedHistory);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatHistoryTruncationReducerTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/ChatHistoryTruncationReducerTests.cs
@@ -137,6 +137,24 @@ public class ChatHistoryTruncationReducerTests
         VerifyReducedHistory(reducedHistory, 10);
     }
 
+    /// <summary>
+    /// Validate history reduced and system message preserved when source history exceeds target threshold.
+    /// </summary>
+    [Fact]
+    public async Task VerifySystemMessageIsNotReducedAsync()
+    {
+        // Arrange
+        IReadOnlyList<ChatMessageContent> sourceHistory = MockChatHistoryGenerator.CreateSimpleHistory(20, includeSystemMessage: true).ToArray();
+        ChatHistoryTruncationReducer reducer = new(10);
+
+        // Act
+        IEnumerable<ChatMessageContent>? reducedHistory = await reducer.ReduceAsync(sourceHistory);
+
+        // Assert
+        VerifyReducedHistory(reducedHistory, 10);
+        Assert.Contains(reducedHistory!, m => m.Role == AuthorRole.System);
+    }
+
     private static void VerifyReducedHistory(IEnumerable<ChatMessageContent>? reducedHistory, int expectedCount)
     {
         Assert.NotNull(reducedHistory);

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/MockChatHistoryGenerator.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/MockChatHistoryGenerator.cs
@@ -14,8 +14,13 @@ internal static class MockChatHistoryGenerator
     /// <summary>
     /// Create a homogeneous list of assistant messages.
     /// </summary>
-    public static IEnumerable<ChatMessageContent> CreateSimpleHistory(int messageCount)
+    public static IEnumerable<ChatMessageContent> CreateSimpleHistory(int messageCount, bool includeSystemMessage = false)
     {
+        if (includeSystemMessage)
+        {
+            yield return new ChatMessageContent(AuthorRole.System, $"system message");
+        }
+
         for (int index = 0; index < messageCount; ++index)
         {
             yield return new ChatMessageContent(AuthorRole.Assistant, $"message #{index}");

--- a/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/MockChatHistoryGenerator.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/AI/ChatCompletion/MockChatHistoryGenerator.cs
@@ -18,7 +18,7 @@ internal static class MockChatHistoryGenerator
     {
         if (includeSystemMessage)
         {
-            yield return new ChatMessageContent(AuthorRole.System, $"system message");
+            yield return new ChatMessageContent(AuthorRole.System, "system message");
         }
 
         for (int index = 0; index < messageCount; ++index)


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Related: https://github.com/microsoft/semantic-kernel/issues/10102

This PR contains changes to the chat history reducer implementations to avoid redaction of system messages if they exist in chat history. It's important to keep system messages in the chat history so the model can follow initial instructions independently from history redaction.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
