### PR TITLE
.Net: First round of MEVD DI changes

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchKernelBuilderExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Azure AI Search <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class AzureAISearchKernelBuilderExtensions
 {
     /// <summary>
@@ -23,7 +24,7 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStore(options, serviceId);
+        builder.Services.AddKeyedAzureAISearchVectorStore(serviceId, options);
         return builder;
     }
 
@@ -38,7 +39,7 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, Uri endpoint, TokenCredential tokenCredential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStore(endpoint, tokenCredential, options, serviceId);
+        builder.Services.AddKeyedAzureAISearchVectorStore(serviceId, endpoint, tokenCredential, options);
         return builder;
     }
 
@@ -53,7 +54,7 @@ public static class AzureAISearchKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddAzureAISearchVectorStore(this IKernelBuilder builder, Uri endpoint, AzureKeyCredential credential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStore(endpoint, credential, options, serviceId);
+        builder.Services.AddKeyedAzureAISearchVectorStore(serviceId, endpoint, credential, options);
         return builder;
     }
 
@@ -73,7 +74,7 @@ public static class AzureAISearchKernelBuilderExtensions
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        builder.Services.AddKeyedAzureAISearchVectorStoreRecordCollection<TRecord>(serviceId, collectionName, options);
         return builder;
     }
 
@@ -97,7 +98,7 @@ public static class AzureAISearchKernelBuilderExtensions
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, endpoint, tokenCredential, options, serviceId);
+        builder.Services.AddKeyedAzureAISearchVectorStoreRecordCollection<TRecord>(serviceId, collectionName, endpoint, tokenCredential, options);
         return builder;
     }
 
@@ -121,7 +122,7 @@ public static class AzureAISearchKernelBuilderExtensions
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureAISearchVectorStoreRecordCollection<TRecord>(collectionName, endpoint, credential, options, serviceId);
+        builder.Services.AddKeyedAzureAISearchVectorStoreRecordCollection<TRecord>(serviceId, collectionName, endpoint, credential, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
@@ -20,229 +20,358 @@ namespace Microsoft.SemanticKernel;
 public static class AzureAISearchServiceCollectionExtensions
 {
     /// <summary>
-    /// Register an Azure AI Search <see cref="IVectorStore"/> with the specified service ID and where <see cref="SearchIndexClient"/> is retrieved from the dependency injection container.
+    /// Registers an Azure AI Search <see cref="IVectorStore"/> in the <see cref="IServiceCollection"/>, retrieving the <see cref="SearchIndexClient"/> from the dependency injection container.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
-    {
+    public static IServiceCollection AddAzureAISearchVectorStore(
+        this IServiceCollection serviceCollection,
+        AzureAISearchVectorStoreOptions? options = default,
         // If we are not constructing the SearchIndexClient, add the IVectorStore as transient, since we
         // cannot make assumptions about how SearchIndexClient is being managed.
-        services.AddKeyedTransient<IVectorStore>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var searchIndexClient = sp.GetRequiredService<SearchIndexClient>();
-                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreOptions>();
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+        => AddKeyedAzureAISearchVectorStore(serviceCollection, serviceKey: null, options, lifetime);
 
-                return new AzureAISearchVectorStore(
-                    searchIndexClient,
-                    selectedOptions);
-            });
+    /// <summary>
+    /// Registers a keyed Azure AI Search <see cref="IVectorStore"/> in the <see cref="IServiceCollection"/>, retrieving the <see cref="SearchIndexClient"/> from the dependency injection container.
+    /// </summary>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedAzureAISearchVectorStore(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        AzureAISearchVectorStoreOptions? options = default,
+        // If we are not constructing the SearchIndexClient, add the IVectorStore as transient, since we
+        // cannot make assumptions about how SearchIndexClient is being managed.
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+    {
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStore),
+                serviceKey,
+                (serviceProvider, _) => new AzureAISearchVectorStore(
+                    serviceProvider.GetRequiredService<SearchIndexClient>(),
+                    options ?? serviceProvider.GetService<AzureAISearchVectorStoreOptions>()),
+                lifetime));
 
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register an Azure AI Search <see cref="IVectorStore"/> with the provided <see cref="Uri"/> and <see cref="TokenCredential"/> and the specified service ID.
+    /// Registers an Azure AI Search <see cref="IVectorStore"/> in the <see cref="IServiceCollection"/>, using the provided <see cref="Uri"/> and <see cref="TokenCredential"/>.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, Uri endpoint, TokenCredential tokenCredential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
+    public static IServiceCollection AddAzureAISearchVectorStore(
+        this IServiceCollection serviceCollection,
+        Uri endpoint,
+        TokenCredential tokenCredential,
+        AzureAISearchVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        => AddKeyedAzureAISearchVectorStore(serviceCollection, serviceKey: null, endpoint, tokenCredential, options, lifetime);
+
+    /// <summary>
+    /// Registers a keyed Azure AI Search <see cref="IVectorStore"/> in the <see cref="IServiceCollection"/>, using the provided <see cref="Uri"/> and <see cref="TokenCredential"/>.
+    /// </summary>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedAzureAISearchVectorStore(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        Uri endpoint,
+        TokenCredential tokenCredential,
+        AzureAISearchVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(tokenCredential);
 
-        services.AddKeyedSingleton<IVectorStore>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreOptions>();
-                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
-                var searchIndexClient = new SearchIndexClient(endpoint, tokenCredential, searchClientOptions);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStore),
+                serviceKey,
+                (serviceProvider, _) =>
+                {
+                    options ??= serviceProvider.GetService<AzureAISearchVectorStoreOptions>();
+                    var searchClientOptions = BuildSearchClientOptions(options?.JsonSerializerOptions);
+                    var searchIndexClient = new SearchIndexClient(endpoint, tokenCredential, searchClientOptions);
 
-                // Construct the vector store.
-                return new AzureAISearchVectorStore(
-                    searchIndexClient,
-                    selectedOptions);
-            });
+                    // Construct the vector store.
+                    return new AzureAISearchVectorStore(searchIndexClient, options);
+                },
+                lifetime));
 
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register an Azure AI Search <see cref="IVectorStore"/> with the provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/> and the specified service ID.
+    /// Registers an Azure AI Search <see cref="IVectorStore"/> in the <see cref="IServiceCollection"/>, using the provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/>.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddAzureAISearchVectorStore(this IServiceCollection services, Uri endpoint, AzureKeyCredential credential, AzureAISearchVectorStoreOptions? options = default, string? serviceId = default)
+    public static IServiceCollection AddAzureAISearchVectorStore(
+        this IServiceCollection serviceCollection,
+        Uri endpoint,
+        AzureKeyCredential credential,
+        AzureAISearchVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        => AddKeyedAzureAISearchVectorStore(serviceCollection, serviceKey: null, endpoint, credential, options, lifetime);
+
+    /// <summary>
+    /// Registers a keyed Azure AI Search <see cref="IVectorStore"/> in the <see cref="IServiceCollection"/>, using the provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/>.
+    /// </summary>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the store. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedAzureAISearchVectorStore(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        Uri endpoint,
+        AzureKeyCredential credential,
+        AzureAISearchVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(credential);
 
-        services.AddKeyedSingleton<IVectorStore>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreOptions>();
-                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
-                var searchIndexClient = new SearchIndexClient(endpoint, credential, searchClientOptions);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStore),
+                serviceKey,
+                (serviceProvider, _) =>
+                {
+                    options ??= serviceProvider.GetService<AzureAISearchVectorStoreOptions>();
+                    var searchClientOptions = BuildSearchClientOptions(options?.JsonSerializerOptions);
+                    var searchIndexClient = new SearchIndexClient(endpoint, credential, searchClientOptions);
 
-                // Construct the vector store.
-                return new AzureAISearchVectorStore(
-                    searchIndexClient,
-                    selectedOptions);
-            });
+                    // Construct the vector store.
+                    return new AzureAISearchVectorStore(searchIndexClient, options);
+                },
+                lifetime));
 
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
-    /// specified service ID and where <see cref="SearchIndexClient"/> is retrieved from the dependency injection container.
+    /// Registers an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/>,
+    /// retrieving the <see cref="SearchIndexClient"/> from the dependency injection container.
     /// </summary>
     /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
