### PR TITLE
.Net: Rename VectorSearchOptions.NewFilter to Filter

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_Common.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_MultiStore_Common.cs
@@ -70,7 +70,7 @@ public class VectorStore_VectorSearch_MultiStore_Common(IVectorStore vectorStore
         // Search the collection using a vector search with pre-filtering.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, NewFilter = g => g.Category == "External Definitions" });
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = g => g.Category == "External Definitions" });
         resultRecords = await searchResult.Results.ToListAsync();
 
         output.WriteLine("Search string: " + searchString);

--- a/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Simple.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Simple.cs
@@ -70,7 +70,7 @@ public class VectorStore_VectorSearch_Simple(ITestOutputHelper output) : BaseTes
         // Search the collection using a vector search with pre-filtering.
         searchString = "What is Retrieval Augmented Generation";
         searchVector = await textEmbeddingGenerationService.GenerateEmbeddingAsync(searchString);
-        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, NewFilter = g => g.Category == "External Definitions" });
+        searchResult = await collection.VectorizedSearchAsync(searchVector, new() { Top = 3, Filter = g => g.Category == "External Definitions" });
         resultRecords = await searchResult.Results.ToListAsync();
 
         Console.WriteLine("Search string: " + searchString);

--- a/dotnet/samples/GettingStartedWithVectorStores/Step2_Vector_Search.cs
+++ b/dotnet/samples/GettingStartedWithVectorStores/Step2_Vector_Search.cs
@@ -71,7 +71,7 @@ public class Step2_Vector_Search(ITestOutputHelper output, VectorStoresFixture f
             new()
             {
                 Top = 1,
-                NewFilter = g => g.Category == "AI"
+                Filter = g => g.Category == "AI"
             });
         var searchResultItems = await searchResult.Results.ToListAsync();
 

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -574,7 +574,7 @@ public class AzureAISearchVectorStoreRecordCollectionTests
             {
                 Top = 5,
                 Skip = 3,
-                Filter = filter,
+                OldFilter = filter,
                 VectorPropertyName = nameof(MultiPropsModel.Vector1)
             },
             this._testCancellationToken);
@@ -616,7 +616,7 @@ public class AzureAISearchVectorStoreRecordCollectionTests
             {
                 Top = 5,
                 Skip = 3,
-                Filter = filter,
+                OldFilter = filter,
                 VectorPropertyName = nameof(MultiPropsModel.Vector1)
             },
             this._testCancellationToken);

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests.cs
@@ -37,7 +37,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
             .EqualTo("TestProperty2", "test-value-2")
             .AnyTagEqualTo("TestProperty3", "test-value-3");
 
