### PR TITLE
.Net: Add invoke overloads for string and no message.

### DIFF
--- a/dotnet/samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/Controllers/AgentCompletionsController.cs
+++ b/dotnet/samples/Demos/AgentFrameworkWithAspire/ChatWithAgent.ApiService/Controllers/AgentCompletionsController.cs
@@ -71,7 +71,7 @@ public sealed class AgentCompletionsController : ControllerBase
     {
         var thread = new ChatHistoryAgentThread(chatHistory);
         IAsyncEnumerable<AgentResponseItem<ChatMessageContent>> content =
-            this._agent.InvokeAsync([], thread, options: new() { KernelArguments = arguments }, cancellationToken: cancellationToken);
+            this._agent.InvokeAsync(thread, options: new() { KernelArguments = arguments }, cancellationToken: cancellationToken);
 
         await foreach (ChatMessageContent item in content.ConfigureAwait(false))
         {
@@ -90,7 +90,7 @@ public sealed class AgentCompletionsController : ControllerBase
     {
         var thread = new ChatHistoryAgentThread(chatHistory);
         IAsyncEnumerable<AgentResponseItem<StreamingChatMessageContent>> content =
-            this._agent.InvokeStreamingAsync([], thread, options: new() { KernelArguments = arguments }, cancellationToken: cancellationToken);
+            this._agent.InvokeStreamingAsync(thread, options: new() { KernelArguments = arguments }, cancellationToken: cancellationToken);
 
         await foreach (StreamingChatMessageContent item in content.ConfigureAwait(false))
         {

--- a/dotnet/samples/GettingStartedWithAgents/AzureAIAgent/Step01_AzureAIAgent.cs
+++ b/dotnet/samples/GettingStartedWithAgents/AzureAIAgent/Step01_AzureAIAgent.cs
@@ -58,7 +58,7 @@ public class Step01_AzureAIAgent(ITestOutputHelper output) : BaseAzureAgentTest(
         // Local function to invoke agent and display the response.
         async Task InvokeAgentAsync(KernelArguments? arguments = null)
         {
-            await foreach (ChatMessageContent response in agent.InvokeAsync([], thread, new() { KernelArguments = arguments }))
+            await foreach (ChatMessageContent response in agent.InvokeAsync(thread, new() { KernelArguments = arguments }))
             {
                 WriteAgentChatMessage(response);
             }

--- a/dotnet/samples/GettingStartedWithAgents/OpenAIAssistant/Step01_Assistant.cs
+++ b/dotnet/samples/GettingStartedWithAgents/OpenAIAssistant/Step01_Assistant.cs
@@ -58,7 +58,7 @@ public class Step01_Assistant(ITestOutputHelper output) : BaseAssistantTest(outp
         // Local function to invoke agent and display the response.
         async Task InvokeAgentAsync(KernelArguments? arguments = null)
         {
-            await foreach (ChatMessageContent response in agent.InvokeAsync([], thread, options: new() { KernelArguments = arguments }))
+            await foreach (ChatMessageContent response in agent.InvokeAsync(thread, options: new() { KernelArguments = arguments }))
             {
                 WriteAgentChatMessage(response);
             }

--- a/dotnet/samples/GettingStartedWithAgents/Step01_Agent.cs
+++ b/dotnet/samples/GettingStartedWithAgents/Step01_Agent.cs
@@ -173,7 +173,7 @@ public class Step01_Agent(ITestOutputHelper output) : BaseAgentsTest(output)
         async Task InvokeAgentAsync(KernelArguments? arguments = null)
         {
             // Invoke the agent without any messages, since the agent has all that it needs via the template and arguments.
-            await foreach (ChatMessageContent content in agent.InvokeAsync([], options: new() { KernelArguments = arguments }))
+            await foreach (ChatMessageContent content in agent.InvokeAsync(options: new() { KernelArguments = arguments }))
             {
                 WriteAgentChatMessage(content);
             }

--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Microsoft.SemanticKernel.Agents;
 
@@ -44,6 +45,51 @@ public abstract class Agent
     public ILoggerFactory? LoggerFactory { get; init; }
 
     /// <summary>
+    /// Invoke the agent with no message assuming that all required instructions are already provided to the agent or on the thread.
+    /// </summary>
+    /// <param name="thread">The conversation thread to continue with this invocation. If not provided, creates a new thread.</param>
+    /// <param name="options">Optional parameters for agent invocation.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>An async list of response items that each contain a <see cref="ChatMessageContent"/> and an <see cref="AgentThread"/>.</returns>
+    /// <remarks>
+    /// To continue this thread in the future, use an <see cref="AgentThread"/> returned in one of the response items.
+    /// </remarks>
+    public virtual IAsyncEnumerable<AgentResponseItem<ChatMessageContent>> InvokeAsync(
+        AgentThread? thread = null,
+        AgentInvokeOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InvokeAsync([], thread, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Invoke the agent with the provided message and arguments.
+    /// </summary>
+    /// <param name="message">The message to pass to the agent.</param>
+    /// <param name="thread">The conversation thread to continue with this invocation. If not provided, creates a new thread.</param>
+    /// <param name="options">Optional parameters for agent invocation.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>An async list of response items that each contain a <see cref="ChatMessageContent"/> and an <see cref="AgentThread"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The provided message string will be treated as a user message.
+    /// </para>
+    /// <para>
+    /// To continue this thread in the future, use an <see cref="AgentThread"/> returned in one of the response items.
+    /// </para>
+    /// </remarks>
+    public virtual IAsyncEnumerable<AgentResponseItem<ChatMessageContent>> InvokeAsync(
+        string message,
+        AgentThread? thread = null,
+        AgentInvokeOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(message);
+
+        return this.InvokeAsync(new ChatMessageContent(AuthorRole.User, message), thread, options, cancellationToken);
+    }
+
+    /// <summary>
     /// Invoke the agent with the provided message and arguments.
     /// </summary>
     /// <param name="message">The message to pass to the agent.</param>
@@ -60,7 +106,9 @@ public abstract class Agent
         AgentInvokeOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return this.InvokeAsync(new[] { message }, thread, options, cancellationToken);
+        Verify.NotNull(message);
+
+        return this.InvokeAsync([message], thread, options, cancellationToken);
     }
 
     /// <summary>
@@ -81,6 +129,51 @@ public abstract class Agent
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Invoke the agent with no message assuming that all required instructions are already provided to the agent or on the thread.
+    /// </summary>
+    /// <param name="thread">The conversation thread to continue with this invocation. If not provided, creates a new thread.</param>
+    /// <param name="options">Optional parameters for agent invocation.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>An async list of response items that each contain a <see cref="ChatMessageContent"/> and an <see cref="AgentThread"/>.</returns>
+    /// <remarks>
+    /// To continue this thread in the future, use an <see cref="AgentThread"/> returned in one of the response items.
+    /// </remarks>
+    public virtual IAsyncEnumerable<AgentResponseItem<StreamingChatMessageContent>> InvokeStreamingAsync(
+        AgentThread? thread = null,
+        AgentInvokeOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return this.InvokeStreamingAsync([], thread, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Invoke the agent with the provided message and arguments.
+    /// </summary>
+    /// <param name="message">The message to pass to the agent.</param>
+    /// <param name="thread">The conversation thread to continue with this invocation. If not provided, creates a new thread.</param>
+    /// <param name="options">Optional parameters for agent invocation.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>An async list of response items that each contain a <see cref="ChatMessageContent"/> and an <see cref="AgentThread"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The provided message string will be treated as a user message.
+    /// </para>
+    /// <para>
+    /// To continue this thread in the future, use an <see cref="AgentThread"/> returned in one of the response items.
+    /// </para>
+    /// </remarks>
+    public virtual IAsyncEnumerable<AgentResponseItem<StreamingChatMessageContent>> InvokeStreamingAsync(
+        string message,
+        AgentThread? thread = null,
+        AgentInvokeOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(message);
+
+        return this.InvokeStreamingAsync(new ChatMessageContent(AuthorRole.User, message), thread, options, cancellationToken);
+    }
+
+    /// <summary>
     /// Invoke the agent with the provided message and arguments.
     /// </summary>
     /// <param name="message">The message to pass to the agent.</param>
@@ -97,7 +190,9 @@ public abstract class Agent
         AgentInvokeOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return this.InvokeStreamingAsync(new[] { message }, thread, options, cancellationToken);
+        Verify.NotNull(message);
+
+        return this.InvokeStreamingAsync([message], thread, options, cancellationToken);
     }
 
     /// <summary>

--- a/dotnet/src/Agents/UnitTests/AgentTests.cs
+++ b/dotnet/src/Agents/UnitTests/AgentTests.cs
@@ -1,0 +1,223 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Moq;
+using Xunit;
+
+namespace SemanticKernel.Agents.UnitTests;
+
+/// <summary>
+/// Unit tests for the <see cref="Agent"/> class.
+/// </summary>
+public class AgentTests
+{
+    private readonly Mock<Agent> _agentMock;
+    private readonly Mock<AgentThread> _agentThreadMock;
+    private readonly List<AgentResponseItem<ChatMessageContent>> _invokeResponses = new();
+    private readonly List<AgentResponseItem<StreamingChatMessageContent>> _invokeStreamingResponses = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentTests"/> class.
+    /// </summary>
+    public AgentTests()
+    {
+        this._agentThreadMock = new Mock<AgentThread>(MockBehavior.Strict);
+
+        this._invokeResponses.Add(new AgentResponseItem<ChatMessageContent>(new ChatMessageContent(AuthorRole.Assistant, "Hi"), this._agentThreadMock.Object));
+        this._invokeStreamingResponses.Add(new AgentResponseItem<StreamingChatMessageContent>(new StreamingChatMessageContent(AuthorRole.Assistant, "Hi"), this._agentThreadMock.Object));
+
+        this._agentMock = new Mock<Agent>() { CallBase = true };
+        this._agentMock
+            .Setup(x => x.InvokeAsync(
+                It.IsAny<ICollection<ChatMessageContent>>(),
+                this._agentThreadMock.Object,
+                It.IsAny<AgentInvokeOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(this._invokeResponses.ToAsyncEnumerable());
+        this._agentMock
+            .Setup(x => x.InvokeStreamingAsync(
+                It.IsAny<ICollection<ChatMessageContent>>(),
+                this._agentThreadMock.Object,
+                It.IsAny<AgentInvokeOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(this._invokeStreamingResponses.ToAsyncEnumerable());
+    }
+
+    /// <summary>
+    /// Tests that invoking without a message calls the mocked invoke method with an empty array.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task InvokeWithoutMessageCallsMockedInvokeWithEmptyArrayAsync()
+    {
+        // Arrange
+        var options = new AgentInvokeOptions();
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await foreach (var response in this._agentMock.Object.InvokeAsync(this._agentThreadMock.Object, options, cancellationToken))
+        {
+            // Assert
+            Assert.Contains(response, this._invokeResponses);
+        }
+
+        // Verify that the mocked method was called with the expected parameters
+        this._agentMock.Verify(
+            x => x.InvokeAsync(
+                It.Is<ICollection<ChatMessageContent>>(messages => messages.Count == 0),
+                this._agentThreadMock.Object,
+                options,
+                cancellationToken),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that invoking with a string message calls the mocked invoke method with the message in the ICollection of messages.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task InvokeWithStringMessageCallsMockedInvokeWithMessageInCollectionAsync()
+    {
+        // Arrange
+        var message = "Hello, Agent!";
+        var options = new AgentInvokeOptions();
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await foreach (var response in this._agentMock.Object.InvokeAsync(message, this._agentThreadMock.Object, options, cancellationToken))
+        {
+            // Assert
+            Assert.Contains(response, this._invokeResponses);
+        }
+
+        // Verify that the mocked method was called with the expected parameters
+        this._agentMock.Verify(
+            x => x.InvokeAsync(
+                It.Is<ICollection<ChatMessageContent>>(messages => messages.Count == 1 && messages.First().Content == message),
+                this._agentThreadMock.Object,
+                options,
+                cancellationToken),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that invoking with a single message calls the mocked invoke method with the message in the ICollection of messages.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task InvokeWithSingleMessageCallsMockedInvokeWithMessageInCollectionAsync()
+    {
+        // Arrange
+        var message = new ChatMessageContent(AuthorRole.User, "Hello, Agent!");
+        var options = new AgentInvokeOptions();
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await foreach (var response in this._agentMock.Object.InvokeAsync(message, this._agentThreadMock.Object, options, cancellationToken))
+        {
+            // Assert
+            Assert.Contains(response, this._invokeResponses);
+        }
+
+        // Verify that the mocked method was called with the expected parameters
+        this._agentMock.Verify(
+            x => x.InvokeAsync(
+                It.Is<ICollection<ChatMessageContent>>(messages => messages.Count == 1 && messages.First() == message),
+                this._agentThreadMock.Object,
+                options,
+                cancellationToken),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that invoking streaming without a message calls the mocked invoke method with an empty array.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task InvokeStreamingWithoutMessageCallsMockedInvokeWithEmptyArrayAsync()
+    {
+        // Arrange
+        var options = new AgentInvokeOptions();
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await foreach (var response in this._agentMock.Object.InvokeStreamingAsync(this._agentThreadMock.Object, options, cancellationToken))
+        {
+            // Assert
+            Assert.Contains(response, this._invokeStreamingResponses);
+        }
+
+        // Verify that the mocked method was called with the expected parameters
+        this._agentMock.Verify(
+            x => x.InvokeStreamingAsync(
+                It.Is<ICollection<ChatMessageContent>>(messages => messages.Count == 0),
+                this._agentThreadMock.Object,
+                options,
+                cancellationToken),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that invoking streaming with a string message calls the mocked invoke method with the message in the ICollection of messages.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task InvokeStreamingWithStringMessageCallsMockedInvokeWithMessageInCollectionAsync()
+    {
+        // Arrange
+        var message = "Hello, Agent!";
+        var options = new AgentInvokeOptions();
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await foreach (var response in this._agentMock.Object.InvokeStreamingAsync(message, this._agentThreadMock.Object, options, cancellationToken))
+        {
+            // Assert
+            Assert.Contains(response, this._invokeStreamingResponses);
+        }
+
+        // Verify that the mocked method was called with the expected parameters
+        this._agentMock.Verify(
+            x => x.InvokeStreamingAsync(
+                It.Is<ICollection<ChatMessageContent>>(messages => messages.Count == 1 && messages.First().Content == message),
+                this._agentThreadMock.Object,
+                options,
+                cancellationToken),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that invoking streaming with a single message calls the mocked invoke method with the message in the ICollection of messages.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task InvokeStreamingWithSingleMessageCallsMockedInvokeWithMessageInCollectionAsync()
+    {
+        // Arrange
+        var message = new ChatMessageContent(AuthorRole.User, "Hello, Agent!");
+        var options = new AgentInvokeOptions();
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await foreach (var response in this._agentMock.Object.InvokeStreamingAsync(message, this._agentThreadMock.Object, options, cancellationToken))
+        {
+            // Assert
+            Assert.Contains(response, this._invokeStreamingResponses);
+        }
+
+        // Verify that the mocked method was called with the expected parameters
+        this._agentMock.Verify(
+            x => x.InvokeStreamingAsync(
+                It.Is<ICollection<ChatMessageContent>>(messages => messages.Count == 1 && messages.First() == message),
+                this._agentThreadMock.Object,
+                options,
+                cancellationToken),
+            Times.Once);
+    }
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/InvokeTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/InvokeTests.cs
@@ -68,7 +68,7 @@ public abstract class InvokeTests(Func<AgentFixture> createAgentFixture) : IAsyn
         var agent = this.Fixture.Agent;
 
         // Act
-        var asyncResults = agent.InvokeAsync([]);
+        var asyncResults = agent.InvokeAsync();
         var results = await asyncResults.ToListAsync();
 
         // Assert

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeStreamingConformance/InvokeStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeStreamingConformance/InvokeStreamingTests.cs
@@ -69,7 +69,7 @@ public abstract class InvokeStreamingTests(Func<AgentFixture> createAgentFixture
         var agent = this.Fixture.Agent;
 
         // Act
-        var asyncResults = agent.InvokeStreamingAsync([]);
+        var asyncResults = agent.InvokeStreamingAsync();
         var results = await asyncResults.ToListAsync();
 
         // Assert


### PR DESCRIPTION
### Motivation and Context

Most invocations take a user message as input, so supporting just passing the string is useful.
Some agents support invoking the agent without any message, so adding explicit support for this is useful.

### Description

Add invoke overloads for string and no message.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
