### PR TITLE
Allow HttpClient to be passed in for AzureOpenAI when building from s…

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     public static IServiceCollection AddAzureOpenAIChatCompletion(
         this IServiceCollection services,
@@ -46,7 +47,8 @@ public static class AzureOpenAIServiceCollectionExtensions
         string apiKey,
         string? serviceId = null,
         string? modelId = null,
-        string? apiVersion = null)
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(endpoint);
@@ -57,7 +59,7 @@ public static class AzureOpenAIServiceCollectionExtensions
             AzureOpenAIClient client = CreateAzureOpenAIClient(
                 endpoint,
                 new ApiKeyCredential(apiKey),
-                HttpClientProvider.GetHttpClient(serviceProvider),
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
                 apiVersion);
 
             return new(deploymentName, client, modelId, serviceProvider.GetService<ILoggerFactory>());
@@ -79,6 +81,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="serviceId">A local identifier for the given AI service</param>
     /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     public static IServiceCollection AddAzureOpenAIChatCompletion(
         this IServiceCollection services,
@@ -87,7 +90,8 @@ public static class AzureOpenAIServiceCollectionExtensions
         TokenCredential credentials,
         string? serviceId = null,
         string? modelId = null,
-        string? apiVersion = null)
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
         Verify.NotNullOrWhiteSpace(endpoint);
@@ -98,7 +102,7 @@ public static class AzureOpenAIServiceCollectionExtensions
             AzureOpenAIClient client = CreateAzureOpenAIClient(
                 endpoint,
                 credentials,
-                HttpClientProvider.GetHttpClient(serviceProvider),
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
                 apiVersion);
 
             return new(deploymentName, client, modelId, serviceProvider.GetService<ILoggerFactory>());
@@ -153,6 +157,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
     public static IServiceCollection AddAzureOpenAITextEmbeddingGeneration(
@@ -163,7 +168,8 @@ public static class AzureOpenAIServiceCollectionExtensions
         string? serviceId = null,
         string? modelId = null,
         int? dimensions = null,
-        string? apiVersion = null)
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
 
@@ -173,7 +179,7 @@ public static class AzureOpenAIServiceCollectionExtensions
                 endpoint,
                 apiKey,
                 modelId,
-                HttpClientProvider.GetHttpClient(serviceProvider),
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
                 serviceProvider.GetService<ILoggerFactory>(),
                 dimensions,
                 apiVersion));
@@ -190,6 +196,7 @@ public static class AzureOpenAIServiceCollectionExtensions
     /// <param name="modelId">Model identifier, see https://learn.microsoft.com/azure/cognitive-services/openai/quickstart</param>
     /// <param name="dimensions">The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.</param>
     /// <param name="apiVersion">Optional Azure OpenAI API version, see available here <see cref="AzureOpenAIClientOptions.ServiceVersion"/></param>
+    /// <param name="httpClient">The HttpClient to use with this service.</param>
     /// <returns>The same instance as <paramref name="services"/>.</returns>
     [Experimental("SKEXP0010")]
     public static IServiceCollection AddAzureOpenAITextEmbeddingGeneration(
@@ -200,7 +207,8 @@ public static class AzureOpenAIServiceCollectionExtensions
         string? serviceId = null,
         string? modelId = null,
         int? dimensions = null,
-        string? apiVersion = null)
+        string? apiVersion = null,
+        HttpClient? httpClient = null)
     {
         Verify.NotNull(services);
         Verify.NotNull(credential);

--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Extensions/AzureOpenAIServiceCollectionExtensions.cs
@@ -219,7 +219,7 @@ public static class AzureOpenAIServiceCollectionExtensions
                 endpoint,
                 credential,
                 modelId,
-                HttpClientProvider.GetHttpClient(serviceProvider),
+                HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
                 serviceProvider.GetService<ILoggerFactory>(),
                 dimensions,
                 apiVersion));


### PR DESCRIPTION
…ervice collection, just like it is from the Kernel Builder

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?   Extension methods for service provider are not consistent with those for the kernel builder.  You cannot specify your own HTTPClient for the service provider ones.
  2. What problem does it solve? Allows for consumers to customize the HTTPClient being used
  3. What scenario does it contribute to? 
  4. If it fixes an open issue, please link to the issue here.
  I think it is associated with this discussion
  https://github.com/microsoft/semantic-kernel/discussions/9277

This solves the problem in this issue at least for azureopenai
https://github.com/microsoft/semantic-kernel/issues/9435

-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Add an optional HTTPClient to the extension methods and utilize it just like the kernel builder versions.  Note that I don't think this is the proper way to handle things.  It would likely be better to allow an optional client name to be sent in and then SK could/should use the client factory to fetch it.  However, my change makes the interface consistent with what is already there.
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ X] The code builds clean without any errors or warnings
- [ X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X ] All unit tests pass, and I have added new tests where possible
- [ X] I didn't break anyone :smile:
