### PR TITLE
.Net: Change three more Redis filtering tests on bools to expect InvalidOperationException

### DIFF
--- a/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/Filter/RedisBasicFilterTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/RedisIntegrationTests/Filter/RedisBasicFilterTests.cs
@@ -37,6 +37,15 @@ public abstract class RedisBasicFilterTests(BasicFilterTests<string>.Fixture fix
     public override Task Not_over_bool()
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Not_over_bool());
 
+    public override Task Bool_And_Bool()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Bool_And_Bool());
+
+    public override Task Bool_Or_Not_Bool()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Bool_Or_Not_Bool());
+
+    public override Task Not_over_bool_And_Comparison()
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Not_over_bool_And_Comparison());
+
     #endregion
 
     #region Contains


### PR DESCRIPTION
### Motivation and Context

Bool is not supported for filtering on Redis

### Description

Change three more Redis filtering tests on bools to expect InvalidOperationException

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
