### PR TITLE
.Net: [MEVD] Implemented Delegating classes for vector store abstractions

### DIFF
--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorData.Abstractions.csproj
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorData.Abstractions.csproj
@@ -42,5 +42,6 @@ Microsoft.Extensions.VectorData.IVectorStoreRecordCollection&lt;TKey, TRecord&gt
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net462' ">
     <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/IsExternalInit.cs" Link="Diagnostics/IsExternalInit.cs" />
+    <Compile Include="$(RepoRoot)/dotnet/src/InternalUtilities/src/Diagnostics/ExperimentalAttribute.cs" Link="Diagnostics/ExperimentalAttribute.cs" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/DelegatingKeywordHybridSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/DelegatingKeywordHybridSearch.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Provides an optional base class for an <see cref="IKeywordHybridSearch{TRecord}"/> that passes through calls to another instance.
+/// </summary>
+/// <remarks>
+/// This is recommended as a base type when building services that can be chained around an underlying <see cref="IKeywordHybridSearch{TRecord}"/>.
+/// The default implementation simply passes each call to the inner search instance.
+/// </remarks>
+/// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+[Experimental("SKEXP0020")]
+public class DelegatingKeywordHybridSearch<TRecord> : IKeywordHybridSearch<TRecord>
+{
+    /// <summary>Gets the inner <see cref="IKeywordHybridSearch{TRecord}"/>.</summary>
+    protected IKeywordHybridSearch<TRecord> InnerSearch { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegatingKeywordHybridSearch{TRecord}"/> class.
+    /// </summary>
+    /// <param name="innerSearch">The wrapped search instance.</param>
+    protected DelegatingKeywordHybridSearch(IKeywordHybridSearch<TRecord> innerSearch)
+    {
+        this.InnerSearch = innerSearch ?? throw new ArgumentNullException(nameof(innerSearch));
+    }
+
+    /// <inheritdoc />
+    public virtual Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(
+        TVector vector,
+        ICollection<string> keywords,
+        HybridSearchOptions<TRecord>? options = default,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InnerSearch.HybridSearchAsync(vector, keywords, options, cancellationToken);
+    }
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/DelegatingVectorizableTextSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/DelegatingVectorizableTextSearch.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Provides an optional base class for an <see cref="IVectorizableTextSearch{TRecord}"/> that passes through calls to another instance.
+/// </summary>
+/// <remarks>
+/// This is recommended as a base type when building services that can be chained around an underlying <see cref="IVectorizableTextSearch{TRecord}"/>.
+/// The default implementation simply passes each call to the inner search instance.
+/// </remarks>
+/// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+[Experimental("SKEXP0020")]
+public class DelegatingVectorizableTextSearch<TRecord> : IVectorizableTextSearch<TRecord>
+{
+    /// <summary>Gets the inner <see cref="IVectorizableTextSearch{TRecord}"/>.</summary>
+    protected IVectorizableTextSearch<TRecord> InnerSearch { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegatingVectorizableTextSearch{TRecord}"/> class.
+    /// </summary>
+    /// <param name="innerSearch">The wrapped search instance.</param>
+    protected DelegatingVectorizableTextSearch(IVectorizableTextSearch<TRecord> innerSearch)
+    {
+        this.InnerSearch = innerSearch ?? throw new ArgumentNullException(nameof(innerSearch));
+    }
+
+    /// <inheritdoc />
+    public virtual Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(
+        string searchText,
+        VectorSearchOptions<TRecord>? options = default,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InnerSearch.VectorizableTextSearchAsync(searchText, options, cancellationToken);
+    }
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/DelegatingVectorizedSearch.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorSearch/DelegatingVectorizedSearch.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Provides an optional base class for an <see cref="IVectorizedSearch{TRecord}"/> that passes through calls to another instance.
+/// </summary>
+/// <remarks>
+/// This is recommended as a base type when building services that can be chained around an underlying <see cref="IVectorizedSearch{TRecord}"/>.
+/// The default implementation simply passes each call to the inner search instance.
+/// </remarks>
+/// <typeparam name="TRecord">The record data model to use for retrieving data from the store.</typeparam>
+[Experimental("SKEXP0020")]
+public class DelegatingVectorizedSearch<TRecord> : IVectorizedSearch<TRecord>
+{
+    /// <summary>Gets the inner <see cref="IVectorizedSearch{TRecord}"/>.</summary>
+    protected IVectorizedSearch<TRecord> InnerSearch { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegatingVectorizedSearch{TRecord}"/> class.
+    /// </summary>
+    /// <param name="innerSearch">The wrapped search instance.</param>
+    protected DelegatingVectorizedSearch(IVectorizedSearch<TRecord> innerSearch)
+    {
+        this.InnerSearch = innerSearch ?? throw new ArgumentNullException(nameof(innerSearch));
+    }
+
+    /// <inheritdoc />
+    public virtual Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(
+        TVector vector,
+        VectorSearchOptions<TRecord>? options = default,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InnerSearch.VectorizedSearchAsync(vector, options, cancellationToken);
+    }
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/DelegatingVectorStore.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/DelegatingVectorStore.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Provides an optional base class for an <see cref="IVectorStore"/> that passes through calls to another instance.
+/// </summary>
+/// <remarks>
+/// This is recommended as a base type when building services that can be chained around an underlying <see cref="IVectorStore"/>.
+/// The default implementation simply passes each call to the inner client instance.
+/// </remarks>
+[Experimental("SKEXP0020")]
+public class DelegatingVectorStore : IVectorStore
+{
+    /// <summary>Gets the inner <see cref="IVectorStore"/>.</summary>
+    protected IVectorStore InnerStore { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegatingVectorStore"/> class.
+    /// </summary>
+    /// <param name="vectorStore">The wrapped store instance.</param>
+    protected DelegatingVectorStore(IVectorStore vectorStore)
+    {
+        this.InnerStore = vectorStore ?? throw new ArgumentNullException(nameof(vectorStore));
+    }
+
+    /// <inheritdoc />
+    public virtual IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TKey : notnull
+    {
+        return this.InnerStore.GetCollection<TKey, TRecord>(name, vectorStoreRecordDefinition);
+    }
+
+    /// <inheritdoc />
+    public virtual IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)
+    {
+        return this.InnerStore.ListCollectionNamesAsync(cancellationToken);
+    }
+}

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/DelegatingVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/DelegatingVectorStoreRecordCollection.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.VectorData;
+
+/// <summary>
+/// Provides an optional base class for an <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/> that passes through calls to another instance.
+/// </summary>
+/// <remarks>
+/// This is recommended as a base type when building services that can be chained around an underlying <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.
+/// The default implementation simply passes each call to the inner collection instance.
+/// </remarks>
+/// <typeparam name="TKey">The data type of the record key.</typeparam>
+/// <typeparam name="TRecord">The record data model to use for adding, updating, and retrieving data from the store.</typeparam>
+[Experimental("SKEXP0020")]
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public class DelegatingVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRecordCollection<TKey, TRecord>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+    where TKey : notnull
+{
+    /// <summary>Gets the inner <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</summary>
+    protected IVectorStoreRecordCollection<TKey, TRecord> InnerCollection { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegatingVectorStoreRecordCollection{TKey, TRecord}"/> class.
+    /// </summary>
+    /// <param name="innerCollection">The wrapped collection instance.</param>
+    protected DelegatingVectorStoreRecordCollection(IVectorStoreRecordCollection<TKey, TRecord> innerCollection)
+    {
+        this.InnerCollection = innerCollection ?? throw new ArgumentNullException(nameof(innerCollection));
+    }
+
+    /// <inheritdoc />
+    public virtual string CollectionName => this.InnerCollection.CollectionName;
+
+    /// <inheritdoc />
+    public virtual Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.CollectionExistsAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.CreateCollectionAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.CreateCollectionIfNotExistsAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.DeleteCollectionAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task<TRecord?> GetAsync(TKey key, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.GetAsync(key, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<TKey> keys, GetRecordOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.GetBatchAsync(keys, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task DeleteAsync(TKey key, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.DeleteAsync(key, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task DeleteBatchAsync(IEnumerable<TKey> keys, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.DeleteBatchAsync(keys, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task<TKey> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.UpsertAsync(record, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual IAsyncEnumerable<TKey> UpsertBatchAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.UpsertBatchAsync(records, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions<TRecord>? options = default, CancellationToken cancellationToken = default)
+    {
+        return this.InnerCollection.VectorizedSearchAsync(vector, options, cancellationToken);
+    }
+}

--- a/dotnet/src/Connectors/VectorData.UnitTests/VectorSearch/DelegatingKeywordHybridSearchTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/VectorSearch/DelegatingKeywordHybridSearchTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Moq;
+using Xunit;
+
+namespace VectorData.UnitTests.VectorSearch;
+
+public class DelegatingKeywordHybridSearchTests
+{
+    private readonly Mock<IKeywordHybridSearch<string>> _mockInnerSearch;
+    private readonly FakeKeywordHybridSearch<string> _delegatingSearch;
+
+    public DelegatingKeywordHybridSearchTests()
+    {
+        this._mockInnerSearch = new Mock<IKeywordHybridSearch<string>>();
+        this._delegatingSearch = new FakeKeywordHybridSearch<string>(this._mockInnerSearch.Object);
+    }
+
+    [Fact]
+    public void ConstructorWithNullInnerSearchThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FakeKeywordHybridSearch<string>(null!));
+    }
+
+    [Fact]
+    public async Task HybridSearchCallsInnerSearchAsync()
+    {
+        var vector = new float[] { 1.0f, 2.0f };
+        var keywords = new List<string> { "test", "search" };
+        var options = new HybridSearchOptions<string>();
+        var searchResults = new[] { new VectorSearchResult<string>("result", 0.9f) }.ToAsyncEnumerable();
+        var results = new VectorSearchResults<string>(searchResults);
+
+        this._mockInnerSearch.Setup(s => s.HybridSearchAsync(vector, keywords, options, default))
+            .ReturnsAsync(results);
+
+        var result = await this._delegatingSearch.HybridSearchAsync(vector, keywords, options);
+
+        Assert.Equal(results, result);
+        this._mockInnerSearch.Verify(x => x.HybridSearchAsync(vector, keywords, options, default), Times.Once);
+    }
+
+    private sealed class FakeKeywordHybridSearch<TRecord> : DelegatingKeywordHybridSearch<TRecord>
+    {
+        public FakeKeywordHybridSearch(IKeywordHybridSearch<TRecord> innerSearch) : base(innerSearch) { }
+    }
+}

--- a/dotnet/src/Connectors/VectorData.UnitTests/VectorSearch/DelegatingVectorizableTextSearchTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/VectorSearch/DelegatingVectorizableTextSearchTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Moq;
+using Xunit;
+
+namespace VectorData.UnitTests.VectorSearch;
+
+public class DelegatingVectorizableTextSearchTests
+{
+    private readonly Mock<IVectorizableTextSearch<string>> _mockInnerSearch;
+    private readonly FakeVectorizableTextSearch<string> _delegatingSearch;
+
+    public DelegatingVectorizableTextSearchTests()
+    {
+        this._mockInnerSearch = new Mock<IVectorizableTextSearch<string>>();
+        this._delegatingSearch = new FakeVectorizableTextSearch<string>(this._mockInnerSearch.Object);
+    }
+
+    [Fact]
+    public void ConstructorWithNullInnerSearchThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FakeVectorizableTextSearch<string>(null!));
+    }
+
+    [Fact]
+    public async Task VectorizableTextSearchCallsInnerSearchAsync()
+    {
+        var searchText = "test query";
+        var options = new VectorSearchOptions<string>();
+        var searchResults = new[] { new VectorSearchResult<string>("result", 0.9f) }.ToAsyncEnumerable();
+        var results = new VectorSearchResults<string>(searchResults);
+
+        this._mockInnerSearch.Setup(s => s.VectorizableTextSearchAsync(searchText, options, default))
+            .ReturnsAsync(results);
+
+        var result = await this._delegatingSearch.VectorizableTextSearchAsync(searchText, options);
+
+        Assert.Equal(results, result);
+        this._mockInnerSearch.Verify(x => x.VectorizableTextSearchAsync(searchText, options, default), Times.Once);
+    }
+
+    private sealed class FakeVectorizableTextSearch<TRecord> : DelegatingVectorizableTextSearch<TRecord>
+    {
+        public FakeVectorizableTextSearch(IVectorizableTextSearch<TRecord> innerSearch) : base(innerSearch) { }
+    }
+}

--- a/dotnet/src/Connectors/VectorData.UnitTests/VectorSearch/DelegatingVectorizedSearchTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/VectorSearch/DelegatingVectorizedSearchTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Moq;
+using Xunit;
+
+namespace VectorData.UnitTests.VectorSearch;
+
+public class DelegatingVectorizedSearchTests
+{
+    private readonly Mock<IVectorizedSearch<string>> _mockInnerSearch;
+    private readonly FakeVectorizedSearch<string> _delegatingSearch;
+
+    public DelegatingVectorizedSearchTests()
+    {
+        this._mockInnerSearch = new Mock<IVectorizedSearch<string>>();
+        this._delegatingSearch = new FakeVectorizedSearch<string>(this._mockInnerSearch.Object);
+    }
+
+    [Fact]
+    public void ConstructorWithNullInnerSearchThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FakeVectorizedSearch<object>(null!));
+    }
+
+    [Fact]
+    public async Task VectorizedSearchCallsInnerSearchAsync()
+    {
+        var vector = new float[] { 1.0f, 2.0f };
+        var options = new VectorSearchOptions<string>();
+        var searchResults = new[] { new VectorSearchResult<string>("result", 0.9f) }.ToAsyncEnumerable();
+        var results = new VectorSearchResults<string>(searchResults);
+
+        this._mockInnerSearch.Setup(s => s.VectorizedSearchAsync(vector, options, default))
+                   .ReturnsAsync(results);
+
+        var result = await this._delegatingSearch.VectorizedSearchAsync(vector, options);
+
+        Assert.Equal(results, result);
+        this._mockInnerSearch.Verify(x => x.VectorizedSearchAsync(vector, options, default), Times.Once);
+    }
+
+    private sealed class FakeVectorizedSearch<TRecord> : DelegatingVectorizedSearch<TRecord>
+    {
+        public FakeVectorizedSearch(IVectorizedSearch<TRecord> innerSearch) : base(innerSearch) { }
+    }
+}

--- a/dotnet/src/Connectors/VectorData.UnitTests/VectorStorage/DelegatingVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/VectorStorage/DelegatingVectorStoreRecordCollectionTests.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Moq;
+using Xunit;
+
+namespace VectorData.UnitTests.VectorStorage;
+
+public class DelegatingVectorStoreRecordCollectionTests
+{
+    private readonly Mock<IVectorStoreRecordCollection<string, object>> _mockInnerCollection;
+    private readonly FakeVectorStoreRecordCollection<string, object> _delegatingCollection;
+
+    public DelegatingVectorStoreRecordCollectionTests()
+    {
+        this._mockInnerCollection = new Mock<IVectorStoreRecordCollection<string, object>>();
+        this._delegatingCollection = new FakeVectorStoreRecordCollection<string, object>(this._mockInnerCollection.Object);
+    }
+
+    [Fact]
+    public void ConstructorWithNullInnerCollectionThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FakeVectorStoreRecordCollection<string, object>(null!));
+    }
+
+    [Fact]
+    public void CollectionNameCallsInnerCollection()
+    {
+        this._mockInnerCollection.Setup(c => c.CollectionName).Returns("test-collection");
+
+        var result = this._delegatingCollection.CollectionName;
+
+        Assert.Equal("test-collection", result);
+        this._mockInnerCollection.Verify(x => x.CollectionName, Times.Once);
+    }
+
+    [Fact]
+    public async Task CollectionExistsCallsInnerCollectionAsync()
+    {
+        this._mockInnerCollection.Setup(c => c.CollectionExistsAsync(default)).ReturnsAsync(true);
+
+        var result = await this._delegatingCollection.CollectionExistsAsync();
+
+        Assert.True(result);
+        this._mockInnerCollection.Verify(x => x.CollectionExistsAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateCollectionCallsInnerCollectionAsync()
+    {
+        await this._delegatingCollection.CreateCollectionAsync();
+        this._mockInnerCollection.Verify(x => x.CreateCollectionAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateCollectionIfNotExistsCallsInnerCollectionAsync()
+    {
+        await this._delegatingCollection.CreateCollectionIfNotExistsAsync();
+        this._mockInnerCollection.Verify(x => x.CreateCollectionIfNotExistsAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteCollectionCallsInnerCollectionAsync()
+    {
+        await this._delegatingCollection.DeleteCollectionAsync();
+        this._mockInnerCollection.Verify(x => x.DeleteCollectionAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAsyncCallsInnerCollectionAsync()
+    {
+        var key = "test-key";
+        var options = new GetRecordOptions();
+        var record = new object();
+
+        this._mockInnerCollection.Setup(c => c.GetAsync(key, options, default)).ReturnsAsync(record);
+
+        var result = await this._delegatingCollection.GetAsync(key, options);
+
+        Assert.Equal(record, result);
+        this._mockInnerCollection.Verify(x => x.GetAsync(key, options, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetBatchAsyncCallsInnerCollectionAsync()
+    {
+        var keys = new[] { "key1", "key2" };
+        var options = new GetRecordOptions();
+        var records = new[] { new object(), new object() };
+
+        this._mockInnerCollection.Setup(c => c.GetBatchAsync(keys, options, default)).Returns(records.ToAsyncEnumerable());
+
+        var result = await this._delegatingCollection.GetBatchAsync(keys, options).ToListAsync();
+
+        Assert.Equal(records, result);
+        this._mockInnerCollection.Verify(x => x.GetBatchAsync(keys, options, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsyncCallsInnerCollectionAsync()
+    {
+        var key = "test-key";
+
+        await this._delegatingCollection.DeleteAsync(key);
+        this._mockInnerCollection.Verify(x => x.DeleteAsync(key, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteBatchAsyncCallsInnerCollectionAsync()
+    {
+        var keys = new[] { "key1", "key2" };
+
+        await this._delegatingCollection.DeleteBatchAsync(keys);
+        this._mockInnerCollection.Verify(x => x.DeleteBatchAsync(keys, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpsertAsyncCallsInnerCollectionAsync()
+    {
+        var record = new object();
+        var key = "test-key";
+
+        this._mockInnerCollection.Setup(c => c.UpsertAsync(record, default)).ReturnsAsync(key);
+
+        var result = await this._delegatingCollection.UpsertAsync(record);
+
+        Assert.Equal(key, result);
+        this._mockInnerCollection.Verify(x => x.UpsertAsync(record, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpsertBatchAsyncCallsInnerCollectionAsync()
+    {
+        var records = new[] { new object(), new object() };
+        var keys = new[] { "key1", "key2" };
+
+        this._mockInnerCollection.Setup(c => c.UpsertBatchAsync(records, default)).Returns(keys.ToAsyncEnumerable());
+
+        var result = await this._delegatingCollection.UpsertBatchAsync(records).ToListAsync();
+
+        Assert.Equal(keys, result);
+        this._mockInnerCollection.Verify(x => x.UpsertBatchAsync(records, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task VectorizedSearchCallsInnerCollectionAsync()
+    {
+        var vector = new float[] { 1.0f, 2.0f };
+        var options = new VectorSearchOptions<object>();
+        var searchResults = new[] { new VectorSearchResult<object>("result", 0.9f) }.ToAsyncEnumerable();
+        var results = new VectorSearchResults<object>(searchResults);
+
+        this._mockInnerCollection.Setup(c => c.VectorizedSearchAsync(vector, options, default))
+            .ReturnsAsync(results);
+
+        var result = await this._delegatingCollection.VectorizedSearchAsync(vector, options);
+
+        Assert.Equal(results, result);
+        this._mockInnerCollection.Verify(x => x.VectorizedSearchAsync(vector, options, default), Times.Once);
+    }
+
+    private sealed class FakeVectorStoreRecordCollection<TKey, TRecord> : DelegatingVectorStoreRecordCollection<TKey, TRecord>
+        where TKey : notnull
+    {
+        public FakeVectorStoreRecordCollection(IVectorStoreRecordCollection<TKey, TRecord> innerCollection) : base(innerCollection) { }
+    }
+}

--- a/dotnet/src/Connectors/VectorData.UnitTests/VectorStorage/DelegatingVectorStoreTests.cs
+++ b/dotnet/src/Connectors/VectorData.UnitTests/VectorStorage/DelegatingVectorStoreTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Moq;
+using Xunit;
+
+namespace VectorData.UnitTests.VectorStorage;
+
+public class DelegatingVectorStoreTests
+{
+    private readonly Mock<IVectorStore> _mockInnerStore;
+    private readonly FakeVectorStore _delegatingStore;
+
+    public DelegatingVectorStoreTests()
+    {
+        this._mockInnerStore = new Mock<IVectorStore>();
+        this._delegatingStore = new FakeVectorStore(this._mockInnerStore.Object);
+    }
+
+    [Fact]
+    public void ConstructorWithNullInnerStoreThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FakeVectorStore(null!));
+    }
+
+    [Fact]
+    public void GetCollectionCallsInnerStore()
+    {
+        var collectionName = "test-collection";
+        var recordDefinition = new VectorStoreRecordDefinition();
+        var mockCollection = new Mock<IVectorStoreRecordCollection<string, object>>().Object;
+
+        this._mockInnerStore.Setup(s => s.GetCollection<string, object>(collectionName, recordDefinition))
+            .Returns(mockCollection);
+
+        var result = this._delegatingStore.GetCollection<string, object>(collectionName, recordDefinition);
+
+        Assert.Equal(mockCollection, result);
+        this._mockInnerStore.Verify(x => x.GetCollection<string, object>(collectionName, recordDefinition), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesCallsInnerStoreAsync()
+    {
+        var collectionNames = new[] { "collection1", "collection2" };
+
+        this._mockInnerStore.Setup(s => s.ListCollectionNamesAsync(default))
+            .Returns(collectionNames.ToAsyncEnumerable());
+
+        var result = await this._delegatingStore.ListCollectionNamesAsync().ToListAsync();
+
+        Assert.Equal(collectionNames, result);
+        this._mockInnerStore.Verify(x => x.ListCollectionNamesAsync(default), Times.Once);
+    }
+
+    private sealed class FakeVectorStore : DelegatingVectorStore
+    {
+        public FakeVectorStore(IVectorStore innerStore) : base(innerStore) { }
+    }
+}

--- a/dotnet/src/Connectors/VectorData/VectorSearch/LoggingKeywordHybridSearch.cs
+++ b/dotnet/src/Connectors/VectorData/VectorSearch/LoggingKeywordHybridSearch.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.VectorData;
 /// A keyword hybrid search that logs operations to an <see cref="ILogger"/>
 /// </summary>
 [Experimental("SKEXP0020")]
-public class LoggingKeywordHybridSearch<TRecord> : IKeywordHybridSearch<TRecord>
+public class LoggingKeywordHybridSearch<TRecord> : DelegatingKeywordHybridSearch<TRecord>
 {
     /// <summary>An <see cref="ILogger"/> instance used for all logging.</summary>
     private readonly ILogger _logger;
@@ -27,7 +27,7 @@ public class LoggingKeywordHybridSearch<TRecord> : IKeywordHybridSearch<TRecord>
     /// </summary>
     /// <param name="innerSearch">The underlying <see cref="LoggingKeywordHybridSearch{TRecord}"/>.</param>
     /// <param name="logger">An <see cref="ILogger"/> instance that will be used for all logging.</param>
-    public LoggingKeywordHybridSearch(IKeywordHybridSearch<TRecord> innerSearch, ILogger logger)
+    public LoggingKeywordHybridSearch(IKeywordHybridSearch<TRecord> innerSearch, ILogger logger) : base(innerSearch)
     {
         Verify.NotNull(innerSearch);
         Verify.NotNull(logger);
@@ -37,11 +37,11 @@ public class LoggingKeywordHybridSearch<TRecord> : IKeywordHybridSearch<TRecord>
     }
 
     /// <inheritdoc/>
-    public Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public override Task<VectorSearchResults<TRecord>> HybridSearchAsync<TVector>(TVector vector, ICollection<string> keywords, HybridSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(HybridSearchAsync),
-            () => this._innerSearch.HybridSearchAsync(vector, keywords, options, cancellationToken));
+            () => base.HybridSearchAsync(vector, keywords, options, cancellationToken));
     }
 }

--- a/dotnet/src/Connectors/VectorData/VectorSearch/LoggingVectorizableTextSearch.cs
+++ b/dotnet/src/Connectors/VectorData/VectorSearch/LoggingVectorizableTextSearch.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.VectorData;
 /// A vectorizable text search that logs operations to an <see cref="ILogger"/>
 /// </summary>
 [Experimental("SKEXP0020")]
-public class LoggingVectorizableTextSearch<TRecord> : IVectorizableTextSearch<TRecord>
+public class LoggingVectorizableTextSearch<TRecord> : DelegatingVectorizableTextSearch<TRecord>
 {
     /// <summary>An <see cref="ILogger"/> instance used for all logging.</summary>
     private readonly ILogger _logger;
@@ -26,7 +26,7 @@ public class LoggingVectorizableTextSearch<TRecord> : IVectorizableTextSearch<TR
     /// </summary>
     /// <param name="innerSearch">The underlying <see cref="IVectorizableTextSearch{TRecord}"/>.</param>
     /// <param name="logger">An <see cref="ILogger"/> instance used for all logging.</param>
-    public LoggingVectorizableTextSearch(IVectorizableTextSearch<TRecord> innerSearch, ILogger logger)
+    public LoggingVectorizableTextSearch(IVectorizableTextSearch<TRecord> innerSearch, ILogger logger) : base(innerSearch)
     {
         Verify.NotNull(innerSearch);
         Verify.NotNull(logger);
@@ -36,11 +36,11 @@ public class LoggingVectorizableTextSearch<TRecord> : IVectorizableTextSearch<TR
     }
 
     /// <inheritdoc/>
-    public Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public override Task<VectorSearchResults<TRecord>> VectorizableTextSearchAsync(string searchText, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(VectorizableTextSearchAsync),
-            () => this._innerSearch.VectorizableTextSearchAsync(searchText, options, cancellationToken));
+            () => base.VectorizableTextSearchAsync(searchText, options, cancellationToken));
     }
 }

--- a/dotnet/src/Connectors/VectorData/VectorSearch/LoggingVectorizedSearch.cs
+++ b/dotnet/src/Connectors/VectorData/VectorSearch/LoggingVectorizedSearch.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.VectorData;
 /// A vectorized search that logs operations to an <see cref="ILogger"/>
 /// </summary>
 [Experimental("SKEXP0020")]
-public class LoggingVectorizedSearch<TRecord> : IVectorizedSearch<TRecord>
+public class LoggingVectorizedSearch<TRecord> : DelegatingVectorizedSearch<TRecord>
 {
     /// <summary>An <see cref="ILogger"/> instance used for all logging.</summary>
     private readonly ILogger _logger;
@@ -26,7 +26,7 @@ public class LoggingVectorizedSearch<TRecord> : IVectorizedSearch<TRecord>
     /// </summary>
     /// <param name="innerSearch">The underlying <see cref="IVectorizedSearch{TRecord}"/>.</param>
     /// <param name="logger">An <see cref="ILogger"/> instance used for all logging.</param>
-    public LoggingVectorizedSearch(IVectorizedSearch<TRecord> innerSearch, ILogger logger)
+    public LoggingVectorizedSearch(IVectorizedSearch<TRecord> innerSearch, ILogger logger) : base(innerSearch)
     {
         Verify.NotNull(innerSearch);
         Verify.NotNull(logger);
@@ -36,11 +36,11 @@ public class LoggingVectorizedSearch<TRecord> : IVectorizedSearch<TRecord>
     }
 
     /// <inheritdoc/>
-    public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public override Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(VectorizedSearchAsync),
-            () => this._innerSearch.VectorizedSearchAsync(vector, options, cancellationToken));
+            () => base.VectorizedSearchAsync(vector, options, cancellationToken));
     }
 }

--- a/dotnet/src/Connectors/VectorData/VectorStorage/LoggingVectorStore.cs
+++ b/dotnet/src/Connectors/VectorData/VectorStorage/LoggingVectorStore.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.VectorData;
 /// A vector store that logs operations to an <see cref="ILogger"/>
 /// </summary>
 [Experimental("SKEXP0020")]
-public class LoggingVectorStore : IVectorStore
+public class LoggingVectorStore : DelegatingVectorStore
 {
     /// <summary>An <see cref="ILogger"/> instance used for all logging.</summary>
     private readonly ILogger _logger;
@@ -26,7 +26,7 @@ public class LoggingVectorStore : IVectorStore
     /// </summary>
     /// <param name="innerStore">The underlying <see cref="IVectorStore"/>.</param>
     /// <param name="logger">An <see cref="ILogger"/> instance that will be used for all logging.</param>
-    public LoggingVectorStore(IVectorStore innerStore, ILogger logger)
+    public LoggingVectorStore(IVectorStore innerStore, ILogger logger) : base(innerStore)
     {
         Verify.NotNull(innerStore);
         Verify.NotNull(logger);
@@ -36,18 +36,18 @@ public class LoggingVectorStore : IVectorStore
     }
 
     /// <inheritdoc/>
-    public IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null) where TKey : notnull
+    public override IVectorStoreRecordCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreRecordDefinition? vectorStoreRecordDefinition = null)
         => new LoggingVectorStoreRecordCollection<TKey, TRecord>(
-            this._innerStore.GetCollection<TKey, TRecord>(name, vectorStoreRecordDefinition),
+            base.GetCollection<TKey, TRecord>(name, vectorStoreRecordDefinition),
             this._logger);
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)
+    public override IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(ListCollectionNamesAsync),
-            () => this._innerStore.ListCollectionNamesAsync(cancellationToken),
+            () => base.ListCollectionNamesAsync(cancellationToken),
             cancellationToken);
     }
 }

--- a/dotnet/src/Connectors/VectorData/VectorStorage/LoggingVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/VectorData/VectorStorage/LoggingVectorStoreRecordCollection.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.VectorData;
 /// </summary>
 [Experimental("SKEXP0020")]
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public class LoggingVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRecordCollection<TKey, TRecord> where TKey : notnull
+public class LoggingVectorStoreRecordCollection<TKey, TRecord> : DelegatingVectorStoreRecordCollection<TKey, TRecord> where TKey : notnull
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     /// <summary>An <see cref="ILogger"/> instance used for all logging.</summary>
@@ -30,6 +30,7 @@ public class LoggingVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRec
     /// <param name="innerCollection">The underlying <see cref="IVectorStoreRecordCollection{TKey, TRecord}"/>.</param>
     /// <param name="logger">An <see cref="ILogger"/> instance that will be used for all logging.</param>
     public LoggingVectorStoreRecordCollection(IVectorStoreRecordCollection<TKey, TRecord> innerCollection, ILogger logger)
+        : base(innerCollection)
     {
         Verify.NotNull(innerCollection);
         Verify.NotNull(logger);
@@ -39,106 +40,103 @@ public class LoggingVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRec
     }
 
     /// <inheritdoc/>
-    public string CollectionName => this._innerCollection.CollectionName;
-
-    /// <inheritdoc/>
-    public Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+    public override Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(CollectionExistsAsync),
-            () => this._innerCollection.CollectionExistsAsync(cancellationToken));
+            () => base.CollectionExistsAsync(cancellationToken));
     }
 
     /// <inheritdoc/>
-    public Task CreateCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task CreateCollectionAsync(CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(CreateCollectionAsync),
-            () => this._innerCollection.CreateCollectionAsync(cancellationToken));
+            () => base.CreateCollectionAsync(cancellationToken));
     }
 
     /// <inheritdoc/>
-    public Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
+    public override Task CreateCollectionIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(CreateCollectionIfNotExistsAsync),
-            () => this._innerCollection.CreateCollectionIfNotExistsAsync(cancellationToken));
+            () => base.CreateCollectionIfNotExistsAsync(cancellationToken));
     }
 
     /// <inheritdoc/>
-    public Task DeleteAsync(TKey key, CancellationToken cancellationToken = default)
+    public override Task DeleteAsync(TKey key, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(DeleteAsync),
-            () => this._innerCollection.DeleteAsync(key, cancellationToken));
+            () => base.DeleteAsync(key, cancellationToken));
     }
 
     /// <inheritdoc/>
-    public Task DeleteBatchAsync(IEnumerable<TKey> keys, CancellationToken cancellationToken = default)
+    public override Task DeleteBatchAsync(IEnumerable<TKey> keys, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(DeleteBatchAsync),
-            () => this._innerCollection.DeleteBatchAsync(keys, cancellationToken));
+            () => base.DeleteBatchAsync(keys, cancellationToken));
     }
 
     /// <inheritdoc/>
-    public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
+    public override Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(DeleteCollectionAsync),
-            () => this._innerCollection.DeleteCollectionAsync(cancellationToken));
+            () => base.DeleteCollectionAsync(cancellationToken));
     }
 
     /// <inheritdoc/>
-    public Task<TRecord?> GetAsync(TKey key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public override Task<TRecord?> GetAsync(TKey key, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(GetAsync),
-            () => this._innerCollection.GetAsync(key, options, cancellationToken));
+            () => base.GetAsync(key, options, cancellationToken));
     }
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<TKey> keys, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
+    public override IAsyncEnumerable<TRecord> GetBatchAsync(IEnumerable<TKey> keys, GetRecordOptions? options = null, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(GetBatchAsync),
-            () => this._innerCollection.GetBatchAsync(keys, options, cancellationToken),
+            () => base.GetBatchAsync(keys, options, cancellationToken),
             cancellationToken);
     }
 
     /// <inheritdoc/>
-    public Task<TKey> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+    public override Task<TKey> UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(UpsertAsync),
-            () => this._innerCollection.UpsertAsync(record, cancellationToken));
+            () => base.UpsertAsync(record, cancellationToken));
     }
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<TKey> UpsertBatchAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default)
+    public override IAsyncEnumerable<TKey> UpsertBatchAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(UpsertBatchAsync),
-            () => this._innerCollection.UpsertBatchAsync(records, cancellationToken),
+            () => base.UpsertBatchAsync(records, cancellationToken),
             cancellationToken);
     }
 
     /// <inheritdoc/>
-    public Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
+    public override Task<VectorSearchResults<TRecord>> VectorizedSearchAsync<TVector>(TVector vector, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default)
     {
         return LoggingExtensions.RunWithLoggingAsync(
             this._logger,
             nameof(VectorizedSearchAsync),
-            () => this._innerCollection.VectorizedSearchAsync(vector, options, cancellationToken));
+            () => base.VectorizedSearchAsync(vector, options, cancellationToken));
     }
 }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Related: https://github.com/microsoft/semantic-kernel/issues/10596

This PR contains `Delegating` classes for vector store abstractions that allows to implement decorators in easier way without a need for implementation of every method when inheriting the interface directly.

The implementation of `Delegating` class simply calls the methods of inner service.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
