### PR TITLE
.NET Agents - Support role-override for `ChatCompletionAgent`

### DIFF
--- a/dotnet/src/Agents/Core/ChatCompletionAgent.cs
+++ b/dotnet/src/Agents/Core/ChatCompletionAgent.cs
@@ -47,6 +47,17 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
         this.Template = templateFactory?.Create(templateConfig);
     }
 
+    /// <summary>
+    /// Gets the role used for the agent instructions.  Defaults to "system".
+    /// </summary>
+    /// <remarks>
+    /// Certain versions of "O*" series (deep reasoning) models require the instructions
+    /// to be provided as "developer" role.  Other versions support neither role and
+    /// an agent targeting such a model cannot provide instructions.  Agent functionality
+    /// will be dictated entirely by the provided plugins.
+    /// </remarks>
+    public AuthorRole InstructionsRole { get; init; } = AuthorRole.System;
+
     /// <inheritdoc/>
     public override IAsyncEnumerable<ChatMessageContent> InvokeAsync(
         ChatHistory history,
@@ -113,7 +124,7 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
 
         if (!string.IsNullOrWhiteSpace(instructions))
         {
-            chat.Add(new ChatMessageContent(AuthorRole.System, instructions) { AuthorName = this.Name });
+            chat.Add(new ChatMessageContent(this.InstructionsRole, instructions) { AuthorName = this.Name });
         }
 
         chat.AddRange(history);


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The "O*" series deep-reasoning models from OpenAI do not support `System` role.  For certain versions, support was added for a `Developer` role.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Allow `ChatCompletionAgent` make use of "O*" series models by supporting `InstructionsRole` that may be optionally overriden.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
