### PR TITLE
add workflow to create issue from needs port

### DIFF
--- a/.github/workflows/label-needs-port.yml
+++ b/.github/workflows/label-needs-port.yml
@@ -1,0 +1,41 @@
+name: Create Issue when Needs Port label is added
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  create_issue:
+    if: startsWith(github.event.issue.labels.*.name, 'needs_port_to_') || startsWith(github.event.pull_request.labels.*.name, 'needs_port_to_')
+    name: "Create Issue"
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Create dotnet issue
+        if: startsWith(github.event.issue.labels.*.name, 'needs_port_to_dotnet') || startsWith(github.event.pull_request.labels.*.name, 'needs_port_to_dotnet')
+        run: |
+          new_issue_url=$(gh issue create \
+            --title "Port python feature: ${{ github.event.issue.title || github.event.pull_request.title }}" \
+            --label ".NET" \
+            --body "# Original issue
+            ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+            ## Description
+            ${{ github.event.issue.body || github.event.pull_request.body }}")
+      - name: Create python issue
+        if: startsWith(github.event.issue.labels.*.name, 'needs_port_to_python') || startsWith(github.event.pull_request.labels.*.name, 'needs_port_to_python')
+        run: |
+          new_issue_url=$(gh issue create \
+            --title "Port dotnet feature: ${{ github.event.issue.title || github.event.pull_request.title }}" \
+            --label "Python" \
+            --body "# Original issue
+            ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+            ## Description
+            ${{ github.event.issue.body || github.event.pull_request.body }}")


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

This adds a workflow for when issues or PR's are assigned the labels: `needs_port_to_dotnet` or `needs_port_to_python`
The workflow then creates a new issues linking to the original PR/Issue to make it easier to keep track of work across languages.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
