### PR TITLE
.Net: Remove EditorBrowsable(EditorBrowsableState.Never) from ChatMessageContent.Content property

### DIFF
--- a/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Contents/ChatMessageContent.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -34,7 +33,6 @@ public class ChatMessageContent : KernelContent
     /// <summary>
     /// A convenience property to get or set the text of the first item in the <see cref="Items" /> collection of <see cref="TextContent"/> type.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [JsonIgnore]
     public string? Content
     {


### PR DESCRIPTION
### Motivation, Context and Description
This PR removes the `EditorBrowsable(EditorBrowsableState.Never)` attribute from the `ChatMessageContent.Content` property because it is confusing and can be handy to set text content with a one-liner: `cmc.Content = "some content"`.