### PR TITLE
.Net: Obsolete custom mappers

### DIFF
--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/AzureAISearchFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/AzureAISearchFactory.cs
@@ -9,6 +9,8 @@ using Microsoft.SemanticKernel.Connectors.AzureAISearch;
 
 namespace Memory.VectorStoreLangchainInterop;
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
+
 /// <summary>
 /// Contains a factory method that can be used to create an Azure AI Search vector store that is compatible with datasets ingested using Langchain.
 /// </summary>

--- a/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/QdrantFactory.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/QdrantFactory.cs
@@ -7,6 +7,8 @@ using Qdrant.Client.Grpc;
 
 namespace Memory.VectorStoreLangchainInterop;
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
+
 /// <summary>
 /// Contains a factory method that can be used to create a Qdrant vector store that is compatible with datasets ingested using Langchain.
 /// </summary>

--- a/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
+++ b/dotnet/samples/Concepts/Memory/VectorStore_DataIngestion_CustomMapper.cs
@@ -12,6 +12,8 @@ using StackExchange.Redis;
 
 namespace Memory;
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
+
 /// <summary>
 /// An example showing how to ingest data into a vector store using <see cref="RedisVectorStore"/> with a custom mapper.
 /// In this example, the storage model differs significantly from the data model, so a custom mapper is used to map between the two.

--- a/dotnet/samples/GettingStartedWithVectorStores/Step6_Use_CustomMapper.cs
+++ b/dotnet/samples/GettingStartedWithVectorStores/Step6_Use_CustomMapper.cs
@@ -10,6 +10,8 @@ using Microsoft.SemanticKernel.Embeddings;
 
 namespace GettingStartedWithVectorStores;
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
+
 /// <summary>
 /// Example that shows how you can use custom mappers if you wish the data model and storage schema to differ.
 /// </summary>

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBMongoDB.UnitTests/AzureCosmosDBMongoDBVectorStoreRecordCollectionTests.cs
@@ -489,6 +489,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
             expectedPropertyName: "bson_hotel_name");
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task UpsertWithCustomMapperWorksCorrectlyAsync()
     {
@@ -564,6 +565,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionTests
         Assert.Equal(RecordKey, result.HotelId);
         Assert.Equal("Name from mapper", result.HotelName);
     }
+#pragma warning restore CS0618
 
     [Theory]
     [MemberData(nameof(VectorizedSearchVectorTypeData))]

--- a/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.AzureCosmosDBNoSQL.UnitTests/AzureCosmosDBNoSQLVectorStoreRecordCollectionTests.cs
@@ -455,6 +455,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
         Assert.Equal("key3", results[2]);
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task UpsertWithCustomMapperWorksCorrectlyAsync()
     {
@@ -537,6 +538,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionTests
         Assert.Equal(RecordKey, result.HotelId);
         Assert.Equal("Name from mapper", result.HotelName);
     }
+#pragma warning restore CS0618
 
     [Fact]
     public async Task VectorizedSearchReturnsValidRecordAsync()

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchGenericDataModelMapper.cs
@@ -15,7 +15,9 @@ namespace Microsoft.SemanticKernel.Connectors.AzureAISearch;
 /// <summary>
 /// A mapper that maps between the generic Semantic Kernel data model and the model that the data is stored under, within Azure AI Search.
 /// </summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class AzureAISearchGenericDataModelMapper(VectorStoreRecordModel model) : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, JsonObject>
