### PR TITLE
.Net: Read the agent and OpenAI model prosp from configuration

### DIFF
--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -448,6 +448,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ProcessFrameworkWithAspire", "ProcessFrameworkWithAspire", "{3F260A77-B6C9-97FD-1304-4B34DA936CF4}"
 	ProjectSection(SolutionItems) = preProject
 		samples\Demos\ProcessFrameworkWithAspire\README.md = samples\Demos\ProcessFrameworkWithAspire\README.md
+		samples\Demos\Hosting\Agent\README.md = samples\Demos\Hosting\Agent\README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProcessFramework.Aspire.AppHost", "samples\Demos\ProcessFrameworkWithAspire\ProcessFramework.Aspire\ProcessFramework.Aspire.AppHost\ProcessFramework.Aspire.AppHost.csproj", "{2756FED3-ABC1-4F58-932E-5DD05A5EE066}"

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Config/AgentConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Config/AgentConfig.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace ChatWithAgent.ApiService.Config;
+
+/// <summary>
+/// Agent configuration.
+/// </summary>
+public sealed class AgentConfig
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string ConfigSectionName = "Agent";
+
+    /// <summary>
+    /// Gets or sets the name of the agent.
+    /// </summary>
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description of the agent.
+    /// </summary>
+    [Required]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the instructions for the agent.
+    /// </summary>
+    [Required]
+    public string Instructions { get; set; } = string.Empty;
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Config/AppConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Config/AppConfig.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using ChatWithAgent.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace ChatWithAgent.ApiService.Config;
+
+/// <summary>
+/// Application configuration.
+/// </summary>
+public sealed class AppConfig
+{
+    private readonly AgentConfig _agentConfig = new();
+    private readonly HostConfig _hostConfig;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppConfig"/> class.
+    /// </summary>
+    /// <param name="configurationManager">The configuration manager.</param>
+    public AppConfig(ConfigurationManager configurationManager)
+    {
+        configurationManager
+            .GetSection(AgentConfig.ConfigSectionName)
+            .Bind(this._agentConfig);
+
+        this._hostConfig = new HostConfig(configurationManager);
+    }
+
+    /// <summary>
+    /// Agent configuration.
+    /// </summary>
+    public AgentConfig Agent => this._agentConfig;
+
+    /// <summary>
+    /// Host configuration.
+    /// </summary>
+    public HostConfig Host => this._hostConfig;
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Config/ServiceConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Config/ServiceConfig.cs
@@ -6,18 +6,18 @@ using Microsoft.Extensions.Configuration;
 namespace ChatWithAgent.ApiService.Config;
 
 /// <summary>
-/// Application configuration.
+/// Service configuration.
 /// </summary>
-public sealed class AppConfig
+public sealed class ServiceConfig
 {
     private readonly AgentConfig _agentConfig = new();
     private readonly HostConfig _hostConfig;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AppConfig"/> class.
+    /// Initializes a new instance of the <see cref="ServiceConfig"/> class.
     /// </summary>
     /// <param name="configurationManager">The configuration manager.</param>
-    public AppConfig(ConfigurationManager configurationManager)
+    public ServiceConfig(ConfigurationManager configurationManager)
     {
         configurationManager
             .GetSection(AgentConfig.ConfigSectionName)

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Extensions/WebApplicationBuilderExtensions.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Extensions/WebApplicationBuilderExtensions.cs
@@ -30,4 +30,18 @@ internal static class WebApplicationBuilderExtensions
         // Add AzureOpenAI chat completion service.
         builder.Services.AddAzureOpenAIChatCompletion(hostConfig.AzureOpenAIChat.DeploymentName);
     }
+
+    /// <summary>
+    /// Adds OpenAI services to the web application.
+    /// </summary>
+    /// <param name="builder">The web application builder.</param>
+    /// <param name="hostConfig">The host configuration.</param>
+    internal static void AddOpenAIServices(this WebApplicationBuilder builder, HostConfig hostConfig)
+    {
+        // Add OpenAI client.
+        builder.AddOpenAIClient(OpenAIChatConfig.ConnectionStringName);
+
+        // Add AzureOpenAI chat completion service.
+        builder.Services.AddOpenAIChatCompletion(hostConfig.OpenAIChat.ModelName);
+    }
 }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Program.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using ChatWithAgent.ApiService.Config;
 using ChatWithAgent.ApiService.Extensions;
 using ChatWithAgent.Configuration;
 using Microsoft.AspNetCore.Builder;
@@ -32,11 +33,11 @@ public static class Program
         // Add services to the container.
         builder.Services.AddProblemDetails();
 
-        // Load the host configuration.
-        var hostConfig = new HostConfig(builder.Configuration);
+        // Load the app configuration.
+        var appConfig = new AppConfig(builder.Configuration);
 
         // Add Kernel and required AI services.
-        AddKernelAndServices(builder, hostConfig);
+        AddKernelAndAgent(builder, appConfig);
 
         var app = builder.Build();
 
@@ -50,21 +51,27 @@ public static class Program
         app.Run();
     }
 
