### PR TITLE
Python: Update install-uv target to install uv into active virtual env if available

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -57,7 +57,13 @@ else ifeq ($(CONTINUE),1)
 else
 	echo "uv could not be found."
 	echo "Installing uv..."
-	curl -LsSf https://astral.sh/uv/install.sh | sh
+	if [ -n "$$VIRTUAL_ENV" ]; then \
+	    echo "Detected virtual environment at $$VIRTUAL_ENV, installing uv there..."; \
+	    curl -LsSf https://astral.sh/uv/install.sh | INSTALL_DIR="$$VIRTUAL_ENV/bin" sh; \
+	else \
+	    echo "No virtual environment detected, installing uv globally..."; \
+	    curl -LsSf https://astral.sh/uv/install.sh | sh; \
+	fi
 	echo "uv installed."
 	echo "Re-executing shell so uv is immediately available on PATH..."
 	exec $$SHELL -c 'make install CONTINUE=1'


### PR DESCRIPTION
### Motivation and Context

The current make install-uv logic wasn't accounting for installing uv into a virtual env if it is available.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This PR makes an update to install uv into the virtual env if it is available/active. Tested on a new venv, and it correctly installs the latest uv version (0.6.1 at the time of this writing) and uses it.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