-        var searchOptions = new VectorSearchOptions<DummyType> { Filter = filter, Skip = 5, Top = 10 };
+        var searchOptions = new VectorSearchOptions<DummyType> { OldFilter = filter, Skip = 5, Top = 10 };
 
         // Act
         var queryDefinition = AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.BuildSearchQuery(
@@ -86,7 +86,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
             .EqualTo("TestProperty2", "test-value-2")
             .AnyTagEqualTo("TestProperty3", "test-value-3");
 
-        var searchOptions = new VectorSearchOptions<DummyType> { Filter = filter, Top = 10 };
+        var searchOptions = new VectorSearchOptions<DummyType> { OldFilter = filter, Top = 10 };
 
         // Act
         var queryDefinition = AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.BuildSearchQuery(
@@ -131,7 +131,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilderTests
 
         var filter = new VectorSearchFilter().EqualTo("non-existent-property", "test-value-2");
 
-        var searchOptions = new VectorSearchOptions<DummyType> { Filter = filter, Skip = 5, Top = 10 };
+        var searchOptions = new VectorSearchOptions<DummyType> { OldFilter = filter, Skip = 5, Top = 10 };
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() =>

--- a/dotnet/src/Connectors/Connectors.InMemory.UnitTests/InMemoryVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.InMemory.UnitTests/InMemoryVectorStoreRecordCollectionTests.cs
@@ -338,7 +338,7 @@ public class InMemoryVectorStoreRecordCollectionTests
         var filter = filterType == "Equality" ? new VectorSearchFilter().EqualTo("Data", $"data {testKey2}") : new VectorSearchFilter().AnyTagEqualTo("Tags", $"tag {testKey2}");
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new float[] { 1, 1, 1, 1 }),
-            new() { IncludeVectors = true, Filter = filter, IncludeTotalCount = true },
+            new() { IncludeVectors = true, OldFilter = filter, IncludeTotalCount = true },
             this._testCancellationToken);
 
         // Assert

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -340,9 +340,9 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorStoreRec
         // Build filter object.
         var filter = internalOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => AzureAISearchVectorStoreCollectionSearchMapping.BuildLegacyFilterString(legacyFilter, this._propertyReader.JsonPropertyNamesMap),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new AzureAISearchFilterTranslator().Translate(newFilter, this._propertyReader.StoragePropertyNamesMap),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => AzureAISearchVectorStoreCollectionSearchMapping.BuildLegacyFilterString(legacyFilter, this._propertyReader.JsonPropertyNamesMap),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new AzureAISearchFilterTranslator().Translate(newFilter, this._propertyReader.StoragePropertyNamesMap),
             _ => null
         };
 #pragma warning restore CS0618
