### PR TITLE
.Net: Make Bedrock agent clients required and public

### DIFF
--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step01_BedrockAgent.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step01_BedrockAgent.cs
@@ -48,7 +48,7 @@ public class Step01_BedrockAgent(ITestOutputHelper output) : BaseBedrockAgentTes
         // Replace "bedrock-agent-id" with the ID of the agent you want to use
         var agentId = "bedrock-agent-id";
         var getAgentResponse = await this.Client.GetAgentAsync(new() { AgentId = agentId });
-        var bedrockAgent = new BedrockAgent(getAgentResponse.Agent, this.Client);
+        var bedrockAgent = new BedrockAgent(getAgentResponse.Agent, this.Client, this.RuntimeClient);
 
         // Respond to user input
         var responses = bedrockAgent.InvokeAsync(BedrockAgent.CreateSessionId(), UserQuery, null);
@@ -89,6 +89,6 @@ public class Step01_BedrockAgent(ITestOutputHelper output) : BaseBedrockAgentTes
         var agentModel = await this.Client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest(agentName));
         // Create a new BedrockAgent instance with the agent model and the client
         // so that we can interact with the agent using Semantic Kernel contents.
-        return new BedrockAgent(agentModel, this.Client);
+        return new BedrockAgent(agentModel, this.Client, this.RuntimeClient);
     }
 }

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step01_BedrockAgent.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step01_BedrockAgent.cs
@@ -33,7 +33,7 @@ public class Step01_BedrockAgent(ITestOutputHelper output) : BaseBedrockAgentTes
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 
@@ -79,7 +79,7 @@ public class Step01_BedrockAgent(ITestOutputHelper output) : BaseBedrockAgentTes
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step02_BedrockAgent_CodeInterpreter.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step02_BedrockAgent_CodeInterpreter.cs
@@ -71,7 +71,7 @@ Dolphin  2";
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step02_BedrockAgent_CodeInterpreter.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step02_BedrockAgent_CodeInterpreter.cs
@@ -81,7 +81,7 @@ Dolphin  2";
         var agentModel = await this.Client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest(agentName));
         // Create a new BedrockAgent instance with the agent model and the client
         // so that we can interact with the agent using Semantic Kernel contents.
-        var bedrockAgent = new BedrockAgent(agentModel, this.Client);
+        var bedrockAgent = new BedrockAgent(agentModel, this.Client, this.RuntimeClient);
         // Create the code interpreter action group and prepare the agent for interaction
         await bedrockAgent.CreateCodeInterpreterActionGroupAsync();
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step03_BedrockAgent_Functions.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step03_BedrockAgent_Functions.cs
@@ -39,7 +39,7 @@ public class Step03_BedrockAgent_Functions(ITestOutputHelper output) : BaseBedro
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 
@@ -70,7 +70,7 @@ public class Step03_BedrockAgent_Functions(ITestOutputHelper output) : BaseBedro
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 
@@ -101,7 +101,7 @@ public class Step03_BedrockAgent_Functions(ITestOutputHelper output) : BaseBedro
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step03_BedrockAgent_Functions.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step03_BedrockAgent_Functions.cs
@@ -114,7 +114,7 @@ public class Step03_BedrockAgent_Functions(ITestOutputHelper output) : BaseBedro
         kernel.Plugins.Add(KernelPluginFactory.CreateFromType<WeatherPlugin>());
         // Create a new BedrockAgent instance with the agent model and the client
         // so that we can interact with the agent using Semantic Kernel contents.
-        var bedrockAgent = new BedrockAgent(agentModel, this.Client)
+        var bedrockAgent = new BedrockAgent(agentModel, this.Client, this.RuntimeClient)
         {
             Kernel = kernel,
         };

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step04_BedrockAgent_Trace.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step04_BedrockAgent_Trace.cs
@@ -62,7 +62,7 @@ public class Step04_BedrockAgent_Trace(ITestOutputHelper output) : BaseBedrockAg
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step04_BedrockAgent_Trace.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step04_BedrockAgent_Trace.cs
@@ -149,7 +149,7 @@ public class Step04_BedrockAgent_Trace(ITestOutputHelper output) : BaseBedrockAg
         kernel.Plugins.Add(KernelPluginFactory.CreateFromType<WeatherPlugin>());
         // Create a new BedrockAgent instance with the agent model and the client
         // so that we can interact with the agent using Semantic Kernel contents.
