### PR TITLE
.Net: Make AzureOpenAI service/model deployment configurable

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="Pinecone.NET" Version="2.1.1" />
     <PackageVersion Include="Prompty.Core" Version="0.0.23-alpha" />
     <PackageVersion Include="PuppeteerSharp" Version="20.0.5" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />

--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -479,6 +479,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatWithAgent.ApiService", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatWithAgent.Web", "samples\Demos\Hosting\Agent\ChatWithAgent.Web\ChatWithAgent.Web.csproj", "{518EBD17-F582-9E69-2716-57C9329DC0BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatWithAgent.Configuration", "samples\Demos\Hosting\Agent\ChatWithAgent.Configuration\ChatWithAgent.Configuration.csproj", "{02663844-E371-416A-969A-66B6512BB2E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1296,6 +1298,12 @@ Global
 		{518EBD17-F582-9E69-2716-57C9329DC0BE}.Publish|Any CPU.Build.0 = Release|Any CPU
 		{518EBD17-F582-9E69-2716-57C9329DC0BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{518EBD17-F582-9E69-2716-57C9329DC0BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02663844-E371-416A-969A-66B6512BB2E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02663844-E371-416A-969A-66B6512BB2E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02663844-E371-416A-969A-66B6512BB2E1}.Publish|Any CPU.ActiveCfg = Release|Any CPU
+		{02663844-E371-416A-969A-66B6512BB2E1}.Publish|Any CPU.Build.0 = Release|Any CPU
+		{02663844-E371-416A-969A-66B6512BB2E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02663844-E371-416A-969A-66B6512BB2E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1474,6 +1482,7 @@ Global
 		{FCEB6560-A377-88A0-3FFC-D82ACCCEB211} = {D1FD2171-A467-4F2D-9CF1-4B0DB753A689}
 		{CB494B28-A90B-C2AA-F7BB-CFD2A88639A0} = {D1FD2171-A467-4F2D-9CF1-4B0DB753A689}
 		{518EBD17-F582-9E69-2716-57C9329DC0BE} = {D1FD2171-A467-4F2D-9CF1-4B0DB753A689}
+		{02663844-E371-416A-969A-66B6512BB2E1} = {D1FD2171-A467-4F2D-9CF1-4B0DB753A689}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBDC56A3-86AD-4323-AA0F-201E59123B83}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/ChatWithAgent.ApiService.csproj
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/ChatWithAgent.ApiService.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ChatWithAgent.ServiceDefaults\ChatWithAgent.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\ChatWithAgent.Configuration\ChatWithAgent.Configuration.csproj" IsAspireProjectResource="false" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Extensions/WebApplicationBuilderExtensions.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Azure.Identity;
+using ChatWithAgent.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.SemanticKernel;
+
+namespace ChatWithAgent.ApiService.Extensions;
+
+/// <summary>
+/// Web application builder extensions.
+/// </summary>
+internal static class WebApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds Azure OpenAI services to the web application.
+    /// </summary>
+    /// <param name="builder">The web application builder.</param>
+    /// <param name="hostConfig">The host configuration.</param>
+    internal static void AddAzureOpenAIServices(this WebApplicationBuilder builder, HostConfig hostConfig)
+    {
+        // Add AzureOpenAI client.
+        builder.AddAzureOpenAIClient(
+            AzureOpenAIChatConfig.ConnectionStringName,
+            (settings) => settings.Credential = builder.Environment.IsProduction()
+                ? new DefaultAzureCredential()
+                : new AzureCliCredential()); // Use credentials from Azure CLI for local development.
+
+        // Add AzureOpenAI chat completion service.
+        builder.Services.AddAzureOpenAIChatCompletion(hostConfig.AzureOpenAIChat.DeploymentName);
+    }
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/ChatWithAgent.AppHost.csproj
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/ChatWithAgent.AppHost.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ChatWithAgent.ApiService\ChatWithAgent.ApiService.csproj" />
+    <ProjectReference Include="..\ChatWithAgent.Configuration\ChatWithAgent.Configuration.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\ChatWithAgent.Web\ChatWithAgent.Web.csproj" />
   </ItemGroup>
 

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Extensions/DistributedApplicationBuilderExtensions.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Extensions/DistributedApplicationBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using ChatWithAgent.Configuration;
+
+namespace ChatWithAgent.AppHost.Extensions;
+
+/// <summary>
+/// Distributed application builder extensions.
+/// </summary>
+internal static class DistributedApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds Azure OpenAI service and OpenAI model(s) to the distributed application.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="config">The host configuration.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{IResourceWithConnectionString}"/>.</returns>
+    internal static IResourceBuilder<IResourceWithConnectionString> AddAzureOpenAI(this IDistributedApplicationBuilder builder, HostConfig config)
+    {
+        if (builder.ExecutionContext.IsPublishMode)
+        {
+            // Deploy and provision Azure OpenAI service with AI models
+            return builder
+                .AddAzureOpenAI(AzureOpenAIChatConfig.ConnectionStringName)
+                .AddDeployment(new AzureOpenAIDeployment(
+                    name: config.AzureOpenAIChat.DeploymentName,
+                    modelName: config.AzureOpenAIChat.ModelName,
+                    modelVersion: config.AzureOpenAIChat.ModelVersion)
+                );
+        }
+
+        // Use an existing Azure OpenAI service via connection string
+        return builder.AddConnectionString(AzureOpenAIChatConfig.ConnectionStringName);
+    }
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Extensions/ResourceBuilderExtensions.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Extensions/ResourceBuilderExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using ChatWithAgent.Configuration;
+
+namespace ChatWithAgent.AppHost.Extensions;
+
+/// <summary>
+/// Resource builder extensions.
+/// </summary>
+public static class ResourceBuilderExtensions
+{
+    /// <summary>
+    /// Adds host configuration as environment variables to the resource.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="config">The host configuration.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, HostConfig config) where T : IResourceWithEnvironment
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(config);
+
+        // Add configured AI chat service to the environment variables so that Api Service can access it.
+        builder.WithEnvironment(nameof(config.AIChatService), config.AIChatService);
+
+        switch (config.AIChatService)
+        {
+            case AzureOpenAIChatConfig.ConfigSectionName:
+            {
+                // Add Azure OpenAI chat model deployment name to environment variables so that Api Service can access it.
+                builder.WithEnvironment($"{HostConfig.AIServicesSectionName}__{AzureOpenAIChatConfig.ConfigSectionName}__{nameof(config.AzureOpenAIChat.DeploymentName)}", config.AzureOpenAIChat.DeploymentName);
+                break;
+            }
+
+            default:
+                throw new NotSupportedException($"AI service '{config.AIChatService}' is not supported.");
+        }
+
+        return builder;
+    }
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Program.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Program.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using ChatWithAgent.Configuration;
 using ChatWithAgent.AppHost.Extensions;
+using ChatWithAgent.Configuration;
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/appsettings.json
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/appsettings.json
@@ -5,5 +5,13 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
-  }
+  },
+  "AIServices": {
+    "AzureOpenAIChat": {
+      "DeploymentName": "gpt-4o-mini",
+      "ModelName": "gpt-4o-mini",
+      "ModelVersion": "2024-07-18"
+    }
+  },
+  "AIChatService": "AzureOpenAIChat"
 }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/AzureOpenAIChatConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/AzureOpenAIChatConfig.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace ChatWithAgent.Configuration;