@@ -395,9 +395,9 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> : IVectorStoreRec
         // Build filter object.
         var filter = internalOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => AzureAISearchVectorStoreCollectionSearchMapping.BuildLegacyFilterString(legacyFilter, this._propertyReader.JsonPropertyNamesMap),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new AzureAISearchFilterTranslator().Translate(newFilter, this._propertyReader.StoragePropertyNamesMap),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => AzureAISearchVectorStoreCollectionSearchMapping.BuildLegacyFilterString(legacyFilter, this._propertyReader.JsonPropertyNamesMap),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new AzureAISearchFilterTranslator().Translate(newFilter, this._propertyReader.StoragePropertyNamesMap),
             _ => null
         };
 #pragma warning restore CS0618

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -275,11 +275,11 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : IVectorS
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
         var filter = searchOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => AzureCosmosDBMongoDBVectorStoreCollectionSearchMapping.BuildFilter(
                 legacyFilter,
                 this._storagePropertyNames),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new AzureCosmosDBMongoDBFilterTranslator().Translate(newFilter, this._storagePropertyNames),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new AzureCosmosDBMongoDBFilterTranslator().Translate(newFilter, this._storagePropertyNames),
             _ => null
         };
 #pragma warning restore CS0618

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder.cs
@@ -49,9 +49,9 @@ internal static class AzureCosmosDBNoSQLVectorStoreCollectionQueryBuilder
         // Build filter object.
         var (whereClause, filterParameters) = searchOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => BuildSearchFilter(legacyFilter, storagePropertyNames),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new AzureCosmosDBNoSqlFilterTranslator().Translate(newFilter, storagePropertyNames),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => BuildSearchFilter(legacyFilter, storagePropertyNames),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new AzureCosmosDBNoSqlFilterTranslator().Translate(newFilter, storagePropertyNames),
             _ => (null, [])
         };
 #pragma warning restore CS0618 // VectorSearchFilter is obsolete

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -240,9 +240,9 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
         var allValues = this.GetCollectionDictionary().Values.Cast<TRecord>();
         var filteredRecords = internalOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => InMemoryVectorStoreCollectionSearchMapping.FilterRecords(legacyFilter, allValues),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => allValues.AsQueryable().Where(newFilter),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => InMemoryVectorStoreCollectionSearchMapping.FilterRecords(legacyFilter, allValues),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => allValues.AsQueryable().Where(newFilter),
             _ => allValues
         };
 #pragma warning restore CS0618 // VectorSearchFilter is obsolete

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -278,9 +278,9 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
         var filter = searchOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => MongoDBVectorStoreCollectionSearchMapping.BuildLegacyFilter(legacyFilter, this._storagePropertyNames),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new MongoDBFilterTranslator().Translate(newFilter, this._storagePropertyNames),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => MongoDBVectorStoreCollectionSearchMapping.BuildLegacyFilter(legacyFilter, this._storagePropertyNames),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new MongoDBFilterTranslator().Translate(newFilter, this._storagePropertyNames),
             _ => null
         };
 #pragma warning restore CS0618

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -262,7 +262,7 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
 
 #pragma warning disable CS0618 // FilterClause is obsolete
         var filter = PineconeVectorStoreCollectionSearchMapping.BuildSearchFilter(
-            internalOptions.Filter?.FilterClauses,
+            internalOptions.OldFilter?.FilterClauses,
             this._propertyReader.StoragePropertyNamesMap);
 #pragma warning restore CS0618
 

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreCollectionSqlBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreCollectionSqlBuilder.cs
@@ -381,7 +381,7 @@ WHERE "{keyColumn}" = ANY($1);
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
         var (where, parameters) = (oldFilter: legacyFilter, newFilter) switch
         {
-            (not null, not null) => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
+            (not null, not null) => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
             (not null, null) => GenerateLegacyFilterWhereClause(schema, tableName, propertyReader.RecordDefinition.Properties, legacyFilter, startParamIndex: 2),
             (null, not null) => new PostgresFilterTranslator().Translate(propertyReader.StoragePropertyNamesMap, newFilter, startParamIndex: 2),
             _ => (Clause: string.Empty, Parameters: [])

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollection.cs
@@ -290,9 +290,9 @@ public class PostgresVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRe
                 pgVector,
                 searchOptions.Top,
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
-                searchOptions.Filter,
+                searchOptions.OldFilter,
 #pragma warning restore CS0618 // VectorSearchFilter is obsolete
-                searchOptions.NewFilter,
+                searchOptions.Filter,
                 searchOptions.Skip,
                 searchOptions.IncludeVectors,
                 cancellationToken)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -478,9 +478,9 @@ public class QdrantVectorStoreRecordCollection<TRecord> : IVectorStoreRecordColl
         // Build filter object.
         var filter = internalOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => QdrantVectorStoreCollectionSearchMapping.BuildFromLegacyFilter(legacyFilter, this._propertyReader.StoragePropertyNamesMap),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new QdrantFilterTranslator().Translate(newFilter, this._propertyReader.StoragePropertyNamesMap),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => QdrantVectorStoreCollectionSearchMapping.BuildFromLegacyFilter(legacyFilter, this._propertyReader.StoragePropertyNamesMap),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new QdrantFilterTranslator().Translate(newFilter, this._propertyReader.StoragePropertyNamesMap),
             _ => new Filter()
         };
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorStoreCollectionSearchMapping.cs
@@ -62,9 +62,9 @@ internal static class RedisVectorStoreCollectionSearchMapping
 #pragma warning disable CS0618 // Type or member is obsolete
         var filter = options switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => BuildLegacyFilter(legacyFilter, storagePropertyNames),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new RedisFilterTranslator().Translate(newFilter, storagePropertyNames),
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => BuildLegacyFilter(legacyFilter, storagePropertyNames),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new RedisFilterTranslator().Translate(newFilter, storagePropertyNames),
             _ => "*"
         };
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollection.cs
@@ -195,22 +195,22 @@ public class SqliteVectorStoreRecordCollection<TRecord> :
 
         if (searchOptions.Filter is not null)
         {
-            if (searchOptions.NewFilter is not null)
+            if (searchOptions.Filter is not null)
             {
-                throw new ArgumentException("Either Filter or NewFilter can be specified, but not both");
+                throw new ArgumentException("Either Filter or OldFilter can be specified, but not both");
             }
 
             // Old filter, we translate it to a list of SqliteWhereCondition, and merge these into the conditions we already have
-            var filterConditions = this.GetFilterConditions(searchOptions.Filter, this._dataTableName);
+            var filterConditions = this.GetFilterConditions(searchOptions.OldFilter, this._dataTableName);
 
             if (filterConditions is { Count: > 0 })
             {
                 conditions.AddRange(filterConditions);
             }
         }
