### PR TITLE
.Net: Fix bug where invoking with no message throws for some agents.

### DIFF
--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -198,6 +198,12 @@ public abstract class Agent
             throw new KernelException($"{this.GetType().Name} currently only supports agent threads of type {nameof(TThreadType)}.");
         }
 
+        // We have to explicitly call create here to ensure that the thread is created
+        // before we invoke using the thread. While threads will be created when
+        // notified of new messages, some agents support invoking without a message,
+        // and in that case no messages will be sent in the next step.
+        await thread.CreateAsync(cancellationToken).ConfigureAwait(false);
+
         // Notify the thread that new messages are available.
         foreach (var message in messages)
         {

--- a/dotnet/src/Agents/Abstractions/AgentThread.cs
+++ b/dotnet/src/Agents/Abstractions/AgentThread.cs
@@ -32,7 +32,7 @@ public abstract class AgentThread
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that completes when the thread has been created.</returns>
     /// <exception cref="InvalidOperationException">The thread has been deleted.</exception>
-    protected virtual async Task CreateAsync(CancellationToken cancellationToken = default)
+    protected internal virtual async Task CreateAsync(CancellationToken cancellationToken = default)
     {
         if (this.IsDeleted)
         {

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/BedrockAgentInvokeTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/BedrockAgentInvokeTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
@@ -38,6 +39,13 @@ public class BedrockAgentInvokeTests() : InvokeTests(() => new BedrockAgentFixtu
     public override Task InvokeWithoutThreadCreatesThreadAsync()
     {
         return base.InvokeWithoutThreadCreatesThreadAsync();
+    }
+
+    [Fact(Skip = "This test is for manual verification.")]
+    public override Task InvokeWithoutMessageCreatesThreadAsync()
+    {
+        // The Bedrock agent does not support invoking without a message.
+        return Assert.ThrowsAsync<InvalidOperationException>(async () => await base.InvokeWithoutThreadCreatesThreadAsync());
     }
 
     [Fact(Skip = "This test is for manual verification.")]

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/InvokeTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/InvokeTests.cs
@@ -62,6 +62,25 @@ public abstract class InvokeTests(Func<AgentFixture> createAgentFixture) : IAsyn
     }
 
     [RetryFact(3, 5000)]
+    public virtual async Task InvokeWithoutMessageCreatesThreadAsync()
+    {
+        // Arrange
+        var agent = this.Fixture.Agent;
+
+        // Act
+        var asyncResults = agent.InvokeAsync([]);
+        var results = await asyncResults.ToListAsync();
+
+        // Assert
+        Assert.Single(results);
+        var firstResult = results.First();
+        Assert.NotNull(firstResult.Thread);
+
+        // Cleanup
+        await this.Fixture.DeleteThread(firstResult.Thread);
+    }
+
+    [RetryFact(3, 5000)]
     public virtual async Task ConversationMaintainsHistoryAsync()
     {
         // Arrange

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeStreamingConformance/InvokeStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeStreamingConformance/InvokeStreamingTests.cs
@@ -63,6 +63,25 @@ public abstract class InvokeStreamingTests(Func<AgentFixture> createAgentFixture
     }
 
     [RetryFact(3, 10_000)]
+    public virtual async Task InvokeStreamingAsyncWithoutMessageCreatesThreadAsync()
+    {
+        // Arrange
+        var agent = this.Fixture.Agent;
+
+        // Act
+        var asyncResults = agent.InvokeStreamingAsync([]);
+        var results = await asyncResults.ToListAsync();
+
+        // Assert
+        var firstResult = results.First();
+        var resultString = string.Join(string.Empty, results.Select(x => x.Message.Content));
+        Assert.NotNull(firstResult.Thread);
+
+        // Cleanup
+        await this.Fixture.DeleteThread(firstResult.Thread);
+    }
+
+    [RetryFact(3, 10_000)]
     public virtual async Task ConversationMaintainsHistoryAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context

We were relying on the thread being created when we added messages to it the first time, but in some cases no messages will be added, since the agent could be invoked with no messages.

### Description

Fix bug where invoking with no message throws for some agents.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
