### PR TITLE
.Net: Switch postgres and sqlserver to preview, and move experimental to only memory store artifacts.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/AssemblyInfo.cs
@@ -1,4 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-// This assembly is currently experimental.
-[assembly: System.Diagnostics.CodeAnalysis.Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/Connectors.Memory.Postgres.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.Postgres</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <VersionSuffix>alpha</VersionSuffix>
+    <VersionSuffix>preview</VersionSuffix>
     <NoWarn>$(NoWarn);CS0436</NoWarn>
   </PropertyGroup>
 

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/IPostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/IPostgresDbClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Pgvector;
@@ -11,6 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// <summary>
 /// Interface for client managing postgres database operations for <see cref="PostgresMemoryStore"/>.
 /// </summary>
+[Experimental("SKEXP0020")]
 public interface IPostgresDbClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresDbClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -16,6 +17,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// An implementation of a client for Postgres. This class is used to managing postgres database operations for <see cref="PostgresMemoryStore"/>.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "We need to build the full table name using schema and collection, it does not support parameterized passing.")]
+[Experimental("SKEXP0020")]
 public class PostgresDbClient : IPostgresDbClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Memory;
 using Npgsql;
 
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Postgres connector.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class PostgresMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryEntry.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryEntry.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Pgvector;
 
 namespace Microsoft.SemanticKernel.Connectors.Postgres;
@@ -8,6 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// <summary>
 /// A postgres memory entry.
 /// </summary>
+[Experimental("SKEXP0020")]
 public record struct PostgresMemoryEntry
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -20,6 +21,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// The embedded data is saved to the Postgres database specified in the constructor.
 /// Similarity search capability is provided through the pgvector extension. Use Postgres's "Table" to implement "Collection".
 /// </remarks>
+[Experimental("SKEXP0020")]
 public class PostgresMemoryStore : IMemoryStore, IDisposable
 {
     internal const string DefaultSchema = "public";

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStore.cs
@@ -32,7 +32,7 @@ public class PostgresVectorStore : IVectorStore
     /// <summary>
     /// Initializes a new instance of the <see cref="PostgresVectorStore"/> class.
     /// </summary>
-    /// <param name="postgresDbClient">An instance of <see cref="IPostgresDbClient"/>.</param>
+    /// <param name="postgresDbClient">An instance of <see cref="IPostgresVectorStoreDbClient"/>.</param>
     /// <param name="options">Optional configuration options for this class</param>
     internal PostgresVectorStore(IPostgresVectorStoreDbClient postgresDbClient, PostgresVectorStoreOptions? options = default)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/AssemblyInfo.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/AssemblyInfo.cs
@@ -1,6 +1,1 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using System.Diagnostics.CodeAnalysis;
-
-// This assembly is currently experimental.
-[assembly: Experimental("SKEXP0020")]

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/Connectors.Memory.SqlServer.csproj
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/Connectors.Memory.SqlServer.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.SqlServer</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-    <VersionSuffix>alpha</VersionSuffix>
+    <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/ISqlServerClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/ISqlServerClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// <summary>
 /// Interface for client managing SQL Server or Azure SQL database operations.
 /// </summary>
+[Experimental("SKEXP0020")]
 internal interface ISqlServerClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerClient.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// Implementation of database client managing SQL Server or Azure SQL database operations.
 /// </summary>
 [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "We need to build the full table name using schema and collection, it does not support parameterized passing.")]
+[Experimental("SKEXP0020")]
 internal sealed class SqlServerClient : ISqlServerClient
 {
     private readonly SqlConnection _connection;

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.SqlServer;
@@ -7,6 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure SQL Server or Azure SQL connector.
 /// </summary>
+[Experimental("SKEXP0020")]
 public static class SqlServerMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryEntry.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryEntry.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 
 /// <summary>
 /// A SQL Server or Azure SQL memory entry.
 /// </summary>
+[Experimental("SKEXP0020")]
 internal record struct SqlServerMemoryEntry
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryStore.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a SQL Server or Azure SQL database.
 /// </summary>
+[Experimental("SKEXP0020")]
 public class SqlServerMemoryStore : IMemoryStore, IDisposable
 {
     internal const string DefaultSchema = "dbo";


### PR DESCRIPTION
### Motivation and Context

As we add vector store implementations to our connectors, we are moving them to preview and limiting experimental only to the memory store implementation.

### Description

- Update Postgres connector from alpha to preview and limit experimental to memorystore only
- Update SqlServer connector from alpha to preview and limit experimental to memorystore only

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