-        else if (searchOptions.NewFilter is not null)
+        else if (searchOptions.Filter is not null)
         {
-            (extraWhereFilter, extraParameters) = new SqliteFilterTranslator().Translate(this._propertyReader.StoragePropertyNamesMap, searchOptions.NewFilter);
+            (extraWhereFilter, extraParameters) = new SqliteFilterTranslator().Translate(this._propertyReader.StoragePropertyNamesMap, searchOptions.Filter);
         }
 #pragma warning restore CS0618 // VectorSearchFilter is obsolete
 

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionQueryBuilder.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionQueryBuilder.cs
@@ -36,13 +36,13 @@ internal static class WeaviateVectorStoreRecordCollectionQueryBuilder
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
         var filter = searchOptions switch
         {
-            { Filter: not null, NewFilter: not null } => throw new ArgumentException("Either Filter or NewFilter can be specified, but not both"),
-            { Filter: VectorSearchFilter legacyFilter } => BuildLegacyFilter(
+            { OldFilter: not null, Filter: not null } => throw new ArgumentException("Either Filter or OldFilter can be specified, but not both"),
+            { OldFilter: VectorSearchFilter legacyFilter } => BuildLegacyFilter(
                 legacyFilter,
                 jsonSerializerOptions,
                 keyPropertyName,
                 storagePropertyNames),
-            { NewFilter: Expression<Func<TRecord, bool>> newFilter } => new WeaviateFilterTranslator().Translate(newFilter, storagePropertyNames),
+            { Filter: Expression<Func<TRecord, bool>> newFilter } => new WeaviateFilterTranslator().Translate(newFilter, storagePropertyNames),
             _ => null
         };
 #pragma warning restore CS0618

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -561,7 +561,7 @@ public class QdrantVectorStoreRecordCollectionTests
         // Act.
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new[] { 1f, 2f, 3f, 4f }),
-            new() { IncludeVectors = true, Filter = filter, Top = 5, Skip = 2 },
+            new() { IncludeVectors = true, OldFilter = filter, Top = 5, Skip = 2 },
             this._testCancellationToken);
 
         // Assert.

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -451,7 +451,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
             new()
             {
                 IncludeVectors = includeVectors,
-                Filter = filter,
+                OldFilter = filter,
                 Top = 5,
                 Skip = 2
             });

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -471,7 +471,7 @@ public class RedisJsonVectorStoreRecordCollectionTests
             new()
             {
                 IncludeVectors = true,
-                Filter = filter,
+                OldFilter = filter,
                 Top = 5,
                 Skip = 2
             });

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionQueryBuilderTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionQueryBuilderTests.cs
@@ -140,7 +140,7 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
             Skip = 2,
             Top = 3,
             VectorPropertyName = "DescriptionEmbedding",
-            Filter = new VectorSearchFilter()
+            OldFilter = new VectorSearchFilter()
                 .EqualTo("HotelName", "Test Name")
                 .AnyTagEqualTo("Tags", "t1")
         };
@@ -171,7 +171,7 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
             Skip = 2,
             Top = 3,
             VectorPropertyName = "DescriptionEmbedding",
-            Filter = new VectorSearchFilter().EqualTo("HotelName", new TestFilterValue())
+            OldFilter = new VectorSearchFilter().EqualTo("HotelName", new TestFilterValue())
         };
 
         // Act & Assert
@@ -196,7 +196,7 @@ public sealed class WeaviateVectorStoreRecordCollectionQueryBuilderTests
             Skip = 2,
             Top = 3,
             VectorPropertyName = "DescriptionEmbedding",
