### PR TITLE
Python: resolving #10642 - public events fail to propagate

### DIFF
--- a/python/semantic_kernel/processes/kernel_process/kernel_process_event.py
+++ b/python/semantic_kernel/processes/kernel_process/kernel_process_event.py
@@ -29,4 +29,4 @@ class KernelProcessEvent(KernelBaseModel):
     data: Any | None = None
     visibility: KernelProcessEventVisibility = KernelProcessEventVisibility.Internal
 
-    model_config = ConfigDict(use_enum_values=True)
+    model_config = ConfigDict(use_enum_values=False)

--- a/python/tests/unit/processes/kernel_process/test_kernel_process_event.py
+++ b/python/tests/unit/processes/kernel_process/test_kernel_process_event.py
@@ -34,7 +34,7 @@ def test_initialization_with_visibility():
     # Assert
     assert event.id == event_id
     assert event.data == event_data
-    assert event.visibility == KernelProcessEventVisibility.Public.value
+    assert event.visibility == KernelProcessEventVisibility.Public
 
 
 def test_invalid_visibility():

--- a/python/tests/unit/processes/local_runtime/test_local_process.py
+++ b/python/tests/unit/processes/local_runtime/test_local_process.py
@@ -311,7 +311,7 @@ async def test_handle_message_with_valid_event_id(mock_process_with_output_edges
         assert isinstance(event, KernelProcessEvent)
         assert event.id == "valid_event_id"
         assert event.data == message.target_event_data
-        assert event.visibility == KernelProcessEventVisibility.Internal.value
+        assert event.visibility == KernelProcessEventVisibility.Internal
 
 
 END_PROCESS_ID = "END"


### PR DESCRIPTION
### Motivation and Context

Resolves #10642 -- failure of `KernelProcessEventVisibility.Public` events to propagate.

### Description

First, `KernelProcessEvent` was configured to use enum values -- though throughout the code, `KernelProcessEvent.visibility` is compared as an enum.

Second, when handling events emitted by a KernelProcessStep, any `Public` visibility events are/were passed through `LocalStep.scoped_event` (which modifies the event's namespace) *before* queueing up any matching edges on the source step. This change to the event namespace effectively prevents the event from propagating (since I don't know how we'd 'listen' for events on the local process handle from within the function that builds that very process...)

Allowing `visibility` on `KernelProcessEvent` to be an enum, combined with an exchange in the order of processing event messages (matching event to edge _before_ re-emitting any events marked as 'Public') causes public events to propagate as expected.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
