### PR TITLE
.Net: Make AgentThread.Create protected and expose on concrete implementations where possible

### DIFF
--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -198,8 +198,6 @@ public abstract class Agent
             throw new KernelException($"{this.GetType().Name} currently only supports agent threads of type {nameof(TThreadType)}.");
         }
 
-        await thread.CreateAsync(cancellationToken).ConfigureAwait(false);
-
         // Notify the thread that new messages are available.
         foreach (var message in messages)
         {

--- a/dotnet/src/Agents/Abstractions/AgentThread.cs
+++ b/dotnet/src/Agents/Abstractions/AgentThread.cs
@@ -31,7 +31,7 @@ public abstract class AgentThread
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that completes when the thread has been created.</returns>
-    public virtual async Task CreateAsync(CancellationToken cancellationToken = default)
+    protected virtual async Task CreateAsync(CancellationToken cancellationToken = default)
     {
         if (this.IsDeleted)
         {

--- a/dotnet/src/Agents/AzureAI/AzureAIAgentThread.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgentThread.cs
@@ -61,6 +61,16 @@ public sealed class AzureAIAgentThread : AgentThread
         this.Id = id;
     }
 
+    /// <summary>
+    /// Creates the thread and returns the thread id.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A task that completes when the thread has been created.</returns>
+    public new Task CreateAsync(CancellationToken cancellationToken = default)
+    {
+        return base.CreateAsync(cancellationToken);
+    }
+
     /// <inheritdoc />
     protected async override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
     {

--- a/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
@@ -36,6 +36,16 @@ public sealed class ChatHistoryAgentThread : AgentThread
         this.Id = id ?? Guid.NewGuid().ToString("N");
     }
 
+    /// <summary>
+    /// Creates the thread and returns the thread id.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A task that completes when the thread has been created.</returns>
+    public new Task CreateAsync(CancellationToken cancellationToken = default)
+    {
+        return base.CreateAsync(cancellationToken);
+    }
+
     /// <inheritdoc />
     protected override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
     {

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgentThread.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgentThread.cs
@@ -47,6 +47,16 @@ public sealed class OpenAIAssistantAgentThread : AgentThread
         this.Id = id;
     }
 
+    /// <summary>
+    /// Creates the thread and returns the thread id.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A task that completes when the thread has been created.</returns>
+    public new Task CreateAsync(CancellationToken cancellationToken = default)
+    {
+        return base.CreateAsync(cancellationToken);
+    }
+
     /// <inheritdoc />
     protected async override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
     {

--- a/dotnet/src/Agents/UnitTests/Core/AgentThreadTests.cs
+++ b/dotnet/src/Agents/UnitTests/Core/AgentThreadTests.cs
@@ -147,6 +147,11 @@ public class AgentThreadTests
         public int DeleteInternalAsyncCount { get; private set; }
         public int OnNewMessageInternalAsyncCount { get; private set; }
 
+        public new Task CreateAsync(CancellationToken cancellationToken = default)
+        {
+            return base.CreateAsync(cancellationToken);
+        }
+
         protected override Task<string?> CreateInternalAsync(CancellationToken cancellationToken)
         {
             this.CreateInternalAsyncCount++;

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentFixture.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentFixture.cs
@@ -17,6 +17,8 @@ public abstract class AgentFixture : IAsyncLifetime
 
     public abstract AgentThread AgentThread { get; }
 
+    public abstract AgentThread CreatedAgentThread { get; }
+
     public abstract AgentThread ServiceFailingAgentThread { get; }
 
     public abstract AgentThread CreatedServiceFailingAgentThread { get; }

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadConformance/AgentThreadTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadConformance/AgentThreadTests.cs
@@ -20,20 +20,16 @@ public abstract class AgentThreadTests(Func<AgentFixture> createAgentFixture) : 
     [Fact]
     public virtual async Task DeletingThreadTwiceDoesNotThrowAsync()
     {
-        await this.Fixture.AgentThread.CreateAsync();
-
-        await this.Fixture.AgentThread.DeleteAsync();
-        await this.Fixture.AgentThread.DeleteAsync();
+        await this.Fixture.CreatedAgentThread.DeleteAsync();
+        await this.Fixture.CreatedAgentThread.DeleteAsync();
     }
 
     [Fact]
     public virtual async Task UsingThreadAfterDeleteThrowsAsync()
     {
-        await this.Fixture.AgentThread.CreateAsync();
-        await this.Fixture.AgentThread.DeleteAsync();
+        await this.Fixture.CreatedAgentThread.DeleteAsync();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await this.Fixture.AgentThread.CreateAsync());
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await this.Fixture.AgentThread.OnNewMessageAsync(new ChatMessageContent(AuthorRole.User, "Hi")));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await this.Fixture.CreatedAgentThread.OnNewMessageAsync(new ChatMessageContent(AuthorRole.User, "Hi")));
     }
 
     [Fact]
@@ -47,12 +43,6 @@ public abstract class AgentThreadTests(Func<AgentFixture> createAgentFixture) : 
     {
         await this.Fixture.AgentThread.OnNewMessageAsync(new ChatMessageContent(AuthorRole.User, "Hi"));
         Assert.NotNull(this.Fixture.AgentThread.Id);
-    }
-
-    [Fact]
-    public virtual async Task CreateThreadWithServiceFailureThrowsAgentOperationExceptionAsync()
-    {
-        await Assert.ThrowsAsync<AgentThreadOperationException>(async () => await this.Fixture.ServiceFailingAgentThread.CreateAsync());
     }
 
     [Fact]

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadConformance/ChatCompletionAgentThreadTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadConformance/ChatCompletionAgentThreadTests.cs
@@ -8,13 +8,6 @@ namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.Agen
 public class ChatCompletionAgentThreadTests() : AgentThreadTests(() => new ChatCompletionAgentFixture())
 {
     [Fact]
-    public override Task CreateThreadWithServiceFailureThrowsAgentOperationExceptionAsync()
-    {
-        // Test not applicable since there is no service to fail.
-        return Task.CompletedTask;
-    }
-
-    [Fact]
     public override Task DeleteThreadWithServiceFailureThrowsAgentOperationExceptionAsync()
     {
         // Test not applicable since there is no service to fail.

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AzureAIAgentFixture.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AzureAIAgentFixture.cs
@@ -26,12 +26,15 @@ public class AzureAIAgentFixture : AgentFixture
     private AAIP.Agent? _aiAgent;
     private AzureAIAgent? _agent;
     private AzureAIAgentThread? _thread;
+    private AzureAIAgentThread? _createdThread;
     private AzureAIAgentThread? _serviceFailingAgentThread;
     private AzureAIAgentThread? _createdServiceFailingAgentThread;
 
     public override Agent Agent => this._agent!;
 
     public override AgentThread AgentThread => this._thread!;
+
+    public override AgentThread CreatedAgentThread => this._createdThread!;
 
     public override AgentThread ServiceFailingAgentThread => this._serviceFailingAgentThread!;
 
@@ -67,6 +70,14 @@ public class AzureAIAgentFixture : AgentFixture
 
         try
         {
+            await this._agentsClient!.DeleteThreadAsync(this._createdThread!.Id);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+        }
+
+        try
+        {
             await this._agentsClient!.DeleteThreadAsync(this._createdServiceFailingAgentThread!.Id);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
@@ -94,6 +105,9 @@ public class AzureAIAgentFixture : AgentFixture
 
         this._agent = new AzureAIAgent(this._aiAgent, this._agentsClient) { Kernel = kernel };
         this._thread = new AzureAIAgentThread(this._agentsClient);
+
+        this._createdThread = new AzureAIAgentThread(this._agentsClient);
+        await this._createdThread.CreateAsync();
 
         var serviceFailingClient = AzureAIAgent.CreateAzureAIClient("swedencentral.api.azureml.ms;<subscription_id>;<resource_group_name>;<project_name>", new AzureCliCredential());
         this._serviceFailingAgentThread = new AzureAIAgentThread(serviceFailingClient.GetAgentsClient());

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/ChatCompletionAgentFixture.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/ChatCompletionAgentFixture.cs
@@ -24,10 +24,13 @@ public class ChatCompletionAgentFixture : AgentFixture
 
     private ChatCompletionAgent? _agent;
     private ChatHistoryAgentThread? _thread;
+    private ChatHistoryAgentThread? _createdThread;
 
     public override Agent Agent => this._agent!;
 
     public override AgentThread AgentThread => this._thread!;
+
+    public override AgentThread CreatedAgentThread => this._createdThread!;
 
     public override AgentThread ServiceFailingAgentThread => null!;
 
@@ -53,7 +56,7 @@ public class ChatCompletionAgentFixture : AgentFixture
         return Task.CompletedTask;
     }
 
-    public override Task InitializeAsync()
+    public async override Task InitializeAsync()
     {
         AzureOpenAIConfiguration configuration = this._configuration.GetSection("AzureOpenAI").Get<AzureOpenAIConfiguration>()!;
 
@@ -70,7 +73,7 @@ public class ChatCompletionAgentFixture : AgentFixture
             Instructions = "You are a helpful assistant.",
         };
         this._thread = new ChatHistoryAgentThread();
-
-        return Task.CompletedTask;
+        this._createdThread = new ChatHistoryAgentThread();
+        await this._createdThread.CreateAsync();
     }
 }


### PR DESCRIPTION
### Motivation and Context

Some Agents don't support a direct create operation, and threads are created automatically on first invocation.

### Description

Make AgentThread.Create protected and expose on concrete implementations where possible

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
