### PR TITLE
.NET - Introduce ChatCompletionAgent `Allow-List` of supported content

### DIFF
--- a/dotnet/src/Agents/Core/ChatHistoryChannel.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryChannel.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SemanticKernel.Agents;
 /// </summary>
 internal sealed class ChatHistoryChannel : AgentChannel
 {
-    // Supported content types for <see cref="RecieveAsync"/> when
+    // Supported content types for <see cref="ReceiveAsync"/> when
     // <see cref="ChatMessageContent.Content"/> is empty.
     private static readonly HashSet<Type> s_contentMap =
         [

--- a/dotnet/src/Agents/Core/ChatHistoryChannel.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryChannel.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -16,6 +17,15 @@ namespace Microsoft.SemanticKernel.Agents;
 /// </summary>
 internal sealed class ChatHistoryChannel : AgentChannel
 {
+    // Supported content types for <see cref="RecieveAsync"/> when
+    // <see cref="ChatMessageContent.Content"/> is empty.
+    private static readonly HashSet<Type> s_contentMap =
+        [
+            typeof(FunctionCallContent),
+            typeof(FunctionResultContent),
+            typeof(ImageContent),
+        ];
+
     private readonly ChatHistory _history;
 
     /// <inheritdoc/>
@@ -105,7 +115,11 @@ internal sealed class ChatHistoryChannel : AgentChannel
     /// <inheritdoc/>
     protected override Task ReceiveAsync(IEnumerable<ChatMessageContent> history, CancellationToken cancellationToken)
     {
-        this._history.AddRange(history);
+        // Only add messages with valid content or supported content-items.
+        this._history.AddRange(
+            history.Where(
+                m => !string.IsNullOrEmpty(m.Content) ||
+                m.Items.Where(i => s_contentMap.Contains(i.GetType())).Any()));
 
         return Task.CompletedTask;
     }

--- a/dotnet/src/Agents/UnitTests/Core/ChatHistoryChannelTests.cs
+++ b/dotnet/src/Agents/UnitTests/Core/ChatHistoryChannelTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Moq;
 using Xunit;
 
@@ -18,13 +20,103 @@ public class ChatHistoryChannelTests
     /// does not implement <see cref="ChatHistoryKernelAgent"/>.
     /// </summary>
     [Fact]
-    public async Task VerifyAgentWithoutIChatHistoryHandlerAsync()
+    public async Task VerifyAgentIsChatHistoryKernelAgentAsync()
     {
         // Arrange
         Mock<Agent> agent = new(); // Not a ChatHistoryKernelAgent
-        ChatHistoryChannel channel = new(); // Requires IChatHistoryHandler
+        ChatHistoryChannel channel = new();
 
         // Act & Assert
         await Assert.ThrowsAsync<KernelException>(() => channel.InvokeAsync(agent.Object).ToArrayAsync().AsTask());
+    }
+
+    /// <summary>
+    /// Verify a <see cref="ChatHistoryChannel"/> filters empty content on receive.
+    /// </summary>
+    [Fact]
+    public async Task VerifyRecieveFiltersEmptyContentAsync()
+    {
+        // Arrange
+        ChatHistoryChannel channel = new();
+
+        // Act
+        await channel.ReceiveAsync([new ChatMessageContent(AuthorRole.Assistant, string.Empty)]);
+
+        // Assert
+        Assert.Empty(await channel.GetHistoryAsync().ToArrayAsync());
+    }
+
+    /// <summary>
+    /// Verify a <see cref="ChatHistoryChannel"/> filters file content on receive.
+    /// </summary>
+    /// <remarks>
+    /// As long as content is not empty, extraneous file content is ok.
+    /// </remarks>
+    [Fact]
+    public async Task VerifyRecieveFiltersFileContentAsync()
+    {
+        // Arrange
+        ChatHistoryChannel channel = new();
+
+        // Act
+        await channel.ReceiveAsync([new ChatMessageContent(AuthorRole.Assistant, [new FileReferenceContent("fileId")])]);
+
+        // Assert
+        Assert.Empty(await channel.GetHistoryAsync().ToArrayAsync());
+
+        // Act
+        await channel.ReceiveAsync(
+            [new ChatMessageContent(
+                AuthorRole.Assistant,
+                [
+                    new TextContent("test"),
+                    new FileReferenceContent("fileId")
+                ])]);
+
+        // Assert
+        var history = await channel.GetHistoryAsync().ToArrayAsync();
+        Assert.Single(history);
+        Assert.Equal(2, history[0].Items.Count);
+    }
+
+    /// <summary>
+    /// Verify a <see cref="ChatHistoryChannel"/> accepts function content on receive.
+    /// </summary>
+    [Fact]
+    public async Task VerifyRecieveAcceptsFunctionContentAsync()
+    {
+        // Arrange
+        ChatHistoryChannel channel = new();
+
+        // Act
+        await channel.ReceiveAsync([new ChatMessageContent(AuthorRole.Assistant, [new FunctionCallContent("test-func")])]);
+
+        // Assert
+        Assert.Single(await channel.GetHistoryAsync().ToArrayAsync());
+
+        // Arrange
+        channel = new();
+
+        // Act
+        await channel.ReceiveAsync([new ChatMessageContent(AuthorRole.Assistant, [new FunctionResultContent("test-func")])]);
+
+        // Assert
+        Assert.Single(await channel.GetHistoryAsync().ToArrayAsync());
+    }
+
+    /// <summary>
+    /// Verify a <see cref="ChatHistoryChannel"/> accepts iamge content on receive.
+    /// </summary>
+    [Fact]
+    public async Task VerifyRecieveAcceptsImageContentAsync()
+    {
+        // Arrange
+        ChatHistoryChannel channel = new();
+
+        // Act
+        await channel.ReceiveAsync([new ChatMessageContent(AuthorRole.Assistant, [new ImageContent(new Uri("http://test.ms/test.jpg"))])]);
+
+        // Assert
+        Assert.Single(await channel.GetHistoryAsync().ToArrayAsync());
     }
 }

--- a/dotnet/src/Agents/UnitTests/Core/ChatHistoryChannelTests.cs
+++ b/dotnet/src/Agents/UnitTests/Core/ChatHistoryChannelTests.cs
@@ -34,7 +34,7 @@ public class ChatHistoryChannelTests
     /// Verify a <see cref="ChatHistoryChannel"/> filters empty content on receive.
     /// </summary>
     [Fact]
-    public async Task VerifyRecieveFiltersEmptyContentAsync()
+    public async Task VerifyReceiveFiltersEmptyContentAsync()
     {
         // Arrange
         ChatHistoryChannel channel = new();
@@ -53,7 +53,7 @@ public class ChatHistoryChannelTests
     /// As long as content is not empty, extraneous file content is ok.
     /// </remarks>
     [Fact]
-    public async Task VerifyRecieveFiltersFileContentAsync()
+    public async Task VerifyReceiveFiltersFileContentAsync()
     {
         // Arrange
         ChatHistoryChannel channel = new();
@@ -83,7 +83,7 @@ public class ChatHistoryChannelTests
     /// Verify a <see cref="ChatHistoryChannel"/> accepts function content on receive.
     /// </summary>
     [Fact]
-    public async Task VerifyRecieveAcceptsFunctionContentAsync()
+    public async Task VerifyReceiveAcceptsFunctionContentAsync()
     {
         // Arrange
         ChatHistoryChannel channel = new();
@@ -105,10 +105,10 @@ public class ChatHistoryChannelTests
     }
 
     /// <summary>
-    /// Verify a <see cref="ChatHistoryChannel"/> accepts iamge content on receive.
+    /// Verify a <see cref="ChatHistoryChannel"/> accepts image content on receive.
     /// </summary>
     [Fact]
-    public async Task VerifyRecieveAcceptsImageContentAsync()
+    public async Task VerifyReceiveAcceptsImageContentAsync()
     {
         // Arrange
         ChatHistoryChannel channel = new();


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Ensure `ChatCompletionAgent` only accepts content types / patterns allowed by chat-completion service.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

The sample [Concepts/Agents/MixedChat_Images](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Agents/MixedChat_Images.cs) fails (connector assertion) when passing a message generated by `OpenAIAssistantAgent` to `ChatCompletionAgent` that contains only `FileReferenceContent`.

> This sample historically worked, but there may have been an internal logic update for the connector as part of a maintenance task.  I didn't bother to do the forensics, as the fact that it fails now is sufficient data to address the bug.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
