### PR TITLE
.Net: Remove AllowUnsafeBlocks

### DIFF
--- a/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.AzureOpenAI/Connectors.AzureOpenAI.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.AzureOpenAI</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);NU5104;SKEXP0001,SKEXP0010</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>

--- a/dotnet/src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Connectors.OpenAI.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.SemanticKernel.Connectors.OpenAI</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);NU5104;SKEXP0001,SKEXP0010</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>

--- a/dotnet/src/SemanticKernel.Core/SemanticKernel.Core.csproj
+++ b/dotnet/src/SemanticKernel.Core/SemanticKernel.Core.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.SemanticKernel.Core</AssemblyName>
     <RootNamespace>Microsoft.SemanticKernel</RootNamespace>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NoWarn>$(NoWarn);SKEXP0001,SKEXP0120</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>


### PR DESCRIPTION
### Motivation and Context

Removing AllowUnsafeBlocks from the project file as this is no more needed in the current code base. This change ensures the project is safer by disallowing the use of unsafe code blocks.