### PR TITLE
Python: Skip Ollama integration tests temporarily to unblock PRs

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -150,7 +150,8 @@ jobs:
   python-merge-gate-ollama:
     name: Python Pre-Merge Integration Tests - Ollama
     needs: paths-filter
-    if: github.event_name != 'pull_request' && github.event_name != 'schedule' && needs.paths-filter.outputs.pythonChanges == 'true'
+    # Ollama tests are very unstable at the moment. It often fails to pull models from the Ollama server. Thus, this job is disabled for now.
+    if: false && github.event_name != 'pull_request' && github.event_name != 'schedule' && needs.paths-filter.outputs.pythonChanges == 'true'
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -305,7 +306,8 @@ jobs:
           ollama serve &
           sleep 5
       - name: Pull model in Ollama
-        if: matrix.os == 'ubuntu-latest'
+        # Ollama tests are very unstable at the moment. It often fails to pull models from the Ollama server. Thus, Ollama is disabled for now.
+        if: false && matrix.os == 'ubuntu-latest'
         run: |
           ollama pull ${{ vars.OLLAMA_CHAT_MODEL_ID }}
           ollama pull ${{ vars.OLLAMA_CHAT_MODEL_ID_IMAGE }}
@@ -343,14 +345,16 @@ jobs:
         id: run_tests_completions
         timeout-minutes: 10
         shell: bash
+        # Ollama tests are very unstable at the moment. It often fails to pull models from the Ollama server. Thus, Ollama is disabled for now.
         run: |
-          uv run pytest -v -n logical --dist loadfile --dist worksteal ./tests/integration/completions
+          uv run pytest -v -n logical --dist loadfile --dist worksteal -m "not ollama" ./tests/integration/completions
       - name: Run Integration Tests - Embeddings
         id: run_tests_embeddings
         timeout-minutes: 5
         shell: bash
+        # Ollama tests are very unstable at the moment. It often fails to pull models from the Ollama server. Thus, Ollama is disabled for now.
         run: |
-          uv run pytest -v -n logical --dist loadfile --dist worksteal ./tests/integration/embeddings
+          uv run pytest -v -n logical --dist loadfile --dist worksteal -m "not ollama" ./tests/integration/embeddings
       - name: Run Integration Tests - Memory
         id: run_tests_memory
         timeout-minutes: 5


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Ollama integration tests are very unstable. It often fails to pull models from the Ollama server. This causes our pipeline to fail and blocks PRs.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Skip the Ollama integration tests temporarily to unblock PRs.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
