### PR TITLE
Fix sample and README

### DIFF
--- a/python/samples/getting_started_with_agents/azure_ai_agent/step2_azure_ai_agent_plugin.py
+++ b/python/samples/getting_started_with_agents/azure_ai_agent/step2_azure_ai_agent_plugin.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from azure.identity.aio import DefaultAzureCredential
 
-from semantic_kernel.agents import AzureAIAgent, AzureAIAgentSettings, AzureAIAgentThread
+from semantic_kernel.agents import AzureAIAgent, AzureAIAgentSettings
 from semantic_kernel.functions import kernel_function
 
 """
@@ -60,29 +60,26 @@ async def main() -> None:
         agent = AzureAIAgent(
             client=client,
             definition=agent_definition,
+            plugins=[MenuPlugin()],  # Add the plugin to the agent
         )
 
-        # 3. Add a plugin to the agent via the kernel
-        agent.kernel.add_plugin(MenuPlugin(), plugin_name="menu")
-
-        # 4. Create a thread for the agent
+        # 3. Create a thread for the agent
         # If no thread is provided, a new thread will be
         # created and returned with the initial response
-        thread: AzureAIAgentThread = None
+        thread = None
 
         try:
             for user_input in USER_INPUTS:
                 print(f"# User: {user_input}")
-                # 5. Invoke the agent for the specified thread for response
+                # 4. Invoke the agent for the specified thread for response
                 async for response in agent.invoke(
                     messages=user_input,
-                    thread_id=thread,
-                    temperature=0.2,  # override the agent-level temperature setting with a run-time value
+                    thread=thread,
                 ):
                     print(f"# {response.name}: {response}")
                     thread = response.thread
         finally:
-            # 6. Cleanup: Delete the thread and agent
+            # 5. Cleanup: Delete the thread and agent
             await thread.delete() if thread else None
             await client.agents.delete_agent(agent.id)
 

--- a/python/samples/getting_started_with_agents/openai_assistant/README.md
+++ b/python/samples/getting_started_with_agents/openai_assistant/README.md
@@ -47,15 +47,19 @@ agent = OpenAIAssistantAgent(
     definition=definition,
 )
 
-# Define a thread and invoke the agent with the user input
-thread = await agent.client.beta.threads.create()
+# Define a thread to hold the conversation's context
+# If a thread is not created initially it will be created
+# and returned as part of the first response
+thread = None
 
-# Add a message to the thread
-await agent.add_chat_message(thread_id=thread.id, message="Why is the sky blue?")
+# Get the agent response
+response = await agent.get_response(messages="Why is the sky blue?", thread=thread)
+thread = response.thread
 
-# Invoke the agent
-async for content in agent.invoke(thread_id=thread.id):
-    print(f"# {content.role}: {content.content}")
+# or use the agent.invoke(...) method
+async for response in agent.invoke(messages="Why is the sky blue?", thread=thread):
+    print(f"# {response.role}: {response.content}")
+    thread = response.thread
 ```
 
 ### Semantic Kernel Azure Assistant Agents
@@ -89,13 +93,17 @@ agent = AzureAssistantAgent(
     definition=definition,
 )
 
-# Define a thread and invoke the agent with the user input
-thread = await agent.client.beta.threads.create()
+# Define a thread to hold the conversation's context
+# If a thread is not created initially it will be created
+# and returned as part of the first response
+thread = None
 
-# Add a message to the thread
-await agent.add_chat_message(thread_id=thread.id, message="Why is the sky blue?")
+# Get the agent response
+response = await agent.get_response(messages="Why is the sky blue?", thread=thread)
+thread = response.thread
 
-# Invoke the agent
-async for content in agent.invoke(thread_id=thread.id):
-    print(f"# {content.role}: {content.content}")
+# or use the agent.invoke(...) method
+async for response in agent.invoke(messages="Why is the sky blue?", thread=thread):
+    print(f"# {response.role}: {response.content}")
+    thread = response.thread
 ```


### PR DESCRIPTION
### Motivation and Context

The AzureAIAgent step1 sample is using a `thread_id` kwarg for `agent.invoke(...)`. Fix this to be `thread` instead, so we can use the created thread for later invokes.

For the OpenAIAssistantAgent README, update the `thread` related items to use the new common agent invoke api constructs. 

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Update a sample and a README.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