-            Filter = new VectorSearchFilter().EqualTo("NonExistentProperty", "value")
+            OldFilter = new VectorSearchFilter().EqualTo("NonExistentProperty", "value")
         };
 
         // Act & Assert

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchFilter.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.VectorData;
 /// to request that the underlying service filter the search results.
 /// All clauses are combined with and.
 /// </remarks>
-[Obsolete("Use VectorSearchOptions.NewFilter instead of VectorSearchOptions.Filter")]
+[Obsolete("Use VectorSearchOptions.Filter instead of VectorSearchOptions.OldFilter")]
 public sealed class VectorSearchFilter
 {
     /// <summary>The filter clauses to and together.</summary>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchOptions.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/VectorSearchOptions.cs
@@ -13,13 +13,13 @@ public class VectorSearchOptions<TRecord>
     /// <summary>
     /// Gets or sets a search filter to use before doing the vector search.
     /// </summary>
-    [Obsolete("Use NewFilter instead")]
-    public VectorSearchFilter? Filter { get; init; }
+    [Obsolete("Use Filter instead")]
+    public VectorSearchFilter? OldFilter { get; init; }
 
     /// <summary>
     /// Gets or sets a search filter to use before doing the vector search.
     /// </summary>
-    public Expression<Func<TRecord, bool>>? NewFilter { get; init; }
+    public Expression<Func<TRecord, bool>>? Filter { get; init; }
 
     /// <summary>
     /// Gets or sets the name of the vector property to search on.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureAISearch/AzureAISearchVectorStoreRecordCollectionTests.cs
@@ -68,7 +68,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
             new()
             {
                 IncludeVectors = true,
-                Filter = new VectorSearchFilter().EqualTo("HotelName", "MyHotel Upsert-1")
+                OldFilter = new VectorSearchFilter().EqualTo("HotelName", "MyHotel Upsert-1")
             });
 
         // Assert
@@ -351,7 +351,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
             {
                 IncludeVectors = includeVectors,
                 VectorPropertyName = "DescriptionEmbedding",
-                Filter = filter,
+                OldFilter = filter,
             });
 
         // Assert.
@@ -390,7 +390,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionTests(ITestOutputHel
             new()
             {
                 VectorPropertyName = "DescriptionEmbedding",
-                Filter = filter,
+                OldFilter = filter,
             });
 
         // Assert.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -409,7 +409,7 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests(AzureCosmosDBM
         // Act
         var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Filter = new VectorSearchFilter().EqualTo(nameof(AzureCosmosDBMongoDBHotel.HotelName), "My Hotel key2")
