### PR TITLE
.Net: Function parameters/arguments type handling fixes

### DIFF
--- a/dotnet/samples/Demos/ModelContextProtocolPlugin/Program.cs
+++ b/dotnet/samples/Demos/ModelContextProtocolPlugin/Program.cs
@@ -55,7 +55,7 @@ kernel.Plugins.AddFromFunctions("GitHub", tools.Select(aiFunction => aiFunction.
 OpenAIPromptExecutionSettings executionSettings = new()
 {
     Temperature = 0,
-    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(options: new() { RetainArgumentTypes = true })
 };
 
 // Test using GitHub tools

--- a/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Core/ClientCore.ChatCompletion.cs
@@ -187,7 +187,7 @@ internal partial class ClientCore
                     throw;
                 }
 
-                chatMessageContent = this.CreateChatMessageContent(chatCompletion, targetModel);
+                chatMessageContent = this.CreateChatMessageContent(chatCompletion, targetModel, functionCallingConfig.Options?.RetainArgumentTypes ?? false);
                 activity?.SetCompletionResponse([chatMessageContent], chatCompletion.Usage.InputTokenCount, chatCompletion.Usage.OutputTokenCount);
             }
 
@@ -358,7 +358,7 @@ internal partial class ClientCore
                         ref toolCallIdsByIndex, ref functionNamesByIndex, ref functionArgumentBuildersByIndex);
 
                     // Translate all entries into FunctionCallContent instances for diagnostics purposes.
-                    functionCallContents = this.GetFunctionCallContents(toolCalls).ToArray();
+                    functionCallContents = this.GetFunctionCallContents(toolCalls, functionCallingConfig.Options?.RetainArgumentTypes ?? false).ToArray();
                 }
                 finally
                 {
@@ -887,11 +887,11 @@ internal partial class ClientCore
         return null;
     }
 
-    private OpenAIChatMessageContent CreateChatMessageContent(OpenAIChatCompletion completion, string targetModel)
+    private OpenAIChatMessageContent CreateChatMessageContent(OpenAIChatCompletion completion, string targetModel, bool retainArgumentTypes)
     {
         var message = new OpenAIChatMessageContent(completion, targetModel, this.GetChatCompletionMetadata(completion));
 
-        message.Items.AddRange(this.GetFunctionCallContents(completion.ToolCalls));
+        message.Items.AddRange(this.GetFunctionCallContents(completion.ToolCalls, retainArgumentTypes));
 
         return message;
     }
@@ -911,7 +911,7 @@ internal partial class ClientCore
         return message;
     }
 
-    private List<FunctionCallContent> GetFunctionCallContents(IEnumerable<ChatToolCall> toolCalls)
+    private List<FunctionCallContent> GetFunctionCallContents(IEnumerable<ChatToolCall> toolCalls, bool retainArgumentTypes)
     {
         List<FunctionCallContent> result = [];
 
@@ -926,7 +926,7 @@ internal partial class ClientCore
                 try
                 {
                     arguments = JsonSerializer.Deserialize<KernelArguments>(toolCall.FunctionArguments);
-                    if (arguments is not null)
+                    if (arguments is { Count: > 0 } && !retainArgumentTypes)
                     {
                         // Iterate over copy of the names to avoid mutating the dictionary while enumerating it
                         var names = arguments.Names.ToArray();

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/AIFunctionKernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/AIFunctionKernelFunction.cs
@@ -78,7 +78,9 @@ internal sealed class AIFunctionKernelFunction : KernelFunction
                 DefaultValue = param.Value.TryGetProperty("default", out JsonElement defaultValue) ? defaultValue : null,
                 IsRequired = param.Value.TryGetProperty("required", out JsonElement required) && required.GetBoolean(),
                 ParameterType = paramInfo?.ParameterType,
-                Schema = param.Value.TryGetProperty("schema", out JsonElement schema) ? new KernelJsonSchema(schema) : null,
+                Schema = param.Value.TryGetProperty("schema", out JsonElement schema)
+                    ? new KernelJsonSchema(schema)
+                    : new KernelJsonSchema(param.Value),
             });
         }
 

--- a/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/FunctionChoiceBehaviors/FunctionChoiceBehaviorOptions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel;
@@ -35,4 +37,14 @@ public sealed class FunctionChoiceBehaviorOptions
     /// </remarks>
     [JsonPropertyName("allow_strict_schema_adherence")]
     public bool AllowStrictSchemaAdherence { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether the types of function arguments provided by the AI model are retained by SK or not.
+    /// By default, or if set to false, SK will deserialize function arguments to strings, and type information will not be retained.
+    /// If set to true, function arguments will be deserialized as <see cref="System.Text.Json.JsonElement"/>, which retains type information.
+    /// </summary>
+    [JsonIgnore]
+    [Experimental("SKEXP0001")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool RetainArgumentTypes { get; set; } = false;
 }


### PR DESCRIPTION
### Motivation, Context and Description
This PR fixes the issue where the schema of parameters of `AIFunction` was not mapped to the schema of parameters of `KernelFunction`. As a result, the types of parameters of kernel functions were not advertised to the LLM, leading to the LLM calling the function with arguments of incorrect types. For example, the LLM called the list_commits function and provided the string value "4" as an argument for the `perPage` parameter of the number type.

This PR also adds the `RetainArgumentTypes` function choice behavior option, which allows preserving the type of function arguments provided by the LLM for a function call, as opposed to converting the arguments to strings and losing the type information. Without this option, the `AIFunctionKernelFunction` invokes `AIFunction` with string arguments, and as a result, the underlying MCP call fails with the _ModelContextProtocol.Client.McpClientException: 'Request failed (server side): Invalid input: [{"code":"invalid_type","expected":"number","received":"string","path":["perPage"],"message":"Expected number, received string"}]'_ error, indicating a parameter type mismatch.