### PR TITLE
Python: Fix agent_id kwarg in AzureAIAgent retrieval sample

### DIFF
--- a/python/samples/getting_started_with_agents/azure_ai_agent/step7_azure_ai_agent_retrieval.py
+++ b/python/samples/getting_started_with_agents/azure_ai_agent/step7_azure_ai_agent_retrieval.py
@@ -25,11 +25,11 @@ async def main() -> None:
         DefaultAzureCredential() as creds,
         AzureAIAgent.create_client(credential=creds) as client,
     ):
-        # 1. Retrieve the agent definition based on the `assistant_id`
-        # Replace the "your-assistant-id" with the actual assistant ID
+        # 1. Retrieve the agent definition based on the `agent_id`
+        # Replace the "your-agent-id" with the actual agent ID
         # you want to use.
         agent_definition = await client.agents.get_agent(
-            assistant_id="your-assistant-id",
+            agent_id="your-agent-id",
         )
 
         # 2. Create a Semantic Kernel agent for the Azure AI agent
@@ -52,7 +52,7 @@ async def main() -> None:
         finally:
             # 6. Cleanup: Delete the thread and agent
             await client.agents.delete_thread(thread.id)
-            # Do not clean up the assistant so it can be used again
+            # Do not clean up the agent so it can be used again
 
         """
         Sample Output:

--- a/python/tests/unit/agents/azure_ai_agent/test_agent_content_generation.py
+++ b/python/tests/unit/agents/azure_ai_agent/test_agent_content_generation.py
@@ -105,7 +105,7 @@ def test_generate_message_content_text_and_image():
     )
 
     thread_msg.content = [image, text]
-    step = RunStep(id="step_id", run_id="run_id", thread_id="thread_id", agent_id="assistant_id")
+    step = RunStep(id="step_id", run_id="run_id", thread_id="thread_id", agent_id="agent_id")
     out = generate_message_content("assistant", thread_msg, step)
     assert len(out.items) == 5
     assert isinstance(out.items[0], FileReferenceContent)


### PR DESCRIPTION
### Motivation and Context

The current AzureAIAgent retrieval sample uses the old `assistant_id` kwarg to retrieve the agent. We need to fix this to use the new `agent_id` kwarg in AzureAIAgent retrieval sample

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Fix the kwarg to use `agent_id`.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