-    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the collection. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddAzureAISearchVectorStoreRecordCollection<TRecord>(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         string collectionName,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
-        string? serviceId = default)
-    {
         // If we are not constructing the SearchIndexClient, add the IVectorStore as transient, since we
         // cannot make assumptions about how SearchIndexClient is being managed.
-        services.AddKeyedTransient<IVectorStoreRecordCollection<string, TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var searchIndexClient = sp.GetRequiredService<SearchIndexClient>();
-                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+        => AddKeyedAzureAISearchVectorStoreRecordCollection(serviceCollection, serviceKey: null, collectionName, options, lifetime);
 
-                return new AzureAISearchVectorStoreRecordCollection<TRecord>(
-                    searchIndexClient,
+    /// <summary>
+    /// Registers a keyed Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/>,
+    /// retrieving the <see cref="SearchIndexClient"/> from the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="options">Configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the collection. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string collectionName,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        // If we are not constructing the SearchIndexClient, add the IVectorStore as transient, since we
+        // cannot make assumptions about how SearchIndexClient is being managed.
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+    {
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStoreRecordCollection<string, TRecord>),
+                serviceKey,
+                (serviceProvider, _) => new AzureAISearchVectorStoreRecordCollection<TRecord>(
+                    serviceProvider.GetRequiredService<SearchIndexClient>(),
                     collectionName,
-                    selectedOptions);
-            });
+                    options ?? serviceProvider.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>()),
+                lifetime));
 
-        AddVectorizedSearch<TRecord>(services, serviceId);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorizedSearch<TRecord>),
+                serviceKey,
+                static (serviceProvider, serviceKey) => serviceProvider.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceKey),
+                lifetime));
 
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
-    /// provided <see cref="Uri"/> and <see cref="TokenCredential"/> and the specified service ID.
+    /// Registers an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="TokenCredential"/>.
     /// </summary>
     /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="lifetime">The service lifetime for the collection. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddAzureAISearchVectorStoreRecordCollection<TRecord>(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         string collectionName,
         Uri endpoint,
         TokenCredential tokenCredential,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
-        string? serviceId = default)
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        => AddKeyedAzureAISearchVectorStoreRecordCollection(serviceCollection, serviceKey: null, collectionName, endpoint, tokenCredential, options, lifetime);
+
+    /// <summary>
+    /// Registers a keyed Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="TokenCredential"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="tokenCredential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the collection. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string collectionName,
+        Uri endpoint,
+        TokenCredential tokenCredential,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(tokenCredential);
 
