### PR TITLE
.Net: don't use a mutable static counter for tests that can run in parallel

### DIFF
--- a/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalMapTests.cs
+++ b/dotnet/src/Experimental/Process.UnitTests/Runtime.Local/LocalMapTests.cs
@@ -261,8 +261,7 @@ public class LocalMapTests
             .SendEventTo(new ProcessFunctionTargetBuilder(mapStep));
 
         // CountStep is not part of the map operation, rather it has been defined on the "outer" process.
-        CommonSteps.CountStep.Index = 0; // Reset static state (test hack)
-        ProcessStepBuilder countStep = process.AddStepFromType<CommonSteps.CountStep>();
+        ProcessStepBuilder countStep = process.AddStepFromType<CommonSteps.CountStep>(name: nameof(ProcessMapResultWithTargetInvalidAsync));
         mapStep.MapOperation
             .OnEvent(ComputeStep.SquareEventId)
             .SendEventTo(new ProcessFunctionTargetBuilder(countStep));
@@ -287,7 +286,6 @@ public class LocalMapTests
     public async Task ProcessMapResultWithTargetExtraAsync()
     {
         // Arrange
-        CommonSteps.CountStep.Index = 0;
         ProcessBuilder process = new(nameof(ProcessMapResultProcessOperationAsync));
 
         ProcessBuilder mapProcess = new("MapOperation");
@@ -296,7 +294,8 @@ public class LocalMapTests
             .OnInputEvent("Anything")
             .SendEventTo(new ProcessFunctionTargetBuilder(computeStep));
 
-        ProcessStepBuilder countStep = mapProcess.AddStepFromType<CommonSteps.CountStep>();
+        const string CounterName = nameof(ProcessMapResultWithTargetExtraAsync);
+        ProcessStepBuilder countStep = mapProcess.AddStepFromType<CommonSteps.CountStep>(name: CounterName);
         computeStep
             .OnEvent(ComputeStep.SquareEventId)
             .SendEventTo(new ProcessFunctionTargetBuilder(countStep));
@@ -320,7 +319,7 @@ public class LocalMapTests
         // Assert
         UnionState unionState = await GetUnionStateAsync(processContext);
         Assert.Equal(55L, unionState.SquareResult);
-        Assert.Equal(5, CommonSteps.CountStep.Index);
+        Assert.Equal(5, CommonSteps.CountStep.GetCount(CounterName));
     }
 
     /// <summary>


### PR DESCRIPTION
By default, xUnit runs tests in parallel. What we were  doing so far was having a static, mutable counter that some tests were setting to 0, while other could use in the meantime (increment or read and assert).

I've changed it to use a static dictionary of counters, where the name of the step is the key. So each step has it's own counter.

fixes #11001