### PR TITLE
.Net: Rename hybrid search and expect single vector property.

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -568,8 +568,6 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
     }
 
     [Theory]
-    [InlineData(null, "TestEmbedding1", 1, 1)]
-    [InlineData("", "TestEmbedding1", 2, 2)]
     [InlineData("TestEmbedding1", "TestEmbedding1", 3, 3)]
     [InlineData("TestEmbedding2", "test_embedding_2", 4, 4)]
     public async Task VectorizedSearchUsesValidQueryAsync(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<string, TRecord>,
     IVectorizableTextSearch<TRecord>,
-    IKeywordVectorizedHybridSearch<TRecord>
+    IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -72,7 +72,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
     private static readonly VectorData.VectorSearchOptions s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
-    private static readonly KeywordVectorizedHybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
+    private static readonly HybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
 
     /// <summary>Azure AI Search client that can be used to manage the list of indices in an Azure AI Search Service.</summary>
     private readonly SearchIndexClient _searchIndexClient;
@@ -326,7 +326,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
 
         // Resolve options.
         var internalOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
         var vectorPropertyName = this._propertyReader.GetJsonPropertyName(vectorProperty!.DataModelPropertyName);
 
         // Configure search settings.
@@ -367,7 +367,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
 
         // Resolve options.
         var internalOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
         var vectorPropertyName = this._propertyReader.GetJsonPropertyName(vectorProperty!.DataModelPropertyName);
 
         // Configure search settings.
@@ -397,16 +397,16 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public Task<VectorSearchResults<TRecord>> KeywordVectorizedHybridSearch<TVector>(TVector vector, ICollection<string> keywords, KeywordVectorizedHybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keywords);
         var floatVector = VerifyVectorParam(vector);
 
         // Resolve options.
         var internalOptions = options ?? s_defaultKeywordVectorizedHybridSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
         var vectorPropertyName = this._propertyReader.GetJsonPropertyName(vectorProperty.DataModelPropertyName);
-        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(internalOptions.FullTextPropertyName);
+        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(internalOptions.AdditionalPropertyName);
         var textDataPropertyName = this._propertyReader.GetJsonPropertyName(textDataProperty.DataModelPropertyName);
 
         // Configure search settings.

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -397,7 +397,7 @@ public sealed class AzureAISearchVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Verify.NotNull(keywords);
         var floatVector = VerifyVectorParam(vector);

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -264,7 +264,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : I
         };
 
         var searchOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
         var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
 
         var filter = AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -400,7 +400,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         const string OperationName = "VectorizedSearch";
         const string ScorePropertyName = "SimilarityScore";

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<string, TRecord>,
     IVectorStoreRecordCollection<AzureCosmosDBNoSQLCompositeKey, TRecord>,
-    IKeywordVectorizedHybridSearch<TRecord>
+    IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -73,7 +73,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
-    private static readonly KeywordVectorizedHybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
+    private static readonly HybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
 
     /// <summary><see cref="Database"/> that can be used to manage the collections in Azure CosmosDB NoSQL.</summary>
     private readonly Database _database;
@@ -372,7 +372,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         this.VerifyVectorType(vector);
 
         var searchOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
         var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
 
         var fields = new List<string>(searchOptions.IncludeVectors ? this._storagePropertyNames.Values : this._nonVectorStoragePropertyNames);