-        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
-                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
-                var searchIndexClient = new SearchIndexClient(endpoint, tokenCredential, searchClientOptions);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStoreRecordCollection<string, TRecord>),
+                serviceKey,
+                (serviceProvider, _) =>
+                {
+                    options ??= serviceProvider.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
+                    var searchClientOptions = BuildSearchClientOptions(options?.JsonSerializerOptions);
+                    var searchIndexClient = new SearchIndexClient(endpoint, tokenCredential, searchClientOptions);
 
-                // Construct the vector store.
-                return new AzureAISearchVectorStoreRecordCollection<TRecord>(
-                    searchIndexClient,
-                    collectionName,
-                    selectedOptions);
-            });
+                    // Construct the vector store.
+                    return new AzureAISearchVectorStoreRecordCollection<TRecord>(searchIndexClient, collectionName, options);
+                },
+                lifetime));
 
-        AddVectorizedSearch<TRecord>(services, serviceId);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorizedSearch<TRecord>),
+                serviceKey,
+                static (serviceProvider, serviceKey) => serviceProvider.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceKey),
+                lifetime));
 
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
-    /// provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/> and the specified service ID.
+    /// Registers an Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/>.
     /// </summary>
     /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
     /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
     /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
     /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
     /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="lifetime">The service lifetime for the collection. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddAzureAISearchVectorStoreRecordCollection<TRecord>(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         string collectionName,
         Uri endpoint,
         AzureKeyCredential credential,
         AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
-        string? serviceId = default)
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        => AddKeyedAzureAISearchVectorStoreRecordCollection(serviceCollection, serviceKey: null, collectionName, endpoint, credential, options, lifetime);
+
+    /// <summary>
+    /// Registers a keyed Azure AI Search <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>, <see cref="IVectorizedSearch{TRecord}"/> and <see cref="IVectorizableTextSearch{TRecord}"/> with the
+    /// provided <see cref="Uri"/> and <see cref="AzureKeyCredential"/>.
+    /// </summary>
+    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="collectionName">The name of the collection that this <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/> will access.</param>
+    /// <param name="endpoint">The service endpoint for Azure AI Search.</param>
+    /// <param name="credential">The credential to authenticate to Azure AI Search with.</param>
+    /// <param name="options">Optional configuration options to pass to the <see cref="AzureAISearchVectorStoreRecordCollection{TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the collection. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedAzureAISearchVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string collectionName,
+        Uri endpoint,
+        AzureKeyCredential credential,
+        AzureAISearchVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
         Verify.NotNull(endpoint);
         Verify.NotNull(credential);
 
-        services.AddKeyedSingleton<IVectorStoreRecordCollection<string, TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var selectedOptions = options ?? sp.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
-                var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
-                var searchIndexClient = new SearchIndexClient(endpoint, credential, searchClientOptions);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStoreRecordCollection<string, TRecord>),
+                serviceKey,
+                (serviceProvider, _) =>
+                {
+                    var selectedOptions = options ?? serviceProvider.GetService<AzureAISearchVectorStoreRecordCollectionOptions<TRecord>>();
+                    var searchClientOptions = BuildSearchClientOptions(selectedOptions?.JsonSerializerOptions);
+                    var searchIndexClient = new SearchIndexClient(endpoint, credential, searchClientOptions);
 
-                // Construct the vector store.
-                return new AzureAISearchVectorStoreRecordCollection<TRecord>(
-                    searchIndexClient,
-                    collectionName,
-                    selectedOptions);
-            });
+                    // Construct the vector store.
+                    return new AzureAISearchVectorStoreRecordCollection<TRecord>(searchIndexClient, collectionName, selectedOptions);
+                },
+                lifetime));
 
-        AddVectorizedSearch<TRecord>(services, serviceId);
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorizedSearch<TRecord>),
+                serviceKey, static (serviceProvider, serviceKey) => serviceProvider.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceKey),
+                lifetime));
 
-        return services;
-    }
-
-    /// <summary>
-    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
-    /// </summary>
-    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
-    /// <param name="services">The service collection to register on.</param>
-    /// <param name="serviceId">The service id that the registrations should use.</param>
-    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
-    {
-        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<string, TRecord>>(serviceId);
-            });
+        return serviceCollection;
     }
 
     /// <summary>