+#pragma warning restore CS0618
 {
     /// <inheritdoc />
     public JsonObject MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollection.cs
@@ -52,7 +52,9 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
     private readonly AzureAISearchVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>A mapper to use for converting between the data model and the Azure AI Search record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, JsonObject>? _mapper;
+#pragma warning restore CS0618
 
     /// <summary>The model for this collection.</summary>
     private readonly VectorStoreRecordModel _model;
@@ -80,6 +82,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         this._model = new VectorStoreRecordJsonModelBuilder(AzureAISearchConstants.s_modelBuildingOptions)
             .Build(typeof(TRecord), this._options.VectorStoreRecordDefinition, this._options.JsonSerializerOptions);
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         // Resolve mapper.
         // First, if someone has provided a custom mapper, use that.
         // If they didn't provide a custom mapper, and the record type is the generic data model, use the built in mapper for that.
@@ -92,6 +95,7 @@ public class AzureAISearchVectorStoreRecordCollection<TRecord> :
         {
             this._mapper = new AzureAISearchGenericDataModelMapper(this._model) as IVectorStoreRecordMapper<TRecord, JsonObject>;
         }
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureAISearch/AzureAISearchVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Search.Documents.Indexes;
@@ -18,6 +19,7 @@ public sealed class AzureAISearchVectorStoreRecordCollectionOptions<TRecord>
     /// <remarks>
     /// If not set, the default mapper that is provided by the Azure AI Search client SDK will be used.
     /// </remarks>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, JsonObject>? JsonObjectCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollection.cs
@@ -48,7 +48,9 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : IVectorS
     private readonly AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>Interface for mapping between a storage model, and the consumer record data model.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, BsonDocument> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>The model for this collection.</summary>
     private readonly VectorStoreRecordModel _model;
@@ -473,6 +475,7 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : IVectorS
         return storagePropertyNames;
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     /// <summary>
     /// Returns custom mapper, generic data model mapper or default record mapper.
     /// </summary>
@@ -490,6 +493,7 @@ public class AzureCosmosDBMongoDBVectorStoreRecordCollection<TRecord> : IVectorS
 
         return new MongoDBVectorStoreRecordMapper<TRecord>(this._model);
     }
+#pragma warning restore CS0618
 
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBMongoDB/AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using MongoDB.Bson;
 
@@ -13,6 +14,7 @@ public sealed class AzureCosmosDBMongoDBVectorStoreRecordCollectionOptions<TReco
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Azure CosmosDB MongoDB BSON object.
     /// </summary>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, BsonDocument>? BsonDocumentCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLGenericDataModelMapper.cs
@@ -12,8 +12,10 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// <summary>
 /// A mapper that maps between the generic Semantic Kernel data model and the model that the data is stored under, within Azure CosmosDB NoSQL.
 /// </summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class AzureCosmosDBNoSQLGenericDataModelMapper(VectorStoreRecordModel model, JsonSerializerOptions jsonSerializerOptions)
     : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, JsonObject>
+#pragma warning restore CS0618
 {
     /// <summary>A default <see cref="JsonSerializerOptions"/> for serialization/deserialization of vector properties.</summary>
     private static readonly JsonSerializerOptions s_vectorJsonSerializerOptions = new()

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollection.cs
@@ -52,7 +52,9 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
     private readonly VectorStoreRecordPropertyModel _partitionKeyProperty;
 
     /// <summary>The mapper to use when mapping between the consumer data model and the Azure CosmosDB NoSQL record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, JsonObject> _mapper;
+#pragma warning restore CS0618
 
     /// <inheritdoc />
     public string CollectionName { get; }
@@ -664,6 +666,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
         }
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private IVectorStoreRecordMapper<TRecord, JsonObject> InitializeMapper(JsonSerializerOptions jsonSerializerOptions)
     {
         if (this._options.JsonObjectCustomMapper is not null)
@@ -679,6 +682,7 @@ public class AzureCosmosDBNoSQLVectorStoreRecordCollection<TRecord> :
 
         return new AzureCosmosDBNoSQLVectorStoreRecordMapper<TRecord>(this._model.KeyProperty, this._options.JsonSerializerOptions);
     }
+#pragma warning restore CS0618
 
     #endregion
 }

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Cosmos;
@@ -18,6 +19,7 @@ public sealed class AzureCosmosDBNoSQLVectorStoreRecordCollectionOptions<TRecord
     /// <remarks>
     /// If not set, the default mapper that is provided by the Azure CosmosDB NoSQL client SDK will be used.
     /// </remarks>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, JsonObject>? JsonObjectCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.AzureCosmosDBNoSQL/AzureCosmosDBNoSQLVectorStoreRecordMapper.cs
@@ -11,8 +11,10 @@ namespace Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL;
 /// Class for mapping between a json node stored in Azure CosmosDB NoSQL and the consumer data model.
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class AzureCosmosDBNoSQLVectorStoreRecordMapper<TRecord>(VectorStoreRecordKeyPropertyModel keyProperty, JsonSerializerOptions? jsonSerializerOptions)
     : IVectorStoreRecordMapper<TRecord, JsonObject>
