### PR TITLE
Python: Add thread_id to assistant message to avoid duplication

### DIFF
--- a/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
+++ b/python/semantic_kernel/agents/open_ai/assistant_thread_actions.py
@@ -554,7 +554,10 @@ class AssistantThreadActions:
 
     @classmethod
     async def get_messages(
-        cls: type[_T], client: AsyncOpenAI, thread_id: str, sort_order: Literal["asc", "desc"] = "desc"
+        cls: type[_T],
+        client: AsyncOpenAI,
+        thread_id: str,
+        sort_order: Literal["asc", "desc"] | None = None,
     ) -> AsyncIterable["ChatMessageContent"]:
         """Get messages from the thread.
 
@@ -572,7 +575,7 @@ class AssistantThreadActions:
         while True:
             messages = await client.beta.threads.messages.list(
                 thread_id=thread_id,
-                order=sort_order,
+                order=sort_order,  # type: ignore
                 after=last_id,
             )
 


### PR DESCRIPTION
### Motivation and Context

The current OpenAI assistant get_response and invoke methods don't add the current thread_id to the CMC's metadata, therefore during a `thread.on_new_message(...)` call, the assistant's message will get added again.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Add the `thread_id` to the metadata so we don't add the assistant's response again.

**Todo**: add agent integration tests and check messages so we have coverage for this.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