@@ -252,8 +381,11 @@ public static class AzureAISearchServiceCollectionExtensions
     /// <returns>The <see cref="SearchClientOptions"/>.</returns>
     private static SearchClientOptions BuildSearchClientOptions(JsonSerializerOptions? jsonSerializerOptions)
     {
-        var searchClientOptions = new SearchClientOptions();
-        searchClientOptions.Diagnostics.ApplicationId = HttpHeaderConstant.Values.UserAgent;
+        var searchClientOptions = new SearchClientOptions
+        {
+            Diagnostics = { ApplicationId = HttpHeaderConstant.Values.UserAgent }
+        };
+
         if (jsonSerializerOptions != null)
         {
             searchClientOptions.Serializer = new JsonObjectSerializer(jsonSerializerOptions);

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 using MongoDB.Driver;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Azure CosmosDB MongoDB <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class AzureCosmosDBMongoDBKernelBuilderExtensions
 {
     /// <summary>
@@ -24,7 +26,7 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         AzureCosmosDBMongoDBVectorStoreOptions? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBMongoDBVectorStore(options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBMongoDBVectorStore(serviceId, options);
         return builder;
     }
 
@@ -45,7 +47,7 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         AzureCosmosDBMongoDBVectorStoreOptions? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBMongoDBVectorStore(connectionString, databaseName, options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBMongoDBVectorStore(serviceId, connectionString, databaseName, options);
         return builder;
     }
 
@@ -65,7 +67,7 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(serviceId, collectionName, options);
         return builder;
     }
 
@@ -89,7 +91,7 @@ public static class AzureCosmosDBMongoDBKernelBuilderExtensions
         AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(collectionName, connectionString, databaseName, options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord>(serviceId, collectionName, connectionString, databaseName, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Azure CosmosDB NoSQL <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class AzureCosmosDBNoSQLKernelBuilderExtensions
 {
     /// <summary>
@@ -24,7 +26,7 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
         AzureCosmosDBNoSQLVectorStoreOptions? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBNoSQLVectorStore(options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBNoSQLVectorStore(serviceId, options);
         return builder;
     }
 
@@ -45,11 +47,11 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
         AzureCosmosDBNoSQLVectorStoreOptions? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBNoSQLVectorStore(
+        builder.Services.AddKeyedAzureCosmosDBNoSQLVectorStore(
+            serviceId,
             connectionString,
             databaseName,
-            options,
-            serviceId);
+            options);
 
         return builder;
     }
@@ -70,7 +72,7 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
         AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(serviceId, collectionName, options);
         return builder;
     }
 
@@ -94,7 +96,7 @@ public static class AzureCosmosDBNoSQLKernelBuilderExtensions
         AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(collectionName, connectionString, databaseName, options, serviceId);
+        builder.Services.AddKeyedAzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord>(serviceId, collectionName, connectionString, databaseName, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.InMemory;
 
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Data services on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class InMemoryKernelBuilderExtensions
 {
     /// <summary>
@@ -18,7 +20,7 @@ public static class InMemoryKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddInMemoryVectorStore(this IKernelBuilder builder, string? serviceId = default)
     {
-        builder.Services.AddInMemoryVectorStore(serviceId);
+        builder.Services.AddKeyedInMemoryVectorStore(serviceId);
         return builder;
     }
 
@@ -39,7 +41,7 @@ public static class InMemoryKernelBuilderExtensions
         string? serviceId = default)
         where TKey : notnull
     {
-        builder.Services.AddInMemoryVectorStoreRecordCollection<TKey, TRecord>(collectionName, options, serviceId);
+        builder.Services.AddKeyedInMemoryVectorStoreRecordCollection<TKey, TRecord>(serviceId, collectionName, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Pinecone;
 using Sdk = Pinecone;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Pinecone <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class PineconeKernelBuilderExtensions
 {
     /// <summary>
@@ -20,7 +22,7 @@ public static class PineconeKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddPineconeVectorStore(this IKernelBuilder builder, PineconeVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddPineconeVectorStore(options, serviceId);
+        builder.Services.AddKeyedPineconeVectorStore(serviceId, options);
         return builder;
     }
 
@@ -34,7 +36,7 @@ public static class PineconeKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddPineconeVectorStore(this IKernelBuilder builder, string apiKey, PineconeVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddPineconeVectorStore(apiKey, options, serviceId);
+        builder.Services.AddKeyedPineconeVectorStore(serviceId, apiKey, options);
         return builder;
     }
 
@@ -54,7 +56,7 @@ public static class PineconeKernelBuilderExtensions
         PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddPineconeVectorStoreRecordCollection<TRecord>(collectionName, options, serviceId);
+        builder.Services.AddKeyedPineconeVectorStoreRecordCollection<TRecord>(serviceId, collectionName, options);
         return builder;
     }
 
@@ -76,7 +78,7 @@ public static class PineconeKernelBuilderExtensions
         PineconeVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddPineconeVectorStoreRecordCollection<TRecord>(collectionName, apiKey, options, serviceId);
+        builder.Services.AddKeyedPineconeVectorStoreRecordCollection<TRecord>(serviceId, collectionName, apiKey, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresServiceCollectionExtensions.cs
@@ -13,160 +13,234 @@ namespace Microsoft.SemanticKernel;
 public static class PostgresServiceCollectionExtensions
 {
     /// <summary>
-    /// Register a Postgres <see cref="IVectorStore"/> with the specified service ID and where the NpgsqlDataSource is retrieved from the dependency injection container.
+    /// Registers a Postgres <see cref="IVectorStore"/>, retrieving the <see cref="NpgsqlDataSource"/> from the dependency injection container.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddPostgresVectorStore(this IServiceCollection services, PostgresVectorStoreOptions? options = default, string? serviceId = default)
-    {
+    public static IServiceCollection AddPostgresVectorStore(
+        this IServiceCollection serviceCollection,
+        PostgresVectorStoreOptions? options = default,
         // Since we are not constructing the data source, add the IVectorStore as transient, since we
         // cannot make assumptions about how data source is being managed.
-        services.AddKeyedTransient<IVectorStore>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var dataSource = sp.GetRequiredService<NpgsqlDataSource>();
-                var selectedOptions = options ?? sp.GetService<PostgresVectorStoreOptions>();
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+        => AddKeyedPostgresVectorStore(serviceCollection, serviceKey: null, options, lifetime);
 
-                return new PostgresVectorStore(
-                    dataSource,
-                    selectedOptions);
-            });
+    /// <summary>
+    /// Register a keyed Postgres <see cref="IVectorStore"/>, retrieving the <see cref="NpgsqlDataSource"/> from the dependency injection container.
+    /// </summary>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedPostgresVectorStore(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        PostgresVectorStoreOptions? options = default,
+        // Since we are not constructing the data source, add the IVectorStore as transient, since we
+        // cannot make assumptions about how data source is being managed.
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+    {
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStore),
+                serviceKey,
+                (serviceProvider, _) => new PostgresVectorStore(
+                    serviceProvider.GetRequiredService<NpgsqlDataSource>(),
+                    options ?? serviceProvider.GetService<PostgresVectorStoreOptions>()),
+                lifetime));
 
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register a Postgres <see cref="IVectorStore"/> with the specified service ID and where an NpgsqlDataSource is constructed using the provided parameters.
+    /// Registers a Postgres <see cref="IVectorStore"/> using the provided parameters.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="connectionString">Postgres database connection string.</param>
     /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddPostgresVectorStore(this IServiceCollection services, string connectionString, PostgresVectorStoreOptions? options = default, string? serviceId = default)
+    public static IServiceCollection AddPostgresVectorStore(
+        this IServiceCollection serviceCollection,
+        string connectionString,
+        PostgresVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+    => AddKeyedPostgresVectorStore(serviceCollection, serviceKey: null, connectionString, options, lifetime);
+
+    /// <summary>
+    /// Registers a keyed Postgres <see cref="IVectorStore"/> using the provided parameters.
+    /// </summary>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="connectionString">Postgres database connection string.</param>
+    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddKeyedPostgresVectorStore(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string connectionString,
+        PostgresVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
-        string? npgsqlServiceId = serviceId == null ? default : $"{serviceId}_NpgsqlDataSource";
         // Register NpgsqlDataSource to ensure proper disposal.
-        services.AddKeyedSingleton<NpgsqlDataSource>(
-            npgsqlServiceId,
-            (sp, obj) =>
-            {
-                NpgsqlDataSourceBuilder dataSourceBuilder = new(connectionString);
-                dataSourceBuilder.UseVector();
-                return dataSourceBuilder.Build();
-            });
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(NpgsqlDataSource),
+                serviceKey,
+                (_, _) =>
+                {
+                    NpgsqlDataSourceBuilder dataSourceBuilder = new(connectionString);
+                    dataSourceBuilder.UseVector();
+                    return dataSourceBuilder.Build();
+                },
+                lifetime));
 
-        services.AddKeyedSingleton<IVectorStore>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var dataSource = sp.GetRequiredKeyedService<NpgsqlDataSource>(npgsqlServiceId);
-                var selectedOptions = options ?? sp.GetService<PostgresVectorStoreOptions>();
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStore),
+                serviceKey,
+                (serviceProvider, _) => new PostgresVectorStore(
+                    serviceProvider.GetRequiredKeyedService<NpgsqlDataSource>(serviceKey),
+                    options ?? serviceProvider.GetService<PostgresVectorStoreOptions>()),
+                lifetime));
 
-                return new PostgresVectorStore(
-                    dataSource,
-                    selectedOptions);
-            });
-
-        return services;
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register a Postgres <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
-    /// and where the NpgsqlDataSource is retrieved from the dependency injection container.
+    /// Register a Postgres <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/>,
+    /// retrieving the <see cref="NpgsqlDataSource"/> from the dependency injection container.
     /// </summary>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <typeparam name="TRecord">The type of the record.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="collectionName">The name of the collection.</param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
     /// <returns>Service collection.</returns>
     public static IServiceCollection AddPostgresVectorStoreRecordCollection<TKey, TRecord>(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         string collectionName,
         PostgresVectorStoreRecordCollectionOptions<TRecord>? options = default,
-        string? serviceId = default)
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
         where TKey : notnull
-    {
-        services.AddKeyedTransient<IVectorStoreRecordCollection<TKey, TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var dataSource = sp.GetRequiredService<NpgsqlDataSource>();
-                var selectedOptions = options ?? sp.GetService<PostgresVectorStoreRecordCollectionOptions<TRecord>>();
-
-                return (new PostgresVectorStoreRecordCollection<TKey, TRecord>(dataSource, collectionName, selectedOptions) as IVectorStoreRecordCollection<TKey, TRecord>)!;
-            });
-
-        AddVectorizedSearch<TKey, TRecord>(services, serviceId);
-
-        return services;
-    }
+        => AddKeyedPostgresVectorStoreRecordCollection<TKey, TRecord>(serviceCollection, serviceKey: null, collectionName, options, lifetime);
 
     /// <summary>
