### PR TITLE
.Net: scrub preceding cross region identifier in Amazon Bedrock model IDs

### DIFF
--- a/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Extensions/BedrockKernelBuilderExtensionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Extensions/BedrockKernelBuilderExtensionTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Amazon.BedrockRuntime;
 using Amazon.Runtime;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -18,13 +19,15 @@ public class BedrockKernelBuilderExtensionTests
     /// <summary>
     /// Checks that AddBedrockTextGenerationService builds a proper kernel with a null bedrockRuntime.
     /// </summary>
-    [Fact]
-    public void AddBedrockTextGenerationCreatesServiceWithNonNullBedrockRuntime()
+    [Theory]
+    [InlineData("amazon.titan-text-premier-v1:0")]
+    [InlineData("us.amazon.titan-text-premier-v1:0")]
+    public void AddBedrockTextGenerationCreatesServiceWithNonNullBedrockRuntime(string modelId)
     {
         // Arrange
         var bedrockRuntime = new Mock<IAmazonBedrockRuntime>().Object;
         var builder = Kernel.CreateBuilder();
-        builder.AddBedrockTextGenerationService("amazon.titan-text-premier-v1:0", bedrockRuntime);
+        builder.AddBedrockTextGenerationService(modelId, bedrockRuntime);
 
         // Act
         var kernel = builder.Build();
@@ -37,13 +40,15 @@ public class BedrockKernelBuilderExtensionTests
     /// <summary>
     /// Checks that AddBedrockChatCompletionService builds a proper kernel with a non-null bedrockRuntime.
     /// </summary>
-    [Fact]
-    public void AddBedrockChatCompletionCreatesServiceWithNonNullBedrockRuntime()
+    [Theory]
+    [InlineData("amazon.titan-text-premier-v1:0")]
+    [InlineData("us.amazon.titan-text-premier-v1:0")]
+    public void AddBedrockChatCompletionCreatesServiceWithNonNullBedrockRuntime(string modelId)
     {
         // Arrange
         var bedrockRuntime = new Mock<IAmazonBedrockRuntime>().Object;
         var builder = Kernel.CreateBuilder();
-        builder.AddBedrockChatCompletionService("amazon.titan-text-premier-v1:0", bedrockRuntime);
+        builder.AddBedrockChatCompletionService(modelId, bedrockRuntime);
 
         // Act
         var kernel = builder.Build();
@@ -64,5 +69,23 @@ public class BedrockKernelBuilderExtensionTests
 
         // Assert
         // No exceptions should be thrown
+    }
+
+    [Theory]
+    [InlineData("unknown.titan-text-premier-v1:0")]
+    [InlineData("us.unknown.titan-text-premier-v1:0")]
+    public void AwsUnknownBedrockTextCompletionModelShouldThrowException(string modelId)
+    {
+        // Arrange
+        var bedrockRuntime = new Mock<IAmazonBedrockRuntime>().Object;
+        var builder = Kernel.CreateBuilder();
+        builder.AddBedrockTextGenerationService(modelId, bedrockRuntime);
+
+        // Act & Assert
+        Assert.Throws<KernelException>(() =>
+        {
+            var kernel = builder.Build();
+            kernel.GetRequiredService<ITextGenerationService>();
+        });
     }
 }

--- a/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Extensions/BedrockKernelBuilderExtensionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Extensions/BedrockKernelBuilderExtensionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using Amazon.BedrockRuntime;
 using Amazon.Runtime;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Core/BedrockServiceFactory.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Core/BedrockServiceFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Linq;
 
 namespace Microsoft.SemanticKernel.Connectors.Amazon.Core;
 
@@ -10,6 +11,30 @@ namespace Microsoft.SemanticKernel.Connectors.Amazon.Core;
 internal sealed class BedrockServiceFactory
 {
     /// <summary>
+    /// Represents an array of region prefixes used to identify different cross-region configurations
+    /// for service operations. The prefixes correspond to general geographic areas such as
+    /// "us" (United States), "eu" (Europe), and "apac" (Asia-Pacific).
+    /// (sourced from https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html)
+    /// </summary>
+    private static readonly string[] s_crossRegionPrefixes = ["us.", "eu.", "apac."];
+
+    /// <summary>
+    /// Removes the cross-region prefix from the provided model identifier if it exists.
+    /// </summary>
+    /// <param name="modelId">The model identifier, which may contain a cross-region prefix.</param>
+    /// <returns>The model identifier without the cross-region prefix.</returns>
+    private static string ScrubCrossRegionPrefix(string modelId)
+    {
+        var prefix = s_crossRegionPrefixes.FirstOrDefault(prefix => modelId.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(prefix))
+        {
+            modelId = modelId.Substring(prefix.Length);
+        }
+
+        return modelId;
+    }
+
+    /// <summary>
     /// Gets the model service for body conversion.
     /// </summary>
     /// <param name="modelId">The model to be used for the service.</param>
@@ -17,7 +42,7 @@ internal sealed class BedrockServiceFactory
     /// <exception cref="NotSupportedException">Thrown if provider or model is not supported for text generation.</exception>
     internal IBedrockTextGenerationService CreateTextGenerationService(string modelId)
     {
-        (string modelProvider, string modelName) = this.GetModelProviderAndName(modelId);
+        (string modelProvider, string modelName) = this.GetModelProviderAndName(ScrubCrossRegionPrefix(modelId));
 
         switch (modelProvider.ToUpperInvariant())
         {
@@ -79,7 +104,7 @@ internal sealed class BedrockServiceFactory
     /// <exception cref="NotSupportedException">Thrown if provider or model is not supported for chat completion.</exception>
     internal IBedrockChatCompletionService CreateChatCompletionService(string modelId)
     {
-        (string modelProvider, string modelName) = this.GetModelProviderAndName(modelId);
+        (string modelProvider, string modelName) = this.GetModelProviderAndName(ScrubCrossRegionPrefix(modelId));
 
         switch (modelProvider.ToUpperInvariant())
         {


### PR DESCRIPTION
…fix from model id

If present, removes the "us.", "eu.", or "apac." preceding the model id when selecting the correct model service for the given model.

### Motivation and Context

1. Why is this change required? This is to allow the use of cross-region inference models in the Amazon Bedrock connector.
2. What problem does it solve? This fixes a bug in `BedrockServiceFactory.cs` in which the cross-regional identifier in a model was getting treated as an LLM provider.
3. What scenario does it contribute to? Use of cross-regional inference models in Amazon Bedrock, namely Claude 3.7 Sonnet from a us-west-2 data center.
4. If it fixes an open issue, please link to the issue here. 
   * #10738 
   * #10047 

### Description

This is a minimal-change quick fix for enabling cross-regional models in Amazon Bedrock. It looks for one of the three standard cross-regional identifiers at the start of the model ID in the bedrock service factory, and if present, removes it. With the model ID stripped of the cross-region header, existing logic is used to select the correct LLM service.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