-    private static void AddKernelAndServices(WebApplicationBuilder builder, HostConfig hostConfig)
+    private static void AddKernelAndAgent(WebApplicationBuilder builder, AppConfig appConfig)
     {
         // Add Kernel.
         var kernelBuilder = builder.Services.AddKernel();
 
-        switch (hostConfig.AIChatService)
+        switch (appConfig.Host.AIChatService)
         {
             case AzureOpenAIChatConfig.ConfigSectionName:
             {
-                builder.AddAzureOpenAIServices(hostConfig);
+                builder.AddAzureOpenAIServices(appConfig.Host);
+                break;
+            }
+
+            case OpenAIChatConfig.ConfigSectionName:
+            {
+                builder.AddOpenAIServices(appConfig.Host);
                 break;
             }
 
             default:
-                throw new NotSupportedException($"AI service '{hostConfig.AIChatService}' is not supported.");
+                throw new NotSupportedException($"AI service '{appConfig.Host.AIChatService}' is not supported.");
         }
 
         // Add chat completion agent.
@@ -73,7 +80,9 @@ public static class Program
             return new ChatCompletionAgent()
             {
                 Kernel = sp.GetRequiredService<Kernel>(),
-                Instructions = "TBD"
+                Name = appConfig.Agent.Name,
+                Description = appConfig.Agent.Description,
+                Instructions = appConfig.Agent.Instructions
             };
         });
     }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Program.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/Program.cs
@@ -33,11 +33,11 @@ public static class Program
         // Add services to the container.
         builder.Services.AddProblemDetails();
 
-        // Load the app configuration.
-        var appConfig = new AppConfig(builder.Configuration);
+        // Load the service configuration.
+        var config = new ServiceConfig(builder.Configuration);
 
         // Add Kernel and required AI services.
-        AddKernelAndAgent(builder, appConfig);
+        AddKernelAndAgent(builder, config);
 
         var app = builder.Build();
 
@@ -51,27 +51,27 @@ public static class Program
         app.Run();
     }
 
-    private static void AddKernelAndAgent(WebApplicationBuilder builder, AppConfig appConfig)
+    private static void AddKernelAndAgent(WebApplicationBuilder builder, ServiceConfig config)
     {
         // Add Kernel.
         var kernelBuilder = builder.Services.AddKernel();
 
-        switch (appConfig.Host.AIChatService)
+        switch (config.Host.AIChatService)
         {
             case AzureOpenAIChatConfig.ConfigSectionName:
             {
-                builder.AddAzureOpenAIServices(appConfig.Host);
+                builder.AddAzureOpenAIServices(config.Host);
                 break;
             }
 
             case OpenAIChatConfig.ConfigSectionName:
             {
-                builder.AddOpenAIServices(appConfig.Host);
+                builder.AddOpenAIServices(config.Host);
                 break;
             }
 
             default:
-                throw new NotSupportedException($"AI service '{appConfig.Host.AIChatService}' is not supported.");
+                throw new NotSupportedException($"AI service '{config.Host.AIChatService}' is not supported.");
         }
 
         // Add chat completion agent.
@@ -80,9 +80,9 @@ public static class Program
             return new ChatCompletionAgent()
             {
                 Kernel = sp.GetRequiredService<Kernel>(),
-                Name = appConfig.Agent.Name,
-                Description = appConfig.Agent.Description,
-                Instructions = appConfig.Agent.Instructions
+                Name = config.Agent.Name,
+                Description = config.Agent.Description,
+                Instructions = config.Agent.Instructions
             };
         });
     }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/appsettings.json
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.ApiService/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Agent": {
+    "Name": "AnalysisMaster",
+    "Description": "A highly capable agent designed to perform comprehensive analysis on various data sets and topics. It utilizes advanced algorithms and methodologies to provide accurate insights and recommendations.",
+    "Instructions": "1. Receive the data or topic to be analyzed. 2. Identify the type and scope of analysis required. 3. Apply appropriate analytical techniques and tools. 4. Generate detailed reports and visualizations. 5. Provide clear and actionable insights based on the analysis. 6. Ensure accuracy and reliability of the results. 7. Be ready to explain the analysis process and findings to non-experts if needed."
+  }
 }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Extensions/ResourceBuilderExtensions.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Extensions/ResourceBuilderExtensions.cs
