### PR TITLE
Python: lazy-loading mechanism for agent dependencies

### DIFF
--- a/python/semantic_kernel/__init__.py
+++ b/python/semantic_kernel/__init__.py
@@ -2,8 +2,8 @@
 
 from semantic_kernel.kernel import Kernel
 
-__version__ = "1.26.0"
+__version__ = "1.26.1"
 
-DEFAULT_RC_VERSION = f"{__version__}-rc4"
+DEFAULT_RC_VERSION = f"{__version__}-rc5"
 
 __all__ = ["DEFAULT_RC_VERSION", "Kernel", "__version__"]

--- a/python/semantic_kernel/agents/__init__.py
+++ b/python/semantic_kernel/agents/__init__.py
@@ -1,35 +1,35 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from semantic_kernel.agents.agent import Agent, AgentResponseItem, AgentThread
-from semantic_kernel.agents.autogen.autogen_conversable_agent import (
-    AutoGenConversableAgent,
-    AutoGenConversableAgentThread,
-)
-from semantic_kernel.agents.azure_ai.azure_ai_agent import AzureAIAgent, AzureAIAgentThread
-from semantic_kernel.agents.azure_ai.azure_ai_agent_settings import AzureAIAgentSettings
-from semantic_kernel.agents.bedrock.bedrock_agent import BedrockAgent, BedrockAgentThread
-from semantic_kernel.agents.chat_completion.chat_completion_agent import ChatCompletionAgent, ChatHistoryAgentThread
-from semantic_kernel.agents.group_chat.agent_chat import AgentChat
-from semantic_kernel.agents.group_chat.agent_group_chat import AgentGroupChat
-from semantic_kernel.agents.open_ai.azure_assistant_agent import AzureAssistantAgent
-from semantic_kernel.agents.open_ai.open_ai_assistant_agent import AssistantAgentThread, OpenAIAssistantAgent
+import importlib
 
-__all__ = [
-    "Agent",
-    "AgentChat",
-    "AgentGroupChat",
-    "AgentResponseItem",
-    "AgentThread",
-    "AssistantAgentThread",
-    "AutoGenConversableAgent",
-    "AutoGenConversableAgentThread",
-    "AzureAIAgent",
-    "AzureAIAgentSettings",
-    "AzureAIAgentThread",
-    "AzureAssistantAgent",
-    "BedrockAgent",
-    "BedrockAgentThread",
-    "ChatCompletionAgent",
-    "ChatHistoryAgentThread",
-    "OpenAIAssistantAgent",
-]
+_AGENTS = {
+    "Agent": ".agent",
+    "AgentResponseItem": ".agent",
+    "AgentThread": ".agent",
+    "AutoGenConversableAgent": ".autogen.autogen_conversable_agent",
+    "AutoGenConversableAgentThread": ".autogen.autogen_conversable_agent",
+    "AzureAIAgent": ".azure_ai.azure_ai_agent",
+    "AzureAIAgentSettings": ".azure_ai.azure_ai_agent_settings",
+    "AzureAIAgentThread": ".azure_ai.azure_ai_agent",
+    "BedrockAgent": ".bedrock.bedrock_agent",
+    "BedrockAgentThread": ".bedrock.bedrock_agent",
+    "ChatCompletionAgent": ".chat_completion.chat_completion_agent",
+    "ChatHistoryAgentThread": ".chat_completion.chat_completion_agent",
+    "AgentChat": ".group_chat.agent_chat",
+    "AgentGroupChat": ".group_chat.agent_group_chat",
+    "AzureAssistantAgent": ".open_ai.azure_assistant_agent",
+    "AssistantAgentThread": ".open_ai.open_ai_assistant_agent",
+    "OpenAIAssistantAgent": ".open_ai.open_ai_assistant_agent",
+}
+
+
+def __getattr__(name: str):
+    if name in _AGENTS:
+        submod_name = _AGENTS[name]
+        module = importlib.import_module(submod_name, package=__name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+def __dir__():
+    return list(_AGENTS.keys())

--- a/python/semantic_kernel/agents/__init__.pyi
+++ b/python/semantic_kernel/agents/__init__.pyi
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from .agent import Agent, AgentResponseItem, AgentThread
+from .autogen.autogen_conversable_agent import AutoGenConversableAgent, AutoGenConversableAgentThread
+from .azure_ai.azure_ai_agent import AzureAIAgent, AzureAIAgentThread
+from .azure_ai.azure_ai_agent_settings import AzureAIAgentSettings
+from .bedrock.bedrock_agent import BedrockAgent, BedrockAgentThread
+from .chat_completion.chat_completion_agent import ChatCompletionAgent, ChatHistoryAgentThread
+from .group_chat.agent_chat import AgentChat
+from .group_chat.agent_group_chat import AgentGroupChat
+from .open_ai.azure_assistant_agent import AzureAssistantAgent
+from .open_ai.open_ai_assistant_agent import AssistantAgentThread, OpenAIAssistantAgent
+
+__all__ = [
+    "Agent",
+    "AgentChat",
+    "AgentGroupChat",
+    "AgentResponseItem",
+    "AgentThread",
+    "AssistantAgentThread",
+    "AutoGenConversableAgent",
+    "AutoGenConversableAgentThread",
+    "AzureAIAgent",
+    "AzureAIAgentSettings",
+    "AzureAIAgentThread",
+    "AzureAssistantAgent",
+    "BedrockAgent",
+    "BedrockAgentThread",
+    "ChatCompletionAgent",
+    "ChatHistoryAgentThread",
+    "OpenAIAssistantAgent",
+]


### PR DESCRIPTION
### Motivation and Context

Consolidated agent imports initially caused issues by eagerly loading all submodules, which forced users to install every optional dependency -- even if only one agent was needed. This PR introduces a lazy-loading mechanism via `__getattr__` in the top-level `__init__.py` to defer imports until actually accessed. Additionally, a corresponding` __init__.pyi` type stub file is provided to restore full IDE autocompletion and type hints without compromising runtime behavior.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Lazy load agent dependencies.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
