### PR TITLE
.Net: Changes to support .NET9 formatting

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         include:
           - { dotnet: "8.0", configuration: Release, os: ubuntu-latest }
+          - { dotnet: "9.0", configuration: Release, os: ubuntu-latest }
 
     runs-on: ${{ matrix.os }}
     env:

--- a/dotnet/src/Experimental/Process.Abstractions/IKernelExternalProcessMessageChannel.cs
+++ b/dotnet/src/Experimental/Process.Abstractions/IKernelExternalProcessMessageChannel.cs
@@ -28,5 +28,5 @@ public interface IExternalKernelProcessMessageChannel
     /// <param name="externalTopicEvent">name of the topic to be used externally as the event name</param>
     /// <param name="eventData">data to be transmitted externally</param>
     /// <returns></returns>
-    public abstract Task EmitExternalEventAsync(string externalTopicEvent, KernelProcessProxyMessage eventData);
+    abstract Task EmitExternalEventAsync(string externalTopicEvent, KernelProcessProxyMessage eventData);
 }


### PR DESCRIPTION
### Motivation and Context

In sdk9, there is a bug fix to one of the analyzers: [https://github.com/dotnet/msbuild/issues/11426](https://github.com/dotnet/msbuild/issues/11426). This causes the code base to fail in the `dotnet format` stage when built on sdk9.

This PR fixes the file that has been changed this week and adds a configuration into the build to format using sdk9.0 so that the build fails if more are introduced.

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

This relates to #10716 and was previously fixed in #10741