@@ -33,6 +33,13 @@ public static class ResourceBuilderExtensions
                 break;
             }
 
+            case OpenAIChatConfig.ConfigSectionName:
+            {
+                // Add OpenAI chat model name to environment variables so that Api Service can access it.
+                builder.WithEnvironment($"{HostConfig.AIServicesSectionName}__{OpenAIChatConfig.ConfigSectionName}__{nameof(config.OpenAIChat.ModelName)}", config.OpenAIChat.ModelName);
+                break;
+            }
+
             default:
                 throw new NotSupportedException($"AI service '{config.AIChatService}' is not supported.");
         }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Program.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/Program.cs
@@ -33,6 +33,12 @@ static IResourceBuilder<IResourceWithConnectionString> AddAIServices(IDistribute
             return builder.AddAzureOpenAI(config);
         }
 
+        case OpenAIChatConfig.ConfigSectionName:
+        {
+            // Use an existing Azure OpenAI service via connection string
+            return builder.AddConnectionString(OpenAIChatConfig.ConnectionStringName);
+        }
+
         default:
             throw new NotSupportedException($"AI service '{config.AIChatService}' is not supported.");
     }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/appsettings.json
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.AppHost/appsettings.json
@@ -11,7 +11,10 @@
       "DeploymentName": "gpt-4o-mini",
       "ModelName": "gpt-4o-mini",
       "ModelVersion": "2024-07-18"
+    },
+    "OpenAIChat": {
+      "ModelName": "gpt-4o-mini"
     }
   },
-  "AIChatService": "AzureOpenAIChat"
+  "AIChatService": "OpenAIChat"
 }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/HostConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/HostConfig.cs
@@ -15,7 +15,11 @@ public sealed class HostConfig
     /// </summary>
     public const string AIServicesSectionName = "AIServices";
 
-    private readonly AzureOpenAIChatConfig _azureOpenAIChat = new();
+    private readonly ConfigurationManager _configurationManager;
+
+    private readonly AzureOpenAIChatConfig _azureOpenAIChatConfig = new();
+
+    private readonly OpenAIChatConfig _openAIChatConfig = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HostConfig"/> class.
@@ -25,9 +29,14 @@ public sealed class HostConfig
     {
         configurationManager
             .GetSection($"{AIServicesSectionName}:{AzureOpenAIChatConfig.ConfigSectionName}")
-            .Bind(this._azureOpenAIChat);
+            .Bind(this._azureOpenAIChatConfig);
+        configurationManager
+            .GetSection($"{AIServicesSectionName}:{OpenAIChatConfig.ConfigSectionName}")
+            .Bind(this._openAIChatConfig);
         configurationManager
             .Bind(this);
+
+        this._configurationManager = configurationManager;
     }
 
     /// <summary>
@@ -39,5 +48,10 @@ public sealed class HostConfig
     /// <summary>
     /// The Azure OpenAI chat configuration.
     /// </summary>
