### PR TITLE
.Net: dotnet format issues with SDK 9.0

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeMemoryStore.cs
@@ -126,7 +126,7 @@ public interface IPineconeMemoryStore : IMemoryStore
     /// <param name="withEmbeddings"> if true, the embedding will be returned in the memory record.</param>
     /// <param name="cancellationToken"></param>
     /// <returns> the memory records that match the filter.</returns>
-    public IAsyncEnumerable<MemoryRecord?> GetBatchWithFilterAsync(
+    IAsyncEnumerable<MemoryRecord?> GetBatchWithFilterAsync(
         string indexName,
         Dictionary<string, object> filter,
         int limit = 10,
@@ -182,7 +182,7 @@ public interface IPineconeMemoryStore : IMemoryStore
     /// <param name="indexNamespace"> the namespace to remove from.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task RemoveWithDocumentIdBatchAsync(
+    Task RemoveWithDocumentIdBatchAsync(
         string indexName,
         IEnumerable<string> documentIds,
         string indexNamespace = "",

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/IPostgresVectorStoreDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/IPostgresVectorStoreDbClient.cs
@@ -17,7 +17,7 @@ internal interface IPostgresVectorStoreDbClient
     /// <summary>
     /// The <see cref="NpgsqlDataSource"/> used to connect to the database.
     /// </summary>
-    public NpgsqlDataSource DataSource { get; }
+    NpgsqlDataSource DataSource { get; }
 
     /// <summary>
     /// Check if a table exists.

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
@@ -22,7 +22,7 @@ public interface IQdrantVectorDbClient
     /// <param name="withVectors">Whether to include the vector data in the returned results.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>An asynchronous list of Qdrant vectors records associated with the given IDs</returns>
-    public IAsyncEnumerable<QdrantVectorRecord> GetVectorsByIdAsync(string collectionName, IEnumerable<string> pointIds, bool withVectors = false,
+    IAsyncEnumerable<QdrantVectorRecord> GetVectorsByIdAsync(string collectionName, IEnumerable<string> pointIds, bool withVectors = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -33,7 +33,7 @@ public interface IQdrantVectorDbClient
     /// <param name="withVector">Whether to include the vector data in the returned result.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The Qdrant vector record associated with the given ID if found, null if not.</returns>
-    public Task<QdrantVectorRecord?> GetVectorByPayloadIdAsync(string collectionName, string metadataId, bool withVector = false, CancellationToken cancellationToken = default);
+    Task<QdrantVectorRecord?> GetVectorByPayloadIdAsync(string collectionName, string metadataId, bool withVector = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete vectors by their unique Qdrant IDs.
@@ -41,7 +41,7 @@ public interface IQdrantVectorDbClient
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="pointIds">The unique IDs used to index Qdrant vector entries.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task DeleteVectorsByIdAsync(string collectionName, IEnumerable<string> pointIds, CancellationToken cancellationToken = default);
+    Task DeleteVectorsByIdAsync(string collectionName, IEnumerable<string> pointIds, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete a vector by its unique identifier in the metadata (Qdrant payload).
@@ -49,7 +49,7 @@ public interface IQdrantVectorDbClient
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="metadataId">The unique ID stored in a Qdrant vector entry's metadata.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task DeleteVectorByPayloadIdAsync(string collectionName, string metadataId, CancellationToken cancellationToken = default);
+    Task DeleteVectorByPayloadIdAsync(string collectionName, string metadataId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Upsert a group of vectors into a collection.
@@ -57,7 +57,7 @@ public interface IQdrantVectorDbClient
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="vectorData">The Qdrant vector records to upsert.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task UpsertVectorsAsync(string collectionName, IEnumerable<QdrantVectorRecord> vectorData, CancellationToken cancellationToken = default);
+    Task UpsertVectorsAsync(string collectionName, IEnumerable<QdrantVectorRecord> vectorData, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Find the nearest vectors in a collection using vector similarity search.
@@ -69,7 +69,7 @@ public interface IQdrantVectorDbClient
     /// <param name="withVectors">Whether to include the vector data in the returned results.</param>
     /// <param name="requiredTags">Qdrant tags used to filter the results.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public IAsyncEnumerable<(QdrantVectorRecord, double)> FindNearestInCollectionAsync(
+    IAsyncEnumerable<(QdrantVectorRecord, double)> FindNearestInCollectionAsync(
         string collectionName,
         ReadOnlyMemory<float> target,
         double threshold,
@@ -83,25 +83,25 @@ public interface IQdrantVectorDbClient
     /// </summary>
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task CreateCollectionAsync(string collectionName, CancellationToken cancellationToken = default);
+    Task CreateCollectionAsync(string collectionName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete a Qdrant vector collection.
     /// </summary>
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task DeleteCollectionAsync(string collectionName, CancellationToken cancellationToken = default);
+    Task DeleteCollectionAsync(string collectionName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Check if a vector collection exists.
     /// </summary>
     /// <param name="collectionName">The name assigned to a collection of vectors.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<bool> DoesCollectionExistAsync(string collectionName, CancellationToken cancellationToken = default);
+    Task<bool> DoesCollectionExistAsync(string collectionName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List all vector collections.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public IAsyncEnumerable<string> ListCollectionsAsync(CancellationToken cancellationToken = default);
+    IAsyncEnumerable<string> ListCollectionsAsync(CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordCollection.cs
@@ -19,7 +19,7 @@ public interface IVectorStoreRecordCollection<TKey, TRecord> : IVectorizedSearch
     /// <summary>
     /// Gets the name of the collection.
     /// </summary>
-    public string CollectionName { get; }
+    string CollectionName { get; }
 
     /// <summary>
     /// Checks if the collection exists in the vector store.

--- a/dotnet/src/Experimental/Process.Abstractions/IKernelExternalProcessMessageChannel.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/IKernelExternalProcessMessageChannel.cs
@@ -14,13 +14,13 @@ public interface IExternalKernelProcessMessageChannel
     /// Initialization of the external messaging channel used
     /// </summary>
     /// <returns>A <see cref="ValueTask"/></returns>
-    public abstract ValueTask Initialize();
+    abstract ValueTask Initialize();
 
     /// <summary>
     /// Uninitialization of the external messaging channel used
     /// </summary>
     /// <returns>A <see cref="ValueTask"/></returns>
-    public abstract ValueTask Uninitialize();
+    abstract ValueTask Uninitialize();
 
     /// <summary>
     /// Emits the specified event from the step outside the SK process
@@ -28,5 +28,5 @@ public interface IExternalKernelProcessMessageChannel
     /// <param name="externalTopicEvent">name of the topic to be used externally as the event name</param>
     /// <param name="eventData">data to be transmitted externally</param>
     /// <returns></returns>
-    public abstract Task EmitExternalEventAsync(string externalTopicEvent, object? eventData);
+    abstract Task EmitExternalEventAsync(string externalTopicEvent, object? eventData);
 }

--- a/dotnet/src/Experimental/Process.Abstractions/IKernelProcessMessageChannel.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/IKernelProcessMessageChannel.cs
@@ -14,5 +14,5 @@ public interface IKernelProcessMessageChannel
     /// </summary>
     /// <param name="processEvent">The event to emit.</param>
     /// <returns>A <see cref="ValueTask"/></returns>
-    public abstract ValueTask EmitEventAsync(KernelProcessEvent processEvent);
+    abstract ValueTask EmitEventAsync(KernelProcessEvent processEvent);
 }

--- a/dotnet/src/InternalUtilities/src/Diagnostics/ActivityExtensions.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/ActivityExtensions.cs
@@ -27,7 +27,8 @@ internal static class ActivityExtensions
         foreach (var tag in tags)
         {
             activity.SetTag(tag.Key, tag.Value);
-        };
+        }
+        ;
 
         return activity;
     }

--- a/dotnet/src/Plugins/Plugins.Document/FileSystem/IFileSystemConnector.cs
+++ b/dotnet/src/Plugins/Plugins.Document/FileSystem/IFileSystemConnector.cs
@@ -16,21 +16,21 @@ public interface IFileSystemConnector
     /// </summary>
     /// <param name="filePath">Path to the file.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<Stream> GetFileContentStreamAsync(string filePath, CancellationToken cancellationToken = default);
+    Task<Stream> GetFileContentStreamAsync(string filePath, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get a writeable stream to an existing file.
     /// </summary>
     /// <param name="filePath">Path to file.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<Stream> GetWriteableFileStreamAsync(string filePath, CancellationToken cancellationToken = default);
+    Task<Stream> GetWriteableFileStreamAsync(string filePath, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a new file and get a writeable stream to it.
     /// </summary>
     /// <param name="filePath">Path to file.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<Stream> CreateFileAsync(string filePath, CancellationToken cancellationToken = default);
+    Task<Stream> CreateFileAsync(string filePath, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Determine whether a file exists at the specified path.
@@ -38,5 +38,5 @@ public interface IFileSystemConnector
     /// <param name="filePath">Path to file.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>True if file exists, false otherwise.</returns>
-    public Task<bool> FileExistsAsync(string filePath, CancellationToken cancellationToken = default);
+    Task<bool> FileExistsAsync(string filePath, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Plugins/Plugins.Document/IDocumentConnector.cs
+++ b/dotnet/src/Plugins/Plugins.Document/IDocumentConnector.cs
@@ -14,18 +14,18 @@ public interface IDocumentConnector
     /// </summary>
     /// <param name="stream">Document stream</param>
     /// <returns>String containing all text from the document.</returns>
-    public string ReadText(Stream stream);
+    string ReadText(Stream stream);
 
     /// <summary>
     /// Initialize a document from the given stream.
     /// </summary>
     /// <param name="stream">IO stream</param>
-    public void Initialize(Stream stream);
+    void Initialize(Stream stream);
 
     /// <summary>
     /// Append the specified text to the document.
     /// </summary>
     /// <param name="stream">Document stream</param>
     /// <param name="text">String of text to write to the document.</param>
-    public void AppendText(Stream stream, string text);
+    void AppendText(Stream stream, string text);
 }

--- a/dotnet/src/SemanticKernel.Abstractions/AI/TextToImage/ITextToImageService.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/TextToImage/ITextToImageService.cs
@@ -23,7 +23,7 @@ public interface ITextToImageService : IAIService
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Generated image contents</returns>
     [Experimental("SKEXP0001")]
-    public Task<IReadOnlyList<ImageContent>> GetImageContentsAsync(
+    Task<IReadOnlyList<ImageContent>> GetImageContentsAsync(
         TextContent input,
         PromptExecutionSettings? executionSettings = null,
         Kernel? kernel = null,

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearch.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearch.cs
@@ -18,7 +18,7 @@ public interface ITextSearch
     /// <param name="query">What to search for.</param>
     /// <param name="searchOptions">Options used when executing a text search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<KernelSearchResults<string>> SearchAsync(
+    Task<KernelSearchResults<string>> SearchAsync(
         string query,
         TextSearchOptions? searchOptions = null,
         CancellationToken cancellationToken = default);
@@ -29,7 +29,7 @@ public interface ITextSearch
     /// <param name="query">What to search for.</param>
     /// <param name="searchOptions">Options used when executing a text search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<KernelSearchResults<TextSearchResult>> GetTextSearchResultsAsync(
+    Task<KernelSearchResults<TextSearchResult>> GetTextSearchResultsAsync(
         string query,
         TextSearchOptions? searchOptions = null,
         CancellationToken cancellationToken = default);
@@ -40,7 +40,7 @@ public interface ITextSearch
     /// <param name="query">What to search for.</param>
     /// <param name="searchOptions">Options used when executing a text search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task<KernelSearchResults<object>> GetSearchResultsAsync(
+    Task<KernelSearchResults<object>> GetSearchResultsAsync(
         string query,
         TextSearchOptions? searchOptions = null,
         CancellationToken cancellationToken = default);

--- a/dotnet/src/SemanticKernel.Abstractions/Memory/ISemanticTextMemory.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Memory/ISemanticTextMemory.cs
@@ -24,7 +24,7 @@ public interface ISemanticTextMemory
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Unique identifier of the saved memory record.</returns>
-    public Task<string> SaveInformationAsync(
+    Task<string> SaveInformationAsync(
         string collection,
         string text,
         string id,
@@ -45,7 +45,7 @@ public interface ISemanticTextMemory
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Unique identifier of the saved memory record.</returns>
-    public Task<string> SaveReferenceAsync(
+    Task<string> SaveReferenceAsync(
         string collection,
         string text,
         string externalId,
@@ -66,7 +66,7 @@ public interface ISemanticTextMemory
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Memory record, or null when nothing is found</returns>
-    public Task<MemoryQueryResult?> GetAsync(string collection, string key, bool withEmbedding = false, Kernel? kernel = null, CancellationToken cancellationToken = default);
+    Task<MemoryQueryResult?> GetAsync(string collection, string key, bool withEmbedding = false, Kernel? kernel = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove a memory by key.
@@ -77,7 +77,7 @@ public interface ISemanticTextMemory
     /// <param name="key">Unique memory record identifier.</param>
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    public Task RemoveAsync(string collection, string key, Kernel? kernel = null, CancellationToken cancellationToken = default);
+    Task RemoveAsync(string collection, string key, Kernel? kernel = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Find some information in memory
@@ -90,7 +90,7 @@ public interface ISemanticTextMemory
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Memories found</returns>
-    public IAsyncEnumerable<MemoryQueryResult> SearchAsync(
+    IAsyncEnumerable<MemoryQueryResult> SearchAsync(
         string collection,
         string query,
         int limit = 1,
@@ -105,5 +105,5 @@ public interface ISemanticTextMemory
     /// <param name="kernel">The <see cref="Kernel"/> containing services, plugins, and other state for use throughout the operation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A group of collection names.</returns>
-    public Task<IList<string>> GetCollectionsAsync(Kernel? kernel = null, CancellationToken cancellationToken = default);
+    Task<IList<string>> GetCollectionsAsync(Kernel? kernel = null, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ICodeRendering.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ICodeRendering.cs
@@ -17,5 +17,5 @@ internal interface ICodeRendering
     /// <param name="arguments">The arguments</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Rendered content</returns>
-    public ValueTask<object?> RenderCodeAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default);
+    ValueTask<object?> RenderCodeAsync(Kernel kernel, KernelArguments? arguments = null, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ITextRendering.cs
+++ b/dotnet/src/SemanticKernel.Core/TemplateEngine/Blocks/ITextRendering.cs
@@ -11,5 +11,5 @@ internal interface ITextRendering
     /// </summary>
     /// <param name="arguments">Optional arguments the block rendering</param>
     /// <returns>Rendered content</returns>
-    public object? Render(KernelArguments? arguments);
+    object? Render(KernelArguments? arguments);
 }


### PR DESCRIPTION
### Motivation and Context
In order to be able to build the dotnet code with version 9 SDK, there were some problems with the following file

`/workspaces/semantic-kernel/dotnet/src/InternalUtilities/src/Diagnostics/ActivityExtensions.cs`. This had a BOM encoding problem which was causing `dotnet format` to fail. As seen in this Issue [https://github.com/dotnet/sdk/issues/46780](https://github.com/dotnet/sdk/issues/46780).

I fixed the encoding and formatting issues ready for version 9. Most of the formatting issues are around removing the access modifiers on interface members

This relates to #10715
### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
