### PR TITLE
.Net: replaces message creation by send messages in CAP and API manifest samples and tests

### DIFF
--- a/dotnet/samples/Concepts/Plugins/CopilotAgentBasedPlugins.cs
+++ b/dotnet/samples/Concepts/Plugins/CopilotAgentBasedPlugins.cs
@@ -100,14 +100,31 @@ public class CopilotAgentBasedPlugins(ITestOutputHelper output) : BaseTest(outpu
     }
     private static readonly HashSet<string> s_fieldsToIgnore = new(
         [
+            "@odata.type",
+            "attachments",
+            "bccRecipients",
             "bodyPreview",
             "categories",
+            "ccRecipients",
             "conversationId",
             "conversationIndex",
+            "extensions",
+            "flag",
+            "from",
+            "hasAttachments",
+            "id",
             "inferenceClassification",
             "internetMessageHeaders",
             "isDeliveryReceiptRequested",
+            "isDraft",
+            "isRead",
+            "isReadReceiptRequested",
             "multiValueExtendedProperties",
+            "parentFolderId",
+            "receivedDateTime",
+            "replyTo",
+            "sender",
+            "sentDateTime",
             "singleValueExtendedProperties",
             "uniqueBody",
             "webLink",
@@ -135,25 +152,40 @@ public class CopilotAgentBasedPlugins(ITestOutputHelper output) : BaseTest(outpu
         {
             return schema;
         }
-        if (jsonNode.TryGetPropertyValue(RequiredPropertyName, out var requiredRawValue) && requiredRawValue is JsonArray requiredArray)
+
+        TrimPropertiesFromJsonNode(jsonNode);
+
+        return KernelJsonSchema.Parse(node.ToString());
+    }
+    private static void TrimPropertiesFromJsonNode(JsonNode jsonNode)
+    {
+        if (jsonNode is not JsonObject jsonObject)
+        {
+            return;
+        }
+        if (jsonObject.TryGetPropertyValue(RequiredPropertyName, out var requiredRawValue) && requiredRawValue is JsonArray requiredArray)
         {
             jsonNode[RequiredPropertyName] = new JsonArray(requiredArray.Where(x => x is not null).Select(x => x!.GetValue<string>()).Where(x => !s_fieldsToIgnore.Contains(x)).Select(x => JsonValue.Create(x)).ToArray());
         }
-
-        if (jsonNode.TryGetPropertyValue(PropertiesPropertyName, out var propertiesRawValue) && propertiesRawValue is JsonObject propertiesObject)
+        if (jsonObject.TryGetPropertyValue(PropertiesPropertyName, out var propertiesRawValue) && propertiesRawValue is JsonObject propertiesObject)
         {
-            var properties = propertiesObject.Where(x => s_fieldsToIgnore.Contains(x.Key)).Select(x => x.Key).ToArray();
+            var properties = propertiesObject.Where(x => s_fieldsToIgnore.Contains(x.Key)).Select(static x => x.Key).ToArray();
             foreach (var property in properties)
             {
                 propertiesObject.Remove(property);
             }
         }
-
-        return KernelJsonSchema.Parse(node.ToString());
+        foreach (var subProperty in jsonObject)
+        {
+            if (subProperty.Value is not null)
+            {
+                TrimPropertiesFromJsonNode(subProperty.Value);
+            }
+        }
     }
     private static readonly RestApiParameterFilter s_restApiParameterFilter = (RestApiParameterFilterContext context) =>
     {
-        if ("me_CreateMessages".Equals(context.Operation.Id, StringComparison.OrdinalIgnoreCase) &&
+        if ("me_sendMail".Equals(context.Operation.Id, StringComparison.OrdinalIgnoreCase) &&
             "payload".Equals(context.Parameter.Name, StringComparison.OrdinalIgnoreCase))
         {
             context.Parameter.Schema = TrimPropertiesFromRequestBody(context.Parameter.Schema);

--- a/dotnet/samples/Concepts/Resources/Plugins/ApiManifestPlugins/MessagesPlugin/apimanifest.json
+++ b/dotnet/samples/Concepts/Resources/Plugins/ApiManifestPlugins/MessagesPlugin/apimanifest.json
@@ -14,7 +14,7 @@
                 },
                 {
                     "method": "Post",
-                    "uriTemplate": "/me/messages"
+                    "uriTemplate": "/me/sendMail"
                 }
             ]
         }

--- a/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/AstronomyPlugin/messages-openapi.yml
+++ b/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/AstronomyPlugin/messages-openapi.yml
@@ -10,8 +10,8 @@ paths:
     get:
       tags:
         - me.message
-      summary: List messages
-      description: 'Get the messages in the signed-in user''s mailbox (including the Deleted Items and Clutter folders). Depending on the page size and mailbox data, getting messages from a mailbox can incur multiple requests. The default page size is 10 messages. Use $top to customize the page size, within the range of 1 and 1000. To improve the operation response time, use $select to specify the exact properties you need; see example 1 below. Fine-tune the values for $select and $top, especially when you must use a larger page size, as returning a page with hundreds of messages each with a full response payload may trigger the gateway timeout (HTTP 504). To get the next page of messages, simply apply the entire URL returned in @odata.nextLink to the next get-messages request. This URL includes any query parameters you may have specified in the initial request. Do not try to extract the $skip value from the @odata.nextLink URL to manipulate responses. This API uses the $skip value to keep count of all the items it has gone through in the user''s mailbox to return a page of message-type items. It''s therefore possible that even in the initial response, the $skip value is larger than the page size. For more information, see Paging Microsoft Graph data in your app. Currently, this operation returns message bodies in only HTML format. There are two scenarios where an app can get messages in another user''s mail folder:'
+      summary: Get the messages in the signed-in user\u0026apos;s mailbox
+      description: Get the messages in the signed-in user\u0026apos;s mailbox (including the Deleted Items and Clutter folders). Depending on the page size and mailbox data, getting messages from a mailbox can incur multiple requests. The default page size is 10 messages. Use $top to customize the page size, within the range of 1 and 1000. To improve the operation response time, use $select to specify the exact properties you need; see example 1 below. Fine-tune the values for $select and $top, especially when you must use a larger page size, as returning a page with hundreds of messages each with a full response payload may trigger the gateway timeout (HTTP 504). To get the next page of messages, simply apply the entire URL returned in @odata.nextLink to the next get-messages request. This URL includes any query parameters you may have specified in the initial request. Do not try to extract the $skip value from the @odata.nextLink URL to manipulate responses. This API uses the $skip value to keep count of all the items it has gone through in the user\u0026apos;s mailbox to return a page of message-type items. It\u0026apos;s therefore possible that even in the initial response, the $skip value is larger than the page size. For more information, see Paging Microsoft Graph data in your app. Currently, this operation returns message bodies in only HTML format. There are two scenarios where an app can get messages in another user\u0026apos;s mail folder
       operationId: me_ListMessages
       parameters:
         - name: includeHiddenMessages
@@ -63,26 +63,18 @@ paths:
         nextLinkName: '@odata.nextLink'
         operationName: listMore
         itemName: value
+  /me/sendMail:
     post:
       tags:
-        - me.message
-      summary: Create message
-      description: "Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:\n- Include an attachment to the message.\n- Update the draft later to add content to the body or change other message properties. When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.\n- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message."
-      operationId: me_CreateMessages
+        - me.user.Actions
+      summary: Invoke action sendMail
+      description: 'Send the message specified in the request body using either JSON or MIME format. When using JSON format, you can include a file attachment in the same sendMail action call. When using MIME format: This method saves the message in the Sent Items folder. Alternatively, create a draft message to send later. To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.'
+      operationId: me_sendMail
       requestBody:
-        description: New navigation property
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/microsoft.graph.message'
-        required: true
+        $ref: '#/components/requestBodies/sendMailRequestBody'
       responses:
-        2XX:
-          description: Created navigation property.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/microsoft.graph.message'
+        '204':
+          description: Success
 components:
   schemas:
     microsoft.graph.message:
@@ -504,3 +496,18 @@ components:
       explode: false
       schema:
         type: boolean
+  requestBodies:
+    sendMailRequestBody:
+      description: Action parameters
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              Message:
+                $ref: '#/components/schemas/microsoft.graph.message'
+              SaveToSentItems:
+                type: boolean
+                default: false
+                nullable: true
+      required: true

--- a/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/MessagesPlugin/messages-apiplugin.json
+++ b/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/MessagesPlugin/messages-apiplugin.json
@@ -12,14 +12,14 @@
         "text": "List messages"
       },
       {
-        "text": "Create message"
+        "text": "Send an email from the current user's mailbox"
       }
     ]
   },
   "functions": [
     {
-      "name": "me_CreateMessages",
-      "description": "Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:\n- Include an attachment to the message.\n- Update the draft later to add content to the body or change other message properties. When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.\n- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message."
+      "name": "me_sendMail",
+      "description": "Send the message specified in the request body using either JSON or MIME format. When using JSON format, you can include a file attachment in the same sendMail action call. When using MIME format: This method saves the message in the Sent Items folder. Alternatively, create a draft message to send later. To learn more about the steps involved in the backend before a mail is delivered to recipients, see here."
     },
     {
       "name": "me_ListMessages",
@@ -35,10 +35,7 @@
       "spec": {
         "url": "messages-openapi.yml"
       },
-      "run_for_functions": [
-        "me_ListMessages",
-        "me_CreateMessages"
-      ]
+      "run_for_functions": ["me_ListMessages", "me_sendMail"]
     }
   ]
 }

