### PR TITLE
Python: Remove custom separator in Bedrock tool call fully qualified name

### DIFF
--- a/python/samples/concepts/setup/chat_completion_services.py
+++ b/python/samples/concepts/setup/chat_completion_services.py
@@ -213,15 +213,14 @@ def get_bedrock_chat_completion_service_and_request_settings() -> tuple[
     """
     from semantic_kernel.connectors.ai.bedrock import BedrockChatCompletion, BedrockChatPromptExecutionSettings
 
-    chat_service = BedrockChatCompletion(service_id=service_id, model_id="cohere.command-r-v1:0")
+    chat_service = BedrockChatCompletion(service_id=service_id, model_id="anthropic.claude-3-sonnet-20240229-v1:0")
     request_settings = BedrockChatPromptExecutionSettings(
         # For model specific settings, specify them in the extension_data dictionary.
         # For example, for Cohere Command specific settings, refer to:
-        # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command-r-plus.html
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html
         service_id=service_id,
         extension_data={
-            "presence_penalty": 0.5,
-            "seed": 5,
+            "temperature": 0.8,
         },
     )
 

--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -21,7 +21,6 @@ from semantic_kernel.connectors.ai.bedrock.services.model_provider.bedrock_model
 from semantic_kernel.connectors.ai.bedrock.services.model_provider.utils import (
     MESSAGE_CONVERTERS,
     finish_reason_from_bedrock_to_semantic_kernel,
-    format_bedrock_function_name_to_kernel_function_fully_qualified_name,
     remove_none_recursively,
     update_settings_from_function_choice_configuration,
 )
@@ -254,9 +253,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
                 items.append(
                     FunctionCallContent(
                         id=content["toolUse"]["toolUseId"],
-                        name=format_bedrock_function_name_to_kernel_function_fully_qualified_name(
-                            content["toolUse"]["name"]
-                        ),
+                        name=content["toolUse"]["name"],
                         arguments=content["toolUse"]["input"],
                     )
                 )
@@ -323,9 +320,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
             items.append(
                 FunctionCallContent(
                     id=event["contentBlockStart"]["start"]["toolUse"]["toolUseId"],
-                    name=format_bedrock_function_name_to_kernel_function_fully_qualified_name(
-                        event["contentBlockStart"]["start"]["toolUse"]["name"]
-                    ),
+                    name=event["contentBlockStart"]["start"]["toolUse"]["name"],
                 )
             )
 

--- a/python/semantic_kernel/connectors/ai/google/shared_utils.py
+++ b/python/semantic_kernel/connectors/ai/google/shared_utils.py
@@ -38,7 +38,9 @@ FUNCTION_CHOICE_TYPE_TO_GOOGLE_FUNCTION_CALLING_MODE = {
 # The separator used in the fully qualified name of the function instead of the default "-" separator.
 # This is required since Gemini doesn't work well with "-" in the function name.
 # https://ai.google.dev/gemini-api/docs/function-calling#function_declarations
-GEMINI_FUNCTION_NAME_SEPARATOR = "_"
+# Using double underscore to avoid situations where the function name already contains a single underscore.
+# For example, we may incorrect split a function name with a single score when the function doesn't have a plugin name.
+GEMINI_FUNCTION_NAME_SEPARATOR = "__"
 
 
 def format_gemini_function_name_to_kernel_function_fully_qualified_name(gemini_function_name: str) -> str:

--- a/python/tests/integration/completions/chat_completion_test_base.py
+++ b/python/tests/integration/completions/chat_completion_test_base.py
@@ -160,7 +160,7 @@ class ChatCompletionTestBase(CompletionTestBase):
                 BedrockChatPromptExecutionSettings,
             ),
             "bedrock_anthropic_claude": (
-                self._try_create_bedrock_chat_completion_client("anthropic.claude-3-5-sonnet-20240620-v1:0"),
+                self._try_create_bedrock_chat_completion_client("anthropic.claude-3-sonnet-20240229-v1:0"),
                 BedrockChatPromptExecutionSettings,
             ),
             "bedrock_cohere_command": (


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Closes #10619 

Bedrock updated its rules on tool names. Previously, Bedrock disallowed "-" in tool names, which is the default plugin name and function name separator in SK. The solution was to use "_" as the separator. However, this introduced a bug where the translation between the SK fully qualified function names and the Bedrock tool names would fail if the function name had an underscore.

Bedrock now allows "-" in tool names, so we can remove the custom logic and just use the default.

Gemini also has rules on how tools are named. It doesn't recommend using "-". The solution was to use "_" just like Bedrock. To address the bug mentioned above, the solution is to use double underscores.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Remove Bedrock custom fully qualified function names.
2. Use double underscores for Gemini fully qualified function names.

TODO: Add a guide for SK function/plugin naming conventions.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