@@ -400,7 +400,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public Task<VectorSearchResults<TRecord>> KeywordVectorizedHybridSearch<TVector>(TVector vector, ICollection<string> keywords, KeywordVectorizedHybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         const string OperationName = "VectorizedSearch";
         const string ScorePropertyName = "SimilarityScore";
@@ -408,10 +408,10 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         this.VerifyVectorType(vector);
 
         var searchOptions = options ?? s_defaultKeywordVectorizedHybridSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
         var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
 
-        var textProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(searchOptions.FullTextPropertyName);
+        var textProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(searchOptions.AdditionalPropertyName);
         var textPropertyName = this._storagePropertyNames[textProperty.DataModelPropertyName];
 
         var fields = new List<string>(searchOptions.IncludeVectors ? this._storagePropertyNames.Values : this._nonVectorStoragePropertyNames);

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -222,7 +222,7 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
 
         // Resolve options and get requested vector property or first as default.
         var internalOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
 
         // Filter records using the provided filter before doing the vector comparison.
         var filteredRecords = InMemoryVectorStoreCollectionSearchMapping.FilterRecords(internalOptions.Filter, this.GetCollectionDictionary().Values);

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IKeywordVectorizedHybridSearch<TRecord>
+public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<string, TRecord>, IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -35,7 +35,7 @@ public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRe
     private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
-    private static readonly KeywordVectorizedHybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
+    private static readonly HybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
 
     /// <summary><see cref="IMongoDatabase"/> that can be used to manage the collections in MongoDB.</summary>
     private readonly IMongoDatabase _mongoDatabase;
@@ -259,7 +259,7 @@ public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRe
         Array vectorArray = VerifyVectorParam(vector);
 
         var searchOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
         var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
 
         var filter = MongoDBVectorStoreCollectionSearchMapping.BuildFilter(
@@ -302,14 +302,14 @@ public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRe
     }
 
     /// <inheritdoc />
-    public async Task<VectorSearchResults<TRecord>> KeywordVectorizedHybridSearch<TVector>(TVector vector, ICollection<string> keywords, KeywordVectorizedHybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Array vectorArray = VerifyVectorParam(vector);
 
         var searchOptions = options ?? s_defaultKeywordVectorizedHybridSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
         var vectorPropertyName = this._storagePropertyNames[vectorProperty.DataModelPropertyName];
-        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(searchOptions.FullTextPropertyName);
+        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(searchOptions.AdditionalPropertyName);
         var textDataPropertyName = this._storagePropertyNames[textDataProperty.DataModelPropertyName];
 
         var filter = MongoDBVectorStoreCollectionSearchMapping.BuildFilter(

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -302,7 +302,7 @@ public sealed class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRe
     }
 
     /// <inheritdoc />
-    public async Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         Array vectorArray = VerifyVectorParam(vector);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollection.cs
@@ -266,7 +266,7 @@ public sealed class PostgresVectorStoreRecordCollection<TKey, TRecord> : IVector
         }
 
         var searchOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
 
         var pgVector = PostgresVectorStoreRecordPropertyMapping.MapVectorForStorageModel(vector);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -516,7 +516,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public async Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         var floatVector = VerifyVectorParam(vector);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 public sealed class QdrantVectorStoreRecordCollection<TRecord> :
     IVectorStoreRecordCollection<ulong, TRecord>,
     IVectorStoreRecordCollection<Guid, TRecord>,
-    IKeywordVectorizedHybridSearch<TRecord>
+    IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>A set of types that a key on the provided model may have.</summary>
@@ -35,7 +35,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> :
     private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
-    private static readonly KeywordVectorizedHybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
+    private static readonly HybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
 
     /// <summary>The name of this database for telemetry purposes.</summary>
     private const string DatabaseName = "Qdrant";
@@ -469,7 +469,7 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> :
 
         // Resolve options.
         var internalOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
 
         // Build filter object.
         var filter = QdrantVectorStoreCollectionSearchMapping.BuildFilter(internalOptions.Filter, this._propertyReader.StoragePropertyNamesMap);
@@ -516,17 +516,17 @@ public sealed class QdrantVectorStoreRecordCollection<TRecord> :
     }
 
     /// <inheritdoc />
