### PR TITLE
.Net: Graduate OpenAPI package

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
@@ -76,7 +76,6 @@ public class OpenApiFunctionExecutionParameters
     /// as a stream rather than as a string.
     /// If the custom reader is not provided, or the reader returns null, the internal reader is used.
     /// </summary>
-    [Experimental("SKEXP0040")]
     public HttpResponseContentReader? HttpResponseContentReader { get; set; }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiKernelExtensions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiKernelExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -90,7 +89,6 @@ public static class OpenApiKernelExtensions
     /// <param name="specification">The specification model.</param>
     /// <param name="executionParameters">The OpenAPI specification parsing and function execution parameters.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance that contains functions corresponding to the operations defined in the OpenAPI specification.</returns>
-    [Experimental("SKEXP0040")]
     public static KernelPlugin ImportPluginFromOpenApi(
         this Kernel kernel,
         string pluginName,
@@ -227,7 +225,6 @@ public static class OpenApiKernelExtensions
     /// <param name="executionParameters">The OpenAPI specification parsing and function execution parameters.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance that contains functions corresponding to the operations defined in the OpenAPI specification.</returns>
-    [Experimental("SKEXP0040")]
     public static KernelPlugin CreatePluginFromOpenApi(
         this Kernel kernel,
         string pluginName,

--- a/dotnet/src/Functions/Functions.OpenApi/Functions.OpenApi.csproj
+++ b/dotnet/src/Functions/Functions.OpenApi/Functions.OpenApi.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);SKEXP0040</NoWarn>
-    <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
   <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/InternalUtilities.props" />

--- a/dotnet/src/Functions/Functions.OpenApi/HttpResponseContentReader.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/HttpResponseContentReader.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,5 +11,4 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <param name="context">The context containing HTTP operation details.</param>
 /// <param name="cancellationToken">The cancellation token.</param>
 /// <returns>The HTTP response content.</returns>
-[Experimental("SKEXP0040")]
 public delegate Task<object?> HttpResponseContentReader(HttpResponseContentReaderContext context, CancellationToken cancellationToken = default);

--- a/dotnet/src/Functions/Functions.OpenApi/HttpResponseContentReaderContext.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/HttpResponseContentReaderContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
@@ -8,7 +7,6 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <summary>
 /// Represents the context for HTTP response content reader.
 /// </summary>
-[Experimental("SKEXP0040")]
 public sealed class HttpResponseContentReaderContext
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParser.cs
@@ -27,7 +27,6 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <summary>
 /// Parser for OpenAPI documents.
 /// </summary>
-[Experimental("SKEXP0040")]
 public sealed class OpenApiDocumentParser(ILoggerFactory? loggerFactory = null)
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParserOptions.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OpenApiDocumentParserOptions.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// Options for OpenAPI document parser.
 /// </summary>
-[Experimental("SKEXP0040")]
 public sealed class OpenApiDocumentParserOptions
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApi/OperationSelectionPredicateContext.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApi/OperationSelectionPredicateContext.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 
 /// <summary>
 /// Represents the context for an operation selection predicate.
 /// </summary>
-[Experimental("SKEXP0040")]
 public readonly struct OperationSelectionPredicateContext : IEquatable<OperationSelectionPredicateContext>
 {
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/OpenApiKernelPluginFactory.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -139,7 +138,6 @@ public static partial class OpenApiKernelPluginFactory
     /// <param name="specification">The specification model.</param>
     /// <param name="executionParameters">The OpenAPI specification parsing and function execution parameters.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance that contains functions corresponding to the operations defined in the OpenAPI specification.</returns>
-    [Experimental("SKEXP0040")]
     public static KernelPlugin CreateFromOpenApi(
         string pluginName,
         RestApiSpecification specification,


### PR DESCRIPTION
The `preview` suffix is removed from the OpenAPI package and a few experimental attributes are removed from the stable API.

Closes: https://github.com/microsoft/semantic-kernel/issues/6531