--- a/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/MessagesPlugin/messages-openapi.yml
+++ b/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/MessagesPlugin/messages-openapi.yml
@@ -10,8 +10,8 @@ paths:
     get:
       tags:
         - me.message
-      summary: List messages
-      description: 'Get the messages in the signed-in user''s mailbox (including the Deleted Items and Clutter folders). Depending on the page size and mailbox data, getting messages from a mailbox can incur multiple requests. The default page size is 10 messages. Use $top to customize the page size, within the range of 1 and 1000. To improve the operation response time, use $select to specify the exact properties you need; see example 1 below. Fine-tune the values for $select and $top, especially when you must use a larger page size, as returning a page with hundreds of messages each with a full response payload may trigger the gateway timeout (HTTP 504). To get the next page of messages, simply apply the entire URL returned in @odata.nextLink to the next get-messages request. This URL includes any query parameters you may have specified in the initial request. Do not try to extract the $skip value from the @odata.nextLink URL to manipulate responses. This API uses the $skip value to keep count of all the items it has gone through in the user''s mailbox to return a page of message-type items. It''s therefore possible that even in the initial response, the $skip value is larger than the page size. For more information, see Paging Microsoft Graph data in your app. Currently, this operation returns message bodies in only HTML format. There are two scenarios where an app can get messages in another user''s mail folder:'
+      summary: Get the messages in the signed-in user\u0026apos;s mailbox
+      description: Get the messages in the signed-in user\u0026apos;s mailbox (including the Deleted Items and Clutter folders). Depending on the page size and mailbox data, getting messages from a mailbox can incur multiple requests. The default page size is 10 messages. Use $top to customize the page size, within the range of 1 and 1000. To improve the operation response time, use $select to specify the exact properties you need; see example 1 below. Fine-tune the values for $select and $top, especially when you must use a larger page size, as returning a page with hundreds of messages each with a full response payload may trigger the gateway timeout (HTTP 504). To get the next page of messages, simply apply the entire URL returned in @odata.nextLink to the next get-messages request. This URL includes any query parameters you may have specified in the initial request. Do not try to extract the $skip value from the @odata.nextLink URL to manipulate responses. This API uses the $skip value to keep count of all the items it has gone through in the user\u0026apos;s mailbox to return a page of message-type items. It\u0026apos;s therefore possible that even in the initial response, the $skip value is larger than the page size. For more information, see Paging Microsoft Graph data in your app. Currently, this operation returns message bodies in only HTML format. There are two scenarios where an app can get messages in another user\u0026apos;s mail folder
       operationId: me_ListMessages
       parameters:
         - name: includeHiddenMessages
