### PR TITLE
Python: Use openai assistant methods not azure ai

### DIFF
--- a/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_content_generation.py
@@ -476,3 +476,20 @@ def generate_streaming_annotation_content(
         start_index=annotation.start_index,
         end_index=annotation.end_index,
     )
+
+
+@experimental
+def generate_function_call_streaming_content(
+    agent_name: str,
+    fccs: list[FunctionCallContent],
+) -> StreamingChatMessageContent:
+    """Generate function call content.
+
+    Args:
+        agent_name: The agent name.
+        fccs: The function call contents.
+
+    Returns:
+        StreamingChatMessageContent: The chat message content containing the function call content as the items.
+    """
+    return StreamingChatMessageContent(role=AuthorRole.ASSISTANT, choice_index=0, name=agent_name, items=fccs)  # type: ignore

--- a/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
@@ -17,11 +17,11 @@ from openai.types.beta.threads.runs import (
     ToolCallsStepDetails,
 )
 
-from semantic_kernel.agents.azure_ai.agent_content_generation import generate_function_call_streaming_content
 from semantic_kernel.agents.open_ai.assistant_content_generation import (
     generate_code_interpreter_content,
     generate_final_streaming_message_content,
     generate_function_call_content,
+    generate_function_call_streaming_content,
     generate_function_result_content,
     generate_message_content,
     generate_streaming_code_interpreter_content,


### PR DESCRIPTION
### Motivation and Context

The OpenAI assistant code is using an import from the AzureAIAgent related code, and when not installing the `azure` extras, this causes an import error.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Use OpenAI assistant specific thread action code.
- Closes #10942

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
