### PR TITLE
.Net: Avoid sending duplicate function tools when creating a thread

### DIFF
--- a/dotnet/src/Agents/OpenAI/Extensions/KernelFunctionExtensions.cs
+++ b/dotnet/src/Agents/OpenAI/Extensions/KernelFunctionExtensions.cs
@@ -4,7 +4,10 @@ using OpenAI.Assistants;
 
 namespace Microsoft.SemanticKernel.Agents.OpenAI;
 
-internal static class KernelFunctionExtensions
+/// <summary>
+/// Extensions for <see cref="KernelFunction"/> to support OpenAI specific operations.
+/// </summary>
+public static class KernelFunctionExtensions
 {
     /// <summary>
     /// Convert <see cref="KernelFunction"/> to an OpenAI tool model.

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -57,7 +57,7 @@ public sealed class OpenAIAssistantAgent : KernelAgent
     internal IReadOnlyList<ToolDefinition> Tools => this._assistant.Tools;
 
     /// <summary>
-    /// Define a new <see cref="OpenAIAssistantAgent"/>.
+    /// Create a new <see cref="OpenAIAssistantAgent"/>.
     /// </summary>
     /// <param name="clientProvider">OpenAI client provider for accessing the API service.</param>
     /// <param name="capabilities">Defines the assistant's capabilities.</param>
@@ -104,7 +104,7 @@ public sealed class OpenAIAssistantAgent : KernelAgent
     }
 
     /// <summary>
-    /// Define a new <see cref="OpenAIAssistantAgent"/>.
+    /// Create a new <see cref="OpenAIAssistantAgent"/>.
     /// </summary>
     /// <param name="clientProvider">OpenAI client provider for accessing the API service.</param>
     /// <param name="definition">The assistant definition.</param>
@@ -130,6 +130,44 @@ public sealed class OpenAIAssistantAgent : KernelAgent
         // Create the assistant
         AssistantCreationOptions assistantCreationOptions = definition.CreateAssistantOptions();
         Assistant model = await client.CreateAssistantAsync(definition.ModelId, assistantCreationOptions, cancellationToken).ConfigureAwait(false);
+
+        // Instantiate the agent
+        return
+            new OpenAIAssistantAgent(model, clientProvider, client)
+            {
+                Kernel = kernel,
+                Arguments = defaultArguments
+            };
+    }
+
+    /// <summary>
+    /// Create a new <see cref="OpenAIAssistantAgent"/>.
+    /// </summary>
+    /// <param name="clientProvider">OpenAI client provider for accessing the API service.</param>
+    /// <param name="modelId">OpenAI model id.</param>
+    /// <param name="creationOptions">The assistant creation options.</param>
+    /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
+    /// <param name="defaultArguments">Optional default arguments, including any <see cref="PromptExecutionSettings"/>.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>An <see cref="OpenAIAssistantAgent"/> instance</returns>
+    public static async Task<OpenAIAssistantAgent> CreateAsync(
+        OpenAIClientProvider clientProvider,
+        string modelId,
+        AssistantCreationOptions creationOptions,
+        Kernel kernel,
+        KernelArguments? defaultArguments = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Validate input
+        Verify.NotNull(kernel, nameof(kernel));
+        Verify.NotNull(clientProvider, nameof(clientProvider));
+        Verify.NotNull(creationOptions, nameof(creationOptions));
+
+        // Create the client
+        AssistantClient client = CreateClient(clientProvider);
+
+        // Create the assistant
+        Assistant model = await client.CreateAssistantAsync(modelId, creationOptions, cancellationToken).ConfigureAwait(false);
 
         // Instantiate the agent
         return


### PR DESCRIPTION
### Motivation and Context

Same issue that was fixed here https://github.com/microsoft/semantic-kernel/pull/10413 but this time the fix is for OpenAI Assistants.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
