### PR TITLE
Python: Pass api_key to azure config base init

### DIFF
--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_realtime.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_realtime.py
@@ -103,6 +103,7 @@ class AzureRealtimeWebsocket(OpenAIRealtimeWebsocketBase, AzureOpenAIConfigBase)
         if not azure_openai_settings.realtime_deployment_name:
             raise ServiceInitializationError("The OpenAI realtime model ID is required.")
         super().__init__(
+            api_key=azure_openai_settings.api_key.get_secret_value() if azure_openai_settings.api_key else None,
             audio_output_callback=audio_output_callback,
             deployment_name=azure_openai_settings.realtime_deployment_name,
             endpoint=azure_openai_settings.endpoint,


### PR DESCRIPTION
### Motivation and Context

In creating the `AzureRealtimeWebsocket` object, one can use an api key as part of `AzureOpenAISettings`. This api_key is not getting passed to the `AzureOpenAIConfigBase`.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Pass the api key to the config base.
- Closes #11003

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