@@ -63,26 +63,18 @@ paths:
         nextLinkName: '@odata.nextLink'
         operationName: listMore
         itemName: value
+  /me/sendMail:
     post:
       tags:
-        - me.message
-      summary: Create message
-      description: "Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:\n- Include an attachment to the message.\n- Update the draft later to add content to the body or change other message properties. When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.\n- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message."
-      operationId: me_CreateMessages
+        - me.user.Actions
+      summary: Invoke action sendMail
+      description: 'Send the message specified in the request body using either JSON or MIME format. When using JSON format, you can include a file attachment in the same sendMail action call. When using MIME format: This method saves the message in the Sent Items folder. Alternatively, create a draft message to send later. To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.'
+      operationId: me_sendMail
       requestBody:
-        description: New navigation property
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/microsoft.graph.message'
-        required: true
+        $ref: '#/components/requestBodies/sendMailRequestBody'
       responses:
-        2XX:
-          description: Created navigation property.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/microsoft.graph.message'
+        '204':
+          description: Success
 components:
   schemas:
     microsoft.graph.message:
@@ -504,3 +496,18 @@ components:
       explode: false
       schema:
         type: boolean
+  requestBodies:
+    sendMailRequestBody:
+      description: Action parameters
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              Message:
+                $ref: '#/components/schemas/microsoft.graph.message'
+              SaveToSentItems:
+                type: boolean
+                default: false
+                nullable: true
+      required: true

