### PR TITLE
.Net: Obsolete the IMemoryStore where an IVectorStore implementation exists

### DIFF
--- a/dotnet/samples/Concepts/Memory/HuggingFace_TextEmbeddingCustomHttpHandler.cs
+++ b/dotnet/samples/Concepts/Memory/HuggingFace_TextEmbeddingCustomHttpHandler.cs
@@ -15,6 +15,7 @@ namespace Memory;
 /// For example, the <a href="https://huggingface.co/cointegrated/LaBSE-en-ru">cointegrated/LaBSE-en-ru</a> model returns results as a 1 * 1 * 4 * 768 matrix, which is different from Hugging Face embedding generation service implementation.
 /// To address this, a custom <see cref="HttpClientHandler"/> can be used to modify the response before sending it back.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class HuggingFace_TextEmbeddingCustomHttpHandler(ITestOutputHelper output) : BaseTest(output)
 {
     public async Task RunInferenceApiEmbeddingCustomHttpHandlerAsync()

--- a/dotnet/samples/Concepts/Memory/SemanticTextMemory_Building.cs
+++ b/dotnet/samples/Concepts/Memory/SemanticTextMemory_Building.cs
@@ -14,6 +14,7 @@ namespace Memory;
  * Semantic Memory allows to store your data like traditional DBs,
  * adding the ability to query it using natural language.
  */
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class SemanticTextMemory_Building(ITestOutputHelper output) : BaseTest(output)
 {
     private const string MemoryCollectionName = "SKGitHub";

--- a/dotnet/samples/Concepts/Memory/TextMemoryPlugin_MultipleMemoryStore.cs
+++ b/dotnet/samples/Concepts/Memory/TextMemoryPlugin_MultipleMemoryStore.cs
@@ -20,6 +20,7 @@ using StackExchange.Redis;
 
 namespace Memory;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class TextMemoryPlugin_MultipleMemoryStore(ITestOutputHelper output) : BaseTest(output)
 {
     private const string MemoryCollectionName = "aboutMe";

--- a/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_AzureAISearch.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_AzureAISearch.cs
@@ -26,6 +26,7 @@ namespace Memory;
 /// dotnet user-secrets set "AzureAISearch:Endpoint" "https://myazureaisearchinstance.search.windows.net"
 /// dotnet user-secrets set "AzureAISearch:ApiKey" "samplesecret"
 /// </remarks>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class VectorStore_ConsumeFromMemoryStore_AzureAISearch(ITestOutputHelper output, VectorStoreQdrantContainerFixture qdrantFixture) : BaseTest(output), IClassFixture<VectorStoreQdrantContainerFixture>
 {
     private const int VectorSize = 1536;

--- a/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_Common.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_Common.cs
@@ -19,6 +19,7 @@ namespace Memory;
 /// <see cref="VectorStore_ConsumeFromMemoryStore_Qdrant"/>
 /// <see cref="VectorStore_ConsumeFromMemoryStore_Redis"/>
 /// </remarks>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public static class VectorStore_ConsumeFromMemoryStore_Common
 {
     public static async Task CreateCollectionAndAddSampleDataAsync(IMemoryStore memoryStore, string collectionName, ITextEmbeddingGenerationService textEmbeddingService)

--- a/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_Qdrant.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_Qdrant.cs
@@ -23,6 +23,7 @@ namespace Memory;
 /// To run this sample, you need a local instance of Docker running, since the associated fixture
 /// will try and start a Qdrant container in the local docker instance to run against.
 /// </remarks>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class VectorStore_ConsumeFromMemoryStore_Qdrant(ITestOutputHelper output, VectorStoreQdrantContainerFixture qdrantFixture) : BaseTest(output), IClassFixture<VectorStoreQdrantContainerFixture>
 {
     private const int VectorSize = 1536;

--- a/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_Redis.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_ConsumeFromMemoryStore_Redis.cs
@@ -22,6 +22,7 @@ namespace Memory;
 /// To run this sample, you need a local instance of Docker running, since the associated fixture
 /// will try and start a Redis container in the local docker instance to run against.
 /// </remarks>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class VectorStore_ConsumeFromMemoryStore_Redis(ITestOutputHelper output, VectorStoreRedisContainerFixture redisFixture) : BaseTest(output), IClassFixture<VectorStoreRedisContainerFixture>
 {
     private const int VectorSize = 1536;

--- a/dotnet/samples/Concepts/Memory/VectorStore_MigrateFromMemoryStore_Redis.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_MigrateFromMemoryStore_Redis.cs
@@ -29,6 +29,7 @@ namespace Memory;
 ///
 /// To run this sample, you need a local instance of Docker running, since the associated fixture will try and start a Redis container in the local docker instance to run against.
 /// </remarks>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class VectorStore_MigrateFromMemoryStore_Redis(ITestOutputHelper output, VectorStoreRedisContainerFixture redisFixture) : BaseTest(output), IClassFixture<VectorStoreRedisContainerFixture>
 {
     private const int VectorSize = 1536;

--- a/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureAISearch.UnitTests/AzureAISearchMemoryStoreTests.cs
@@ -21,6 +21,7 @@ namespace SemanticKernel.Connectors.UnitTests.Memory.AzureAISearch;
 /// <summary>
 /// Unit tests for <see cref="AzureAISearchMemoryStore"/> class.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class AzureAISearchMemoryStoreTests
 {
     private readonly Mock<SearchIndexClient> _mockSearchIndexClient = new();

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryRecord.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// Azure AI Search record and index definition.
 /// Note: once defined, index cannot be modified.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureAISearchVectorStore")]
 internal sealed class AzureAISearchMemoryRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchMemoryStore.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -21,10 +20,12 @@ using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// <see cref="AzureAISearchMemoryStore"/> is a memory store implementation using Azure AI Search.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureAISearchVectorStore")]
 public partial class AzureAISearchMemoryStore : IMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConfig.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConfig.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using Microsoft.SemanticKernel.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <remarks>
 /// Initialize the <see cref="AzureCosmosDBMongoDBConfig"/> with default values.
 /// </remarks>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 public class AzureCosmosDBMongoDBConfig(int dimensions)
 {
     private const string DefaultIndexName = "default_index";

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConfig.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBConfig.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <remarks>
 /// Initialize the <see cref="AzureCosmosDBMongoDBConfig"/> with default values.
 /// </remarks>
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 public class AzureCosmosDBMongoDBConfig(int dimensions)
 {
     private const string DefaultIndexName = "default_index";

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecord.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// A MongoDB memory record.
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 internal sealed class AzureCosmosDBMongoDBMemoryRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecord.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson;
@@ -10,10 +9,12 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// A MongoDB memory record.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 internal sealed class AzureCosmosDBMongoDBMemoryRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
@@ -1,16 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// A MongoDB memory record metadata.
 /// </summary>
 #pragma warning disable CA1815 // Override equals and operator equals on value types
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 internal struct AzureCosmosDBMongoDBMemoryRecordMetadata
 #pragma warning restore CA1815 // Override equals and operator equals on value types
 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryRecordMetadata.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// A MongoDB memory record metadata.
 /// </summary>
 #pragma warning disable CA1815 // Override equals and operator equals on value types
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 internal struct AzureCosmosDBMongoDBMemoryRecordMetadata
 #pragma warning restore CA1815 // Override equals and operator equals on value types
 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -14,11 +13,13 @@ using MongoDB.Driver;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a Azure CosmosDB Mongo vCore database.
 /// Get more details about Azure Cosmos Mongo vCore vector search  https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 public class AzureCosmosDBMongoDBMemoryStore : IMemoryStore, IDisposable
 {
     private readonly MongoClient _mongoClient;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStore.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// An implementation of <see cref="IMemoryStore"/> backed by a Azure CosmosDB Mongo vCore database.
 /// Get more details about Azure Cosmos Mongo vCore vector search  https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 public class AzureCosmosDBMongoDBMemoryStore : IMemoryStore, IDisposable
 {
     private readonly MongoClient _mongoClient;

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBSimilarityType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBSimilarityType.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Similarity metric to use with the index. Possible options are COS (cosine distance), L2 (Euclidean distance), and IP (inner product).
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 public enum AzureCosmosDBSimilarityType
 {
     /// <summary>
@@ -33,7 +33,7 @@ public enum AzureCosmosDBSimilarityType
     Euclidean
 }
 
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 internal static class AzureCosmosDBSimilarityTypeExtensions
 {
     public static string GetCustomName(this AzureCosmosDBSimilarityType type)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBSimilarityType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBSimilarityType.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Reflection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Similarity metric to use with the index. Possible options are COS (cosine distance), L2 (Euclidean distance), and IP (inner product).
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 public enum AzureCosmosDBSimilarityType
 {
     /// <summary>
@@ -33,7 +33,7 @@ public enum AzureCosmosDBSimilarityType
     Euclidean
 }
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 internal static class AzureCosmosDBSimilarityTypeExtensions
 {
     public static string GetCustomName(this AzureCosmosDBSimilarityType type)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBVectorSearchType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBVectorSearchType.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Reflection;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Type of vector index to create. The options are vector-ivf and vector-hnsw.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 public enum AzureCosmosDBVectorSearchType
 {
     /// <summary>
@@ -26,7 +26,7 @@ public enum AzureCosmosDBVectorSearchType
     VectorHNSW
 }
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
 internal static class AzureCosmosDBVectorSearchTypeExtensions
 {
     public static string GetCustomName(this AzureCosmosDBVectorSearchType type)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBVectorSearchType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBVectorSearchType.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Type of vector index to create. The options are vector-ivf and vector-hnsw.
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 public enum AzureCosmosDBVectorSearchType
 {
     /// <summary>
@@ -26,7 +26,7 @@ public enum AzureCosmosDBVectorSearchType
     VectorHNSW
 }
 
-[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being phased out, use Microsoft.Extensions.VectorData and AzureMongoDBMongoDBVectorStore")]
 internal static class AzureCosmosDBVectorSearchTypeExtensions
 {
     public static string GetCustomName(this AzureCosmosDBVectorSearchType type)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -18,11 +17,13 @@ using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a Azure Cosmos DB database.
 /// Get more details about Azure Cosmos DB vector search  https://learn.microsoft.com/en-us/azure/cosmos-db/
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLMemoryStore")]
 public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 {
     private const string EmbeddingPath = "/embedding";
@@ -289,7 +290,7 @@ public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
         var queryStart = $"""
             SELECT x.id,x.key,x.metadata,x.timestamp{(withEmbeddings ? ",x.embedding" : "")}
             FROM x
-            WHERE 
+            WHERE
             """;
         // NOTE: Cosmos DB queries are limited to 512kB, so we'll break this into chunks
         // of around 500kB. We don't go all the way to 512kB so that we don't have to
@@ -446,7 +447,7 @@ public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 /// <param name="timestamp"></param>
 [DebuggerDisplay("{GetDebuggerDisplay()}")]
 #pragma warning disable CA1812 // 'MemoryRecordWithSimilarityScore' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic). (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812)
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLMemoryStore")]
 internal sealed class MemoryRecordWithSimilarityScore(
 #pragma warning restore CA1812
     MemoryRecordMetadata metadata,
@@ -468,7 +469,7 @@ internal sealed class MemoryRecordWithSimilarityScore(
 /// <summary>
 /// Creates a new record that also serializes an "id" property.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLMemoryStore")]
 [DebuggerDisplay("{GetDebuggerDisplay()}")]
 internal sealed class MemoryRecordWithId : MemoryRecord
 {

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStore.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// An implementation of <see cref="IMemoryStore"/> backed by a Azure Cosmos DB database.
 /// Get more details about Azure Cosmos DB vector search  https://learn.microsoft.com/en-us/azure/cosmos-db/
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLVectorStore")]
 public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 {
     private const string EmbeddingPath = "/embedding";
@@ -447,7 +447,7 @@ public class AzureCosmosDBNoSQLMemoryStore : IMemoryStore, IDisposable
 /// <param name="timestamp"></param>
 [DebuggerDisplay("{GetDebuggerDisplay()}")]
 #pragma warning disable CA1812 // 'MemoryRecordWithSimilarityScore' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic). (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812)
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLVectorStore")]
 internal sealed class MemoryRecordWithSimilarityScore(
 #pragma warning restore CA1812
     MemoryRecordMetadata metadata,
@@ -469,7 +469,7 @@ internal sealed class MemoryRecordWithSimilarityScore(
 /// <summary>
 /// Creates a new record that also serializes an "id" property.
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLMemoryStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and AzureCosmosDBNoSQLVectorStore")]
 [DebuggerDisplay("{GetDebuggerDisplay()}")]
 internal sealed class MemoryRecordWithId : MemoryRecord
 {

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryEntry.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryEntry.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// A MongoDB memory entry.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and MongoDBVectorStore")]
 public sealed class MongoDBMemoryEntry
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryRecordMetadata.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryRecordMetadata.cs
@@ -1,16 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using Microsoft.SemanticKernel.Memory;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// A MongoDB record metadata.
 /// </summary>
 #pragma warning disable CA1815 // Override equals and operator equals on value types
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and MongoDBVectorStore")]
 public struct MongoDBMemoryRecordMetadata
 #pragma warning restore CA1815 // Override equals and operator equals on value types
 {

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,10 +11,12 @@ using MongoDB.Driver.Core.Configuration;
 
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a MongoDB database.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and MongoDBVectorStore")]
 public class MongoDBMemoryStore : IMemoryStore, IDisposable
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ConfigureIndexRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ConfigureIndexRequest.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// This operation specifies the pod type and number of replicas for an index.
 /// See https://docs.pinecone.io/reference/configure_index
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class ConfigureIndexRequest
 {
     public string IndexName { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteIndexRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteIndexRequest.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Deletes an index and all its data.
 /// See https://docs.pinecone.io/reference/delete_index
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class DeleteIndexRequest
 {
     public static DeleteIndexRequest Create(string indexName)

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DeleteRequest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// DeleteRequest
 /// See https://docs.pinecone.io/reference/delete_post
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class DeleteRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexRequest.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Get information about an index.
 /// See https://docs.pinecone.io/reference/describe_index
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class DescribeIndexRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexStatsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/DescribeIndexStatsRequest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// DescribeIndexStatsRequest
 /// See https://docs.pinecone.io/reference/describe_index_stats_post
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class DescribeIndexStatsRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchRequest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// FetchRequest
 /// See https://docs.pinecone.io/reference/fetch
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class FetchRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/FetchResponse.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json.Serialization;
 
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// FetchResponse
 /// See https://docs.pinecone.io/reference/fetch
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class FetchResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ListIndexesRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/ListIndexesRequest.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// ListIndexesRequest
 /// See https://docs.pinecone.io/reference/list_indexes
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class ListIndexesRequest
 {
     public static ListIndexesRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryRequest.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -12,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// QueryRequest
 /// See https://docs.pinecone.io/reference/query
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class QueryRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/QueryResponse.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// QueryResponse
 /// See https://docs.pinecone.io/reference/query
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class QueryResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpdateVectorRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpdateVectorRequest.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -14,7 +13,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// If a set_metadata is included, the values of the fields specified in it will be added or overwrite the previous value.
 /// See https://docs.pinecone.io/reference/update
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class UpdateVectorRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertRequest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// UpsertRequest
 /// See https://docs.pinecone.io/reference/upsert
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class UpsertRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Http/ApiSchema/UpsertResponse.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// UpsertResponse
 /// See https://docs.pinecone.io/reference/upsert
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class UpsertResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeClient.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Interface for a Pinecone client
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public interface IPineconeClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/IPineconeMemoryStore.cs
@@ -2,18 +2,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// Interface for Pinecone memory store that extends the memory store interface
 /// to add support for namespaces
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public interface IPineconeMemoryStore : IMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexDefinition.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexDefinition.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -11,7 +11,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Used to create a new index.
 /// See https://docs.pinecone.io/reference/create_index
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class IndexDefinition
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetadataConfig.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetadataConfig.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.Memory;
 
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed; when metadata_config is present, only specified metadata fields are indexed.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class MetadataIndexConfig
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetric.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexMetric.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// The vector similarity metric of the index
 /// </summary>
 /// <value>The vector similarity metric of the index</value>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum IndexMetric
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexNamespaceStats.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexNamespaceStats.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Index namespace parameters.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class IndexNamespaceStats
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexState.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexState.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// The current status of a index.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum IndexState
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStats.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStats.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Index parameters.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class IndexStats
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStatus.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/IndexStatus.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Status of the index.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class IndexStatus
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/OperationType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/OperationType.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal enum OperationType
 {
     Upsert,

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PineconeIndex.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PineconeIndex.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Index entity.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public sealed class PineconeIndex
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PodType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/PodType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -13,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Pod type of the index, see https://docs.pinecone.io/docs/indexes#pods-pod-types-and-pod-sizes.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 [JsonConverter(typeof(PodTypeJsonConverter))]
 public enum PodType
 {
@@ -108,7 +107,7 @@ public enum PodType
 }
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 internal sealed class PodTypeJsonConverter : JsonConverter<PodType>
 #pragma warning restore CA1812
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/Query.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/Query.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -10,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Query parameters for use in a query request.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public sealed class Query
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/SparseVectorData.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/Model/SparseVectorData.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
@@ -10,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Represents a sparse vector data, which is a list of indices and a list of corresponding values, both of the same length.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class SparseVectorData
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// A client for the Pinecone API
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public sealed class PineconeClient : IPineconeClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocument.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocument.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Pinecone Document entity.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class PineconeDocument
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocumentExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeDocumentExtensions.cs
@@ -2,17 +2,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// Extensions for <see cref="PineconeDocument"/> class.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public static class PineconeDocumentExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryBuilderExtensions.cs
@@ -1,16 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Pinecone connector.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public static class PineconeMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -12,6 +11,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Pinecone;
+
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
 
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> for Pinecone Vector database.
@@ -23,7 +24,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// For that reason, we use the term "Index" in Pinecone to refer to what is a "Collection" in IMemoryStore. So, in the case of Pinecone,
 ///  "Collection" is synonymous with "Index" when referring to IMemoryStore.
 /// </remarks>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public class PineconeMemoryStore : IPineconeMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeUtils.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeUtils.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -16,7 +15,7 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// <summary>
 /// Utils for Pinecone connector.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PineconeVectorStore")]
 public static class PineconeUtils
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/IPostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/IPostgresDbClient.cs
@@ -2,17 +2,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Pgvector;
 
 namespace Microsoft.SemanticKernel.Connectors.Postgres;
 
+#pragma warning disable SKEXP0020
+
 /// <summary>
 /// Interface for client managing postgres database operations for <see cref="PostgresMemoryStore"/>.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PostgresVectorStore")]
 public interface IPostgresDbClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresDbClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// An implementation of a client for Postgres. This class is used to managing postgres database operations for <see cref="PostgresMemoryStore"/>.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "We need to build the full table name using schema and collection, it does not support parameterized passing.")]
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PostgresVectorStore")]
 public class PostgresDbClient : IPostgresDbClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresDbClient.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using Microsoft.SemanticKernel.Memory;
 using Npgsql;
 
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Postgres connector.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PostgresVectorStore")]
 public static class PostgresMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryBuilderExtensions.cs
@@ -6,6 +6,8 @@ using Npgsql;
 
 namespace Microsoft.SemanticKernel.Connectors.Postgres;
 
+#pragma warning disable SKEXP0001
+
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Postgres connector.
 /// </summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryEntry.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryEntry.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Pgvector;
 
 namespace Microsoft.SemanticKernel.Connectors.Postgres;
@@ -9,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// <summary>
 /// A postgres memory entry.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PostgresVectorStore")]
 public record struct PostgresMemoryEntry
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -14,6 +13,8 @@ using Pgvector;
 
 namespace Microsoft.SemanticKernel.Connectors.Postgres;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a Postgres database with pgvector extension.
 /// </summary>
@@ -21,7 +22,7 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// The embedded data is saved to the Postgres database specified in the constructor.
 /// Similarity search capability is provided through the pgvector extension. Use Postgres's "Table" to implement "Collection".
 /// </remarks>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and PostgresVectorStore")]
 public class PostgresMemoryStore : IMemoryStore, IDisposable
 {
     internal const string DefaultSchema = "public";

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/CreateCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/CreateCollectionRequest.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class CreateCollectionRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteCollectionRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class DeleteCollectionRequest
 {
     public static DeleteCollectionRequest Create(string collectionName)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsRequest.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class DeleteVectorsRequest
 {
     [JsonPropertyName("points")]

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/DeleteVectorsResponse.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
@@ -8,6 +8,6 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// Empty qdrant response for requests that return nothing but status / error.
 /// </summary>
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes. Justification: deserialized by QdrantVectorDbClient.DeleteVectorsByIdAsync & QdrantVectorDbClient.DeleteVectorByPayloadIdAsync
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class DeleteVectorsResponse : QdrantResponse;
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetCollectionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetCollectionRequest.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class GetCollectionsRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsRequest.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class GetVectorsRequest
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/GetVectorsResponse.cs
@@ -2,13 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class GetVectorsResponse : QdrantResponse
 {
     internal sealed class Record

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class ListCollectionsRequest
 {
     public static ListCollectionsRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/ListCollectionsResponse.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class ListCollectionsResponse : QdrantResponse
 {
     internal sealed class CollectionResult

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/NumberToStringConverter.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/NumberToStringConverter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +8,7 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class NumberToStringConverter : JsonConverter<string>
 {
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/QdrantResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/QdrantResponse.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Base class for Qdrant response schema.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal abstract class QdrantResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsRequest.cs
@@ -2,13 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class SearchVectorsRequest
 {
     [JsonPropertyName("vector")]

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/SearchVectorsResponse.cs
@@ -2,13 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class SearchVectorsResponse : QdrantResponse
 {
     internal sealed class ScoredPoint

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorRequest.cs
@@ -2,13 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class UpsertVectorRequest
 {
     public static UpsertVectorRequest Create(string collectionName)

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/Http/ApiSchema/UpsertVectorResponse.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes: Used for Json Deserialization
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 internal sealed class UpsertVectorResponse : QdrantResponse
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/IQdrantVectorDbClient.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// Interface for a Qdrant vector database client.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 public interface IQdrantVectorDbClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantDistanceType.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantDistanceType.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// The vector distance type used by Qdrant.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 public enum QdrantDistanceType
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryBuilderExtensions.cs
@@ -1,16 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Qdrant connector.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 public static class QdrantMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -14,13 +13,15 @@ using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> for Qdrant Vector Database.
 /// </summary>
 /// <remarks>The Embedding data is saved to a Qdrant Vector Database instance specified in the constructor by url and port.
 /// The embedding data persists between subsequent instances and has similarity search capability.
 /// </remarks>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 public class QdrantMemoryStore : IMemoryStore
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorDbClient.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -21,7 +20,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// connect, create, delete, and get embeddings data from a Qdrant Vector Database instance.
 /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 public sealed class QdrantVectorDbClient : IQdrantVectorDbClient
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecord.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorRecord.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// <summary>
 /// A record structure used by Qdrant that contains an embedding and metadata.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and QdrantVectorStore")]
 public class QdrantVectorRecord
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -18,13 +17,15 @@ using static NRedisStack.Search.Schema.VectorField;
 
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> for Redis.
 /// </summary>
 /// <remarks>The embedded data is saved to the Redis server database specified in the constructor.
 /// Similarity search capability is provided through the RediSearch module. Use RediSearch's "Index" to implement "Collection".
 /// </remarks>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and RedisVectorStore")]
 public class RedisMemoryStore : IMemoryStore, IDisposable
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorDistanceMetric.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisVectorDistanceMetric.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Redis;
 
@@ -8,7 +8,7 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// Supported distance metrics are {L2, IP, COSINE}. The default value is "COSINE".
 /// <see href="https://redis.io/docs/interact/search-and-query/search/vectors/"/>
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and RedisVectorStore")]
 public enum VectorDistanceMetric
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/ISqlServerClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/ISqlServerClient.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,7 +10,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// <summary>
 /// Interface for client managing SQL Server or Azure SQL database operations.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqlServerVectorStore")]
 internal interface ISqlServerClient
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// Implementation of database client managing SQL Server or Azure SQL database operations.
 /// </summary>
 [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "We need to build the full table name using schema and collection, it does not support parameterized passing.")]
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqlServerVectorStore")]
 internal sealed class SqlServerClient : ISqlServerClient
 {
     private readonly SqlConnection _connection;

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryBuilderExtensions.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 
+#pragma warning disable SKEXP0001
+
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure SQL Server or Azure SQL connector.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqlServerVectorStore")]
 public static class SqlServerMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryEntry.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryEntry.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 
 /// <summary>
 /// A SQL Server or Azure SQL memory entry.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqlServerVectorStore")]
 internal record struct SqlServerMemoryEntry
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,10 +10,12 @@ using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 
+#pragma warning disable SKEXP0001
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a SQL Server or Azure SQL database.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqlServerVectorStore")]
 public class SqlServerMemoryStore : IMemoryStore, IDisposable
 {
     internal const string DefaultSchema = "dbo";

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/Database.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -10,7 +10,7 @@ using Microsoft.Data.Sqlite;
 
 namespace Microsoft.SemanticKernel.Connectors.Sqlite;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal struct DatabaseEntry
 {
     public string Key { get; set; }
@@ -22,7 +22,7 @@ internal struct DatabaseEntry
     public string? Timestamp { get; set; }
 }
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class Database
 {
     private const string TableName = "SKMemoryTable";

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Numerics.Tensors;
@@ -16,13 +15,15 @@ using Microsoft.SemanticKernel.Text;
 
 namespace Microsoft.SemanticKernel.Connectors.Sqlite;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore"/> backed by a SQLite database.
 /// </summary>
 /// <remarks>The data is saved to a database file, specified in the constructor.
 /// The data persists between subsequent instances. Only one instance may access the file at a time.
 /// The caller is responsible for deleting the file.</remarks>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 public class SqliteMemoryStore : IMemoryStore, IDisposable
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchRequest.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class BatchRequest
 {
     private readonly string _class;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/BatchResponse.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 #pragma warning disable CA1812 // 'BatchResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class BatchResponse : WeaviateObject
 #pragma warning restore CA1812 // 'BatchResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class CreateClassSchemaRequest
 {
     private CreateClassSchemaRequest(string @class, string description)

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaResponse.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'CreateClassSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class CreateClassSchemaResponse
 #pragma warning restore CA1812 // 'CreateClassSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateClassSchemaResponse.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'CreateClassSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class CreateClassSchemaResponse
 #pragma warning restore CA1812 // 'CreateClassSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateGraphRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateGraphRequest.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassCannotBeInstantiated
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class CreateGraphRequest
 {
 #pragma warning disable CS8618

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateGraphRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/CreateGraphRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -9,7 +8,7 @@ using System.Net.Http;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassCannotBeInstantiated
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class CreateGraphRequest
 {
 #pragma warning disable CS8618

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteObjectRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteObjectRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class DeleteObjectRequest
 {
     public string? Class { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteObjectRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteObjectRequest.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class DeleteObjectRequest
 {
     public string? Class { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteSchemaRequest.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class DeleteSchemaRequest
 {
     private readonly string _class;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/DeleteSchemaRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class DeleteSchemaRequest
 {
     private readonly string _class;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassRequest.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GetClassRequest
 {
     private GetClassRequest(string @class)

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassRequest.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class GetClassRequest
 {
     private GetClassRequest(string @class)

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassResponse.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GetClassResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GetClassResponse
 #pragma warning restore CA1812 // 'GetClassResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetClassResponse.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GetClassResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class GetClassResponse
 #pragma warning restore CA1812 // 'GetClassResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetObjectRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetObjectRequest.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GetObjectRequest
 {
     public string? Id { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetObjectRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetObjectRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class GetObjectRequest
 {
     public string? Id { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaRequest.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GetSchemaRequest
 {
     public static GetSchemaRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaRequest.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class GetSchemaRequest
 {
     public static GetSchemaRequest Create()

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaResponse.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GetSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class GetSchemaResponse
 #pragma warning restore CA1812 // 'GetSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GetSchemaResponse.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GetSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GetSchemaResponse
 #pragma warning restore CA1812 // 'GetSchemaResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GraphResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GraphResponse.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class GraphResponse
 #pragma warning restore CA1812 // 'GraphResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GraphResponse.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/GraphResponse.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Nodes;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GraphResponse
 #pragma warning restore CA1812 // 'GraphResponse' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/ObjectResponseResult.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/ApiSchema/ObjectResponseResult.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 #pragma warning disable CA1812 // 'ObjectResponseResult' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class ObjectResponseResult
 #pragma warning restore CA1812 // 'ObjectResponseResult' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/JsonConverter/UnixSecondsDateTimeJsonConverter.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/JsonConverter/UnixSecondsDateTimeJsonConverter.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'UnixSecondsDateTimeJsonConverter' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 internal sealed class UnixSecondsDateTimeJsonConverter : JsonConverter<DateTime?>
 #pragma warning restore CA1812 // 'UnixSecondsDateTimeJsonConverter' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/JsonConverter/UnixSecondsDateTimeJsonConverter.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Http/JsonConverter/UnixSecondsDateTimeJsonConverter.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'UnixSecondsDateTimeJsonConverter' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class UnixSecondsDateTimeJsonConverter : JsonConverter<DateTime?>
 #pragma warning restore CA1812 // 'UnixSecondsDateTimeJsonConverter' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Deprecation.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Deprecation.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'Deprecation' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class Deprecation
 #pragma warning restore CA1812 // 'Deprecation' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphError.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphError.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphError' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GraphError
 #pragma warning restore CA1812 // 'GraphError' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphErrorLocationsItems.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/GraphErrorLocationsItems.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
 #pragma warning disable CA1812 // 'GraphErrorLocationsItems' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class GraphErrorLocationsItems
 #pragma warning restore CA1812 // 'GraphErrorLocationsItems' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic).
 {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Property.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/Property.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal sealed class Property
 {
     public string? Name { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/WeaviateObject.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/Model/WeaviateObject.cs
@@ -2,11 +2,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 internal class WeaviateObject
 {
     public string? Id { get; set; }

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Weaviate connector.
 /// </summary>
-[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 public static class WeaviateMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryBuilderExtensions.cs
@@ -1,16 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 using System.Net.Http;
 using Microsoft.SemanticKernel.Http;
 using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// Provides extension methods for the <see cref="MemoryBuilder"/> class to configure Weaviate connector.
 /// </summary>
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and SqliteVectorStore")]
 public static class WeaviateMemoryBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateMemoryStore.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -21,6 +20,8 @@ using Microsoft.SemanticKernel.Memory;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+#pragma warning disable SKEXP0001 // IMemoryStore is experimental (but we're obsoleting)
+
 /// <summary>
 /// An implementation of <see cref="IMemoryStore" /> for Weaviate.
 /// </summary>
@@ -29,7 +30,7 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// </remarks>
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
-[Experimental("SKEXP0020")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted, use Microsoft.Extensions.VectorData and WeaviateVectorStore")]
 public partial class WeaviateMemoryStore : IMemoryStore
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable. No need to dispose the Http client here. It can either be an internal client using NonDisposableHttpClientHandler or an external client managed by the calling code, which should handle its disposal.
 {

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeMemoryStoreTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace SemanticKernel.Connectors.Pinecone.UnitTests;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class PineconeMemoryStoreTests
 {
     private readonly string _id = "Id";

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeUtilsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeUtilsTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace SemanticKernel.Connectors.Pinecone.UnitTests;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class PineconeUtilsTests
 {
     [Fact]

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryBuilderExtensionsTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace SemanticKernel.Connectors.Qdrant.UnitTests;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class QdrantMemoryBuilderExtensionsTests : IDisposable
 {
     private readonly HttpMessageHandlerStub _messageHandlerStub;

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryStoreTests.cs
@@ -17,6 +17,7 @@ namespace SemanticKernel.Connectors.Qdrant.UnitTests;
 /// <summary>
 /// Tests for <see cref="QdrantMemoryStore"/> collection and upsert operations.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class QdrantMemoryStoreTests
 {
     private readonly string _id = "Id";

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryStoreTests2.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryStoreTests2.cs
@@ -16,6 +16,7 @@ namespace SemanticKernel.Connectors.Qdrant.UnitTests;
 /// <summary>
 /// Tests for <see cref="QdrantMemoryStore"/> Get and Remove operations.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class QdrantMemoryStoreTests2
 {
     private readonly string _id = "Id";

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryStoreTests3.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantMemoryStoreTests3.cs
@@ -20,6 +20,7 @@ namespace SemanticKernel.Connectors.Qdrant.UnitTests;
 /// <summary>
 /// Tests for <see cref="QdrantMemoryStore"/> Search operations.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class QdrantMemoryStoreTests3
 {
     private readonly string _id = "Id";

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorDbClientTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorDbClientTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace SemanticKernel.Connectors.Qdrant.UnitTests;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class QdrantVectorDbClientTests : IDisposable
 {
     private readonly HttpMessageHandlerStub _messageHandlerStub;

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisMemoryStoreTests.cs
@@ -20,6 +20,7 @@ namespace SemanticKernel.Connectors.Redis.UnitTests;
 /// <summary>
 /// Unit tests of <see cref="RedisMemoryStore"/>.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class RedisMemoryStoreTests
 {
     private readonly Mock<IDatabase> _mockDatabase;

--- a/dotnet/src/Connectors/Connectors.Sqlite.UnitTests/SqliteMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Sqlite.UnitTests/SqliteMemoryStoreTests.cs
@@ -16,6 +16,7 @@ namespace SemanticKernel.Connectors.Sqlite.UnitTests;
 /// Unit tests of <see cref="SqliteMemoryStore"/>.
 /// </summary>
 [Collection("Sequential")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class SqliteMemoryStoreTests : IDisposable
 {
     private const string DatabaseFile = "SqliteMemoryStoreTests.db";

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/MongoDB/MongoDBMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/MongoDB/MongoDBMemoryStoreTests.cs
@@ -17,6 +17,7 @@ namespace SemanticKernel.Connectors.UnitTests.MongoDB;
 /// <summary>
 /// Unit tests for <see cref="MongoDBMemoryStore"/> class.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class MongoDBMemoryStoreTests
 {
     private const string CollectionName = "test-collection";

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Postgres/PostgresMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Postgres/PostgresMemoryStoreTests.cs
@@ -15,6 +15,7 @@ namespace SemanticKernel.Connectors.UnitTests.Postgres;
 /// <summary>
 /// Unit tests for <see cref="PostgresMemoryStore"/> class.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class PostgresMemoryStoreTests
 {
     private const string CollectionName = "fake-collection-name";

--- a/dotnet/src/Connectors/Connectors.UnitTests/Memory/Sqlite/SqliteMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.UnitTests/Memory/Sqlite/SqliteMemoryStoreTests.cs
@@ -16,6 +16,7 @@ namespace SemanticKernel.Connectors.UnitTests.Sqlite;
 /// Unit tests of <see cref="SqliteMemoryStore"/>.
 /// </summary>
 [Collection("Sequential")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class SqliteMemoryStoreTests : IDisposable
 {
     private const string DatabaseFile = "SqliteMemoryStoreTests.db";

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateMemoryBuilderExtensionsTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateMemoryBuilderExtensionsTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace SemanticKernel.Connectors.UnitTests.Weaviate;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class WeaviateMemoryBuilderExtensionsTests : IDisposable
 {
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateMemoryStoreTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateMemoryStoreTests.cs
@@ -16,6 +16,7 @@ namespace SemanticKernel.Connectors.UnitTests.Weaviate;
 /// <summary>
 /// Unit tests for <see cref="WeaviateMemoryStore"/> class.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class WeaviateMemoryStoreTests : IDisposable
 {
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStoreTests.cs
@@ -13,6 +13,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.AzureCosmosDBMongoDB;
 /// <summary>
 /// Integration tests of <see cref="AzureCosmosDBMongoDBMemoryStore"/>.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class AzureCosmosDBMongoDBMemoryStoreTests : IClassFixture<AzureCosmosDBMongoDBMemoryStoreTestsFixture>
 {
     private const string? SkipReason = "Azure CosmosDB Mongo vCore cluster is required";

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStoreTestsFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBMongoDB/AzureCosmosDBMongoDBMemoryStoreTestsFixture.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Connectors.AzureCosmosDBMongoDB;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class AzureCosmosDBMongoDBMemoryStoreTestsFixture : IAsyncLifetime
 {
     public AzureCosmosDBMongoDBMemoryStore MemoryStore { get; }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStoreTests.cs
@@ -18,6 +18,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.AzureCosmosDBNoSQL;
 /// <summary>
 /// Integration tests of <see cref="AzureCosmosDBNoSQLMemoryStore"/>.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class AzureCosmosDBNoSQLMemoryStoreTests : IClassFixture<AzureCosmosDBNoSQLMemoryStoreTestsFixture>
 {
     private const string? SkipReason = "Azure Cosmos DB Account with Vector indexing enabled required";

--- a/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStoreTestsFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/AzureCosmosDBNoSQL/AzureCosmosDBNoSQLMemoryStoreTestsFixture.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Connectors.AzureCosmosDBNoSQL;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class AzureCosmosDBNoSQLMemoryStoreTestsFixture : IAsyncLifetime
 {
     public AzureCosmosDBNoSQLMemoryStore MemoryStore { get; }

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBMemoryStoreTests.cs
@@ -13,6 +13,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
 /// <summary>
 /// Integration tests of <see cref="MongoDBMemoryStore"/>.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class MongoDBMemoryStoreTests(MongoDBMemoryStoreTestsFixture fixture) : IClassFixture<MongoDBMemoryStoreTestsFixture>
 {
     // If null, all tests will be enabled

--- a/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBMemoryStoreTestsFixture.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBMemoryStoreTestsFixture.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Connectors.MongoDB;
 
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class MongoDBMemoryStoreTestsFixture : IAsyncLifetime
 {
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Postgres/PostgresMemoryStoreTests.cs
@@ -16,6 +16,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Postgres;
 /// <summary>
 /// Integration tests of <see cref="PostgresMemoryStore"/>.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class PostgresMemoryStoreTests : IAsyncLifetime
 {
     // If null, all tests will be enabled

--- a/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateMemoryStoreTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Memory/Weaviate/WeaviateMemoryStoreTests.cs
@@ -17,6 +17,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.Memory.Weaviate;
 /// The Weaviate instance API key is set in the Docker Container as "my-secret-key".
 /// </summary>
 [Collection("Sequential")]
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public sealed class WeaviateMemoryStoreTests : IDisposable
 {
     // If null, all tests will be enabled

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerMemoryStoreTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerMemoryStoreTests.cs
@@ -11,6 +11,7 @@ namespace SemanticKernel.IntegrationTests.Connectors.SqlServer;
 /// <summary>
 /// Unit tests for <see cref="SqlServerMemoryStore"/> class.
 /// </summary>
+[Obsolete("The IMemoryStore abstraction is being obsoleted")]
 public class SqlServerMemoryStoreTests : IAsyncLifetime
 {
     private const string? SkipReason = "Configure SQL Server or Azure SQL connection string and then set this to 'null'.";
@@ -339,7 +340,7 @@ public class SqlServerMemoryStoreTests : IAsyncLifetime
         await connection.OpenAsync();
         cmd.CommandText = $"""
             DECLARE tables_cursor CURSOR FOR
-            SELECT table_name 
+            SELECT table_name
             FROM information_schema.tables
             WHERE table_type = 'BASE TABLE'
                 AND table_schema = '{SchemaName}'

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Support/SqlServerTestEnvironment.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Support/SqlServerTestEnvironment.cs
@@ -17,7 +17,7 @@ internal static class SqlServerTestEnvironment
             .AddJsonFile(path: "testsettings.json", optional: true)
             .AddJsonFile(path: "testsettings.development.json", optional: true)
             .AddEnvironmentVariables()
-            .AddUserSecrets<SqlServerMemoryStore>()
+            .AddUserSecrets<SqlServerVectorStore>()
             .Build();
 
         return configuration.GetSection("SqlServer")["ConnectionString"];


### PR DESCRIPTION
This obsoletes the IMemoryStore implementations for all connectors where a new IVectorStore implementation exists. I've left the other connectors - and the IMemoryStore abstraction itself - un-obsolete for now, since users of those connectors don't yet have an upgrade path. These are still marked as experimental, so we'll be able to obsolete and remove them later.

Closes #10808
