### PR TITLE
.Net MEVD: Use BulkWrite API for Upsert batch on MongoDB

### DIFF
--- a/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
+++ b/dotnet/src/Connectors/Connectors.Memory.MongoDB/MongoDBVectorStoreRecordCollection.cs
@@ -209,7 +209,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
 
         const string OperationName = "ReplaceOne";
 
-        var replacement = CreateReplaceOne(record, OperationName);
+        var replacement = this.CreateReplaceOne(record, OperationName);
 
         return this.RunOperationAsync(OperationName, async () =>
         {
@@ -228,7 +228,7 @@ public class MongoDBVectorStoreRecordCollection<TRecord> : IVectorStoreRecordCol
 
         const string OperationName = "ReplaceOne.BulkWrite";
 
-        var replacements = records.Select(r => CreateReplaceOne(r, OperationName));
+        var replacements = records.Select(r => this.CreateReplaceOne(r, OperationName));
 
         await this.RunOperationAsync(OperationName, async () =>
         {


### PR DESCRIPTION
### Motivation and Context

Updates the MongoDB provider to perform UpsertBatch using the BulkWrite API for performance.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
