### PR TITLE
Python: Add deprecaton warning to add_chat_message for server agents

### DIFF
--- a/python/semantic_kernel/agents/azure_ai/azure_ai_agent.py
+++ b/python/semantic_kernel/agents/azure_ai/azure_ai_agent.py
@@ -5,6 +5,8 @@ import sys
 from collections.abc import AsyncIterable, Callable, Iterable
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
+from typing_extensions import deprecated
+
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
 else:
@@ -598,6 +600,9 @@ class AzureAIAgent(Agent):
 
         return AzureAIChannel(client=self.client, thread_id=thread.id)
 
+    @deprecated(
+        "Pass messages directly to get_response(...)/invoke(...) instead. This method will be removed after May 1st 2025."  # noqa: E501
+    )
     async def add_chat_message(self, thread_id: str, message: str | ChatMessageContent) -> "ThreadMessage | None":
         """Add a chat message to the thread.
 

--- a/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
+++ b/python/semantic_kernel/agents/open_ai/open_ai_assistant_agent.py
@@ -6,6 +6,8 @@ from collections.abc import AsyncIterable, Callable, Iterable
 from copy import copy
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
+from typing_extensions import deprecated
+
 if sys.version_info >= (3, 12):
     from typing import override  # pragma: no cover
 else:
@@ -440,6 +442,9 @@ class OpenAIAssistantAgent(Agent):
 
     # region Message Handling
 
+    @deprecated(
+        "Pass messages directly to get_response(...)/invoke(...) instead. This method will be removed after May 1st 2025."  # noqa: E501
+    )
     async def add_chat_message(
         self, thread_id: str, message: "str | ChatMessageContent", **kwargs: Any
     ) -> "Message | None":


### PR DESCRIPTION
### Motivation and Context

Now that we have a common agent invocation API, that uses threads, we will be deprecating the `add_chat_message` for the `AzureAIAgent` and `OpenAIAssistantAgent`. Add the deprecation decorator and message.

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Add the deprecation decorator and message.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