+#pragma warning restore CS0618
 {
     private readonly VectorStoreRecordKeyPropertyModel _keyProperty = keyProperty;
 

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -48,7 +48,9 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
     private readonly MongoDBVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>Interface for mapping between a storage model, and the consumer record data model.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, BsonDocument> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>The model for this collection.</summary>
     private readonly VectorStoreRecordModel _model;
@@ -597,6 +599,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
         throw new VectorStoreOperationException("Retry logic failed.");
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     /// <summary>
     /// Returns custom mapper, generic data model mapper or default record mapper.
     /// </summary>
@@ -614,6 +617,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
 
         return new MongoDBVectorStoreRecordMapper<TRecord>(this._model);
     }
+#pragma warning restore CS0618
 
     private static Array VerifyVectorParam<TVector>(TVector vector)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using MongoDB.Bson;
 
@@ -13,6 +14,7 @@ public sealed class MongoDBVectorStoreRecordCollectionOptions<TRecord>
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the MongoDB BSON object.
     /// </summary>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, BsonDocument>? BsonDocumentCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollection.cs
@@ -29,7 +29,9 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     private readonly Sdk.PineconeClient _pineconeClient;
     private readonly PineconeVectorStoreRecordCollectionOptions<TRecord> _options;
     private readonly VectorStoreRecordModel _model;
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, Sdk.Vector> _mapper;
+#pragma warning restore CS0618
     private IndexClient? _indexClient;
 
     /// <inheritdoc />
@@ -54,7 +56,9 @@ public class PineconeVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
         this._model = new VectorStoreRecordModelBuilder(PineconeVectorStoreRecordFieldMapping.ModelBuildingOptions)
             .Build(typeof(TRecord), this._options.VectorStoreRecordDefinition);
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         this._mapper = this._options.VectorCustomMapper ?? new PineconeVectorStoreRecordMapper<TRecord>(this._model);
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Pinecone;
 
@@ -13,6 +14,7 @@ public sealed class PineconeVectorStoreRecordCollectionOptions<TRecord>
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Pinecone vector.
     /// </summary>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, Vector>? VectorCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Pinecone/PineconeVectorStoreRecordMapper.cs
