### PR TITLE
.Net: Disable link chekc

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -11,9 +11,9 @@ ignorePatterns:
   - pattern: "https:\/\/outlook.office.com/bookings"
 excludedFiles:
   # Files that are temporarily excluded because they contain links that are temporarily unavailable.
-  - ./docs/decisions/0067-hybrid-search.md
-  - ./docs/decisions/0054-processes.md
-  - ./dotnet/src/Experimental/Process.IntegrationTestRunner.Dapr/README.md
+  - ./docs/decisions/0054-processes.md # Cannot reach https://docs.dapr.io/developing-applications/building-blocks/actors/actors-overview/. Status: 404" location:{path:"docs/decisions/0054-processes.md" 
+  - ./dotnet/src/Experimental/Process.IntegrationTestRunner.Dapr/README.md # Cannot reach https://docs.dapr.io/getting-started/install-dapr-selfhost/. Status: 404" location:{path:"dotnet/src/Experimental/Process.IntegrationTestRunner.Dapr/README.md" 
+  - ./python/DEV_SETUP.md # "Cannot reach https://code.visualstudio.com/docs/editor/workspaces. Status: 404"
 excludedDirs:
   # Folders which include links to localhost, since it's not ignored with regular expressions
   - ./python/samples/demos/telemetry


### PR DESCRIPTION
Enable link checking for hybrid search document because one of the links in it is now available, and exclude the Python development setup document because one of its links has become unavailable.

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/9edc68c4-cb81-434a-b19b-bf00344ccb9e" />
