### PR TITLE
.Net: Add thread retrieval interface to enforce thread retrieval requirement for stateless agents.

### DIFF
--- a/dotnet/src/Agents/Abstractions/Agent.cs
+++ b/dotnet/src/Agents/Abstractions/Agent.cs
@@ -266,6 +266,7 @@ public abstract class Agent
 
     private ILogger? _logger;
 
+#pragma warning disable SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     /// Ensures that the thread exists, is of the expected type, and is active, plus adds the provided message to the thread.
     /// </summary>
@@ -273,13 +274,14 @@ public abstract class Agent
     /// <param name="messages">The messages to add to the thread once it is setup.</param>
     /// <param name="thread">The thread to create if it's null, validate it's type if not null, and start if it is not active.</param>
     /// <param name="constructThread">A callback to use to construct the thread if it's null.</param>
+    /// <param name="requiresThreadRetrieval">true if the thread must implement <see cref="IAgentThreadRetrievable"/> to allow message retrieval.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>An async task that completes once all update are complete.</returns>
-    /// <exception cref="KernelException"></exception>
     protected virtual async Task<TThreadType> EnsureThreadExistsWithMessagesAsync<TThreadType>(
         ICollection<ChatMessageContent> messages,
         AgentThread? thread,
         Func<TThreadType> constructThread,
+        bool requiresThreadRetrieval,
         CancellationToken cancellationToken)
         where TThreadType : AgentThread
     {
@@ -290,7 +292,12 @@ public abstract class Agent
 
         if (thread is not TThreadType concreteThreadType)
         {
-            throw new KernelException($"{this.GetType().Name} currently only supports agent threads of type {nameof(TThreadType)}.");
+            throw new InvalidOperationException($"{this.GetType().Name} currently only supports agent threads of type {nameof(TThreadType)}.");
+        }
+
+        if (requiresThreadRetrieval && thread is not IAgentThreadRetrievable)
+        {
+            throw new InvalidOperationException($"{this.GetType().Name} currently only supports agent threads that allow retrieving chat history via the {nameof(IAgentThreadRetrievable)} interface.");
         }
 
         // We have to explicitly call create here to ensure that the thread is created
@@ -307,6 +314,7 @@ public abstract class Agent
 
         return concreteThreadType;
     }
+#pragma warning restore SKEXP0110 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     /// Notfiy the given thread that a new message is available.

--- a/dotnet/src/Agents/Abstractions/IAgentThreadRetrievable.cs
+++ b/dotnet/src/Agents/Abstractions/IAgentThreadRetrievable.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Microsoft.SemanticKernel.Agents;
+
+/// <summary>
+/// Interface for any Semantic Kernel agent threads that allow the messages
+/// contained in them to be passed to an agent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AgentThread"/> types that implement this interface can
+/// be used with Agents that do not maintain a server-side chat history
+/// and require the entire set of messages, that are needed to generate
+/// a response, to be provided to the agent at invocation time.
+/// </para>
+/// <para>
+/// The set of messages returned may be truncated or processed
+/// by the <see cref="AgentThread"/> as needed before passed to the
+/// agent to achieve a scalable and performant solution.
+/// </para>
+/// </remarks>
+[Experimental("SKEXP0110")]
+public interface IAgentThreadRetrievable
+{
+    /// <summary>
+    /// Asynchronously retrieves all messages to be used for the agent invocation.
+    /// </summary>
+    /// <remarks>
+    /// Messages are returned in ascending chronological order.
+    /// </remarks>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The messages in the thread.</returns>
+    /// <exception cref="InvalidOperationException">The thread has been deleted.</exception>
+    [Experimental("SKEXP0110")]
+    IAsyncEnumerable<ChatMessageContent> GetMessagesAsync(CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
@@ -184,6 +184,7 @@ public sealed partial class AzureAIAgent : KernelAgent
             messages,
             thread,
             () => new AzureAIAgentThread(this.Client),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         var invokeResults = ActivityExtensions.RunWithActivityAsync(
@@ -303,6 +304,7 @@ public sealed partial class AzureAIAgent : KernelAgent
             messages,
             thread,
             () => new AzureAIAgentThread(this.Client),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/dotnet/src/Agents/Bedrock/BedrockAgent.cs
+++ b/dotnet/src/Agents/Bedrock/BedrockAgent.cs
@@ -115,6 +115,7 @@ public sealed class BedrockAgent : KernelAgent
             messages,
             thread,
             () => new BedrockAgentThread(this.RuntimeClient),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         // Ensure that the last message provided is a user message
@@ -193,6 +194,7 @@ public sealed class BedrockAgent : KernelAgent
             [],
             thread,
             () => new BedrockAgentThread(this.RuntimeClient),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         // Configure the agent request with the provided options
@@ -347,6 +349,7 @@ public sealed class BedrockAgent : KernelAgent
             messages,
             thread,
             () => new BedrockAgentThread(this.RuntimeClient),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         // Ensure that the last message provided is a user message
@@ -426,6 +429,7 @@ public sealed class BedrockAgent : KernelAgent
             [],
             thread,
             () => new BedrockAgentThread(this.RuntimeClient),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         // Configure the agent request with the provided options

--- a/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Agents;
 /// <summary>
 /// Represents a conversation thread based on an instance of <see cref="ChatHistory"/> that is maanged inside this class.
 /// </summary>
-public sealed class ChatHistoryAgentThread : AgentThread
+public sealed class ChatHistoryAgentThread : AgentThread, IAgentThreadRetrievable
 {
     private readonly ChatHistory _chatHistory = new();
 

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -401,6 +401,7 @@ public sealed partial class OpenAIAssistantAgent : KernelAgent
             messages,
             thread,
             () => new OpenAIAssistantAgentThread(this.Client),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         // Create options that use the RunCreationOptions from the options param if provided or
@@ -547,6 +548,7 @@ public sealed partial class OpenAIAssistantAgent : KernelAgent
             messages,
             thread,
             () => new OpenAIAssistantAgentThread(this.Client),
+            requiresThreadRetrieval: false,
             cancellationToken).ConfigureAwait(false);
 
         // Create options that use the RunCreationOptions from the options param if provided or


### PR DESCRIPTION
### Motivation and Context

We need to have a standard way to retrieve chat history from a thread for agents that require
chat history at invocation time. This also allows these agents to check that the thread is
compatible before processing.

### Description

- Add an interface to decorate compatible threads with.
- Update ChatHistoryAgentThread to implement the new interface.
- Update ChatCompletionAgent to use the new interface

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
