### PR TITLE
Python: Exclude certain fields from KernelFunction model dump

### DIFF
--- a/python/semantic_kernel/functions/kernel_function.py
+++ b/python/semantic_kernel/functions/kernel_function.py
@@ -92,9 +92,11 @@ class KernelFunction(KernelBaseModel):
 
     metadata: KernelFunctionMetadata
 
-    invocation_duration_histogram: metrics.Histogram = Field(default_factory=_create_function_duration_histogram)
+    invocation_duration_histogram: metrics.Histogram = Field(
+        default_factory=_create_function_duration_histogram, exclude=True
+    )
     streaming_duration_histogram: metrics.Histogram = Field(
-        default_factory=_create_function_streaming_duration_histogram
+        default_factory=_create_function_streaming_duration_histogram, exclude=True
     )
 
     @classmethod

--- a/python/semantic_kernel/functions/kernel_function_from_method.py
+++ b/python/semantic_kernel/functions/kernel_function_from_method.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from inspect import isasyncgen, isasyncgenfunction, isawaitable, iscoroutinefunction, isgenerator, isgeneratorfunction
 from typing import Any
 
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from semantic_kernel.exceptions import FunctionExecutionException, FunctionInitializationError
 from semantic_kernel.filters.functions.function_invocation_context import FunctionInvocationContext
@@ -21,8 +21,8 @@ logger: logging.Logger = logging.getLogger(__name__)
 class KernelFunctionFromMethod(KernelFunction):
     """Semantic Kernel Function from a method."""
 
-    method: Callable[..., Any]
-    stream_method: Callable[..., Any] | None = None
+    method: Callable[..., Any] = Field(exclude=True)
+    stream_method: Callable[..., Any] | None = Field(default=None, exclude=True)
 
     def __init__(
         self,

--- a/python/semantic_kernel/functions/kernel_parameter_metadata.py
+++ b/python/semantic_kernel/functions/kernel_parameter_metadata.py
@@ -17,7 +17,7 @@ class KernelParameterMetadata(KernelBaseModel):
     default_value: Any | None = None
     type_: str | None = Field(default="str", alias="type")
     is_required: bool | None = False
-    type_object: Any | None = None
+    type_object: Any | None = Field(default=None, exclude=True)
     schema_data: dict[str, Any] | None = None
     include_in_function_choices: bool = True
 

--- a/python/tests/unit/functions/test_kernel_function_from_method.py
+++ b/python/tests/unit/functions/test_kernel_function_from_method.py
@@ -544,3 +544,25 @@ def test_gather_function_parameters_exception_handling(get_custom_type_function_
 
     with pytest.raises(FunctionExecutionException, match=r"Parameter param is expected to be parsed to .* but is not."):
         func.gather_function_parameters(context)
+
+
+@pytest.mark.parametrize(
+    ("mode"),
+    [
+        ("python"),
+        ("json"),
+    ],
+)
+def test_function_model_dump(get_custom_type_function_pydantic, mode):
+    func: KernelFunctionFromMethod = get_custom_type_function_pydantic
+    model_dump = func.model_dump(mode=mode)
+    assert isinstance(model_dump, dict)
+    assert "metadata" in model_dump
+    assert len(model_dump["metadata"]["parameters"]) == 1
+
+
+def test_function_model_dump_json(get_custom_type_function_pydantic):
+    func = get_custom_type_function_pydantic
+    model_dump = func.model_dump_json()
+    assert isinstance(model_dump, str)
+    assert "metadata" in model_dump

--- a/python/tests/unit/functions/test_kernel_function_from_prompt.py
+++ b/python/tests/unit/functions/test_kernel_function_from_prompt.py
@@ -382,3 +382,39 @@ async def test_prompt_render_with_filter(kernel: Kernel, openai_unit_test_env):
     context = FunctionInvocationContext(function=function, kernel=kernel, arguments=KernelArguments())
     prompt_render_result = await function._render_prompt(context)
     assert prompt_render_result.rendered_prompt == "preface test"
+
+
+@pytest.mark.parametrize(
+    ("mode"),
+    [
+        ("python"),
+        ("json"),
+    ],
+)
+def test_function_model_dump(mode: str):
+    function = KernelFunctionFromPrompt(
+        function_name="test",
+        plugin_name="test",
+        prompt="test",
+        template_format="semantic-kernel",
+        prompt_template_config=PromptTemplateConfig(
+            template="test",
+            input_variables=[InputVariable(name="input", type="str", default="test", is_required=False)],
+        ),
+    )
+    model_dump = function.model_dump(mode=mode)
+    assert isinstance(model_dump, dict)
+    assert "metadata" in model_dump
+    assert len(model_dump["metadata"]["parameters"]) == 1
+
+
+def test_function_model_dump_json():
+    function = KernelFunctionFromPrompt(
+        function_name="test",
+        plugin_name="test",
+        prompt="test",
+        template_format="semantic-kernel",
+    )
+    model_dump_json = function.model_dump_json()
+    assert isinstance(model_dump_json, str)
+    assert "test" in model_dump_json


### PR DESCRIPTION
### Motivation and Context

When trying to do a model dump for `KernelFunction` models, they are failing with a message related to: 

```
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'type'>
```

There are some class-level attributes that cannot be properly serialized.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Exclude dumping certain model attributes from the model dump, which allows the main KernelFunction metadata and its underlying parameters to be serialized.
- Closes #11078 
- Adds unit tests to ensure we have coverage and can dump Pydantic models.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