-    public AzureOpenAIChatConfig AzureOpenAIChat => this._azureOpenAIChat;
+    public AzureOpenAIChatConfig AzureOpenAIChat => this._azureOpenAIChatConfig;
+
+    /// <summary>
+    /// The OpenAI chat configuration.
+    /// </summary>
+    public OpenAIChatConfig OpenAIChat => this._openAIChatConfig;
 }

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/OpenAIChatConfig.cs
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Configuration/OpenAIChatConfig.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace ChatWithAgent.Configuration;
+
+/// <summary>
+/// OpenAI chat configuration.
+/// </summary>
+public sealed class OpenAIChatConfig
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string ConfigSectionName = "OpenAIChat";
+
+    /// <summary>
+    /// The name of the connection string of the OpenAI chat service.
+    /// </summary>
+    public const string ConnectionStringName = ConfigSectionName;
+
+    /// <summary>
+    /// The name of the chat model.
+    /// </summary>
+    [Required]
+    public string ModelName { get; set; } = string.Empty;
+}

--- a/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Web/Components/Pages/Chat.razor
+++ b/dotnet/samples/Demos/Hosting/Agent/ChatWithAgent.Web/Components/Pages/Chat.razor
@@ -35,13 +35,15 @@
         {
             messages.Add(new Message { Sender = "User", Text = userMessage });
 
+            var prompt = userMessage;
+
             userMessage = string.Empty;
 
             bool agentMessageAdded = false;
 
             var agentMessage = new Message { Sender = "Agent", Text = string.Empty };
 
-            await foreach (var update in AgentCompletionsApi.CompleteStreamingAsync(userMessage, CancellationToken.None))
+            await foreach (var update in AgentCompletionsApi.CompleteStreamingAsync(prompt, CancellationToken.None))
             {
                 if (!agentMessageAdded)
                 {

--- a/dotnet/samples/Demos/Hosting/Agent/README.md
+++ b/dotnet/samples/Demos/Hosting/Agent/README.md
@@ -19,17 +19,115 @@ The following steps will guide you through provisioning, deploying, and cleaning
 - `.azure/config.json`: Configuration file that informs **azd** what the current active environment is.
 - `.azure/{env-name}/.env`: Contains environment-specific overrides.
 
+### Configure the Project  
+
+Before deploying the agent to Azure, it's necessary to configure both the agent and its upstream dependencies, which include chat completion service and the vector store.
+For detailed instructions on how to configure the agent and the dependencies, please refer to the [Configuration](#configuration) section.
+ 
 ### Deploy the project
 
 1. Authenticate with Azure by running the `az login` command.
 2. Provision all required resources and deploy the app to Azure by running the `azd up` command.
 3. Select the subscription and location of the resources where the app will be deployed when prompted.
-4. Copy the app endpoint URL from the output of the `azd up` command and paste it into a browser to see the app dashboard.
-5. Click on the web frontend app link on the dashboard to navigate to the app and select the `Chat` tab to start chatting with the agent.
+4. Provide required connection strings when prompted. More information on connection strings can be found in the [Connection strings](#connection-strings) section.
+5. Copy the app endpoint URL from the output of the `azd up` command and paste it into a browser to see the app dashboard.
+6. Click on the web frontend app link on the dashboard to navigate to the app and select the `Chat` tab to start chatting with the agent.
 
 ### Clean up the resources
 
 1. To clean up the resources, run the `azd down` command. This command will delete all the resources provisioned for the app.
+
+## Configuration
+
+### Agent Configuration
+   
+To configure the agent, locate, open, and edit the `appsettings.json` file in the `ChatWithAgent.ApiService` project. The following settings are available:
+
+```json
+{
+  "Agent": {
+    "Name": "",
+    "Description": "",  
+    "Instructions": ""
+  }
+}
+```
+
+Configure the relevant properties:
+- `Name`: This property defines the name of the agent. For example, `SupportBot` could be a name for an agent that provides customer support.
+- `Description`: This property provides a brief description of the agent's role or purpose. For instance, `This bot assists users with support inquiries.` describes that the bot is intended to help users with their support-related questions.
+- `Instructions`: This property gives specific instructions on how the agent should interact with users. An example could be, `Greet the user, ask how you can help, and provide solutions based on their questions.` This guides the agent on how to initiate conversations and respond to user inquiries.
+
+### Chat completion model configuration
+
+To configure the chat completion model, locate, open, and edit the `appsettings.json` file in the `ChatWithAgent.AppHost` project. The following settings are available:
+
+```json
+{
+  "Logging": {
+  },
+  "AIServices": {
+    "AzureOpenAIChat": {
+      "DeploymentName": "gpt-4o-mini",
+      "ModelName": "gpt-4o-mini",
+      "ModelVersion": "2024-07-18"
+    },
+    "OpenAIChat": {
+      "ModelName": "gpt-4o-mini"
+    }
+  },
+  "AIChatService": "AzureOpenAIChat"
+}
+```
+
+#### 1. Choose the chat completion service
+   
+Set the `AIChatService` property to the chat completion service you want to use. The available services are:  
+   
+- `AzureOpenAIChat`: Azure OpenAI chat completion model.  
+- `OpenAIChat`: OpenAI chat completion model.  
+   
+#### 2. Configure the Selected Chat Completion Model  
+   
+Depending on the selected service, configure the relevant properties:  
+   
+`AzureOpenAIChat`:  
+- `DeploymentName`: The name of the deployment that hosts the chat completion model.  
+- `ModelName`: The name of the chat completion model.  
+- `ModelVersion`: The version of the chat completion model.  
+   
+`OpenAIChat`:  
+- `ModelName`: The name of the chat completion model.  
+
+### Vector Store Configuration
+`TBD`
+
+## Connection strings
+   
+Some upstream dependencies require connection strings, which `azd` will prompt you for during deployment. Refer to the table below for the required formats:  
+   
+| Dependency | Format                         | Example                                          |  
+|------------|--------------------------------|--------------------------------------------------|  
+| OpenAI     | `Endpoint=<uri>;Key=<key>`     | `Endpoint=https://api.openai.com/v1;Key=123` or `Key=123` |
+
+When running agent locally, the connections string should be specified in user secrets. Please refer to the [Running the agent locally](#running-the-agent-locally) section for more information.
+
+
+## Running the agent locally
+
+To run the agent locally, follow these steps:
+1. Right-click on the `ChatWithAgent.AppHost` project in Visual Studio and select `Set as Startup Project`.  
+2. Right-click on the `ChatWithAgent.AppHost` project in Visual Studio and select `Manage User Secrets` and add the agent dependencies connection strings to the `ConnectionStrings` section.
+    ```json
+    {
+      "ConnectionStrings": {
+        "OpenAI": "Endpoint=https://api.openai.com/v1;Key=123"
+      }
+    }
+    ```
+    The format for connection strings can be found in the [Connection Strings](#connection-strings) section above.
+
+3. Press `F5` to run the project.
 
 ## Billing
 

--- a/dotnet/samples/Demos/Hosting/Agent/README.md
+++ b/dotnet/samples/Demos/Hosting/Agent/README.md
@@ -103,12 +103,12 @@ Depending on the selected service, configure the relevant properties:
 `TBD`
 
 ## Connection strings
-   
-Some upstream dependencies require connection strings, which `azd` will prompt you for during deployment. Refer to the table below for the required formats:  
-   
-| Dependency | Format                         | Example                                          |  
-|------------|--------------------------------|--------------------------------------------------|  
-| OpenAI     | `Endpoint=<uri>;Key=<key>`     | `Endpoint=https://api.openai.com/v1;Key=123` or `Key=123` |
+
+Some upstream dependencies require connection strings, which `azd` will prompt you for during deployment. Refer to the table below for the required formats:
+
+| Dependency | Format                         | Example                                          |
+|------------|--------------------------------|--------------------------------------------------|
+| OpenAIChat     | `Endpoint=<uri>;Key=<key>`     | `Endpoint=https://api.openai.com/v1;Key=123` or `Key=123` |
 
 When running agent locally, the connections string should be specified in user secrets. Please refer to the [Running the agent locally](#running-the-agent-locally) section for more information.
 
@@ -121,7 +121,7 @@ To run the agent locally, follow these steps:
     ```json
     {
       "ConnectionStrings": {
-        "OpenAI": "Endpoint=https://api.openai.com/v1;Key=123"
+        "OpenAIChat": "Endpoint=https://api.openai.com/v1;Key=123"
       }
     }
     ```


### PR DESCRIPTION
### Motivation, Context, and Description  

This PR reads the agent and OpenAI related configuration: name, description, instructions, model name from a config file instead of using hardcoded values.

Next steps include:  
- Add support for {Azure}OpenAI embeddings model
   
Note: This PR targets the `feature-agents-hosting` feature branch.    
Contributes to: https://github.com/microsoft/semantic-kernel/issues/10149