### PR TITLE
.Net: Initial pass for native aot annotations for inmemory connector.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryKernelBuilderExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryKernelBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel.Connectors.InMemory;
 
@@ -32,7 +33,7 @@ public static class InMemoryKernelBuilderExtensions
     /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The kernel builder.</returns>
-    public static IKernelBuilder AddInMemoryVectorStoreRecordCollection<TKey, TRecord>(
+    public static IKernelBuilder AddInMemoryVectorStoreRecordCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord>(
         this IKernelBuilder builder,
         string collectionName,
         InMemoryVectorStoreRecordCollectionOptions<TKey, TRecord>? options = default,

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryServiceCollectionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ public static class InMemoryServiceCollectionExtensions
     /// <param name="options">Optional options to further configure the <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
     /// <param name="serviceId">An optional service id to use as the service key.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddInMemoryVectorStoreRecordCollection<TKey, TRecord>(
+    public static IServiceCollection AddInMemoryVectorStoreRecordCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord>(
         this IServiceCollection services,
         string collectionName,
         InMemoryVectorStoreRecordCollectionOptions<TKey, TRecord>? options = default,

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStore.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.VectorData;
@@ -38,7 +39,7 @@ public sealed class InMemoryVectorStore : IVectorStore
     }
 
     /// <inheritdoc />
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull
     {
         if (this._internalCollectionTypes.TryGetValue(name, out var existingCollectionDataType) && existingCollectionDataType != typeof(TRecord))

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -26,7 +27,7 @@ public static class InMemoryVectorStoreExtensions
     /// <param name="collectionName">The collection name.</param>
     /// <param name="stream">The stream to write the serialized JSON to.</param>
     /// <param name="jsonSerializerOptions">The JSON serializer options to use.</param>
-    public static async Task SerializeCollectionAsJsonAsync<TKey, TRecord>(
+    public static async Task SerializeCollectionAsJsonAsync<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord>(
         this InMemoryVectorStore vectorStore,
         string collectionName,
         Stream stream,
@@ -55,7 +56,7 @@ public static class InMemoryVectorStoreExtensions
     /// <typeparam name="TRecord">Type of the record.</typeparam>
     /// <param name="vectorStore">Instance of <see cref="InMemoryVectorStore"/> used to retrieve the collection.</param>
     /// <param name="stream">The stream to read the serialized JSON from.</param>
-    public static async Task<IVectorStoreRecordCollection<TKey, TRecord>?> DeserializeCollectionFromJsonAsync<TKey, TRecord>(
+    public static async Task<IVectorStoreRecordCollection<TKey, TRecord>?> DeserializeCollectionFromJsonAsync<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord>(
         this InMemoryVectorStore vectorStore,
         Stream stream)
         where TKey : notnull

--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
@@ -18,7 +19,7 @@ namespace Microsoft.SemanticKernel.Connectors.InMemory;
 /// <typeparam name="TKey">The data type of the record key.</typeparam>
 /// <typeparam name="TRecord">The data model to use for adding, updating and retrieving data from storage.</typeparam>
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
+public sealed class InMemoryVectorStoreRecordCollection<TKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     where TKey : notnull
 {

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStore.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Threading;
 
 namespace Microsoft.Extensions.VectorData;
@@ -28,7 +31,11 @@ public interface IVectorStore
     /// <seealso cref="VectorStoreRecordKeyAttribute"/>
     /// <seealso cref="VectorStoreRecordDataAttribute"/>
     /// <seealso cref="VectorStoreRecordVectorAttribute"/>
-    IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
+    IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey,
+#if NET7_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         where TKey : notnull;
 
     /// <summary>

--- a/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordMapping.cs
+++ b/dotnet/src/InternalUtilities/src/Data/VectorStoreRecordMapping.cs
@@ -100,7 +100,8 @@ internal static class VectorStoreRecordMapping
     /// <param name="requiredEnumerable">The type to convert to.</param>
     /// <returns>The new enumerable in the required type.</returns>
     /// <exception cref="NotSupportedException">Thrown when a target type is requested that is not supported.</exception>
-    public static object? CreateEnumerable<T>(IEnumerable<T> input, Type requiredEnumerable)
+    [RequiresDynamicCode("Calls System.Collections.ArrayList.ToArray(Type)")]
+    public static object? CreateEnumerable<T>(IEnumerable<T> input, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type requiredEnumerable)
     {
         if (input is null)
         {

--- a/dotnet/src/InternalUtilities/src/Type/TypeExtensions.cs
+++ b/dotnet/src/InternalUtilities/src/Type/TypeExtensions.cs
@@ -20,6 +20,7 @@ internal static class TypeExtensions
     /// <param name="resultType">The result type of the Nullable generic parameter.</param>
     /// <returns><c>true</c> if the result type was successfully retrieved; otherwise, <c>false</c>.</returns>
     /// TODO [@teresaqhoang]: Issue #4202 Cache Generic Types Extraction - Handlebars
+    [RequiresDynamicCode("Calls System.Type.MakeGenericType(params Type[])")]
     public static bool TryGetGenericResultType(this Type? returnType, out Type resultType)
     {
         resultType = typeof(object);


### PR DESCRIPTION
### Motivation and Context
Microsoft.SemanticKernel.Connectors.InMemory warns if using NativeAOT.
This PR contributes to #10256, and helps make SK NativeAOT compatible.

### Description
In the InMemory project, I've turned PublishAot to true, then built the project.
This shows a number of warnings. This PR solves all of those warning but the JsonSerializer ones, that are part of a longer discussion in the linked issue. The solution is to simply annotate the calling methods/types/generic definitions with the suggested attributes, which now bubble up to any possible callers, allowing the linker to not remove some specific methods/ctors.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
