### PR TITLE
Python: Clarify in READMEs which Assistant api versions should be used.

### DIFF
--- a/python/samples/concepts/agents/assistant_agent/README.md
+++ b/python/samples/concepts/agents/assistant_agent/README.md
@@ -1,8 +1,4 @@
-## OpenAI Assistant Agents
-
-The following getting started samples show how to use OpenAI Assistant agents with Semantic Kernel.
-
-### Azure Assistant Agents
+## Azure Assistant Agents
 
 Azure Assistant Agents are currently in preview and require a `-preview` API version (minimum version: `2024-05-01-preview`). As new features are introduced, API versions will be updated accordingly. For the latest versioning details, please refer to the [Azure OpenAI API preview lifecycle](/azure/ai-services/openai/api-version-deprecation).
 

--- a/python/samples/concepts/agents/assistant_agent/README.md
+++ b/python/samples/concepts/agents/assistant_agent/README.md
@@ -1,6 +1,6 @@
 ## Azure Assistant Agents
 
-Azure Assistant Agents are currently in preview and require a `-preview` API version (minimum version: `2024-05-01-preview`). As new features are introduced, API versions will be updated accordingly. For the latest versioning details, please refer to the [Azure OpenAI API preview lifecycle](/azure/ai-services/openai/api-version-deprecation).
+Azure Assistant Agents are currently in preview and require a `-preview` API version (minimum version: `2024-05-01-preview`). As new features are introduced, API versions will be updated accordingly. For the latest versioning details, please refer to the [Azure OpenAI API preview lifecycle](https://learn.microsoft.com/azure/ai-services/openai/api-version-deprecation).
 
 To specify the correct API version, set the following environment variable (for example, in your `.env` file):
 

--- a/python/samples/getting_started_with_agents/azure_ai_agent/README.md
+++ b/python/samples/getting_started_with_agents/azure_ai_agent/README.md
@@ -55,45 +55,22 @@ async with DefaultAzureCredential() as credential:
 The required imports for the `Azure AI Agent` include async libraries:
 
 ```python
-from azure.ai.projects.aio import AIProjectClient
 from azure.identity.aio import DefaultAzureCredential
 ```
 
 ### Initializing the Agent
 
-You can create an `AIProjectClient` using a connection string:
+You can pass in a connection string (shown above) to create the client:
 
 ```python
-async def main():
-    ai_agent_settings = AzureAIAgentSettings.create()
-
-    async with (
+async with (
         DefaultAzureCredential() as creds,
-        AIProjectClient.from_connection_string(
+        AzureAIAgent.create_client(
             credential=creds,
             conn_str=ai_agent_settings.project_connection_string.get_secret_value(),
         ) as client,
     ):
-    # code
-```
-
-Or by explicitly specifying the endpoint and credentials:
-
-```python
-async def main():
-    ai_agent_settings = AzureAIAgentSettings.create()
-
-    async with (
-        DefaultAzureCredential() as creds,
-        AIProjectClient(
-            credential=creds,
-            endpoint=ai_agent_settings.endpoint,
-            subscription_id=ai_agent_settings.subscription_id,
-            resource_group_name=ai_agent_settings.resource_group_name,
-            project_name=ai_agent_settings.project_name
-        ) as client,
-    ):
-    # code
+        # operational logic
 ```
 
 ### Creating an Agent Definition

--- a/python/samples/getting_started_with_agents/openai_assistant/README.md
+++ b/python/samples/getting_started_with_agents/openai_assistant/README.md
@@ -4,7 +4,7 @@ The following getting started samples show how to use OpenAI Assistant agents wi
 
 ### Azure Assistant Agents
 
-Azure Assistant Agents are currently in preview and require a `-preview` API version (minimum version: `2024-05-01-preview`). As new features are introduced, API versions will be updated accordingly. For the latest versioning details, please refer to the [Azure OpenAI API preview lifecycle](/azure/ai-services/openai/api-version-deprecation).
+Azure Assistant Agents are currently in preview and require a `-preview` API version (minimum version: `2024-05-01-preview`). As new features are introduced, API versions will be updated accordingly. For the latest versioning details, please refer to the [Azure OpenAI API preview lifecycle](https://learn.microsoft.com/azure/ai-services/openai/api-version-deprecation).
 
 To specify the correct API version, set the following environment variable (for example, in your `.env` file):
 


### PR DESCRIPTION
### Motivation and Context

Clarify in READMEs which Assistant api versions should be used. Assistants are still in preview and require the use of `-preview` api versions. Include this in our READMEs to help make sure users/devs understand which api versions they should be targeting.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Update the README for Assistants and add a README to the samples/concepts/agents/assistant_agent directory.
- Closes #10231 

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
