### PR TITLE
.Net: Rename OnNewMessage callback to OnIntermediateMessage

### DIFF
--- a/dotnet/samples/Concepts/Agents/AzureAIAgent_Streaming.cs
+++ b/dotnet/samples/Concepts/Agents/AzureAIAgent_Streaming.cs
@@ -111,7 +111,7 @@ public class AzureAIAgent_Streaming(ITestOutputHelper output) : BaseAzureAgentTe
 
         bool isFirst = false;
         bool isCode = false;
-        await foreach (StreamingChatMessageContent response in agent.InvokeStreamingAsync(message, agentThread, new AgentInvokeOptions() { OnNewMessage = OnNewMessage }))
+        await foreach (StreamingChatMessageContent response in agent.InvokeStreamingAsync(message, agentThread, new AgentInvokeOptions() { OnIntermediateMessage = OnNewMessage }))
         {
             if (string.IsNullOrEmpty(response.Content))
             {

--- a/dotnet/samples/Concepts/Agents/OpenAIAssistant_Streaming.cs
+++ b/dotnet/samples/Concepts/Agents/OpenAIAssistant_Streaming.cs
@@ -107,7 +107,7 @@ public class OpenAIAssistant_Streaming(ITestOutputHelper output) : BaseAssistant
 
         bool isFirst = false;
         bool isCode = false;
-        await foreach (StreamingChatMessageContent response in agent.InvokeStreamingAsync(message, agentThread, new() { OnNewMessage = OnNewMessage }))
+        await foreach (StreamingChatMessageContent response in agent.InvokeStreamingAsync(message, agentThread, new() { OnIntermediateMessage = OnNewMessage }))
         {
             if (string.IsNullOrEmpty(response.Content))
             {

--- a/dotnet/src/Agents/Abstractions/AgentInvokeOptions.cs
+++ b/dotnet/src/Agents/Abstractions/AgentInvokeOptions.cs
@@ -28,7 +28,7 @@ public class AgentInvokeOptions
         this.KernelArguments = options.KernelArguments;
         this.Kernel = options.Kernel;
         this.AdditionalInstructions = options.AdditionalInstructions;
-        this.OnNewMessage = options.OnNewMessage;
+        this.OnIntermediateMessage = options.OnIntermediateMessage;
     }
 
     /// <summary>
@@ -56,5 +56,5 @@ public class AgentInvokeOptions
     /// when invoking the agent with streaming.
     /// </para>
     /// </remarks>
-    public Func<ChatMessageContent, Task>? OnNewMessage { get; init; } = null;
+    public Func<ChatMessageContent, Task>? OnIntermediateMessage { get; init; } = null;
 }

--- a/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgent.cs
@@ -205,9 +205,9 @@ public sealed partial class AzureAIAgent : KernelAgent
             {
                 // The thread and the caller should be notified of all messages regardless of visibility.
                 await this.NotifyThreadOfNewMessage(azureAIAgentThread, message, cancellationToken).ConfigureAwait(false);
-                if (options?.OnNewMessage is not null)
+                if (options?.OnIntermediateMessage is not null)
                 {
-                    await options.OnNewMessage(message).ConfigureAwait(false);
+                    await options.OnIntermediateMessage(message).ConfigureAwait(false);
                 }
 
                 if (isVisible)
@@ -328,9 +328,9 @@ public sealed partial class AzureAIAgent : KernelAgent
         {
             await this.NotifyThreadOfNewMessage(azureAIAgentThread, newMessage, cancellationToken).ConfigureAwait(false);
 
-            if (options?.OnNewMessage is not null)
+            if (options?.OnIntermediateMessage is not null)
             {
-                await options.OnNewMessage(newMessage).ConfigureAwait(false);
+                await options.OnIntermediateMessage(newMessage).ConfigureAwait(false);
             }
         }
     }

--- a/dotnet/src/Agents/Core/ChatCompletionAgent.cs
+++ b/dotnet/src/Agents/Core/ChatCompletionAgent.cs
@@ -85,9 +85,9 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
             async (m) =>
             {
                 await this.NotifyThreadOfNewMessage(chatHistoryAgentThread, m, cancellationToken).ConfigureAwait(false);
-                if (options?.OnNewMessage is not null)
+                if (options?.OnIntermediateMessage is not null)
                 {
-                    await options.OnNewMessage(m).ConfigureAwait(false);
+                    await options.OnIntermediateMessage(m).ConfigureAwait(false);
                 }
             },
             options?.KernelArguments,
@@ -115,9 +115,9 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
             {
                 await this.NotifyThreadOfNewMessage(chatHistoryAgentThread, result, cancellationToken).ConfigureAwait(false);
 
-                if (options?.OnNewMessage is not null)
+                if (options?.OnIntermediateMessage is not null)
                 {
-                    await options.OnNewMessage(result).ConfigureAwait(false);
+                    await options.OnIntermediateMessage(result).ConfigureAwait(false);
                 }
             }
 
@@ -169,9 +169,9 @@ public sealed class ChatCompletionAgent : ChatHistoryKernelAgent
             async (m) =>
             {
                 await this.NotifyThreadOfNewMessage(chatHistoryAgentThread, m, cancellationToken).ConfigureAwait(false);
-                if (options?.OnNewMessage is not null)
+                if (options?.OnIntermediateMessage is not null)
                 {
-                    await options.OnNewMessage(m).ConfigureAwait(false);
+                    await options.OnIntermediateMessage(m).ConfigureAwait(false);
                 }
             },
             options?.KernelArguments,

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgent.cs
@@ -430,9 +430,9 @@ public sealed partial class OpenAIAssistantAgent : KernelAgent
             {
                 // The thread and the caller should be notified of all messages regardless of visibility.
                 await this.NotifyThreadOfNewMessage(openAIAssistantAgentThread, message, cancellationToken).ConfigureAwait(false);
-                if (options?.OnNewMessage is not null)
+                if (options?.OnIntermediateMessage is not null)
                 {
-                    await options.OnNewMessage(message).ConfigureAwait(false);
+                    await options.OnIntermediateMessage(message).ConfigureAwait(false);
                 }
 
                 if (isVisible)
@@ -580,9 +580,9 @@ public sealed partial class OpenAIAssistantAgent : KernelAgent
         {
             await this.NotifyThreadOfNewMessage(openAIAssistantAgentThread, newMessage, cancellationToken).ConfigureAwait(false);
 
-            if (options?.OnNewMessage is not null)
+            if (options?.OnIntermediateMessage is not null)
             {
-                await options.OnNewMessage(newMessage).ConfigureAwait(false);
+                await options.OnIntermediateMessage(newMessage).ConfigureAwait(false);
             }
         }
     }

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/ChatCompletionAgentInvokeTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/ChatCompletionAgentInvokeTests.cs
@@ -35,7 +35,7 @@ public class ChatCompletionAgentInvokeTests() : InvokeTests(() => new ChatComple
             options: new()
             {
                 KernelArguments = new KernelArguments(new PromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) }),
-                OnNewMessage = (message) =>
+                OnIntermediateMessage = (message) =>
                 {
                     notifiedMessages.Add(message);
                     return Task.CompletedTask;
@@ -63,7 +63,7 @@ public class ChatCompletionAgentInvokeTests() : InvokeTests(() => new ChatComple
             options: new()
             {
                 KernelArguments = new KernelArguments(new PromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false) }),
-                OnNewMessage = (message) =>
+                OnIntermediateMessage = (message) =>
                 {
                     notifiedMessages.Add(message);
                     return Task.CompletedTask;

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/InvokeTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/InvokeTests.cs
@@ -170,7 +170,7 @@ public abstract class InvokeTests(Func<AgentFixture> createAgentFixture) : IAsyn
             options: new()
             {
                 KernelArguments = new KernelArguments(new PromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
-                OnNewMessage = (message) =>
+                OnIntermediateMessage = (message) =>
                 {
                     notifiedMessages.Add(message);
                     return Task.CompletedTask;

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeStreamingConformance/InvokeStreamingTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeStreamingConformance/InvokeStreamingTests.cs
@@ -175,7 +175,7 @@ public abstract class InvokeStreamingTests(Func<AgentFixture> createAgentFixture
             options: new()
             {
                 KernelArguments = new KernelArguments(new PromptExecutionSettings() { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }),
-                OnNewMessage = (message) =>
+                OnIntermediateMessage = (message) =>
                 {
                     notifiedMessages.Add(message);
                     return Task.CompletedTask;


### PR DESCRIPTION
### Motivation and Context

A concern was raised bout confusion between OnNewMessage on the thread and on the invoke options, so renaming the invoke option callback to try and avoid confusion.

### Description

Rename OnNewMessage callback to OnIntermediateMessage

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
