### PR TITLE
Add conformance tests for checking messages passed to thread.

### DIFF
--- a/dotnet/src/Agents/AzureAI/AzureAIAgentThread.cs
+++ b/dotnet/src/Agents/AzureAI/AzureAIAgentThread.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Agents.AzureAI;
 /// <summary>
 /// Represents a conversation thread for an Azure AI agent.
 /// </summary>
-public sealed class AzureAIAgentThread : AgentThread
+public class AzureAIAgentThread : AgentThread
 {
     private readonly AgentsClient _client;
     private readonly IEnumerable<ThreadMessageOptions>? _messages;

--- a/dotnet/src/Agents/Bedrock/BedrockAgentThread.cs
+++ b/dotnet/src/Agents/Bedrock/BedrockAgentThread.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SemanticKernel.Agents.Bedrock;
 /// <summary>
 /// Represents a conversation thread for a Bedrock agent.
 /// </summary>
-public sealed class BedrockAgentThread : AgentThread
+public class BedrockAgentThread : AgentThread
 {
     private readonly AmazonBedrockAgentRuntimeClient _runtimeClient;
 

--- a/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
+++ b/dotnet/src/Agents/Core/ChatHistoryAgentThread.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SemanticKernel.Agents;
 /// <summary>
 /// Represents a conversation thread based on an instance of <see cref="ChatHistory"/> that is maanged inside this class.
 /// </summary>
-public sealed class ChatHistoryAgentThread : AgentThread
+public class ChatHistoryAgentThread : AgentThread
 {
     private readonly ChatHistory _chatHistory = new();
 

--- a/dotnet/src/Agents/OpenAI/OpenAIAssistantAgentThread.cs
+++ b/dotnet/src/Agents/OpenAI/OpenAIAssistantAgentThread.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SemanticKernel.Agents.OpenAI;
 /// <summary>
 /// Represents a conversation thread for an Open AI Assistant agent.
 /// </summary>
-public sealed class OpenAIAssistantAgentThread : AgentThread
+public class OpenAIAssistantAgentThread : AgentThread
 {
     private readonly bool _useThreadConstructorExtension = false;
     private readonly AssistantClient _client;

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentFixture.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentFixture.cs
@@ -3,6 +3,8 @@
 using System.Threading.Tasks;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Moq;
+using SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
 using Xunit;
 
 namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance;
@@ -18,6 +20,10 @@ public abstract class AgentFixture : IAsyncLifetime
     public abstract AgentThread AgentThread { get; }
 
     public abstract AgentThread CreatedAgentThread { get; }
+
+    public abstract AgentThread MockCreatedAgentThread { get; }
+
+    public abstract Mock<IMessageMockableAgentThread> MockableMessageCreatedAgentThread { get; }
 
     public abstract AgentThread ServiceFailingAgentThread { get; }
 

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/IMessageMockableAgentThread.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/IMessageMockableAgentThread.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
+
+/// <summary>
+/// Interface for mocking <see cref="AgentThread"/> objects in a way that we can check messages sent to the thread.
+/// </summary>
+public interface IMessageMockableAgentThread
+{
+    void MockableOnNewMessage(ChatMessageContent newMessage, CancellationToken cancellationToken = default);
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockAzureAIAgentThread.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockAzureAIAgentThread.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.AI.Projects;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents.AzureAI;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
+
+/// <summary>
+/// Mock implementation of <see cref="AzureAIAgentThread"/> to allow
+/// checking of messages received.
+/// </summary>
+public class MockAzureAIAgentThread(AgentsClient client, string id) : AzureAIAgentThread(client, id), IMessageMockableAgentThread
+{
+    protected override Task OnNewMessageInternalAsync(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+        this.MockableOnNewMessage(newMessage, cancellationToken);
+        return base.OnNewMessageInternalAsync(newMessage, cancellationToken);
+    }
+
+    public virtual void MockableOnNewMessage(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+    }
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockBedrockAgentThread.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockBedrockAgentThread.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.BedrockAgentRuntime;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents.Bedrock;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
+
+/// <summary>
+/// Mock implementation of <see cref="BedrockAgentThread"/> to allow
+/// checking of messages received.
+/// </summary>
+public class MockBedrockAgentThread(AmazonBedrockAgentRuntimeClient client, string id) : BedrockAgentThread(client, id), IMessageMockableAgentThread
+{
+    protected override Task OnNewMessageInternalAsync(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+        this.MockableOnNewMessage(newMessage, cancellationToken);
+        return base.OnNewMessageInternalAsync(newMessage, cancellationToken);
+    }
+
+    public virtual void MockableOnNewMessage(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+    }
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockChatHistoryAgentThread.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockChatHistoryAgentThread.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
+
+/// <summary>
+/// Mock implementation of <see cref="ChatHistoryAgentThread"/> to allow
+/// checking of messages received.
+/// </summary>
+public class MockChatHistoryAgentThread : ChatHistoryAgentThread, IMessageMockableAgentThread
+{
+    protected override Task OnNewMessageInternalAsync(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+        this.MockableOnNewMessage(newMessage, cancellationToken);
+        return base.OnNewMessageInternalAsync(newMessage, cancellationToken);
+    }
+
+    public virtual void MockableOnNewMessage(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+    }
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockOpenAIAssistantAgentThread.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/AgentThreadMocks/MockOpenAIAssistantAgentThread.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents.OpenAI;
+using OpenAI.Assistants;
+
+namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
+
+/// <summary>
+/// Mock implementation of <see cref="OpenAIAssistantAgentThread"/> to allow
+/// checking of messages received.
+/// </summary>
+public class MockOpenAIAssistantAgentThread(AssistantClient client, string id) : OpenAIAssistantAgentThread(client, id), IMessageMockableAgentThread
+{
+    protected override Task OnNewMessageInternalAsync(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+        this.MockableOnNewMessage(newMessage, cancellationToken);
+        return base.OnNewMessageInternalAsync(newMessage, cancellationToken);
+    }
+
+    public virtual void MockableOnNewMessage(ChatMessageContent newMessage, CancellationToken cancellationToken = default)
+    {
+    }
+}

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/ChatCompletionAgentFixture.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/ChatCompletionAgentFixture.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Moq;
+using SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance.AgentThreadMocks;
 using SemanticKernel.IntegrationTests.TestSettings;
 
 namespace SemanticKernel.IntegrationTests.Agents.CommonInterfaceConformance;
@@ -25,12 +28,17 @@ public class ChatCompletionAgentFixture : AgentFixture
     private ChatCompletionAgent? _agent;
     private ChatHistoryAgentThread? _thread;
     private ChatHistoryAgentThread? _createdThread;
+    private Mock<MockChatHistoryAgentThread>? _mockCreatedAgentThread;
 
     public override KernelAgent Agent => this._agent!;
 
     public override AgentThread AgentThread => this._thread!;
 
     public override AgentThread CreatedAgentThread => this._createdThread!;
+
+    public override AgentThread MockCreatedAgentThread => this._mockCreatedAgentThread!.Object;
+
+    public override Mock<IMessageMockableAgentThread> MockableMessageCreatedAgentThread => this._mockCreatedAgentThread!.As<IMessageMockableAgentThread>();
 
     public override AgentThread ServiceFailingAgentThread => null!;
 
@@ -75,5 +83,8 @@ public class ChatCompletionAgentFixture : AgentFixture
         this._thread = new ChatHistoryAgentThread();
         this._createdThread = new ChatHistoryAgentThread();
         await this._createdThread.CreateAsync();
+
+        this._mockCreatedAgentThread = new Mock<MockChatHistoryAgentThread>() { CallBase = true };
+        this._mockCreatedAgentThread.Setup(x => x.MockableOnNewMessage(It.IsAny<ChatMessageContent>(), It.IsAny<CancellationToken>()));
     }
 }

--- a/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/BedrockAgentInvokeTests.cs
+++ b/dotnet/src/IntegrationTests/Agents/CommonInterfaceConformance/InvokeConformance/BedrockAgentInvokeTests.cs
@@ -80,8 +80,14 @@ public class BedrockAgentInvokeTests() : InvokeTests(() => new BedrockAgentFixtu
     }
 
     [Fact(Skip = "This test is for manual verification.")]
-    public override Task InvokeWithPluginNotifiesForAllMessagesAsync()
+    public override Task InvokeWithPluginNotifiesCallbackForAllMessagesAsync()
     {
-        return base.InvokeWithPluginNotifiesForAllMessagesAsync();
+        return base.InvokeWithPluginNotifiesCallbackForAllMessagesAsync();
+    }
+
+    [Fact(Skip = "This test is for manual verification.")]
+    public override Task InvokeWithPluginNotifiesThreadForAllMessagesBaseAsync()
+    {
+        return base.InvokeWithPluginNotifiesThreadForAllMessagesBaseAsync();
     }
 }


### PR DESCRIPTION
### Motivation and Context

We want to make sure that all agents pass the same messages to the caller in the options callback and to the thread.
We already have tests for the option callback, also adding one to check the thread.

### Description

Add conformance tests for checking messages passed to thread.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