--- a/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/README.md
+++ b/dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins/README.md
@@ -5,7 +5,7 @@
 These plugins have been generated thanks to [kiota](https://aka.ms/kiota) and can be regenerated if needed.
 
 ```shell
-cd dotnet/samples/Concepts/Resources/Plugins/CopilotAgentPlugins
+cd dotnet/samples/Concepts/Resources/Plugins
 ```
 
 ### Calendar plugin
@@ -37,7 +37,7 @@ kiota plugin add -t APIPlugin -d https://aka.ms/graph/v1.0/openapi.yaml -i /driv
 Microsoft Graph list message and create a draft message for the current user.
 
 ```shell
-kiota plugin add -t APIPlugin -d https://aka.ms/graph/v1.0/openapi.yaml -i /me/messages#GET -i /me/messages#POST -o CopilotAgentPlugins/MessagesPlugin --pn Messages
+kiota plugin add -t APIPlugin -d https://aka.ms/graph/v1.0/openapi.yaml -i /me/messages#GET -i /me/sendMail#POST -o CopilotAgentPlugins/MessagesPlugin --pn Messages
 ```
 
 ### Astronomy plugin

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/CopilotAgentPluginKernelExtensionsTests.cs
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/Extensions/CopilotAgentPluginKernelExtensionsTests.cs
@@ -23,7 +23,7 @@ public sealed class CopilotAgentPluginKernelExtensionsTests
         // Assert
         Assert.NotNull(plugin);
         Assert.Equal(2, plugin.FunctionCount);
-        Assert.Equal(683, plugin["me_CreateMessages"].Description.Length);
+        Assert.Equal(411, plugin["me_sendMail"].Description.Length);
         Assert.Equal(1000, plugin["me_ListMessages"].Description.Length);
     }
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/messages-apiplugin.json
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/messages-apiplugin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://developer.microsoft.com/json-schemas/copilot/plugin/v2.1/schema.json",
   "schema_version": "v2.1",
   "name_for_human": "OData Service for namespace microsoft.graph",
@@ -12,14 +12,14 @@
         "text": "List messages"
       },
       {
-        "text": "Create message"
+        "text": "Send an email from the current user's mailbox"
       }
     ]
   },
   "functions": [
     {
-      "name": "me_CreateMessages",
-      "description": "Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:\n- Include an attachment to the message.\n- Update the draft later to add content to the body or change other message properties. When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.\n- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message."
+      "name": "me_sendMail",
+      "description": "Send the message specified in the request body using either JSON or MIME format. When using JSON format, you can include a file attachment in the same sendMail action call. When using MIME format: This method saves the message in the Sent Items folder. Alternatively, create a draft message to send later. To learn more about the steps involved in the backend before a mail is delivered to recipients, see here."
     },
     {
       "name": "me_ListMessages",
@@ -35,10 +35,7 @@
       "spec": {
         "url": "messages-openapi.yml"
       },
-      "run_for_functions": [
-        "me_ListMessages",
-        "me_CreateMessages"
-      ]
+      "run_for_functions": ["me_ListMessages", "me_sendMail"]
     }
   ]
 }

--- a/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/messages-openapi.yml
+++ b/dotnet/src/Functions/Functions.UnitTests/OpenApi/TestPlugins/messages-openapi.yml
@@ -1,4 +1,4 @@
-﻿openapi: 3.0.1
+openapi: 3.0.1
 info:
   title: OData Service for namespace microsoft.graph - Subset
   description: This OData service is located at https://graph.microsoft.com/v1.0
