### PR TITLE
.Net: Fix InMemory collection deletion.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.InMemory/InMemoryVectorStoreRecordCollection.cs
@@ -141,6 +141,7 @@ public sealed class InMemoryVectorStoreRecordCollection<TKey, TRecord> : IVector
     public Task DeleteCollectionAsync(CancellationToken cancellationToken = default)
     {
         this._internalCollections.TryRemove(this._collectionName, out _);
+        this._internalCollectionTypes.TryRemove(this._collectionName, out _);
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
When deleting a collection, both `_internalCollections` and `_internalCollectionTypes` must be updated, as they are both used during collection creation.

Note: maintaining two separate dictionaries introduces the risk of temporary inconsistency under concurrency, which can lead to exceptions. Consider synchronizing updates or refactoring to use a single source of truth.

### Motivation and Context

Fix bug causing `Microsoft.Extensions.VectorData.VectorStoreOperationException: Collection already exists.`

Example:

```csharp
var vectorStore = new InMemoryVectorStore();

var def = new VectorStoreRecordDefinition
{
    Properties = new List<VectorStoreRecordProperty>
    {
        new VectorStoreRecordKeyProperty("id", typeof(string)),
        new VectorStoreRecordVectorProperty("vec", typeof(ReadOnlyMemory<float>))
    }
};

var collection = vectorStore.GetCollection<string, VectorStoreGenericDataModel<string>>("name", def);


await collection.CreateCollectionIfNotExistsAsync().ConfigureAwait(false);
await collection.DeleteCollectionAsync().ConfigureAwait(false);
await collection.CreateCollectionIfNotExistsAsync().ConfigureAwait(false); // exception
```