### PR TITLE
Python: Remove old references of plugin import

### DIFF
--- a/python/samples/concepts/filtering/auto_function_invoke_filters.py
+++ b/python/samples/concepts/filtering/auto_function_invoke_filters.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
-import os
 
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai import FunctionChoiceBehavior
@@ -29,13 +28,11 @@ kernel = Kernel()
 # Note: the underlying gpt-35/gpt-4 model version needs to be at least version 0613 to support tools.
 kernel.add_service(OpenAIChatCompletion(service_id="chat"))
 
-plugins_directory = os.path.join(__file__, "../../../../../prompt_template_samples/")
 # adding plugins to the kernel
-# the joke plugin in the FunPlugins is a semantic plugin and has the function calling disabled.
-# kernel.import_plugin_from_prompt_directory("chat", plugins_directory, "FunPlugin")
 # the math plugin is a core plugin and has the function calling enabled.
 kernel.add_plugin(MathPlugin(), plugin_name="math")
 kernel.add_plugin(TimePlugin(), plugin_name="time")
+kernel.add_plugin()
 
 chat_function = kernel.add_function(
     prompt="{{$chat_history}}{{$user_input}}",

--- a/python/samples/concepts/filtering/auto_function_invoke_filters.py
+++ b/python/samples/concepts/filtering/auto_function_invoke_filters.py
@@ -32,7 +32,6 @@ kernel.add_service(OpenAIChatCompletion(service_id="chat"))
 # the math plugin is a core plugin and has the function calling enabled.
 kernel.add_plugin(MathPlugin(), plugin_name="math")
 kernel.add_plugin(TimePlugin(), plugin_name="time")
-kernel.add_plugin()
 
 chat_function = kernel.add_function(
     prompt="{{$chat_history}}{{$user_input}}",

--- a/python/samples/getting_started/05-using-the-planner.ipynb
+++ b/python/samples/getting_started/05-using-the-planner.ipynb
@@ -435,7 +435,7 @@
     "    Description: EmailPlugin provides a set of functions to send emails.\n",
     "\n",
     "    Usage:\n",
-    "        kernel.import_plugin_from_object(EmailPlugin(), plugin_name=\"email\")\n",
+    "        kernel.add_plugin(EmailPlugin(), plugin_name=\"email\")\n",
     "\n",
     "    Examples:\n",
     "        {{email.SendEmail}} => Sends an email with the provided subject and body.\n",
@@ -581,7 +581,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Motivation and Context

We had two places in code that showed how to perform a plugin import using old code - `kernel.import_plugin...`.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Removes old old comments, replacing it with the current `kernel.add_plugin(...)`.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