-    public async Task<VectorSearchResults<TRecord>> KeywordVectorizedHybridSearch<TVector>(TVector vector, ICollection<string> keywords, KeywordVectorizedHybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         var floatVector = VerifyVectorParam(vector);
 
         // Resolve options.
         var internalOptions = options ?? s_defaultKeywordVectorizedHybridSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
 
         // Build filter object.
         var filter = QdrantVectorStoreCollectionSearchMapping.BuildFilter(internalOptions.Filter, this._propertyReader.StoragePropertyNamesMap);
-        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(internalOptions.FullTextPropertyName);
+        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(internalOptions.AdditionalPropertyName);
         var textDataPropertyName = this._propertyReader.GetStoragePropertyName(textDataProperty.DataModelPropertyName);
 
         // Specify the vector name if named vectors are used.

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -333,7 +333,7 @@ public sealed class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorSt
         Verify.NotNull(vector);
 
         var internalOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
 
         // Build query & search.
         var selectFields = internalOptions.IncludeVectors ? null : this._dataStoragePropertyNamesWithScore;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -379,7 +379,7 @@ public sealed class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStore
         Verify.NotNull(vector);
 
         var internalOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(internalOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(internalOptions.VectorPropertyName);
 
         // Build query & search.
         byte[] vectorBytes = RedisVectorStoreCollectionSearchMapping.ValidateVectorAndConvertToBytes(vector, "JSON");

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollection.cs
@@ -169,7 +169,7 @@ public sealed class SqliteVectorStoreRecordCollection<TRecord> :
         }
 
         var searchOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
 
         var mappedArray = SqliteVectorStoreRecordPropertyMapping.MapVectorForStorageModel(vector);
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// </summary>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<Guid, TRecord>, IKeywordVectorizedHybridSearch<TRecord>
+public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCollection<Guid, TRecord>, IKeywordHybridSearch<TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>The name of this database for telemetry purposes.</summary>
@@ -87,7 +87,7 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
     private static readonly VectorSearchOptions s_defaultVectorSearchOptions = new();
 
     /// <summary>The default options for hybrid vector search.</summary>
-    private static readonly KeywordVectorizedHybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
+    private static readonly HybridSearchOptions s_defaultKeywordVectorizedHybridSearchOptions = new();
 
     /// <summary><see cref="HttpClient"/> that is used to interact with Weaviate API.</summary>
     private readonly HttpClient _httpClient;
@@ -349,7 +349,7 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
         VerifyVectorParam(vector);
 
         var searchOptions = options ?? s_defaultVectorSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
 
         var vectorPropertyName = this._propertyReader.GetJsonPropertyName(vectorProperty.DataModelPropertyName);
         var fields = this._propertyReader.DataPropertyJsonNames;
@@ -369,15 +369,15 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
-    public async Task<VectorSearchResults<TRecord>> KeywordVectorizedHybridSearch<TVector>(TVector vector, ICollection<string> keywords, KeywordVectorizedHybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         const string OperationName = "HybridSearch";
 
         VerifyVectorParam(vector);
 
         var searchOptions = options ?? s_defaultKeywordVectorizedHybridSearchOptions;
-        var vectorProperty = this._propertyReader.GetVectorPropertyOrFirst(searchOptions.VectorPropertyName);
-        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(searchOptions.FullTextPropertyName);
+        var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions.VectorPropertyName);
+        var textDataProperty = this._propertyReader.GetFullTextDataPropertyOrSingle(searchOptions.AdditionalPropertyName);
 
         var vectorPropertyName = this._propertyReader.GetJsonPropertyName(vectorProperty.DataModelPropertyName);
         var textDataPropertyName = this._propertyReader.GetJsonPropertyName(textDataProperty.DataModelPropertyName);

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -369,7 +369,7 @@ public sealed class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreR
     }
 
     /// <inheritdoc />
-    public async Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions? options = null, CancellationToken cancellationToken = default)
     {
         const string OperationName = "HybridSearch";
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionQueryBuilder.cs
@@ -76,7 +76,7 @@ internal static class WeaviateVectorStoreRecordCollectionQueryBuilder
         string keyPropertyName,
         string textPropertyName,
         JsonSerializerOptions jsonSerializerOptions,
-        KeywordVectorizedHybridSearchOptions searchOptions,
+        HybridSearchOptions searchOptions,
         IReadOnlyDictionary<string, string> storagePropertyNames,
         IReadOnlyList<string> vectorPropertyStorageNames,
         IReadOnlyList<string> dataPropertyStorageNames)

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordCollectionTests.cs
@@ -568,8 +568,6 @@ public sealed class MongoDBVectorStoreRecordCollectionTests
     }
 
     [Theory]
-    [InlineData(null, "TestEmbedding1", 1, 1)]
-    [InlineData("", "TestEmbedding1", 2, 2)]
     [InlineData("TestEmbedding1", "TestEmbedding1", 3, 3)]
     [InlineData("TestEmbedding2", "test_embedding_2", 4, 4)]
     public async Task VectorizedSearchUsesValidQueryAsync(

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -470,6 +470,7 @@ public class RedisJsonVectorStoreRecordCollectionTests
             {
                 IncludeVectors = true,
                 Filter = filter,
+                VectorPropertyName = nameof(MultiPropsModel.Vector1),
                 Top = 5,
                 Skip = 2
             });

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/HybridSearchOptions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/HybridSearchOptions.cs
@@ -3,22 +3,31 @@
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>
-/// Options for vector search.
+/// Options for hybrid search when using a dense vector and string keywords to do the search.
 /// </summary>