-    /// Register a Postgres <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID
-    /// and where the NpgsqlDataSource is constructed using the provided parameters.
+    /// Register a keyed Postgres <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/>,
+    /// retrieving the <see cref="NpgsqlDataSource"/> from the dependency injection container.
     /// </summary>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <typeparam name="TRecord">The type of the record.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddKeyedPostgresVectorStoreRecordCollection<TKey, TRecord>(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string collectionName,
+        PostgresVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+        where TKey : notnull
+    {
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStoreRecordCollection<TKey, TRecord>),
+                serviceKey,
+                (serviceProvider, _) => new PostgresVectorStoreRecordCollection<TKey, TRecord>(
+                    serviceProvider.GetRequiredService<NpgsqlDataSource>(),
+                    collectionName,
+                    options ?? serviceProvider.GetService<PostgresVectorStoreRecordCollectionOptions<TRecord>>()),
+                lifetime));
+
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorizedSearch<TRecord>),
+                serviceKey,
+                static (serviceProvider, serviceKey) => serviceProvider.GetRequiredKeyedService<IVectorStoreRecordCollection<TKey, TRecord>>(serviceKey),
+                lifetime));
+
+        return serviceCollection;
+    }
+
+    /// <summary>
+    /// Registers a Postgres <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/>,
+    /// using the provided parameters.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="collectionName">The name of the collection.</param>
     /// <param name="connectionString">Postgres database connection string.</param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>Service collection.</returns>
     public static IServiceCollection AddPostgresVectorStoreRecordCollection<TKey, TRecord>(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         string collectionName,
         string connectionString,
         PostgresVectorStoreRecordCollectionOptions<TRecord>? options = default,
-        string? serviceId = default)
-        where TKey : notnull
-    {
-        string? npgsqlServiceId = serviceId == null ? default : $"{serviceId}_NpgsqlDataSource";
-        // Register NpgsqlDataSource to ensure proper disposal.
-        services.AddKeyedSingleton<NpgsqlDataSource>(
-            npgsqlServiceId,
-            (sp, obj) =>
-            {
-                NpgsqlDataSourceBuilder dataSourceBuilder = new(connectionString);
-                dataSourceBuilder.UseVector();
-                return dataSourceBuilder.Build();
-            });
-
-        services.AddKeyedSingleton<IVectorStoreRecordCollection<TKey, TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var dataSource = sp.GetRequiredKeyedService<NpgsqlDataSource>(npgsqlServiceId);
-
-                return (new PostgresVectorStoreRecordCollection<TKey, TRecord>(dataSource, collectionName, options) as IVectorStoreRecordCollection<TKey, TRecord>)!;
-            });
-
-        AddVectorizedSearch<TKey, TRecord>(services, serviceId);
-
-        return services;
-    }
+        ServiceLifetime lifetime = ServiceLifetime.Singleton) where TKey : notnull
+        => AddKeyedPostgresVectorStoreRecordCollection<TKey, TRecord>(serviceCollection, serviceKey: null, collectionName, connectionString, options, lifetime);
 
     /// <summary>
