### PR TITLE
.Net: Fix bug where special chars in collection name fails index creation.

### DIFF
--- a/dotnet/samples/GettingStartedWithAgents/Step04_KernelFunctionStrategies.cs
+++ b/dotnet/samples/GettingStartedWithAgents/Step04_KernelFunctionStrategies.cs
@@ -133,9 +133,9 @@ public class Step04_KernelFunctionStrategies(ITestOutputHelper output) : BaseAge
         chat.AddChatMessage(message);
         this.WriteAgentChatMessage(message);
 
-        await foreach (ChatMessageContent responese in chat.InvokeAsync())
+        await foreach (ChatMessageContent response in chat.InvokeAsync())
         {
-            this.WriteAgentChatMessage(responese);
+            this.WriteAgentChatMessage(response);
         }
 
         Console.WriteLine($"\n[IS COMPLETED: {chat.IsComplete}]");

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreCollectionSqlBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreCollectionSqlBuilder.cs
@@ -147,7 +147,7 @@ internal class PostgresVectorStoreCollectionSqlBuilder : IPostgresVectorStoreCol
 
         return new PostgresSqlCommandInfo(
             commandText: $@"
-                CREATE INDEX {indexName} ON {schema}.""{tableName}"" USING {indexTypeName} (""{vectorColumnName}"" {indexOps});"
+                CREATE INDEX ""{indexName}"" ON {schema}.""{tableName}"" USING {indexTypeName} (""{vectorColumnName}"" {indexOps});"
         );
     }
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresVectorStoreRecordCollectionTests.cs
@@ -45,6 +45,24 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
     }
 
     [Fact]
+    public async Task CanCreateCollectionWithSpecialCharactersInNameAsync()
+    {
+        // Arrange
+        var sut = fixture.GetCollection<int, PostgresHotel<int>>("Special-Char");
+
+        try
+        {
+            // Act
+            await sut.CreateCollectionAsync();
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
+    }
+
+    [Fact]
     public async Task CollectionCanUpsertAndGetAsync()
     {
         // Arrange
@@ -82,8 +100,10 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
             Assert.Equal("tag1", fetchedHotel1!.Tags![0]);
             Assert.Equal("tag2", fetchedHotel1!.Tags![1]);
             Assert.Null(fetchedHotel1!.ListInts);
-            Assert.Equal(TruncateMilliseconds(fetchedHotel1.CreatedAt), TruncateMilliseconds(writtenHotel1.CreatedAt));
-            Assert.Equal(TruncateMilliseconds(fetchedHotel1.UpdatedAt), TruncateMilliseconds(writtenHotel1.UpdatedAt));
+
+            // Since these values are updated in the database, they will not match existly, but should be very close to each other.
+            Assert.True(TruncateMilliseconds(fetchedHotel1.CreatedAt) >= TruncateMilliseconds(writtenHotel1.CreatedAt) && TruncateMilliseconds(fetchedHotel1.CreatedAt) <= TruncateMilliseconds(writtenHotel1.CreatedAt).AddSeconds(1));
+            Assert.True(TruncateMilliseconds(fetchedHotel1.UpdatedAt) >= TruncateMilliseconds(writtenHotel1.UpdatedAt) && TruncateMilliseconds(fetchedHotel1.UpdatedAt) <= TruncateMilliseconds(writtenHotel1.UpdatedAt).AddSeconds(1));
 
             Assert.NotNull(fetchedHotel2);
             Assert.Equal(2, fetchedHotel2!.HotelId);
@@ -97,8 +117,10 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
             Assert.Equal(2, fetchedHotel2!.ListInts!.Count);
             Assert.Equal(1, fetchedHotel2!.ListInts![0]);
             Assert.Equal(2, fetchedHotel2!.ListInts![1]);
-            Assert.Equal(TruncateMilliseconds(fetchedHotel2.CreatedAt), TruncateMilliseconds(writtenHotel2.CreatedAt));
-            Assert.Equal(TruncateMilliseconds(fetchedHotel2.UpdatedAt), TruncateMilliseconds(writtenHotel2.UpdatedAt));
+
+            // Since these values are updated in the database, they will not match existly, but should be very close to each other.
+            Assert.True(TruncateMilliseconds(fetchedHotel2.CreatedAt) >= TruncateMilliseconds(writtenHotel2.CreatedAt) && TruncateMilliseconds(fetchedHotel2.CreatedAt) <= TruncateMilliseconds(writtenHotel2.CreatedAt).AddSeconds(1));
+            Assert.True(TruncateMilliseconds(fetchedHotel2.UpdatedAt) >= TruncateMilliseconds(writtenHotel2.UpdatedAt) && TruncateMilliseconds(fetchedHotel2.UpdatedAt) <= TruncateMilliseconds(writtenHotel2.UpdatedAt).AddSeconds(1));
         }
         finally
         {


### PR DESCRIPTION
### Motivation and Context

Fixes #10521

### Description

- Wrap index name in double quotes to handle special characters in collection names
- Add integration test to verify fix.
- Fix unrelated flaky integration test

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
