### PR TITLE
Python: set openai package to newer version and removed default value of parallel tool calls

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numpy >= 1.25.0; python_version < '3.12'",
     "numpy >= 1.26.0; python_version >= '3.12'",
     # openai connector
-    "openai ~= 1.0",
+    "openai ~= 1.61",
     # openapi and swagger
     "openapi_core >= 0.18,<0.20",
     # OpenTelemetry

--- a/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/prompt_execution_settings/open_ai_prompt_execution_settings.py
@@ -66,7 +66,7 @@ class OpenAIChatPromptExecutionSettings(OpenAIPromptExecutionSettings):
     messages: Annotated[
         list[dict[str, Any]] | None, Field(description="Do not set this manually. It is set by the service.")
     ] = None
-    parallel_tool_calls: bool | None = True
+    parallel_tool_calls: bool | None = None
     tools: Annotated[
         list[dict[str, Any]] | None,
         Field(

--- a/python/tests/unit/connectors/ai/open_ai/services/test_azure_chat_completion.py
+++ b/python/tests/unit/connectors/ai/open_ai/services/test_azure_chat_completion.py
@@ -669,7 +669,6 @@ async def test_cmc_tool_calling_parallel_tool_calls(
             model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
             stream=False,
             messages=azure_chat_completion._prepare_chat_history_for_request(orig_chat_history),
-            parallel_tool_calls=True,
             tools=[
                 {
                     "type": "function",

--- a/python/tests/unit/connectors/ai/open_ai/services/test_openai_chat_completion_base.py
+++ b/python/tests/unit/connectors/ai/open_ai/services/test_openai_chat_completion_base.py
@@ -265,7 +265,6 @@ async def test_cmc_function_choice_behavior(
             model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
             stream=False,
             messages=openai_chat_completion._prepare_chat_history_for_request(orig_chat_history),
-            parallel_tool_calls=True,
             tools=[
                 {
                     "type": "function",
@@ -757,7 +756,6 @@ async def test_scmc_function_choice_behavior(
         mock_create.assert_awaited_once_with(
             model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
             stream=True,
-            parallel_tool_calls=True,
             tools=[
                 {
                     "type": "function",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2896,7 +2896,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.60.2"
+version = "1.61.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -2908,9 +2908,9 @@ dependencies = [
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ae/8d9706b8ff2363287b4a8807de2dd29cdbdad5424e9d05d345df724320f5/openai-1.60.2.tar.gz", hash = "sha256:a8f843e10f2855713007f491d96afb2694b11b5e02cb97c7d01a0be60bc5bb51", size = 348185 }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/cf/61e71ce64cf0a38f029da0f9a5f10c9fa0e69a7a977b537126dac50adfea/openai-1.61.1.tar.gz", hash = "sha256:ce1851507218209961f89f3520e06726c0aa7d0512386f0f977e3ac3e4f2472e", size = 350784 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/5a/d5474ca67a547dde9b87b5bc8a8f90eadf29f523d410f2ba23d63c9b82ec/openai-1.60.2-py3-none-any.whl", hash = "sha256:993bd11b96900b9098179c728026f016b4982ded7ee30dfcf4555eab1171fff9", size = 456107 },
+    { url = "https://files.pythonhosted.org/packages/9a/b6/2e2a011b2dc27a6711376808b4cd8c922c476ea0f1420b39892117fa8563/openai-1.61.1-py3-none-any.whl", hash = "sha256:72b0826240ce26026ac2cd17951691f046e5be82ad122d20a8e1b30ca18bd11e", size = 463126 },
 ]
 
 [[package]]
@@ -4854,7 +4854,7 @@ requires-dist = [
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = "~=0.4" },
     { name = "onnxruntime-genai", marker = "extra == 'onnx'", specifier = "~=0.5" },
-    { name = "openai", specifier = "~=1.0" },
+    { name = "openai", specifier = "~=1.61" },
     { name = "openapi-core", specifier = ">=0.18,<0.20" },
     { name = "opentelemetry-api", specifier = "~=1.24" },
     { name = "opentelemetry-sdk", specifier = "~=1.24" },


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We noticed that the openai package dependency spec was off and did not update that when present to the newest version, fixed now.
Also we mistakenly had a default value for parallel_tool_calls in our prompt executions settings, as with other settings we do not maintain a default value if the API has a default and in this case having that parameter when calling a reasoning model threw an error, fixed here.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