-    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// Registers a keyed Postgres <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/>,
+    /// using the provided parameters.
     /// </summary>
     /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
-    /// <param name="services">The service collection to register on.</param>
-    /// <param name="serviceId">The service id that the registrations should use.</param>
-    private static void AddVectorizedSearch<TKey, TRecord>(IServiceCollection services, string? serviceId)
-        where TKey : notnull
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="connectionString">Postgres database connection string.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddKeyedPostgresVectorStoreRecordCollection<TKey, TRecord>(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string collectionName,
+        string connectionString,
+        PostgresVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton) where TKey : notnull
     {
-        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<TKey, TRecord>>(serviceId);
-            });
+        // Register NpgsqlDataSource to ensure proper disposal.
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(NpgsqlDataSource),
+                serviceKey,
+                (_, _) =>
+                {
+                    NpgsqlDataSourceBuilder dataSourceBuilder = new(connectionString);
+                    dataSourceBuilder.UseVector();
+                    return dataSourceBuilder.Build();
+                },
+                lifetime));
+
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStoreRecordCollection<TKey, TRecord>),
+                serviceKey,
+                (serviceProvider, _) => new PostgresVectorStoreRecordCollection<TKey, TRecord>(
+                    serviceProvider.GetRequiredKeyedService<NpgsqlDataSource>(serviceKey),
+                    collectionName,
+                    options),
+                lifetime));
+
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorizedSearch<TRecord>),
+                serviceKey,
+                static (serviceProvider, serviceKey) => serviceProvider.GetRequiredKeyedService<IVectorStoreRecordCollection<TKey, TRecord>>(serviceKey),
+                lifetime));
+
+        return serviceCollection;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Qdrant;
 using Qdrant.Client;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Qdrant <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class QdrantKernelBuilderExtensions
 {
     /// <summary>
@@ -20,7 +22,7 @@ public static class QdrantKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddQdrantVectorStore(this IKernelBuilder builder, QdrantVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddQdrantVectorStore(options, serviceId);
+        builder.Services.AddKeyedQdrantVectorStore(serviceId, options);
         return builder;
     }
     /// <summary>
@@ -36,7 +38,7 @@ public static class QdrantKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddQdrantVectorStore(this IKernelBuilder builder, string host, int port = 6334, bool https = false, string? apiKey = default, QdrantVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddQdrantVectorStore(host, port, https, apiKey, options, serviceId);
+        builder.Services.AddKeyedQdrantVectorStore(serviceId, host, port, https, apiKey, options);
         return builder;
     }
 
@@ -58,7 +60,7 @@ public static class QdrantKernelBuilderExtensions
         string? serviceId = default)
         where TKey : notnull
     {
-        builder.Services.AddQdrantVectorStoreRecordCollection<TKey, TRecord>(collectionName, options, serviceId);
+        builder.Services.AddKeyedQdrantVectorStoreRecordCollection<TKey, TRecord>(serviceId, collectionName, options);
         return builder;
     }
 