-public class VectorSearchOptions
+public class HybridSearchOptions
 {
     /// <summary>
-    /// Gets or sets a search filter to use before doing the vector search.
+    /// Gets or sets a search filter to use before doing the hybrid search.
     /// </summary>
     public VectorSearchFilter? Filter { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the vector property to search on.
+    /// Gets or sets the name of the target dense vector property to search on.
     /// Use the name of the vector property from your data model or as provided in the record definition.
     /// If not provided will look if there is a vector property, and
     /// will throw if either none or multiple exist.
     /// </summary>
     public string? VectorPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the additional target property to do the text/keyword search on.
+    /// The property must have full text search enabled.
+    /// Use the name of the data property from your data model or as provided in the record definition.
+    /// If not provided will look if there is a text property with full text search enabled, and
+    /// will throw if either none or multiple exist.
+    /// </summary>
+    public string? AdditionalPropertyName { get; init; }
 
     /// <summary>
     /// Gets or sets the maximum number of results to return.

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IKeywordHybridSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IKeywordHybridSearch.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Contains a method for doing a hybrid search using a vector and keywords.
+/// </summary>
+/// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+public interface IKeywordHybridSearch<TRecord>
+{
+    /// <summary>
+    /// Performs a hybrid search for records that match the given embedding and keywords, after applying the provided filters.
+    /// </summary>
+    /// <typeparam name="TVector">The type of the vector.</typeparam>
+    /// <param name="vector">The vector to search the store with.</param>
+    /// <param name="keywords">A collection of keywords to search the store with.</param>
+    /// <param name="options">The options that control the behavior of the search.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The records found by the hybrid search, including their result scores.</returns>
+    Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(
+        TVector vector,
+        ICollection<string> keywords,
+        HybridSearchOptions? options = default,
+        CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IKeywordHybridSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/IKeywordHybridSearch.cs
@@ -21,7 +21,7 @@ public interface IKeywordHybridSearch<TRecord>
     /// <param name="options">The options that control the behavior of the search.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The records found by the hybrid search, including their result scores.</returns>
-    Task<VectorSearchResults<TRecord>> HybridSearch<TVector>(
+    Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(
         TVector vector,
         ICollection<string> keywords,
         HybridSearchOptions? options = default,

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchKeywordVectorizedHybridSearchTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureAISearch;
 
 /// <summary>
-/// Inherits common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Inherits common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 /// <param name="fixture">Azure AI Search setup and teardown.</param>
 [Collection("AzureAISearchVectorStoreCollection")]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKeywordVectorizedHybridSearchTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.AzureCosmosDBNoSQL;
 
 /// <summary>
-/// Inherits common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Inherits common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 [Collection("AzureCosmosDBNoSQLVectorStoreCollection")]
 [AzureCosmosDBNoSQLConnectionStringSetCondition]

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseKeywordVectorizedHybridSearchTests.cs
@@ -48,7 +48,7 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             // Act
             // All records have the same vector, but the third contains Grapes, so searching for
             // Grapes should return the third record first.
-            var searchResult = await hybridSearch!.HybridSearch(vector, ["Grapes"]);
+            var searchResult = await hybridSearch!.HybridSearchAsync(vector, ["Grapes"]);
 
             // Assert
             var results = await searchResult.Results.ToListAsync();
@@ -85,7 +85,7 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             {
                 Filter = new VectorSearchFilter().EqualTo("Code", 1)
             };
-            var searchResult = await hybridSearch!.HybridSearch(vector, ["Oranges"], options);
+            var searchResult = await hybridSearch!.HybridSearchAsync(vector, ["Oranges"], options);
 
             // Assert
             var results = await searchResult.Results.ToListAsync();
@@ -118,7 +118,7 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             // Act
             // All records have the same vector, but the second contains Oranges, so the
             // second should be returned first.
-            var searchResult = await hybridSearch!.HybridSearch(vector, ["Oranges"], new() { Top = 1 });
+            var searchResult = await hybridSearch!.HybridSearchAsync(vector, ["Oranges"], new() { Top = 1 });
 
             // Assert
             var results = await searchResult.Results.ToListAsync();
@@ -151,7 +151,7 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             // Act
             // All records have the same vector, but the first and third contain healthy,
             // so when skipping the first two results, we should get the second record.
-            var searchResult = await hybridSearch!.HybridSearch(vector, ["healthy"], new() { Skip = 2 });
+            var searchResult = await hybridSearch!.HybridSearchAsync(vector, ["healthy"], new() { Skip = 2 });
 
             // Assert
             var results = await searchResult.Results.ToListAsync();
@@ -182,7 +182,7 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             await this.CreateCollectionAndAddDataAsync(sut, vector);
 
             // Act
-            var searchResult = await hybridSearch!.HybridSearch(vector, ["tangy", "nourishing"]);
+            var searchResult = await hybridSearch!.HybridSearchAsync(vector, ["tangy", "nourishing"]);
 
             // Assert
             var results = await searchResult.Results.ToListAsync();
@@ -215,8 +215,8 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             await this.CreateCollectionAndAddDataAsync(sut, vector);
 
             // Act
-            var searchResult1 = await hybridSearch!.HybridSearch(vector, ["Apples"], new() { AdditionalPropertyName = nameof(MultiSearchStringRecord<string>.Text2) });
-            var searchResult2 = await hybridSearch!.HybridSearch(vector, ["Oranges"], new() { AdditionalPropertyName = nameof(MultiSearchStringRecord<string>.Text2) });
+            var searchResult1 = await hybridSearch!.HybridSearchAsync(vector, ["Apples"], new() { AdditionalPropertyName = nameof(MultiSearchStringRecord<string>.Text2) });
+            var searchResult2 = await hybridSearch!.HybridSearchAsync(vector, ["Oranges"], new() { AdditionalPropertyName = nameof(MultiSearchStringRecord<string>.Text2) });
 
             // Assert
             var results1 = await searchResult1.Results.ToListAsync();

--- a/dotnet/src/IntegrationTests/Connectors/Memory/BaseKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/BaseKeywordVectorizedHybridSearchTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.Memory;
 
 /// <summary>
-/// Base class for common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Base class for common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 /// <typeparam name="TKey">The type of key to use with the record collection.</typeparam>
 public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
@@ -38,24 +38,29 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             "kwhybrid",
             this.KeyWithVectorAndStringRecordDefinition);
 
-        var hybridSearch = sut as IKeywordVectorizedHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
+        var hybridSearch = sut as IKeywordHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
 
-        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
-        await this.CreateCollectionAndAddDataAsync(sut, vector);
+        try
+        {
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+            await this.CreateCollectionAndAddDataAsync(sut, vector);
 
-        // Act
-        // All records have the same vector, but the third contains Grapes, so searching for
-        // Grapes should return the third record first.
-        var searchResult = await hybridSearch!.KeywordVectorizedHybridSearch(vector, ["Grapes"]);
+            // Act
+            // All records have the same vector, but the third contains Grapes, so searching for
+            // Grapes should return the third record first.
+            var searchResult = await hybridSearch!.HybridSearch(vector, ["Grapes"]);
 
-        // Assert
-        var results = await searchResult.Results.ToListAsync();
-        Assert.Equal(3, results.Count);
+            // Assert
+            var results = await searchResult.Results.ToListAsync();
+            Assert.Equal(3, results.Count);
 
-        Assert.Equal(this.Key3, results[0].Record.Key);
-
-        // Cleanup
-        await sut.DeleteCollectionAsync();
+            Assert.Equal(this.Key3, results[0].Record.Key);
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
     }
 
     [VectorStoreFact]
@@ -66,28 +71,33 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             "kwfilteredhybrid",
             this.KeyWithVectorAndStringRecordDefinition);
 
-        var hybridSearch = sut as IKeywordVectorizedHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
+        var hybridSearch = sut as IKeywordHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
 
-        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
-        await this.CreateCollectionAndAddDataAsync(sut, vector);
-
-        // Act
-        // All records have the same vector, but the second contains Oranges, however
-        // adding the filter should limit the results to only the first.
-        var options = new KeywordVectorizedHybridSearchOptions
+        try
         {
-            Filter = new VectorSearchFilter().EqualTo("Code", 1)
-        };
-        var searchResult = await hybridSearch!.KeywordVectorizedHybridSearch(vector, ["Oranges"], options);
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+            await this.CreateCollectionAndAddDataAsync(sut, vector);
 
-        // Assert
-        var results = await searchResult.Results.ToListAsync();
-        Assert.Single(results);
+            // Act
+            // All records have the same vector, but the second contains Oranges, however
+            // adding the filter should limit the results to only the first.
+            var options = new HybridSearchOptions
+            {
+                Filter = new VectorSearchFilter().EqualTo("Code", 1)
+            };
+            var searchResult = await hybridSearch!.HybridSearch(vector, ["Oranges"], options);
 
-        Assert.Equal(this.Key1, results[0].Record.Key);
+            // Assert
+            var results = await searchResult.Results.ToListAsync();
+            Assert.Single(results);
 
-        // Cleanup
-        await sut.DeleteCollectionAsync();
+            Assert.Equal(this.Key1, results[0].Record.Key);
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
     }
 
     [VectorStoreFact]
@@ -98,24 +108,29 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             "kwtophybrid",
             this.KeyWithVectorAndStringRecordDefinition);
 
-        var hybridSearch = sut as IKeywordVectorizedHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
+        var hybridSearch = sut as IKeywordHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
 
-        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
-        await this.CreateCollectionAndAddDataAsync(sut, vector);
+        try
+        {
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+            await this.CreateCollectionAndAddDataAsync(sut, vector);
 
-        // Act
-        // All records have the same vector, but the second contains Oranges, so the
-        // second should be returned first.
-        var searchResult = await hybridSearch!.KeywordVectorizedHybridSearch(vector, ["Oranges"], new() { Top = 1 });
+            // Act
+            // All records have the same vector, but the second contains Oranges, so the
+            // second should be returned first.
+            var searchResult = await hybridSearch!.HybridSearch(vector, ["Oranges"], new() { Top = 1 });
 
-        // Assert
-        var results = await searchResult.Results.ToListAsync();
-        Assert.Single(results);
+            // Assert
+            var results = await searchResult.Results.ToListAsync();
+            Assert.Single(results);
 
-        Assert.Equal(this.Key2, results[0].Record.Key);
-
-        // Cleanup
-        await sut.DeleteCollectionAsync();
+            Assert.Equal(this.Key2, results[0].Record.Key);
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
     }
 
     [VectorStoreFact]
@@ -126,24 +141,29 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             "kwskiphybrid",
             this.KeyWithVectorAndStringRecordDefinition);
 
-        var hybridSearch = sut as IKeywordVectorizedHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
+        var hybridSearch = sut as IKeywordHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
 
-        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
-        await this.CreateCollectionAndAddDataAsync(sut, vector);
+        try
+        {
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+            await this.CreateCollectionAndAddDataAsync(sut, vector);
 
-        // Act
-        // All records have the same vector, but the first and third contain healthy,
-        // so when skipping the first two results, we should get the second record.
-        var searchResult = await hybridSearch!.KeywordVectorizedHybridSearch(vector, ["healthy"], new() { Skip = 2 });
+            // Act
+            // All records have the same vector, but the first and third contain healthy,
+            // so when skipping the first two results, we should get the second record.
+            var searchResult = await hybridSearch!.HybridSearch(vector, ["healthy"], new() { Skip = 2 });
 
-        // Assert
-        var results = await searchResult.Results.ToListAsync();
-        Assert.Single(results);
+            // Assert
+            var results = await searchResult.Results.ToListAsync();
+            Assert.Single(results);
 
-        Assert.Equal(this.Key2, results[0].Record.Key);
-
-        // Cleanup
-        await sut.DeleteCollectionAsync();
+            Assert.Equal(this.Key2, results[0].Record.Key);
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
     }
 
     [VectorStoreFact]
@@ -154,24 +174,68 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
             "kwmultikeywordhybrid",
             this.KeyWithVectorAndStringRecordDefinition);
 
