### PR TITLE
.Net: Update AI Clients to defend against URL injection attacks

### DIFF
--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiCountingTokensTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/Gemini/Clients/GeminiCountingTokensTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -113,6 +114,77 @@ public sealed class GeminiCountingTokensTests : IDisposable
         var header = this._messageHandlerStub.RequestHeaders.GetValues(HttpHeaderConstant.Names.SemanticKernelVersion).SingleOrDefault();
         Assert.NotNull(header);
         Assert.Equal(expectedVersion, header);
+    }
+
+    [Theory]
+    [InlineData("https://malicious-site.com")]
+    [InlineData("http://internal-network.local")]
+    [InlineData("ftp://attacker.com")]
+    [InlineData("//bypass.com")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public void ItThrowsOnLocationUrlInjectionAttempt(string maliciousLocation)
+    {
+        // Arrange
+        var bearerTokenGenerator = new BearerTokenGenerator()
+        {
+            BearerKeys = ["key1", "key2", "key3"]
+        };
+
+        using var httpClient = new HttpClient();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var client = new GeminiTokenCounterClient(
+                httpClient: httpClient,
+                modelId: "fake-model",
+                apiVersion: VertexAIVersion.V1,
+                bearerTokenProvider: bearerTokenGenerator.GetBearerToken,
+                location: maliciousLocation,
+                projectId: "fake-project-id");
+        });
+    }
+
+    [Theory]
+    [InlineData("useast1")]
+    [InlineData("us-east1")]
+    [InlineData("europe-west4")]
+    [InlineData("asia-northeast1")]
+    [InlineData("us-central1-a")]
+    [InlineData("northamerica-northeast1")]
+    [InlineData("australia-southeast1")]
+    public void ItAcceptsValidHostnameSegments(string validLocation)
+    {
+        // Arrange
+        var bearerTokenGenerator = new BearerTokenGenerator()
+        {
+            BearerKeys = ["key1", "key2", "key3"]
+        };
+
+        using var httpClient = new HttpClient();
+
+        // Act & Assert
+        var exception = Record.Exception(() =>
+        {
+            var client = new GeminiTokenCounterClient(
+                httpClient: httpClient,
+                modelId: "fake-model",
+                apiVersion: VertexAIVersion.V1,
+                bearerTokenProvider: bearerTokenGenerator.GetBearerToken,
+                location: validLocation,
+                projectId: "fake-project-id");
+        });
+
+        Assert.Null(exception);
+    }
+
+    private sealed class BearerTokenGenerator()
+    {
+        private int _index = 0;
+        public required List<string> BearerKeys { get; init; }
+
+        public ValueTask<string> GetBearerToken() => ValueTask.FromResult(this.BearerKeys[this._index++]);
     }
 
     private GeminiTokenCounterClient CreateTokenCounterClient(

--- a/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/VertexAI/VertexAIClientEmbeddingsGenerationTests.cs
+++ b/dotnet/src/Connectors/Connectors.Google.UnitTests/Core/VertexAI/VertexAIClientEmbeddingsGenerationTests.cs
@@ -136,6 +136,75 @@ public sealed class VertexAIClientEmbeddingsGenerationTests : IDisposable
         Assert.Equal(expectedVersion, header);
     }
 
+    public void Dispose()
+    {
+        this._httpClient.Dispose();
+        this._messageHandlerStub.Dispose();
+    }
+
+    [Theory]
+    [InlineData("https://malicious-site.com")]
+    [InlineData("http://internal-network.local")]
+    [InlineData("ftp://attacker.com")]
+    [InlineData("//bypass.com")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public void ItThrowsOnLocationUrlInjectionAttempt(string maliciousLocation)
+    {
+        // Arrange
+        var bearerTokenGenerator = new BearerTokenGenerator()
+        {
+            BearerKeys = ["key1", "key2", "key3"]
+        };
+
+        using var httpClient = new HttpClient();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var client = new VertexAIEmbeddingClient(
+                httpClient: httpClient,
+                modelId: "fake-model",
+                apiVersion: VertexAIVersion.V1,
+                bearerTokenProvider: bearerTokenGenerator.GetBearerToken,
+                location: maliciousLocation,
+                projectId: "fake-project-id");
+        });
+    }
+
+    [Theory]
+    [InlineData("useast1")]
+    [InlineData("us-east1")]
+    [InlineData("europe-west4")]
+    [InlineData("asia-northeast1")]
+    [InlineData("us-central1-a")]
+    [InlineData("northamerica-northeast1")]
+    [InlineData("australia-southeast1")]
+    public void ItAcceptsValidHostnameSegments(string validLocation)
+    {
+        // Arrange
+        var bearerTokenGenerator = new BearerTokenGenerator()
+        {
+            BearerKeys = ["key1", "key2", "key3"]
+        };
+
+        using var httpClient = new HttpClient();
+
+        // Act & Assert
+        var exception = Record.Exception(() =>
+        {
+            var client = new VertexAIEmbeddingClient(
+                httpClient: httpClient,
+                modelId: "fake-model",
+                apiVersion: VertexAIVersion.V1,
+                bearerTokenProvider: bearerTokenGenerator.GetBearerToken,
+                location: validLocation,
+                projectId: "fake-project-id");
+        });
+
+        Assert.Null(exception);
+    }
+
     private VertexAIEmbeddingClient CreateEmbeddingsClient(
         string modelId = "fake-model",
         string? bearerKey = "fake-key")
