### PR TITLE
.Net: Remove old warnings

### DIFF
--- a/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx.UnitTests/Connectors.Onnx.UnitTests.csproj
@@ -7,7 +7,7 @@
     <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);SKEXP0001;SKEXP0070;CS1591;IDE1006;RCS1261;CA1031;CA1308;CA1861;CA2007;CA2234;VSTHRD111</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001;SKEXP0070;CS1591;IDE1006;RCS1261;CA1031;CA1308;CA1861;CA2007;CA2234;VSTHRD111;SYSLIB1222</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
+++ b/dotnet/src/Connectors/Connectors.Onnx/Connectors.Onnx.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
     <VersionSuffix>alpha</VersionSuffix>
+    <NoWarn>SYSLIB1222</NoWarn>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->

--- a/dotnet/src/SemanticKernel.UnitTests/Utilities/ExceptionConverterTests.cs
+++ b/dotnet/src/SemanticKernel.UnitTests/Utilities/ExceptionConverterTests.cs
@@ -21,7 +21,9 @@ public class ExceptionJsonConverterTests
 #pragma warning disable CA1031 // Do not catch general exception types
         try
         {
+#pragma warning disable JSON001 // Invalid JSON pattern
             JsonSerializer.Deserialize<object>("invalid_json");
+#pragma warning restore JSON001 // Invalid JSON pattern
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
### Motivation and Context

For quite a while the SYSLIB1222, are present in the solution.

This PR suppress them and another new JSON001 warning.

![image](https://github.com/user-attachments/assets/4e39833d-6453-4440-9efa-01f561f80743)