-        var hybridSearch = sut as IKeywordVectorizedHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
+        var hybridSearch = sut as IKeywordHybridSearch<KeyWithVectorAndStringRecord<TKey>>;
 
-        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
-        await this.CreateCollectionAndAddDataAsync(sut, vector);
+        try
+        {
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+            await this.CreateCollectionAndAddDataAsync(sut, vector);
 
-        // Act
-        var searchResult = await hybridSearch!.KeywordVectorizedHybridSearch(vector, ["tangy", "nourishing"]);
+            // Act
+            var searchResult = await hybridSearch!.HybridSearch(vector, ["tangy", "nourishing"]);
 
-        // Assert
-        var results = await searchResult.Results.ToListAsync();
-        Assert.Equal(3, results.Count);
+            // Assert
+            var results = await searchResult.Results.ToListAsync();
+            Assert.Equal(3, results.Count);
 
-        Assert.True(results[0].Record.Key.Equals(this.Key1) || results[0].Record.Key.Equals(this.Key2));
-        Assert.True(results[1].Record.Key.Equals(this.Key1) || results[1].Record.Key.Equals(this.Key2));
-        Assert.Equal(this.Key3, results[2].Record.Key);
+            Assert.True(results[0].Record.Key.Equals(this.Key1) || results[0].Record.Key.Equals(this.Key2));
+            Assert.True(results[1].Record.Key.Equals(this.Key1) || results[1].Record.Key.Equals(this.Key2));
+            Assert.Equal(this.Key3, results[2].Record.Key);
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
+    }
 