@@ -11,7 +11,9 @@ namespace Microsoft.SemanticKernel.Connectors.Pinecone;
 /// Mapper between a Pinecone record and the consumer data model that uses json as an intermediary to allow supporting a wide range of models.
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class PineconeVectorStoreRecordMapper<TRecord>(VectorStoreRecordModel model) : IVectorStoreRecordMapper<TRecord, Vector>
+#pragma warning restore CS0618
 {
     /// <inheritdoc />
     public Vector MapFromDataToStorageModel(TRecord dataModel)

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollection.cs
@@ -35,7 +35,9 @@ public class PostgresVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRe
     private readonly VectorStoreRecordModel _model;
 
     /// <summary>A mapper to use for converting between the data model and the Azure AI Search record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, Dictionary<string, object?>> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>The default options for vector search.</summary>
     private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
@@ -74,7 +76,9 @@ public class PostgresVectorStoreRecordCollection<TKey, TRecord> : IVectorStoreRe
         this._model = new VectorStoreRecordModelBuilder(PostgresConstants.ModelBuildingOptions)
             .Build(typeof(TRecord), options?.VectorStoreRecordDefinition);
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         this._mapper = this._options.DictionaryCustomMapper ?? new PostgresVectorStoreRecordMapper<TRecord>(this._model);
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.VectorData;
 
@@ -21,6 +22,7 @@ public sealed class PostgresVectorStoreRecordCollectionOptions<TRecord>
     /// <remarks>
     /// If not set, the default mapper will be used.
     /// </remarks>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, Dictionary<string, object?>>? DictionaryCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Postgres/PostgresVectorStoreRecordMapper.cs
@@ -13,8 +13,10 @@ namespace Microsoft.SemanticKernel.Connectors.Postgres;
 /// A mapper class that handles the conversion between data models and storage models for Postgres vector store.
 /// </summary>
 /// <typeparam name="TRecord">The type of the data model record.</typeparam>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class PostgresVectorStoreRecordMapper<TRecord>(VectorStoreRecordModel model)
     : IVectorStoreRecordMapper<TRecord, Dictionary<string, object?>>
+#pragma warning restore CS0618
 {
     public Dictionary<string, object?> MapFromDataToStorageModel(TRecord dataModel)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreCollectionSearchMapping.cs
@@ -98,7 +98,9 @@ internal static class QdrantVectorStoreCollectionSearchMapping
     /// <param name="collectionName">The name of the collection the operation is being run on.</param>
     /// <param name="operationName">The type of database operation being run.</param>
     /// <returns>The mapped <see cref="VectorSearchResult{TRecord}"/>.</returns>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     public static VectorSearchResult<TRecord> MapScoredPointToVectorSearchResult<TRecord>(ScoredPoint point, IVectorStoreRecordMapper<TRecord, PointStruct> mapper, bool includeVectors, string databaseSystemName, string collectionName, string operationName)
+#pragma warning restore CS0618
     {
         // Since the mapper doesn't know about scored points, we need to convert the scored point to a point struct first.
         var pointStruct = new PointStruct

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollection.cs
@@ -54,7 +54,9 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
     private readonly VectorStoreRecordModel _model;
 
     /// <summary>A mapper to use for converting between qdrant point and consumer models.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, PointStruct> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QdrantVectorStoreRecordCollection{TRecord}"/> class.
@@ -91,7 +93,9 @@ public class QdrantVectorStoreRecordCollection<TRecord> :
         this._model = new VectorStoreRecordModelBuilder(QdrantVectorStoreRecordFieldMapping.GetModelBuildOptions(this._options.HasNamedVectors))
             .Build(typeof(TRecord), this._options.VectorStoreRecordDefinition);
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         this._mapper = this._options.PointStructCustomMapper ?? new QdrantVectorStoreRecordMapper<TRecord>(this._model, this._options.HasNamedVectors);
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using Qdrant.Client.Grpc;
 
@@ -22,6 +23,7 @@ public sealed class QdrantVectorStoreRecordCollectionOptions<TRecord>
     /// <remarks>
     /// If not set, a default mapper that uses json as an intermediary to allow automatic mapping to a wide variety of types will be used.
     /// </remarks>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, PointStruct>? PointStructCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Qdrant/QdrantVectorStoreRecordMapper.cs
@@ -13,8 +13,10 @@ namespace Microsoft.SemanticKernel.Connectors.Qdrant;
 /// Mapper between a Qdrant record and the consumer data model that uses json as an intermediary to allow supporting a wide range of models.
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class QdrantVectorStoreRecordMapper<TRecord>(VectorStoreRecordModel model, bool hasNamedVectors)
     : IVectorStoreRecordMapper<TRecord, PointStruct>
+#pragma warning restore CS0618
 {
     /// <inheritdoc />
     public PointStruct MapFromDataToStorageModel(TRecord dataModel)

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetGenericDataModelMapper.cs
@@ -12,7 +12,9 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// <summary>
 /// A mapper that maps between the generic Semantic Kernel data model and the model that the data is stored under, within Redis when using hash sets.
 /// </summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class RedisHashSetGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, (string Key, HashEntry[] HashEntries)>
+#pragma warning restore CS0618
 {
     /// <summary>All the properties from the record definition.</summary>
     private readonly IReadOnlyList<VectorStoreRecordProperty> _properties;

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollection.cs
@@ -82,7 +82,9 @@ public class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorStoreReco
     private readonly string[] _dataStoragePropertyNamesWithScore;
 
     /// <summary>The mapper to use when mapping between the consumer data model and the Redis record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, (string Key, HashEntry[] HashEntries)> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RedisHashSetVectorStoreRecordCollection{TRecord}"/> class.
@@ -108,7 +110,9 @@ public class RedisHashSetVectorStoreRecordCollection<TRecord> : IVectorStoreReco
         this._dataStoragePropertyNamesWithScore = [.. this._model.DataProperties.Select(p => p.StorageName), "vector_score"];
 
         // Assign Mapper.
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         this._mapper = this._options.HashEntriesCustomMapper ?? new RedisHashSetVectorStoreRecordMapper<TRecord>(this._model);
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Extensions.VectorData;
 using StackExchange.Redis;
 
@@ -23,6 +24,7 @@ public sealed class RedisHashSetVectorStoreRecordCollectionOptions<TRecord>
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the Redis record.
     /// </summary>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, (string Key, HashEntry[] HashEntries)>? HashEntriesCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisHashSetVectorStoreRecordMapper.cs
@@ -14,8 +14,10 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 /// Class for mapping between a hashset stored in redis, and the consumer data model.
 /// </summary>
 /// <typeparam name="TConsumerDataModel">The consumer data model to map to or from.</typeparam>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class RedisHashSetVectorStoreRecordMapper<TConsumerDataModel>(VectorStoreRecordModel model)
     : IVectorStoreRecordMapper<TConsumerDataModel, (string Key, HashEntry[] HashEntries)>
+#pragma warning restore CS0618
 {
     /// <inheritdoc />
     public (string Key, HashEntry[] HashEntries) MapFromDataToStorageModel(TConsumerDataModel dataModel)

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonGenericDataModelMapper.cs
@@ -14,7 +14,9 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 internal sealed class RedisJsonGenericDataModelMapper(
     IReadOnlyList<VectorStoreRecordPropertyModel> properties,
     JsonSerializerOptions jsonSerializerOptions)
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, (string Key, JsonNode Node)>
+#pragma warning restore CS0618
 {
     /// <inheritdoc />
     public (string Key, JsonNode Node) MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollection.cs
@@ -70,7 +70,9 @@ public class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStoreRecordC
     private readonly string[] _dataStoragePropertyNames;
 
     /// <summary>The mapper to use when mapping between the consumer data model and the Redis record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>The JSON serializer options to use when converting between the data model and the Redis record.</summary>
     private readonly JsonSerializerOptions _jsonSerializerOptions;
@@ -99,6 +101,7 @@ public class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStoreRecordC
         // Lookup storage property names.
         this._dataStoragePropertyNames = this._model.DataProperties.Select(p => p.StorageName).ToArray();
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         // Assign Mapper.
         if (this._options.JsonNodeCustomMapper is not null)
         {
@@ -117,6 +120,7 @@ public class RedisJsonVectorStoreRecordCollection<TRecord> : IVectorStoreRecordC
             // Default Mapper.
             this._mapper = new RedisJsonVectorStoreRecordMapper<TRecord>(this._model.KeyProperty, this._jsonSerializerOptions);
         }
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.VectorData;
@@ -27,6 +28,7 @@ public sealed class RedisJsonVectorStoreRecordCollectionOptions<TRecord>
     /// <remarks>
     /// If not set, the default built in mapper will be used, which uses record attrigutes or the provided <see cref="VectorStoreRecordDefinition"/> to map the record.
     /// </remarks>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, (string Key, JsonNode Node)>? JsonNodeCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Redis/RedisJsonVectorStoreRecordMapper.cs
@@ -14,7 +14,9 @@ namespace Microsoft.SemanticKernel.Connectors.Redis;
 internal sealed class RedisJsonVectorStoreRecordMapper<TConsumerDataModel>(
     VectorStoreRecordKeyPropertyModel keyProperty,
     JsonSerializerOptions jsonSerializerOptions)
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     : IVectorStoreRecordMapper<TConsumerDataModel, (string Key, JsonNode Node)>
+#pragma warning restore CS0618
 {
     /// <summary>The key property.</summary>
     private readonly string _keyPropertyStorageName = keyProperty.StorageName;

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/RecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/RecordMapper.cs
@@ -7,7 +7,9 @@ using Microsoft.Extensions.VectorData.ConnectorSupport;
 
 namespace Microsoft.SemanticKernel.Connectors.SqlServer;
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class RecordMapper<TRecord>(VectorStoreRecordModel model) : IVectorStoreRecordMapper<TRecord, IDictionary<string, object?>>
+#pragma warning restore CS0618
 {
     public IDictionary<string, object?> MapFromDataToStorageModel(TRecord dataModel)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollection.cs
@@ -26,7 +26,9 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
     private readonly string _connectionString;
     private readonly SqlServerVectorStoreRecordCollectionOptions<TRecord> _options;
     private readonly VectorStoreRecordModel _model;
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, IDictionary<string, object?>> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlServerVectorStoreRecordCollection{TKey, TRecord}"/> class.
@@ -49,6 +51,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
         this.CollectionName = name;
         // We need to create a copy, so any changes made to the option bag after
         // the ctor call do not affect this instance.
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         this._options = options is null
             ? s_defaultOptions
             : new()
@@ -59,6 +62,7 @@ public sealed class SqlServerVectorStoreRecordCollection<TKey, TRecord>
             };
 
         this._mapper = this._options.Mapper ?? new RecordMapper<TRecord>(this._model);
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.SqlServer/SqlServerVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.VectorData;
 
@@ -21,6 +22,7 @@ public sealed class SqlServerVectorStoreRecordCollectionOptions<TRecord>
     /// <remarks>
     /// If not set, the default mapper will be used.
     /// </remarks>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, IDictionary<string, object?>>? Mapper { get; init; }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollection.cs
@@ -34,7 +34,9 @@ public class SqliteVectorStoreRecordCollection<TRecord> :
     private readonly SqliteVectorStoreRecordCollectionOptions<TRecord> _options;
 
     /// <summary>The mapper to use when mapping between the consumer data model and the SQLite record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, Dictionary<string, object?>> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>The default options for vector search.</summary>
     private static readonly VectorSearchOptions<TRecord> s_defaultVectorSearchOptions = new();
@@ -130,7 +132,9 @@ public class SqliteVectorStoreRecordCollection<TRecord> :
             }
         }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
         this._mapper = this._options.DictionaryCustomMapper ?? new SqliteVectorStoreRecordMapper<TRecord>(this._model);
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc />

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordCollectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.VectorData;
 
@@ -13,6 +14,7 @@ public sealed class SqliteVectorStoreRecordCollectionOptions<TRecord>
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and the SQLite record.
     /// </summary>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, Dictionary<string, object?>>? DictionaryCustomMapper { get; set; }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Sqlite/SqliteVectorStoreRecordMapper.cs
@@ -11,7 +11,9 @@ namespace Microsoft.SemanticKernel.Connectors.Sqlite;
 /// Class for mapping between a dictionary and the consumer data model.
 /// </summary>
 /// <typeparam name="TRecord">The consumer data model to map to or from.</typeparam>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class SqliteVectorStoreRecordMapper<TRecord>(VectorStoreRecordModel model) : IVectorStoreRecordMapper<TRecord, Dictionary<string, object?>>
+#pragma warning restore CS0618
 {
     public Dictionary<string, object?> MapFromDataToStorageModel(TRecord dataModel)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateGenericDataModelMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateGenericDataModelMapper.cs
@@ -12,7 +12,9 @@ namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 /// <summary>
 /// A mapper that maps between the generic Semantic Kernel data model and the model that the data is stored under, within Weaviate.
 /// </summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class WeaviateGenericDataModelMapper : IVectorStoreRecordMapper<VectorStoreGenericDataModel<Guid>, JsonObject>
+#pragma warning restore CS0618
 {
     /// <summary>The name of the Weaviate collection.</summary>
     private readonly string _collectionName;

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollection.cs
@@ -51,7 +51,9 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     private readonly VectorStoreRecordModel _model;
 
     /// <summary>The mapper to use when mapping between the consumer data model and the Weaviate record.</summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private readonly IVectorStoreRecordMapper<TRecord, JsonObject> _mapper;
+#pragma warning restore CS0618
 
     /// <summary>Weaviate endpoint.</summary>
     private readonly Uri _endpoint;
@@ -418,6 +420,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
     /// <summary>
     /// Returns custom mapper, generic data model mapper or default record mapper.
     /// </summary>
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private IVectorStoreRecordMapper<TRecord, JsonObject> InitializeMapper()
     {
         if (this._options.JsonObjectCustomMapper is not null)
@@ -434,6 +437,7 @@ public class WeaviateVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCo
 
         return new WeaviateVectorStoreRecordMapper<TRecord>(this.CollectionName, this._model, s_jsonSerializerOptions);
     }
+#pragma warning restore CS0618
 
     private static void VerifyVectorParam<TVector>(TVector vector)
     {

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionOptions.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordCollectionOptions.cs
@@ -14,6 +14,7 @@ public sealed class WeaviateVectorStoreRecordCollectionOptions<TRecord>
     /// <summary>
     /// Gets or sets an optional custom mapper to use when converting between the data model and Weaviate record.
     /// </summary>
+    [Obsolete("Custom mappers are being obsoleted.")]
     public IVectorStoreRecordMapper<TRecord, JsonObject>? JsonObjectCustomMapper { get; init; } = null;
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.Weaviate/WeaviateVectorStoreRecordMapper.cs
@@ -8,7 +8,9 @@ using Microsoft.Extensions.VectorData.ConnectorSupport;
 
 namespace Microsoft.SemanticKernel.Connectors.Weaviate;
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class WeaviateVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, JsonObject>
+#pragma warning restore CS0618
 {
     private readonly string _collectionName;
     private readonly VectorStoreRecordModel _model;

--- a/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.MongoDB.UnitTests/MongoDBVectorStoreRecordCollectionTests.cs
@@ -489,6 +489,7 @@ public sealed class MongoDBVectorStoreRecordCollectionTests
             expectedPropertyName: "bson_hotel_name");
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task UpsertWithCustomMapperWorksCorrectlyAsync()
     {
@@ -564,6 +565,7 @@ public sealed class MongoDBVectorStoreRecordCollectionTests
         Assert.Equal(RecordKey, result.HotelId);
         Assert.Equal("Name from mapper", result.HotelName);
     }
+#pragma warning restore CS0618
 
     [Theory]
     [MemberData(nameof(VectorizedSearchVectorTypeData))]

--- a/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Pinecone.UnitTests/PineconeVectorStoreRecordCollectionTests.cs
@@ -17,6 +17,7 @@ public class PineconeVectorStoreRecordCollectionTests
 {
     private const string TestCollectionName = "testcollection";
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     /// <summary>
     /// Tests that the collection can be created even if the definition and the type do not match.
     /// In this case, the expectation is that a custom mapper will be provided to map between the
@@ -43,6 +44,7 @@ public class PineconeVectorStoreRecordCollectionTests
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, VectorCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel, Sdk.Vector>>() });
     }
+#pragma warning restore CS0618
 
     public sealed class SinglePropsModel
     {

--- a/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Qdrant.UnitTests/QdrantVectorStoreRecordCollectionTests.cs
@@ -253,6 +253,7 @@ public class QdrantVectorStoreRecordCollectionTests
         Assert.Equal(testRecordKeys[1], actual[1].Key);
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task CanGetRecordWithCustomMapperAsync()
     {
@@ -298,6 +299,7 @@ public class QdrantVectorStoreRecordCollectionTests
                     It.Is<StorageToDataModelMapperOptions>(x => x.IncludeVectors)),
                 Times.Once);
     }
+#pragma warning restore CS0618
 
     [Theory]
     [InlineData(true, true)]
@@ -479,6 +481,7 @@ public class QdrantVectorStoreRecordCollectionTests
                 Times.Once);
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task CanUpsertRecordWithCustomMapperAsync()
     {
@@ -544,6 +547,7 @@ public class QdrantVectorStoreRecordCollectionTests
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, PointStructCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel<ulong>, PointStruct>>() });
     }
+#pragma warning restore CS0618
 
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
     [Theory]

--- a/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Redis.UnitTests/RedisHashSetVectorStoreRecordCollectionTests.cs
@@ -236,6 +236,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
         Assert.Equal(new float[] { 5, 6, 7, 8 }, actual[1].Vector!.Value.ToArray());
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task CanGetRecordWithCustomMapperAsync()
     {
@@ -284,6 +285,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
                     It.Is<StorageToDataModelMapperOptions>(x => x.IncludeVectors)),
                 Times.Once);
     }
+#pragma warning restore CS0618
 
     [Theory]
     [InlineData(true)]
@@ -375,6 +377,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
             Times.Once);
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task CanUpsertRecordWithCustomMapperAsync()
     {
@@ -414,6 +417,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
                 x => x.MapFromDataToStorageModel(It.Is<SinglePropsModel>(x => x == model)),
                 Times.Once);
     }
