### PR TITLE
.Net: Make a few OpenAPI APIs non-experimental

### DIFF
--- a/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/Extensions/OpenApiFunctionExecutionParameters.cs
@@ -47,7 +47,6 @@ public class OpenApiFunctionExecutionParameters
     /// To support more complex payloads, it should be disabled and the payload should be provided via the 'payload' argument.
     /// See the 'Providing Payload for OpenAPI Functions' ADR for more details: https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0062-open-api-payload.md
     /// </summary>
-    [Experimental("SKEXP0040")]
     public bool EnableDynamicPayload { get; set; }
 
     /// <summary>
@@ -58,7 +57,6 @@ public class OpenApiFunctionExecutionParameters
     /// the parameters 'sender.email' and 'sender.receiver' will be correctly resolved from arguments with the same names.
     /// See the 'Providing Payload for OpenAPI Functions' ADR for more details: https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0062-open-api-payload.md
     /// </summary>
-    [Experimental("SKEXP0040")]
     public bool EnablePayloadNamespacing { get; set; }
 
     /// <summary>
@@ -84,7 +82,6 @@ public class OpenApiFunctionExecutionParameters
     /// changing response content, adjusting the schema, or providing a completely new response.
     /// If a custom factory is not supplied, the internal factory will be used by default.
     /// </summary>
-    [Experimental("SKEXP0040")]
     public RestApiOperationResponseFactory? RestApiOperationResponseFactory { get; set; }
 
     /// <summary>

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactory.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,5 +11,4 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <param name="context">The context that contains the operation details.</param>
 /// <param name="cancellationToken">The cancellation token used to signal cancellation.</param>
 /// <returns>A task that represents the asynchronous operation, containing an instance of <see cref="RestApiOperationResponse"/>.</returns>
-[Experimental("SKEXP0040")]
 public delegate Task<RestApiOperationResponse> RestApiOperationResponseFactory(RestApiOperationResponseFactoryContext context, CancellationToken cancellationToken = default);

--- a/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
+++ b/dotnet/src/Functions/Functions.OpenApi/RestApiOperationResponseFactoryContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Plugins.OpenApi;
@@ -8,7 +7,6 @@ namespace Microsoft.SemanticKernel.Plugins.OpenApi;
 /// <summary>
 /// Represents the context for the <see cref="RestApiOperationResponseFactory"/>."/>
 /// </summary>
-[Experimental("SKEXP0040")]
 public sealed class RestApiOperationResponseFactoryContext
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
@@ -47,7 +47,6 @@ public sealed class RestApiOperationResponse
     /// <summary>
     /// The response headers.
     /// </summary>
-    [Experimental("SKEXP0040")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IDictionary<string, IEnumerable<string>>? Headers { get; set; }
 


### PR DESCRIPTION
### Motivation and Context

Some OpenAPI APIs have been available for a while and can be considered stable.