-        var bedrockAgent = new BedrockAgent(agentModel, this.Client)
+        var bedrockAgent = new BedrockAgent(agentModel, this.Client, this.RuntimeClient)
         {
             Kernel = kernel,
         };

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step05_BedrockAgent_FileSearch.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step05_BedrockAgent_FileSearch.cs
@@ -25,7 +25,7 @@ public class Step05_BedrockAgent_FileSearch(ITestOutputHelper output) : BaseBedr
         var agentModel = await this.Client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest(agentName));
         // Create a new BedrockAgent instance with the agent model and the client
         // so that we can interact with the agent using Semantic Kernel contents.
-        var bedrockAgent = new BedrockAgent(agentModel, this.Client);
+        var bedrockAgent = new BedrockAgent(agentModel, this.Client, this.RuntimeClient);
         // Associate the agent with a knowledge base and prepare the agent
         await bedrockAgent.AssociateAgentKnowledgeBaseAsync(
             KnowledgeBaseId,

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step05_BedrockAgent_FileSearch.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step05_BedrockAgent_FileSearch.cs
@@ -69,7 +69,7 @@ public class Step05_BedrockAgent_FileSearch(ITestOutputHelper output) : BaseBedr
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 }

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step06_BedrockAgent_AgentChat.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step06_BedrockAgent_AgentChat.cs
@@ -70,7 +70,7 @@ public class Step06_BedrockAgent_AgentChat(ITestOutputHelper output) : BaseBedro
         }
         finally
         {
-            await this.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 

--- a/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step06_BedrockAgent_AgentChat.cs
+++ b/dotnet/samples/GettingStartedWithAgents/BedrockAgent/Step06_BedrockAgent_AgentChat.cs
@@ -20,7 +20,7 @@ public class Step06_BedrockAgent_AgentChat(ITestOutputHelper output) : BaseBedro
         var agentModel = await this.Client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest(agentName));
         // Create a new BedrockAgent instance with the agent model and the client
         // so that we can interact with the agent using Semantic Kernel contents.
-        return new BedrockAgent(agentModel, this.Client);
+        return new BedrockAgent(agentModel, this.Client, this.RuntimeClient);
     }
 
     /// <summary>