-        // Cleanup
-        await sut.DeleteCollectionAsync();
+    [VectorStoreFact]
+    public async Task SearchWithMultiTextRecordSearchesRequestedFieldAsync()
+    {
+        // Arrange
+        var sut = this.GetTargetRecordCollection<MultiSearchStringRecord<TKey>>(
+            "kwmultitexthybrid",
+            this.MultiSearchStringRecordDefinition);
+
+        var hybridSearch = sut as IKeywordHybridSearch<MultiSearchStringRecord<TKey>>;
+
+        try
+        {
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+            await this.CreateCollectionAndAddDataAsync(sut, vector);
+
+            // Act
+            var searchResult1 = await hybridSearch!.HybridSearch(vector, ["Apples"], new() { AdditionalPropertyName = nameof(MultiSearchStringRecord<string>.Text2) });
+            var searchResult2 = await hybridSearch!.HybridSearch(vector, ["Oranges"], new() { AdditionalPropertyName = nameof(MultiSearchStringRecord<string>.Text2) });
+
+            // Assert
+            var results1 = await searchResult1.Results.ToListAsync();
+            Assert.Equal(2, results1.Count);
+
+            Assert.Equal(this.Key2, results1[0].Record.Key);
+            Assert.Equal(this.Key1, results1[1].Record.Key);
+
+            var results2 = await searchResult2.Results.ToListAsync();
+            Assert.Equal(2, results2.Count);
+
+            Assert.Equal(this.Key1, results2[0].Record.Key);
+            Assert.Equal(this.Key2, results2[1].Record.Key);
+        }
+        finally
+        {
+            // Cleanup
+            await sut.DeleteCollectionAsync();
+        }
     }
 
     private async Task CreateCollectionAndAddDataAsync(IVectorStoreRecordCollection<TKey, KeyWithVectorAndStringRecord<TKey>> sut, ReadOnlyMemory<float> vector)