+            OldFilter = new VectorSearchFilter().EqualTo(nameof(AzureCosmosDBMongoDBHotel.HotelName), "My Hotel key2")
         });
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -343,7 +343,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests(AzureCosm
         // Act
         var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Filter = filter,
+            OldFilter = filter,
             Top = 4,
         });
 

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreRecordCollectionTests.cs
@@ -410,7 +410,7 @@ public class MongoDBVectorStoreRecordCollectionTests(MongoDBVectorStoreFixture f
         // Act
         var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Filter = new VectorSearchFilter().EqualTo(nameof(MongoDBHotel.HotelName), "My Hotel key2")
+            OldFilter = new VectorSearchFilter().EqualTo(nameof(MongoDBHotel.HotelName), "My Hotel key2")
         });
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Pinecone/PineconeVectorStoreRecordCollectionTests.cs
@@ -375,7 +375,7 @@ public class PineconeVectorStoreRecordCollectionTests(PineconeVectorStoreFixture
 
         // Act.
         var filter = new VectorSearchFilter().EqualTo(nameof(PineconeHotel.HotelCode), 42);
-        var actual = await hotelRecordCollection.VectorizedSearchAsync(searchVector, new() { Top = 1, Filter = filter });
+        var actual = await hotelRecordCollection.VectorizedSearchAsync(searchVector, new() { Top = 1, OldFilter = filter });
         var searchResults = await actual.Results.ToListAsync();
         Assert.Single(searchResults);
         var searchResultRecord = searchResults.First().Record;

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresVectorStoreRecordCollectionTests.cs
@@ -387,7 +387,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
         {
             IncludeVectors = false,
             Top = 5,
-            Filter = new([
+            OldFilter = new([
                 new EqualToFilterClause("HotelRating", 2.5f)
             ])
         });
@@ -420,7 +420,7 @@ public sealed class PostgresVectorStoreRecordCollectionTests(PostgresVectorStore
         {
             IncludeVectors = false,
             Top = 5,
-            Filter = new([
+            OldFilter = new([
                 new AnyTagEqualToFilterClause("Tags", "tag2")
             ])
         });

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Qdrant/QdrantVectorStoreRecordCollectionTests.cs
@@ -68,7 +68,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
         var vector = await fixture.EmbeddingGenerator.GenerateEmbeddingAsync("A great hotel");
         var actual = await sut.VectorizedSearchAsync(
             vector,
-            new() { Filter = new VectorSearchFilter().EqualTo("HotelCode", 30).AnyTagEqualTo("Tags", "t2") });
+            new() { OldFilter = new VectorSearchFilter().EqualTo("HotelCode", 30).AnyTagEqualTo("Tags", "t2") });
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
@@ -396,7 +396,7 @@ public sealed class QdrantVectorStoreRecordCollectionTests(ITestOutputHelper out
             vector,
             new()
             {
-                Filter = filter
+                OldFilter = filter
             });
 
         // Assert.

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -67,7 +67,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
         var actual = await sut
             .VectorizedSearchAsync(
                 new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }),
-                new() { Filter = new VectorSearchFilter().EqualTo("HotelCode", 1), IncludeVectors = true });
+                new() { OldFilter = new VectorSearchFilter().EqualTo("HotelCode", 1), IncludeVectors = true });
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
@@ -321,7 +321,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionTests(ITestOutputHelp
             new()
             {
                 IncludeVectors = includeVectors,
-                Filter = filter
+                OldFilter = filter
             });
 
         // Assert

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Redis/RedisJsonVectorStoreRecordCollectionTests.cs
@@ -66,7 +66,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         var getResult = await sut.GetAsync("Upsert-10", new GetRecordOptions { IncludeVectors = true });
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new[] { 30f, 31f, 32f, 33f }),
-            new() { Filter = new VectorSearchFilter().EqualTo("HotelCode", 10) });
+            new() { OldFilter = new VectorSearchFilter().EqualTo("HotelCode", 10) });
 
         // Assert
         var collectionExistResult = await sut.CollectionExistsAsync();
@@ -348,7 +348,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionTests(ITestOutputHelper 
         // Act
         var actual = await sut.VectorizedSearchAsync(
             vector,
-            new() { IncludeVectors = true, Filter = filter });
+            new() { IncludeVectors = true, OldFilter = filter });
 
         // Assert
         var searchResults = await actual.Results.ToListAsync();

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Sqlite/SqliteVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Sqlite/SqliteVectorStoreRecordCollectionTests.cs
@@ -423,7 +423,7 @@ public sealed class SqliteVectorStoreRecordCollectionTests(SqliteVectorStoreFixt
         // Act
         var searchResults = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Filter = new VectorSearchFilter().EqualTo(nameof(SqliteHotel<string>.HotelName), "My Hotel key2")
+            OldFilter = new VectorSearchFilter().EqualTo(nameof(SqliteHotel<string>.HotelName), "My Hotel key2")
         });
 
         var results = await searchResults.Results.ToListAsync();

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateVectorStoreRecordCollectionTests.cs
@@ -300,7 +300,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         // Act
         var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([30f, 31f, 32f, 33f]), new()
         {
-            Filter = filter,
+            OldFilter = filter,
             Top = 4,
         });
 