+#pragma warning restore CS0618
 
 #pragma warning disable CS0618 // VectorSearchFilter is obsolete
     [Theory]
@@ -511,6 +515,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
     }
 #pragma warning restore CS0618 // VectorSearchFilter is obsolete
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     /// <summary>
     /// Tests that the collection can be created even if the definition and the type do not match.
     /// In this case, the expectation is that a custom mapper will be provided to map between the
@@ -536,6 +541,7 @@ public class RedisHashSetVectorStoreRecordCollectionTests
             TestCollectionName,
             new() { VectorStoreRecordDefinition = definition, HashEntriesCustomMapper = Mock.Of<IVectorStoreRecordMapper<SinglePropsModel, (string key, HashEntry[] hashEntries)>>() });
     }
+#pragma warning restore CS0618
 
     private RedisHashSetVectorStoreRecordCollection<SinglePropsModel> CreateRecordCollection(bool useDefinition)
     {

--- a/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionTests.cs
+++ b/dotnet/src/Connectors/Connectors.Weaviate.UnitTests/WeaviateVectorStoreRecordCollectionTests.cs
@@ -349,6 +349,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests : IDisposable
         Assert.Equal("Test Name 2", jsonObject2["properties"]?["hotelName"]?.GetValue<string>());
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [Fact]
     public async Task UpsertWithCustomMapperWorksCorrectlyAsync()
     {
@@ -427,6 +428,7 @@ public sealed class WeaviateVectorStoreRecordCollectionTests : IDisposable
         Assert.Equal(id, result.HotelId);
         Assert.Equal("Test Name from mapper", result.HotelName);
     }
+#pragma warning restore CS0618
 
     [Theory]
     [InlineData(true, "http://test-endpoint/schema", "Bearer fake-key")]

--- a/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordMapper.cs
+++ b/dotnet/src/Connectors/VectorData.Abstractions/VectorStorage/IVectorStoreRecordMapper.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+
 namespace Microsoft.Extensions.VectorData;
 
 /// <summary>
@@ -7,6 +9,7 @@ namespace Microsoft.Extensions.VectorData;
 /// </summary>
 /// <typeparam name="TRecordDataModel">The consumer record data model to map to or from.</typeparam>
 /// <typeparam name="TStorageModel">The storage model to map to or from.</typeparam>
+[Obsolete("Custom mappers are being obsoleted.")]
 public interface IVectorStoreRecordMapper<TRecordDataModel, TStorageModel>
 {
     /// <summary>

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDBGenericDataModelMapper.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDBGenericDataModelMapper.cs
@@ -16,7 +16,9 @@ namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 /// A mapper that maps between the generic Semantic Kernel data model and the model that the data is stored under, within MongoDB.
 /// </summary>
 [ExcludeFromCodeCoverage]
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class MongoDBGenericDataModelMapper(VectorStoreRecordModel model) : IVectorStoreRecordMapper<VectorStoreGenericDataModel<string>, BsonDocument>
+#pragma warning restore CS0618
 {
     /// <inheritdoc />
     public BsonDocument MapFromDataToStorageModel(VectorStoreGenericDataModel<string> dataModel)

--- a/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDBVectorStoreRecordMapper.cs
+++ b/dotnet/src/InternalUtilities/connectors/Memory/MongoDB/MongoDBVectorStoreRecordMapper.cs
@@ -13,7 +13,9 @@ using MongoDB.Bson.Serialization.Conventions;
 namespace Microsoft.SemanticKernel.Connectors.MongoDB;
 
 [ExcludeFromCodeCoverage]
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
 internal sealed class MongoDBVectorStoreRecordMapper<TRecord> : IVectorStoreRecordMapper<TRecord, BsonDocument>
+#pragma warning restore CS0618
 {
     /// <summary>A key property info of the data model.</summary>
     private readonly PropertyInfo? _keyClrProperty;

--- a/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerVectorStoreTests.cs
+++ b/dotnet/src/VectorDataIntegrationTests/SqlServerIntegrationTests/SqlServerVectorStoreTests.cs
@@ -150,6 +150,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         }
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     [ConditionalFact]
     public async Task CustomMapper()
     {
@@ -201,6 +202,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
             await collection.DeleteCollectionAsync();
         }
     }
+#pragma warning restore CS0618
 
     [ConditionalFact]
     public async Task BatchCRUD()
@@ -467,6 +469,7 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
         public ReadOnlyMemory<float> Floats { get; set; }
     }
 
+#pragma warning disable CS0618 // IVectorStoreRecordMapper is obsolete
     private sealed class TestModelMapper : IVectorStoreRecordMapper<TestModel, IDictionary<string, object?>>
     {
         internal bool MapFromDataToStorageModel_WasCalled { get; set; }
@@ -499,4 +502,5 @@ public class SqlServerVectorStoreTests(SqlServerFixture fixture) : IClassFixture
             };
         }
     }
+#pragma warning restore CS0618
 }


### PR DESCRIPTION
This obsoletes the public-facing parts of custom mappers, and suppresses internal warnings around them. After we release the next preview, we'll be removing these.

First step of #11129