@@ -205,6 +269,30 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
         await Task.Delay(this.DelayAfterUploadInMilliseconds);
     }
 
+    private async Task CreateCollectionAndAddDataAsync(IVectorStoreRecordCollection<TKey, MultiSearchStringRecord<TKey>> sut, ReadOnlyMemory<float> vector)
+    {
+        await sut.CreateCollectionIfNotExistsAsync();
+        await Task.Delay(this.DelayAfterIndexCreateInMilliseconds);
+
+        var record1 = new MultiSearchStringRecord<TKey>
+        {
+            Key = this.Key1,
+            Text1 = "Apples",
+            Text2 = "Oranges",
+            Vector = vector
+        };
+        var record2 = new MultiSearchStringRecord<TKey>
+        {
+            Key = this.Key2,
+            Text1 = "Oranges",
+            Text2 = "Apples",
+            Vector = vector
+        };
+
+        await sut.UpsertBatchAsync([record1, record2]).ToListAsync();
+        await Task.Delay(this.DelayAfterUploadInMilliseconds);
+    }
+
     private VectorStoreRecordDefinition KeyWithVectorAndStringRecordDefinition => new()
     {
         Properties = new List<VectorStoreRecordProperty>()
@@ -223,6 +311,28 @@ public abstract class BaseKeywordVectorizedHybridSearchTests<TKey>
         public string Text { get; set; } = string.Empty;
 
         public int Code { get; set; }
+
+        public ReadOnlyMemory<float> Vector { get; set; }
+    }
+
+    private VectorStoreRecordDefinition MultiSearchStringRecordDefinition => new()
+    {
+        Properties = new List<VectorStoreRecordProperty>()
+        {
+            new VectorStoreRecordKeyProperty("Key", typeof(TKey)),
+            new VectorStoreRecordDataProperty("Text1", typeof(string)) { IsFullTextSearchable = true },
+            new VectorStoreRecordDataProperty("Text2", typeof(string)) { IsFullTextSearchable = true },
+            new VectorStoreRecordVectorProperty("Vector", typeof(ReadOnlyMemory<float>)) { Dimensions = 4, IndexKind = this.IndexKind },
+        }
+    };
+
+    private sealed class MultiSearchStringRecord<TRecordKey>
+    {
+        public TRecordKey Key { get; set; } = default!;
+
+        public string Text1 { get; set; } = string.Empty;
+
+        public string Text2 { get; set; } = string.Empty;
 
         public ReadOnlyMemory<float> Vector { get; set; }
     }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBKeywordVectorizedHybridSearchTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
 
 /// <summary>
-/// Inherits common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Inherits common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 [Collection("MongoDBVectorStoreCollection")]
 public class MongoDBKeywordVectorizedHybridSearchTests(MongoDBVectorStoreFixture fixture) : BaseKeywordVectorizedHybridSearchTests<string>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantNamedVectorsKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantNamedVectorsKeywordVectorizedHybridSearchTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 
 /// <summary>
-/// Inherits common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Inherits common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 [Collection("QdrantVectorStoreCollection")]
 public class QdrantNamedVectorsKeywordVectorizedHybridSearchTests(QdrantVectorStoreFixture fixture) : BaseKeywordVectorizedHybridSearchTests<ulong>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantSingleVectorKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantSingleVectorKeywordVectorizedHybridSearchTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.Qdrant;
 
 /// <summary>
-/// Inherits common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Inherits common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 [Collection("QdrantVectorStoreCollection")]
 public class QdrantSingleVectorKeywordVectorizedHybridSearchTests(QdrantVectorStoreFixture fixture) : BaseKeywordVectorizedHybridSearchTests<ulong>

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateKeywordVectorizedHybridSearchTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateKeywordVectorizedHybridSearchTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace SemanticKernel.IntegrationTests.Connectors.Memory.Weaviate;
 
 /// <summary>
-/// Inherits common integration tests that should pass for any <see cref="IKeywordVectorizedHybridSearch{TRecord}"/>.
+/// Inherits common integration tests that should pass for any <see cref="IKeywordHybridSearch{TRecord}"/>.
 /// </summary>
 /// <param name="fixture">Weaviate setup and teardown.</param>
 [Collection("WeaviateVectorStoreCollection")]

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordPropertyReader.cs
@@ -339,11 +339,12 @@ internal sealed class VectorStoreRecordPropertyReader
 
     /// <summary>
     /// Get the vector property with the provided name if a name is provided, and fall back
