### PR TITLE
.Net: Update MultipleFunctionsVsParameters.cs to fix the parameter description in the SearchByPurchaseOrder function

### DIFF
--- a/dotnet/samples/Concepts/FunctionCalling/MultipleFunctionsVsParameters.cs
+++ b/dotnet/samples/Concepts/FunctionCalling/MultipleFunctionsVsParameters.cs
@@ -131,7 +131,7 @@ public class MultipleFunctionsVsParameters(ITestOutputHelper output) : BaseTest(
 
         [KernelFunction]
         [Description("Search for invoices by purchase order.")]
-        public IEnumerable<Invoice> SearchByPurchaseOrder([Description("The purchase order. Purchase orders begin with a PN prefix.")] string purchaseOrder)
+        public IEnumerable<Invoice> SearchByPurchaseOrder([Description("The purchase order. Purchase orders begin with a PO prefix.")] string purchaseOrder)
         {
             return
                 [


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. The description of the function is incorrect. The purchase orders should begin with a PO prefix, not PN.
  2. It fixes the function calling when the user ask a question including `PO`.
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The description of the parameter of `SearchByPurchaseOrder` method is incorrect. Update it to `PO` so the model can recognize the parameter correctly.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