@@ -150,9 +219,11 @@ public sealed class VertexAIClientEmbeddingsGenerationTests : IDisposable
         return client;
     }
 
-    public void Dispose()
+    private sealed class BearerTokenGenerator()
     {
-        this._httpClient.Dispose();
-        this._messageHandlerStub.Dispose();
+        private int _index = 0;
+        public required List<string> BearerKeys { get; init; }
+
+        public ValueTask<string> GetBearerToken() => ValueTask.FromResult(this.BearerKeys[this._index++]);
     }
 }

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiChatCompletionClient.cs
@@ -137,6 +137,7 @@ internal sealed class GeminiChatCompletionClient : ClientBase
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(location);
+        Verify.ValidHostnameSegment(location);
         Verify.NotNullOrWhiteSpace(projectId);
 
         string versionSubLink = GetApiVersionSubLink(apiVersion);

--- a/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiTokenCounterClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/Gemini/Clients/GeminiTokenCounterClient.cs
@@ -69,6 +69,7 @@ internal sealed class GeminiTokenCounterClient : ClientBase
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(location);
+        Verify.ValidHostnameSegment(location);
         Verify.NotNullOrWhiteSpace(projectId);
 
         string versionSubLink = GetApiVersionSubLink(apiVersion);

--- a/dotnet/src/Connectors/Connectors.Google/Core/VertexAI/VertexAIEmbeddingClient.cs
+++ b/dotnet/src/Connectors/Connectors.Google/Core/VertexAI/VertexAIEmbeddingClient.cs
@@ -43,6 +43,7 @@ internal sealed class VertexAIEmbeddingClient : ClientBase
     {
         Verify.NotNullOrWhiteSpace(modelId);
         Verify.NotNullOrWhiteSpace(location);
+        Verify.ValidHostnameSegment(location);
         Verify.NotNullOrWhiteSpace(projectId);
 
         string versionSubLink = GetApiVersionSubLink(apiVersion);

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeClient.cs
@@ -32,6 +32,8 @@ public sealed class PineconeClient : IPineconeClient
     /// <param name="httpClient">An optional HttpClient instance for making HTTP requests.</param>
     public PineconeClient(string pineconeEnvironment, string apiKey, ILoggerFactory? loggerFactory = null, HttpClient? httpClient = null)
     {
+        Verify.NotNullOrWhiteSpace(pineconeEnvironment);
+        Verify.ValidHostnameSegment(pineconeEnvironment);
         this._pineconeEnvironment = pineconeEnvironment;
         this._authHeader = new KeyValuePair<string, string>("Api-Key", apiKey);
         this._jsonSerializerOptions = PineconeUtils.DefaultSerializerOptions;

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeClientTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeClientTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.SemanticKernel.Connectors.Pinecone;
+using Xunit;
+
+namespace SemanticKernel.Connectors.Pinecone.UnitTests;
+
+/// <summary>
+/// Unit tests for PineconeClient class
+/// </summary>
+public sealed class PineconeClientTests
+{
+    [Theory]
+    [InlineData("https://malicious-site.com")]
+    [InlineData("http://internal-network.local")]
+    [InlineData("ftp://attacker.com")]
+    [InlineData("//bypass.com")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public void ItThrowsOnEnvironmentUrlInjectionAttempt(string maliciousEnvironment)
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var client = new PineconeClient(
+                pineconeEnvironment: maliciousEnvironment,
+                apiKey: "fake-api-key");
+        });
+    }
+
+    [Theory]
+    [InlineData("pinecone1")]
+    [InlineData("pncn-starter")]
+    [InlineData("us-east-1-pncn")]
+    [InlineData("us-west-2-pncn")]
+    [InlineData("asia-southeast-1-pncn")]
+    [InlineData("eu-west-1-pncn")]
+    [InlineData("northamerica-northeast1-pncn")]
+    public void ItAcceptsValidEnvironmentNames(string validEnvironment)
+    {
+        // Arrange & Act & Assert
+        var exception = Record.Exception(() =>
+        {
+            var client = new PineconeClient(
+                pineconeEnvironment: validEnvironment,
+                apiKey: "fake-api-key");
+        });
+
+        Assert.Null(exception);
+    }
+}