-    /// to the first vector property in the schema if not.
+    /// to a vector property in the schema if not. If no name is provided and there is more
+    /// than one vector property, an exception will be thrown.
     /// </summary>
     /// <param name="vectorPropertyName">The vector property name.</param>
     /// <exception cref="InvalidOperationException">Thrown if the provided property name is not a valid vector property name.</exception>
-    public VectorStoreRecordVectorProperty GetVectorPropertyOrFirst(string? vectorPropertyName)
+    public VectorStoreRecordVectorProperty GetVectorPropertyOrSingle(string? vectorPropertyName)
     {
         // If vector property name is provided, try to find it in schema or throw an exception.
         if (!string.IsNullOrWhiteSpace(vectorPropertyName))
@@ -364,6 +365,11 @@ internal sealed class VectorStoreRecordPropertyReader
         if (this.VectorProperty is null)
         {
             throw new InvalidOperationException($"The {this._dataModelType.FullName} type does not have any vector properties.");
+        }
+
+        if (this.VectorProperties.Count > 1)
+        {
+            throw new InvalidOperationException($"The {this._dataModelType.FullName} type has multiple vector properties, please specify your chosen property via options.");
         }
 
         return this.VectorProperty;
@@ -410,7 +416,7 @@ internal sealed class VectorStoreRecordPropertyReader
 
         if (fullTextStringProperties.Count > 1)
         {
-            throw new InvalidOperationException($"The {this._dataModelType.FullName} type does has multiple text data properties that have full text search enabled, please specify your chosen property via options.");
+            throw new InvalidOperationException($"The {this._dataModelType.FullName} type has multiple text data properties that have full text search enabled, please specify your chosen property via options.");
         }
 
         return fullTextStringProperties[0];

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VectorStoreRecordPropertyReaderTests.cs
@@ -432,26 +432,36 @@ public class VectorStoreRecordPropertyReaderTests
 
     [Theory]
     [MemberData(nameof(MultiPropsTypeAndDefinitionCombos))]
-    public void GetVectorPropertyOrFirstReturnsRequestedVectorOrFirstVectorAndThrowsForInvalidVector(Type type, VectorStoreRecordDefinition? definition)
+    public void GetVectorPropertyOrSingleReturnsRequestedVectorAndThrowsForInvalidVector(Type type, VectorStoreRecordDefinition? definition)
     {
         // Arrange.
         var sut = new VectorStoreRecordPropertyReader(type, definition, null);
 
         // Act & Assert.
-        Assert.Equal("Vector2", sut.GetVectorPropertyOrFirst("Vector2").DataModelPropertyName);
-        Assert.Equal("Vector1", sut.GetVectorPropertyOrFirst(null).DataModelPropertyName);
-        Assert.Throws<InvalidOperationException>(() => sut.GetVectorPropertyOrFirst("DoesNotExist"));
+        Assert.Equal("Vector2", sut.GetVectorPropertyOrSingle("Vector2").DataModelPropertyName);
+        Assert.Throws<InvalidOperationException>(() => sut.GetVectorPropertyOrSingle("DoesNotExist"));
     }
 
     [Theory]
     [MemberData(nameof(NoVectorsTypeAndDefinitionCombos))]
-    public void GetVectorPropertyOrFirstThrowsForNoVectors(Type type, VectorStoreRecordDefinition? definition)
+    public void GetVectorPropertyOrSingleThrowsForMultipleVectors(Type type, VectorStoreRecordDefinition? definition)
     {
         // Arrange.
         var sut = new VectorStoreRecordPropertyReader(type, definition, null);
 
         // Act & Assert.
-        Assert.Throws<InvalidOperationException>(() => sut.GetVectorPropertyOrFirst(null));
+        Assert.Throws<InvalidOperationException>(() => sut.GetVectorPropertyOrSingle(null));
+    }
+
+    [Theory]
+    [MemberData(nameof(NoVectorsTypeAndDefinitionCombos))]
+    public void GetVectorPropertyOrSingleThrowsForNoVectors(Type type, VectorStoreRecordDefinition? definition)
+    {
+        // Arrange.
+        var sut = new VectorStoreRecordPropertyReader(type, definition, null);
+
+        // Act & Assert.
+        Assert.Throws<InvalidOperationException>(() => sut.GetVectorPropertyOrSingle(null));
     }
 
     [Theory]


### PR DESCRIPTION
### Description

Renames hybrid search to agreed naming
Switch validation to expect a single vector property if one is not named.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
