### PR TITLE
Add Bedrock agent integration tests

### DIFF
--- a/python/tests/integration/agents/bedrock_agent/test_bedrock_agent.py
+++ b/python/tests/integration/agents/bedrock_agent/test_bedrock_agent.py
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import pytest
+from semantic_kernel.agents.bedrock.bedrock_agent import BedrockAgent
+from semantic_kernel.agents.bedrock.models.bedrock_agent_model import BedrockAgentModel
+from semantic_kernel.agents.bedrock.models.bedrock_agent_status import BedrockAgentStatus
+from semantic_kernel.kernel import Kernel
+from semantic_kernel.functions.kernel_arguments import KernelArguments
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
+
+
+class TestBedrockAgentIntegration:
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        self.bedrock_agent = BedrockAgent(
+            name="test_agent",
+            agent_resource_role_arn="arn:aws:iam::123456789012:role/test-role",
+            foundation_model="test_model",
+        )
+        yield
+        if self.bedrock_agent.agent_model.agent_id:
+            self.bedrock_agent.delete_agent()
+
+    @pytest.mark.asyncio
+    async def test_create_bedrock_agent(self):
+        await self.bedrock_agent.create_agent()
+        assert self.bedrock_agent.agent_model.agent_id is not None
+
+    @pytest.mark.asyncio
+    async def test_update_bedrock_agent(self):
+        self.bedrock_agent.agent_model.agent_id = "test_agent_id"
+        await self.bedrock_agent.update_agent(agentName="updated_agent")
+        assert self.bedrock_agent.agent_model.agent_name == "updated_agent"
+
+    @pytest.mark.asyncio
+    async def test_delete_bedrock_agent(self):
+        self.bedrock_agent.agent_model.agent_id = "test_agent_id"
+        await self.bedrock_agent.delete_agent()
+        assert self.bedrock_agent.agent_model.agent_id is None
+
+    @pytest.mark.asyncio
+    async def test_invoke_bedrock_agent(self):
+        session_id = "test_session_id"
+        input_text = "Hello"
+        async for message in self.bedrock_agent.invoke(session_id, input_text):
+            assert isinstance(message, ChatMessageContent)
+            assert message.role == AuthorRole.ASSISTANT
+            assert message.content is not None
+
+    @pytest.mark.asyncio
+    async def test_streaming_invoke_bedrock_agent(self):
+        session_id = "test_session_id"
+        input_text = "Hello"
+        async for message in self.bedrock_agent.invoke_stream(session_id, input_text):
+            assert isinstance(message, StreamingChatMessageContent)
+            assert message.role == AuthorRole.ASSISTANT
+            assert message.content is not None
+
+    @pytest.mark.asyncio
+    async def test_code_interpreter_file_generation(self):
+        await self.bedrock_agent.create_agent(enable_code_interpreter=True)
+        session_id = "test_session_id"
+        input_text = "Generate a file with the content 'Hello, world!'"
+        async for message in self.bedrock_agent.invoke(session_id, input_text):
+            assert isinstance(message, ChatMessageContent)
+            assert message.role == AuthorRole.ASSISTANT
+            assert any(item.metadata["name"] == "generated_file.txt" for item in message.items)
+
+    @pytest.mark.asyncio
+    async def test_function_calling(self):
+        kernel = Kernel()
+        kernel.add_function("dummy_function", lambda: "dummy_result")
+        await self.bedrock_agent.create_agent(enable_kernel_function=True)
+        session_id = "test_session_id"
+        input_text = "Call the dummy_function"
+        async for message in self.bedrock_agent.invoke(session_id, input_text, kernel=kernel):
+            assert isinstance(message, ChatMessageContent)
+            assert message.role == AuthorRole.ASSISTANT
+            assert "dummy_result" in message.content

--- a/python/tests/integration/agents/bedrock_agent/test_bedrock_agent_streaming.py
+++ b/python/tests/integration/agents/bedrock_agent/test_bedrock_agent_streaming.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import pytest
+from semantic_kernel.agents.bedrock.bedrock_agent import BedrockAgent
+from semantic_kernel.agents.bedrock.models.bedrock_agent_model import BedrockAgentModel
+from semantic_kernel.agents.bedrock.models.bedrock_agent_status import BedrockAgentStatus
+from semantic_kernel.kernel import Kernel
+from semantic_kernel.functions.kernel_arguments import KernelArguments
+from semantic_kernel.contents.streaming_chat_message_content import StreamingChatMessageContent
+from semantic_kernel.contents.utils.author_role import AuthorRole
+
+
+@pytest.fixture
+def bedrock_agent():
+    return BedrockAgent(
+        name="test_agent",
+        agent_resource_role_arn="arn:aws:iam::123456789012:role/test-role",
+        foundation_model="test_model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_invoke_bedrock_agent(bedrock_agent):
+    session_id = "test_session_id"
+    input_text = "Hello"
+    async for message in bedrock_agent.invoke_stream(session_id, input_text):
+        assert isinstance(message, StreamingChatMessageContent)
+        assert message.role == AuthorRole.ASSISTANT
+        assert message.content is not None
+
+
+@pytest.mark.asyncio
+async def test_handle_function_calls_bedrock_agent(bedrock_agent):
+    event = {
+        "returnControl": {
+            "invocationId": "test_invocation_id",
+            "invocationInputs": [],
+        }
+    }
+    kernel = Kernel()
+    arguments = KernelArguments()
+    result = await bedrock_agent._handle_return_control_event(event, kernel, arguments)
+    assert result["invocationId"] == "test_invocation_id"
+    assert result["returnControlInvocationResults"] == []
+
+
+@pytest.mark.asyncio
+async def test_handle_file_events_bedrock_agent(bedrock_agent):
+    event = {
+        "files": {
+            "files": [
+                {
+                    "name": "test_file.txt",
+                    "type": "text/plain",
+                    "bytes": b"Hello, world!",
+                }
+            ]
+        }
+    }
+    result = bedrock_agent._handle_files_event(event)
+    assert len(result) == 1
+    assert result[0].metadata["name"] == "test_file.txt"
+    assert result[0].data == b"Hello, world!"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Integration tests for Bedrock agents in Python

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Add integration tests for Bedrock agent integration in `python/tests/integration/agents/bedrock_agent`.

* **TestBedrockAgentIntegration class**
  - Add setup and teardown methods to create and delete Bedrock agent.
  - Add test methods for creating, updating, deleting, and invoking agents.
  - Add test methods for streaming invocation.
  - Add test methods for code interpretation that generates files.
  - Add test methods for function calling that requires a dummy kernel function.

* **test_bedrock_agent_streaming.py**
  - Add test for streaming invocation of Bedrock agent.
  - Add test for handling function calls in Bedrock agent.
  - Add test for handling file events in Bedrock agent.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/semantic-kernel/pull/10400?shareId=42d1f5cd-0a90-48c3-810f-bb2a6744026e).