### PR TITLE
.Net MEVD: SqlServerVectorStore should accept a connection string to be thread safe

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/ExceptionWrapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/ExceptionWrapper.cs
@@ -33,6 +33,12 @@ internal static class ExceptionWrapper
         }
         catch (Exception ex)
         {
+#if NET
+            await connection.DisposeAsync().ConfigureAwait(false);
+#else
+            connection.Dispose();
+#endif
+
             throw new VectorStoreOperationException(ex.Message, ex)
             {
                 OperationName = operationName,

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
@@ -12,9 +12,9 @@ namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 /// <summary>
 /// An implementation of <see cref="IVectorStore"/> backed by a SQL Server or Azure SQL database.
 /// </summary>
-public sealed class SqlServerVectorStore : IVectorStore, IDisposable
+public sealed class SqlServerVectorStore : IVectorStore
 {
-    private readonly SqlConnection _connection;
+    private readonly string _connectionString;
     private readonly SqlServerVectorStoreOptions _options;
 
     /// <summary>
@@ -22,9 +22,22 @@ public sealed class SqlServerVectorStore : IVectorStore, IDisposable
     /// </summary>
     /// <param name="connection">Database connection.</param>
     /// <param name="options">Optional configuration options.</param>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public SqlServerVectorStore(SqlConnection connection, SqlServerVectorStoreOptions? options = null)
+        : this(connection?.ConnectionString ?? throw new ArgumentNullException(nameof(connection)), options)
     {
-        this._connection = connection;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerVectorStore"/> class.
+    /// </summary>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="options">Optional configuration options.</param>
+    public SqlServerVectorStore(string connectionString, SqlServerVectorStoreOptions? options = null)
+    {
+        Verify.NotNullOrWhiteSpace(connectionString);
+
+        this._connectionString = connectionString;
         // We need to create a copy, so any changes made to the option bag after
         // the ctor call do not affect this instance.
         this._options = options is not null
@@ -33,15 +46,12 @@ public sealed class SqlServerVectorStore : IVectorStore, IDisposable
     }
 
     /// <inheritdoc/>
-    public void Dispose() => this._connection.Dispose();
-
-    /// <inheritdoc/>
     public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TKey : notnull
     {
         Verify.NotNull(name);
 
         return new SqlServerVectorStoreRecordCollection<TKey, TRecord>(
-            this._connection,
+            this._connectionString,
             name,
             new()
             {
@@ -53,9 +63,10 @@ public sealed class SqlServerVectorStore : IVectorStore, IDisposable
     /// <inheritdoc/>
     public async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        using SqlCommand command = SqlServerCommandBuilder.SelectTableNames(this._connection, this._options.Schema);
+        using SqlConnection connection = new(this._connectionString);
+        using SqlCommand command = SqlServerCommandBuilder.SelectTableNames(connection, this._options.Schema);
 
-        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(this._connection, command,
+        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteReaderAsync(ct),
             cancellationToken, "ListCollection").ConfigureAwait(false);
 

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStore.cs
@@ -20,17 +20,6 @@ public sealed class SqlServerVectorStore : IVectorStore
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlServerVectorStore"/> class.
     /// </summary>
-    /// <param name="connection">Database connection.</param>
-    /// <param name="options">Optional configuration options.</param>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public SqlServerVectorStore(SqlConnection connection, SqlServerVectorStoreOptions? options = null)
-        : this(connection?.ConnectionString ?? throw new ArgumentNullException(nameof(connection)), options)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SqlServerVectorStore"/> class.
-    /// </summary>
     /// <param name="connectionString">The connection string.</param>
     /// <param name="options">Optional configuration options.</param>
     public SqlServerVectorStore(string connectionString, SqlServerVectorStoreOptions? options = null)

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
@@ -22,7 +22,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
     private static readonly SqlServerVectorStoreRecordCollectionOptions<TRecord> s_defaultOptions = new();
 
-    private readonly SqlConnection _sqlConnection;
+    private readonly string _connectionString;
     private readonly SqlServerVectorStoreRecordCollectionOptions<TRecord> _options;
     private readonly VectorStoreRecordPropertyReader _propertyReader;
     private readonly IVectorStoreRecordMapper<TRecord, IDictionary<string, object?>> _mapper;
@@ -33,12 +33,27 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     /// <param name="connection">Database connection.</param>
     /// <param name="name">The name of the collection.</param>
     /// <param name="options">Optional configuration options.</param>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public SqlServerVectorStoreRecordCollection(
         SqlConnection connection,
         string name,
         SqlServerVectorStoreRecordCollectionOptions<TRecord>? options = null)
+        : this(connection?.ConnectionString ?? throw new ArgumentNullException(nameof(connection)), name, options)
     {
-        Verify.NotNull(connection);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlServerVectorStoreRecordCollection{TKey, TRecord}"/> class.
+    /// </summary>
+    /// <param name="connectionString">Database connection string.</param>
+    /// <param name="name">The name of the collection.</param>
+    /// <param name="options">Optional configuration options.</param>
+    public SqlServerVectorStoreRecordCollection(
+        string connectionString,
+        string name,
+        SqlServerVectorStoreRecordCollectionOptions<TRecord>? options = null)
+    {
+        Verify.NotNullOrWhiteSpace(connectionString);
         Verify.NotNull(name);
 
         VectorStoreRecordPropertyReader propertyReader = new(typeof(TRecord),
@@ -61,7 +76,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
         propertyReader.VerifyDataProperties(SqlServerConstants.SupportedDataTypes, supportEnumerable: false);
         propertyReader.VerifyVectorProperties(SqlServerConstants.SupportedVectorTypes);
 
-        this._sqlConnection = connection;
+        this._connectionString = connectionString;
         this.CollectionName = name;
         // We need to create a copy, so any changes made to the option bag after
         // the ctor call do not affect this instance.
@@ -96,10 +111,11 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     /// <inheritdoc/>
     public async Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
     {
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.SelectTableName(
-            this._sqlConnection, this._options.Schema, this.CollectionName);
+            connection, this._options.Schema, this.CollectionName);
 
-        return await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        return await ExceptionWrapper.WrapAsync(connection, command,
             static async (cmd, ct) =>
             {
                 using SqlDataReader reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -125,8 +141,9 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             }
         }
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.CreateTable(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             ifNotExists,
@@ -134,7 +151,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             this._propertyReader.DataProperties,
             this._propertyReader.VectorProperties);
 
-        await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
             cancellationToken, "CreateCollection", this.CollectionName).ConfigureAwait(false);
     }
@@ -142,10 +159,11 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     /// <inheritdoc/>
     public async Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.DropTableIfExists(
-            this._sqlConnection, this._options.Schema, this.CollectionName);
+            connection, this._options.Schema, this.CollectionName);
 
-        await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
             cancellationToken, "DeleteCollection", this.CollectionName).ConfigureAwait(false);
     }
@@ -155,14 +173,15 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     {
         Verify.NotNull(key);
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.DeleteSingle(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             this._propertyReader.KeyProperty,
             key);
 
-        await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
             cancellationToken, "Delete", this.CollectionName).ConfigureAwait(false);
     }
@@ -172,8 +191,9 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     {
         Verify.NotNull(keys);
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand? command = SqlServerCommandBuilder.DeleteMany(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             this._propertyReader.KeyProperty,
@@ -184,7 +204,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             return; // keys is empty, there is nothing to delete
         }
 
-        await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteNonQueryAsync(ct),
             cancellationToken, "DeleteBatch", this.CollectionName).ConfigureAwait(false);
     }
@@ -196,8 +216,9 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
         bool includeVectors = options?.IncludeVectors is true;
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.SelectSingle(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             this._propertyReader.KeyProperty,
@@ -205,7 +226,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             key,
             includeVectors);
 
-        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(connection, command,
             static async (cmd, ct) =>
             {
                 SqlDataReader reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -228,8 +249,9 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
 
         bool includeVectors = options?.IncludeVectors is true;
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand? command = SqlServerCommandBuilder.SelectMany(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             this._propertyReader.KeyProperty,
@@ -242,7 +264,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             yield break; // keys is empty
         }
 
-        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteReaderAsync(ct),
             cancellationToken, "GetBatch", this.CollectionName).ConfigureAwait(false);
 
@@ -259,15 +281,16 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     {
         Verify.NotNull(record);
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand command = SqlServerCommandBuilder.MergeIntoSingle(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             this._propertyReader.KeyProperty,
             this._propertyReader.Properties,
             this._mapper.MapFromDataToStorageModel(record));
 
-        return await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        return await ExceptionWrapper.WrapAsync(connection, command,
             async static (cmd, ct) =>
             {
                 using SqlDataReader reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -282,8 +305,9 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     {
         Verify.NotNull(records);
 
+        using SqlConnection connection = new(this._connectionString);
         using SqlCommand? command = SqlServerCommandBuilder.MergeIntoMany(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             this._propertyReader.KeyProperty,
@@ -295,7 +319,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             yield break; // records is empty
         }
 
-        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        using SqlDataReader reader = await ExceptionWrapper.WrapAsync(connection, command,
             static (cmd, ct) => cmd.ExecuteReaderAsync(ct),
             cancellationToken, "GetBatch", this.CollectionName).ConfigureAwait(false);
 
@@ -326,8 +350,13 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
         var searchOptions = options ?? s_defaultVectorSearchOptions;
         var vectorProperty = this._propertyReader.GetVectorPropertyOrSingle(searchOptions);
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        // This connection will be disposed by the ReadVectorSearchResultsAsync
+        // when the user is done with the results.
+        SqlConnection connection = new(this._connectionString);
+#pragma warning restore CA2000 // Dispose objects before losing scope
         using SqlCommand command = SqlServerCommandBuilder.SelectVector(
-            this._sqlConnection,
+            connection,
             this._options.Schema,
             this.CollectionName,
             vectorProperty,
@@ -336,34 +365,42 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             searchOptions,
             allowed);
 
-        return await ExceptionWrapper.WrapAsync(this._sqlConnection, command,
+        return await ExceptionWrapper.WrapAsync(connection, command,
             (cmd, ct) =>
             {
-                var results = this.ReadVectorSearchResultsAsync(cmd, searchOptions.IncludeVectors, ct);
+                var results = this.ReadVectorSearchResultsAsync(connection, cmd, searchOptions.IncludeVectors, ct);
                 return Task.FromResult(new VectorSearchResults<TRecord>(results));
             }, cancellationToken, "VectorizedSearch", this.CollectionName).ConfigureAwait(false);
     }
 
     private async IAsyncEnumerable<VectorSearchResult<TRecord>> ReadVectorSearchResultsAsync(
+        SqlConnection connection,
         SqlCommand command,
         bool includeVectors,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        StorageToDataModelMapperOptions options = new() { IncludeVectors = includeVectors };
-        var vectorPropertyStoragePropertyNames = includeVectors ? this._propertyReader.VectorPropertyStoragePropertyNames : [];
-        using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-
-        int scoreIndex = -1;
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            if (scoreIndex < 0)
-            {
-                scoreIndex = reader.GetOrdinal("score");
-            }
+            StorageToDataModelMapperOptions options = new() { IncludeVectors = includeVectors };
+            var vectorPropertyStoragePropertyNames = includeVectors ? this._propertyReader.VectorPropertyStoragePropertyNames : [];
+            using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
 
-            yield return new VectorSearchResult<TRecord>(
-                this._mapper.MapFromStorageToDataModel(new SqlDataReaderDictionary(reader, vectorPropertyStoragePropertyNames), options),
-                reader.GetDouble(scoreIndex));
+            int scoreIndex = -1;
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (scoreIndex < 0)
+                {
+                    scoreIndex = reader.GetOrdinal("score");
+                }
+
+                yield return new VectorSearchResult<TRecord>(
+                    this._mapper.MapFromStorageToDataModel(new SqlDataReaderDictionary(reader, vectorPropertyStoragePropertyNames), options),
+                    reader.GetDouble(scoreIndex));
+            }
+        }
+        finally
+        {
+            connection.Dispose();
         }
     }
 }

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
@@ -30,21 +30,6 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlServerVectorStoreRecordCollection{TKey, TRecord}"/> class.
     /// </summary>
-    /// <param name="connection">Database connection.</param>
-    /// <param name="name">The name of the collection.</param>
-    /// <param name="options">Optional configuration options.</param>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public SqlServerVectorStoreRecordCollection(
-        SqlConnection connection,
-        string name,
-        SqlServerVectorStoreRecordCollectionOptions<TRecord>? options = null)
-        : this(connection?.ConnectionString ?? throw new ArgumentNullException(nameof(connection)), name, options)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SqlServerVectorStoreRecordCollection{TKey, TRecord}"/> class.
-    /// </summary>
     /// <param name="connectionString">Database connection string.</param>
     /// <param name="name">The name of the collection.</param>
     /// <param name="options">Optional configuration options.</param>

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerVectorStoreTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerVectorStoreTests.cs
@@ -159,8 +159,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         {
             Mapper = mapper
         };
-        using SqlConnection connection = new(SqlServerTestEnvironment.ConnectionString);
-        SqlServerVectorStoreRecordCollection<string, TestModel> collection = new(connection, collectionName, options);
+        SqlServerVectorStoreRecordCollection<string, TestModel> collection = new(SqlServerTestEnvironment.ConnectionString!, collectionName, options);
 
         try
         {

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Support/SqlServerTestStore.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/Support/SqlServerTestStore.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.SqlServer;
 using VectorDataSpecificationTests.Support;
 
 namespace SqlServerIntegrationTests.Support;
 
-public sealed class SqlServerTestStore : TestStore, IDisposable
+public sealed class SqlServerTestStore : TestStore
 {
     public static readonly SqlServerTestStore Instance = new();
 
@@ -18,20 +17,15 @@ public sealed class SqlServerTestStore : TestStore, IDisposable
 
     private SqlServerVectorStore? _connectedStore;
 
-    protected override async Task StartAsync()
+    protected override Task StartAsync()
     {
         if (string.IsNullOrWhiteSpace(SqlServerTestEnvironment.ConnectionString))
         {
             throw new InvalidOperationException("Connection string is not configured, set the SqlServer:ConnectionString environment variable");
         }
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
-        SqlConnection connection = new(SqlServerTestEnvironment.ConnectionString);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-        await connection.OpenAsync();
+        this._connectedStore = new(SqlServerTestEnvironment.ConnectionString);
 
-        this._connectedStore = new(connection);
+        return Task.CompletedTask;
     }
-
-    public void Dispose() => this._connectedStore?.Dispose();
 }


### PR DESCRIPTION
By accepting a connection string rather than a connection itself we can allow the store to be thread safe and we don't need to worry about the lifetime of provided connection.

It's a breaking change, but we really want to steer the users to do the right thing, so the sooner we release it, the better.