@@ -88,7 +90,7 @@ public static class QdrantKernelBuilderExtensions
         string? serviceId = default)
         where TKey : notnull
     {
-        builder.Services.AddQdrantVectorStoreRecordCollection<TKey, TRecord>(collectionName, host, port, https, apiKey, options, serviceId);
+        builder.Services.AddKeyedQdrantVectorStoreRecordCollection<TKey, TRecord>(serviceId, collectionName, host, port, https, apiKey, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Redis;
 using StackExchange.Redis;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Redis <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class RedisKernelBuilderExtensions
 {
     /// <summary>
@@ -20,7 +22,7 @@ public static class RedisKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddRedisVectorStore(this IKernelBuilder builder, RedisVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddRedisVectorStore(options, serviceId);
+        builder.Services.AddKeyedRedisVectorStore(serviceId, options);
         return builder;
     }
 
@@ -34,7 +36,7 @@ public static class RedisKernelBuilderExtensions
     /// <returns>The kernel builder.</returns>
     public static IKernelBuilder AddRedisVectorStore(this IKernelBuilder builder, string redisConnectionConfiguration, RedisVectorStoreOptions? options = default, string? serviceId = default)
     {
-        builder.Services.AddRedisVectorStore(redisConnectionConfiguration, options, serviceId);
+        builder.Services.AddKeyedRedisVectorStore(serviceId, redisConnectionConfiguration, options);
         return builder;
     }
 
@@ -54,7 +56,7 @@ public static class RedisKernelBuilderExtensions
         RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddRedisHashSetVectorStoreRecordCollection(collectionName, options, serviceId);
+        builder.Services.AddKeyedRedisHashSetVectorStoreRecordCollection(serviceId, collectionName, options);
         return builder;
     }
 
@@ -76,7 +78,7 @@ public static class RedisKernelBuilderExtensions
         RedisHashSetVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddRedisHashSetVectorStoreRecordCollection(collectionName, redisConnectionConfiguration, options, serviceId);
+        builder.Services.AddKeyedRedisHashSetVectorStoreRecordCollection(serviceId, collectionName, redisConnectionConfiguration, options);
         return builder;
     }
 
@@ -96,7 +98,7 @@ public static class RedisKernelBuilderExtensions
         RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddRedisJsonVectorStoreRecordCollection(collectionName, options, serviceId);
+        builder.Services.AddKeyedRedisJsonVectorStoreRecordCollection(serviceId, collectionName, options);
         return builder;
     }
 
@@ -118,7 +120,7 @@ public static class RedisKernelBuilderExtensions
         RedisJsonVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddRedisJsonVectorStoreRecordCollection(collectionName, redisConnectionConfiguration, options, serviceId);
+        builder.Services.AddKeyedRedisJsonVectorStoreRecordCollection(serviceId, collectionName, redisConnectionConfiguration, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Net.Http;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.Weaviate;
@@ -9,6 +10,7 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register Weaviate <see cref="IVectorStore"/> instances on the <see cref="IKernelBuilder"/>.
 /// </summary>
+[Obsolete("Call the corresponding method on the Services property of your IKernelBuilder instance.")]
 public static class WeaviateKernelBuilderExtensions
 {
     /// <summary>
@@ -29,7 +31,7 @@ public static class WeaviateKernelBuilderExtensions
         WeaviateVectorStoreOptions? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddWeaviateVectorStore(httpClient, options, serviceId);
+        builder.Services.AddKeyedWeaviateVectorStore(serviceId, httpClient, options);
         return builder;
     }
 
@@ -54,7 +56,7 @@ public static class WeaviateKernelBuilderExtensions
         WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
         string? serviceId = default)
     {
-        builder.Services.AddWeaviateVectorStoreRecordCollection(collectionName, httpClient, options, serviceId);
+        builder.Services.AddKeyedWeaviateVectorStoreRecordCollection(serviceId, collectionName, httpClient, options);
         return builder;
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateServiceCollectionExtensions.cs
@@ -15,84 +15,118 @@ namespace Microsoft.SemanticKernel;
 public static class WeaviateServiceCollectionExtensions
 {
     /// <summary>
-    /// Register a Weaviate <see cref="IVectorStore"/> with the specified service ID.
+    /// Registers a Weaviate <see cref="IVectorStore"/>.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStore"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="httpClient">
     /// <see cref="HttpClient"/> that is used to interact with Weaviate API.
     /// <see cref="HttpClient.BaseAddress"/> should point to remote or local cluster and API key can be configured via <see cref="HttpClient.DefaultRequestHeaders"/>.
     /// It's also possible to provide these parameters via <see cref="WeaviateVectorStoreOptions"/>.
     /// </param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStore"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
     /// <returns>Service collection.</returns>
     public static IServiceCollection AddWeaviateVectorStore(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         HttpClient? httpClient = default,
         WeaviateVectorStoreOptions? options = default,
-        string? serviceId = default)
-    {
-        services.AddKeyedTransient<IVectorStore>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var selectedHttpClient = HttpClientProvider.GetHttpClient(httpClient, sp);
-                var selectedOptions = options ?? sp.GetService<WeaviateVectorStoreOptions>();
-                return new WeaviateVectorStore(selectedHttpClient, options);
-            });
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+        => AddKeyedWeaviateVectorStore(serviceCollection, serviceKey: null, httpClient, options, lifetime);
 
-        return services;
+    /// <summary>
+    /// Registers a keyed Weaviate <see cref="IVectorStore"/>.
+    /// </summary>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="httpClient">
+    /// <see cref="HttpClient"/> that is used to interact with Weaviate API.
+    /// <see cref="HttpClient.BaseAddress"/> should point to remote or local cluster and API key can be configured via <see cref="HttpClient.DefaultRequestHeaders"/>.
+    /// It's also possible to provide these parameters via <see cref="WeaviateVectorStoreOptions"/>.
+    /// </param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStore"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddKeyedWeaviateVectorStore(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        HttpClient? httpClient = default,
+        WeaviateVectorStoreOptions? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+    {
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStore),
+                serviceKey,
+                (serviceProvider, _) => new WeaviateVectorStore(
+                    HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                    options ?? serviceProvider.GetService<WeaviateVectorStoreOptions>()),
+                lifetime));
+
+        return serviceCollection;
     }
 
     /// <summary>
