### PR TITLE
Remove experimental flags for stable items

### DIFF
--- a/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
+++ b/dotnet/src/Connectors/Connectors.OpenAI/Settings/OpenAIPromptExecutionSettings.cs
@@ -28,7 +28,6 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// <para>- <see cref="string"/> values: <c>"low"</c>, <c>"medium"</c>, <c>"high"</c>;</para>
     /// <para>- <see cref="ChatReasoningEffortLevel"/> object;</para>
     /// </remarks>
-    [Experimental("SKEXP0010")]
     [JsonPropertyName("reasoning_effort")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public object? ReasoningEffort
@@ -175,7 +174,6 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// <para>- <see cref="ChatResponseFormat"/> object;</para>
     /// <para>- <see cref="Type"/> object, which will be used to automatically create a JSON schema.</para>
     /// </remarks>
-    [Experimental("SKEXP0010")]
     [JsonPropertyName("response_format")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public object? ResponseFormat
@@ -299,7 +297,6 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// Whether to return log probabilities of the output tokens or not.
     /// If true, returns the log probabilities of each output token returned in the `content` of `message`.
     /// </summary>
-    [Experimental("SKEXP0010")]
     [JsonPropertyName("logprobs")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Logprobs
@@ -316,7 +313,6 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// <summary>
     /// An integer specifying the number of most likely tokens to return at each token position, each with an associated log probability.
     /// </summary>
-    [Experimental("SKEXP0010")]
     [JsonPropertyName("top_logprobs")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? TopLogprobs
@@ -333,7 +329,6 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// <summary>
     /// Developer-defined tags and values used for filtering completions in the OpenAI dashboard.
     /// </summary>
-    [Experimental("SKEXP0010")]
     [JsonPropertyName("metadata")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IDictionary<string, string>? Metadata
@@ -350,7 +345,6 @@ public class OpenAIPromptExecutionSettings : PromptExecutionSettings
     /// <summary>
     /// Whether or not to store the output of this chat completion request for use in the OpenAI model distillation or evals products.
     /// </summary>
-    [Experimental("SKEXP0010")]
     [JsonPropertyName("store")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Store

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatHistoryExtensions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatHistoryExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 /// <summary>
 /// Extension methods for chat history.
 /// </summary>
-[Experimental("SKEXP0001")]
 public static class ChatHistoryExtensions
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatHistoryReducer.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/IChatHistoryReducer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,7 +9,6 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 /// <summary>
 /// Interface for reducing the chat history.
 /// </summary>
-[Experimental("SKEXP0001")]
 public interface IChatHistoryReducer
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/PromptExecutionSettings.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.TextGeneration;
@@ -36,7 +35,6 @@ public class PromptExecutionSettings
     /// When provided, this service identifier will be the key in a dictionary collection of execution settings for both <see cref="KernelArguments"/> and <see cref="PromptTemplateConfig"/>.
     /// If not provided the service identifier will be the default value in <see cref="DefaultServiceId"/>.
     /// </remarks>
-    [Experimental("SKEXP0001")]
     [JsonPropertyName("service_id")]
     public string? ServiceId
     {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearch.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearch.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,7 +8,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// <summary>
 /// Interface for text based search queries for use with Semantic Kernel prompts and automatic function calling.
 /// </summary>
-[Experimental("SKEXP0001")]
 public interface ITextSearch
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchResultMapper.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchResultMapper.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Interface for mapping between a <see cref="ITextSearch" /> implementation result value, and a <see cref="TextSearchResult" /> instance.
 /// </summary>
-[Experimental("SKEXP0001")]
 public interface ITextSearchResultMapper
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchStringMapper.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/ITextSearchStringMapper.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Interface for mapping between a <see cref="ITextSearch" /> implementation result value, and a <see cref="string" /> instance.
 /// </summary>
-[Experimental("SKEXP0001")]
 public interface ITextSearchStringMapper
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/KernelSearchResults.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/KernelSearchResults.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -13,7 +12,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// <param name="results">The search results.</param>
 /// <param name="totalCount">The total count of results found by the search operation, or null if the count was not requested.</param>
 /// <param name="metadata">Metadata associated with the search results.</param>
-[Experimental("SKEXP0001")]
 public sealed class KernelSearchResults<T>(IAsyncEnumerable<T> results, long? totalCount = null, IReadOnlyDictionary<string, object?>? metadata = null)
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchOptions.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchOptions.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
 /// Options which can be applied when using <see cref="ITextSearch"/>.
 /// </summary>
-[Experimental("SKEXP0001")]
 public sealed class TextSearchOptions
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResult.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResult.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.SemanticKernel.Data;
 
 /// <summary>
@@ -14,7 +12,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// - Link reference associated with the search result
 /// </remarks>
 /// <param name="value">The text search result value.</param>
-[Experimental("SKEXP0001")]
 public sealed class TextSearchResult(string value)
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultLinkAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultLinkAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -10,7 +9,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// <remarks>
 /// The characteristics defined here will influence how the property is treated when converting a record to a <see cref="TextSearchResult"/>.
 /// </remarks>
-[Experimental("SKEXP0001")]
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class TextSearchResultLinkAttribute : Attribute
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultNameAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultNameAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -11,7 +10,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// <remarks>
 /// The characteristics defined here will influence how the property is treated when converting a record to a <see cref="TextSearchResult"/>.
 /// </remarks>
-[Experimental("SKEXP0001")]
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class TextSearchResultNameAttribute : Attribute
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultValueAttribute.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Data/TextSearch/TextSearchResultValueAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.SemanticKernel.Data;
 
@@ -10,7 +9,6 @@ namespace Microsoft.SemanticKernel.Data;
 /// <remarks>
 /// The characteristics defined here will influence how the property is treated when converting a record to a <see cref="TextSearchResult"/>.
 /// </remarks>
-[Experimental("SKEXP0001")]
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class TextSearchResultValueAttribute : Attribute
 {

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/AutoFunctionInvocationContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/AutoFunctionInvocation/AutoFunctionInvocationContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.SemanticKernel.ChatCompletion;
 
@@ -83,7 +82,6 @@ public class AutoFunctionInvocationContext
     /// <summary>
     /// The execution settings associated with the operation.
     /// </summary>
-    [Experimental("SKEXP0001")]
     public PromptExecutionSettings? ExecutionSettings { get; init; }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderContext.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Filters/Prompt/PromptRenderContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.SemanticKernel;
@@ -58,7 +57,6 @@ public sealed class PromptRenderContext
     /// <summary>
     /// The execution settings associated with the operation.
     /// </summary>
-    [Experimental("SKEXP0001")]
     public PromptExecutionSettings? ExecutionSettings { get; init; }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelFunction.cs
@@ -509,7 +509,6 @@ public abstract class KernelFunction
     /// The <see cref="Kernel"/> instance to pass to the <see cref="KernelFunction"/> when it's invoked as part of the <see cref="AIFunction"/>'s invocation.
     /// </param>
     /// <returns>An instance of <see cref="AIFunction"/> that, when invoked, will in turn invoke the current <see cref="KernelFunction"/>.</returns>
-    [Experimental("SKEXP0001")]
     public AIFunction AsAIFunction(Kernel? kernel = null)
     {
         return new KernelAIFunction(this, kernel);

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelParameterMetadata.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelParameterMetadata.cs
@@ -37,7 +37,6 @@ public sealed class KernelParameterMetadata
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
     /// <exception cref="ArgumentNullException">The <paramref name="name"/> was null.</exception>
     /// <exception cref="ArgumentException">The <paramref name="name"/> was empty or composed entirely of whitespace.</exception>
-    [Experimental("SKEXP0120")]
     public KernelParameterMetadata(string name, JsonSerializerOptions jsonSerializerOptions)
     {
         this.Name = name;
@@ -66,7 +65,6 @@ public sealed class KernelParameterMetadata
     /// <param name="metadata">The metadata to copy.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
     /// <remarks>This creates a shallow clone of <paramref name="metadata"/>.</remarks>
-    [Experimental("SKEXP0120")]
     public KernelParameterMetadata(KernelParameterMetadata metadata, JsonSerializerOptions jsonSerializerOptions)
     {
         Verify.NotNull(metadata);

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelPlugin.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelPlugin.cs
@@ -98,7 +98,6 @@ public abstract class KernelPlugin : IEnumerable<KernelFunction>
     /// The <see cref="Kernel"/> instance to pass to the <see cref="KernelFunction"/>s when invoked as part of the <see cref="AIFunction"/>'s invocation.
     /// </param>
     /// <returns>An enumerable of <see cref="AIFunction"/> instances, one for each <see cref="KernelFunction"/> in this plugin.</returns>
-    [Experimental("SKEXP0001")]
     public IEnumerable<AIFunction> AsAIFunctions(Kernel? kernel = null)
     {
         foreach (KernelFunction function in this)

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/KernelReturnParameterMetadata.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/KernelReturnParameterMetadata.cs
@@ -40,7 +40,6 @@ public sealed class KernelReturnParameterMetadata
 
     /// <summary>Initializes the <see cref="KernelReturnParameterMetadata"/>.</summary>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
-    [Experimental("SKEXP0120")]
     public KernelReturnParameterMetadata(JsonSerializerOptions jsonSerializerOptions)
     {
         this._jsonSerializerOptions = jsonSerializerOptions;
@@ -60,7 +59,6 @@ public sealed class KernelReturnParameterMetadata
     /// <summary>Initializes a <see cref="KernelReturnParameterMetadata"/> as a copy of another <see cref="KernelReturnParameterMetadata"/>.</summary>
     /// <param name="metadata">The metadata to copy.</param>
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to generate JSON schema.</param>
-    [Experimental("SKEXP0120")]
     public KernelReturnParameterMetadata(KernelReturnParameterMetadata metadata, JsonSerializerOptions jsonSerializerOptions)
     {
         this._description = metadata._description;

--- a/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/Functions/RestApiOperationResponse.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.SemanticKernel;
@@ -53,7 +52,6 @@ public sealed class RestApiOperationResponse
     /// <summary>
     /// Gets a dictionary for ambient data associated with the response.
     /// </summary>
-    [Experimental("SKEXP0040")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IDictionary<string, object?>? Data { get; set; }
 

--- a/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistorySummarizationReducer.cs
+++ b/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistorySummarizationReducer.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +17,6 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 /// is provided (recommended), reduction will scan within the threshold window in an attempt to
 /// avoid orphaning a user message from an assistant response.
 /// </remarks>
-[Experimental("SKEXP0001")]
 public class ChatHistorySummarizationReducer : IChatHistoryReducer
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistoryTruncationReducer.cs
+++ b/dotnet/src/SemanticKernel.Core/AI/ChatCompletion/ChatHistoryTruncationReducer.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +17,6 @@ namespace Microsoft.SemanticKernel.ChatCompletion;
 /// is provided (recommended), reduction will scan within the threshold window in an attempt to
 /// avoid orphaning a user message from an assistant response.
 /// </remarks>
-[Experimental("SKEXP0001")]
 public class ChatHistoryTruncationReducer : IChatHistoryReducer
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchExtensions.cs
@@ -49,7 +49,6 @@ public static class TextSearchExtensions
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="description">A description of the plugin.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateWithSearch(this ITextSearch textSearch, string pluginName, JsonSerializerOptions jsonSerializerOptions, string? description = null)
     {
         Verify.NotNull(textSearch);
@@ -91,7 +90,6 @@ public static class TextSearchExtensions
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="description">A description of the plugin.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a GetTextSearchResults operation that calls the provided <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateWithGetTextSearchResults(this ITextSearch textSearch, string pluginName, JsonSerializerOptions jsonSerializerOptions, string? description = null)
     {
         Verify.NotNull(textSearch);
@@ -133,7 +131,6 @@ public static class TextSearchExtensions
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="description">A description of the plugin.</param>
     /// <returns>A <see cref="KernelPlugin"/> instance with a GetSearchResults operation that calls the provided <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateWithGetSearchResults(this ITextSearch textSearch, string pluginName, JsonSerializerOptions jsonSerializerOptions, string? description = null)
     {
         Verify.NotNull(textSearch);
@@ -191,7 +188,6 @@ public static class TextSearchExtensions
     /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
     /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.SearchAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateSearch(this ITextSearch textSearch, JsonSerializerOptions jsonSerializerOptions, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
     {
         async Task<IEnumerable<string>> SearchAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken, int count = 2, int skip = 0)
@@ -269,7 +265,6 @@ public static class TextSearchExtensions
     /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
     /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.GetTextSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateGetTextSearchResults(this ITextSearch textSearch, JsonSerializerOptions jsonSerializerOptions, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
     {
         async Task<IEnumerable<TextSearchResult>> GetTextSearchResultAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken, int count = 2, int skip = 0)
@@ -346,7 +341,6 @@ public static class TextSearchExtensions
     /// <param name="options">Optional KernelFunctionFromMethodOptions which allow the KernelFunction metadata to be specified.</param>
     /// <param name="searchOptions">Optional TextSearchOptions which override the options provided when the function is invoked.</param>
     /// <returns>A <see cref="KernelFunction"/> instance with a Search operation that calls the provided <see cref="ITextSearch.GetSearchResultsAsync(string, TextSearchOptions?, CancellationToken)"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateGetSearchResults(this ITextSearch textSearch, JsonSerializerOptions jsonSerializerOptions, KernelFunctionFromMethodOptions? options = null, TextSearchOptions? searchOptions = null)
     {
         async Task<IEnumerable<object>> GetSearchResultAsync(Kernel kernel, KernelFunction function, KernelArguments arguments, CancellationToken cancellationToken, int count = 2, int skip = 0)

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchKernelBuilderExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchKernelBuilderExtensions.cs
@@ -8,7 +8,6 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register <see cref="ITextSearch"/> for use with <see cref="KernelBuilder"/>.
 /// </summary>
-[Experimental("SKEXP0001")]
 public static class TextSearchKernelBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchServiceCollectionExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/Data/TextSearch/TextSearchServiceCollectionExtensions.cs
@@ -12,7 +12,6 @@ namespace Microsoft.SemanticKernel;
 /// <summary>
 /// Extension methods to register <see cref="ITextSearch"/> for use with <see cref="IServiceCollection"/>.
 /// </summary>
-[Experimental("SKEXP0001")]
 public static class TextSearchServiceCollectionExtensions
 {
     /// <summary>

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFactory.cs
@@ -50,7 +50,6 @@ public static class KernelFunctionFactory
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         Delegate method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -81,7 +80,6 @@ public static class KernelFunctionFactory
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         Delegate method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -125,7 +123,6 @@ public static class KernelFunctionFactory
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -162,7 +159,6 @@ public static class KernelFunctionFactory
     /// <param name="target">The target object for the <paramref name="method"/> if it represents an instance method. This should be null if and only if <paramref name="method"/> is a static method.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromMethod(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -221,7 +217,6 @@ public static class KernelFunctionFactory
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         string promptTemplate,
         JsonSerializerOptions jsonSerializerOptions,
@@ -282,7 +277,6 @@ public static class KernelFunctionFactory
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         string promptTemplate,
         JsonSerializerOptions jsonSerializerOptions,
@@ -322,7 +316,6 @@ public static class KernelFunctionFactory
     /// </param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         PromptTemplateConfig promptConfig,
         JsonSerializerOptions jsonSerializerOptions,
@@ -351,7 +344,6 @@ public static class KernelFunctionFactory
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFromPrompt(
         IPromptTemplate promptTemplate,
         PromptTemplateConfig promptConfig,

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromMethod.cs
@@ -94,7 +94,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -167,7 +166,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="target">The target object for the <paramref name="method"/> if it represents an instance method. This should be null if and only if <paramref name="method"/> is a static method.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -210,7 +208,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0001")]
     [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunctionMetadata CreateMetadata(
@@ -242,7 +239,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging. If null, no logging will be performed.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunctionMetadata CreateMetadata(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,
@@ -269,7 +265,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="method">The method to be represented via the created <see cref="KernelFunction"/>.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0001")]
     [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelFunctionMetadata CreateMetadata(
@@ -303,7 +298,6 @@ internal sealed partial class KernelFunctionFromMethod : KernelFunction
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="options">Optional function creation options.</param>
     /// <returns>The created <see cref="KernelFunction"/> wrapper for <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunctionMetadata CreateMetadata(
         MethodInfo method,
         JsonSerializerOptions jsonSerializerOptions,

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionFromPrompt.cs
@@ -89,7 +89,6 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <param name="promptTemplateFactory">Optional: Prompt template factory</param>
     /// <param name="loggerFactory">Logger factory</param>
     /// <returns>A function ready to use</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         string promptTemplate,
         JsonSerializerOptions jsonSerializerOptions,
@@ -162,7 +161,6 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <param name="promptTemplateFactory">Optional: Prompt template factory</param>
     /// <param name="loggerFactory">Logger factory</param>
     /// <returns>A function ready to use</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         PromptTemplateConfig promptConfig,
         JsonSerializerOptions jsonSerializerOptions,
@@ -209,7 +207,6 @@ internal sealed class KernelFunctionFromPrompt : KernelFunction
     /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization of various aspects of the function.</param>
     /// <param name="loggerFactory">Logger factory</param>
     /// <returns>A function ready to use</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction Create(
         IPromptTemplate promptTemplate,
         PromptTemplateConfig promptConfig,

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionMetadataFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelFunctionMetadataFactory.cs
@@ -13,7 +13,6 @@ namespace Microsoft.SemanticKernel;
 /// Provides factory methods for creating collections of <see cref="KernelFunctionMetadata"/>, such as
 /// those backed by a prompt to be submitted to an LLM or those backed by a .NET method.
 /// </summary>
-[Experimental("SKEXP0001")]
 public static class KernelFunctionMetadataFactory
 {
     /// <summary>
@@ -63,7 +62,6 @@ public static class KernelFunctionMetadataFactory
     /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
     /// Attributed methods must all have different names; overloads are not supported.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static IEnumerable<KernelFunctionMetadata> CreateFromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type instanceType, JsonSerializerOptions jsonSerializerOptions, ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(instanceType);

--- a/dotnet/src/SemanticKernel.Core/Functions/KernelPluginFactory.cs
+++ b/dotnet/src/SemanticKernel.Core/Functions/KernelPluginFactory.cs
@@ -55,7 +55,6 @@ public static partial class KernelPluginFactory
     /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
     /// Attributed methods must all have different names; overloads are not supported.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateFromType<[DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicMethods |
@@ -81,7 +80,6 @@ public static partial class KernelPluginFactory
     /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
     /// Attributed methods must all have different names; overloads are not supported.
     /// </remarks>
-    [Experimental("SKEXP0001")]
     [RequiresUnreferencedCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     [RequiresDynamicCode("Uses reflection to handle various aspects of the function creation and invocation, making it incompatible with AOT scenarios.")]
     public static KernelPlugin CreateFromType(Type instanceType, string? pluginName = null, IServiceProvider? serviceProvider = null)
@@ -109,7 +107,6 @@ public static partial class KernelPluginFactory
     /// Methods decorated with <see cref="KernelFunctionAttribute"/> will be included in the plugin.
     /// Attributed methods must all have different names; overloads are not supported.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateFromType([DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicMethods |
@@ -151,7 +148,6 @@ public static partial class KernelPluginFactory
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "This method is AOT save.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "This method is AOT safe.")]
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreateFromObject<[DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] T>(T target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null, ILoggerFactory? loggerFactory = null)
     {
         Verify.NotNull(jsonSerializerOptions);

--- a/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
+++ b/dotnet/src/SemanticKernel.Core/KernelExtensions.cs
@@ -57,7 +57,6 @@ public static class KernelExtensions
     /// <param name="parameters">Optional parameter descriptions. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromMethod(
         this Kernel kernel,
         Delegate method,
@@ -115,7 +114,6 @@ public static class KernelExtensions
     /// <param name="parameters">Optional parameter descriptions. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <param name="returnParameter">Optional return parameter description. If null, it will default to one derived from the method represented by <paramref name="method"/>.</param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking <paramref name="method"/>.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromMethod(
         this Kernel kernel,
         MethodInfo method,
@@ -189,7 +187,6 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromPrompt(
         this Kernel kernel,
         string promptTemplate,
@@ -267,7 +264,6 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromPrompt(
         this Kernel kernel,
         string promptTemplate,
@@ -326,7 +322,6 @@ public static class KernelExtensions
     /// If null, a default factory will be used.
     /// </param>
     /// <returns>The created <see cref="KernelFunction"/> for invoking the prompt.</returns>
-    [Experimental("SKEXP0120")]
     public static KernelFunction CreateFunctionFromPrompt(
         this Kernel kernel,
         PromptTemplateConfig promptConfig,
@@ -373,7 +368,6 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreatePluginFromType<[DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicMethods |
@@ -418,7 +412,6 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin CreatePluginFromObject<[DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] T>(this Kernel kernel, T target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         Verify.NotNull(kernel);
@@ -491,7 +484,6 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin ImportPluginFromType<[DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicMethods |
@@ -538,7 +530,6 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin AddFromType<[DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicMethods |
@@ -585,7 +576,6 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static IKernelBuilderPlugins AddFromType<[DynamicallyAccessedMembers(
         DynamicallyAccessedMemberTypes.PublicConstructors |
         DynamicallyAccessedMemberTypes.PublicMethods |
@@ -646,7 +636,6 @@ public static class KernelExtensions
     /// Methods that have the <see cref="KernelFunctionAttribute"/> attribute will be included in the plugin.
     /// See <see cref="KernelFunctionAttribute"/> attribute for details.
     /// </remarks>
-    [Experimental("SKEXP0120")]
     public static KernelPlugin ImportPluginFromObject<[DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] T>(this Kernel kernel, T target, JsonSerializerOptions jsonSerializerOptions, string? pluginName = null)
     {
         KernelPlugin plugin = CreatePluginFromObject<T>(kernel, target, jsonSerializerOptions, pluginName);


### PR DESCRIPTION
### Motivation and Context

1. Native-AOT
2. OpenAI execution settings
3. ITextSearch
4. IChatHistoryReducer
5. Some Misc. core/abstractions experimental flags that are over 60 days

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