--- a/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs
@@ -197,8 +197,49 @@ internal static partial class Verify
         throw new ArgumentOutOfRangeException(paramName, actualValue, message);
 
     private static readonly HashSet<string> s_invalidLocationCharacters = [
+
+/* Unmerged change from project 'Connectors.Google(netstandard2.0)'
+Before:
         "://", "..", "\\", "/", "@", "?", "#", "[", "]", "&", ":",
         "<", ">", "'", "\"", "+", "|", "="
+After:
+        "://",
+        "..",
+        "\\",
+        "/",
+        "@",
+        "?",
+        "#",
+        "[",
+        "]",
+        "&",
+        ":",
+        "<",
+        ">",
+        "'",
+        "\"",
+        "+",
+        "|",
+        "="
+*/
+        "://",
+        "..",
+        "\\",
+        "/",
+        "@",
+        "?",
+        "#",
+        "[",
+        "]",
+        "&",
+        ":",
+        "<",
+        ">",
+        "'",
+        "\"",
+        "+",
+        "|",
+        "="
     ];
 
     /// <summary>

--- a/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs
@@ -197,31 +197,6 @@ internal static partial class Verify
         throw new ArgumentOutOfRangeException(paramName, actualValue, message);
 
     private static readonly HashSet<string> s_invalidLocationCharacters = [
-
-/* Unmerged change from project 'Connectors.Google(netstandard2.0)'
-Before:
-        "://", "..", "\\", "/", "@", "?", "#", "[", "]", "&", ":",
-        "<", ">", "'", "\"", "+", "|", "="
-After:
-        "://",
-        "..",
-        "\\",
-        "/",
-        "@",
-        "?",
-        "#",
-        "[",
-        "]",
-        "&",
-        ":",
-        "<",
-        ">",
-        "'",
-        "\"",
-        "+",
-        "|",
-        "="
-*/
         "://",
         "..",
         "\\",

--- a/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs
+++ b/dotnet/src/InternalUtilities/src/Diagnostics/Verify.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
@@ -194,4 +195,31 @@ internal static partial class Verify
     [DoesNotReturn]
     internal static void ThrowArgumentOutOfRangeException<T>(string? paramName, T actualValue, string message) =>
         throw new ArgumentOutOfRangeException(paramName, actualValue, message);
+
+    private static readonly HashSet<string> s_invalidLocationCharacters = [
+        "://", "..", "\\", "/", "@", "?", "#", "[", "]", "&", ":",
+        "<", ">", "'", "\"", "+", "|", "="
+    ];
+
+    /// <summary>
+    /// Validates that a hostname segment string is safe for use as a URL segment, preventing URL injection.
+    /// </summary>
+    /// <param name="hostNameSegment">The hostname segment string to validate (e.g., 'us-east1', 'europe-west4')</param>
+    /// <param name="paramName">Optional parameter name for the exception</param>
+    /// <exception cref="ArgumentException">Thrown when the location contains invalid characters or patterns</exception>
+    internal static void ValidHostnameSegment(string hostNameSegment, [CallerArgumentExpression(nameof(hostNameSegment))] string? paramName = null)
+    {
+        // Check for URL injection patterns and invalid characters
+        if (s_invalidLocationCharacters.Any(hostNameSegment.Contains))
+        {
+            throw new ArgumentException($"The location '{hostNameSegment}' contains invalid characters that could enable URL injection.", paramName);
+        }
+
+        // Validate location format (allows alphanumeric, hyphens, and underscores)
+        // Common format examples: us-east1, europe-west4, asia-northeast1
+        if (!System.Text.RegularExpressions.Regex.IsMatch(hostNameSegment, @"^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$"))
+        {
+            throw new ArgumentException($"The location '{hostNameSegment}' is not valid. Location must start and end with alphanumeric characters and can contain hyphens and underscores.", paramName);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation and Context

This change adds security validation tests for URL injection attempts in various client constructors across the Google and Pinecone connectors. It helps prevent potential security vulnerabilities where malicious URLs could be injected through location or environment parameters.

### Description

Added URL injection validation tests for:
- `GeminiChatCompletionClient`
- `GeminiTokenCounterClient`
- `VertexAIEmbeddingClient`
- `PineconeClient`

Each test suite includes:
1. Validation against common URL injection patterns (e.g., malicious protocols, script injection)
2. Verification of valid hostname/environment patterns
3. Consistent testing approach using xUnit Theory tests

The tests ensure that:
- Malicious URL attempts are caught and throw `ArgumentException`
- Valid location/environment names are accepted without throwing exceptions
- Constructor parameter validation works as expected

This change improves the security posture of the connectors by ensuring proper input validation and maintaining consistent validation behavior across different client implementations.

### Tests

- Added new test files and test cases
- All tests pass locally
- No breaking changes introduced
- Maintains existing validation patterns