### PR TITLE
.Net: Change OnNewMessage to be internal.

### DIFF
--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -201,9 +201,38 @@ public abstract class Agent
         // Notify the thread that new messages are available.
         foreach (var message in messages)
         {
-            await thread.OnNewMessageAsync(message, cancellationToken).ConfigureAwait(false);
+            await this.NotifyThreadOfNewMessage(thread, message, cancellationToken).ConfigureAwait(false);
         }
 
         return concreteThreadType;
+    }
+
+    /// <summary>
+    /// Notfiy the given thread that a new message is available.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Note that while all agents should notify their threads of new messages,
+    /// not all threads will necesarily take action. For some treads, this may be
+    /// the only way that they would know that a new message is available to be added
+    /// to their history.
+    /// </para>
+    /// <para>
+    /// For other thread types, where history is managed by the service, the thread may
+    /// not need to take any action.
+    /// </para>
+    /// <para>
+    /// Where threads manage other memory components that need access to new messages,
+    /// notifying the thread will be important, even if the thread itself does not
+    /// require the message.
+    /// </para>
+    /// </remarks>
+    /// <param name="thread">The thread to notify of the new message.</param>
+    /// <param name="message">The message to pass to the thread.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>An async task that completes once the notification is complete.</returns>
+    protected Task NotifyThreadOfNewMessage(AgentThread thread, ChatMessageContent message, CancellationToken cancellationToken)
+    {
+        return thread.OnNewMessageAsync(message, cancellationToken);
     }
 }

--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -213,7 +213,7 @@ public abstract class Agent
     /// <remarks>
     /// <para>
     /// Note that while all agents should notify their threads of new messages,
-    /// not all threads will necesarily take action. For some treads, this may be
+    /// not all threads will necessarily take action. For some treads, this may be
     /// the only way that they would know that a new message is available to be added
     /// to their history.
     /// </para>

--- a/dotnet/src/Agents/Abstractions/AgentThread.cs
+++ b/dotnet/src/Agents/Abstractions/AgentThread.cs
@@ -80,7 +80,7 @@ public abstract class AgentThread
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that completes when the context has been updated.</returns>
     /// <exception cref="InvalidOperationException">The thread has been deleted.</exception>
