### PR TITLE
Python: small fix for Pinecone integrated embeddings

### DIFF
--- a/python/semantic_kernel/connectors/memory/pinecone/pinecone_settings.py
+++ b/python/semantic_kernel/connectors/memory/pinecone/pinecone_settings.py
@@ -16,9 +16,12 @@ class PineconeSettings(KernelBaseSettings):
     - api_key: SecretStr - Pinecone API key
         (Env var PINECONE_API_KEY)
     - namespace: str - Pinecone namespace (optional, default is "")
+    - embed_model: str - Embedding model (optional, default is None)
+        (Env var PINECONE_EMBED_MODEL)
     """
 
     env_prefix: ClassVar[str] = "PINECONE_"
 
     api_key: SecretStr
     namespace: str = ""
+    embed_model: str | None = None

--- a/python/semantic_kernel/data/vector_storage/vector_store_record_collection.py
+++ b/python/semantic_kernel/data/vector_storage/vector_store_record_collection.py
@@ -8,6 +8,8 @@ from abc import abstractmethod
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import Any, ClassVar, Generic, TypeVar
 
+from semantic_kernel.data.record_definition.vector_store_record_fields import VectorStoreRecordVectorField
+
 if sys.version_info >= (3, 11):
     from typing import Self  # pragma: no cover
 else:
@@ -531,12 +533,17 @@ class VectorStoreRecordCollection(KernelBaseModel, Generic[TKey, TModel]):
             return self._serialize_vectors(record.model_dump())
 
         store_model = {}
-        for field_name in self.data_model_definition.field_names:
-            value = record[field_name] if isinstance(record, Mapping) else getattr(record, field_name)
-            if (
-                func := getattr(self.data_model_definition.fields[field_name], "serialize_function", None)
-            ) and value is not None:
-                value = func(value)
+        for field_name, field in self.data_model_definition.fields.items():
+            if isinstance(field, VectorStoreRecordVectorField) and not field.local_embedding:
+                logger.info(f"Vector field {field_name} is not local, skipping serialization.")
+                continue
+            value = record.get(field_name, None) if isinstance(record, Mapping) else getattr(record, field_name)
+            if isinstance(field, VectorStoreRecordVectorField):
+                if (func := getattr(field, "serialize_function", None)) and value is not None:
+                    value = func(value)
+            elif value is None:
+                # if the field is not a vector field, then it should have a value.
+                raise VectorStoreModelSerializationException(f"Field {field_name} is None, cannot serialize.")
             store_model[field_name] = value
         return store_model
 
@@ -629,12 +636,16 @@ class VectorStoreRecordCollection(KernelBaseModel, Generic[TKey, TModel]):
                 record = self._deserialize_vector(record)
             return self.data_model_type.model_validate(record)  # type: ignore
         data_model_dict: dict[str, Any] = {}
-        for field_name in self.data_model_definition.fields:
-            if not include_vectors and field_name in self.data_model_definition.vector_field_names:
-                continue
-            value = record[field_name]
-            if func := getattr(self.data_model_definition.fields[field_name], "deserialize_function", None):
-                value = func(value)
+        for field_name, field in self.data_model_definition.fields.items():
+            value = record.get(field_name, None)
+            if isinstance(field, VectorStoreRecordVectorField):
+                if not include_vectors or not field.local_embedding:
+                    continue
+                if field.deserialize_function and value is not None:
+                    value = field.deserialize_function(value)
+            elif value is None:
+                # if the field is not a vector field, then it should have a value.
+                raise VectorStoreModelDeserializationException(f"Field {field_name} is None, cannot deserialize.")
             data_model_dict[field_name] = value
         if self.data_model_type is dict:
             return data_model_dict  # type: ignore
@@ -643,7 +654,10 @@ class VectorStoreRecordCollection(KernelBaseModel, Generic[TKey, TModel]):
     def _deserialize_vector(self, record: dict[str, Any]) -> dict[str, Any]:
         for field in self.data_model_definition.vector_fields:
             if field.deserialize_function:
-                record[field.name or ""] = field.deserialize_function(record[field.name or ""])
+                if not field.local_embedding:
+                    logger.info(f"Vector field {field.name} is not local, skipping deserialization.")
+                    continue
+                record[field.name] = field.deserialize_function(record[field.name])
         return record
 
     # region Internal Functions

--- a/python/tests/unit/connectors/memory/pinecone/test_pinecone.py
+++ b/python/tests/unit/connectors/memory/pinecone/test_pinecone.py
@@ -168,7 +168,7 @@ async def test_load_index_client(collection, mock_index_asyncio):
     assert collection.index is not None
     assert collection.index_client is not None
     assert isinstance(collection.index_client, _IndexAsyncio)
-    assert collection._integrated_embeddings is (collection.index.embed is not None)
+    assert collection.embed_settings == collection.index.embed
 
 
 async def test_create_collection(collection, mock_create_index):
@@ -312,10 +312,7 @@ async def test_search(collection):
 
 @mark.parametrize("embed", [{"model": "test-model"}])
 async def test_search_embed(collection):
-    record = {
-        "id": "test_id",
-        "content": "test_content",
-    }
+    record = {"id": "test_id", "content": "test_content", "vector": None}
     query_response = SearchRecordsResponse._from_openapi_data(
         result=SearchRecordsResponseResult._from_openapi_data(**{
             "hits": [

--- a/python/tests/unit/data/test_vector_search_base.py
+++ b/python/tests/unit/data/test_vector_search_base.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from semantic_kernel.data.vector_search.vector_search import VectorSearchBase
@@ -30,9 +32,11 @@ async def test_get_vector_search_results(vector_store_record_collection: VectorS
 
 
 async def test_get_vector_search_results_fail(vector_store_record_collection: VectorSearchBase):
-    # vector_store_record_collection.data_model_type.serialize = MagicMock(side_effect=Exception)
+    vector_store_record_collection.data_model_definition.vector_fields[0].deserialize_function = MagicMock(
+        side_effect=Exception
+    )
     options = VectorSearchOptions(include_vectors=True)
-    results = [{"id": "test_id", "content": "test_content"}]
+    results = [{"id": "test_id", "content": "test_content", "vector": [1.0, 2.0, 3.0]}]
     with pytest.raises(VectorStoreModelDeserializationException):
         async for result in vector_store_record_collection._get_vector_search_results_from_results(
             results=results, options=options

--- a/python/tests/unit/data/test_vector_store_record_collection.py
+++ b/python/tests/unit/data/test_vector_store_record_collection.py
@@ -400,7 +400,7 @@ def test_serialize_data_model_to_dict_fail_mapping(DictVectorStoreRecordCollecti
         data_model_definition=data_model_definition,
     )
     record = {"content": "test_content", "vector": [1.0, 2.0, 3.0]}
-    with raises(KeyError):
+    with raises(VectorStoreModelSerializationException):
         vector_store_record_collection._serialize_data_model_to_dict(record)
 
 
@@ -502,7 +502,7 @@ def test_deserialize_dict_data_model_fail(DictVectorStoreRecordCollection, data_
         data_model_type=dict,
         data_model_definition=data_model_definition,
     )
-    with raises(KeyError):
+    with raises(VectorStoreModelDeserializationException):
         vector_store_record_collection._deserialize_dict_to_data_model({
             "content": "test_content",
             "vector": [1.0, 2.0, 3.0],

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
@@ -1487,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.82.0"
+version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1503,9 +1504,9 @@ dependencies = [
     { name = "shapely", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/f2/86f7c064b04415c61f1952c09e972a80054708e29f443c068d7410d4c71e/google_cloud_aiplatform-1.82.0.tar.gz", hash = "sha256:b7ea7379249cc1821aa46300a16e4b15aa64aa22665e2536b2bcb7e473d7438e", size = 8735542 }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/e4/ab73a6dcf77d5ac0d245c5dd506e4494ad80fdb49193b1ea4c930708b1e9/google_cloud_aiplatform-1.83.0.tar.gz", hash = "sha256:cda870c2cce1682ef006f8b87f18cfa8927ff9daf3944aa4ff01f8e552e89928", size = 8756256 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/e9/f0ad7ef7e50eb2e98b48e087d321b1a1f765b97c6392f00cc3109ca98af0/google_cloud_aiplatform-1.82.0-py2.py3-none-any.whl", hash = "sha256:13368a961b2bfa8f46ccd10371bb19bd5f946d8f29c411726061ed1a140ce890", size = 7291872 },
+    { url = "https://files.pythonhosted.org/packages/c3/a7/440d4d1cac03e6cde2f432bc78e0b109b732d4d0b58e6ae5dda9666af423/google_cloud_aiplatform-1.83.0-py2.py3-none-any.whl", hash = "sha256:fa33932af5d88ccf42f901f6ffdf8abee87f6db82ea17df713062dd41707a154", size = 7311467 },
 ]
 
 [[package]]
@@ -5377,7 +5378,7 @@ requires-dist = [
     { name = "defusedxml", specifier = "~=0.7" },
     { name = "faiss-cpu", marker = "extra == 'faiss'", specifier = ">=1.10.0" },
     { name = "flask-dapr", marker = "extra == 'dapr'", specifier = ">=1.14.0" },
-    { name = "google-cloud-aiplatform", marker = "extra == 'google'", specifier = "==1.82.0" },
+    { name = "google-cloud-aiplatform", marker = "extra == 'google'", specifier = "==1.83.0" },
     { name = "google-generativeai", marker = "extra == 'google'", specifier = "~=0.8" },
     { name = "ipykernel", marker = "extra == 'notebooks'", specifier = "~=6.29" },
     { name = "jinja2", specifier = "~=3.1" },
@@ -5414,7 +5415,8 @@ requires-dist = [
     { name = "usearch", marker = "extra == 'usearch'", specifier = "~=2.16" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = ">=4.10,<5.0" },
     { name = "websockets", specifier = ">=13,<15" },
-    { name = "websockets", marker = "extra == 'realtime'", specifier = ">=13,<15" },
+    { name = "websockets", specifier = ">=13,<16" },
+    { name = "websockets", marker = "extra == 'realtime'", specifier = ">=13,<16" },
 ]
 provides-extras = ["anthropic", "autogen", "aws", "azure", "chroma", "dapr", "faiss", "google", "hugging-face", "milvus", "mistralai", "mongo", "notebooks", "ollama", "onnx", "pandas", "pinecone", "postgres", "qdrant", "realtime", "redis", "usearch", "weaviate"]
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Pinecone offers integrated embeddings, expended the way you can set up for that
Made some fixes in the DeSer process of the vector stores to deal with non-returned vectors.

Now (finally) uses local_embeddings field to allow the field to be present but not used.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