@@ -345,7 +345,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests(WeaviateVectorStore
         // Act
         var actual = await sut.VectorizedSearchAsync(new ReadOnlyMemory<float>([40f, 40f, 40f, 40f]), new()
         {
-            Filter = filter,
+            OldFilter = filter,
             Top = 4,
         });
 

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/VectorStoreTextSearch.cs
@@ -200,7 +200,7 @@ public sealed class VectorStoreTextSearch<[DynamicallyAccessedMembers(Dynamicall
         var vectorSearchOptions = new VectorSearchOptions<TRecord>
         {
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
-            Filter = searchOptions.Filter?.FilterClauses is not null ? new VectorSearchFilter(searchOptions.Filter.FilterClauses) : null,
+            OldFilter = searchOptions.Filter?.FilterClauses is not null ? new VectorSearchFilter(searchOptions.Filter.FilterClauses) : null,
 #pragma warning restore CS0618 // VectorSearchFilter is obsolete
             Skip = searchOptions.Skip,
             Top = searchOptions.Top,

--- a/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/VolatileVectorStoreRecordCollection.cs
@@ -238,12 +238,12 @@ public sealed class VolatileVectorStoreRecordCollection<TKey, TRecord> : IVector
         }
 
         // Filter records using the provided filter before doing the vector comparison.
-        if (internalOptions.NewFilter is not null)
+        if (internalOptions.Filter is not null)
         {
             throw new NotSupportedException("LINQ-based filtering is not supported with VolatileVectorStore, use Microsoft.SemanticKernel.Connectors.InMemory instead");
         }
 
-        var filteredRecords = VolatileVectorStoreCollectionSearchMapping.FilterRecords(internalOptions.Filter, this.GetCollectionDictionary().Values);
+        var filteredRecords = VolatileVectorStoreCollectionSearchMapping.FilterRecords(internalOptions.OldFilter, this.GetCollectionDictionary().Values);
 
         // Compare each vector in the filtered results with the provided vector.
         var results = filteredRecords.Select<object, (object record, float score)?>((record) =>

--- a/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Data/VolatileVectorStoreRecordCollectionTests.cs
@@ -338,7 +338,7 @@ public class VolatileVectorStoreRecordCollectionTests
         var filter = filterType == "Equality" ? new VectorSearchFilter().EqualTo("Data", $"data {testKey2}") : new VectorSearchFilter().AnyTagEqualTo("Tags", $"tag {testKey2}");
         var actual = await sut.VectorizedSearchAsync(
             new ReadOnlyMemory<float>(new float[] { 1, 1, 1, 1 }),
-            new() { IncludeVectors = true, Filter = filter, IncludeTotalCount = true },
+            new() { IncludeVectors = true, OldFilter = filter, IncludeTotalCount = true },
             this._testCancellationToken);
 
         // Assert

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Filter/BasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Filter/BasicFilterTests.cs
@@ -235,7 +235,7 @@ public abstract class BasicFilterTests<TKey>(BasicFilterTests<TKey>.Fixture fixt
             new ReadOnlyMemory<float>([1, 2, 3]),
             new()
             {
-                NewFilter = filter,
+                Filter = filter,
                 Top = fixture.TestData.Count
             });
 
@@ -270,7 +270,7 @@ public abstract class BasicFilterTests<TKey>(BasicFilterTests<TKey>.Fixture fixt
             new ReadOnlyMemory<float>([1, 2, 3]),
             new()
             {
-                Filter = legacyFilter,
+                OldFilter = legacyFilter,
                 Top = fixture.TestData.Count
             });
 

--- a/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/TestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/VectorDataIntegrationTests/Support/TestStore.cs
@@ -84,7 +84,7 @@ public abstract class TestStore
                     Top = recordCount,
                     // In some databases (Azure AI Search), the data shows up but the filtering index isn't yet updated,
                     // so filtered searches show empty results. Add a filter to the seed data check below.
-                    NewFilter = filter
+                    Filter = filter
                 });
             var count = await results.Results.CountAsync();
             if (count == recordCount)


### PR DESCRIPTION
And the obsoleted Filter to OldFilter. Continues #10273.