-    /// Register a Weaviate <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/> with the specified service ID.
+    /// Registers a Weaviate <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/>.
     /// </summary>
     /// <typeparam name="TRecord">The type of the record.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> on.</param>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
     /// <param name="collectionName">The name of the collection.</param>
     /// <param name="httpClient">
     /// <see cref="HttpClient"/> that is used to interact with Weaviate API.
     /// <see cref="HttpClient.BaseAddress"/> should point to remote or local cluster and API key can be configured via <see cref="HttpClient.DefaultRequestHeaders"/>.
     /// It's also possible to provide these parameters via <see cref="WeaviateVectorStoreOptions"/>.
     /// </param>
-    /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
-    /// <param name="serviceId">An optional service id to use as the service key.</param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
     /// <returns>Service collection.</returns>
     public static IServiceCollection AddWeaviateVectorStoreRecordCollection<TRecord>(
-        this IServiceCollection services,
+        this IServiceCollection serviceCollection,
         string collectionName,
         HttpClient? httpClient = default,
         WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
-        string? serviceId = default)
-    {
-        services.AddKeyedTransient<IVectorStoreRecordCollection<Guid, TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                var selectedHttpClient = HttpClientProvider.GetHttpClient(httpClient, sp);
-                var selectedOptions = options ?? sp.GetService<WeaviateVectorStoreRecordCollectionOptions<TRecord>>();
-
-                return new WeaviateVectorStoreRecordCollection<TRecord>(selectedHttpClient, collectionName, selectedOptions);
-            });
-
-        AddVectorizedSearch<TRecord>(services, serviceId);
-
-        return services;
-    }
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
+        => AddKeyedWeaviateVectorStoreRecordCollection(serviceCollection, serviceKey: null, collectionName, httpClient, options, lifetime);
 
     /// <summary>
-    /// Also register the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> with the given <paramref name="serviceId"/> as a <see cref="IVectorizedSearch{TRecord}"/>.
+    /// Registers a keyed Weaviate <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> and <see cref="IVectorizedSearch{TRecord}"/>.
     /// </summary>
-    /// <typeparam name="TRecord">The type of the data model that the collection should contain.</typeparam>
-    /// <param name="services">The service collection to register on.</param>
-    /// <param name="serviceId">The service id that the registrations should use.</param>
-    private static void AddVectorizedSearch<TRecord>(IServiceCollection services, string? serviceId)
+    /// <typeparam name="TRecord">The type of the record.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to which the vector store should be added.</param>
+    /// <param name="serviceKey">The key with which to associate the vector store.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="httpClient">
+    /// <see cref="HttpClient"/> that is used to interact with Weaviate API.
+    /// <see cref="HttpClient.BaseAddress"/> should point to remote or local cluster and API key can be configured via <see cref="HttpClient.DefaultRequestHeaders"/>.
+    /// It's also possible to provide these parameters via <see cref="WeaviateVectorStoreOptions"/>.
+    /// </param>
+    /// <param name="options">Options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
+    /// <param name="lifetime">The service lifetime for the client. Defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>Service collection.</returns>
+    public static IServiceCollection AddKeyedWeaviateVectorStoreRecordCollection<TRecord>(
+        this IServiceCollection serviceCollection,
+        object? serviceKey,
+        string collectionName,
+        HttpClient? httpClient = default,
+        WeaviateVectorStoreRecordCollectionOptions<TRecord>? options = default,
+        ServiceLifetime lifetime = ServiceLifetime.Transient)
     {
-        services.AddKeyedTransient<IVectorizedSearch<TRecord>>(
-            serviceId,
-            (sp, obj) =>
-            {
-                return sp.GetRequiredKeyedService<IVectorStoreRecordCollection<Guid, TRecord>>(serviceId);
-            });
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorStoreRecordCollection<Guid, TRecord>),
+                serviceKey,
+                (serviceProvider, _) => new WeaviateVectorStoreRecordCollection<TRecord>(
+                    HttpClientProvider.GetHttpClient(httpClient, serviceProvider),
+                    collectionName,
+                    options ?? serviceProvider.GetService<WeaviateVectorStoreRecordCollectionOptions<TRecord>>()),
+                lifetime));
+
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IVectorizedSearch<TRecord>),
+                serviceKey,
+                static (serviceProvider, serviceKey) => serviceProvider.GetRequiredKeyedService<IVectorStoreRecordCollection<Guid, TRecord>>(serviceKey),
+                lifetime));
+
+        return serviceCollection;
     }
 }


### PR DESCRIPTION
* Align to the .NET (and MEAI) standard of having AddQdrant() (no service key) and AddKeyedQdrant() (non-optional service key).
* Rename serviceId to the more standard serviceKey naming, and change its type from `string` to `object`.
* Add ServiceLifetime parameters to all methods.
* Obsolete the KernelBuilderExtensions, in preparation for [#10855](https://github.com/microsoft/semantic-kernel/issues/10855)

Contributes to #10549

/cc @westey-m @adamsitnik @dmytrostruk 