### PR TITLE
.Net: Enable SK telemetry

### DIFF
--- a/dotnet/samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/Program.cs
+++ b/dotnet/samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.Data;
@@ -30,6 +31,24 @@ public static class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+
+        // Enable diagnostics.
+        AppContext.SetSwitch("Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnostics", true);
+
+        // Uncomment the following line to enable diagnostics with sensitive data: prompts, completions, function calls, and more.
+        //AppContext.SetSwitch("Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive", true);
+
+        // Enable SK traces using OpenTelemetry.Extensions.Hosting extensions.
+        // An alternative approach to enabling traces can be found here: https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-aspire-dashboard?tabs=Powershell&pivots=programming-language-csharp 
+        builder.Services.AddOpenTelemetry().WithTracing(b => b.AddSource("Microsoft.SemanticKernel*"));
+
+        // Enable SK metrics using OpenTelemetry.Extensions.Hosting extensions.
+        // An alternative approach to enabling metrics can be found here: https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-aspire-dashboard?tabs=Powershell&pivots=programming-language-csharp
+        builder.Services.AddOpenTelemetry().WithMetrics(b => b.AddMeter("Microsoft.SemanticKernel*"));
+
+        // Enable SK logs.
+        // Log source and log level for SK is configured in appsettings.json.
+        // An alternative approach to enabling logs can be found here: https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-aspire-dashboard?tabs=Powershell&pivots=programming-language-csharp
 
         // Add service defaults & Aspire client integrations.
         builder.AddServiceDefaults();

--- a/dotnet/samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/appsettings.json
+++ b/dotnet/samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.SemanticKernel": "Warning"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
### Motivation, Context and Description
This PR enables SK telemetry: logs, traces, and metrics using OpenTelemetry.Extensions.Hosting API.

**Note**: This PR targets the `feature-agents-hosting` feature branch.    
**Contributes** to: https://github.com/microsoft/semantic-kernel/issues/10149