### PR TITLE
.Net: Remove returned id from AgentThread.Create to support responses

### DIFF
--- a/dotnet/src/Agents/Abstractions/AgentInvokeOptions.cs
+++ b/dotnet/src/Agents/Abstractions/AgentInvokeOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.SemanticKernel.Agents;
 /// <summary>
 /// Optional parameters for agent invocation.
 /// </summary>
-public class AgentInvokeOptions
+public sealed class AgentInvokeOptions
 {
     /// <summary>
     /// Gets or sets optional arguments to pass to the agent's invocation, including any <see cref="PromptExecutionSettings"/>

--- a/dotnet/src/Agents/Abstractions/AgentThread.cs
+++ b/dotnet/src/Agents/Abstractions/AgentThread.cs
@@ -30,8 +30,8 @@ public abstract class AgentThread
     /// Creates the thread and returns the thread id.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>The id of the new thread.</returns>
-    public virtual async Task<string> CreateAsync(CancellationToken cancellationToken = default)
+    /// <returns>A task that completes when the thread has been created.</returns>
+    public virtual async Task CreateAsync(CancellationToken cancellationToken = default)
     {
         if (this.IsDeleted)
         {
@@ -40,11 +40,10 @@ public abstract class AgentThread
 
         if (this.Id is not null)
         {
-            return this.Id;
+            return;
         }
 
         this.Id = await this.CreateInternalAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        return this.Id;
     }
 
     /// <summary>
@@ -98,8 +97,8 @@ public abstract class AgentThread
     /// Checks have already been completed in the <see cref="CreateAsync"/> method to ensure that the thread can be created.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
-    /// <returns>The id of the thread that was created.</returns>
-    protected abstract Task<string> CreateInternalAsync(CancellationToken cancellationToken);
+    /// <returns>The id of the thread that was created if one is available.</returns>
+    protected abstract Task<string?> CreateInternalAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Deletes the current thread.

--- a/dotnet/src/Agents/AzureAI/AzureAIAgentThread.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgentThread.cs
@@ -62,7 +62,7 @@ public sealed class AzureAIAgentThread : AgentThread
     }
 
     /// <inheritdoc />
-    protected async override Task<string> CreateInternalAsync(CancellationToken cancellationToken)
+    protected async override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
     {
         const string ErrorMessage = "The thread could not be created due to an error response from the service.";
 

--- a/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
@@ -37,9 +37,9 @@ public sealed class ChatHistoryAgentThread : AgentThread
     }
 
     /// <inheritdoc />
-    protected override Task<string> CreateInternalAsync(CancellationToken cancellationToken)
+    protected override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult(Guid.NewGuid().ToString("N"));
+        return Task.FromResult<string?>(Guid.NewGuid().ToString("N"));
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgentThread.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgentThread.cs
@@ -48,7 +48,7 @@ public sealed class OpenAIAssistantAgentThread : AgentThread
     }
 
     /// <inheritdoc />
-    protected async override Task<string> CreateInternalAsync(CancellationToken cancellationToken)
+    protected async override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
     {
         const string ErrorMessage = "The thread could not be created due to an error response from the service.";
 


### PR DESCRIPTION
### Motivation and Context

Responses doesn't support an explicit create and will create a thread on invoke automatically so create is a no-op and there is no id available on create.

### Description

Remove returned id from AgentThread.Create to support responses

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
