### PR TITLE
.Net: Remove experimental attribute from AllowStrictSchemaAdherence property

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
@@ -35,6 +35,5 @@ public sealed class FunctionChoiceBehaviorOptions
     /// The default value is set to false. If set to true, the AI model will strictly adhere to the function schema.
     /// </remarks>
     [JsonPropertyName("allow_strict_schema_adherence")]
-    [Experimental("SKEXP0001")]
     public bool AllowStrictSchemaAdherence { get; set; } = false;
 }


### PR DESCRIPTION
### Motivation, Context and Description
The `AllowStrictSchemaAdherence` property has been released more than a month ago and can be considered stable.