--- a/dotnet/src/Agents/Bedrock/BedrockAgent.cs
+++ b/dotnet/src/Agents/Bedrock/BedrockAgent.cs
@@ -19,9 +19,15 @@ namespace Microsoft.SemanticKernel.Agents.Bedrock;
 /// </summary>
 public class BedrockAgent : KernelAgent
 {
-    internal readonly AmazonBedrockAgentClient Client;
+    /// <summary>
+    /// The client used to interact with the Bedrock Agent service.
+    /// </summary>
+    public AmazonBedrockAgentClient Client { get; }
 
-    internal readonly AmazonBedrockAgentRuntimeClient RuntimeClient;
+    /// <summary>
+    /// The client used to interact with the Bedrock Agent runtime service.
+    /// </summary>
+    public AmazonBedrockAgentRuntimeClient RuntimeClient { get; }
 
     internal readonly Amazon.BedrockAgent.Model.Agent AgentModel;
 
@@ -41,12 +47,12 @@ public class BedrockAgent : KernelAgent
     /// <param name="runtimeClient">A client used to interact with the Bedrock Agent runtime service.</param>
     public BedrockAgent(
         Amazon.BedrockAgent.Model.Agent agentModel,
-        AmazonBedrockAgentClient? client = null,
-        AmazonBedrockAgentRuntimeClient? runtimeClient = null)
+        AmazonBedrockAgentClient client,
+        AmazonBedrockAgentRuntimeClient runtimeClient)
     {
         this.AgentModel = agentModel;
-        this.Client = client ?? new AmazonBedrockAgentClient();
-        this.RuntimeClient = runtimeClient ?? new AmazonBedrockAgentRuntimeClient();
+        this.Client = client;
+        this.RuntimeClient = runtimeClient;
 
         this.Id = agentModel.AgentId;
         this.Name = agentModel.AgentName;

--- a/dotnet/src/IntegrationTests/Agents/BedrockAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/BedrockAgentTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.BedrockAgent;
 using Amazon.BedrockAgent.Model;
+using Amazon.BedrockAgentRuntime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents.Bedrock;
@@ -29,6 +30,8 @@ public sealed class BedrockAgentTests : IDisposable
 
     private readonly AmazonBedrockAgentClient _client = new();
 
+    private readonly AmazonBedrockAgentRuntimeClient _runtimeClient = new();
+
     /// <summary>
     /// Integration test for invoking a <see cref="BedrockAgent"/>.
     /// </summary>
@@ -37,7 +40,7 @@ public sealed class BedrockAgentTests : IDisposable
     public async Task InvokeTestAsync(string input)
     {
         var agentModel = await this._client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest());
-        var bedrockAgent = new BedrockAgent(agentModel, this._client);
+        var bedrockAgent = new BedrockAgent(agentModel, this._client, this._runtimeClient);
 
         try
         {
@@ -57,7 +60,7 @@ public sealed class BedrockAgentTests : IDisposable
     public async Task InvokeStreamingTestAsync(string input)
     {
         var agentModel = await this._client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest());
-        var bedrockAgent = new BedrockAgent(agentModel, this._client);
+        var bedrockAgent = new BedrockAgent(agentModel, this._client, this._runtimeClient);
 
         try
         {
@@ -82,7 +85,7 @@ Dolphin  2")]
     public async Task InvokeWithCodeInterpreterTestAsync(string input)
     {
         var agentModel = await this._client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest());
-        var bedrockAgent = new BedrockAgent(agentModel, this._client);
+        var bedrockAgent = new BedrockAgent(agentModel, this._client, this._runtimeClient);
         await bedrockAgent.CreateCodeInterpreterActionGroupAsync();
 
         try
@@ -115,7 +118,7 @@ Dolphin  2")]
         kernel.Plugins.Add(KernelPluginFactory.CreateFromType<WeatherPlugin>());
 
         var agentModel = await this._client.CreateAndPrepareAgentAsync(this.GetCreateAgentRequest());
-        var bedrockAgent = new BedrockAgent(agentModel, this._client)
+        var bedrockAgent = new BedrockAgent(agentModel, this._client, this._runtimeClient)
         {
             Kernel = kernel,
         };
@@ -217,6 +220,7 @@ Dolphin  2")]
     public void Dispose()
     {
         this._client.Dispose();
+        this._runtimeClient.Dispose();
     }
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes

--- a/dotnet/src/IntegrationTests/Agents/BedrockAgentTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/BedrockAgentTests.cs
@@ -48,7 +48,7 @@ public sealed class BedrockAgentTests : IDisposable
         }
         finally
         {
-            await this._client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 
@@ -68,7 +68,7 @@ public sealed class BedrockAgentTests : IDisposable
         }
         finally
         {
-            await this._client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 
@@ -103,7 +103,7 @@ Dolphin  2")]
         }
         finally
         {
-            await this._client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 
@@ -130,7 +130,7 @@ Dolphin  2")]
         }
         finally
         {
-            await this._client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
+            await bedrockAgent.Client.DeleteAgentAsync(new() { AgentId = bedrockAgent.Id });
         }
     }
 

--- a/dotnet/src/InternalUtilities/samples/AgentUtilities/BaseBedrockAgentTest.cs
+++ b/dotnet/src/InternalUtilities/samples/AgentUtilities/BaseBedrockAgentTest.cs
@@ -2,6 +2,7 @@
 
 using Amazon.BedrockAgent;
 using Amazon.BedrockAgent.Model;
+using Amazon.BedrockAgentRuntime;
 using Microsoft.SemanticKernel.Agents.Bedrock;
 
 /// <summary>
@@ -12,10 +13,12 @@ public abstract class BaseBedrockAgentTest : BaseTest
     protected const string AgentDescription = "A helpful assistant who helps users find information.";
     protected const string AgentInstruction = "You're a helpful assistant who helps users find information.";
     protected readonly AmazonBedrockAgentClient Client;
+    protected readonly AmazonBedrockAgentRuntimeClient RuntimeClient;
 
     protected BaseBedrockAgentTest(ITestOutputHelper output) : base(output, redirectSystemConsoleOutput: true)
     {
         Client = new AmazonBedrockAgentClient();
+        RuntimeClient = new AmazonBedrockAgentRuntimeClient();
     }
 
     protected CreateAgentRequest GetCreateAgentRequest(string agentName) => new()
@@ -30,6 +33,7 @@ public abstract class BaseBedrockAgentTest : BaseTest
     protected override void Dispose(bool disposing)
     {
         Client?.Dispose();
+        RuntimeClient?.Dispose();
         base.Dispose(disposing);
     }
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Following the construction pattern of the other agent types where clients are required to construct the agents. This change makes the Bedrock agent clients required and public.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Makes the Bedrock agent clients required at construction time and public.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