+
+/// <summary>
+/// Azure OpenAI chat configuration.
+/// </summary>
+public sealed class AzureOpenAIChatConfig
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string ConfigSectionName = "AzureOpenAIChat";
+
+    /// <summary>
+    /// The name of the connection string of the Azure OpenAI chat service.
+    /// </summary>
+    public const string ConnectionStringName = ConfigSectionName;
+
+    /// <summary>
+    /// The name of the chat deployment.
+    /// </summary>
+    [Required]
+    public string DeploymentName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the chat model.
+    /// </summary>
+    public string ModelName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The chat model version.
+    /// </summary>
+    public string ModelVersion { get; set; } = string.Empty;
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/ChatWithAgent.Configuration.csproj
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/ChatWithAgent.Configuration.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/HostConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/HostConfig.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Configuration;
+
+namespace ChatWithAgent.Configuration;
+
+/// <summary>
+/// Helper class for loading host configuration settings.
+/// </summary>
+public sealed class HostConfig
+{
+    /// <summary>
+    /// The AI services section name.
+    /// </summary>
+    public const string AIServicesSectionName = "AIServices";
+
+    private readonly AzureOpenAIChatConfig _azureOpenAIChat = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HostConfig"/> class.
+    /// </summary>
+    /// <param name="configurationManager">The configuration manager.</param>
+    public HostConfig(ConfigurationManager configurationManager)
+    {
+        configurationManager
+            .GetSection($"{AIServicesSectionName}:{AzureOpenAIChatConfig.ConfigSectionName}")
+            .Bind(this._azureOpenAIChat);
+        configurationManager
+            .Bind(this);
+    }
+
+    /// <summary>
+    /// The AI chat service to use.
+    /// </summary>
+    [Required]
+    public string AIChatService { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Azure OpenAI chat configuration.
+    /// </summary>
+    public AzureOpenAIChatConfig AzureOpenAIChat => this._azureOpenAIChat;
+}


### PR DESCRIPTION
### Motivation, Context, and Description  

This PR reads Azure OpenAI related configuration: deployment, model, and version from a config file instead of using hardcoded values. Additionally, it adds a configuration property that points to an AI chat service for the agent to use. At the moment, only the Azure OpenAI service is supported, but other services like OpenAI will be added in one of the next PRs.  
   
It also copies some values from the host configuration to environment variables so that the Agent API service can access them. This allows us to keep the host/deployment configuration in one place - the host rather than having the same config in two projects: the host and the API service. The host uses it for deployment and provisioning of Azure resources, while the service uses it to access the provisioned resources.  
   
Next steps include:  
- Reading agent parameters from the configuration.  
- Adding support for OpenAI chat models.
   
Note: This PR targets the `feature-agents-hosting` feature branch.    
Contributes to: https://github.com/microsoft/semantic-kernel/issues/10149