-    public virtual async Task OnNewMessageAsync(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    internal virtual async Task OnNewMessageAsync(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
     {
         if (this.IsDeleted)
         {

--- a/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
@@ -173,7 +173,7 @@ public sealed partial class AzureAIAgent : KernelAgent
         // Notify the thread of new messages and return them to the caller.
         await foreach (var result in invokeResults.ConfigureAwait(false))
         {
-            await azureAIAgentThread.OnNewMessageAsync(result, cancellationToken).ConfigureAwait(false);
+            await this.NotifyThreadOfNewMessage(azureAIAgentThread, result, cancellationToken).ConfigureAwait(false);
             yield return new(result, azureAIAgentThread);
         }
     }
@@ -257,7 +257,7 @@ public sealed partial class AzureAIAgent : KernelAgent
         // Notify the thread of any new messages that were assembled from the streaming response.
         foreach (var newMessage in newMessagesReceiver)
         {
-            await azureAIAgentThread.OnNewMessageAsync(newMessage, cancellationToken).ConfigureAwait(false);
+            await this.NotifyThreadOfNewMessage(azureAIAgentThread, newMessage, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/dotnet/src/Agents/Core/ChatCompletionAgent.cs
+++ b/dotnet/src/Agents/Core/ChatCompletionAgent.cs
@@ -90,7 +90,7 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
         // Notify the thread of new messages and return them to the caller.
         await foreach (var result in invokeResults.ConfigureAwait(false))
         {
-            await chatHistoryAgentThread.OnNewMessageAsync(result, cancellationToken).ConfigureAwait(false);
+            await this.NotifyThreadOfNewMessage(chatHistoryAgentThread, result, cancellationToken).ConfigureAwait(false);
             yield return new(result, chatHistoryAgentThread);
         }
     }
@@ -135,7 +135,7 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
         var invokeResults = this.InternalInvokeStreamingAsync(
             agentName,
             chatHistory,
-            (newMessage) => chatHistoryAgentThread.OnNewMessageAsync(newMessage),
+            (newMessage) => this.NotifyThreadOfNewMessage(chatHistoryAgentThread, newMessage, cancellationToken),
             this.MergeArguments(options?.KernelArguments),
             options?.Kernel ?? this.Kernel,
             options?.AdditionalInstructions,

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -392,7 +392,7 @@ public sealed partial class OpenAIAssistantAgent : KernelAgent
         // Notify the thread of new messages and return them to the caller.
         await foreach (var result in invokeResults.ConfigureAwait(false))
         {
-            await openAIAssistantAgentThread.OnNewMessageAsync(result, cancellationToken).ConfigureAwait(false);
+            await this.NotifyThreadOfNewMessage(openAIAssistantAgentThread, result, cancellationToken).ConfigureAwait(false);
             yield return new(result, openAIAssistantAgentThread);
         }
     }
@@ -494,7 +494,7 @@ public sealed partial class OpenAIAssistantAgent : KernelAgent
         // Notify the thread of any new messages that were assembled from the streaming response.
         foreach (var newMessage in newMessagesReceiver)
         {
-            await openAIAssistantAgentThread.OnNewMessageAsync(newMessage, cancellationToken).ConfigureAwait(false);
+            await this.NotifyThreadOfNewMessage(openAIAssistantAgentThread, newMessage, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadConformance/AgentThreadTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadConformance/AgentThreadTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
@@ -29,7 +30,7 @@ public abstract class AgentThreadTests(Func<AgentFixture> createAgentFixture) : 
     {
         await this.Fixture.CreatedAgentThread.DeleteAsync();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await this.Fixture.CreatedAgentThread.OnNewMessageAsync(new ChatMessageContent(AuthorRole.User, "Hi")));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await InvokeInternalOnNewMessage(this.Fixture.CreatedAgentThread, new ChatMessageContent(AuthorRole.User, "Hi")));
     }
 
     [Fact]
@@ -39,9 +40,9 @@ public abstract class AgentThreadTests(Func<AgentFixture> createAgentFixture) : 
     }
 
     [Fact]
-    public virtual async Task UsingThreadbeforeCreateCreatesAsync()
+    public virtual async Task UsingThreadBeforeCreateCreatesAsync()
     {
-        await this.Fixture.AgentThread.OnNewMessageAsync(new ChatMessageContent(AuthorRole.User, "Hi"));
+        await InvokeInternalOnNewMessage(this.Fixture.AgentThread, new ChatMessageContent(AuthorRole.User, "Hi"));
         Assert.NotNull(this.Fixture.AgentThread.Id);
     }
 
@@ -55,7 +56,7 @@ public abstract class AgentThreadTests(Func<AgentFixture> createAgentFixture) : 
     public virtual async Task OnNewMessageWithServiceFailureThrowsAgentOperationExceptionAsync()
     {
         await Assert.ThrowsAsync<AgentThreadOperationException>(
-            async () => await this.Fixture.CreatedServiceFailingAgentThread.OnNewMessageAsync(new ChatMessageContent(AuthorRole.User, "Hi")));
+            async () => await InvokeInternalOnNewMessage(this.Fixture.CreatedServiceFailingAgentThread, new ChatMessageContent(AuthorRole.User, "Hi")));
     }
 
     public Task InitializeAsync()
@@ -67,5 +68,18 @@ public abstract class AgentThreadTests(Func<AgentFixture> createAgentFixture) : 
     public Task DisposeAsync()
     {
         return this._agentFixture.DisposeAsync();
+    }
+
+    private static Task InvokeInternalOnNewMessage(AgentThread thread, ChatMessageContent message)
+    {
+        // User reflection to invoke the internal method.
+        var method = thread.GetType().GetMethod("OnNewMessageAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        if (method == null)
+        {
+            throw new InvalidOperationException("Method not found");
+        }
+
+        var task = (Task)method.Invoke(thread, new object[] { message, CancellationToken.None })!;
+        return task;
     }
 }


### PR DESCRIPTION
### Motivation and Context

OnNewMessage is really a way for agents to communicate with threads, so we don't want this to be publicly exposed.

### Description

Change OnNewMessage to be internal.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
