### PR TITLE
.Net: Small fix to support cloning for new property on VectorStoreRecordKeyProperty

### DIFF
--- a/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreRecordKeyProperty.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/RecordDefinition/VectorStoreRecordKeyProperty.cs
@@ -29,6 +29,7 @@ public sealed class VectorStoreRecordKeyProperty : VectorStoreRecordProperty
     public VectorStoreRecordKeyProperty(VectorStoreRecordKeyProperty source)
         : base(source)
     {
+        this.AutoGenerate = source.AutoGenerate;
     }
 
     /// <summary>


### PR DESCRIPTION
…Property

### Motivation and Context

The Definition Property classes support easy cloning with modifications via a pattern like this:
```csharp
var clonedProp = new VectorStoreRecordVectorProperty(oldprop) { Dimensions = 100 };
```

### Description

Updating VectorStoreRecordKeyProperty, so that the new property on it also gets cloned by default.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