@@ -10,8 +10,8 @@ paths:
     get:
       tags:
         - me.message
-      summary: List messages
-      description: 'Get the messages in the signed-in user''s mailbox (including the Deleted Items and Clutter folders). Depending on the page size and mailbox data, getting messages from a mailbox can incur multiple requests. The default page size is 10 messages. Use $top to customize the page size, within the range of 1 and 1000. To improve the operation response time, use $select to specify the exact properties you need; see example 1 below. Fine-tune the values for $select and $top, especially when you must use a larger page size, as returning a page with hundreds of messages each with a full response payload may trigger the gateway timeout (HTTP 504). To get the next page of messages, simply apply the entire URL returned in @odata.nextLink to the next get-messages request. This URL includes any query parameters you may have specified in the initial request. Do not try to extract the $skip value from the @odata.nextLink URL to manipulate responses. This API uses the $skip value to keep count of all the items it has gone through in the user''s mailbox to return a page of message-type items. It''s therefore possible that even in the initial response, the $skip value is larger than the page size. For more information, see Paging Microsoft Graph data in your app. Currently, this operation returns message bodies in only HTML format. There are two scenarios where an app can get messages in another user''s mail folder:'
+      summary: Get the messages in the signed-in user\u0026apos;s mailbox
+      description: Get the messages in the signed-in user\u0026apos;s mailbox (including the Deleted Items and Clutter folders). Depending on the page size and mailbox data, getting messages from a mailbox can incur multiple requests. The default page size is 10 messages. Use $top to customize the page size, within the range of 1 and 1000. To improve the operation response time, use $select to specify the exact properties you need; see example 1 below. Fine-tune the values for $select and $top, especially when you must use a larger page size, as returning a page with hundreds of messages each with a full response payload may trigger the gateway timeout (HTTP 504). To get the next page of messages, simply apply the entire URL returned in @odata.nextLink to the next get-messages request. This URL includes any query parameters you may have specified in the initial request. Do not try to extract the $skip value from the @odata.nextLink URL to manipulate responses. This API uses the $skip value to keep count of all the items it has gone through in the user\u0026apos;s mailbox to return a page of message-type items. It\u0026apos;s therefore possible that even in the initial response, the $skip value is larger than the page size. For more information, see Paging Microsoft Graph data in your app. Currently, this operation returns message bodies in only HTML format. There are two scenarios where an app can get messages in another user\u0026apos;s mail folder
       operationId: me_ListMessages
       parameters:
         - name: includeHiddenMessages
@@ -63,26 +63,18 @@ paths:
         nextLinkName: '@odata.nextLink'
         operationName: listMore
         itemName: value
+  /me/sendMail:
     post:
       tags:
-        - me.message
-      summary: Create message
-      description: "Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:\n- Include an attachment to the message.\n- Update the draft later to add content to the body or change other message properties. When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.\n- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message."
-      operationId: me_CreateMessages
+        - me.user.Actions
+      summary: Invoke action sendMail
+      description: 'Send the message specified in the request body using either JSON or MIME format. When using JSON format, you can include a file attachment in the same sendMail action call. When using MIME format: This method saves the message in the Sent Items folder. Alternatively, create a draft message to send later. To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.'
+      operationId: me_sendMail
       requestBody:
-        description: New navigation property
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/microsoft.graph.message'
-        required: true
+        $ref: '#/components/requestBodies/sendMailRequestBody'
       responses:
-        2XX:
-          description: Created navigation property.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/microsoft.graph.message'
+        '204':
+          description: Success
 components:
   schemas:
     microsoft.graph.message:
@@ -504,3 +496,18 @@ components:
       explode: false
       schema:
         type: boolean
+  requestBodies:
+    sendMailRequestBody:
+      description: Action parameters
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              Message:
+                $ref: '#/components/schemas/microsoft.graph.message'
+              SaveToSentItems:
+                type: boolean
+                default: false
+                nullable: true
+      required: true


### PR DESCRIPTION
this PR replaces message creation by send messages in CAP and API manifest samples and tests as requested by our dear PM @fabianwilliams